### PR TITLE
Privacy Choices: clear if user selected shared preferences choice on log out

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -979,11 +979,11 @@ object AppPrefs {
 
     var savedPrivacySettings: Boolean
         get() = getBoolean(
-            key = PrefKeyString("${DeletablePrefKey.HAS_SAVED_PRIVACY_SETTINGS}"),
+            key = DeletablePrefKey.HAS_SAVED_PRIVACY_SETTINGS,
             default = false
         )
         set(value) = setBoolean(
-            key = PrefKeyString("${DeletablePrefKey.HAS_SAVED_PRIVACY_SETTINGS}"),
+            key = DeletablePrefKey.HAS_SAVED_PRIVACY_SETTINGS,
             value = value
         )
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9121
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the broken "saved privacy settings" preference reset/removal upon user log out. To see more context why it works, please see #9121 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Log in and make the Privacy Banner appear
2. Press "Save"
3. Re-open the app
4. Assert that the Privacy Banner doesn't appear again
5. Log out
6. Log in again (can be the same account)
7. Assert that the Privacy Banner does appear

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
