### PR TITLE
Privacy Banner: handle Settings CTA

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -12,6 +12,7 @@ import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.os.Handler
+import android.os.Parcelable
 import android.text.method.LinkMovementMethod
 import android.view.Menu
 import android.view.MenuItem
@@ -96,6 +97,7 @@ import com.woocommerce.android.ui.plans.di.StartUpgradeFlowFactory
 import com.woocommerce.android.ui.plans.di.TrialStatusBarFormatterFactory
 import com.woocommerce.android.ui.plans.trial.DetermineTrialStatusBarState.TrialStatusBarState
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
+import com.woocommerce.android.ui.prefs.RequestedAnalyticsValue
 import com.woocommerce.android.ui.products.ProductListFragmentDirections
 import com.woocommerce.android.ui.reviews.ReviewListFragmentDirections
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -596,6 +598,17 @@ class MainActivity :
         startActivityForResult(intent, RequestCodes.SETTINGS)
     }
 
+    private fun showPrivacySettingsScreen(requestedAnalyticsValue: Parcelable) {
+        val intent = Intent(this, AppSettingsActivity::class.java).apply {
+            putExtra(AppSettingsActivity.EXTRA_SHOW_PRIVACY_SETTINGS, true)
+            putExtra(
+                AppSettingsActivity.EXTRA_REQUESTED_ANALYTICS_VALUE_FROM_ERROR,
+                requestedAnalyticsValue
+            )
+        }
+        startActivityForResult(intent, RequestCodes.SETTINGS)
+    }
+
     override fun showAnalytics(targetPeriod: StatsTimeRangeSelection.SelectionType) {
         val action = MyStoreFragmentDirections.actionMyStoreToAnalytics(targetPeriod)
         navController.navigateSafely(action)
@@ -748,6 +761,12 @@ class MainActivity :
                     ) {
                         viewModel.onRequestPrivacyUpdate(event.analyticsEnabled)
                     }.show()
+                }
+                MainActivityViewModel.ShowPrivacySettings -> {
+                    showPrivacySettingsScreen(RequestedAnalyticsValue.NONE)
+                }
+                is MainActivityViewModel.ShowPrivacySettingsWithError -> {
+                    showPrivacySettingsScreen(event.requestedAnalyticsValue)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.ui.moremenu.MoreMenuNewFeature
 import com.woocommerce.android.ui.moremenu.MoreMenuNewFeatureHandler
 import com.woocommerce.android.ui.plans.trial.DetermineTrialStatusBarState
 import com.woocommerce.android.ui.prefs.PrivacySettingsRepository
+import com.woocommerce.android.ui.prefs.RequestedAnalyticsValue
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.WooLog
@@ -270,6 +271,14 @@ class MainActivityViewModel @Inject constructor(
         }
     }
 
+    fun onPrivacySettingsTapped() {
+        triggerEvent(ShowPrivacySettings)
+    }
+
+    fun onSettingsPrivacyPreferenceUpdateFailed(requestedAnalyticsPreference: RequestedAnalyticsValue) {
+        triggerEvent(ShowPrivacySettingsWithError(requestedAnalyticsPreference))
+    }
+
     object ViewOrderList : Event()
     object ViewReviewList : Event()
     object ViewMyStoreStats : Event()
