### PR TITLE
Activate: Show "Share" CTA next to ellipsis menu if Save/Publish option is not shown there.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -366,6 +366,10 @@ class AnalyticsTracker private constructor(private val context: Context) {
 
         private const val PREFKEY_SEND_USAGE_STATS = "wc_pref_send_usage_stats"
 
+        // -- Product details
+        const val VALUE_SHARE_BUTTON_SOURCE_PRODUCT_FORM = "product_form"
+        const val VALUE_SHARE_BUTTON_SOURCE_MORE_MENU = "more_menu"
+
         // -- Product Variations
         const val KEY_VARIATIONS_COUNT = "variations_count"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -559,9 +559,8 @@ class ProductDetailFragment :
         findItem(R.id.menu_share)?.apply {
             isVisible = state.shareOption
 
-            // Show as action with text if "Save" or "Publish" is not currently shown as action with text.
             setShowAsActionFlags(
-                if (isVisible && !state.saveOption && !state.publishOption) {
+                if (state.showShareOptionAsActionWithText) {
                     MenuItem.SHOW_AS_ACTION_IF_ROOM
                 } else {
                     MenuItem.SHOW_AS_ACTION_NEVER

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -556,7 +556,18 @@ class ProductDetailFragment :
                 setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_IF_ROOM)
             }
         }
-        findItem(R.id.menu_share)?.isVisible = state.shareOption
+        findItem(R.id.menu_share)?.apply {
+            isVisible = state.shareOption
+
+            // Show as action with text if "Save" or "Publish" is not currently shown as action with text.
+            setShowAsActionFlags(
+                if (isVisible && !state.saveOption && !state.publishOption) {
+                    MenuItem.SHOW_AS_ACTION_IF_ROOM
+                } else {
+                    MenuItem.SHOW_AS_ACTION_NEVER
+                }
+            )
+        }
         findItem(R.id.menu_trash_product)?.isVisible = state.trashOption
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -89,7 +89,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -255,12 +255,20 @@ class ProductDetailViewModel @Inject constructor(
             val showSaveOptionAsActionWithText = hasChanges && (isNotPublishedUnderCreation || !isProductUnderCreation)
             val isProductPublished = productDraft.status == ProductStatus.PUBLISH
             val isProductPublishedOrPrivate = isProductPublished || productDraft.status == ProductStatus.PRIVATE
+            val showPublishOption = !isProductPublishedOrPrivate || isProductUnderCreation
+            val showShareOption = !isProductUnderCreation
+
+            // Show as action with text if "Save" or "Publish" is not currently shown as action with text.
+            val showShareOptionAsActionWithText =
+                showShareOption && !showSaveOptionAsActionWithText && !showPublishOption
+
             MenuButtonsState(
                 saveOption = showSaveOptionAsActionWithText,
                 saveAsDraftOption = canBeSavedAsDraft,
-                publishOption = !isProductPublishedOrPrivate || isProductUnderCreation,
+                publishOption = showPublishOption,
                 viewProductOption = isProductPublished && !isProductUnderCreation,
-                shareOption = !isProductUnderCreation,
+                shareOption = showShareOption,
+                showShareOptionAsActionWithText = showShareOptionAsActionWithText,
                 trashOption = !isProductUnderCreation && navArgs.isTrashEnabled
             )
         }.asLiveData()
@@ -2339,6 +2347,7 @@ class ProductDetailViewModel @Inject constructor(
         val publishOption: Boolean,
         val viewProductOption: Boolean,
         val shareOption: Boolean,
+        val showShareOptionAsActionWithText: Boolean,
         val trashOption: Boolean
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -240,8 +240,6 @@ class ProductDetailViewModel @Inject constructor(
     val productDraftAttributes
         get() = viewState.productDraft?.attributes ?: emptyList()
 
-    private var isShareButtonShownAsActionWithText = false
-
     val menuButtonsState = draftChanges
         .filterNotNull()
         .combine(_hasChanges) { productDraft, hasChanges ->
@@ -262,8 +260,6 @@ class ProductDetailViewModel @Inject constructor(
             // Show as action with text if "Save" or "Publish" is not currently shown as action with text.
             val showShareOptionAsActionWithText =
                 showShareOption && !showSaveOptionAsActionWithText && !showPublishOption
-
-            isShareButtonShownAsActionWithText = showShareOptionAsActionWithText
 
             MenuButtonsState(
                 saveOption = showSaveOptionAsActionWithText,
@@ -373,21 +369,23 @@ class ProductDetailViewModel @Inject constructor(
      * Called when the Share menu button is clicked in Product detail screen
      */
     fun onShareButtonClicked() {
-        val source = if (isShareButtonShownAsActionWithText) {
-            AnalyticsTracker.VALUE_SHARE_BUTTON_SOURCE_PRODUCT_FORM
-        } else {
-            AnalyticsTracker.VALUE_SHARE_BUTTON_SOURCE_MORE_MENU
-        }
+        menuButtonsState.value?.showShareOptionAsActionWithText?.let { isShownAsActionWithText ->
+            val source = if (isShownAsActionWithText) {
+                AnalyticsTracker.VALUE_SHARE_BUTTON_SOURCE_PRODUCT_FORM
+            } else {
+                AnalyticsTracker.VALUE_SHARE_BUTTON_SOURCE_MORE_MENU
+            }
 
-        tracker.track(
-            AnalyticsEvent.PRODUCT_DETAIL_SHARE_BUTTON_TAPPED,
-            mapOf(
-                AnalyticsTracker.KEY_SOURCE to source
+            tracker.track(
+                AnalyticsEvent.PRODUCT_DETAIL_SHARE_BUTTON_TAPPED,
+                mapOf(
+                    AnalyticsTracker.KEY_SOURCE to source
+                )
             )
-        )
 
-        viewState.productDraft?.let {
-            triggerEvent(ProductNavigationTarget.ShareProduct(it.permalink, it.name))
+            viewState.productDraft?.let {
+                triggerEvent(ProductNavigationTarget.ShareProduct(it.permalink, it.name))
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -241,6 +241,8 @@ class ProductDetailViewModel @Inject constructor(
     val productDraftAttributes
         get() = viewState.productDraft?.attributes ?: emptyList()
 
+    private var isShareButtonShownAsActionWithText = false
+
     val menuButtonsState = draftChanges
         .filterNotNull()
         .combine(_hasChanges) { productDraft, hasChanges ->
@@ -261,6 +263,8 @@ class ProductDetailViewModel @Inject constructor(
             // Show as action with text if "Save" or "Publish" is not currently shown as action with text.
             val showShareOptionAsActionWithText =
                 showShareOption && !showSaveOptionAsActionWithText && !showPublishOption
+
+            isShareButtonShownAsActionWithText = showShareOptionAsActionWithText
 
             MenuButtonsState(
                 saveOption = showSaveOptionAsActionWithText,
@@ -370,7 +374,19 @@ class ProductDetailViewModel @Inject constructor(
      * Called when the Share menu button is clicked in Product detail screen
      */
     fun onShareButtonClicked() {
-        tracker.track(AnalyticsEvent.PRODUCT_DETAIL_SHARE_BUTTON_TAPPED)
+        val source = if (isShareButtonShownAsActionWithText) {
+            AnalyticsTracker.VALUE_SHARE_BUTTON_SOURCE_PRODUCT_FORM
+        } else {
+            AnalyticsTracker.VALUE_SHARE_BUTTON_SOURCE_MORE_MENU
+        }
+
+        tracker.track(
+            AnalyticsEvent.PRODUCT_DETAIL_SHARE_BUTTON_TAPPED,
+            mapOf(
+                AnalyticsTracker.KEY_SOURCE to source
+            )
+        )
+
         viewState.productDraft?.let {
             triggerEvent(ProductNavigationTarget.ShareProduct(it.permalink, it.name))
         }


### PR DESCRIPTION
Part of #9080

Ref: pe5sF9-1xq-p2/#show-the-share-cta-in-product-form
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As part of improving the product sharing experience, we're exposing the "Share" menu item at any times, next to the ellipsis button, assuming the product is published and do not currently has any edits. In other words, whenever the "Publish" or "Save" menu item is not currently exposed next to the ellipsis button.

This also adds analytics to check which one is more performant: the exposed menu item, or the hidden-in-dropdown menu item. This is done by adding a source `product_form` or `more_menu` to the existing `product_detail_share_button_tapped` event. This is done to match the tracking [added in iOS here](https://github.com/woocommerce/woocommerce-ios/pull/9789).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

**Display testing:**

1. Start app, go to Products, and pick an already published product. Make sure the "Share" menu item is shown on top right.
2. Make changes to the product title. Ensure the button changes from "Share" to "Save". 
3. Manually delete the added changes to the product title. Ensure the button changes back to "Share".
4. Go back, then create a new product using the Plus button.
5. Make sure on top right the "Publish" button is shown, and the "Share" button is not shown.
6. Do various other checks (e.g. by setting a product's status to draft) to ensure the Save/Publish buttons always has priority over the "Share" button.

**Analytics testing:**
1. Start app, go to Products, and pick an already published product. Make sure the "Share" menu item is shown on top right.
2. Tap "Share". Make sure something like this is shown: `🔵 Tracked: product_detail_share_button_tapped, Properties: {"source":"product_form"`
3. Edit site title randomly, then tap ellipsis button on top right,
4. From the dropdown, tap "Share". Make sure something like this is shown: ` 🔵 Tracked: product_detail_share_button_tapped, Properties: {"source":"more_menu"`
