### PR TITLE
Fix/refresh site data after plan upgrade

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] [Internal] Fixed a crash related to a product image viewing [https://github.com/woocommerce/woocommerce-android/pull/9111]
 - [*] [Internal] Fixes crashes in order details list when activity gets destroyed and recreated [https://github.com/woocommerce/woocommerce-android/pull/9113]
 - [***] In-Person Payments: A merchant can now scan to add product during order creation. [https://github.com/woocommerce/woocommerce-android/pull/9125]
+- [*] Scan To Pay: Set maximum screen brightness to make QR easier to scan. [https://github.com/woocommerce/woocommerce-android/pull/9098]
 
 13.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
@@ -4,6 +4,7 @@ import android.text.TextUtils
 import com.woocommerce.android.ui.plans.domain.FREE_TRIAL_PLAN_ID
 import com.woocommerce.android.util.WooLog
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.PUBLIC
 import org.wordpress.android.fluxc.utils.SiteUtils.getNormalizedTimezone
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import java.time.Clock
@@ -62,3 +63,6 @@ val SiteModel.clock: Clock
 
 val SiteModel?.isFreeTrial: Boolean
     get() = this?.planId == FREE_TRIAL_PLAN_ID
+
+val SiteModel?.isSitePublic: Boolean
+    get() = this?.publishedStatus == PUBLIC.value()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.LaunchSiteErrorType.ALREADY_LAUNCHED
 import org.wordpress.android.fluxc.store.SiteStore.LaunchSiteErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.SiteStore.LaunchSiteErrorType.UNAUTHORIZED
+import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.PUBLIC
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -69,7 +70,7 @@ class StoreOnboardingRepository @Inject constructor(
     }
 
     private fun shouldMarkLaunchStoreAsCompleted(task: OnboardingTask) =
-        task.type == LAUNCH_YOUR_STORE && selectedSite.get().isVisible && !selectedSite.get().isFreeTrial
+        task.type == LAUNCH_YOUR_STORE && selectedSite.get().publishedStatus == PUBLIC.value() && !selectedSite.get().isFreeTrial
 
     suspend fun launchStore(): LaunchStoreResult {
         WooLog.d(WooLog.T.ONBOARDING, "Launching store")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -70,7 +70,9 @@ class StoreOnboardingRepository @Inject constructor(
     }
 
     private fun shouldMarkLaunchStoreAsCompleted(task: OnboardingTask) =
-        task.type == LAUNCH_YOUR_STORE && selectedSite.get().publishedStatus == PUBLIC.value() && !selectedSite.get().isFreeTrial
+        task.type == LAUNCH_YOUR_STORE &&
+            selectedSite.get().publishedStatus == PUBLIC.value() &&
+            !selectedSite.get().isFreeTrial
 
     suspend fun launchStore(): LaunchStoreResult {
         WooLog.d(WooLog.T.ONBOARDING, "Launching store")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreFragment.kt
@@ -59,9 +59,9 @@ class LaunchStoreFragment : BaseFragment() {
         setupObservers()
     }
 
-    override fun onDestroyView() {
+    override fun onDestroy() {
         lifecycle.removeObserver(viewModel)
-        super.onDestroyView()
+        super.onDestroy()
     }
 
     private fun setupObservers() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.isSitePublic
 import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler
@@ -22,7 +23,6 @@ import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository
-import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LAUNCH_YOUR_STORE
 import com.woocommerce.android.ui.mystore.domain.GetStats
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.HasOrders
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.PluginNotActive
@@ -152,21 +152,7 @@ class MyStoreViewModel @Inject constructor(
     }
 
     private fun updateShareStoreButtonVisibility() {
-        _appbarState.value = AppbarState(showShareStoreButton = false)
-        if (appPrefsWrapper.isOnboardingCompleted(selectedSite.getSelectedSiteId())) {
-            _appbarState.value = _appbarState.value?.copy(showShareStoreButton = true)
-        } else {
-            launch {
-                onboardingRepository.observeOnboardingTasks()
-                    .collectLatest { tasks ->
-                        _appbarState.value = _appbarState.value?.copy(
-                            showShareStoreButton = tasks
-                                .filter { it.type == LAUNCH_YOUR_STORE }
-                                .all { it.isComplete }
-                        )
-                    }
-            }
-        }
+        _appbarState.value = AppbarState(showShareStoreButton = selectedSite.get().isSitePublic)
     }
 
     override fun onCleared() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -22,7 +22,6 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
-import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository
 import com.woocommerce.android.ui.mystore.domain.GetStats
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.HasOrders
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.PluginNotActive
@@ -79,7 +78,6 @@ class MyStoreViewModel @Inject constructor(
     private val usageTracksEventEmitter: MyStoreStatsUsageTracksEventEmitter,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val myStoreTransactionLauncher: MyStoreTransactionLauncher,
-    private val onboardingRepository: StoreOnboardingRepository,
     notificationScheduler: LocalNotificationScheduler,
     shouldShowPrivacyBanner: ShouldShowPrivacyBanner
 ) : ScopedViewModel(savedState) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -32,7 +32,8 @@ object WooLog {
         JITM,
         PLUGINS,
         IAP,
-        ONBOARDING
+        ONBOARDING,
+        WOO_TRIAL
     }
 
     // Breaking convention to be consistent with org.wordpress.android.util.AppLog

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
-import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository
 import com.woocommerce.android.ui.mystore.domain.GetStats
 import com.woocommerce.android.ui.mystore.domain.GetTopPerformers
 import com.woocommerce.android.ui.mystore.domain.GetTopPerformers.TopPerformerProduct
@@ -53,7 +52,6 @@ class MyStoreViewModelTest : BaseUnitTest() {
     private val usageTracksEventEmitter: MyStoreStatsUsageTracksEventEmitter = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val myStoreTransactionLauncher: MyStoreTransactionLauncher = mock()
-    private val onboardingRepository: StoreOnboardingRepository = mock()
     private val localNotificationScheduler: LocalNotificationScheduler = mock()
     private val shouldShowPrivacyBanner: ShouldShowPrivacyBanner = mock()
 
@@ -472,7 +470,6 @@ class MyStoreViewModelTest : BaseUnitTest() {
             usageTracksEventEmitter,
             analyticsTrackerWrapper,
             myStoreTransactionLauncher,
-            onboardingRepository,
             localNotificationScheduler,
             shouldShowPrivacyBanner,
         )

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2739-d335fcfcf72f65a144398d982a68b0346356752a'
+    fluxCVersion = 'trunk-7998641fa714a504265d844923a20f4a71d198fb'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-bdf3cbb96b0db995fcd55237783deadef2f95b72'
+    fluxCVersion = '2739-d335fcfcf72f65a144398d982a68b0346356752a'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes an issues where upgrading to the `eCommerce` plan was not refreshing the selected site data. So, the plan was still considered "free trial" leading to some UI issues such as not being able to launch the store from the onboarding task
### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Create a new free trial site
- Click on launch store task
- Upgrade to `eCommerce` plan by tapping on the banner at the top
- Check the banner is gone after upgrading successfully
- Check the site can be now launched

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/144526ef-5ed3-4d5d-9268-910a8ead26b1

