### PR TITLE
SKU search in product selector 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 13.9
 -----
-
+- [**] Added possibility to search by SKU in the product selector screen [https://github.com/woocommerce/woocommerce-android/pull/9164]
 
 13.8
 -----

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductSelectorScreenTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductSelectorScreenTest.kt
@@ -38,6 +38,7 @@ class ProductSelectorScreenTest {
                 onProductClick = { _, _ -> },
                 onLoadMore = {},
                 onSearchQueryChanged = {},
+                onSearchTypeChanged = {},
                 onClearFiltersButtonClick = {}
             )
         }
@@ -64,6 +65,7 @@ class ProductSelectorScreenTest {
                 onProductClick = { _, _ -> },
                 onLoadMore = {},
                 onSearchQueryChanged = {},
+                onSearchTypeChanged = {},
                 onClearFiltersButtonClick = {}
             )
         }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductSelectorScreenTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductSelectorScreenTest.kt
@@ -30,7 +30,7 @@ class ProductSelectorScreenTest {
                     recentProducts = emptyList(),
                     selectedItemsCount = 0,
                     filterState = ProductSelectorViewModel.FilterState(emptyMap(), null),
-                    searchQuery = ""
+                    searchState = ProductSelectorViewModel.SearchState.EMPTY
                 ),
                 onDoneButtonClick = {},
                 onClearButtonClick = {},
@@ -57,7 +57,7 @@ class ProductSelectorScreenTest {
                     recentProducts = emptyList(),
                     selectedItemsCount = 0,
                     filterState = ProductSelectorViewModel.FilterState(emptyMap(), null),
-                    searchQuery = ""
+                    searchState = ProductSelectorViewModel.SearchState.EMPTY
                 ),
                 onDoneButtonClick = {},
                 onClearButtonClick = {},

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductSelectorScreenTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductSelectorScreenTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.selector.ProductSelectorScreen
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ListItem.ProductListItem
 import com.woocommerce.android.ui.products.selector.SelectionState
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Rule
@@ -72,10 +73,10 @@ class ProductSelectorScreenTest {
         ).assertDoesNotExist()
     }
 
