### PR TITLE
Activate: Add notification permission request to store creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -669,6 +669,8 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     // -- Application permissions
     APP_PERMISSION_GRANTED,
     APP_PERMISSION_DENIED,
+    APP_PERMISSION_RATIONALE_ACCEPTED,
+    APP_PERMISSION_RATIONALE_DISMISSED,
 
     // -- Encrypted logging
     ENCRYPTED_LOGGING_UPLOAD_SUCCESSFUL,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerFragment.kt
@@ -1,9 +1,12 @@
 package com.woocommerce.android.ui.login.storecreation.name
 
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
@@ -12,10 +15,13 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.navigateToHelpScreen
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.CheckNotificationsPermission
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToDomainPicker
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToStoreProfiler
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToSummary
+import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.RequestNotificationsPermission
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -25,6 +31,10 @@ class StoreNamePickerFragment : BaseFragment() {
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
+
+    private val requestPermissionLauncher = registerForActivityResult(RequestPermission()) { isGranted: Boolean ->
+        (viewModel.event.value as? RequestNotificationsPermission)?.onPermissionsRequestResult?.invoke(isGranted)
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
@@ -50,6 +60,19 @@ class StoreNamePickerFragment : BaseFragment() {
                 is NavigateToDomainPicker -> navigateToDomainPicker(event.domainInitialQuery)
                 is NavigateToStoreProfiler -> navigateToStoreProfiler()
                 is NavigateToSummary -> navigateToSummary()
+                is RequestNotificationsPermission -> {
+                    if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+                        WooPermissionUtils.requestNotificationsPermission(requestPermissionLauncher)
+                    }
+                }
+                is CheckNotificationsPermission -> {
+                    if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+                        event.onPermissionsCheckResult(
+                            WooPermissionUtils.hasNotificationsPermission(requireContext()),
+                            WooPermissionUtils.shouldShowNotificationsRationale(requireActivity())
+                        )
+                    }
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.livedata.observeAsState
@@ -26,6 +27,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.AlertDialog
 import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
@@ -36,10 +38,13 @@ fun StoreNamePickerScreen(viewModel: StoreNamePickerViewModel) {
     viewModel.viewState.observeAsState().value?.let {
         StoreNamePickerScreen(
             storeName = it.storeName,
+            isPermissionDialogVisible = it.isPermissionRationaleVisible,
             onCancelPressed = viewModel::onCancelPressed,
             onHelpPressed = viewModel::onHelpPressed,
             onStoreNameChanged = viewModel::onStoreNameChanged,
-            onContinueClicked = viewModel::onContinueClicked
+            onContinueClicked = viewModel::onContinueClicked,
+            onPermissionRationaleDismissed = viewModel::onPermissionRationaleDismissed,
+            onPermissionRationaleConfirmed = viewModel::onPermissionRationaleConfirmed
         )
     }
 }
@@ -47,10 +52,13 @@ fun StoreNamePickerScreen(viewModel: StoreNamePickerViewModel) {
 @Composable
 private fun StoreNamePickerScreen(
     storeName: String,
+    isPermissionDialogVisible: Boolean,
     onCancelPressed: () -> Unit,
     onHelpPressed: () -> Unit,
     onStoreNameChanged: (String) -> Unit,
-    onContinueClicked: () -> Unit
+    onContinueClicked: () -> Unit,
+    onPermissionRationaleDismissed: () -> Unit,
+    onPermissionRationaleConfirmed: () -> Unit
 ) {
     Scaffold(topBar = {
         ToolbarWithHelpButton(
@@ -67,6 +75,30 @@ private fun StoreNamePickerScreen(
                 .fillMaxSize()
                 .padding(padding)
                 .padding(dimensionResource(id = R.dimen.major_125))
+        )
+    }
+
+    if (isPermissionDialogVisible) {
+        AlertDialog(
+            onDismissRequest = onPermissionRationaleDismissed,
+            title = {
+                Text(text = stringResource(id = R.string.notifications_permission_title))
+            },
+            text = {
+                Text(text = stringResource(id = R.string.notifications_permission_description))
+            },
+            confirmButton = {
+                TextButton(onClick = onPermissionRationaleConfirmed) {
+                    Text(stringResource(id = R.string.allow))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onPermissionRationaleDismissed) {
+                    Text(stringResource(id = R.string.dismiss))
+                }
+            },
+            neutralButton = {
+            }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerScreen.kt
@@ -33,9 +33,9 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 fun StoreNamePickerScreen(viewModel: StoreNamePickerViewModel) {
-    viewModel.storeName.observeAsState().value?.let { storeName ->
+    viewModel.viewState.observeAsState().value?.let {
         StoreNamePickerScreen(
-            storeName = storeName,
+            storeName = it.storeName,
             onCancelPressed = viewModel::onCancelPressed,
             onHelpPressed = viewModel::onHelpPressed,
             onStoreNameChanged = viewModel::onStoreNameChanged,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerScreen.kt
@@ -44,7 +44,7 @@ fun StoreNamePickerScreen(viewModel: StoreNamePickerViewModel) {
             onStoreNameChanged = viewModel::onStoreNameChanged,
             onContinueClicked = viewModel::onContinueClicked,
             onPermissionRationaleDismissed = viewModel::onPermissionRationaleDismissed,
-            onPermissionRationaleConfirmed = viewModel::onPermissionRationaleConfirmed
+            onPermissionRationaleConfirmed = viewModel::onPermissionRationaleAccepted
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -1,5 +1,10 @@
 package com.woocommerce.android.ui.login.storecreation.name
 
+import android.Manifest
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import android.os.Parcelable
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppPrefsWrapper
@@ -9,10 +14,15 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.help.HelpOrigin.STORE_CREATION
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.util.FeatureFlag
-import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.SingleLiveEvent
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.update
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,9 +32,12 @@ class StoreNamePickerViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val prefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
+    override val _event = SingleLiveEvent<Event>()
+    override val event: LiveData<Event> = _event
+
     private val _viewState = savedState.getStateFlow(
         scope = this,
-        initialValue = ViewState("")
+        initialValue = ViewState("", false)
     )
     val viewState = _viewState.asLiveData()
 
@@ -39,6 +52,8 @@ class StoreNamePickerViewModel @Inject constructor(
                 AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_STEP_STORE_NAME
             )
         )
+
+        triggerEvent(CheckNotificationsPermission(::onCheckNotificationsPermissionResult))
     }
 
     fun onCancelPressed() {
@@ -51,21 +66,22 @@ class StoreNamePickerViewModel @Inject constructor(
                 AnalyticsTracker.KEY_IS_FREE_TRIAL to FeatureFlag.FREE_TRIAL_M2.isEnabled()
             )
         )
-        triggerEvent(MultiLiveEvent.Event.Exit)
+        triggerEvent(Exit)
     }
 
     fun onExitTriggered() {
-        triggerEvent(MultiLiveEvent.Event.Exit)
+        triggerEvent(Exit)
     }
 
     fun onHelpPressed() {
-        triggerEvent(MultiLiveEvent.Event.NavigateToHelpScreen(STORE_CREATION))
+        triggerEvent(NavigateToHelpScreen(STORE_CREATION))
     }
 
     fun onStoreNameChanged(newName: String) {
         _viewState.update {
             ViewState(
-                storeName = newName
+                storeName = newName,
+                isPermissionRationaleVisible = it.isPermissionRationaleVisible
             )
         }
     }
@@ -81,14 +97,79 @@ class StoreNamePickerViewModel @Inject constructor(
         }
     }
 
-    data class NavigateToDomainPicker(val domainInitialQuery: String) : MultiLiveEvent.Event()
+    fun onPermissionRationaleDismissed() {
+        setPermissionRationaleVisible(false)
+    }
 
-    object NavigateToStoreProfiler : MultiLiveEvent.Event()
+    fun onPermissionRationaleConfirmed() {
+        setPermissionRationaleVisible(false)
+        triggerEvent(RequestNotificationsPermission(::onRequestNotificationsPermissionResult))
+    }
 
-    object NavigateToSummary : MultiLiveEvent.Event()
+    private fun onCheckNotificationsPermissionResult(granted: Boolean, shouldShowRationale: Boolean) {
+        if (granted) {
+            onNotificationsPermissionGranted()
+        } else {
+            if (shouldShowRationale) {
+                setPermissionRationaleVisible(true)
+            } else {
+                triggerEvent(RequestNotificationsPermission(::onRequestNotificationsPermissionResult))
+            }
+        }
+    }
+
+    private fun onRequestNotificationsPermissionResult(granted: Boolean) {
+        if (granted) {
+            onNotificationsPermissionGranted()
+        } else {
+            onNotificationsPermissionDenied()
+        }
+    }
+
+    private fun onNotificationsPermissionGranted() {
+        if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+            analyticsTrackerWrapper.track(
+                AnalyticsEvent.APP_PERMISSION_GRANTED,
+                mapOf(AnalyticsTracker.KEY_TYPE to Manifest.permission.POST_NOTIFICATIONS)
+            )
+        }
+    }
+
+    private fun onNotificationsPermissionDenied() {
+        if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+            analyticsTrackerWrapper.track(
+                AnalyticsEvent.APP_PERMISSION_DENIED,
+                mapOf(AnalyticsTracker.KEY_TYPE to Manifest.permission.POST_NOTIFICATIONS)
+            )
+        }
+    }
+
+    private fun setPermissionRationaleVisible(isVisible: Boolean) {
+        _viewState.update {
+            ViewState(
+                storeName = it.storeName,
+                isPermissionRationaleVisible = isVisible
+            )
+        }
+    }
+
+    data class NavigateToDomainPicker(val domainInitialQuery: String) : Event()
+
+    object NavigateToStoreProfiler : Event()
+
+    object NavigateToSummary : Event()
+
+    data class RequestNotificationsPermission(
+        val onPermissionsRequestResult: (Boolean) -> Unit
+    ) : Event()
+
+    data class CheckNotificationsPermission(
+        val onPermissionsCheckResult: (permissionGranted: Boolean, showRationale: Boolean) -> Unit
+    ) : Event()
 
     @Parcelize
     data class ViewState(
-        val storeName: String
+        val storeName: String,
+        val isPermissionRationaleVisible: Boolean
     ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -99,11 +99,25 @@ class StoreNamePickerViewModel @Inject constructor(
 
     fun onPermissionRationaleDismissed() {
         setPermissionRationaleVisible(false)
+
+        if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+            analyticsTrackerWrapper.track(
+                AnalyticsEvent.APP_PERMISSION_RATIONALE_DISMISSED,
+                mapOf(AnalyticsTracker.KEY_TYPE to Manifest.permission.POST_NOTIFICATIONS)
+            )
+        }
     }
 
-    fun onPermissionRationaleConfirmed() {
+    fun onPermissionRationaleAccepted() {
         setPermissionRationaleVisible(false)
         triggerEvent(RequestNotificationsPermission(::onRequestNotificationsPermissionResult))
+
+        if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+            analyticsTrackerWrapper.track(
+                AnalyticsEvent.APP_PERMISSION_RATIONALE_ACCEPTED,
+                mapOf(AnalyticsTracker.KEY_TYPE to Manifest.permission.POST_NOTIFICATIONS)
+            )
+        }
     }
 
     private fun onCheckNotificationsPermissionResult(granted: Boolean, shouldShowRationale: Boolean) {


### PR DESCRIPTION
Fixes #9061, a subtask of #8999.

[device-2023-05-19-170735.webm](https://github.com/woocommerce/woocommerce-android/assets/1522856/fa2080e1-8465-4901-992a-27c42274e5a1)

**To test:**
1. Run the app on a device running API 33
2. Start the store creation flow
3. Create a new account
4. When you enter the store name picker, notice a notification permission request is displayed
5. Tap on Allow
6. Go to the app settings and verify the Notifications permission is listed in the allowed permissions
7. Alternatively, if you deny the permission and re-enter the name picker, a dialog with a permission rationale is shown