### PR TITLE
Fix/hide banner after plan upgrade

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreFragment.kt
@@ -59,9 +59,9 @@ class LaunchStoreFragment : BaseFragment() {
         setupObservers()
     }
 
-    override fun onDestroyView() {
+    override fun onDestroy() {
         lifecycle.removeObserver(viewModel)
-        super.onDestroyView()
+        super.onDestroy()
     }
 
     private fun setupObservers() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -32,7 +32,8 @@ object WooLog {
         JITM,
         PLUGINS,
         IAP,
-        ONBOARDING
+        ONBOARDING,
+        WOO_TRIAL
     }
 
     // Breaking convention to be consistent with org.wordpress.android.util.AppLog

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/dispatcher/PlanUpgradeStartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/dispatcher/PlanUpgradeStartViewModelTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
@@ -29,6 +30,7 @@ class PlanUpgradeStartViewModelTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock {
         on { get() } doReturn selectedSiteModel
     }
+    private val wooCommerceStore: WooCommerceStore = mock()
 
     private val sitePlan = SitePlan(
         "test",
@@ -45,7 +47,8 @@ class PlanUpgradeStartViewModelTest : BaseUnitTest() {
             userAgent = mock(),
             selectedSite = selectedSite,
             tracks = mock(),
-            sitePlanRepository = sitePlanRepository
+            sitePlanRepository = sitePlanRepository,
+            wooCommerceStore = wooCommerceStore
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Coming from this PR  #9127
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes an issues where upgrading to the `eCommerce` plan was not refreshing the current site data. So, the plan was still considered on "free trial", leading to some UI issues such as not being able to launch the store from the onboarding task, or displaying the free trial banner from launch store screen.
### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Create a new free trial site
- Click on launch store task
- Upgrade to `eCommerce` plan by tapping on the banner at the top
- Check the banner is gone after upgrading successfully
- Check the site can be now launched

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/144526ef-5ed3-4d5d-9268-910a8ead26b1

