### PR TITLE
Activate: 1 day after trial expiration notification

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -62,4 +62,18 @@ sealed class LocalNotification(
             return resourceProvider.getString(description, expiryDate)
         }
     }
+
+    data class FreeTrialExpiredNotification(val name: String, val siteId: Long) : LocalNotification(
+        title = R.string.local_notification_one_day_after_free_trial_expires_title,
+        description = R.string.local_notification_one_day_after_free_trial_expires_description,
+        type = LocalNotificationType.FREE_TRIAL_EXPIRED,
+        delay = 15,
+        delayUnit = TimeUnit.SECONDS
+    ) {
+        override val data: String = siteId.toString()
+
+        override fun getDescriptionString(resourceProvider: ResourceProvider): String {
+            return resourceProvider.getString(description, name)
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -68,7 +68,7 @@ sealed class LocalNotification(
         description = R.string.local_notification_one_day_after_free_trial_expires_description,
         type = LocalNotificationType.FREE_TRIAL_EXPIRED,
         delay = 15,
-        delayUnit = TimeUnit.SECONDS
+        delayUnit = TimeUnit.DAYS
     ) {
         override val data: String = siteId.toString()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -32,18 +32,20 @@ class PreconditionCheckWorker @AssistedInject constructor(
             type == null -> cancelWork("Notification check data is invalid")
             type == LocalNotificationType.STORE_CREATION_FINISHED.value -> Result.success()
             type == LocalNotificationType.STORE_CREATION_INCOMPLETE.value -> Result.success()
-            type == LocalNotificationType.FREE_TRIAL_EXPIRING.value -> {
-                val site = selectedSite.get()
-                if (site.isFreeTrial && site.siteId == data?.toLongOrNull()) {
-                    Result.success()
-                } else {
-                    cancelWork("Store plan upgraded or a different site. Cancelling work.")
-                }
-            }
-            type == LocalNotificationType.FREE_TRIAL_EXPIRED.value -> Result.success()
+            type == LocalNotificationType.FREE_TRIAL_EXPIRING.value -> proceedIfFreeMatchingSite(data?.toLongOrNull())
+            type == LocalNotificationType.FREE_TRIAL_EXPIRED.value -> proceedIfFreeMatchingSite(data?.toLongOrNull())
             else -> {
                 cancelWork("Unknown notification $type. Cancelling work.")
             }
+        }
+    }
+
+    private fun proceedIfFreeMatchingSite(siteId: Long?): Result {
+        val site = selectedSite.get()
+        return if (site.isFreeTrial && site.siteId == siteId) {
+            Result.success()
+        } else {
+            cancelWork("Store plan upgraded or a different site. Cancelling work.")
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -257,6 +257,7 @@ class MainActivityViewModel @Inject constructor(
             LocalNotificationType.STORE_CREATION_INCOMPLETE.value -> {
                 triggerEvent(ShortcutOpenStoreCreation(storeName = notification.data))
             }
+            LocalNotificationType.FREE_TRIAL_EXPIRED.value,
             LocalNotificationType.FREE_TRIAL_EXPIRING.value -> {
                 triggerEvent(ViewStorePlanUpgrade(NOTIFICATION))
             }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/StoreInstallationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/StoreInstallationViewModelTest.kt
@@ -33,6 +33,7 @@ import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import kotlin.test.assertEquals
 
@@ -48,6 +49,7 @@ class StoreInstallationViewModelTest : BaseUnitTest() {
     private val observeSiteInstallation: ObserveSiteInstallation = mock()
     private val localNotificationScheduler: LocalNotificationScheduler = mock()
     private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled = mock()
+    private val accountStore: AccountStore = mock()
 
     private lateinit var viewModel: StoreInstallationViewModel
 
@@ -72,7 +74,8 @@ class StoreInstallationViewModelTest : BaseUnitTest() {
             installationTransactionLauncher,
             observeSiteInstallation,
             localNotificationScheduler,
-            isRemoteFeatureFlagEnabled
+            isRemoteFeatureFlagEnabled,
+            accountStore
         )
         viewModel.viewState.observeForever {}
     }


### PR DESCRIPTION
Fixes #9105, a subtask of #8999.

This PR schedules a notification 1 day after a trial expiration and when a user taps on it, the app's redirected to the plan upgrade webview. There is a precondition that's checked before a notification's displayed -- a site must be still in trial and the site ID must match the original site that was created.

**To test:**

To make the testing quicker, change the notification delay units to seconds [here](https://github.com/woocommerce/woocommerce-android/compare/issue/9105-1-day-after-notification?expand=1#diff-74c116a16145d5ea7d01758d98557b5a20c465d60e70c9e45b59373b810b057bR71) to see it sooner than after 15 days :)

1. Start the store creation flow and create a new store
2. Wait for 15 days (or seconds)
3. Notice a notification is displayed
4. Tap on the notification
5. Notice the plan upgrade web view is displayed