### PR TITLE
Order with coupon: analytics events tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -292,6 +292,10 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     ORDER_TRACKING_PROVIDERS_LOADED,
     SHIPMENT_TRACKING_MENU_ACTION,
 
+    // -- Order Coupon
+    ORDER_COUPON_ADD,
+    ORDER_COUPON_REMOVE,
+
     // -- Shipping Labels
     SHIPPING_LABEL_API_REQUEST,
     SHIPPING_LABEL_PRINT_REQUESTED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R.string
 import com.woocommerce.android.WooException
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_COUPON_ADD
+import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_COUPON_REMOVE
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATE_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_FAILED
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_SUCCESS
@@ -636,12 +638,22 @@ class OrderCreateEditViewModel @Inject constructor(
     fun onCouponEntered(couponCode: String?) {
         _orderDraft.update { draft ->
             val couponLines = if (couponCode.isNullOrEmpty()) {
+                trackCouponRemoved()
                 emptyList()
             } else {
+                trackCouponAdded()
                 listOf(Order.CouponLine(code = couponCode))
             }
             draft.copy(couponLines = couponLines)
         }
+    }
+
+    private fun trackCouponAdded() {
+        tracker.track(ORDER_COUPON_ADD, mapOf(KEY_FLOW to flow))
+    }
+
+    private fun trackCouponRemoved() {
+        tracker.track(ORDER_COUPON_REMOVE, mapOf(KEY_FLOW to flow))
     }
 
     @Parcelize

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -1083,4 +1083,30 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
             )
         )
     }
+
+    @Test
+    fun `when coupon added should track event`() {
+        initMocksForAnalyticsWithOrder(defaultOrderValue)
+        createSut()
+
+        sut.onCouponEntered("code")
+
+        verify(tracker).track(
+            AnalyticsEvent.ORDER_COUPON_ADD,
+            mapOf(AnalyticsTracker.KEY_FLOW to VALUE_FLOW_CREATION)
+        )
+    }
+
+    @Test
+    fun `when coupon removed should track event`() {
+        initMocksForAnalyticsWithOrder(defaultOrderValue)
+        createSut()
+
+        sut.onCouponEntered("")
+
+        verify(tracker).track(
+            AnalyticsEvent.ORDER_COUPON_REMOVE,
+            mapOf(AnalyticsTracker.KEY_FLOW to VALUE_FLOW_CREATION)
+        )
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
@@ -222,4 +222,30 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
         createSut()
         assertFalse(sut.viewStateData.liveData.value!!.isCouponButtonEnabled)
     }
+
+    @Test
+    fun `when coupon added should track event`() {
+        initMocksForAnalyticsWithOrder(defaultOrderValue)
+        createSut()
+
+        sut.onCouponEntered("code")
+
+        verify(tracker).track(
+            AnalyticsEvent.ORDER_COUPON_ADD,
+            mapOf(AnalyticsTracker.KEY_FLOW to VALUE_FLOW_EDITING)
+        )
+    }
+
+    @Test
+    fun `when coupon removed should track event`() {
+        initMocksForAnalyticsWithOrder(defaultOrderValue)
+        createSut()
+
+        sut.onCouponEntered("")
+
+        verify(tracker).track(
+            AnalyticsEvent.ORDER_COUPON_REMOVE,
+            mapOf(AnalyticsTracker.KEY_FLOW to VALUE_FLOW_EDITING)
+        )
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9068 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Added tracking of 2 analytics events:
* `ORDER_COUPON_ADD` tracked when adding a coupon to an order
* `ORDER_COUPON_REMOVE` tracked when removing coupon from an order
Both events include a property `flow` equal to "creation" or "editing" - depending on the order flow.

The events names and property are matching [iOS implementation](https://github.com/woocommerce/woocommerce-ios/pull/9090).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Verify both events are tracked properly when adding and removing a valid coupon:
<img width="1026" alt="Zrzut ekranu 2023-05-18 o 11 30 54" src="https://github.com/woocommerce/woocommerce-android/assets/4527432/8ec277d7-ed02-4c3f-a5e7-57cc8d0608c7">

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
