### PR TITLE
Provide ViewModel by viewModels

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/customfields/CustomOrderFieldsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/customfields/CustomOrderFieldsFragment.kt
@@ -6,7 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -16,7 +16,7 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class CustomOrderFieldsFragment : BaseFragment(), CustomOrderFieldClickListener {
-    private val viewModel by hiltNavGraphViewModels<OrderDetailViewModel>(R.id.nav_graph_orders)
+    private val viewModel by viewModels<OrderDetailViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Add the correct view model delegate to [CustomOrderFieldsFragment](https://github.com/woocommerce/woocommerce-android/compare/fix/update-viewmodel-delegates?expand=1#diff-d2a437a1949b832b301fe563975efa8d7c7d5efeca9d5c26431168ecdadfafbb)

 The scope of the view model will now be tied to the fragment lifecycle rather than nav_graph lifecycle
