### PR TITLE
[UI Tests] Refactored `e2eCreateOrderTest`.

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/2201/2201_detailed.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/2201/2201_detailed.json
@@ -32,7 +32,7 @@
         "order_key": "wc_order_itGmODLV25QAx",
         "billing": {
           "first_name": "Mira",
-          "last_name": "",
+          "last_name": "Workman",
           "company": "",
           "address_1": "",
           "address_2": "",
@@ -45,7 +45,7 @@
         },
         "shipping": {
           "first_name": "Mira",
-          "last_name": "",
+          "last_name": "Workman",
           "company": "",
           "address_1": "",
           "address_2": "",

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_create_simple_product.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/orders/orders_create_simple_product.json
@@ -31,7 +31,7 @@
         "order_key": "wc_order_itGmODLV25QAx",
         "billing": {
           "first_name": "Mira",
-          "last_name": "",
+          "last_name": "Workman",
           "company": "",
           "address_1": "",
           "address_2": "",
@@ -44,7 +44,7 @@
         },
         "shipping": {
           "first_name": "Mira",
-          "last_name": "",
+          "last_name": "Workman",
           "company": "",
           "address_1": "",
           "address_2": "",

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/DataClasses.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/DataClasses.kt
@@ -93,7 +93,7 @@ data class OrderData(
     val feeAmount = "\$$feeRaw"
     val taxesAmount = "\$$taxesRaw"
     val shippingAmount = "\$$shippingRaw"
-    val status = orderStatusMap[statusRaw]
+    val status = orderStatusMap.getOrDefault(statusRaw, statusRaw)
     val total = "\$$totalRaw"
 }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/DataClasses.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/DataClasses.kt
@@ -82,12 +82,16 @@ data class OrderData(
     val feeRaw: String = "",
     val id: Int = -1,
     val productName: String = "",
+    val productsTotalRaw: String = "",
     val shippingRaw: String = "",
+    val taxesRaw: String = "",
     val statusRaw: String = "",
     val totalRaw: String = "",
 ) {
     val customerNote = "\"$customerNoteRaw\""
+    val productsTotalAmount = "\$$productsTotalRaw"
     val feeAmount = "\$$feeRaw"
+    val taxesAmount = "\$$taxesRaw"
     val shippingAmount = "\$$shippingRaw"
     val status = orderStatusMap[statusRaw]
     val total = "\$$totalRaw"

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.e2e.screens.orders
 
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -14,19 +15,19 @@ import org.hamcrest.Matchers
 
 class SingleOrderScreen : Screen {
     companion object {
+        const val AMOUNT_PRODUCTS_TOTAL = R.id.paymentInfo_productsTotal
         const val AMOUNT_FEE = R.id.paymentInfo_Fees
         const val AMOUNT_SHIPPING = R.id.paymentInfo_shippingTotal
+        const val AMOUNT_TAXES = R.id.paymentInfo_taxesTotal
         const val AMOUNT_TOTAL = R.id.paymentInfo_total
         const val COLLECT_PAYMENT_BUTTON = R.id.paymentInfo_collectCardPresentPaymentButton
         const val CUSTOMER_NOTE = R.id.customerInfo_customerNote
-        const val CUSTOMER_NOTE_TEXT_FIELD = R.id.notEmptyLabel
-        const val ORDER_NUMBER_LABEL = R.id.orderStatus_subtitle
         const val ORDER_STATUS_CUSTOMER = R.id.orderStatus_header
         const val ORDER_STATUS_TAG = R.id.orderStatus_orderTags
         const val TOOLBAR = R.id.toolbar
     }
 
-    constructor() : super(ORDER_NUMBER_LABEL)
+    constructor() : super(TOOLBAR)
 
     fun goBackToOrdersScreen(): OrderListScreen {
         pressBack()
@@ -41,29 +42,73 @@ class SingleOrderScreen : Screen {
         ).check(ViewAssertions.matches(isDisplayed()))
     }
 
-    fun assertSingleOrderScreenWithProduct(order: OrderData): SingleOrderScreen {
+    private fun assertOrderStatus(orderStatus: String?): SingleOrderScreen {
+        assertIdAndTextDisplayed(ORDER_STATUS_TAG, orderStatus)
+        return this
+    }
+
+    private fun assertCustomerName(customerName: String): SingleOrderScreen {
+        assertIdAndTextDisplayed(ORDER_STATUS_CUSTOMER, customerName)
+        return this
+    }
+
+    private fun assertOrderId(orderId: Int): SingleOrderScreen {
         Espresso.onView(withId(TOOLBAR))
-            .check(ViewAssertions.matches(hasDescendant(withText("Order #${order.id}"))))
+            .check(ViewAssertions.matches(hasDescendant(withText("Order #$orderId"))))
             .check(ViewAssertions.matches(isDisplayed()))
+        return this
+    }
+
+    private fun assertCustomerNote(customerNote: String): SingleOrderScreen {
+        Espresso.onView(
+            Matchers.allOf(
+                ViewMatchers.isDescendantOfA(withId(CUSTOMER_NOTE)),
+                Matchers.allOf(
+                    withId(R.id.notEmptyLabel),
+                    withText(customerNote)
+                )
+            )
+        )
+            .perform(NestedScrollViewExtension())
+            .check(ViewAssertions.matches(isDisplayed()))
+
+        return this
+    }
+
+    private fun assertPayments(order: OrderData): SingleOrderScreen {
+        Espresso.onView(withId(AMOUNT_TOTAL))
+            .perform(NestedScrollViewExtension())
+
+        if (order.productsTotalRaw.isNotBlank()) {
+            assertIdAndTextDisplayed(AMOUNT_PRODUCTS_TOTAL, order.productsTotalAmount)
+        }
+
+        if (order.shippingRaw.isNotBlank()) {
+            assertIdAndTextDisplayed(AMOUNT_SHIPPING, order.shippingAmount)
+        }
+
+        if (order.feeRaw.isNotBlank()) {
+            assertIdAndTextDisplayed(AMOUNT_FEE, order.feeAmount)
+        }
+
+        if (order.taxesRaw.isNotBlank()) {
+            assertIdAndTextDisplayed(AMOUNT_TAXES, order.taxesAmount)
+        }
+
+        assertIdAndTextDisplayed(AMOUNT_TOTAL, order.total)
+        return this
+    }
+
+    fun assertSingleOrderScreenWithProduct(order: OrderData): SingleOrderScreen {
+        assertOrderId(order.id)
 
         Espresso.onView(withText(order.productName))
             .check(ViewAssertions.matches(isDisplayed()))
 
-        assertIdAndTextDisplayed(ORDER_STATUS_TAG, order.status)
-        // The element for customer name has a trailing space in the text value,
-        // adjusting here to match that
-        assertIdAndTextDisplayed(ORDER_STATUS_CUSTOMER, "${order.customerName} ")
-
-        Espresso.onView(withId(AMOUNT_TOTAL))
-            .perform(NestedScrollViewExtension())
-        assertIdAndTextDisplayed(AMOUNT_SHIPPING, order.shippingAmount)
-        assertIdAndTextDisplayed(AMOUNT_FEE, order.feeAmount)
-        assertIdAndTextDisplayed(AMOUNT_TOTAL, order.total)
-
-        Espresso.onView(withId(CUSTOMER_NOTE))
-            .perform(NestedScrollViewExtension())
-        assertIdAndTextDisplayed(CUSTOMER_NOTE_TEXT_FIELD, order.customerNote)
-
+        assertOrderStatus(order.status)
+        assertCustomerName(order.customerName)
+        assertPayments(order)
+        assertCustomerNote(order.customerNote)
         return this
     }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt
@@ -79,20 +79,22 @@ class SingleOrderScreen : Screen {
         Espresso.onView(withId(AMOUNT_TOTAL))
             .perform(NestedScrollViewExtension())
 
-        if (order.productsTotalRaw.isNotBlank()) {
-            assertIdAndTextDisplayed(AMOUNT_PRODUCTS_TOTAL, order.productsTotalAmount)
-        }
+        with(order) {
+            if (productsTotalRaw.isNotBlank()) {
+                assertIdAndTextDisplayed(AMOUNT_PRODUCTS_TOTAL, productsTotalAmount)
+            }
 
-        if (order.shippingRaw.isNotBlank()) {
-            assertIdAndTextDisplayed(AMOUNT_SHIPPING, order.shippingAmount)
-        }
+            if (shippingRaw.isNotBlank()) {
+                assertIdAndTextDisplayed(AMOUNT_SHIPPING, shippingAmount)
+            }
 
-        if (order.feeRaw.isNotBlank()) {
-            assertIdAndTextDisplayed(AMOUNT_FEE, order.feeAmount)
-        }
+            if (feeRaw.isNotBlank()) {
+                assertIdAndTextDisplayed(AMOUNT_FEE, feeAmount)
+            }
 
-        if (order.taxesRaw.isNotBlank()) {
-            assertIdAndTextDisplayed(AMOUNT_TAXES, order.taxesAmount)
+            if (taxesRaw.isNotBlank()) {
+                assertIdAndTextDisplayed(AMOUNT_TAXES, taxesAmount)
+            }
         }
 
         assertIdAndTextDisplayed(AMOUNT_TOTAL, order.total)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt
@@ -42,7 +42,7 @@ class SingleOrderScreen : Screen {
         ).check(ViewAssertions.matches(isDisplayed()))
     }
 
-    private fun assertOrderStatus(orderStatus: String?): SingleOrderScreen {
+    private fun assertOrderStatus(orderStatus: String): SingleOrderScreen {
         assertIdAndTextDisplayed(ORDER_STATUS_TAG, orderStatus)
         return this
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
@@ -76,7 +76,8 @@ class OrdersUITest : TestBase() {
 
     private fun mapJSONToOrder(orderJSON: JSONObject): OrderData {
         return OrderData(
-            customerName = orderJSON.getJSONObject("billing").getString("first_name"),
+            customerName = orderJSON.getJSONObject("billing").getString("first_name") + " " +
+                orderJSON.getJSONObject("billing").getString("last_name"),
             customerNoteRaw = orderJSON.getString("customer_note"),
             feeRaw = orderJSON.getJSONArray("fee_lines").getJSONObject(0).getString("total"),
             id = orderJSON.getInt("id"),


### PR DESCRIPTION
### Description
While automating an existing orders details test (coming in a separate #9118), I realized that a lot of code can be shared with `e2eCreateOrderTest`, however, there were a number of differences that did not allow doing so with no changes:
- In `e2eCreateOrderTest`, the `assertSingleOrderScreenWithProduct` only checked for `Total`, `Shipping` and `Fees` when it comes to `Payments` section. I also needed to check for `Products Total` and `Taxes`. Additionally, depending on the individual order settings, the order might not have Fees or Taxes section on screen at all.
- The mocks that populated the new order screen contained only the customer first name, but not the last name. Since the app presents customer name as a combination of both, divided by a space, the absence of last name caused a trailing space included into the assertion [here](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt#L55).
- The `assertSingleOrderScreenWithProduct` only checked one product title, while I had to check for several products full info.

In this PR, I'm refactoring some of those areas:
- Added customer last name to mock files, which allowed to remove the expectation for trailing space in the assertion.
- Almost all the assertions from `assertSingleOrderScreenWithProduct` were extracted to separate functions, providing more space for flexibility and reuse.
- A dedicated assertion for payments section (`assertPayments`) will check only for the values that are provided in the instance of `OrderData`.
- `assertCustomerNote` will check that customer note actually belongs to customer note section (previously, it checked for text to be present in `CUSTOMER_NOTE_TEXT_FIELD = R.id.notEmptyLabel`, which matched two elements on screen).

### Testing instructions
- CI is 🟢 
