### PR TITLE
Add new prop to `ORDER_CREATION_SUCCESS` event

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -255,6 +255,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_TIME_ELAPSED_SINCE_ADD_NEW_ORDER_IN_MILLIS = "milliseconds_since_order_add_new"
         const val KEY_TIME_ELAPSED_SINCE_CARD_COLLECT_PAYMENT_IN_MILLIS = "milliseconds_since_card_collect_payment_flow"
 
+        const val KEY_COUPONS_COUNT = "coupons_count"
+
         enum class OrderNoteType(val value: String) {
             CUSTOMER("customer"),
             PRIVATE("private"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_SHIPPING_METHOD_AD
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_SHIPPING_METHOD_REMOVE
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_STATUS_CHANGE
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_COUPONS_COUNT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_DESC
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_TYPE
@@ -432,11 +433,12 @@ class OrderCreateEditViewModel @Inject constructor(
     private fun trackOrderCreationSuccess() {
         tracker.track(
             ORDER_CREATION_SUCCESS,
-            mutableMapOf<String, String>().also { mutableMap ->
+            mutableMapOf<String, Any>().also { mutableMap ->
                 OrderDurationRecorder.millisecondsSinceOrderAddNew().getOrNull()?.let { timeElapsed ->
                     mutableMap[AnalyticsTracker.KEY_TIME_ELAPSED_SINCE_ADD_NEW_ORDER_IN_MILLIS] =
                         timeElapsed.toString()
                 }
+                mutableMap[KEY_COUPONS_COUNT] = orderDraft.value?.couponLines?.size ?: 0
             }
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
The goal of this PR is to enable tracking of the number of discount coupons added to an order.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Added "coupons_count" property to the `ORDER_CREATION_SUCCESS` event.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Create an order with a (valid) coupon
2. Verify `ORDER_CREATION_SUCCESS` is tracked and contains `coupons_count` = 1 property.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="1394" alt="Zrzut ekranu 2023-05-19 o 15 13 59" src="https://github.com/woocommerce/woocommerce-android/assets/4527432/029f6d4a-93a2-432c-87d0-33721c49f7e2">

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
