### PR TITLE
Feature/8955 close account from site picker

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -97,9 +97,15 @@ class AccountRepository @Inject constructor(
                 CloseAccountErrorType.GENERIC_ERROR -> CloseAccountResult.Error(hasActiveStores = false)
             }
         } else {
-            selectedSite.reset()
+            val event: OnAccountChanged = dispatcher.dispatchAndAwait(AccountActionBuilder.newSignOutAction())
+            if (event.isError) {
+                WooLog.d(LOGIN, "Error while trying to log out after successfully closing the account")
+                CloseAccountResult.Error(hasActiveStores = false)
+            } else {
+                selectedSite.reset()
                 cleanup()
                 CloseAccountResult.Success
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -97,8 +97,9 @@ class AccountRepository @Inject constructor(
                 CloseAccountErrorType.GENERIC_ERROR -> CloseAccountResult.Error(hasActiveStores = false)
             }
         } else {
-            cleanup()
-            CloseAccountResult.Success
+            selectedSite.reset()
+                cleanup()
+                CloseAccountResult.Success
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountDialogFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.prefs
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -41,10 +42,13 @@ import com.woocommerce.android.support.requests.SupportRequestFormActivity
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.prefs.CloseAccountViewModel.CloseAccountState
 import com.woocommerce.android.ui.prefs.CloseAccountViewModel.ContactSupport
+import com.woocommerce.android.ui.prefs.CloseAccountViewModel.OnAccountClosed
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.login.LoginMode
 
 @AndroidEntryPoint
 class CloseAccountDialogFragment : DialogFragment() {
@@ -87,8 +91,19 @@ class CloseAccountDialogFragment : DialogFragment() {
                     ).let { activity?.startActivity(it) }
                     findNavController().popBackStack()
                 }
+
+                is OnAccountClosed -> onAccountClosed()
             }
         }
+    }
+
+    private fun onAccountClosed() {
+        findNavController().popBackStack()
+        val intent = Intent(context, LoginActivity::class.java)
+        LoginMode.WOO_LOGIN_MODE.putInto(intent)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        startActivity(intent)
+        activity?.finish()
     }
 
     @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountViewModel.kt
@@ -40,8 +40,11 @@ class CloseAccountViewModel @Inject constructor(
     )
     val viewState = _viewState
 
