### PR TITLE
[FIX] Order editing crash after activity death

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 13.8
 -----
-
+[*] [Internal] Fixes crashes in order details list when activity gets destroyed and recreated [https://github.com/woocommerce/woocommerce-android/pull/9113]
 
 13.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -19,7 +19,6 @@ import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -222,7 +222,9 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         if (!isReadOnly) {
             binding.customerInfoCustomerNoteSection.setOnClickListener {
                 val action =
-                    OrderDetailFragmentDirections.actionOrderDetailFragmentToEditCustomerOrderNoteFragment()
+                    OrderDetailFragmentDirections.actionOrderDetailFragmentToEditCustomerOrderNoteFragment(
+                        order.id
+                    )
                 findNavController().navigateSafely(action)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -107,7 +107,9 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
 
         binding.customerInfoBillingAddr.setIsReadOnly(isReadOnly)
         if (!isReadOnly) {
-            binding.customerInfoBillingAddressSection.setOnClickListener { navigateToBillingAddressEditingView() }
+            binding.customerInfoBillingAddressSection.setOnClickListener {
+                navigateToBillingAddressEditingView(order.id)
+            }
             binding.customerInfoBillingAddr.binding.notEmptyLabel.setClickableParent(
                 binding.customerInfoBillingAddressSection
             )
@@ -257,22 +259,24 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         binding.customerInfoShippingAddr.setIsReadOnly(isReadOnly)
 
         if (!isReadOnly) {
-            binding.customerInfoShippingAddressSection.setOnClickListener { navigateToShippingAddressEditingView() }
+            binding.customerInfoShippingAddressSection.setOnClickListener {
+                navigateToShippingAddressEditingView(order.id)
+            }
             binding.customerInfoShippingAddr.binding.notEmptyLabel.setClickableParent(
                 binding.customerInfoShippingAddressSection
             )
         }
     }
 
-    private fun navigateToShippingAddressEditingView() {
+    private fun navigateToShippingAddressEditingView(orderId: Long) {
         OrderDetailFragmentDirections
-            .actionOrderDetailFragmentToShippingAddressEditingFragment()
+            .actionOrderDetailFragmentToShippingAddressEditingFragment(orderId)
             .let { findNavController().navigateSafely(it) }
     }
 
-    private fun navigateToBillingAddressEditingView() {
+    private fun navigateToBillingAddressEditingView(orderId: Long) {
         OrderDetailFragmentDirections
-            .actionOrderDetailFragmentToBillingAddressEditingFragment()
+            .actionOrderDetailFragmentToBillingAddressEditingFragment(orderId)
             .let { findNavController().navigateSafely(it) }
     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -538,12 +538,22 @@
         android:id="@+id/shippingAddressEditingFragment"
         android:name="com.woocommerce.android.ui.orders.details.editing.address.ShippingAddressEditingFragment"
         android:label="ShippingAddressEditingFragment"
-        tools:layout="@layout/fragment_base_edit_address" />
+        tools:layout="@layout/fragment_base_edit_address" >
+        <argument
+            android:name="orderId"
+            app:argType="long"
+            app:nullable="false" />
+    </fragment>
     <fragment
         android:id="@+id/billingAddressEditingFragment"
         android:name="com.woocommerce.android.ui.orders.details.editing.address.BillingAddressEditingFragment"
         android:label="BillingAddressEditingFragment"
-        tools:layout="@layout/fragment_base_edit_address" />
+        tools:layout="@layout/fragment_base_edit_address" >
+        <argument
+            android:name="orderId"
+            app:argType="long"
+            app:nullable="false" />
+    </fragment>
     <fragment
         android:id="@+id/customOrderFieldsFragment"
         android:name="com.woocommerce.android.ui.orders.details.customfields.CustomOrderFieldsFragment">

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -528,7 +528,12 @@
         android:id="@+id/editCustomerOrderNoteFragment"
         android:name="com.woocommerce.android.ui.orders.details.editing.CustomerOrderNoteEditingFragment"
         android:label="EditCustomerOrderNoteFragment"
-        tools:layout="@layout/fragment_order_create_edit_customer_note" />
+        tools:layout="@layout/fragment_order_create_edit_customer_note">
+        <argument
+            android:name="orderId"
+            app:argType="long"
+            app:nullable="false" />
+    </fragment>
     <fragment
         android:id="@+id/shippingAddressEditingFragment"
         android:name="com.woocommerce.android.ui.orders.details.editing.address.ShippingAddressEditingFragment"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9112
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Sentry Issue: [WOOCOMMERCE-ANDROID-6PW](https://a8c.sentry.io/issues/4150505917/?referrer=github_integration)

To reproduce:
* Open order
* Add customer note/shipping address or billing address
* Enabled `don't keep activities`
* Come back

The crash happens because 3 fragments use the same ViewModel while inside of the model, it expects specific sets of arguments passed from a Bundle

In the older version of Hilt, for some unclear reason in this situation, it was a passing bundle from the first fragment in the back stack, which was `OrderDetailsFragment`, and therefore crash didn't happen

With the update hilt, it passes the latest bundle there - that's why it cannot recover the required `orderId`

The PR passes `orderId` to the fragments so it will be in the Bundle. The workaround is not ideal - we may want to completely redesign the architecture of the taken approach

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
* Open order
* Add customer note/shipping address or billing address
* Enabled `don't keep activities`
* Come back
* Notice crash doesn't happen


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
