### PR TITLE
Increment product quantity when the same product is scanned more than one time

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -93,6 +93,7 @@ import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.store.WCProductStore
 import java.math.BigDecimal
 import javax.inject.Inject
+import com.woocommerce.android.model.Product as ModelProduct
 
 @HiltViewModel
 class OrderCreateEditViewModel @Inject constructor(
@@ -367,13 +368,13 @@ class OrderCreateEditViewModel @Inject constructor(
         }
     }
 
-    private fun getItemIdIfVariableProductIsAlreadySelected(product: com.woocommerce.android.model.Product): Long? {
+    private fun getItemIdIfVariableProductIsAlreadySelected(product: ModelProduct): Long? {
         return _orderDraft.value.items.firstOrNull { item ->
             item.variationId == product.remoteId
         }?.itemId
     }
 
-    private fun getItemIdIfProductIsAlreadySelected(product: com.woocommerce.android.model.Product): Long? {
+    private fun getItemIdIfProductIsAlreadySelected(product: ModelProduct): Long? {
         return _orderDraft.value.items.firstOrNull { item ->
             item.productId == product.remoteId
         }?.itemId
@@ -800,7 +801,7 @@ data class ProductUIModel(
     val stockStatus: ProductStockStatus
 )
 
-private fun com.woocommerce.android.model.Product.isVariable() =
+private fun ModelProduct.isVariable() =
     productType == ProductType.VARIABLE ||
         productType == ProductType.VARIABLE_SUBSCRIPTION ||
         productType == ProductType.VARIATION

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -341,11 +341,8 @@ class OrderCreateEditViewModel @Inject constructor(
                 viewState = viewState.copy(isUpdatingOrderDraft = false)
                 products.firstOrNull()?.let { product ->
                     if (product.isVariable()) {
-                        val selectedOrder = _orderDraft.value.items.firstOrNull { item ->
-                            item.variationId == product.remoteId
-                        }
-                        selectedOrder?.let {
-                            onIncreaseProductsQuantity(it.itemId)
+                        getItemIdIfVariableProductIsAlreadySelected(product)?.let { itemId ->
+                            onIncreaseProductsQuantity(itemId)
                         } ?: run {
                             onProductsSelected(
                                 selectedItems + SelectedItem.ProductVariation(
@@ -355,11 +352,8 @@ class OrderCreateEditViewModel @Inject constructor(
                             )
                         }
                     } else {
-                        val selectedOrder = _orderDraft.value.items.firstOrNull { item ->
-                            item.productId == product.remoteId
-                        }
-                        selectedOrder?.let {
-                            onIncreaseProductsQuantity(it.itemId)
+                        getItemIdIfProductIsAlreadySelected(product)?.let { itemId ->
+                            onIncreaseProductsQuantity(itemId)
                         } ?: run {
                             onProductsSelected(
                                 selectedItems + Product(productId = product.remoteId)
@@ -371,6 +365,18 @@ class OrderCreateEditViewModel @Inject constructor(
                 sendProductSearchBySKUFailedEvent()
             }
         }
+    }
+
+    private fun getItemIdIfVariableProductIsAlreadySelected(product: com.woocommerce.android.model.Product): Long? {
+        return _orderDraft.value.items.firstOrNull { item ->
+            item.variationId == product.remoteId
+        }?.itemId
+    }
+
+    private fun getItemIdIfProductIsAlreadySelected(product: com.woocommerce.android.model.Product): Long? {
+        return _orderDraft.value.items.firstOrNull { item ->
+            item.productId == product.remoteId
+        }?.itemId
     }
 
     private fun sendBarcodeScanningFailedEvent(error: Throwable?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -341,16 +341,30 @@ class OrderCreateEditViewModel @Inject constructor(
                 viewState = viewState.copy(isUpdatingOrderDraft = false)
                 products.firstOrNull()?.let { product ->
                     if (product.isVariable()) {
-                        onProductsSelected(
-                            selectedItems + SelectedItem.ProductVariation(
-                                productId = product.parentId,
-                                variationId = product.remoteId
+                        val selectedOrder = _orderDraft.value.items.firstOrNull { item ->
+                            item.variationId == product.remoteId
+                        }
+                        selectedOrder?.let {
+                            onIncreaseProductsQuantity(it.itemId)
+                        } ?: run {
+                            onProductsSelected(
+                                selectedItems + SelectedItem.ProductVariation(
+                                    productId = product.parentId,
+                                    variationId = product.remoteId
+                                )
                             )
-                        )
+                        }
                     } else {
-                        onProductsSelected(
-                            selectedItems + Product(productId = product.remoteId)
-                        )
+                        val selectedOrder = _orderDraft.value.items.firstOrNull { item ->
+                            item.productId == product.remoteId
+                        }
+                        selectedOrder?.let {
+                            onIncreaseProductsQuantity(it.itemId)
+                        } ?: run {
+                            onProductsSelected(
+                                selectedItems + Product(productId = product.remoteId)
+                            )
+                        }
                     }
                 }
             } ?: run {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.creation
 
 import android.os.Parcelable
 import android.view.View
+import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
@@ -342,14 +343,20 @@ class OrderCreateEditViewModel @Inject constructor(
                 viewState = viewState.copy(isUpdatingOrderDraft = false)
                 products.firstOrNull()?.let { product ->
                     if (product.isVariable()) {
-                        when (val alreadySelectedItemId = getItemIdIfVariableProductIsAlreadySelected(product)) {
-                            null -> onProductsSelected(selectedItems +
-                                SelectedItem.ProductVariation(
-                                    productId = product.parentId,
-                                    variationId = product.remoteId
-                                )
+                        if (product.parentId == 0L) {
+                            sendAddingProductsViaScanningFailedEvent(
+                                message = string.order_creation_barcode_scanning_unable_to_add_variable_product
                             )
-                            else -> onIncreaseProductsQuantity(alreadySelectedItemId)
+                        } else {
+                            when (val alreadySelectedItemId = getItemIdIfVariableProductIsAlreadySelected(product)) {
+                                null -> onProductsSelected(selectedItems +
+                                    SelectedItem.ProductVariation(
+                                        productId = product.parentId,
+                                        variationId = product.remoteId
+                                    )
+                                )
+                                else -> onIncreaseProductsQuantity(alreadySelectedItemId)
+                            }
                         }
                     } else {
                         when (val alreadySelectedItemId = getItemIdIfProductIsAlreadySelected(product)) {
@@ -378,11 +385,11 @@ class OrderCreateEditViewModel @Inject constructor(
         }?.itemId
     }
 
-    private fun sendAddingProductsViaScanningFailedEvent() {
+    private fun sendAddingProductsViaScanningFailedEvent(
+        @StringRes message: Int = string.order_creation_barcode_scanning_unable_to_add_product
+    ) {
         triggerEvent(
-            OnAddingProductViaScanningFailed(
-                string.order_creation_barcode_scanning_unable_to_add_product
-            ) {
+            OnAddingProductViaScanningFailed(message) {
                 startScan()
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.WooException
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -199,6 +200,7 @@ class OrderCreateEditViewModel @Inject constructor(
             }
         }
     }
+
     fun onCustomerNoteEdited(newNote: String) {
         _orderDraft.value.let { order ->
             tracker.track(
@@ -317,7 +319,7 @@ class OrderCreateEditViewModel @Inject constructor(
                 when (status) {
                     is CodeScannerStatus.Failure -> {
                         sendAddingProductsViaScanningFailedEvent(
-                            string.order_creation_barcode_scanning_scanning_failed
+                            R.string.order_creation_barcode_scanning_scanning_failed
                         )
                     }
                     is CodeScannerStatus.Success -> {
@@ -347,15 +349,16 @@ class OrderCreateEditViewModel @Inject constructor(
                     if (product.isVariable()) {
                         if (product.parentId == 0L) {
                             sendAddingProductsViaScanningFailedEvent(
-                                message = string.order_creation_barcode_scanning_unable_to_add_variable_product
+                                message = R.string.order_creation_barcode_scanning_unable_to_add_variable_product
                             )
                         } else {
                             when (val alreadySelectedItemId = getItemIdIfVariableProductIsAlreadySelected(product)) {
-                                null -> onProductsSelected(selectedItems +
-                                    SelectedItem.ProductVariation(
-                                        productId = product.parentId,
-                                        variationId = product.remoteId
-                                    )
+                                null -> onProductsSelected(
+                                    selectedItems +
+                                        SelectedItem.ProductVariation(
+                                            productId = product.parentId,
+                                            variationId = product.remoteId
+                                        )
                                 )
                                 else -> onIncreaseProductsQuantity(alreadySelectedItemId)
                             }
@@ -371,7 +374,7 @@ class OrderCreateEditViewModel @Inject constructor(
                 }
             } ?: run {
                 sendAddingProductsViaScanningFailedEvent(
-                    string.order_creation_barcode_scanning_unable_to_add_product
+                    R.string.order_creation_barcode_scanning_unable_to_add_product
                 )
             }
         }
@@ -398,6 +401,7 @@ class OrderCreateEditViewModel @Inject constructor(
             }
         )
     }
+
     private fun Order.removeItem(item: Order.Item) = adjustProductQuantity(item.itemId, -item.quantity.toInt())
 
     fun onCustomerAddressEdited(customerId: Long?, billingAddress: Address, shippingAddress: Address) {
@@ -777,6 +781,7 @@ class OrderCreateEditViewModel @Inject constructor(
         ) : MultipleLinesContext()
     }
 }
+
 data class OnAddingProductViaScanningFailed(
     val message: Int,
     val retry: View.OnClickListener,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -342,23 +342,21 @@ class OrderCreateEditViewModel @Inject constructor(
                 viewState = viewState.copy(isUpdatingOrderDraft = false)
                 products.firstOrNull()?.let { product ->
                     if (product.isVariable()) {
-                        getItemIdIfVariableProductIsAlreadySelected(product)?.let { itemId ->
-                            onIncreaseProductsQuantity(itemId)
-                        } ?: run {
-                            onProductsSelected(
-                                selectedItems + SelectedItem.ProductVariation(
+                        when (val alreadySelectedItemId = getItemIdIfVariableProductIsAlreadySelected(product)) {
+                            null -> onProductsSelected(selectedItems +
+                                SelectedItem.ProductVariation(
                                     productId = product.parentId,
                                     variationId = product.remoteId
                                 )
                             )
+                            else -> onIncreaseProductsQuantity(alreadySelectedItemId)
                         }
                     } else {
-                        getItemIdIfProductIsAlreadySelected(product)?.let { itemId ->
-                            onIncreaseProductsQuantity(itemId)
-                        } ?: run {
-                            onProductsSelected(
+                        when (val alreadySelectedItemId = getItemIdIfProductIsAlreadySelected(product)) {
+                            null -> onProductsSelected(
                                 selectedItems + Product(productId = product.remoteId)
                             )
+                            else -> onIncreaseProductsQuantity(alreadySelectedItemId)
                         }
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -801,6 +801,8 @@ data class ProductUIModel(
 )
 
 private fun com.woocommerce.android.model.Product.isVariable() =
-    productType == ProductType.VARIABLE || productType == ProductType.VARIABLE_SUBSCRIPTION
+    productType == ProductType.VARIABLE ||
+        productType == ProductType.VARIABLE_SUBSCRIPTION ||
+        productType == ProductType.VARIATION
 
 fun Order.Item.isSynced() = this.itemId != 0L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
@@ -21,7 +21,7 @@ enum class ProductType(@StringRes val stringResource: Int = 0, val value: String
             return when (type.lowercase(Locale.US)) {
                 "grouped" -> GROUPED
                 "external" -> EXTERNAL
-                "variable" -> VARIABLE
+                "variable", "variation" -> VARIABLE
                 "simple" -> SIMPLE
                 "subscription" -> SUBSCRIPTION
                 "variable-subscription" -> VARIABLE_SUBSCRIPTION

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
@@ -14,6 +14,7 @@ enum class ProductType(@StringRes val stringResource: Int = 0, val value: String
     VARIABLE_SUBSCRIPTION(R.string.product_type_subscription, "variable-subscription"),
     BUNDLE(R.string.product_type_bundle, CoreProductType.BUNDLE.value),
     COMPOSITE(R.string.product_type_composite, "composite"),
+    VARIATION(R.string.product_type_variation, "variation"),
     OTHER;
 
     companion object {
@@ -21,12 +22,13 @@ enum class ProductType(@StringRes val stringResource: Int = 0, val value: String
             return when (type.lowercase(Locale.US)) {
                 "grouped" -> GROUPED
                 "external" -> EXTERNAL
-                "variable", "variation" -> VARIABLE
+                "variable" -> VARIABLE
                 "simple" -> SIMPLE
                 "subscription" -> SUBSCRIPTION
                 "variable-subscription" -> VARIABLE_SUBSCRIPTION
                 "bundle" -> BUNDLE
                 "composite" -> COMPOSITE
+                "variation" -> VARIATION
                 else -> OTHER
             }
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -549,6 +549,7 @@
     <string name="order_creation_customer_search_hint">Search customers</string>
     <string name="order_creation_change_product_quantity">Change the product quantity from %1$d to %2$d</string>
     <string name="order_creation_barcode_scanning_unable_to_add_product">Product not found. Unable to add to new order</string>
+    <string name="order_creation_barcode_scanning_unable_to_add_variable_product">You cannot add variable product directly. Please select a specific variation</string>
 
     <!--
         Domains

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2222,6 +2222,7 @@
     <string name="product_type_subscription">Subscription</string>
     <string name="product_type_bundle">Bundle</string>
     <string name="product_type_composite">Composite product</string>
+    <string name="product_type_variation">Variation product</string>
 
     <!-- Product type bottom sheets -->
     <string name="product_type_list_header">Select a product type</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -36,6 +36,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -47,7 +48,7 @@ import java.util.function.Consumer
 @ExperimentalCoroutinesApi
 class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() {
     override val mode: Mode = Creation
-    override val sku: String = "123"
+    override val sku: String = ""
     override val tracksFlow: String = VALUE_FLOW_CREATION
 
     companion object {
@@ -1135,7 +1136,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
 
             createSut(navArgs)
 
-            verify(productListRepository, times(2)).searchProductList(
+            verify(productListRepository).searchProductList(
                 "123",
                 WCProductStore.SkuSearchOptions.ExactSearch
             )
@@ -1161,7 +1162,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
 
             createSut(navArgs)
 
-            verify(productListRepository, times(1)).searchProductList(
+            verify(productListRepository, never()).searchProductList(
                 "123",
                 WCProductStore.SkuSearchOptions.ExactSearch
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -23,8 +23,8 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -748,7 +748,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 ?.takeIf { it.isNotEmpty() }
                 ?.find { it.variationId == 10L }
                 ?.let { assertThat(it.quantity).isEqualTo(3f) }
-                ?: Assertions.fail("Expected an item with variationId 10L with quantity as 3")
+                ?: fail("Expected an item with variationId 10L with quantity as 3")
         }
     }
 
@@ -789,7 +789,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 ?.takeIf { it.isNotEmpty() }
                 ?.find { it.productId == 10L }
                 ?.let { assertThat(it.quantity).isEqualTo(3f) }
-                ?: Assertions.fail("Expected an item with productId 10L with quantity as 3")
+                ?: fail("Expected an item with productId 10L with quantity as 3")
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -671,7 +671,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
 
             orderDraft?.items
                 ?.takeIf { it.isNotEmpty() }
-                ?.find { it.variationId == 10L}
+                ?.find { it.variationId == 10L }
                 ?.let { assertThat(it.quantity).isEqualTo(3f) }
                 ?: Assertions.fail("Expected an item with variationId 10L with quantity as 3")
         }
@@ -712,7 +712,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
 
             orderDraft?.items
                 ?.takeIf { it.isNotEmpty() }
-                ?.find { it.productId == 10L}
+                ?.find { it.productId == 10L }
                 ?.let { assertThat(it.quantity).isEqualTo(3f) }
                 ?: Assertions.fail("Expected an item with productId 10L with quantity as 3")
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -15,6 +15,7 @@ import java.time.Instant
 object ProductTestUtils {
     fun generateProduct(
         productId: Long = 1L,
+        parentID: Long = 0L,
         isVirtual: Boolean = false,
         isVariable: Boolean = false,
         isPurchasable: Boolean = true,
@@ -26,6 +27,7 @@ object ProductTestUtils {
             dateCreated = "2018-01-05T05:14:30Z"
             localSiteId = 1
             remoteProductId = productId
+            parentId = parentID
             status = customStatus ?: "publish"
             type = productType ?: if (isVariable) "variable" else "simple"
             stockStatus = "instock"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9081 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
**Before this PR**
When you scan the same product more than once, the same product was being added to the list in a separate row instead of just incrementing the already existing product count.

**After this PR**
When you scan the same product more than once, the product quantity gets incremented as expected.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Navigate to the Order details screen (orders -> "+")
2. Click on the barcode icon present under the products section
3. Scan the barcode (Make sure to generate the barcode with an **valid SKU** present in your store - example: https://barcode.tec-it.com/en/?data=AC-1)
4. Ensure the product gets added
5. Scan the same barcode again
6. Ensure the already added product's quantity gets incremented and no new product gets added.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

Please ignore the scanner not displaying the camera session. It's something to do with Google play services. It's messed up on my device, again.

https://github.com/woocommerce/woocommerce-android/assets/1331230/ce657b4d-5498-4e59-b48c-dfe8b8f6aa51




- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