-    fun onConfirmCloseAccount() {
+    init {
         analyticsTrackerWrapper.track(CLOSE_ACCOUNT_TAPPED)
+    }
+
+    fun onConfirmCloseAccount() {
         launch {
             _viewState.value = _viewState.value?.copy(isLoading = true)
             when (val result = accountRepository.closeAccount()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/CloseAccountViewModel.kt
@@ -39,7 +39,7 @@ class CloseAccountViewModel @Inject constructor(
         launch {
             _viewState.value = _viewState.value?.copy(isLoading = true)
             when (val result = accountRepository.closeAccount()) {
-                Success -> triggerEvent(Exit)
+                Success -> triggerEvent(OnAccountClosed)
                 is Error -> {
                     val errorDescription =
                         if (result.hasActiveStores) R.string.settings_close_account_active_stores_error_description
@@ -79,4 +79,5 @@ class CloseAccountViewModel @Inject constructor(
     )
 
     data class ContactSupport(val origin: HelpOrigin) : MultiLiveEvent.Event()
+    object OnAccountClosed : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -179,8 +179,7 @@ class SitePickerViewModel @Inject constructor(
             isHelpBtnVisible = true,
             isSecondaryBtnVisible = true,
             primaryBtnText = resourceProvider.getString(string.continue_button),
-            toolbarTitle = "",
-            showCloseAccountMenuItem = true
+            toolbarTitle = ""
         )
     }
 
@@ -308,7 +307,8 @@ class SitePickerViewModel @Inject constructor(
             noStoresLabelText = resourceProvider.getString(string.login_no_stores_header),
             noStoresSubText = resourceProvider.getString(string.login_no_stores_subtitle),
             isNoStoresBtnVisible = false,
-            currentSitePickerState = SitePickerState.NoStoreState
+            currentSitePickerState = SitePickerState.NoStoreState,
+            showCloseAccountMenuItem = true
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -85,7 +85,7 @@ class SitePickerViewModel @Inject constructor(
         get() = savedState["key"] ?: appPrefsWrapper.getLoginSiteAddress()
         set(value) = savedState.set("key", value)
 
-    val shouldShowToolbar: Boolean
+    val openedFromLogin: Boolean
         get() = !navArgs.openedFromLogin
 
     init {
@@ -178,7 +178,9 @@ class SitePickerViewModel @Inject constructor(
         sitePickerViewState = sitePickerViewState.copy(
             isHelpBtnVisible = true,
             isSecondaryBtnVisible = true,
-            primaryBtnText = resourceProvider.getString(string.continue_button)
+            primaryBtnText = resourceProvider.getString(string.continue_button),
+            toolbarTitle = "",
+            showCloseAccountMenuItem = true
         )
     }
 
@@ -679,6 +681,7 @@ class SitePickerViewModel @Inject constructor(
         val isPrimaryBtnVisible: Boolean = false,
         val isSecondaryBtnVisible: Boolean = false,
         val isNoStoresBtnVisible: Boolean = false,
+        val showCloseAccountMenuItem: Boolean = false,
         val currentSitePickerState: SitePickerState = SitePickerState.StoreListState
     ) : Parcelable
 

--- a/WooCommerce/src/main/res/layout/fragment_site_picker.xml
+++ b/WooCommerce/src/main/res/layout/fragment_site_picker.xml
@@ -23,27 +23,17 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
-                <ImageButton
-                    android:id="@+id/button_help"
-                    style="@style/Woo.Button.TextButton"
-                    android:layout_width="48dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/minor_50"
-                    android:contentDescription="@string/help"
-                    android:src="@drawable/ic_help_24dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
                 <!-- Login User Info -->
                 <com.woocommerce.android.ui.sitepicker.views.LoginUserInfoView
                     android:id="@+id/login_user_info"
                     style="@style/Woo.Card.WithoutPadding"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/major_100"
                     android:layout_marginHorizontal="@dimen/major_100"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/button_help"
+                    app:layout_constraintTop_toTopOf="parent"
                     app:layout_goneMarginTop="@dimen/minor_100" />
 
                 <androidx.recyclerview.widget.RecyclerView

--- a/WooCommerce/src/main/res/menu/menu_site_picker.xml
+++ b/WooCommerce/src/main/res/menu/menu_site_picker.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/menu_help"
+        android:icon="@drawable/ic_help_24dp"
+        android:title="@string/help"
+        android:visible="true"
+        app:showAsAction="always" />
+
+    <item
+        android:id="@+id/menu_close_account"
+        android:title="@string/settings_close_account"
+        android:visible="false"
+        app:showAsAction="never" />
+
+</menu>

--- a/WooCommerce/src/main/res/navigation/nav_graph_site_picker.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_site_picker.xml
@@ -36,6 +36,9 @@
         <action
             android:id="@+id/action_sitePickerFragment_to_storeCreationNativeFlow"
             app:destination="@id/nav_graph_store_creation" />
+        <action
+            android:id="@+id/action_sitePickerFragment_to_closeAccountDialogFragment"
+            app:destination="@id/closeAccountDialogFragment" />
     </fragment>
     <fragment
         android:id="@+id/sitePickerSiteDiscoveryFragment"
@@ -85,4 +88,8 @@
             android:id="@+id/action_addStoreBottomSheetFragment_to_storeCreationNativeFlow"
             app:destination="@id/nav_graph_store_creation" />
     </dialog>
+    <dialog
+        android:id="@+id/closeAccountDialogFragment"
+        android:name="com.woocommerce.android.ui.prefs.CloseAccountDialogFragment"
+        android:label="CloseAccountDialogFragment" />
 </navigation>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerTestUtils.kt
@@ -47,7 +47,8 @@ object SitePickerTestUtils {
     fun getDefaultLoginViewState(defaultViewState: SitePickerViewModel.SitePickerViewState) = defaultViewState.copy(
         isHelpBtnVisible = true,
         isSecondaryBtnVisible = true,
-        isPrimaryBtnVisible = true
+        isPrimaryBtnVisible = true,
+        toolbarTitle = ""
     )
 
     fun getDefaultSwitchStoreViewState(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Final PR for: #8955 
<!-- Id number of the GitHub issue this PR addresses. -->

Please do not merge until base branch is set to `trunk`

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
These changes add: 
- Close account feature from overflow menu in site picker screen when the site picker list is empty. Replicating iOS behavior
- Tracking for the following user interactions: 
  - Whenever the close account option is tapped (either from settings of from site picker) 
  - When close account is closed successfully
  - When close account fails
- Better error messaging when close account fails due to having active stores.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Create a new account
- Land on site picker
- Click on "Close account" 
- Land on Login prologue and try to log in using the email from the deleted account. You'll see an "Account deleted" error after entering your password. 
- Verify the following events are tracked along the process:
```
Tracked: close_account_tapped, Properties: {"is_debug":true}
Tracked: close_account_success, Properties: {"is_debug":true}
```

- Now log in with WP.com account with existing stores
- Check site picker doesn't display the close account option anymore
- Navigate to setting 
- Click close account at the bottom
- Attempt to close the account a see how it fails because you have existing stores. The error message should explain this. 
- Check the following events are tracked: 
```
Tracked: close_account_tapped, Properties: {"is_debug":true}
Tracked: close_account_failed, Properties: {"is_debug":true}
```
### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
Account deletion: 

https://github.com/woocommerce/woocommerce-android/assets/2663464/48d83c0c-da7c-45bd-8645-51f2173de2d1

Log in error: 

https://github.com/woocommerce/woocommerce-android/assets/2663464/21b53cde-8653-4e2f-9694-26333cf3c47d

