### PR TITLE
Pass order id so we it doesn't crash in runtime

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigationTarget.kt
@@ -57,5 +57,5 @@ sealed class OrderNavigationTarget : Event() {
     data class ViewOrderedAddons(val remoteOrderID: Long, val orderItemID: Long, val addonsProductID: Long) :
         OrderNavigationTarget()
     data class EditOrder(val orderId: Long) : OrderNavigationTarget()
-    object ViewCustomFields : OrderNavigationTarget()
+    data class ViewCustomFields(val orderId: Long) : OrderNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -186,7 +186,9 @@ class OrderNavigator @Inject constructor() {
                     ).let { fragment.findNavController().navigateSafely(it) }
             }
             is ViewCustomFields -> {
-                val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToCustomOrderFieldsFragment()
+                val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToCustomOrderFieldsFragment(
+                    orderId = target.orderId
+                )
                 fragment.findNavController().navigateSafely(action)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -240,7 +240,7 @@ class OrderDetailViewModel @Inject constructor(
      */
     fun onCustomFieldsButtonClicked() {
         AnalyticsTracker.track(AnalyticsEvent.ORDER_VIEW_CUSTOM_FIELDS_TAPPED)
-        triggerEvent(OrderNavigationTarget.ViewCustomFields)
+        triggerEvent(OrderNavigationTarget.ViewCustomFields(navArgs.orderId))
     }
 
     /**

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -207,7 +207,7 @@
             app:destination="@id/receiptPreviewFragment" />
         <action
             android:id="@+id/action_orderDetailFragment_to_printingInstructionsFragment"
-            app:destination="@id/printingInstructionsFragment"/>
+            app:destination="@id/printingInstructionsFragment" />
         <action
             android:id="@+id/action_orderDetailFragment_to_printShippingLabelCustomsFormFragment"
             app:destination="@id/printShippingLabelCustomsFormFragment" />
@@ -219,7 +219,7 @@
             app:destination="@id/editCustomerOrderNoteFragment" />
         <action
             android:id="@+id/action_orderDetailFragment_to_shippingAddressEditingFragment"
-            app:destination="@id/shippingAddressEditingFragment"/>
+            app:destination="@id/shippingAddressEditingFragment" />
         <action
             android:id="@+id/action_orderDetailFragment_to_billingAddressEditingFragment"
             app:destination="@id/billingAddressEditingFragment" />
@@ -241,7 +241,7 @@
             app:enterAnim="@anim/activity_fade_in"
             app:exitAnim="@null"
             app:popEnterAnim="@null"
-            app:popExitAnim="@anim/activity_fade_out" >
+            app:popExitAnim="@anim/activity_fade_out">
             <argument
                 android:name="mode"
                 app:argType="com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel$Mode" />
@@ -327,7 +327,7 @@
             app:popExitAnim="@anim/activity_fade_out" />
         <action
             android:id="@+id/action_createShippingLabelFragment_to_printShippingLabelFragment"
-            app:destination="@id/printShippingLabelFragment"/>
+            app:destination="@id/printShippingLabelFragment" />
         <action
             android:id="@+id/action_createShippingLabelFragment_to_shippingCustomsFragment"
             app:destination="@id/shippingCustomsFragment" />
@@ -385,7 +385,7 @@
             app:destination="@id/moveShippingItemDialog" />
         <action
             android:id="@+id/action_editShippingLabelPackagesFragment_to_shippingLabelCreatePackageFragment"
-            app:destination="@id/shippingLabelCreatePackageFragment"/>
+            app:destination="@id/shippingLabelCreatePackageFragment" />
     </fragment>
     <fragment
         android:id="@+id/shippingPackageSelectorFragment"
@@ -537,7 +537,15 @@
         tools:layout="@layout/fragment_base_edit_address" />
     <fragment
         android:id="@+id/customOrderFieldsFragment"
-        android:name="com.woocommerce.android.ui.orders.details.customfields.CustomOrderFieldsFragment" />
+        android:name="com.woocommerce.android.ui.orders.details.customfields.CustomOrderFieldsFragment">
+        <argument
+            android:name="orderId"
+            app:argType="long" />
+        <argument
+            android:name="remoteNoteId"
+            android:defaultValue="0L"
+            app:argType="long" />
+    </fragment>
     <action
         android:id="@+id/action_global_item_selector_dialog"
         app:destination="@id/itemSelectorDialog" />


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

This PR cherry-picks changes from this PR: #9045 that have already been reviewed and approved.  For all the details on the issue and the fix please refer to that PR.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Changes have already been tested but if you want to test them again here are the instructions:
* Create an order
* Pay for it via IPP
* Notice the "View Custom Fields" button on the orders details
* Click on it - notice that it doesn't crash



