### PR TITLE
Make login prologue responsive to different text lenghts

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_login_prologue.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_prologue.xml
@@ -10,21 +10,21 @@
         android:id="@+id/image_prologue_bg"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:adjustViewBounds="true"
         android:layout_marginTop="100dp"
+        android:adjustViewBounds="true"
         android:importantForAccessibility="no"
         android:scaleType="fitXY"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:srcCompat="@drawable/img_prologue_bg" />
 
     <ImageView
         android:id="@+id/image_prologue"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/prologue_logo_height"
-        android:layout_marginTop="@dimen/major_300"
         android:layout_centerHorizontal="true"
+        android:layout_marginTop="@dimen/major_300"
         android:importantForAccessibility="no"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -35,15 +35,14 @@
         android:id="@+id/imageView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:adjustViewBounds="true"
         android:layout_marginTop="@dimen/major_400"
+        android:adjustViewBounds="true"
         android:importantForAccessibility="no"
         android:src="@drawable/img_prologue"
+        app:layout_constraintBottom_toTopOf="@id/prologueIntro"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/image_prologue"
-        app:layout_constraintBottom_toTopOf="@id/prologueIntro"
-        app:layout_constraintWidth_percent="0.8"/>
+        app:layout_constraintWidth_percent="0.8" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/prologueIntro"
@@ -51,37 +50,39 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"
+        android:paddingStart="@dimen/major_350"
+        android:paddingEnd="@dimen/major_350"
         android:text="@string/simplified_login_prologue_intro"
         android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@id/prologueTitle"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/imageView"
-        app:layout_constraintBottom_toTopOf="@id/prologueTitle" />
+        app:layout_constraintTop_toTopOf="@id/prologueTitle" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/prologueTitle"
         style="@style/Woo.TextView.Subtitle1"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:gravity="center"
-        android:textAlignment="gravity"
+        android:paddingStart="@dimen/major_350"
+        android:paddingEnd="@dimen/major_350"
         android:text="@string/simplified_login_prologue_title"
+        android:textAlignment="gravity"
         android:textStyle="bold"
-        android:layout_marginStart="@dimen/major_350"
-        android:layout_marginEnd="@dimen/major_350"
+        app:layout_constraintBottom_toTopOf="@id/loginButtons"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/prologueIntro"
-        app:layout_constraintBottom_toTopOf="@id/loginButtons"/>
+        app:layout_constraintTop_toBottomOf="@id/prologueIntro" />
 
     <LinearLayout
         android:id="@+id/loginButtons"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
         android:layout_marginTop="@dimen/major_150"
-        app:layout_constraintTop_toBottomOf="@id/prologueTitle"
-        app:layout_constraintBottom_toBottomOf="parent">
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/prologueTitle">
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/button_login_wpcom"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes: #9059 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes issues with login prologue not supporting different locales where description test is longer than in English.

<img width="300"  src="https://github.com/woocommerce/woocommerce-android/assets/2663464/16b674ce-dbef-42e6-947e-1d6f0008b060"> 

### Testing instructions
Run the app in Spanish for example and check the text fits the prologue nicely. You can also manually hard-code the text in `fragment_login_prologue` in line 70 and add a very long text to see how it adapts

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="300"  src="https://github.com/woocommerce/woocommerce-android/assets/2663464/a85bd706-077e-4b44-9e65-1d37c8555207"> 

