### PR TITLE
Privacy Choices: fix phone carrier returning lowercase country code

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/domain/IsUsersCountryGdprCompliant.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/domain/IsUsersCountryGdprCompliant.kt
@@ -22,7 +22,7 @@ class IsUsersCountryGdprCompliant @Inject constructor(
             }
         }
 
-        return countryCode in PRIVACY_BANNER_ELIGIBLE_COUNTRY_CODES
+        return countryCode.uppercase() in PRIVACY_BANNER_ELIGIBLE_COUNTRY_CODES
     }
 
     companion object {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/domain/IsUsersCountryGdprCompliantTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/domain/IsUsersCountryGdprCompliantTest.kt
@@ -65,6 +65,20 @@ class IsUsersCountryGdprCompliantTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given user has not WPCOM account, when network carrier country code in EU and network carrier returns country code lowercase, then show the banner`() {
+        // given
+        accountStore.stub {
+            on { hasAccessToken() } doReturn false
+        }
+        telephonyManagerProvider.stub {
+            on { getCountryCode() } doReturn "de"
+        }
+
+        // then
+        assertThat(sut()).isTrue
+    }
+
+    @Test
     fun `given user has not WPCOM account, when network carrier country code outside EU, then do not show the banner`() {
         // given
         accountStore.stub {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9115
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR addresses the issue of a scenario, when phone carrier provider returns country code lowercase "it" of a GDPR country. Before this PR, codes like this were not recognized as GDPR country codes.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Not needed and, frankly, not possible. Unit test covers the fix.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
