### PR TITLE
fix: do not crash if sold items exceed int range

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-6d22230eeff08917c78304402839405f0618bc8c'
+    fluxCVersion = 'trunk-2657b447f5c5f3ebb9c87de1cb9f8adf94886c63'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8825
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR only updates FluxC hash. For the fix and description, please see: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2722

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
None

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