@@ -286,6 +295,8 @@ class MainActivityViewModel @Inject constructor(
     data class ViewReviewDetail(val uniqueId: Long) : Event()
     data class ViewOrderDetail(val uniqueId: Long, val remoteNoteId: Long) : Event()
     data class ShowPrivacyPreferenceUpdatedFailed(val analyticsEnabled: Boolean) : Event()
+    object ShowPrivacySettings : Event()
+    data class ShowPrivacySettingsWithError(val requestedAnalyticsValue: RequestedAnalyticsValue) : Event()
 
     sealed class MoreMenuBadgeState {
         data class UnseenReviews(val count: Int) : MoreMenuBadgeState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.prefs.MainSettingsFragment.AppSettingsListener
 import com.woocommerce.android.util.AnalyticsUtils
+import com.woocommerce.android.util.parcelable
 import dagger.android.DispatchingAndroidInjector
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -37,6 +38,8 @@ class AppSettingsActivity :
     AppSettingsListener,
     AppSettingsContract.View {
     companion object {
+        const val EXTRA_SHOW_PRIVACY_SETTINGS = "extra_show_privacy_settings"
+        const val EXTRA_REQUESTED_ANALYTICS_VALUE_FROM_ERROR = "extra_requested_analytics_value_from_error"
         const val RESULT_CODE_BETA_OPTIONS_CHANGED = 2
         const val KEY_BETA_OPTION_CHANGED = "key_beta_option_changed"
     }
@@ -74,6 +77,19 @@ class AppSettingsActivity :
 
         if (isBetaOptionChanged) {
             setResult(RESULT_CODE_BETA_OPTIONS_CHANGED)
+        }
+
+        if (intent.getBooleanExtra(EXTRA_SHOW_PRIVACY_SETTINGS, false)) {
+
+            val requestedAnalyticsValue =
+                intent.parcelable(EXTRA_REQUESTED_ANALYTICS_VALUE_FROM_ERROR)
+                    ?: RequestedAnalyticsValue.NONE
+
+            navHostFragment.navController.navigate(
+                MainSettingsFragmentDirections.actionMainSettingsFragmentToPrivacySettingsFragment(
+                    requestedAnalyticsValue
+                )
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -184,7 +184,11 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
 
         binding.optionPrivacy.setOnClickListener {
             AnalyticsTracker.track(SETTINGS_PRIVACY_SETTINGS_BUTTON_TAPPED)
-            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_privacySettingsFragment)
+            findNavController().navigateSafely(
+                MainSettingsFragmentDirections.actionMainSettingsFragmentToPrivacySettingsFragment(
+                    RequestedAnalyticsValue.NONE
+                )
+            )
         }
 
         binding.optionSendFeedback.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
@@ -64,9 +64,9 @@ class PrivacySettingsViewModel @Inject constructor(
                     )
                 }
 
-                if (args.targetAnalyticsPreference != RequestedAnalyticsValue.NONE) {
+                if (args.requestedAnalyticsValue != RequestedAnalyticsValue.NONE) {
                     val checked =
-                        args.targetAnalyticsPreference == RequestedAnalyticsValue.ENABLED
+                        args.requestedAnalyticsValue == RequestedAnalyticsValue.ENABLED
 
                     triggerEvent(
                         MultiLiveEvent.Event.ShowActionSnackbar(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
@@ -114,6 +114,7 @@ class PrivacySettingsViewModel @Inject constructor(
 
                 event.fold(
                     onSuccess = {
+                        appPrefs.savedPrivacyBannerSettings = true
                         analyticsTrackerWrapper.sendUsageStats = checked
                     },
                     onFailure = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.combineWith
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -23,6 +24,8 @@ class PrivacySettingsViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val repository: PrivacySettingsRepository,
 ) : ScopedViewModel(savedState) {
+
+    private val args: PrivacySettingsFragmentArgs by savedState.navArgs()
 
     private val analyticsEnabled: LiveData<Boolean> = analyticsTrackerWrapper
         .observeSendUsageStats()
@@ -58,6 +61,17 @@ class PrivacySettingsViewModel @Inject constructor(
                         ) {
                             initialize()
                         }
+                    )
+                }
+
+                if (args.targetAnalyticsPreference != RequestedAnalyticsValue.NONE) {
+                    val checked =
+                        args.targetAnalyticsPreference == RequestedAnalyticsValue.ENABLED
+
+                    triggerEvent(
+                        MultiLiveEvent.Event.ShowActionSnackbar(
+                            resourceProvider.getString(R.string.settings_tracking_analytics_error_update)
+                        ) { onSendStatsSettingChanged(checked) }
                     )
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/RequestedAnalyticsValue.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/RequestedAnalyticsValue.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.ui.prefs
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+enum class RequestedAnalyticsValue : Parcelable {
+    NONE, ENABLED, DISABLE
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerFragment.kt
@@ -37,11 +37,21 @@ class PrivacyBannerFragment : WCBottomSheetDialogFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is PrivacyBannerViewModel.ShowError -> {
-                    mainViewModel.onPrivacyPreferenceUpdateFailed(event.requestedChange)
+                    mainViewModel.onPrivacyPreferenceUpdateFailed(event.requestedAnalyticsValue)
                     dismiss()
                 }
 
                 is PrivacyBannerViewModel.Dismiss -> {
+                    dismiss()
+                }
+
+                is PrivacyBannerViewModel.ShowSettings -> {
+                    mainViewModel.onPrivacySettingsTapped()
+                    dismiss()
+                }
+
+                is PrivacyBannerViewModel.ShowErrorOnSettings -> {
+                    mainViewModel.onSettingsPrivacyPreferenceUpdateFailed(event.requestedAnalyticsValue)
                     dismiss()
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
@@ -44,7 +44,8 @@ fun PrivacyBannerScreen(viewModel: PrivacyBannerViewModel) {
     PrivacyBannerScreen(
         state,
         viewModel::onSwitchChanged,
-        viewModel::onSavePressed
+        viewModel::onSavePressed,
+        viewModel::onSettingsPressed,
     )
 }
 
@@ -53,6 +54,7 @@ fun PrivacyBannerScreen(
     state: PrivacyBannerViewModel.State,
     onSwitchChanged: (Boolean) -> Unit,
     onSavePressed: () -> Unit,
+    onSettingsPressed: () -> Unit,
 ) {
     Box(Modifier.background(MaterialTheme.colors.surface)) {
         Column(
@@ -120,7 +122,7 @@ fun PrivacyBannerScreen(
                         hoveredElevation = 0.dp,
                         focusedElevation = 0.dp
                     ),
-                    onClick = { /*TODO*/ }
+                    onClick = onSettingsPressed
                 ) {
                     Text(stringResource(R.string.privacy_banner_settings))
                 }
@@ -178,7 +180,7 @@ private fun Default() {
                 analyticsSwitchEnabled = false,
                 loading = true
             ),
-            {}, {}
+            {}, {}, {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerViewModel.kt
@@ -39,6 +39,7 @@ class PrivacyBannerViewModel @Inject constructor(
         val analyticsPreference = _state.value?.analyticsSwitchEnabled ?: false
 
         if (analyticsPreference == initialUserPreference) {
+            appPrefsWrapper.savedPrivacyBannerSettings = true
             triggerEvent(ShowSettings)
             return
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.prefs.PrivacySettingsRepository
+import com.woocommerce.android.ui.prefs.RequestedAnalyticsValue
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -20,10 +21,11 @@ class PrivacyBannerViewModel @Inject constructor(
     private val repository: PrivacySettingsRepository,
 ) : ScopedViewModel(savedStateHandle) {
 
+    private val initialUserPreference: Boolean = analyticsTrackerWrapper.sendUsageStats
+
     private val _state: MutableLiveData<State> = MutableLiveData(
         State(
-            analyticsSwitchEnabled = analyticsTrackerWrapper.sendUsageStats,
-            loading = false
+            analyticsSwitchEnabled = initialUserPreference, loading = false
         )
     )
 
@@ -31,6 +33,44 @@ class PrivacyBannerViewModel @Inject constructor(
 
     fun onSwitchChanged(checked: Boolean) {
         _state.value = _state.value?.copy(analyticsSwitchEnabled = checked)
+    }
+
+    fun onSettingsPressed() {
+        val analyticsPreference = _state.value?.analyticsSwitchEnabled ?: false
+
+        if (analyticsPreference == initialUserPreference) {
+            triggerEvent(ShowSettings)
+            return
+        }
+
+        launch {
+            if (repository.isUserWPCOM()) {
+                _state.value = _state.value?.copy(loading = true)
+                val event =
+                    repository.updateTracksSetting(_state.value?.analyticsSwitchEnabled ?: false)
+                _state.value = _state.value?.copy(loading = false)
+
+                event.fold(
+                    onSuccess = {
+                        appPrefsWrapper.savedPrivacyBannerSettings = true
+                        analyticsTrackerWrapper.sendUsageStats = analyticsPreference
+                        triggerEvent(ShowSettings)
+                    },
+                    onFailure = {
+                        triggerEvent(
+                            ShowErrorOnSettings(
+                                requestedAnalyticsValue = if (analyticsPreference) RequestedAnalyticsValue.ENABLED
+                                else RequestedAnalyticsValue.DISABLE
+                            )
+                        )
+                    }
+                )
+            } else {
+                appPrefsWrapper.savedPrivacyBannerSettings = true
+                analyticsTrackerWrapper.sendUsageStats = analyticsPreference
+                triggerEvent(ShowSettings)
+            }
+        }
     }
 
     fun onSavePressed() {
@@ -50,7 +90,7 @@ class PrivacyBannerViewModel @Inject constructor(
                         triggerEvent(Dismiss)
                     },
                     onFailure = {
-                        triggerEvent(ShowError(requestedChange = analyticsPreference))
+                        triggerEvent(ShowError(requestedAnalyticsValue = analyticsPreference))
                     }
                 )
             } else {
@@ -67,5 +107,9 @@ class PrivacyBannerViewModel @Inject constructor(
     )
 
     object Dismiss : MultiLiveEvent.Event()
-    data class ShowError(val requestedChange: Boolean) : MultiLiveEvent.Event()
+    data class ShowError(val requestedAnalyticsValue: Boolean) : MultiLiveEvent.Event()
+    object ShowSettings : MultiLiveEvent.Event()
+    data class ShowErrorOnSettings(
+        val requestedAnalyticsValue: RequestedAnalyticsValue
+    ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
@@ -6,6 +6,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build.VERSION.SDK_INT
+import android.os.Parcelable
 import androidx.core.content.FileProvider
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.intentActivities
@@ -139,4 +141,10 @@ object ActivityUtils {
         val title = context.resources.getText(R.string.share_store_dialog_title)
         context.startActivity(Intent.createChooser(sendIntent, title))
     }
+}
+
+@Suppress("MagicNumber")
+inline fun <reified T : Parcelable> Intent.parcelable(key: String): T? = when {
+    SDK_INT >= 33 -> getParcelableExtra(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getParcelableExtra(key) as? T
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -48,7 +48,10 @@
     <fragment
         android:id="@+id/privacySettingsFragment"
         android:name="com.woocommerce.android.ui.prefs.PrivacySettingsFragment"
-        android:label="PrivacySettingsFragment" >
+        android:label="PrivacySettingsFragment">
+        <argument
+            android:name="requestedAnalyticsValue"
+            app:argType="com.woocommerce.android.ui.prefs.RequestedAnalyticsValue" />
         <action
             android:id="@+id/action_privacySettingsFragment_to_privacySettingsPolicesFragment"
             app:destination="@id/privacySettingsPolicesFragment" />


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8949 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds behavior after pressing "Settings" button on the Privacy Banner. The behavior is described in #8949 and should match iOS described in https://github.com/woocommerce/woocommerce-ios/pull/9802

It targets ` feature/new_privacy_screen` because I needed to provide changes in the Privacy Screen to make it possible to show an error message.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Every test case should start with opening the Privacy Banner: you should use VPN connection if needed to any European country. To show the banner at the next fresh app launch without reinstalling the app, please use option in Developer Settings.

#### WPCOM account

All tests in this section should be performed when logged in as WPCOM user

##### TC 1 Not updating settings
1. Tap on "Settings"
2. Assert that you're redirected to the Privacy Settings screen
3. Restart the app and assert that the Privacy Banner doesn't appear again

##### TC 2 Updating settings
1. Be logged-in into WPCOM account
2. Alternate the current Analytics preference value
4. Tap on "Settings"
5. Assert that you're redirected to the Privacy Settings and the Analytics setting was updated (validate by going to https://wordpress.com/me/privacy)
6. Restart the app and assert that the Privacy Banner doesn't appear again

##### TC 3 Not updating settings + error
1. Turn off the internet connection
1. Tap on "Settings"
2. Assert that you're redirected to the Privacy Settings screen and there's Snackbar: "There was an error fetching(...)
3. Restart the app and assert that the Privacy Banner doesn't appear again

##### TC 4 Updating settings + error
1. Turn off the internet connection
2. Alternate the current Analytics preference value
1. Tap on "Settings"
3. Assert that you're redirected to the Privacy Settings screen and there's Snackbar: "There was an error updating(...) with retry button
4. Restart the app and assert that the Privacy Banner does appear again
2. Alternate the current Analytics preference value
1. Tap on "Settings" again
2. Assert that you're redirected to the Privacy Settings screen and there's Snackbar: "There was an error updating(...) with retry button
3. Turn on the internet connection
4. Tap on "Retry"
4. Restart the app and assert that the Privacy Banner doesn't appear again

#### Non-WPCOM account

In the case of non-WPCOM account, it doesn't matter whether we change the initial setting or not, there's also no chance for the error.

##### TC1
1. Change Analytics setting
1. Tap on "Settings"
3. Assert that you're redirected to the Privacy Settings screen and the new Analytics setting is checked
4. Restart the app and assert that the Privacy Banner doesn't appear again

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
