### PR TITLE
Gift cards no order crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -208,13 +208,15 @@ class OrderDetailViewModel @Inject constructor(
                 fetchShipmentTrackingAsync(),
                 fetchOrderRefundsAsync(),
                 fetchSLCreationEligibilityAsync(),
-                fetchGiftCardsAsync()
             )
             isFetchingData = false
 
             if (hasOrder()) {
                 displayOrderDetails()
-                fetchOrderSubscriptionsAsync().await()
+                awaitAll(
+                    fetchOrderSubscriptionsAsync(),
+                    fetchGiftCardsAsync()
+                )
             }
 
             viewState = viewState.copy(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1853,12 +1853,19 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when the order is null then don't fetch gift cards summaries`() = testBlocking {
+        val giftCards = WooCommerceStore.WooPlugin.WOO_GIFT_CARDS.pluginName
+        pluginsInfo[giftCards] = WooPlugin(
+            isInstalled = true,
+            isActive = true,
+            version = "1.0.0"
+        )
         doReturn(null).whenever(orderDetailRepository).getOrderById(any())
-        doReturn(true).whenever(addonsRepository).containsAddonsFrom(any())
+        doReturn(null).whenever(orderDetailRepository).fetchOrderById(any())
         doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
         createViewModel()
 
         viewModel.start()
+
         verify(giftCardRepository, never()).fetchGiftCardSummaryByOrderId(any(), anyOrNull())
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1850,4 +1850,15 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         verify(analyticsTraWrapper, never()).track(AnalyticsEvent.ORDER_DETAILS_GIFT_CARD_SHOWN)
     }
+
+    @Test
+    fun `when the order is null then don't fetch gift cards summaries`() = testBlocking {
+        doReturn(null).whenever(orderDetailRepository).getOrderById(any())
+        doReturn(true).whenever(addonsRepository).containsAddonsFrom(any())
+        doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
+        createViewModel()
+
+        viewModel.start()
+        verify(giftCardRepository, never()).fetchGiftCardSummaryByOrderId(any(), anyOrNull())
+    }
 }


### PR DESCRIPTION
### Description
Gift card representation accesses the order field on the ViewModel to obtain the currency code of the order. Trying to access the order field from the ViewModel when the order is still null will result in a crash because of the order get property: `requireNotNull(viewState.orderInfo?.order)`. This PR moves the gift card fetching request to after the order is fetched to ensure the get order will not return null and hence not crash.

You can try this Patch if you want to reproduce the crash

<img width="1509" alt="Screenshot 2023-05-28 at 23 30 33" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/7aaf7acb-d956-4fc4-81c3-f5c1daaf8023">

<details>
  <summary>Patch</summary>
 
```
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt	(revision ea33d638f3f0a412c36b8714a7dc0692c98dc563)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt	(date 1685327378646)
@@ -80,6 +80,7 @@
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.parcelize.Parcelize
@@ -167,18 +168,12 @@
 
     init {
         productImageMap.subscribeToOnProductFetchedEvents(this)
-        launch {
-            pluginsInformation = orderDetailRepository.getOrderDetailsPluginsInfo()
-        }
     }
 
     fun start() {
         launch {
-            orderDetailRepository.getOrderById(navArgs.orderId)?.let {
-                order = it
-                displayOrderDetails()
-                fetchOrder(showSkeleton = false)
-            } ?: fetchOrder(showSkeleton = true)
+            pluginsInformation = orderDetailRepository.getOrderDetailsPluginsInfo()
+            fetchOrder(showSkeleton = false)
         }
     }
 
@@ -202,7 +197,7 @@
 
             isFetchingData = true
             awaitAll(
-                fetchOrderAsync(),
+                fetchGiftCardsAsync(),
                 fetchOrderNotesAsync(),
                 fetchOrderShippingLabelsAsync(),
                 fetchShipmentTrackingAsync(),
@@ -214,8 +209,7 @@
             if (hasOrder()) {
                 displayOrderDetails()
                 awaitAll(
-                    fetchOrderSubscriptionsAsync(),
-                    fetchGiftCardsAsync()
+                    fetchOrderSubscriptionsAsync()
                 )
             }
 
  ```
</details>

### Testing instructions
1. Create a order with gift cards information
2. Force the order field on the OrderDetailViewModel to be null
3. Check that the app doesn't crash
