### PR TITLE
feat: make Privacy Banner undismissable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerFragment.kt
@@ -33,6 +33,10 @@ class PrivacyBannerFragment : WCBottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        dialog?.apply {
+            setCanceledOnTouchOutside(false)
+            setCancelable(false)
+        }
 
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9103
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This small PR makes the Privacy Banner undismissable.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Run the app, trigger the Privacy Banner and try to dismiss differently than tapping on Settings or Save buttons.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/5845095/d076c8ae-62e0-45c2-beeb-bfe48d1bbe57



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
