### PR TITLE
Privacy Screen: Fix retry button 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android
 
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
-import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PersistentOnboardingData
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.prefs.domain.DomainFlowSource
@@ -12,12 +11,6 @@ import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 
 class AppPrefsWrapper @Inject constructor() {
-
-    fun setSendUsageStats(enabled: Boolean) {
-        AnalyticsTracker.sendUsageStats = enabled
-    }
-
-    fun getSendUsageStats() = AnalyticsTracker.sendUsageStats
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =
         AppPrefs.getReceiptUrl(localSiteId, remoteSiteId, selfHostedSiteId, orderId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTrackerWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTrackerWrapper.kt
@@ -1,11 +1,35 @@
 package com.woocommerce.android.analytics
 
+import android.content.SharedPreferences
+import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.PREFKEY_SEND_USAGE_STATS
 import dagger.Reusable
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.onStart
 import javax.inject.Inject
 
 @Reusable
-class AnalyticsTrackerWrapper @Inject constructor() {
-    var sendUsageStats: Boolean by AnalyticsTracker.Companion::sendUsageStats
+open class AnalyticsTrackerWrapper @Inject constructor() {
+    open var sendUsageStats: Boolean by AnalyticsTracker.Companion::sendUsageStats
+
+    open fun observeSendUsageStats(): Flow<Boolean> {
+        return callbackFlow {
+            val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+                if (key == PREFKEY_SEND_USAGE_STATS) {
+                    trySend(sendUsageStats)
+                }
+            }
+            AppPrefs.getPreferences().registerOnSharedPreferenceChangeListener(listener)
+
+            awaitClose {
+                AppPrefs.getPreferences().unregisterOnSharedPreferenceChangeListener(listener)
+            }
+        }.onStart {
+            emit(sendUsageStats)
+        }
+    }
 
     fun track(stat: AnalyticsEvent, properties: Map<String, *> = emptyMap<String, Any>()) {
         AnalyticsTracker.track(stat, properties)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
@@ -107,7 +107,7 @@ class PrivacySettingsViewModel @Inject constructor(
                         triggerEvent(
                             MultiLiveEvent.Event.ShowActionSnackbar(
                                 resourceProvider.getString(R.string.settings_tracking_analytics_error_update)
-                            ) { onSendStatsSettingChanged(!checked) }
+                            ) { onSendStatsSettingChanged(checked) }
                         )
                     }
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
@@ -3,11 +3,14 @@ package com.woocommerce.android.ui.prefs
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.combineWith
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -16,18 +19,26 @@ import javax.inject.Inject
 class PrivacySettingsViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val appPrefs: AppPrefsWrapper,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val resourceProvider: ResourceProvider,
     private val repository: PrivacySettingsRepository,
 ) : ScopedViewModel(savedState) {
 
-    private val _state = MutableLiveData(
-        State(
-            sendUsageStats = getSendUsageStats(),
-            crashReportingEnabled = getCrashReportingEnabled(),
-            progressBarVisible = false,
-        )
+    private val analyticsEnabled: LiveData<Boolean> = analyticsTrackerWrapper
+        .observeSendUsageStats()
+        .asLiveData()
+
+    private val _state = MutableLiveData(defaultState())
+
+    val state: LiveData<State> = _state.combineWith(analyticsEnabled) { state, analyticsEnabled ->
+        state?.copy(sendUsageStats = analyticsEnabled == true) ?: defaultState()
+    }
+
+    private fun defaultState() = State(
+        sendUsageStats = analyticsTrackerWrapper.sendUsageStats,
+        crashReportingEnabled = getCrashReportingEnabled(),
+        progressBarVisible = false,
     )
-    val state: LiveData<State> = _state
 
     init {
         initialize()
@@ -37,31 +48,21 @@ class PrivacySettingsViewModel @Inject constructor(
         if (repository.isUserWPCOM()) {
             launch {
                 _state.value = _state.value?.copy(progressBarVisible = true)
-                val event = repository.fetchAccountSettings()
+                val event = repository.updateAccountSettings()
                 _state.value = _state.value?.copy(progressBarVisible = false)
 
-                event.fold(
-                    onSuccess = {
-                        appPrefs.setSendUsageStats(!repository.userOptOutFromTracks())
-                        _state.value =
-                            _state.value?.copy(sendUsageStats = !repository.userOptOutFromTracks())
-                    },
-                    onFailure = {
-                        triggerEvent(
-                            MultiLiveEvent.Event.ShowActionSnackbar(
-                                resourceProvider.getString(R.string.settings_tracking_analytics_error_fetch)
-                            ) {
-                                initialize()
-                            }
-                        )
-                    }
-                )
+                event.onFailure {
+                    triggerEvent(
+                        MultiLiveEvent.Event.ShowActionSnackbar(
+                            resourceProvider.getString(R.string.settings_tracking_analytics_error_fetch)
+                        ) {
+                            initialize()
+                        }
+                    )
+                }
             }
         }
     }
-
-    private fun getSendUsageStats() =
-        if (repository.isUserWPCOM()) !repository.userOptOutFromTracks() else appPrefs.getSendUsageStats()
 
     private fun getCrashReportingEnabled() = appPrefs.isCrashReportingEnabled()
 
@@ -87,12 +88,11 @@ class PrivacySettingsViewModel @Inject constructor(
     }
 
     fun onSendStatsSettingChanged(checked: Boolean) {
+        analyticsTrackerWrapper.sendUsageStats = checked
         launch {
             if (repository.isUserWPCOM()) {
 
-                _state.value = _state.value?.copy(
-                    sendUsageStats = checked, progressBarVisible = true
-                )
+                _state.value = _state.value?.copy(progressBarVisible = true)
 
                 val event = repository.updateTracksSetting(checked)
 
@@ -100,10 +100,10 @@ class PrivacySettingsViewModel @Inject constructor(
 
                 event.fold(
                     onSuccess = {
-                        appPrefs.setSendUsageStats(checked)
+                        analyticsTrackerWrapper.sendUsageStats = checked
                     },
                     onFailure = {
-                        _state.value = _state.value?.copy(sendUsageStats = !checked)
+                        analyticsTrackerWrapper.sendUsageStats = !checked
                         triggerEvent(
                             MultiLiveEvent.Event.ShowActionSnackbar(
                                 resourceProvider.getString(R.string.settings_tracking_analytics_error_update)
@@ -111,9 +111,6 @@ class PrivacySettingsViewModel @Inject constructor(
                         )
                     }
                 )
-            } else {
-                _state.value = _state.value?.copy(sendUsageStats = checked)
-                appPrefs.setSendUsageStats(checked)
             }
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModelTest.kt
@@ -1,10 +1,14 @@
 package com.woocommerce.android.ui.prefs
 
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import org.assertj.core.api.Assertions.assertThat
@@ -19,6 +23,7 @@ import org.mockito.kotlin.verify
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PrivacySettingsViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
+    private val fakeSharedPreferencesEmitter = MutableStateFlow(false)
 
     private val appPrefs: AppPrefsWrapper = mock()
     private val repository: PrivacySettingsRepository = mock {
@@ -29,26 +34,41 @@ class PrivacySettingsViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
         on { getString(any()) } doAnswer { it.arguments[0].toString() }
     }
 
+    val analyticsTrackerWrapper: AnalyticsTrackerWrapper = object : AnalyticsTrackerWrapper() {
+        override fun observeSendUsageStats(): Flow<Boolean> = fakeSharedPreferencesEmitter
+
+        override var sendUsageStats: Boolean = false
+            set(value) {
+                runBlocking {
+                    fakeSharedPreferencesEmitter.emit(value)
+                }
+                field = value
+            }
+    }
+
     lateinit var sut: PrivacySettingsViewModel
 
     fun init() {
         sut = PrivacySettingsViewModel(
             mock(),
             appPrefs,
+            analyticsTrackerWrapper,
             resourceProvider,
             repository,
         )
+        sut.state.observeForever { }
     }
 
     @Test
     fun `given successful API response, when user turns on analytical events, turn on analytical events and update state`(): Unit =
         testBlocking {
             // given
+            analyticsTrackerWrapper.sendUsageStats = false
             repository.stub {
-                on { userOptOutFromTracks() } doReturn true
                 onBlocking { updateTracksSetting(true) } doReturn Result.success(Unit)
             }
             init()
+            sut.state.observeForever { }
 
             // when
             sut.onSendStatsSettingChanged(true)
@@ -56,16 +76,16 @@ class PrivacySettingsViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
 
             // then
             assertThat(sut.state.value?.sendUsageStats).isTrue
-            verify(appPrefs).setSendUsageStats(true)
+            assertThat(analyticsTrackerWrapper.sendUsageStats).isTrue
         }
 
     @Test
     fun `given failed API response, when user turns on tracking analytical events, keep state unchanged and show snackbar`() =
         testBlocking {
             // given
+            analyticsTrackerWrapper.sendUsageStats = false
             repository.stub {
                 onBlocking { updateTracksSetting(true) } doReturn Result.failure(Exception())
-                on { userOptOutFromTracks() } doReturn true
             }
             init()
 
@@ -79,30 +99,12 @@ class PrivacySettingsViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
         }
 
     @Test
-    fun `given the API responses with disabled tracking and tracking locally enabled, when user opens the screen, turn off tracking and update state`(): Unit =
-        testBlocking {
-            // given
-            repository.stub {
-                onBlocking { fetchAccountSettings() } doReturn Result.success(Unit)
-                on { userOptOutFromTracks() } doReturn false doReturn true
-            }
-
-            // when
-            init()
-            runCurrent()
-
-            // then
-            assertThat(sut.state.value?.sendUsageStats).isFalse
-            verify(appPrefs).setSendUsageStats(false)
-        }
-
-    @Test
     fun `given failed API response, when user opens the screen, keep state unchanged and show snackbar`() =
         testBlocking {
             // given
+            analyticsTrackerWrapper.sendUsageStats = false
             repository.stub {
-                on { userOptOutFromTracks() } doReturn true
-                onBlocking { fetchAccountSettings() } doReturn Result.failure(Exception())
+                onBlocking { updateAccountSettings() } doReturn Result.failure(Exception())
             }
 
             // when
@@ -121,17 +123,15 @@ class PrivacySettingsViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
             repository.stub {
                 on { isUserWPCOM() } doReturn false
             }
-            appPrefs.stub {
-                on { getSendUsageStats() } doReturn false
-            }
+            analyticsTrackerWrapper.sendUsageStats = false
 
             // when
             init()
             runCurrent()
 
             // then
-            verify(appPrefs).getSendUsageStats()
-            verify(repository, never()).fetchAccountSettings()
-            assertThat(sut.state.value?.sendUsageStats).isFalse()
+            assertThat(analyticsTrackerWrapper.sendUsageStats).isFalse
+            verify(repository, never()).updateAccountSettings()
+            assertThat(sut.state.value?.sendUsageStats).isFalse
         }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9091
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR contains 2 parts:
- refactor how we keep Analytics preference state. I've removed state kept in `PrivacySettingsViewModel` in favor of observing value directly from `SharedPreferences`. It's easier to follow a single source of truth and removes unnecessary distinguishment between WPCOM and non-WPCOM account
- fix of the issue described in #9091 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Open the Privacy Screen with Analytics enabled
2. Turn off the internet connection
3. Tap on "Analytics" switch
4. Assert you can see "There was an error (...)"
5. Turn on the internet connection, wait a second
6. Tap on "Retry"
7. Assert that the Analytics switch is **disabled** (you can also verify HTTP request via Flipper)


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/5845095/b8708e06-fadb-4728-8126-769918c7fbaa



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
