### PR TITLE
Activate: Store creation incomplete notification

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Notification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Notification.kt
@@ -22,7 +22,8 @@ data class Notification(
     val noteMessage: String?,
     val noteType: WooNotificationType,
     val channelType: NotificationChannelType,
-    val tag: String? = null
+    val tag: String? = null,
+    val data: String? = null
 ) : Parcelable {
     @IgnoredOnParcel
     val isOrderNotification = noteType == WooNotificationType.NEW_ORDER

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -17,6 +17,8 @@ sealed class LocalNotification(
     abstract fun getTitleString(resourceProvider: ResourceProvider): String
     abstract fun getDescriptionString(resourceProvider: ResourceProvider): String
 
+    open val data: String? = null
+
     data class StoreCreationFinishedNotification(
         val name: String
     ) : LocalNotification(
@@ -49,5 +51,7 @@ sealed class LocalNotification(
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description, name, storeName)
         }
+
+        override val data: String = storeName
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -34,4 +34,20 @@ sealed class LocalNotification(
             return resourceProvider.getString(description, name)
         }
     }
+
+    data class StoreCreationIncompleteNotification(val name: String, val storeName: String) : LocalNotification(
+        title = R.string.local_notification_without_free_trial_title,
+        description = R.string.local_notification_without_free_trial_description,
+        type = LocalNotificationType.STORE_CREATION_INCOMPLETE,
+        delay = 24,
+        delayUnit = TimeUnit.HOURS
+    ) {
+        override fun getTitleString(resourceProvider: ResourceProvider): String {
+            return resourceProvider.getString(title)
+        }
+
+        override fun getDescriptionString(resourceProvider: ResourceProvider): String {
+            return resourceProvider.getString(description, name, storeName)
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
@@ -22,6 +22,7 @@ class LocalNotificationScheduler @Inject constructor(
         const val LOCAL_NOTIFICATION_ID = "local_notification_id"
         const val LOCAL_NOTIFICATION_TITLE = "local_notification_title"
         const val LOCAL_NOTIFICATION_DESC = "local_notification_description"
+        const val LOCAL_NOTIFICATION_DATA = "local_notification_data"
     }
 
     private val workManager = WorkManager.getInstance(appContext)
@@ -54,7 +55,8 @@ class LocalNotificationScheduler @Inject constructor(
             LOCAL_NOTIFICATION_TYPE to notification.type.value,
             LOCAL_NOTIFICATION_ID to notification.id,
             LOCAL_NOTIFICATION_TITLE to notification.getTitleString(resourceProvider),
-            LOCAL_NOTIFICATION_DESC to notification.getDescriptionString(resourceProvider)
+            LOCAL_NOTIFICATION_DESC to notification.getDescriptionString(resourceProvider),
+            LOCAL_NOTIFICATION_DATA to notification.data
         )
         return OneTimeWorkRequestBuilder<LocalNotificationWorker>()
             .addTag(notification.type.value)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.model.Notification
 import com.woocommerce.android.notifications.NotificationChannelType.OTHER
 import com.woocommerce.android.notifications.WooNotificationBuilder
 import com.woocommerce.android.notifications.WooNotificationType.LOCAL_REMINDER
+import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_DATA
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_DESC
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_ID
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_TITLE
@@ -35,13 +36,14 @@ class LocalNotificationWorker @AssistedInject constructor(
         val id = inputData.getInt(LOCAL_NOTIFICATION_ID, -1)
         val title = inputData.getString(LOCAL_NOTIFICATION_TITLE)
         val description = inputData.getString(LOCAL_NOTIFICATION_DESC)
+        val data = inputData.getString(LOCAL_NOTIFICATION_DATA)
 
         if (type != null && id != -1 && title != null && description != null) {
-            val notification = buildNotification(id, type, title, description)
+            val notification = buildNotification(id, type, title, description, data)
             wooNotificationBuilder.buildAndDisplayLocalNotification(
                 appContext.getString(R.string.notification_channel_general_id),
                 notification,
-                getIntent(appContext, notification),
+                getIntent(notification),
             )
 
             AnalyticsTracker.track(
@@ -54,14 +56,20 @@ class LocalNotificationWorker @AssistedInject constructor(
         return Result.success()
     }
 
-    private fun getIntent(context: Context, notification: Notification): Intent {
-        return Intent(context, MainActivity::class.java).apply {
+    private fun getIntent(notification: Notification): Intent {
+        return Intent(appContext, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
             putExtra(MainActivity.FIELD_LOCAL_NOTIFICATION, notification)
         }
     }
 
-    private fun buildNotification(id: Int, type: String, title: String, description: String) = Notification(
+    private fun buildNotification(
+        id: Int,
+        type: String,
+        title: String,
+        description: String,
+        data: String?
+    ) = Notification(
         noteId = id,
         tag = type,
         uniqueId = 0,
@@ -71,6 +79,7 @@ class LocalNotificationWorker @AssistedInject constructor(
         noteTitle = title,
         noteMessage = description,
         noteType = LOCAL_REMINDER,
-        channelType = OTHER
+        channelType = OTHER,
+        data = data
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/iap/CheckIapEligibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/iap/CheckIapEligibilityFragment.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.navigateToHelpScreen
 import com.woocommerce.android.ui.base.BaseFragment
@@ -25,6 +26,8 @@ class CheckIapEligibilityFragment : BaseFragment() {
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
+
+    private val navArgs by navArgs<CheckIapEligibilityFragmentArgs>()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
@@ -68,7 +71,8 @@ class CheckIapEligibilityFragment : BaseFragment() {
     private fun navigateToStoreCreationNative() {
         findNavController()
             .navigateSafely(
-                CheckIapEligibilityFragmentDirections.actionCheckIapEligibilityFragmentToStoreNamePickerFragment(),
+                CheckIapEligibilityFragmentDirections
+                    .actionCheckIapEligibilityFragmentToStoreNamePickerFragment(navArgs.storeName),
                 skipThrottling = true
             )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -11,9 +11,14 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.isNotNullOrEmpty
+import com.woocommerce.android.notifications.local.LocalNotification.StoreCreationIncompleteNotification
+import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.support.help.HelpOrigin.STORE_CREATION
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
+import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
@@ -23,6 +28,7 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.store.AccountStore
 import javax.inject.Inject
 
 @HiltViewModel
@@ -30,7 +36,10 @@ class StoreNamePickerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val newStore: NewStore,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val prefsWrapper: AppPrefsWrapper
+    private val prefsWrapper: AppPrefsWrapper,
+    private val localNotificationScheduler: LocalNotificationScheduler,
+    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
+    private val accountStore: AccountStore
 ) : ScopedViewModel(savedStateHandle) {
     override val _event = SingleLiveEvent<Event>()
     override val event: LiveData<Event> = _event
@@ -88,12 +97,31 @@ class StoreNamePickerViewModel @Inject constructor(
 
     fun onContinueClicked() {
         newStore.update(name = _viewState.value.storeName)
+
+        scheduleDeferredNotification()
+
         if (canCreateFreeTrialStore) {
             triggerEvent(NavigateToSummary)
         } else if (FeatureFlag.STORE_CREATION_PROFILER.isEnabled()) {
             triggerEvent(NavigateToStoreProfiler)
         } else {
             triggerEvent(NavigateToDomainPicker(_viewState.value.storeName))
+        }
+    }
+
+    private fun scheduleDeferredNotification() {
+        if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D)) {
+            val name = if (accountStore.account.firstName.isNotNullOrEmpty())
+                accountStore.account.firstName
+            else
+                accountStore.account.userName
+
+            localNotificationScheduler.scheduleNotification(
+                StoreCreationIncompleteNotification(
+                    name,
+                    _viewState.value.storeName
+                )
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScre
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.SingleLiveEvent
 import com.woocommerce.android.viewmodel.getStateFlow
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
@@ -54,6 +55,8 @@ class StoreNamePickerViewModel @Inject constructor(
         get() = FeatureFlag.FREE_TRIAL_M2.isEnabled() &&
             FeatureFlag.STORE_CREATION_PROFILER.isEnabled().not()
 
+    private val navArgs: StoreNamePickerFragmentArgs by savedStateHandle.navArgs()
+
     init {
         analyticsTrackerWrapper.track(
             AnalyticsEvent.SITE_CREATION_STEP,
@@ -63,6 +66,10 @@ class StoreNamePickerViewModel @Inject constructor(
         )
 
         triggerEvent(CheckNotificationsPermission(::onCheckNotificationsPermissionResult))
+
+        if (navArgs.storeName != null) {
+            onStoreNameChanged(navArgs.storeName!!)
+        }
     }
 
     fun onCancelPressed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.notifications.local.LocalNotification.StoreCreationFinishedNotification
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler
+import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_INCOMPLETE
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Failed
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Finished
@@ -92,6 +93,9 @@ class StoreCreationSummaryViewModel @Inject constructor(
                 accountStore.account.userName
             localNotificationScheduler.scheduleNotification(StoreCreationFinishedNotification(name))
         }
+
+        // No need to display a notification to complete store creation anymore
+        localNotificationScheduler.cancelScheduledNotification(STORE_CREATION_INCOMPLETE)
     }
 
     object OnCancelPressed : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -35,6 +35,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.navOptions
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.google.android.material.appbar.AppBarLayout
 import com.woocommerce.android.AppPrefs
@@ -77,6 +78,7 @@ import com.woocommerce.android.ui.main.MainActivityViewModel.RestartActivityForA
 import com.woocommerce.android.ui.main.MainActivityViewModel.RestartActivityForNotification
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShortcutOpenOrderCreation
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShortcutOpenPayments
+import com.woocommerce.android.ui.main.MainActivityViewModel.ShortcutOpenStoreCreation
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShowFeatureAnnouncement
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewMyStoreStats
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewOrderDetail
@@ -98,6 +100,7 @@ import com.woocommerce.android.ui.plans.trial.DetermineTrialStatusBarState.Trial
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
 import com.woocommerce.android.ui.products.ProductListFragmentDirections
 import com.woocommerce.android.ui.reviews.ReviewListFragmentDirections
+import com.woocommerce.android.ui.sitepicker.SitePickerFragmentDirections
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.util.WooAnimUtils.animateBottomBar
@@ -738,6 +741,7 @@ class MainActivity :
                 is ShowFeatureAnnouncement -> navigateToFeatureAnnouncement(event)
                 is ViewUrlInWebView -> navigateToWebView(event)
                 is RequestNotificationsPermission -> requestNotificationsPermission()
+                is ShortcutOpenStoreCreation -> shortcutOpenStoreCreation(event.storeName)
                 ViewPayments -> showPayments()
                 ViewTapToPay -> showTapToPaySummary()
                 ShortcutOpenPayments -> shortcutShowPayments()
@@ -749,6 +753,22 @@ class MainActivity :
         observeMoreMenuBadgeStateEvent()
         observeTrialStatus()
         observeBottomBarState()
+    }
+
+    private fun shortcutOpenStoreCreation(storeName: String?) {
+        navController.apply {
+            navigate(
+                NavGraphMainDirections.actionGlobalLoginToSitePickerFragment(
+                    openedFromLogin = AppPrefs.getStoreCreationSource() != AnalyticsTracker.VALUE_SWITCHING_STORE
+                )
+            )
+            navigate(
+                SitePickerFragmentDirections.actionSitePickerFragmentToStoreCreationNativeFlow(storeName),
+                navOptions {
+                    popUpTo(R.id.sitePickerFragment) { inclusive = true }
+                }
+            )
+        }
     }
 
     private fun observeNotificationsPermissionBarVisibility() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -718,6 +718,7 @@ class MainActivity :
             viewModel.handleIncomingNotification(localPushId, notification)
         } else if (localNotification != null) {
             viewModel.onLocalNotificationTapped(localNotification)
+            intent.removeExtra(FIELD_LOCAL_NOTIFICATION)
         }
     }
     // endregion

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.model.FeatureAnnouncement
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
+import com.woocommerce.android.notifications.local.LocalNotificationType
 import com.woocommerce.android.notifications.push.NotificationMessageHandler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType.Jetpack
@@ -249,6 +250,10 @@ class MainActivityViewModel @Inject constructor(
             AnalyticsEvent.LOCAL_NOTIFICATION_TAPPED,
             mapOf(AnalyticsTracker.KEY_TYPE to notification.tag)
         )
+
+        if (notification.tag == LocalNotificationType.STORE_CREATION_INCOMPLETE.value) {
+            triggerEvent(ShortcutOpenStoreCreation(storeName = notification.data))
+        }
     }
 
     object ViewOrderList : Event()
@@ -261,6 +266,7 @@ class MainActivityViewModel @Inject constructor(
     data class ViewUrlInWebView(val url: String) : Event()
     object ShortcutOpenPayments : Event()
     object ShortcutOpenOrderCreation : Event()
+    data class ShortcutOpenStoreCreation(val storeName: String?) : Event()
     data class RestartActivityForNotification(val pushId: Int, val notification: Notification) : Event()
     data class RestartActivityForAppLink(val data: Uri) : Event()
     data class ShowFeatureAnnouncement(val announcement: FeatureAnnouncement) : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerFragment.kt
@@ -12,6 +12,7 @@ import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.NavGraphMainDirections
@@ -71,6 +72,7 @@ class SitePickerFragment :
     private val binding get() = _binding!!
 
     private val viewModel: SitePickerViewModel by viewModels()
+    private val navArgs by navArgs<SitePickerFragmentArgs>()
 
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
@@ -80,7 +82,7 @@ class SitePickerFragment :
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Visible(
-            navigationIcon = if (viewModel.openedFromLogin) R.drawable.ic_back_24dp else null,
+            navigationIcon = if (!navArgs.openedFromLogin) R.drawable.ic_back_24dp else null,
             hasShadow = false,
             hasDivider = false,
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -85,9 +85,6 @@ class SitePickerViewModel @Inject constructor(
         get() = savedState["key"] ?: appPrefsWrapper.getLoginSiteAddress()
         set(value) = savedState.set("key", value)
 
-    val openedFromLogin: Boolean
-        get() = !navArgs.openedFromLogin
-
     init {
         when (navArgs.openedFromLogin) {
             true -> loadLoginView()

--- a/WooCommerce/src/main/res/navigation/nav_graph_site_picker.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_site_picker.xml
@@ -35,7 +35,13 @@
             app:destination="@id/nav_graph_store_creation_web" />
         <action
             android:id="@+id/action_sitePickerFragment_to_storeCreationNativeFlow"
-            app:destination="@id/nav_graph_store_creation" />
+            app:destination="@id/nav_graph_store_creation">
+            <argument
+                android:name="storeName"
+                android:defaultValue="@null"
+                app:argType="string"
+                app:nullable="true" />
+        </action>
         <action
             android:id="@+id/action_sitePickerFragment_to_closeAccountDialogFragment"
             app:destination="@id/closeAccountDialogFragment" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
@@ -20,6 +20,11 @@
             app:destination="@id/storeNamePickerFragment"
             app:popUpTo="@+id/sitePickerFragment"
             app:popUpToInclusive="false" />
+        <argument
+            android:name="storeName"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
     </fragment>
 
     <fragment
@@ -36,6 +41,11 @@
             android:id="@+id/action_storeNamePickerFragment_to_summaryFragment"
             app:destination="@id/summaryFragment"
             app:popUpTo="@id/nav_graph_store_creation" />
+        <argument
+            android:name="storeName"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
     </fragment>
 
     <fragment

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
@@ -19,8 +19,6 @@ import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.store.AccountStore
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -141,14 +139,5 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
 
         // Then
         assertThat(latestEvent).isEqualTo(MultiLiveEvent.Event.NavigateToHelpScreen(HelpOrigin.STORE_CREATION))
-    }
-
-
-    companion object {
-        val TEST_ACCOUNT = AccountModel().apply {
-            userId = 123L
-            email = "mail@a8c.com"
-            userName = "username"
-        }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
@@ -5,9 +5,11 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToStoreProfiler
 import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -17,6 +19,9 @@ import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.store.AccountStore
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class StoreNamePickerViewModelTest : BaseUnitTest() {
@@ -24,6 +29,9 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
     private lateinit var analyticsTracker: AnalyticsTrackerWrapper
     private lateinit var prefsWrapper: AppPrefsWrapper
     private val savedState = SavedStateHandle()
+    private val localNotificationScheduler: LocalNotificationScheduler = mock()
+    private val accountStore: AccountStore = mock()
+    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled = mock()
 
     @Before
     fun setUp() {
@@ -33,7 +41,10 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
             savedStateHandle = savedState,
             newStore = mock(),
             analyticsTrackerWrapper = analyticsTracker,
-            prefsWrapper = prefsWrapper
+            prefsWrapper = prefsWrapper,
+            localNotificationScheduler,
+            isRemoteFeatureFlagEnabled,
+            accountStore
         )
     }
 
@@ -64,7 +75,10 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
             savedStateHandle = savedState,
             newStore = mock(),
             analyticsTrackerWrapper = analyticsTracker,
-            prefsWrapper = prefsWrapper
+            prefsWrapper = prefsWrapper,
+            localNotificationScheduler,
+            isRemoteFeatureFlagEnabled,
+            accountStore
         )
 
         var latestEvent: MultiLiveEvent.Event? = null
@@ -127,5 +141,14 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
 
         // Then
         assertThat(latestEvent).isEqualTo(MultiLiveEvent.Event.NavigateToHelpScreen(HelpOrigin.STORE_CREATION))
+    }
+
+
+    companion object {
+        val TEST_ACCOUNT = AccountModel().apply {
+            userId = 123L
+            email = "mail@a8c.com"
+            userName = "username"
+        }
     }
 }


### PR DESCRIPTION
Fixes #9088, a subtask of #8999.

This PR schedules a notification 24 hours after a store name is entered during store creation and then it's abandoned without completion. When the notification is tapped, the store creation is restarted with the original name pre-filled.

[device-2023-05-24-010103.webm](https://github.com/woocommerce/woocommerce-android/assets/1522856/5799439e-5a9c-4290-a335-1232093726e4)

**To test:**

_Test 1_

1. From a logged-out state, tap on Get Started CTA and begin the store creation process
2. When you enter the store name and tap Continue, minimize the app
3. Wait for 24 hours
4. **Verify that a notification is displayed**
5. Tap on it
6. **Verify that the store name picker is shown with the original name pre-filled**
7. Tap on the back button and **make sure the back stack is looking normal** (no duplicates or anything weird)

_Test 2_

1. Log in
2. Go to More menu -> Settings -> Site picker
3. Repeat steps 1-7 from Test 1
4. Verify that everything is working

> **Note**
> If you want to make the testing go quicker, you can change the notification units to seconds [here](https://github.com/woocommerce/woocommerce-android/compare/issue/9060-store-ready-notification...issue/9088-store-creation-incomplete?expand=1#diff-74c116a16145d5ea7d01758d98557b5a20c465d60e70c9e45b59373b810b057bR45). 🙂 