### PR TITLE
Reliability: Persist when Timezone track is triggered for a given site

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -999,14 +999,14 @@ object AppPrefs {
             key = PrefKeyString("$STORE_PHONE_NUMBER:$siteId"),
         )
 
-    fun setTimezoneTrackEventTriggeredFor(siteId: Int, localTimezone: String, storeTimezone: String) {
+    fun setTimezoneTrackEventTriggeredFor(siteId: Long, localTimezone: String, storeTimezone: String) {
         setBoolean(
             key = PrefKeyString("$siteId$localTimezone$storeTimezone"),
             value = true
         )
     }
 
-    fun isTimezoneTrackEventTriggeredFor(siteId: Int, localTimezone: String, storeTimezone: String) =
+    fun isTimezoneTrackEventTriggeredFor(siteId: Long, localTimezone: String, storeTimezone: String) =
         getBoolean(
             key = PrefKeyString("$siteId$localTimezone$storeTimezone"),
             default = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -999,6 +999,19 @@ object AppPrefs {
             key = PrefKeyString("$STORE_PHONE_NUMBER:$siteId"),
         )
 
+    fun setTimezoneTrackEventTriggeredFor(siteId: Int, localTimezone: String, storeTimezone: String) {
+        setBoolean(
+            key = PrefKeyString("$siteId$localTimezone$storeTimezone"),
+            value = true
+        )
+    }
+
+    fun isTimezoneTrackEventTriggeredFor(siteId: Int, localTimezone: String, storeTimezone: String) =
+        getBoolean(
+            key = PrefKeyString("$siteId$localTimezone$storeTimezone"),
+            default = false
+        )
+
     /**
      * Remove all user and site-related preferences.
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -341,4 +341,11 @@ class AppPrefsWrapper @Inject constructor() {
     fun setCrashReportingEnabled(enabled: Boolean) {
         AppPrefs.setCrashReportingEnabled(enabled)
     }
+
+    fun setTimezoneTrackEventTriggeredFor(siteId: Int, localTimezone: String, storeTimezone: String) {
+        AppPrefs.setTimezoneTrackEventTriggeredFor(siteId, localTimezone, storeTimezone)
+    }
+
+    fun isTimezoneTrackEventTriggeredFor(siteId: Int, localTimezone: String, storeTimezone: String) =
+        AppPrefs.isTimezoneTrackEventTriggeredFor(siteId, localTimezone, storeTimezone)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -342,10 +342,10 @@ class AppPrefsWrapper @Inject constructor() {
         AppPrefs.setCrashReportingEnabled(enabled)
     }
 
-    fun setTimezoneTrackEventTriggeredFor(siteId: Int, localTimezone: String, storeTimezone: String) {
+    fun setTimezoneTrackEventTriggeredFor(siteId: Long, localTimezone: String, storeTimezone: String) {
         AppPrefs.setTimezoneTrackEventTriggeredFor(siteId, localTimezone, storeTimezone)
     }
 
-    fun isTimezoneTrackEventTriggeredFor(siteId: Int, localTimezone: String, storeTimezone: String) =
+    fun isTimezoneTrackEventTriggeredFor(siteId: Long, localTimezone: String, storeTimezone: String) =
         AppPrefs.isTimezoneTrackEventTriggeredFor(siteId, localTimezone, storeTimezone)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -346,6 +346,6 @@ class AppPrefsWrapper @Inject constructor() {
         AppPrefs.setTimezoneTrackEventTriggeredFor(siteId, localTimezone, storeTimezone)
     }
 
-    fun isTimezoneTrackEventTriggeredFor(siteId: Long, localTimezone: String, storeTimezone: String) =
-        AppPrefs.isTimezoneTrackEventTriggeredFor(siteId, localTimezone, storeTimezone)
+    fun isTimezoneTrackEventNeverTriggeredFor(siteId: Long, localTimezone: String, storeTimezone: String) =
+        AppPrefs.isTimezoneTrackEventTriggeredFor(siteId, localTimezone, storeTimezone).not()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -345,6 +345,11 @@ class MyStoreViewModel @Inject constructor(
                     AnalyticsTracker.KEY_LOCAL_TIMEZONE to localTimeZoneOffset
                 )
             )
+            appPrefsWrapper.setTimezoneTrackEventTriggeredFor(
+                siteId = selectedSite.siteId,
+                localTimezone = localTimeZoneOffset,
+                storeTimezone = selectedSite.timezone
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -328,19 +328,23 @@ class MyStoreViewModel @Inject constructor(
     }
 
     private fun trackLocalTimezoneDifferenceFromStore() {
-        viewModelScope.launch {
-            val siteTimeZoneOffset = selectedSite.getIfExists()?.timezone ?: return@launch
-            val localTimeZoneOffset = timezoneProvider.deviceTimezone.offsetInHours.toString()
+        val selectedSite = selectedSite.getIfExists() ?: return
+        val localTimeZoneOffset = timezoneProvider.deviceTimezone.offsetInHours.toString()
 
-            if (siteTimeZoneOffset != localTimeZoneOffset) {
-                analyticsTrackerWrapper.track(
-                    stat = DASHBOARD_STORE_TIMEZONE_DIFFER_FROM_DEVICE,
-                    properties = mapOf(
-                        AnalyticsTracker.KEY_STORE_TIMEZONE to siteTimeZoneOffset,
-                        AnalyticsTracker.KEY_LOCAL_TIMEZONE to localTimeZoneOffset
-                    )
+        val shouldTriggerTimezoneTrack = appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(
+            siteId = selectedSite.siteId,
+            localTimezone = localTimeZoneOffset,
+            storeTimezone = selectedSite.timezone
+        ) && selectedSite.timezone != localTimeZoneOffset
+
+        if (shouldTriggerTimezoneTrack) {
+            analyticsTrackerWrapper.track(
+                stat = DASHBOARD_STORE_TIMEZONE_DIFFER_FROM_DEVICE,
+                properties = mapOf(
+                    AnalyticsTracker.KEY_STORE_TIMEZONE to selectedSite.timezone,
+                    AnalyticsTracker.KEY_LOCAL_TIMEZONE to localTimeZoneOffset
                 )
-            }
+            )
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -487,7 +487,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
         // Given
         val testSite = SiteModel().apply {
             timezone = "-3"
-            id = 7777777
+            siteId = 7777777
         }
 
         val deviceTimezone = mock<TimeZone> {
@@ -522,7 +522,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
         // Given
         val testSite = SiteModel().apply {
             timezone = "-3"
-            id = 7777777
+            siteId = 7777777
         }
 
         val deviceTimezone = mock<TimeZone> {
@@ -531,7 +531,6 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
         whenever(selectedSite.getIfExists()) doReturn testSite
         whenever(timezoneProvider.deviceTimezone) doReturn deviceTimezone
-        whenever(appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(any(), any(), any())) doReturn true
         whenever(
             appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(
                 siteId = 7777777,
@@ -565,9 +564,6 @@ class MyStoreViewModelTest : BaseUnitTest() {
         }
 
         whenever(selectedSite.getIfExists()) doReturn null
-        whenever(
-            appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(any(), any(), any())
-        ) doReturn true
 
         // When
         whenViewModelIsCreated()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -518,6 +518,39 @@ class MyStoreViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given the viewModel started, when timezone track is triggered, then set appPrefs flag`() = testBlocking {
+        // Given
+        val testSite = SiteModel().apply {
+            timezone = "-3"
+            siteId = 7777777
+        }
+
+        val deviceTimezone = mock<TimeZone> {
+            on { rawOffset } doReturn 0
+        }
+
+        whenever(selectedSite.getIfExists()) doReturn testSite
+        whenever(timezoneProvider.deviceTimezone) doReturn deviceTimezone
+        whenever(
+            appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(
+                siteId = 7777777,
+                localTimezone = "0",
+                storeTimezone = "-3"
+            )
+        ) doReturn true
+
+        // When
+        whenViewModelIsCreated()
+
+        // Then
+        verify(appPrefsWrapper).setTimezoneTrackEventTriggeredFor(
+            siteId = 7777777,
+            localTimezone = "0",
+            storeTimezone = "-3"
+        )
+    }
+
+    @Test
     fun `given the viewModel started, when timezone track was triggered before, then do nothing`() = testBlocking {
         // Given
         val testSite = SiteModel().apply {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -490,14 +490,14 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
         whenever(selectedSite.getIfExists()) doReturn testSite
         whenever(timezoneProvider.deviceTimezone) doReturn deviceTimezone
-        whenever(appPrefsWrapper.isTimezoneTrackEventTriggeredFor(any(), any(), any())) doReturn true
+        whenever(appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(any(), any(), any())) doReturn false
         whenever(
-            appPrefsWrapper.isTimezoneTrackEventTriggeredFor(
+            appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(
                 siteId = 7777777,
                 localTimezone = "0",
                 storeTimezone = "-3"
             )
-        ) doReturn false
+        ) doReturn true
 
         // When
         whenViewModelIsCreated()
@@ -526,14 +526,14 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
         whenever(selectedSite.getIfExists()) doReturn testSite
         whenever(timezoneProvider.deviceTimezone) doReturn deviceTimezone
-        whenever(appPrefsWrapper.isTimezoneTrackEventTriggeredFor(any(), any(), any())) doReturn false
+        whenever(appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(any(), any(), any())) doReturn true
         whenever(
-            appPrefsWrapper.isTimezoneTrackEventTriggeredFor(
+            appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(
                 siteId = 7777777,
                 localTimezone = "0",
                 storeTimezone = "-3"
             )
-        ) doReturn true
+        ) doReturn false
 
         // When
         whenViewModelIsCreated()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -435,6 +435,9 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
         whenever(selectedSite.getIfExists()) doReturn testSite
         whenever(timezoneProvider.deviceTimezone) doReturn deviceTimezone
+        whenever(
+            appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(any(), any(), any())
+        ) doReturn true
 
         // When
         whenViewModelIsCreated()
@@ -462,6 +465,9 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
         whenever(selectedSite.getIfExists()) doReturn testSite
         whenever(timezoneProvider.deviceTimezone) doReturn deviceTimezone
+        whenever(
+            appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(any(), any(), any())
+        ) doReturn true
 
         // When
         whenViewModelIsCreated()
@@ -490,7 +496,6 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
         whenever(selectedSite.getIfExists()) doReturn testSite
         whenever(timezoneProvider.deviceTimezone) doReturn deviceTimezone
-        whenever(appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(any(), any(), any())) doReturn false
         whenever(
             appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(
                 siteId = 7777777,
@@ -560,6 +565,9 @@ class MyStoreViewModelTest : BaseUnitTest() {
         }
 
         whenever(selectedSite.getIfExists()) doReturn null
+        whenever(
+            appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(any(), any(), any())
+        ) doReturn true
 
         // When
         whenViewModelIsCreated()


### PR DESCRIPTION
Summary
==========
Fix issue #9171 by introducing persistence to the timezone track event preventing it from being triggered multiple times for the same site + timezone configuration.

This way, we ensure we only trigger this when relevant data changes for the site.

How to Test
==========
1. Open the app with a store configured in a different timezone from the device you're testing
2. Verify that the `DASHBOARD_STORE_TIMEZONE_DIFFER_FROM_DEVICE` event is triggered as soon as the `My Store` section is loaded
3. Verify that the same event contains the `store_timezone` and `local_timezone` carrying the expected values from each
4. Now, without reopening the app, go to the App More menu and switch the store to another one with a different timezone from the local
5. Verify that again the `DASHBOARD_STORE_TIMEZONE_DIFFER_FROM_DEVICE` event is triggered, containing the same `local_timezone` as before, and that `store_timezone` follows the value of the newly selected store
6. Go back to the previously selected site, and verify that the time zone track event is not triggering anymore
7. Switch to the second site once again, and verify that the same timezone track is not triggering there too

### Scenario 2
1. Fresh start the app after triggering the timezone track for a given store
2. Verify that the timezone track is not triggered


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.