### PR TITLE
Privacy Choices: do not crash on empty ip code

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/domain/IsUsersCountryGdprCompliant.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/domain/IsUsersCountryGdprCompliant.kt
@@ -12,18 +12,17 @@ class IsUsersCountryGdprCompliant @Inject constructor(
 ) {
 
     operator fun invoke(): Boolean {
-        val countryCode = if (accountStore.hasAccessToken()) {
-            accountStore.account.userIpCountryCode
+        val countryCode: String = if (accountStore.hasAccessToken()) {
+            accountStore.account.userIpCountryCode ?: countryCodeFromPhoneCarrierOrLocale()
         } else {
-            val networkCarrierCountryCode = telephonyManagerProvider.getCountryCode()
-
-            networkCarrierCountryCode.ifEmpty {
-                localeProvider.provideLocale()?.country.orEmpty()
-            }
+            countryCodeFromPhoneCarrierOrLocale()
         }
 
         return countryCode.uppercase() in PRIVACY_BANNER_ELIGIBLE_COUNTRY_CODES
     }
+
+    private fun countryCodeFromPhoneCarrierOrLocale() = telephonyManagerProvider.getCountryCode()
+        .ifEmpty { localeProvider.provideLocale()?.country.orEmpty() }
 
     companion object {
         private val PRIVACY_BANNER_ELIGIBLE_COUNTRY_CODES = listOf(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/domain/IsUsersCountryGdprCompliantTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/domain/IsUsersCountryGdprCompliantTest.kt
@@ -125,4 +125,19 @@ class IsUsersCountryGdprCompliantTest : BaseUnitTest() {
         // then
         assertThat(sut()).isFalse
     }
+
+    @Test
+    fun `given user has WPCOM account but it returns empty ip code, when requesting if user is gdpr compliant, fall back to phone carrier check`() {
+        // given
+        accountStore.stub {
+            on { hasAccessToken() } doReturn true
+            on { account } doReturn AccountModel().apply { userIpCountryCode = null }
+        }
+        telephonyManagerProvider.stub {
+            on { getCountryCode() } doReturn "pl"
+        }
+
+        // then
+        assertThat(sut()).isTrue
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9136
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
If `user_ip_country_code` from the API ends up being `null` and user is logged in via WPCOM account, then app crashes. This PR fixes this by falling back to other methods of getting country code, if `user_ip_country_code` is null.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Not needed, unit test covers this.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
