### PR TITLE
Privacy Choices: Banner UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerFragment.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.ui.prefs.privacy.banner
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class PrivacyBannerFragment : WCBottomSheetDialogFragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                WooThemeWithBackground {
+                    PrivacyBannerScreen()
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
@@ -1,0 +1,112 @@
+package com.woocommerce.android.ui.prefs.privacy.banner
+
+import android.content.res.Configuration
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
+import androidx.compose.material.SwitchDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun PrivacyBannerScreen() {
+    Column(
+        Modifier.padding(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.privacy_banner_title),
+            style = MaterialTheme.typography.h5
+        )
+
+        Text(
+            modifier = Modifier.padding(top = 8.dp),
+            style = MaterialTheme.typography.body2,
+            text = stringResource(R.string.privacy_banner_description)
+        )
+
+        Row(
+            modifier = Modifier
+                .padding(top = 16.dp)
+                .fillMaxWidth()
+                .clickable { },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.privacy_banner_analytics),
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Switch(
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = MaterialTheme.colors.primary
+                ),
+                checked = true,
+                onCheckedChange = {},
+            )
+        }
+
+        Text(
+            modifier = Modifier.padding(top = 16.dp),
+            style = textAppearanceWooBody2(),
+            text = stringResource(R.string.privacy_banner_analytics_description)
+        )
+
+        Row(
+            modifier = Modifier
+                .padding(top = 16.dp)
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Button(
+                modifier = Modifier.weight(1f),
+                colors = ButtonDefaults.outlinedButtonColors(), onClick = { /*TODO*/ }
+            ) {
+                Text(stringResource(R.string.privacy_banner_go_to_settings))
+            }
+            Spacer(modifier = Modifier.padding(horizontal = 4.dp))
+            Button(
+                modifier = Modifier.weight(1f),
+                onClick = { /*TODO*/ }
+            ) {
+                Text(stringResource(R.string.privacy_banner_save))
+            }
+        }
+    }
+}
+
+@Composable
+// Style of TextAppearance.Woo.Body2
+private fun textAppearanceWooBody2() = TextStyle(
+    lineHeight = 20.sp,
+    color = MaterialTheme.colors.onSurface.copy(
+        alpha = 0.60f
+    ),
+    fontSize = 14.sp,
+)
+
+@Preview(name = "Light mode")
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "RTL mode", locale = "ar")
+@Preview(name = "Smaller screen", device = Devices.NEXUS_5)
+@Composable
+private fun Default() {
+    WooThemeWithBackground {
+        PrivacyBannerScreen()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Devices
@@ -102,6 +103,9 @@ fun PrivacyBannerScreen() {
                     modifier = Modifier.weight(1f),
                     onClick = { /*TODO*/ },
                     shape = MaterialTheme.shapes.small.copy(CornerSize(8.dp)),
+                    colors = ButtonDefaults.buttonColors(
+                        contentColor = Color.White,
+                    ),
                     elevation = ButtonDefaults.elevation(
                         defaultElevation = 0.dp,
                         pressedElevation = 0.dp,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
@@ -1,18 +1,22 @@
 package com.woocommerce.android.ui.prefs.privacy.banner
 
 import android.content.res.Configuration
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Switch
 import androidx.compose.material.SwitchDefaults
 import androidx.compose.material.Text
+import androidx.compose.material.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -27,64 +31,87 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 fun PrivacyBannerScreen() {
-    Column(
-        Modifier.padding(16.dp)
-    ) {
-        Text(
-            text = stringResource(R.string.privacy_banner_title),
-            style = MaterialTheme.typography.h5
-        )
-
-        Text(
-            modifier = Modifier.padding(top = 8.dp),
-            style = MaterialTheme.typography.body2,
-            text = stringResource(R.string.privacy_banner_description)
-        )
-
-        Row(
-            modifier = Modifier
-                .padding(top = 16.dp)
-                .fillMaxWidth()
-                .clickable { },
-            verticalAlignment = Alignment.CenterVertically,
+    Box(Modifier.background(MaterialTheme.colors.surface)) {
+        Column(
+            Modifier.padding(16.dp)
         ) {
             Text(
-                text = stringResource(R.string.privacy_banner_analytics),
+                text = stringResource(R.string.privacy_banner_title),
+                style = MaterialTheme.typography.h6
             )
-            Spacer(modifier = Modifier.weight(1f))
-            Switch(
-                colors = SwitchDefaults.colors(
-                    checkedThumbColor = MaterialTheme.colors.primary
-                ),
-                checked = true,
-                onCheckedChange = {},
+
+            Text(
+                modifier = Modifier.padding(top = 8.dp),
+                style = MaterialTheme.typography.body2,
+                text = stringResource(R.string.privacy_banner_description)
             )
-        }
 
-        Text(
-            modifier = Modifier.padding(top = 16.dp),
-            style = textAppearanceWooBody2(),
-            text = stringResource(R.string.privacy_banner_analytics_description)
-        )
-
-        Row(
-            modifier = Modifier
-                .padding(top = 16.dp)
-                .fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Button(
-                modifier = Modifier.weight(1f),
-                colors = ButtonDefaults.outlinedButtonColors(), onClick = { /*TODO*/ }
+            Row(
+                modifier = Modifier
+                    .padding(top = 8.dp)
+                    .fillMaxWidth()
+                    .clickable { },
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(stringResource(R.string.privacy_banner_go_to_settings))
+                Text(
+                    text = stringResource(R.string.privacy_banner_analytics),
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Switch(
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = MaterialTheme.colors.primary
+                    ),
+                    checked = true,
+                    onCheckedChange = {},
+                )
             }
-            Spacer(modifier = Modifier.padding(horizontal = 4.dp))
-            Button(
-                modifier = Modifier.weight(1f),
-                onClick = { /*TODO*/ }
+
+            Text(
+                modifier = Modifier.padding(top = 8.dp, end = 64.dp),
+                style = textAppearanceWooBody2(),
+                text = stringResource(R.string.privacy_banner_analytics_description)
+            )
+
+            Row(
+                modifier = Modifier
+                    .padding(top = 16.dp)
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(stringResource(R.string.privacy_banner_save))
+                Button(
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = MaterialTheme.colors.surface,
+                        contentColor = contentColorFor(MaterialTheme.colors.surface)
+                    ),
+                    border = ButtonDefaults.outlinedBorder,
+                    shape = MaterialTheme.shapes.small.copy(CornerSize(8.dp)),
+                    elevation = ButtonDefaults.elevation(
+                        defaultElevation = 0.dp,
+                        pressedElevation = 0.dp,
+                        disabledElevation = 0.dp,
+                        hoveredElevation = 0.dp,
+                        focusedElevation = 0.dp
+                    ),
+                    onClick = { /*TODO*/ }
+                ) {
+                    Text(stringResource(R.string.privacy_banner_settings))
+                }
+                Spacer(modifier = Modifier.padding(horizontal = 4.dp))
+                Button(
+                    modifier = Modifier.weight(1f),
+                    onClick = { /*TODO*/ },
+                    shape = MaterialTheme.shapes.small.copy(CornerSize(8.dp)),
+                    elevation = ButtonDefaults.elevation(
+                        defaultElevation = 0.dp,
+                        pressedElevation = 0.dp,
+                        disabledElevation = 0.dp,
+                        hoveredElevation = 0.dp,
+                        focusedElevation = 0.dp
+                    ),
+                ) {
+                    Text(stringResource(R.string.privacy_banner_save))
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
@@ -34,15 +34,16 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 fun PrivacyBannerScreen() {
     Box(Modifier.background(MaterialTheme.colors.surface)) {
         Column(
-            Modifier.padding(16.dp)
+            Modifier.padding(vertical = 16.dp)
         ) {
             Text(
                 text = stringResource(R.string.privacy_banner_title),
+                modifier = Modifier.padding(horizontal = 16.dp),
                 style = MaterialTheme.typography.h6
             )
 
             Text(
-                modifier = Modifier.padding(top = 8.dp),
+                modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp),
                 style = MaterialTheme.typography.body2,
                 text = stringResource(R.string.privacy_banner_description)
             )
@@ -55,10 +56,12 @@ fun PrivacyBannerScreen() {
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
+                    modifier = Modifier.padding(start = 16.dp),
                     text = stringResource(R.string.privacy_banner_analytics),
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 Switch(
+                    modifier = Modifier.padding(end = 16.dp),
                     colors = SwitchDefaults.colors(
                         checkedThumbColor = MaterialTheme.colors.primary
                     ),
@@ -68,14 +71,14 @@ fun PrivacyBannerScreen() {
             }
 
             Text(
-                modifier = Modifier.padding(top = 8.dp, end = 64.dp),
+                modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 64.dp),
                 style = textAppearanceWooBody2(),
                 text = stringResource(R.string.privacy_banner_analytics_description)
             )
 
             Row(
                 modifier = Modifier
-                    .padding(top = 16.dp)
+                    .padding(top = 16.dp, start = 16.dp, end = 16.dp)
                     .fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -523,6 +523,9 @@
             app:destination="@id/getPaidFragment"
             app:popUpTo="@id/dashboard" />
     </fragment>
+    <dialog
+        android:id="@+id/privacyBannerFragment"
+        android:name="com.woocommerce.android.ui.prefs.privacy.banner.PrivacyBannerFragment" />
     <fragment
         android:id="@+id/launchStoreFragment"
         android:name="com.woocommerce.android.ui.login.storecreation.onboarding.launchstore.LaunchStoreFragment"
@@ -548,4 +551,7 @@
     <action
         android:id="@+id/action_global_planUpgradeStartFragment"
         app:destination="@id/planUpgradeStartFragment" />
+    <action
+        android:id="@+id/action_global_privacyBannerFragment"
+        app:destination="@id/privacyBannerFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1919,6 +1919,12 @@
     <string name="settings_privacy_detail">This information helps us improve our products, make marketing to you more relevant, personalize your WooCommerce experience, and more as detailed in our privacy policy</string>
     <string name="settings_privacy_policy">Read privacy policy</string>
     <string name="settings_privacy_policy_ca">Privacy Notice for California Users</string>
+    <string name="privacy_banner_description">Your privacy is critically important to us and always has been. We use, store, and process your personal data to optimize our app (and your experience) in various ways. Some uses of your data we absolutely need in order to make things work, and others you can customize from your Settings.</string>
+    <string name="privacy_banner_title">Manage privacy</string>
+    <string name="privacy_banner_analytics">Analytics</string>
+    <string name="privacy_banner_analytics_description">Allow us to optimize performance by collecting information on how users interact with our mobile apps.</string>
+    <string name="privacy_banner_go_to_settings">Go to settings</string>
+    <string name="privacy_banner_save">Save</string>
     <string name="settings_tracking">We use other tracking tools, including some from third parties. Read about these and how to control them.</string>
     <string name="settings_footer">Made with love by Automattic. %1$s</string>
     <string name="settings_hiring">We\'re hiring!</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1923,7 +1923,7 @@
     <string name="privacy_banner_title">Manage privacy</string>
     <string name="privacy_banner_analytics">Analytics</string>
     <string name="privacy_banner_analytics_description">Allow us to optimize performance by collecting information on how users interact with our mobile apps.</string>
-    <string name="privacy_banner_go_to_settings">Go to settings</string>
+    <string name="privacy_banner_settings">Settings</string>
     <string name="privacy_banner_save">Save</string>
     <string name="settings_tracking">We use other tracking tools, including some from third parties. Read about these and how to control them.</string>
     <string name="settings_footer">Made with love by Automattic. %1$s</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8943
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds UI for privacy banner.


This design was discussed internally here: p1684230196395219-slack-C0354HSNUJH

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Not needed - it's just UI PR.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="1053" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/5845095/2e4a66e7-409f-473f-bca0-0c8f889a98a1">

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->