### PR TITLE
Track barcode format when the product search via SKU fails

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -199,6 +199,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_FAILURE = "failure"
         const val KEY_IS_FREE_TRIAL = "is_free_trial"
         const val KEY_SCANNING_SOURCE = "source"
+        const val KEY_SCANNING_BARCODE_FORMAT = "barcode_format"
         const val KEY_PRODUCT_ADDED_VIA = "added_via"
         const val KEY_SCANNING_FAILURE_REASON = "reason"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CodeScannerModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/CodeScannerModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.google.mlkit.vision.codescanner.GmsBarcodeScannerOptions
 import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
 import com.woocommerce.android.ui.orders.creation.CodeScanner
+import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper
 import com.woocommerce.android.ui.orders.creation.GoogleCodeScanner
 import com.woocommerce.android.ui.orders.creation.GoogleCodeScannerErrorMapper
 import dagger.Module
@@ -19,12 +20,14 @@ class CodeScannerModule {
     @Reusable
     fun provideGoogleCodeScanner(
         context: Context,
-        googleCodeScannerErrorMapper: GoogleCodeScannerErrorMapper
+        googleCodeScannerErrorMapper: GoogleCodeScannerErrorMapper,
+        barcodeFormatMapper: GoogleBarcodeFormatMapper,
     ): CodeScanner {
         val options = GmsBarcodeScannerOptions.Builder().allowManualInput().build()
         return GoogleCodeScanner(
             GmsBarcodeScanning.getClient(context, options),
-            googleCodeScannerErrorMapper
+            googleCodeScannerErrorMapper,
+            barcodeFormatMapper
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -964,7 +964,8 @@ class MainActivity :
         binding.bottomNav.active(ORDERS.position)
         val action = OrderListFragmentDirections.actionOrderListFragmentToOrderCreationFragment(
             OrderCreateEditViewModel.Mode.Creation,
-            null
+            null,
+            null,
         )
         navController.navigateSafely(action)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -183,7 +183,8 @@ class OrderNavigator @Inject constructor() {
                 OrderDetailFragmentDirections
                     .actionOrderDetailFragmentToOrderCreationFragment(
                         OrderCreateEditViewModel.Mode.Edit(target.orderId),
-                        null
+                        null,
+                        null,
                     ).let { fragment.findNavController().navigateSafely(it) }
             }
             is ViewCustomFields -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CodeScanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CodeScanner.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.creation
 
 import com.google.mlkit.vision.barcode.common.Barcode
 import com.google.mlkit.vision.codescanner.GmsBarcodeScanner
+import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -14,7 +15,8 @@ interface CodeScanner {
 
 class GoogleCodeScanner @Inject constructor(
     private val scanner: GmsBarcodeScanner,
-    private val errorMapper: GoogleCodeScannerErrorMapper
+    private val errorMapper: GoogleCodeScannerErrorMapper,
+    private val barcodeFormatMapper: GoogleBarcodeFormatMapper,
 ) : CodeScanner {
     override fun startScan(): Flow<CodeScannerStatus> {
         return callbackFlow {
@@ -38,7 +40,12 @@ class GoogleCodeScanner @Inject constructor(
 
     private fun ProducerScope<CodeScannerStatus>.handleScanSuccess(code: Barcode) {
         code.rawValue?.let {
-            trySend(CodeScannerStatus.Success(it))
+            trySend(
+                CodeScannerStatus.Success(
+                    it,
+                    barcodeFormatMapper.mapBarcodeFormat(code.format)
+                )
+            )
         } ?: run {
             trySend(
                 CodeScannerStatus.Failure(
@@ -51,7 +58,7 @@ class GoogleCodeScanner @Inject constructor(
 }
 
 sealed class CodeScannerStatus {
-    data class Success(val code: String) : CodeScannerStatus()
+    data class Success(val code: String, val format: BarcodeFormat) : CodeScannerStatus()
     data class Failure(
         val error: String?,
         val type: CodeScanningErrorType

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/GoogleBarcodeFormatMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/GoogleBarcodeFormatMapper.kt
@@ -6,6 +6,7 @@ import javax.inject.Inject
 import com.google.mlkit.vision.barcode.common.Barcode as GoogleBarcode
 
 class GoogleBarcodeFormatMapper @Inject constructor() {
+    @Suppress("ComplexMethod")
     fun mapBarcodeFormat(format: Int): BarcodeFormat {
         return when (format) {
             GoogleBarcode.FORMAT_AZTEC -> BarcodeFormat.FormatAztec

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/GoogleBarcodeFormatMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/GoogleBarcodeFormatMapper.kt
@@ -33,27 +33,27 @@ class GoogleBarcodeFormatMapper @Inject constructor() {
         @Parcelize
         object FormatCodaBar : BarcodeFormat("codabar")
         @Parcelize
-        object FormatCode128 : BarcodeFormat("code 128")
+        object FormatCode128 : BarcodeFormat("code_128")
         @Parcelize
-        object FormatCode39 : BarcodeFormat("code 39")
+        object FormatCode39 : BarcodeFormat("code_39")
         @Parcelize
-        object FormatCode93 : BarcodeFormat("code 93")
+        object FormatCode93 : BarcodeFormat("code_93")
         @Parcelize
-        object FormatDataMatrix : BarcodeFormat("data matrix")
+        object FormatDataMatrix : BarcodeFormat("data_matrix")
         @Parcelize
-        object FormatEAN13 : BarcodeFormat("ean 13")
+        object FormatEAN13 : BarcodeFormat("ean_13")
         @Parcelize
-        object FormatEAN8 : BarcodeFormat("ean 8")
+        object FormatEAN8 : BarcodeFormat("ean_8")
         @Parcelize
         object FormatITF : BarcodeFormat("itf")
         @Parcelize
-        object FormatPDF417 : BarcodeFormat("pdf 417")
+        object FormatPDF417 : BarcodeFormat("pdf_417")
         @Parcelize
-        object FormatQRCode : BarcodeFormat("qr code")
+        object FormatQRCode : BarcodeFormat("qr_code")
         @Parcelize
-        object FormatUPCA : BarcodeFormat("upc a")
+        object FormatUPCA : BarcodeFormat("upc_a")
         @Parcelize
-        object FormatUPCE : BarcodeFormat("upc e")
+        object FormatUPCE : BarcodeFormat("upc_e")
         @Parcelize
         object FormatUnknown : BarcodeFormat("unknown")
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/GoogleBarcodeFormatMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/GoogleBarcodeFormatMapper.kt
@@ -1,0 +1,59 @@
+package com.woocommerce.android.ui.orders.creation
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import javax.inject.Inject
+import com.google.mlkit.vision.barcode.common.Barcode as GoogleBarcode
+
+class GoogleBarcodeFormatMapper @Inject constructor() {
+    fun mapBarcodeFormat(format: Int): BarcodeFormat {
+        return when (format) {
+            GoogleBarcode.FORMAT_AZTEC -> BarcodeFormat.FormatAztec
+            GoogleBarcode.FORMAT_CODABAR -> BarcodeFormat.FormatCodaBar
+            GoogleBarcode.FORMAT_CODE_128 -> BarcodeFormat.FormatCode128
+            GoogleBarcode.FORMAT_CODE_39 -> BarcodeFormat.FormatCode39
+            GoogleBarcode.FORMAT_CODE_93 -> BarcodeFormat.FormatCode93
+            GoogleBarcode.FORMAT_DATA_MATRIX -> BarcodeFormat.FormatDataMatrix
+            GoogleBarcode.FORMAT_EAN_13 -> BarcodeFormat.FormatEAN13
+            GoogleBarcode.FORMAT_EAN_8 -> BarcodeFormat.FormatEAN8
+            GoogleBarcode.FORMAT_ITF -> BarcodeFormat.FormatITF
+            GoogleBarcode.FORMAT_PDF417 -> BarcodeFormat.FormatPDF417
+            GoogleBarcode.FORMAT_QR_CODE -> BarcodeFormat.FormatQRCode
+            GoogleBarcode.FORMAT_UPC_A -> BarcodeFormat.FormatUPCA
+            GoogleBarcode.FORMAT_UPC_E -> BarcodeFormat.FormatUPCE
+            GoogleBarcode.FORMAT_UNKNOWN -> BarcodeFormat.FormatUnknown
+            else -> BarcodeFormat.FormatUnknown
+        }
+    }
+
+    sealed class BarcodeFormat(val formatName: String) : Parcelable {
+        @Parcelize
+        object FormatAztec : BarcodeFormat("aztec")
+        @Parcelize
+        object FormatCodaBar : BarcodeFormat("codabar")
+        @Parcelize
+        object FormatCode128 : BarcodeFormat("code 128")
+        @Parcelize
+        object FormatCode39 : BarcodeFormat("code 39")
+        @Parcelize
+        object FormatCode93 : BarcodeFormat("code 93")
+        @Parcelize
+        object FormatDataMatrix : BarcodeFormat("data matrix")
+        @Parcelize
+        object FormatEAN13 : BarcodeFormat("ean 13")
+        @Parcelize
+        object FormatEAN8 : BarcodeFormat("ean 8")
+        @Parcelize
+        object FormatITF : BarcodeFormat("itf")
+        @Parcelize
+        object FormatPDF417 : BarcodeFormat("pdf 417")
+        @Parcelize
+        object FormatQRCode : BarcodeFormat("qr code")
+        @Parcelize
+        object FormatUPCA : BarcodeFormat("upc a")
+        @Parcelize
+        object FormatUPCE : BarcodeFormat("upc e")
+        @Parcelize
+        object FormatUnknown : BarcodeFormat("unknown")
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -49,6 +49,7 @@ import com.woocommerce.android.ui.jitm.JitmFragment
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.orders.OrderStatusUpdateSource
+import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowErrorSnack
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowOrderFilters
@@ -354,7 +355,7 @@ class OrderListFragment :
                     showIPPFeedbackDismissConfirmationDialog()
                 }
                 is OrderListViewModel.OrderListEvent.OnBarcodeScanned -> {
-                    openOrderCreationFragment(event.code)
+                    openOrderCreationFragment(event.code, event.barcodeFormat)
                 }
                 is OrderListViewModel.OrderListEvent.OnAddingProductViaScanningFailed -> {
                     uiMessageResolver.getRetrySnack(
@@ -465,13 +466,14 @@ class OrderListFragment :
         findNavController().navigateSafely(R.id.action_orderListFragment_to_orderFilterListFragment)
     }
 
-    private fun openOrderCreationFragment(code: String? = null) {
+    private fun openOrderCreationFragment(code: String? = null, barcodeFormat: BarcodeFormat? = null) {
         OrderDurationRecorder.startRecording()
         AnalyticsTracker.track(AnalyticsEvent.ORDERS_ADD_NEW)
         findNavController().navigateSafely(
             OrderListFragmentDirections.actionOrderListFragmentToOrderCreationFragment(
                 OrderCreateEditViewModel.Mode.Creation,
-                code
+                code,
+                barcodeFormat,
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -42,6 +42,8 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderStatusUpdateSource
 import com.woocommerce.android.ui.orders.creation.CodeScanner
 import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
+import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper
+import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
 import com.woocommerce.android.ui.orders.creation.ScanningSource
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.filters.domain.GetSelectedOrderFiltersCount
@@ -295,6 +297,7 @@ class OrderListViewModel @Inject constructor(
     private fun trackScanClickedEvent() {
         analyticsTracker.track(ORDER_LIST_PRODUCT_BARCODE_SCANNING_TAPPED)
     }
+
     private fun startScan() {
         launch {
             codeScanner.startScan().collect { status ->
@@ -322,7 +325,12 @@ class OrderListViewModel @Inject constructor(
                                 KEY_SCANNING_SOURCE to ScanningSource.ORDER_LIST.source
                             )
                         )
-                        triggerEvent(OrderListEvent.OnBarcodeScanned(status.code))
+                        triggerEvent(
+                            OrderListEvent.OnBarcodeScanned(
+                                status.code,
+                                status.format
+                            )
+                        )
                     }
                 }
             }
@@ -758,6 +766,7 @@ class OrderListViewModel @Inject constructor(
             val url: String,
             @StringRes val titleRes: Int,
         ) : OrderListEvent()
+
         data class ShowRetryErrorSnack(
             val message: String,
             val retry: View.OnClickListener
@@ -769,7 +778,10 @@ class OrderListViewModel @Inject constructor(
 
         data class OpenIPPFeedbackSurveyLink(val url: String) : OrderListEvent()
 
-        data class OnBarcodeScanned(val code: String) : OrderListEvent()
+        data class OnBarcodeScanned(
+            val code: String,
+            val barcodeFormat: BarcodeFormat
+        ) : OrderListEvent()
 
         data class OnAddingProductViaScanningFailed(
             val message: Int,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -42,7 +42,6 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderStatusUpdateSource
 import com.woocommerce.android.ui.orders.creation.CodeScanner
 import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
-import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper
 import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
 import com.woocommerce.android.ui.orders.creation.ScanningSource
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -108,6 +108,10 @@
                 android:name="sku"
                 app:argType="string"
                 app:nullable="true"/>
+            <argument
+                android:name="barcodeFormat"
+                app:argType="com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper$BarcodeFormat"
+                app:nullable="true"/>
         </action>
     </fragment>
     <fragment

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -99,6 +99,10 @@
             android:name="sku"
             app:argType="string"
             app:nullable="true"/>
+        <argument
+            android:name="barcodeFormat"
+            app:argType="com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper$BarcodeFormat"
+            app:nullable="true"/>
     </fragment>
     <dialog
         android:id="@+id/orderStatusSelectorDialog"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -249,6 +249,10 @@
                 android:name="sku"
                 app:argType="string"
                 app:nullable="true"/>
+            <argument
+                android:name="barcodeFormat"
+                app:argType="com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper$BarcodeFormat"
+                app:nullable="true"/>
         </action>
 
         <action

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.creation.CodeScanner
 import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
 import com.woocommerce.android.ui.orders.creation.CodeScanningErrorType
+import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
 import com.woocommerce.android.ui.orders.creation.ScanningSource
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.filters.domain.GetSelectedOrderFiltersCount
@@ -970,7 +971,7 @@ class OrderListViewModelTest : BaseUnitTest() {
     fun `when code scanner succeeds, then trigger proper event`() {
         whenever(codeScanner.startScan()).thenAnswer {
             flow<CodeScannerStatus> {
-                emit(CodeScannerStatus.Success("12345"))
+                emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
             }
         }
 
@@ -1046,14 +1047,16 @@ class OrderListViewModelTest : BaseUnitTest() {
     fun `when code scanner succeeds, then trigger event with proper sku`() {
         whenever(codeScanner.startScan()).thenAnswer {
             flow<CodeScannerStatus> {
-                emit(CodeScannerStatus.Success("12345"))
+                emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
             }
         }
 
         viewModel = createViewModel()
         viewModel.onScanClicked()
 
-        assertThat(viewModel.event.value).isEqualTo(OrderListViewModel.OrderListEvent.OnBarcodeScanned("12345"))
+        assertThat(viewModel.event.value).isEqualTo(
+            OrderListViewModel.OrderListEvent.OnBarcodeScanned("12345", BarcodeFormat.FormatUPCA)
+        )
     }
 
     @Test
@@ -1069,7 +1072,7 @@ class OrderListViewModelTest : BaseUnitTest() {
     fun `when scan success, then track proper analytics event`() {
         whenever(codeScanner.startScan()).thenAnswer {
             flow<CodeScannerStatus> {
-                emit(CodeScannerStatus.Success("12345"))
+                emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
             }
         }
         viewModel = createViewModel()
@@ -1086,7 +1089,7 @@ class OrderListViewModelTest : BaseUnitTest() {
     fun `when scan success, then track analytics event with proper source`() {
         whenever(codeScanner.startScan()).thenAnswer {
             flow<CodeScannerStatus> {
-                emit(CodeScannerStatus.Success("12345"))
+                emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
             }
         }
         viewModel = createViewModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CodeScannerTest.kt
@@ -5,6 +5,7 @@ import com.google.android.gms.tasks.OnSuccessListener
 import com.google.android.gms.tasks.Task
 import com.google.mlkit.vision.barcode.common.Barcode
 import com.google.mlkit.vision.codescanner.GmsBarcodeScanner
+import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -21,11 +22,12 @@ class CodeScannerTest : BaseUnitTest() {
 
     private val scanner: GmsBarcodeScanner = mock()
     private val errorMapper: GoogleCodeScannerErrorMapper = mock()
+    private val barcodeFormatMapper: GoogleBarcodeFormatMapper = mock()
     private lateinit var codeScanner: CodeScanner
 
     @Before
     fun setup() {
-        codeScanner = GoogleCodeScanner(scanner, errorMapper)
+        codeScanner = GoogleCodeScanner(scanner, errorMapper, barcodeFormatMapper)
     }
 
     @Test
@@ -36,6 +38,7 @@ class CodeScannerTest : BaseUnitTest() {
             whenever(scanner.startScan()).thenAnswer {
                 mockBarcode
             }
+            whenever(barcodeFormatMapper.mapBarcodeFormat(any())).thenReturn(BarcodeFormat.FormatUPCA)
             whenever(mockBarcode.addOnSuccessListener(any())).thenAnswer {
                 @Suppress("UNCHECKED_CAST")
                 (it.arguments[0] as OnSuccessListener<Barcode>).onSuccess(
@@ -61,6 +64,7 @@ class CodeScannerTest : BaseUnitTest() {
             whenever(scanner.startScan()).thenAnswer {
                 mockBarcode
             }
+            whenever(barcodeFormatMapper.mapBarcodeFormat(any())).thenReturn(BarcodeFormat.FormatUPCA)
             val barcodeRawValue = "12345"
             whenever(mockBarcode.addOnSuccessListener(any())).thenAnswer {
                 @Suppress("UNCHECKED_CAST")
@@ -151,7 +155,6 @@ class CodeScannerTest : BaseUnitTest() {
     @Test
     fun `when scanning code succeeds but does not contain raw value, then failure is emitted`() {
         testBlocking {
-//            val errorMessage = "Invalid Barcode"
             val mockBarcode = mock<Task<Barcode>>()
             whenever(scanner.startScan()).thenAnswer {
                 mockBarcode

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_PRODUCT_ADDED_VIA
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SCANNING_BARCODE_FORMAT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SCANNING_FAILURE_REASON
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FLOW_CREATION
 import com.woocommerce.android.initSavedStateHandle
@@ -14,6 +15,7 @@ import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateS
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus.Ongoing
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus.PendingDebounce
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus.Succeeded
+import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel.Mode
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel.Mode.Creation
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel.ViewState
@@ -51,6 +53,7 @@ import java.util.function.Consumer
 class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() {
     override val mode: Mode = Creation
     override val sku: String = ""
+    override val barcodeFormat: BarcodeFormat = BarcodeFormat.FormatUPCA
     override val tracksFlow: String = VALUE_FLOW_CREATION
 
     companion object {
@@ -1123,7 +1126,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `given sku, when view model init, then fetch product information`() {
         testBlocking {
             val navArgs = OrderCreateEditFormFragmentArgs(
-                OrderCreateEditViewModel.Mode.Creation, "123"
+                OrderCreateEditViewModel.Mode.Creation, "123", BarcodeFormat.FormatUPCA,
             ).initSavedStateHandle()
             whenever(parameterRepository.getParameters("parameters_key", navArgs)).thenReturn(
                 SiteParameters(
@@ -1149,7 +1152,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `given empty sku, when view model init, then do not fetch product information`() {
         testBlocking {
             val navArgs = OrderCreateEditFormFragmentArgs(
-                OrderCreateEditViewModel.Mode.Creation, ""
+                OrderCreateEditViewModel.Mode.Creation, "", null,
             ).initSavedStateHandle()
             whenever(parameterRepository.getParameters("parameters_key", navArgs)).thenReturn(
                 SiteParameters(
@@ -1175,7 +1178,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `given scanning initiated from the order list screen, when product search via sku succeeds, then track event with proper source`() {
         testBlocking {
             val navArgs = OrderCreateEditFormFragmentArgs(
-                OrderCreateEditViewModel.Mode.Creation, "12345"
+                OrderCreateEditViewModel.Mode.Creation, "12345", BarcodeFormat.FormatUPCA,
             ).initSavedStateHandle()
             whenever(parameterRepository.getParameters("parameters_key", navArgs)).thenReturn(
                 SiteParameters(
@@ -1217,7 +1220,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `given scanning initiated from the order list screen, when product search via sku fails, then track event with proper source`() {
         testBlocking {
             val navArgs = OrderCreateEditFormFragmentArgs(
-                OrderCreateEditViewModel.Mode.Creation, "12345"
+                OrderCreateEditViewModel.Mode.Creation, "12345", BarcodeFormat.FormatUPCA,
             ).initSavedStateHandle()
             whenever(parameterRepository.getParameters("parameters_key", navArgs)).thenReturn(
                 SiteParameters(
@@ -1242,6 +1245,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
                 AnalyticsEvent.PRODUCT_SEARCH_VIA_SKU_FAILURE,
                 mapOf(
                     AnalyticsTracker.KEY_SCANNING_SOURCE to "order_list",
+                    KEY_SCANNING_BARCODE_FORMAT to BarcodeFormat.FormatUPCA.formatName,
                     KEY_SCANNING_FAILURE_REASON to "Product search via SKU API call failed"
                 )
             )
@@ -1252,7 +1256,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `given scanning initiated from the order list screen, when product search via sku succeeds but contains no product, then track event with proper source`() {
         testBlocking {
             val navArgs = OrderCreateEditFormFragmentArgs(
-                OrderCreateEditViewModel.Mode.Creation, "12345"
+                OrderCreateEditViewModel.Mode.Creation, "12345", BarcodeFormat.FormatUPCA,
             ).initSavedStateHandle()
             whenever(parameterRepository.getParameters("parameters_key", navArgs)).thenReturn(
                 SiteParameters(
@@ -1277,6 +1281,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
                 AnalyticsEvent.PRODUCT_SEARCH_VIA_SKU_FAILURE,
                 mapOf(
                     AnalyticsTracker.KEY_SCANNING_SOURCE to "order_list",
+                    KEY_SCANNING_BARCODE_FORMAT to BarcodeFormat.FormatUPCA.formatName,
                     KEY_SCANNING_FAILURE_REASON to "Empty data response (no product found for the SKU)"
                 )
             )
@@ -1287,7 +1292,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `given variable product from order list screen, when product added via scanning, then track correct source`() {
         testBlocking {
             val navArgs = OrderCreateEditFormFragmentArgs(
-                OrderCreateEditViewModel.Mode.Creation, "12345"
+                OrderCreateEditViewModel.Mode.Creation, "12345", BarcodeFormat.FormatUPCA,
             ).initSavedStateHandle()
             whenever(parameterRepository.getParameters("parameters_key", navArgs)).thenReturn(
                 SiteParameters(
@@ -1332,7 +1337,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `given non-variable product from order list screen, when product added via scanning, then track correct source`() {
         testBlocking {
             val navArgs = OrderCreateEditFormFragmentArgs(
-                OrderCreateEditViewModel.Mode.Creation, "12345"
+                OrderCreateEditViewModel.Mode.Creation, "12345", BarcodeFormat.FormatUPCA,
             ).initSavedStateHandle()
             whenever(parameterRepository.getParameters("parameters_key", navArgs)).thenReturn(
                 SiteParameters(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
@@ -32,6 +32,7 @@ import org.mockito.kotlin.verify
 class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() {
     override val mode: Mode = Edit(defaultOrderValue.id)
     override val sku: String = "123"
+    override val barcodeFormat: GoogleBarcodeFormatMapper.BarcodeFormat = GoogleBarcodeFormatMapper.BarcodeFormat.FormatUPCA
     override val tracksFlow: String = VALUE_FLOW_EDITING
 
     override fun initMocksForAnalyticsWithOrder(order: Order) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FLOW_EDITING
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus.Succeeded
+import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel.Mode
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel.Mode.Edit
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget
@@ -32,7 +33,7 @@ import org.mockito.kotlin.verify
 class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() {
     override val mode: Mode = Edit(defaultOrderValue.id)
     override val sku: String = "123"
-    override val barcodeFormat: GoogleBarcodeFormatMapper.BarcodeFormat = GoogleBarcodeFormatMapper.BarcodeFormat.FormatUPCA
+    override val barcodeFormat: BarcodeFormat = BarcodeFormat.FormatUPCA
     override val tracksFlow: String = VALUE_FLOW_EDITING
 
     override fun initMocksForAnalyticsWithOrder(order: Order) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/GoogleBarcodeFormatMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/GoogleBarcodeFormatMapperTest.kt
@@ -1,0 +1,123 @@
+package com.woocommerce.android.ui.orders.creation
+
+import com.google.mlkit.vision.barcode.common.Barcode as GoogleBarcode
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class GoogleBarcodeFormatMapperTest : BaseUnitTest() {
+    private lateinit var barcodeFormatMapper: GoogleBarcodeFormatMapper
+
+    @Before
+    fun setup() {
+        barcodeFormatMapper = GoogleBarcodeFormatMapper()
+    }
+
+    @Test
+    fun `when barcode format is AZTEC, then return AZTEC type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(GoogleBarcode.FORMAT_AZTEC)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatAztec)
+    }
+
+    @Test
+    fun `when barcode format is CODABAR, then return CODABAR type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(GoogleBarcode.FORMAT_CODABAR)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatCodaBar)
+    }
+
+    @Test
+    fun `when barcode format is CODE_128, then return CODE_128 type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(GoogleBarcode.FORMAT_CODE_128)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatCode128)
+    }
+
+    @Test
+    fun `when barcode format is CODE_39, then return CODE_39 type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(GoogleBarcode.FORMAT_CODE_39)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatCode39)
+    }
+
+    @Test
+    fun `when barcode format is CODE_93, then return CODE_93 type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(GoogleBarcode.FORMAT_CODE_93)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatCode93)
+    }
+
+    @Test
+    fun `when barcode format is CODE_DATA_MATRIX, then return CODE_DATA_MATRIX type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(GoogleBarcode.FORMAT_DATA_MATRIX)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatDataMatrix)
+    }
+
+    @Test
+    fun `when barcode format is CODE_EAN_13, then return CODE_EAN_13 type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(GoogleBarcode.FORMAT_EAN_13)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN13)
+    }
+
+    @Test
+    fun `when barcode format is CODE_EAN_8, then return CODE_EAN_8 type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(GoogleBarcode.FORMAT_EAN_8)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8)
+    }
+
+    @Test
+    fun `when barcode format is ITF, then return ITF type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(GoogleBarcode.FORMAT_ITF)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatITF)
+    }
+
+    @Test
+    fun `when barcode format is PDF417, then return PDF417 type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(GoogleBarcode.FORMAT_PDF417)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatPDF417)
+    }
+
+    @Test
+    fun `when barcode format is QR_CODE, then return QR_CODE type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(GoogleBarcode.FORMAT_QR_CODE)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatQRCode)
+    }
+
+    @Test
+    fun `when barcode format is UPC_A, then return UPC_A type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(GoogleBarcode.FORMAT_UPC_A)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatUPCA)
+    }
+
+    @Test
+    fun `when barcode format is UPC_E, then return UPC_E type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(GoogleBarcode.FORMAT_UPC_E)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatUPCE)
+    }
+
+    @Test
+    fun `when barcode format is UNKNOWN, then return UNKNOWN type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(GoogleBarcode.FORMAT_UNKNOWN)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatUnknown)
+    }
+
+    @Test
+    fun `when barcode format is Invalid, then return UNKNOWN type`() {
+        assertThat(
+            barcodeFormatMapper.mapBarcodeFormat(-1)
+        ).isEqualTo(GoogleBarcodeFormatMapper.BarcodeFormat.FormatUnknown)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/GoogleBarcodeFormatMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/GoogleBarcodeFormatMapperTest.kt
@@ -1,11 +1,11 @@
 package com.woocommerce.android.ui.orders.creation
 
-import com.google.mlkit.vision.barcode.common.Barcode as GoogleBarcode
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import com.google.mlkit.vision.barcode.common.Barcode as GoogleBarcode
 
 @ExperimentalCoroutinesApi
 class GoogleBarcodeFormatMapperTest : BaseUnitTest() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_SEARCH_VIA_SKU_F
 import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_SEARCH_VIA_SKU_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_PRODUCT_ADDED_VIA
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SCANNING_BARCODE_FORMAT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SCANNING_FAILURE_REASON
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SCANNING_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -17,6 +18,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus.Failed
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus.Succeeded
+import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductListRepository
@@ -76,12 +78,13 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
 
     protected abstract val mode: OrderCreateEditViewModel.Mode
     protected abstract val sku: String
+    protected abstract val barcodeFormat: BarcodeFormat
 
     private fun initMocks() {
         val defaultOrderItem = createOrderItem()
         val emptyOrder = Order.EMPTY
         viewState = OrderCreateEditViewModel.ViewState()
-        savedState = spy(OrderCreateEditFormFragmentArgs(mode, sku).toSavedStateHandle()) {
+        savedState = spy(OrderCreateEditFormFragmentArgs(mode, sku, barcodeFormat).toSavedStateHandle()) {
             on { getLiveData(viewState.javaClass.name, viewState) } doReturn MutableLiveData(viewState)
             on { getLiveData(eq(Order.EMPTY.javaClass.name), any<Order>()) } doReturn MutableLiveData(emptyOrder)
         }
@@ -353,7 +356,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         createSut()
         whenever(codeScanner.startScan()).thenAnswer {
             flow<CodeScannerStatus> {
-                emit(CodeScannerStatus.Success("12345"))
+                emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
             }
         }
         var isUpdatingOrderDraft: Boolean? = null
@@ -372,7 +375,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -400,7 +403,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -437,7 +440,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -474,7 +477,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -506,7 +509,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -538,7 +541,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -573,7 +576,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -610,7 +613,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -639,7 +642,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -730,7 +733,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -752,7 +755,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -774,7 +777,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -798,7 +801,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -821,7 +824,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -864,7 +867,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -913,7 +916,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         createSut()
         whenever(codeScanner.startScan()).thenAnswer {
             flow<CodeScannerStatus> {
-                emit(CodeScannerStatus.Success("12345"))
+                emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
             }
         }
 
@@ -930,7 +933,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         createSut()
         whenever(codeScanner.startScan()).thenAnswer {
             flow<CodeScannerStatus> {
-                emit(CodeScannerStatus.Success("12345"))
+                emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
             }
         }
 
@@ -1022,7 +1025,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -1055,7 +1058,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -1090,7 +1093,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -1115,7 +1118,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -1131,6 +1134,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 PRODUCT_SEARCH_VIA_SKU_FAILURE,
                 mapOf(
                     KEY_SCANNING_SOURCE to "order_creation",
+                    KEY_SCANNING_BARCODE_FORMAT to BarcodeFormat.FormatUPCA.formatName,
                     KEY_SCANNING_FAILURE_REASON to "Product search via SKU API call failed"
                 )
             )
@@ -1143,7 +1147,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -1159,6 +1163,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 PRODUCT_SEARCH_VIA_SKU_FAILURE,
                 mapOf(
                     KEY_SCANNING_SOURCE to "order_creation",
+                    KEY_SCANNING_BARCODE_FORMAT to BarcodeFormat.FormatUPCA.formatName,
                     KEY_SCANNING_FAILURE_REASON to "Product search via SKU API call failed"
                 )
             )
@@ -1171,7 +1176,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -1195,6 +1200,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 PRODUCT_SEARCH_VIA_SKU_FAILURE,
                 mapOf(
                     KEY_SCANNING_SOURCE to "order_creation",
+                    KEY_SCANNING_BARCODE_FORMAT to BarcodeFormat.FormatUPCA.formatName,
                     KEY_SCANNING_FAILURE_REASON to
                         "Instead of specific variations, user tried to add parent variable product."
                 )
@@ -1208,7 +1214,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -1224,6 +1230,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 PRODUCT_SEARCH_VIA_SKU_FAILURE,
                 mapOf(
                     KEY_SCANNING_SOURCE to "order_creation",
+                    KEY_SCANNING_BARCODE_FORMAT to BarcodeFormat.FormatUPCA.formatName,
                     KEY_SCANNING_FAILURE_REASON to "Empty data response (no product found for the SKU)"
                 )
             )
@@ -1236,7 +1243,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(
@@ -1274,7 +1281,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345"))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
                 }
             }
             whenever(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9126 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR tracks the barcode format when the product search via SKU fails. This information gives us which barcode format is failing the most. Do we need to handle the checksum for that format ...etc

More context: p1685078975281749-slack-C025A8VV728

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Navigate to the order creation screen (Orders tab -> "+")
2. Tap on the barcode icon under the products section
3. Scan any invalid SKU with a different barcode format from the online barcode generator website
4. On product search via SKU failure, ensure product_search_via_sku_failure event is tracked
5. Ensure the `barcode_format` property is proper.
6. Repeat step 3 to 5 with different barcode formats.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
