### PR TITLE
fix: make privacy banner scrollable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
@@ -58,7 +60,7 @@ fun PrivacyBannerScreen(
 ) {
     Box(Modifier.background(MaterialTheme.colors.surface)) {
         Column(
-            Modifier.padding(vertical = 16.dp)
+            Modifier.padding(vertical = 16.dp).verticalScroll(rememberScrollState())
         ) {
             Text(
                 text = stringResource(R.string.privacy_banner_title),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9131
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR makes the Privacy Banner scrollable, so the CTA buttons are available for users with large font sizes.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Make app show Privacy Banner (VPN to European country if needed + WPCOM account or device locale to European country + non WPCOM account)
2. Enable max font size + max display size
3. Try to scroll Privacy Banner to access "Save" and "Settings" buttons

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/5845095/62851dde-188e-4f6c-b0cb-0d4ce989ac8f



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