-    private fun generateProductList(): List<ProductSelectorViewModel.ProductListItem> {
+    private fun generateProductList(): List<ProductSelectorViewModel.ListItem> {
         return listOf(
-            ProductSelectorViewModel.ProductListItem(
-                id = 1,
+            ProductListItem(
+                productId = 1,
                 title = "Product 1",
                 type = ProductType.SIMPLE,
                 imageUrl = null,
@@ -85,8 +86,8 @@ class ProductSelectorScreenTest {
                 selectionState = SelectionState.SELECTED
             ),
 
-            ProductSelectorViewModel.ProductListItem(
-                id = 2,
+            ProductListItem(
+                productId = 2,
                 title = "Product 2",
                 type = ProductType.VARIABLE,
                 imageUrl = null,
@@ -96,8 +97,8 @@ class ProductSelectorScreenTest {
                 selectionState = SelectionState.PARTIALLY_SELECTED
             ),
 
-            ProductSelectorViewModel.ProductListItem(
-                id = 3,
+            ProductListItem(
+                productId = 3,
                 title = "Product 3",
                 type = ProductType.GROUPED,
                 imageUrl = "",
@@ -106,8 +107,8 @@ class ProductSelectorScreenTest {
                 sku = null
             ),
 
-            ProductSelectorViewModel.ProductListItem(
-                id = 4,
+            ProductListItem(
+                productId = 4,
                 title = "Product 4",
                 type = ProductType.GROUPED,
                 imageUrl = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
@@ -26,3 +26,30 @@ inline fun <T1, T2, T3, T4, T5, T6, T7, R> combine(
         )
     }
 }
+
+@Suppress("LongParameterList")
+inline fun <T1, T2, T3, T4, T5, T6, T7, T8, R> combine(
+    flow: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+    flow4: Flow<T4>,
+    flow5: Flow<T5>,
+    flow6: Flow<T6>,
+    flow7: Flow<T7>,
+    flow8: Flow<T8>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8) -> R
+): Flow<R> {
+    return kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6, flow7, flow8) { args: Array<*> ->
+        @Suppress("UNCHECKED_CAST", "MagicNumber")
+        transform(
+            args[0] as T1,
+            args[1] as T2,
+            args[2] as T3,
+            args[3] as T4,
+            args[4] as T5,
+            args[5] as T6,
+            args[6] as T7,
+            args[7] as T8,
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
@@ -26,30 +26,3 @@ inline fun <T1, T2, T3, T4, T5, T6, T7, R> combine(
         )
     }
 }
-
-@Suppress("LongParameterList")
-inline fun <T1, T2, T3, T4, T5, T6, T7, T8, R> combine(
-    flow: Flow<T1>,
-    flow2: Flow<T2>,
-    flow3: Flow<T3>,
-    flow4: Flow<T4>,
-    flow5: Flow<T5>,
-    flow6: Flow<T6>,
-    flow7: Flow<T7>,
-    flow8: Flow<T8>,
-    crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8) -> R
-): Flow<R> {
-    return kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6, flow7, flow8) { args: Array<*> ->
-        @Suppress("UNCHECKED_CAST", "MagicNumber")
-        transform(
-            args[0] as T1,
-            args[1] as T2,
-            args[2] as T3,
-            args[3] as T4,
-            args[4] as T5,
-            args[5] as T6,
-            args[6] as T7,
-            args[7] as T8,
-        )
-    }
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonColors
 import androidx.compose.material.ButtonDefaults
@@ -311,6 +313,7 @@ private fun ButtonsPreview() {
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp)
+                .verticalScroll(rememberScrollState())
         ) {
             WCColoredButton(onClick = {}) {
                 Text("Button")
@@ -371,12 +374,12 @@ private fun ButtonsPreview() {
 
             WCSelectableChip(
                 onClick = {},
-                text = "Selectable Button: selected",
+                text = "Selectable Chip: selected",
                 isSelected = true
             )
             WCSelectableChip(
                 onClick = {},
-                text = "Selectable Button",
+                text = "Selectable Chip: not selected",
                 isSelected = false
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonColors
 import androidx.compose.material.ButtonDefaults
@@ -184,6 +185,41 @@ fun WCOutlinedButton(
 }
 
 @Composable
+fun WCSelectableChip(
+    onClick: () -> Unit,
+    text: String,
+    modifier: Modifier = Modifier,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    enabled: Boolean = true,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    selectedButtonColors: ButtonColors = ButtonDefaults.buttonColors(),
+    defaultButtonColors: ButtonColors = ButtonDefaults.buttonColors(backgroundColor = Color.Transparent),
+    isSelected: Boolean,
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        colors = if (isSelected) selectedButtonColors else defaultButtonColors,
+        shape = RoundedCornerShape(50),
+    ) {
+        if (leadingIcon != null) {
+            leadingIcon()
+            Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
+        }
+        Text(text = text)
+        if (trailingIcon != null) {
+            Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.minor_100)))
+            trailingIcon()
+        }
+    }
+}
+
+@Composable
 fun WCTextButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -331,6 +367,17 @@ private fun ButtonsPreview() {
                 onClick = {},
                 text = "Text Button",
                 icon = Icons.Default.Add
+            )
+
+            WCSelectableChip(
+                onClick = {},
+                text = "Selectable Button: selected",
+                isSelected = true
+            )
+            WCSelectableChip(
+                onClick = {},
+                text = "Selectable Button",
+                isSelected = false
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -196,8 +196,13 @@ fun WCSelectableChip(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     enabled: Boolean = true,
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
-    selectedButtonColors: ButtonColors = ButtonDefaults.buttonColors(),
-    defaultButtonColors: ButtonColors = ButtonDefaults.buttonColors(backgroundColor = Color.Transparent),
+    selectedButtonColors: ButtonColors = ButtonDefaults.outlinedButtonColors(
+        backgroundColor = colorResource(id = R.color.color_primary),
+        contentColor = colorResource(id = R.color.woo_white)
+    ),
+    defaultButtonColors: ButtonColors = ButtonDefaults.outlinedButtonColors(
+        backgroundColor = Color.Transparent,
+    ),
     isSelected: Boolean,
 ) {
     OutlinedButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -202,7 +202,7 @@ fun WCSearchField(
         value = value,
         onValueChange = onValueChange,
         textStyle = TextStyle(
-            color = colorResource(id = R.color.color_on_surface_medium),
+            color = colorResource(id = R.color.color_on_surface),
             textDirection = ContentOrLtr
         ),
         modifier = modifier
@@ -246,7 +246,7 @@ fun WCSearchField(
                         Icon(
                             imageVector = Icons.Default.Clear,
                             contentDescription = stringResource(id = R.string.clear),
-                            tint = colorResource(id = R.color.color_on_surface_medium)
+                            tint = colorResource(id = R.color.color_on_surface_high)
                         )
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductListHandler.kt
@@ -22,7 +22,7 @@ class ProductListHandler @Inject constructor(private val repository: ProductSele
     private var canLoadMore = true
 
     private val searchQuery = MutableStateFlow("")
-    private val searchType = MutableStateFlow(SearchType.SKU)
+    private val searchType = MutableStateFlow(SearchType.DEFAULT)
     private val searchResults = MutableStateFlow(emptyList<Product>())
 
     private val productFilters = MutableStateFlow(mapOf<ProductFilterOption, String>())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.ProductFilterResult
 import com.woocommerce.android.ui.products.ProductListFragment.Companion.PRODUCT_FILTER_RESULT_KEY
 import com.woocommerce.android.ui.products.ProductNavigationTarget
@@ -25,7 +26,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class ProductSelectorFragment : BaseFragment() {
+class ProductSelectorFragment : BaseFragment(), BackPressListener {
     companion object {
         const val PRODUCT_SELECTOR_RESULT = "product-selector-result"
     }
@@ -93,4 +94,8 @@ class ProductSelectorFragment : BaseFragment() {
     }
 
     override fun getFragmentTitle() = getString(R.string.coupon_conditions_products_select_products_title)
+
+    override fun onRequestAllowBackPress(): Boolean {
+        return viewModel.onExternalBackPressInterceptRequest()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorRepository.kt
@@ -36,13 +36,15 @@ class ProductSelectorRepository @Inject constructor(
     suspend fun searchProducts(
         searchQuery: String,
         offset: Int,
-        pageSize: Int
+        pageSize: Int,
+        skuSearchOption: WCProductStore.SkuSearchOptions,
     ): Result<SearchResult> {
         return productStore.searchProducts(
             selectedSite.get(),
             searchString = searchQuery,
             offset = offset,
-            pageSize = pageSize
+            pageSize = pageSize,
+            skuSearchOptions = skuSearchOption,
         ).let { result ->
             if (result.isError) {
                 WooLog.w(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -345,16 +345,18 @@ private fun ProductList(
                 enabled = state.selectedItemsCount > 0,
                 modifier = Modifier.align(Alignment.CenterStart)
             )
-            WCTextButton(
-                onClick = onFilterButtonClick,
-                text = StringUtils.getQuantityString(
-                    quantity = state.filterState.filterOptions.size,
-                    default = string.product_selector_filter_button_title_default,
-                    zero = string.product_selector_filter_button_title_zero
-                ),
-                allCaps = false,
-                modifier = Modifier.align(Alignment.CenterEnd)
-            )
+            if (state.searchQuery.isEmpty()) {
+                WCTextButton(
+                    onClick = onFilterButtonClick,
+                    text = StringUtils.getQuantityString(
+                        quantity = state.filterState.filterOptions.size,
+                        default = string.product_selector_filter_button_title_default,
+                        zero = string.product_selector_filter_button_title_zero
+                    ),
+                    allCaps = false,
+                    modifier = Modifier.align(Alignment.CenterEnd)
+                )
+            }
         }
         LazyColumn(
             state = listState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -54,6 +54,7 @@ import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
+import com.woocommerce.android.ui.products.ProductType.VARIABLE_SUBSCRIPTION
 import com.woocommerce.android.ui.products.selector.ProductListHandler.SearchType
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.FilterState
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ListItem
@@ -454,7 +455,7 @@ private fun ProductList(
 }
 
 private fun ListItem.hasVariations() =
-    this is ListItem.ProductListItem && type == VARIABLE && numVariations > 0
+    this is ListItem.ProductListItem && (type == VARIABLE|| type == VARIABLE_SUBSCRIPTION) && numVariations > 0
 
 @Composable
 @Suppress("MagicNumber")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -455,7 +455,7 @@ private fun ProductList(
 }
 
 private fun ListItem.hasVariations() =
-    this is ListItem.ProductListItem && (type == VARIABLE|| type == VARIABLE_SUBSCRIPTION) && numVariations > 0
+    this is ListItem.ProductListItem && (type == VARIABLE || type == VARIABLE_SUBSCRIPTION) && numVariations > 0
 
 @Composable
 @Suppress("MagicNumber")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -25,17 +25,22 @@ import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
@@ -123,6 +128,7 @@ fun SearchLayout(
     onSearchTypeChanged: (SearchType) -> Unit
 ) {
     val isFocused = remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
     Column {
         WCSearchField(
             value = state.searchQuery,
@@ -134,7 +140,8 @@ fun SearchLayout(
                     horizontal = dimensionResource(id = dimen.major_100),
                     vertical = dimensionResource(id = dimen.minor_100)
                 )
-                .onFocusChanged { isFocused.value = it.isFocused },
+                .onFocusChanged { isFocused.value = it.isFocused }
+                .focusRequester(focusRequester),
         )
         if (isFocused.value) {
             Row(
@@ -160,6 +167,11 @@ fun SearchLayout(
                     isSelected = state.searchType == SearchType.SKU
                 )
             }
+        }
+    }
+    LaunchedEffect(state.searchQuery) {
+        if (state.searchQuery.isNotEmpty()) {
+            focusRequester.requestFocus()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -35,12 +35,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
@@ -129,9 +128,10 @@ fun SearchLayout(
 ) {
     val isFocused = remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
     Column {
         WCSearchField(
-            value = state.searchQuery,
+            value = state.searchState.searchQuery,
             onValueChange = onSearchQueryChanged,
             hint = stringResource(id = string.product_selector_search_hint),
             modifier = Modifier
@@ -156,7 +156,7 @@ fun SearchLayout(
                         .weight(1f),
                     onClick = { onSearchTypeChanged(SearchType.DEFAULT) },
                     text = stringResource(id = string.product_search_all),
-                    isSelected = state.searchType == SearchType.DEFAULT
+                    isSelected = state.searchState.searchType == SearchType.DEFAULT
                 )
                 WCSelectableChip(
                     modifier = Modifier
@@ -164,14 +164,16 @@ fun SearchLayout(
                         .weight(1f),
                     onClick = { onSearchTypeChanged(SearchType.SKU) },
                     text = stringResource(id = string.product_search_sku),
-                    isSelected = state.searchType == SearchType.SKU
+                    isSelected = state.searchState.searchType == SearchType.SKU
                 )
             }
         }
     }
-    LaunchedEffect(state.searchQuery) {
-        if (state.searchQuery.isNotEmpty()) {
+    LaunchedEffect(state.searchState.isActive) {
+        if (state.searchState.isActive) {
             focusRequester.requestFocus()
+        } else {
+            focusManager.clearFocus()
         }
     }
 }
@@ -192,8 +194,8 @@ private fun EmptyProductList(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        val message = if (state.searchQuery.isNotEmpty()) {
-            stringResource(id = string.empty_message_with_search, state.searchQuery)
+        val message = if (state.searchState.searchQuery.isNotEmpty()) {
+            stringResource(id = string.empty_message_with_search, state.searchState.searchQuery)
         } else if (state.filterState.filterOptions.isNotEmpty()) {
             stringResource(id = string.empty_message_with_filters)
         } else {
@@ -345,7 +347,7 @@ private fun ProductList(
                 enabled = state.selectedItemsCount > 0,
                 modifier = Modifier.align(Alignment.CenterStart)
             )
-            if (state.searchQuery.isEmpty()) {
+            if (state.searchState.searchQuery.isEmpty()) {
                 WCTextButton(
                     onClick = onFilterButtonClick,
                     text = StringUtils.getQuantityString(
@@ -549,7 +551,7 @@ fun PopularProductsListPreview() {
             selectedItemsCount = 3,
             loadingState = IDLE,
             filterState = FilterState(),
-            searchQuery = "",
+            searchState = ProductSelectorViewModel.SearchState(),
             popularProducts = products,
             recentProducts = emptyList(),
         ),
@@ -616,7 +618,7 @@ fun RecentProductsListPreview() {
             selectedItemsCount = 3,
             loadingState = IDLE,
             filterState = FilterState(),
-            searchQuery = "",
+            searchState = ProductSelectorViewModel.SearchState(),
             popularProducts = emptyList(),
             recentProducts = products,
         ),
@@ -682,7 +684,7 @@ fun ProductListPreview() {
             selectedItemsCount = 3,
             loadingState = IDLE,
             filterState = FilterState(),
-            searchQuery = "",
+            searchState = ProductSelectorViewModel.SearchState(),
             popularProducts = products,
             recentProducts = products,
         ),
@@ -703,7 +705,7 @@ fun ProductListEmptyPreview() {
             selectedItemsCount = 3,
             loadingState = IDLE,
             filterState = FilterState(),
-            searchQuery = "",
+            searchState = ProductSelectorViewModel.SearchState(),
             popularProducts = emptyList(),
             recentProducts = emptyList(),
         ),
@@ -724,7 +726,7 @@ fun SearchLayoutPreview() {
         selectedItemsCount = 3,
         loadingState = IDLE,
         filterState = FilterState(),
-        searchQuery = "",
+        searchState = ProductSelectorViewModel.SearchState(),
         popularProducts = emptyList(),
         recentProducts = emptyList(),
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -515,11 +515,7 @@ class ProductSelectorViewModel @Inject constructor(
 
     fun onExternalBackPressInterceptRequest(): Boolean {
         return if (searchState.value.isActive) {
-            searchState.value = searchState.value.copy(
-                isActive = false,
-                searchQuery = "",
-                searchType = SearchType.DEFAULT
-            )
+            searchState.value = SearchState.EMPTY
             false
         } else {
             true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -16,6 +16,9 @@ import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE_SUBSCRIPTION
+import com.woocommerce.android.ui.products.ProductType.VARIATION
+import com.woocommerce.android.ui.products.selector.ProductListHandler.SearchType
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ListItem.ProductListItem
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.APPENDING
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.IDLE
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.LOADING
@@ -39,6 +42,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.map
@@ -80,6 +84,7 @@ class ProductSelectorViewModel @Inject constructor(
     private val productSelectorFlow = navArgs.productSelectorFlow
 
     private val searchQuery = savedState.getStateFlow(this, "")
+    private val searchType = savedState.getStateFlow(this, SearchType.DEFAULT)
     private val loadingState = MutableStateFlow(IDLE)
     private val selectedItems = savedState.getStateFlow(
         viewModelScope,
@@ -113,8 +118,9 @@ class ProductSelectorViewModel @Inject constructor(
             .map { it.value },
         flow5 = selectedItems,
         flow6 = filterState,
-        flow7 = searchQuery
-    ) { products, popularProducts, recentProducts, loadingState, selectedIds, filterState, searchQuery ->
+        flow7 = searchQuery,
+        flow8 = searchType
+    ) { products, popularProducts, recentProducts, loadingState, selectedIds, filterState, searchQuery, searchType ->
         ViewState(
             loadingState = loadingState,
             products = products.map { it.toUiModel(selectedIds) },
@@ -122,7 +128,8 @@ class ProductSelectorViewModel @Inject constructor(
             recentProducts = getRecentProductsToDisplay(recentProducts, selectedIds),
             selectedItemsCount = selectedIds.size,
             filterState = filterState,
-            searchQuery = searchQuery
+            searchQuery = searchQuery,
+            searchType = searchType,
         )
     }.asLiveData()
 
@@ -132,28 +139,28 @@ class ProductSelectorViewModel @Inject constructor(
         viewModelScope.launch {
             loadPopularProducts()
             loadRecentProducts()
-            fetchProducts(forceRefresh = true)
+            fetchProducts(forceRefresh = true, searchType = searchType.value)
         }
     }
 
     private fun getPopularProductsToDisplay(
         popularProducts: List<Product>,
         selectedIds: List<SelectedItem>
-    ): List<ProductListItem> {
+    ): List<ListItem> {
         return getProductItemsIfSearchQueryEmptyOrNoFilter(popularProducts, selectedIds)
     }
 
     private fun getRecentProductsToDisplay(
         recentProducts: List<Product>,
         selectedIds: List<SelectedItem>
-    ): List<ProductListItem> {
+    ): List<ListItem> {
         return getProductItemsIfSearchQueryEmptyOrNoFilter(recentProducts, selectedIds)
     }
 
     private fun getProductItemsIfSearchQueryEmptyOrNoFilter(
         productsList: List<Product>,
         selectedIds: List<SelectedItem>
-    ): List<ProductListItem> {
+    ): List<ListItem> {
         if (searchQuery.value.isNotNullOrEmpty() || filterState.value.filterOptions.isNotEmpty()) {
             return emptyList()
         }
@@ -208,7 +215,9 @@ class ProductSelectorViewModel @Inject constructor(
         orderEntity.getLineItemList().mapNotNull { it.productId }
     }
 
-    private fun Product.toUiModel(selectedItems: Collection<SelectedItem>): ProductListItem {
+    private fun Product.toUiModel(selectedItems: Collection<SelectedItem>): ListItem {
+        val isVariation = productType == VARIATION
+
         fun getProductSelection(): SelectionState {
             return if (isVariable() && numVariations > 0) {
                 val intersection = variationIds.intersect(selectedItems.variationIds.toSet())
@@ -217,6 +226,11 @@ class ProductSelectorViewModel @Inject constructor(
                     intersection.size < variationIds.size -> PARTIALLY_SELECTED
                     else -> SELECTED
                 }
+            } else if (isVariation) { // variation can be displayed in search results
+                if (selectedItems.variationIds.contains(this.remoteId))
+                    SELECTED
+                else
+                    UNSELECTED
             } else {
                 val selectedProductsIds = selectedItems.map { it.id }.toSet()
                 if (selectedProductsIds.contains(remoteId)) SELECTED else UNSELECTED
@@ -229,17 +243,30 @@ class ProductSelectorViewModel @Inject constructor(
 
         val stockAndPrice = listOfNotNull(stockStatus, price).joinToString(" \u2022 ")
 
-        return ProductListItem(
-            id = remoteId,
-            title = name,
-            type = productType,
-            imageUrl = firstImageUrl,
-            sku = sku.takeIf { it.isNotBlank() },
-            stockAndPrice = stockAndPrice,
-            numVariations = numVariations,
-            selectedVariationIds = variationIds.intersect(selectedItems.variationIds.toSet()),
-            selectionState = getProductSelection()
-        )
+        return if (isVariation) {
+            ListItem.VariationListItem(
+                parentId = parentId,
+                variationId = remoteId,
+                title = name,
+                type = productType,
+                imageUrl = firstImageUrl,
+                sku = sku.takeIf { it.isNotBlank() },
+                stockAndPrice = stockAndPrice,
+                selectionState = getProductSelection()
+            )
+        } else {
+            ProductListItem(
+                productId = remoteId,
+                title = name,
+                type = productType,
+                imageUrl = firstImageUrl,
+                sku = sku.takeIf { it.isNotBlank() },
+                stockAndPrice = stockAndPrice,
+                numVariations = numVariations,
+                selectedVariationIds = variationIds.intersect(selectedItems.variationIds.toSet()),
+                selectionState = getProductSelection()
+            )
+        }
     }
 
     fun onClearButtonClick() {
@@ -266,31 +293,47 @@ class ProductSelectorViewModel @Inject constructor(
         )
     }
 
-    fun onProductClick(item: ProductListItem, productSourceForTracking: ProductSourceForTracking) {
+    fun onProductClick(item: ListItem, productSourceForTracking: ProductSourceForTracking) {
         val productSource = updateProductSourceIfSearchIsEnabled(productSourceForTracking)
-        if ((item.type == VARIABLE || item.type == VARIABLE_SUBSCRIPTION) && item.numVariations > 0) {
-            triggerEvent(
-                NavigateToVariationSelector(
-                    item.id,
-                    item.selectedVariationIds,
-                    productSelectorFlow,
-                    productSource
+        if (item is ProductListItem) {
+            if (item.isVariable() && item.numVariations > 0) {
+                triggerEvent(
+                    NavigateToVariationSelector(
+                        item.id,
+                        item.selectedVariationIds,
+                        productSelectorFlow,
+                        productSource
+                    )
                 )
-            )
-        } else if (item.type != VARIABLE && item.type != VARIABLE_SUBSCRIPTION) {
-            selectedItems.update { items ->
-                val selectedProductItems = items.filter {
-                    it is SelectedItem.ProductOrVariation || it is SelectedItem.Product
+            } else if (!item.isVariable()) {
+                selectedItems.update { items ->
+                    val selectedProductItems = items.filter {
+                        it is SelectedItem.ProductOrVariation || it is SelectedItem.Product
+                    }
+                    if (selectedProductItems.map { it.id }.contains(item.id)) {
+                        tracker.trackItemUnselected(productSelectorFlow)
+                        selectedItemsSource.remove(item.id)
+                        val productItemToUnselect = selectedProductItems.filter { it.id == item.id }.toSet()
+                        selectedItems.value - productItemToUnselect
+                    } else {
+                        selectedItemsSource[item.id] = productSource
+                        tracker.trackItemSelected(productSelectorFlow)
+                        selectedItems.value + SelectedItem.Product(item.id)
+                    }
                 }
-                if (selectedProductItems.map { it.id }.contains(item.id)) {
-                    tracker.trackItemUnselected(productSelectorFlow)
-                    selectedItemsSource.remove(item.id)
-                    val productItemToUnselect = selectedProductItems.filter { it.id == item.id }.toSet()
-                    selectedItems.value - productItemToUnselect
-                } else {
-                    selectedItemsSource[item.id] = productSource
-                    tracker.trackItemSelected(productSelectorFlow)
-                    selectedItems.value + SelectedItem.Product(item.id)
+            }
+        } else if (item is ListItem.VariationListItem) { // variation can be displayed in search results
+            if (selectedItems.value.map { it.id }.contains(item.id)) {
+                tracker.trackItemUnselected(productSelectorFlow)
+                selectedItemsSource.remove(item.id)
+                selectedItems.update { items ->
+                    items.filter { it.id != item.id }
+                }
+            } else {
+                tracker.trackItemSelected(productSelectorFlow)
+                selectedItemsSource[item.id] = productSource
+                selectedItems.update { items ->
+                    items + SelectedItem.ProductVariation(item.parentId, item.id)
                 }
             }
         }
@@ -390,14 +433,17 @@ class ProductSelectorViewModel @Inject constructor(
                     it.index == 0 && it.value.isEmpty()
                 }
                 .map { it.value }
+                .combine(searchType) { query, type ->
+                    Pair(query, type)
+                }
                 .onEach {
                     loadingState.value = LOADING
                 }
-                .debounce {
-                    if (it.isEmpty()) 0L else AppConstants.SEARCH_TYPING_DELAY_MS
+                .debounce { (query, _) ->
+                    if (query.isEmpty()) 0L else AppConstants.SEARCH_TYPING_DELAY_MS
                 }
-                .collectLatest { query ->
-                    fetchProducts(query = query)
+                .collectLatest { (query, type) ->
+                    fetchProducts(query = query, searchType = type)
                 }
         }
     }
@@ -420,6 +466,7 @@ class ProductSelectorViewModel @Inject constructor(
     private suspend fun fetchProducts(
         filters: FilterState = filterState.value,
         query: String = "",
+        searchType: SearchType = SearchType.DEFAULT,
         forceRefresh: Boolean = false
     ) {
         loadMoreJob?.cancel()
@@ -429,7 +476,8 @@ class ProductSelectorViewModel @Inject constructor(
             listHandler.loadFromCacheAndFetch(
                 filters = filters.filterOptions,
                 searchQuery = query,
-                forceRefresh = forceRefresh
+                forceRefresh = forceRefresh,
+                searchType = searchType,
             ).onFailure {
                 val message = if (query.isEmpty()) string.product_selector_loading_failed
                 else string.product_selector_search_failed
@@ -439,27 +487,71 @@ class ProductSelectorViewModel @Inject constructor(
         }
     }
 
+    fun onSearchTypeChanged(searchType: SearchType) {
+        this.searchType.update {
+            searchType
+        }
+    }
+
     data class ViewState(
         val loadingState: LoadingState,
-        val products: List<ProductListItem>,
-        val popularProducts: List<ProductListItem>,
-        val recentProducts: List<ProductListItem>,
+        val products: List<ListItem>,
+        val popularProducts: List<ListItem>,
+        val recentProducts: List<ListItem>,
         val selectedItemsCount: Int,
         val filterState: FilterState,
-        val searchQuery: String
+        val searchQuery: String,
+        val searchType: SearchType = SearchType.DEFAULT,
     )
 
-    data class ProductListItem(
+    sealed class ListItem(
         val id: Long,
-        val title: String,
-        val type: ProductType,
-        val imageUrl: String? = null,
-        val numVariations: Int,
-        val stockAndPrice: String? = null,
-        val sku: String? = null,
-        val selectedVariationIds: Set<Long> = emptySet(),
-        val selectionState: SelectionState = UNSELECTED
-    )
+        open val title: String,
+        open val type: ProductType,
+        open val imageUrl: String? = null,
+        open val stockAndPrice: String? = null,
+        open val sku: String? = null,
+        open val selectionState: SelectionState = UNSELECTED
+    ) {
+        data class ProductListItem(
+            val productId: Long,
+            val numVariations: Int,
+            val selectedVariationIds: Set<Long> = emptySet(),
+            override val title: String,
+            override val type: ProductType,
+            override val imageUrl: String? = null,
+            override val stockAndPrice: String? = null,
+            override val sku: String? = null,
+            override val selectionState: SelectionState = UNSELECTED
+        ) : ListItem(
+            id = productId,
+            title = title,
+            type = type,
+            imageUrl = imageUrl,
+            stockAndPrice = stockAndPrice,
+            sku = sku,
+            selectionState = selectionState
+        )
+
+        data class VariationListItem(
+            val parentId: Long,
+            val variationId: Long,
+            override val title: String,
+            override val type: ProductType,
+            override val imageUrl: String? = null,
+            override val stockAndPrice: String? = null,
+            override val sku: String? = null,
+            override val selectionState: SelectionState = UNSELECTED
+        ) : ListItem(
+            id = variationId,
+            title = title,
+            type = type,
+            imageUrl = imageUrl,
+            stockAndPrice = stockAndPrice,
+            sku = sku,
+            selectionState = selectionState
+        )
+    }
 
     @Parcelize
     data class FilterState(
@@ -513,6 +605,8 @@ class ProductSelectorViewModel @Inject constructor(
 }
 
 private fun Product.isVariable() = productType == VARIABLE || productType == VARIABLE_SUBSCRIPTION
+
+private fun ProductSelectorViewModel.ListItem.isVariable() = (type == VARIABLE || type == VARIABLE_SUBSCRIPTION)
 
 val Collection<ProductSelectorViewModel.SelectedItem>.variationIds: List<Long>
     get() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -468,126 +468,6 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         assertThat(state!!.searchState.isActive).isFalse
     }
 
-    // region Sort by popularity and recently sold products
-
-    @Test
-    fun `given published products restriction, when view model created, should not show draft products in the popular section`() {
-        testBlocking {
-            val navArgs = ProductSelectorFragmentArgs(
-                selectedItems = emptyArray(),
-                restrictions = arrayOf(OnlyPublishedProducts),
-                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
-            ).initSavedStateHandle()
-            val popularOrdersList = generatePopularOrders()
-            val ordersList = generateTestOrders()
-            val totalOrders = ordersList + popularOrdersList
-            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
-            whenever(productsMapper.mapProductIdsToProduct(any())).thenReturn(
-                listOf(
-                    DRAFT_PRODUCT,
-                    DRAFT_PRODUCT,
-                    VALID_PRODUCT
-                )
-            )
-
-            val sut = createViewModel(navArgs)
-
-            var viewState: ProductSelectorViewModel.ViewState? = null
-            sut.viewState.observeForever { state ->
-                viewState = state
-            }
-            assertThat(viewState?.popularProducts).isNotEmpty
-            assertThat(viewState?.popularProducts?.filter { it.id == DRAFT_PRODUCT.remoteId }).isEmpty()
-        }
-    }
-
-    @Test
-    fun `given published products restriction, when view model created, should not show draft products in the last sold section`() {
-        testBlocking {
-            val navArgs = ProductSelectorFragmentArgs(
-                selectedItems = emptyArray(),
-                restrictions = arrayOf(OnlyPublishedProducts),
-                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
-            ).initSavedStateHandle()
-            val ordersList = generateTestOrders()
-            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(ordersList)
-            whenever(productsMapper.mapProductIdsToProduct(any())).thenReturn(
-                listOf(
-                    DRAFT_PRODUCT,
-                    DRAFT_PRODUCT,
-                    VALID_PRODUCT
-                )
-            )
-
-            val sut = createViewModel(navArgs)
-
-            var viewState: ProductSelectorViewModel.ViewState? = null
-            sut.viewState.observeForever { state ->
-                viewState = state
-            }
-            assertThat(viewState?.recentProducts).isNotEmpty
-            assertThat(viewState?.recentProducts?.filter { it.id == DRAFT_PRODUCT.remoteId }).isEmpty()
-        }
-    }
-
-    @Test
-    fun `given popular products, when view model created, then verify popular products are sorted in descending order`() {
-        testBlocking {
-            val navArgs = ProductSelectorFragmentArgs(
-                selectedItems = emptyArray(),
-                restrictions = arrayOf(OnlyPublishedProducts),
-                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
-            ).initSavedStateHandle()
-            val popularOrdersList = generatePopularOrders()
-            val ordersList = generateTestOrders()
-            val totalOrders = ordersList + popularOrdersList
-            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
-            val argumentCaptor = argumentCaptor<List<Long>>()
-
-            createViewModel(navArgs)
-
-            verify(productsMapper, times(2)).mapProductIdsToProduct(argumentCaptor.capture())
-            assertThat(argumentCaptor.firstValue).isEqualTo(
-                listOf(2445L, 2448L, 2447L, 2444L, 2446L)
-            )
-        }
-    }
-
-    @Test
-    fun `given popular products, when view model created, then only filter popular products from the orders that are already paid`() {
-        testBlocking {
-            val navArgs = ProductSelectorFragmentArgs(
-                selectedItems = emptyArray(),
-                restrictions = arrayOf(OnlyPublishedProducts),
-                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
-            ).initSavedStateHandle()
-            val popularOrdersList = generatePopularOrders()
-            val popularOrdersThatAreNotPaidYet = mutableListOf<OrderEntity>()
-            repeat(10) {
-                popularOrdersThatAreNotPaidYet.add(
-                    OrderTestUtils.generateOrder(
-                        lineItems = generateLineItems(
-                            name = "ACME Bike",
-                            productId = "1111"
-                        ),
-                        datePaid = ""
-                    ),
-                )
-            }
-            val ordersList = generateTestOrders()
-            val totalOrders = ordersList + popularOrdersList + popularOrdersThatAreNotPaidYet
-            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
-            val argumentCaptor = argumentCaptor<List<Long>>()
-
-            createViewModel(navArgs)
-
-            verify(productsMapper, times(2)).mapProductIdsToProduct(argumentCaptor.capture())
-            assertThat(argumentCaptor.firstValue).isEqualTo(
-                listOf(2445L, 2448L, 2447L, 2444L, 2446L)
-            )
-        }
-    }
-
     @Test
     fun `given search results containing variation, then it should be rendered correctly`() =
         testBlocking {
@@ -715,6 +595,126 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
                 assertThat(selectionState).isEqualTo(SelectionState.UNSELECTED)
             }
         }
+
+    // region Sort by popularity and recently sold products
+
+    @Test
+    fun `given published products restriction, when view model created, should not show draft products in the popular section`() {
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
+            ).initSavedStateHandle()
+            val popularOrdersList = generatePopularOrders()
+            val ordersList = generateTestOrders()
+            val totalOrders = ordersList + popularOrdersList
+            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
+            whenever(productsMapper.mapProductIdsToProduct(any())).thenReturn(
+                listOf(
+                    DRAFT_PRODUCT,
+                    DRAFT_PRODUCT,
+                    VALID_PRODUCT
+                )
+            )
+
+            val sut = createViewModel(navArgs)
+
+            var viewState: ProductSelectorViewModel.ViewState? = null
+            sut.viewState.observeForever { state ->
+                viewState = state
+            }
+            assertThat(viewState?.popularProducts).isNotEmpty
+            assertThat(viewState?.popularProducts?.filter { it.id == DRAFT_PRODUCT.remoteId }).isEmpty()
+        }
+    }
+
+    @Test
+    fun `given published products restriction, when view model created, should not show draft products in the last sold section`() {
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
+            ).initSavedStateHandle()
+            val ordersList = generateTestOrders()
+            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(ordersList)
+            whenever(productsMapper.mapProductIdsToProduct(any())).thenReturn(
+                listOf(
+                    DRAFT_PRODUCT,
+                    DRAFT_PRODUCT,
+                    VALID_PRODUCT
+                )
+            )
+
+            val sut = createViewModel(navArgs)
+
+            var viewState: ProductSelectorViewModel.ViewState? = null
+            sut.viewState.observeForever { state ->
+                viewState = state
+            }
+            assertThat(viewState?.recentProducts).isNotEmpty
+            assertThat(viewState?.recentProducts?.filter { it.id == DRAFT_PRODUCT.remoteId }).isEmpty()
+        }
+    }
+
+    @Test
+    fun `given popular products, when view model created, then verify popular products are sorted in descending order`() {
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+            ).initSavedStateHandle()
+            val popularOrdersList = generatePopularOrders()
+            val ordersList = generateTestOrders()
+            val totalOrders = ordersList + popularOrdersList
+            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
+            val argumentCaptor = argumentCaptor<List<Long>>()
+
+            createViewModel(navArgs)
+
+            verify(productsMapper, times(2)).mapProductIdsToProduct(argumentCaptor.capture())
+            assertThat(argumentCaptor.firstValue).isEqualTo(
+                listOf(2445L, 2448L, 2447L, 2444L, 2446L)
+            )
+        }
+    }
+
+    @Test
+    fun `given popular products, when view model created, then only filter popular products from the orders that are already paid`() {
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+            ).initSavedStateHandle()
+            val popularOrdersList = generatePopularOrders()
+            val popularOrdersThatAreNotPaidYet = mutableListOf<OrderEntity>()
+            repeat(10) {
+                popularOrdersThatAreNotPaidYet.add(
+                    OrderTestUtils.generateOrder(
+                        lineItems = generateLineItems(
+                            name = "ACME Bike",
+                            productId = "1111"
+                        ),
+                        datePaid = ""
+                    ),
+                )
+            }
+            val ordersList = generateTestOrders()
+            val totalOrders = ordersList + popularOrdersList + popularOrdersThatAreNotPaidYet
+            whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
+            val argumentCaptor = argumentCaptor<List<Long>>()
+
+            createViewModel(navArgs)
+
+            verify(productsMapper, times(2)).mapProductIdsToProduct(argumentCaptor.capture())
+            assertThat(argumentCaptor.firstValue).isEqualTo(
+                listOf(2445L, 2448L, 2447L, 2444L, 2446L)
+            )
+        }
+    }
 
     @Test
     fun `given popular products, when searched for products, then hide the popular products section`() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.products.ProductNavigationTarget
 import com.woocommerce.android.ui.products.ProductTestUtils
+import com.woocommerce.android.ui.products.ProductTestUtils.generateProduct
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ListItem.ProductListItem
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorRestriction.NoVariableProductsWithNoVariations
@@ -22,6 +23,7 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -42,20 +44,20 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 @ExperimentalCoroutinesApi
 internal class ProductSelectorViewModelTest : BaseUnitTest() {
     companion object {
-        private val VALID_PRODUCT = ProductTestUtils.generateProduct(productId = 1L)
-        private val DRAFT_PRODUCT = ProductTestUtils.generateProduct(productId = 2L, customStatus = "draft")
-        private val VARIABLE_PRODUCT_WITH_NO_VARIATIONS = ProductTestUtils.generateProduct(
+        private val VALID_PRODUCT = generateProduct(productId = 1L)
+        private val DRAFT_PRODUCT = generateProduct(productId = 2L, customStatus = "draft")
+        private val VARIABLE_PRODUCT_WITH_NO_VARIATIONS = generateProduct(
             productId = 3L,
             isVariable = true,
             variationIds = "[]",
         )
-        private val VARIABLE_SUBSCRIPTION_PRODUCT = ProductTestUtils.generateProduct(
+        private val VARIABLE_SUBSCRIPTION_PRODUCT = generateProduct(
             productId = 4L,
             isVariable = true,
             productType = "variable-subscription",
             variationIds = "[1,2]",
         )
-        private val VARIABLE_PRODUCT = ProductTestUtils.generateProduct(
+        private val VARIABLE_PRODUCT = generateProduct(
             productId = 5L,
             isVariable = true,
             variationIds = "[1,2]",
@@ -526,6 +528,134 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
             )
         }
     }
+
+    @Test
+    fun `given search results containing variation, then it should be rendered correctly`() =
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+            ).initSavedStateHandle()
+
+            whenever(listHandler.productsFlow).thenReturn(
+                flow {
+                    emit(
+                        listOf(
+                            generateProduct(
+                                productId = 1,
+                                parentID = 2,
+                                productType = "variation"
+                            )
+                        )
+                    )
+                }
+            )
+
+            val sut = createViewModel(navArgs)
+
+            var viewState: ProductSelectorViewModel.ViewState? = null
+            sut.viewState.observeForever { state ->
+                viewState = state
+            }
+
+            with(viewState?.products) {
+                assertThat(this).size().isEqualTo(1)
+                val item = this?.first()
+                assertThat(item).isInstanceOf(ProductSelectorViewModel.ListItem.VariationListItem::class.java)
+                assertThat(item!!.id).isEqualTo(1)
+                assertThat((item as ProductSelectorViewModel.ListItem.VariationListItem).parentId).isEqualTo(2)
+            }
+        }
+
+    @Test
+    fun `given search results containing variation, when variation is tapped, it should get selected`() =
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+            ).initSavedStateHandle()
+
+            whenever(listHandler.productsFlow).thenReturn(
+                flow {
+                    emit(
+                        listOf(
+                            generateProduct(
+                                productId = 1,
+                                parentID = 2,
+                                productType = "variation"
+                            )
+                        )
+                    )
+                }
+            )
+
+            val sut = createViewModel(navArgs)
+
+            var viewState: ProductSelectorViewModel.ViewState? = null
+            sut.viewState.observeForever { state ->
+                viewState = state
+            }
+
+            sut.onProductClick(viewState!!.products.first(), ProductSourceForTracking.SEARCH)
+
+            with(viewState?.products) {
+                assertThat(this).size().isEqualTo(1)
+                val item = this?.first()
+                assertThat(item).isInstanceOf(ProductSelectorViewModel.ListItem.VariationListItem::class.java)
+                assertThat(item!!.id).isEqualTo(1)
+                assertThat((item as ProductSelectorViewModel.ListItem.VariationListItem).parentId).isEqualTo(2)
+                assertThat(item.selectionState).isEqualTo(SelectionState.SELECTED)
+            }
+        }
+
+    @Test
+    fun `given search results containing selected variation, when variation is tapped, it should get unselected`() =
+        testBlocking {
+            val navArgs = ProductSelectorFragmentArgs(
+                selectedItems = emptyArray(),
+                restrictions = arrayOf(OnlyPublishedProducts),
+                productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+            ).initSavedStateHandle()
+
+            whenever(listHandler.productsFlow).thenReturn(
+                flow {
+                    emit(
+                        listOf(
+                            generateProduct(
+                                productId = 1,
+                                parentID = 2,
+                                productType = "variation"
+                            )
+                        )
+                    )
+                }
+            )
+
+            val sut = createViewModel(navArgs)
+
+            var viewState: ProductSelectorViewModel.ViewState? = null
+            sut.viewState.observeForever { state ->
+                viewState = state
+            }
+            val variationItem = viewState!!.products.first()
+            sut.onProductClick(variationItem, ProductSourceForTracking.SEARCH)
+            with(viewState!!.products.first()) {
+                assertThat(this).isInstanceOf(ProductSelectorViewModel.ListItem.VariationListItem::class.java)
+                assertThat(id).isEqualTo(1)
+                assertThat((this as ProductSelectorViewModel.ListItem.VariationListItem).parentId).isEqualTo(2)
+                assertThat(selectionState).isEqualTo(SelectionState.SELECTED)
+            }
+
+            sut.onProductClick(variationItem, ProductSourceForTracking.SEARCH)
+            with(viewState!!.products.first()) {
+                assertThat(this).isInstanceOf(ProductSelectorViewModel.ListItem.VariationListItem::class.java)
+                assertThat(id).isEqualTo(1)
+                assertThat((this as ProductSelectorViewModel.ListItem.VariationListItem).parentId).isEqualTo(2)
+                assertThat(selectionState).isEqualTo(SelectionState.UNSELECTED)
+            }
+        }
 
     @Test
     fun `given popular products, when searched for products, then hide the popular products section`() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -13,7 +13,7 @@ import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.products.ProductNavigationTarget
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.ProductType
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductListItem
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ListItem.ProductListItem
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorRestriction.NoVariableProductsWithNoVariations
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorRestriction.OnlyPublishedProducts
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorRepository
@@ -122,7 +122,8 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
             assertThat(state.products).isNotEmpty
             assertThat(
                 state.products.filter {
-                    (it.type == ProductType.VARIABLE || it.type == ProductType.VARIABLE_SUBSCRIPTION) &&
+                    it is ProductListItem &&
+                        (it.type == ProductType.VARIABLE || it.type == ProductType.VARIABLE_SUBSCRIPTION) &&
                         it.numVariations == 0
                 }
             ).isEmpty()
@@ -143,7 +144,8 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
             assertThat(state.products).isNotEmpty
             assertThat(
                 state.products.filter {
-                    (it.type == ProductType.VARIABLE || it.type == ProductType.VARIABLE_SUBSCRIPTION) &&
+                    it is ProductListItem &&
+                        (it.type == ProductType.VARIABLE || it.type == ProductType.VARIABLE_SUBSCRIPTION) &&
                         it.numVariations == 0
                 }
             ).isEmpty()
@@ -250,7 +252,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         val sut = createViewModel(navArgs)
 
         sut.onProductClick(
-            item = ProductListItem(1, "", ProductType.SIMPLE, numVariations = 0),
+            item = ProductListItem(productId = 1, numVariations = 0, title = "", type = ProductType.SIMPLE),
             productSourceForTracking = ProductSourceForTracking.ALPHABETICAL,
         )
         verify(tracker).track(AnalyticsEvent.ORDER_CREATION_PRODUCT_SELECTOR_ITEM_SELECTED)
@@ -265,7 +267,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         ).initSavedStateHandle()
 
         val sut = createViewModel(navArgs)
-        val listItem = ProductListItem(1, "", ProductType.SIMPLE, numVariations = 0)
+        val listItem = ProductListItem(productId = 1, numVariations = 0, title = "", type = ProductType.SIMPLE)
         sut.onProductClick(listItem, ProductSourceForTracking.ALPHABETICAL) // select
         sut.onProductClick(listItem, ProductSourceForTracking.ALPHABETICAL) // unselect
 
@@ -305,11 +307,11 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
 
             val sut = createViewModel(navArgs)
             sut.onProductClick(
-                item = ProductListItem(1, "", ProductType.SIMPLE, numVariations = 0),
+                item = ProductListItem(productId = 1, numVariations = 0, title = "", type = ProductType.SIMPLE),
                 productSourceForTracking = ProductSourceForTracking.ALPHABETICAL
             )
             sut.onProductClick(
-                item = ProductListItem(2, "", ProductType.SIMPLE, numVariations = 0),
+                item = ProductListItem(productId = 2, numVariations = 0, title = "", type = ProductType.SIMPLE),
                 productSourceForTracking = ProductSourceForTracking.ALPHABETICAL
             )
             sut.onDoneButtonClick()
@@ -358,7 +360,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
 
         val sut = createViewModel(navArgs)
         sut.onProductClick(
-            item = ProductListItem(1, "", ProductType.VARIABLE, numVariations = 2),
+            item = ProductListItem(productId = 1, numVariations = 2, title = "", type = ProductType.VARIABLE),
             productSourceForTracking = ProductSourceForTracking.ALPHABETICAL
         )
 
@@ -386,7 +388,12 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
 
         val sut = createViewModel(navArgs)
         sut.onProductClick(
-            item = ProductListItem(23, "", ProductType.VARIABLE_SUBSCRIPTION, numVariations = 2),
+            item = ProductListItem(
+                productId = 23,
+                title = "",
+                type = ProductType.VARIABLE_SUBSCRIPTION,
+                numVariations = 2
+            ),
             productSourceForTracking = ProductSourceForTracking.ALPHABETICAL
         )
 
@@ -1242,7 +1249,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
     private fun generateProductListItem(
         id: Long,
     ) = ProductListItem(
-        id = id,
+        productId = id,
         title = "",
         type = ProductType.SIMPLE,
         imageUrl = null,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -409,6 +409,65 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `when search query entered, should set search state as active`() {
+        val navArgs = ProductSelectorFragmentArgs(
+            selectedItems = emptyArray(),
+            restrictions = emptyArray(),
+            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+        ).initSavedStateHandle()
+        val sut = createViewModel(navArgs)
+        sut.onSearchQueryChanged("test")
+
+        var state: ProductSelectorViewModel.ViewState? = null
+        sut.viewState.observeForever {
+            state = it
+        }
+
+        assertThat(state!!.searchState.isActive).isTrue
+    }
+
+    @Test
+    fun `given active search, when back pressed, should intercept and clear search field`() {
+        val navArgs = ProductSelectorFragmentArgs(
+            selectedItems = emptyArray(),
+            restrictions = emptyArray(),
+            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+        ).initSavedStateHandle()
+        val sut = createViewModel(navArgs)
+        sut.onSearchQueryChanged("test")
+
+        var state: ProductSelectorViewModel.ViewState? = null
+        sut.viewState.observeForever {
+            state = it
+        }
+
+        val backPressInterceptionResult = sut.onExternalBackPressInterceptRequest()
+
+        assertThat(backPressInterceptionResult).isFalse
+        assertThat(state!!.searchState.isActive).isFalse
+    }
+
+    @Test
+    fun `given active search, when filter applied, should set search as inactive`() {
+        val navArgs = ProductSelectorFragmentArgs(
+            selectedItems = emptyArray(),
+            restrictions = emptyArray(),
+            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+        ).initSavedStateHandle()
+        val sut = createViewModel(navArgs)
+        sut.onSearchQueryChanged("test")
+
+        var state: ProductSelectorViewModel.ViewState? = null
+        sut.viewState.observeForever {
+            state = it
+        }
+
+        sut.onFiltersChanged("test", null, null, null, null)
+
+        assertThat(state!!.searchState.isActive).isFalse
+    }
+
     // region Sort by popularity and recently sold products
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9150
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the possibility to search products by SKU (partial match) in the product selector. The UX follows the iOS implementation as described here: pdfdoF-2Wl-p2

### Testing instructions
1. Create a new order and click the "Add products" button to open the product selector.
2. Verify that when the search field is active the search type options appear.
3. Verify that it's possible to search products by SKU.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src=https://github.com/woocommerce/woocommerce-android/assets/4527432/a7473853-0661-46a0-a5dd-f377557493b1 height=600/>


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->