### PR TITLE
Handle UPC barcode formats

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemover.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemover.kt
@@ -1,0 +1,14 @@
+package com.woocommerce.android.ui.orders.creation
+
+import javax.inject.Inject
+
+interface CheckDigitRemover {
+    fun getSKUWithoutCheckDigit(sku: String): String
+}
+
+class UPCCheckDigitRemover @Inject constructor(): CheckDigitRemover {
+    override fun getSKUWithoutCheckDigit(sku: String): String {
+        return sku.substring(0, sku.length - 1)
+    }
+
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemover.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemover.kt
@@ -6,9 +6,8 @@ interface CheckDigitRemover {
     fun getSKUWithoutCheckDigit(sku: String): String
 }
 
-class UPCCheckDigitRemover @Inject constructor(): CheckDigitRemover {
+class UPCCheckDigitRemover @Inject constructor() : CheckDigitRemover {
     override fun getSKUWithoutCheckDigit(sku: String): String {
         return sku.substring(0, sku.length - 1)
     }
-
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -406,12 +406,9 @@ class OrderCreateEditViewModel @Inject constructor(
                 } ?: run {
                     if (shouldWeRetryProductSearchByRemovingTheCheckDigitFor(barcodeOptions)) {
                         viewState = viewState.copy(isUpdatingOrderDraft = true)
-                        val skuWithoutCheckDigit = checkDigitRemover.getSKUWithoutCheckDigit(
-                            barcodeOptions.sku
-                        )
                         fetchProductBySKU(
                             barcodeOptions.copy(
-                                sku = skuWithoutCheckDigit,
+                                sku = checkDigitRemover.getSKUWithoutCheckDigit(barcodeOptions.sku),
                                 shouldHandleCheckDigitOnFailure = false
                             )
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -194,6 +194,7 @@ class OrderCreateEditViewModel @Inject constructor(
                 // Presence of barcode indicates that this screen was called from the
                 // Order listing screen after scanning the barcode.
                 if (args.sku.isNotNullOrEmpty() && args.barcodeFormat != null) {
+                    viewState = viewState.copy(isUpdatingOrderDraft = true)
                     fetchProductBySKU(
                         BarcodeOptions(sku = args.sku!!, barcodeFormat = args.barcodeFormat!!),
                         ScanningSource.ORDER_LIST

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -404,6 +404,7 @@ class OrderCreateEditViewModel @Inject constructor(
                     addScannedProduct(product, selectedItems, source, barcodeOptions.barcodeFormat)
                 } ?: run {
                     if (isBarcodeFormatUPC(barcodeOptions) || barcodeOptions.shouldHandleCheckDigitOnFailure) {
+                        viewState = viewState.copy(isUpdatingOrderDraft = true)
                         val skuWithoutCheckDigit = checkDigitRemover.getSKUWithoutCheckDigit(
                             barcodeOptions.sku
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -404,7 +404,7 @@ class OrderCreateEditViewModel @Inject constructor(
                 products.firstOrNull()?.let { product ->
                     addScannedProduct(product, selectedItems, source, barcodeOptions.barcodeFormat)
                 } ?: run {
-                    if (isBarcodeFormatUPC(barcodeOptions) || barcodeOptions.shouldHandleCheckDigitOnFailure) {
+                    if (isBarcodeFormatUPC(barcodeOptions) && barcodeOptions.shouldHandleCheckDigitOnFailure) {
                         viewState = viewState.copy(isUpdatingOrderDraft = true)
                         val skuWithoutCheckDigit = checkDigitRemover.getSKUWithoutCheckDigit(
                             barcodeOptions.sku

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -404,7 +404,7 @@ class OrderCreateEditViewModel @Inject constructor(
                 products.firstOrNull()?.let { product ->
                     addScannedProduct(product, selectedItems, source, barcodeOptions.barcodeFormat)
                 } ?: run {
-                    if (isBarcodeFormatUPC(barcodeOptions) && barcodeOptions.shouldHandleCheckDigitOnFailure) {
+                    if (shouldWeRetryProductSearchByRemovingTheCheckDigitFor(barcodeOptions)) {
                         viewState = viewState.copy(isUpdatingOrderDraft = true)
                         val skuWithoutCheckDigit = checkDigitRemover.getSKUWithoutCheckDigit(
                             barcodeOptions.sku
@@ -438,6 +438,9 @@ class OrderCreateEditViewModel @Inject constructor(
             }
         }
     }
+
+    private fun shouldWeRetryProductSearchByRemovingTheCheckDigitFor(barcodeOptions: BarcodeOptions) =
+        isBarcodeFormatUPC(barcodeOptions) && barcodeOptions.shouldHandleCheckDigitOnFailure
 
     private fun isBarcodeFormatUPC(barcodeOptions: BarcodeOptions) =
         barcodeOptions.barcodeFormat == BarcodeFormat.FormatUPCA ||

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -1149,6 +1149,33 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     }
 
     @Test
+    fun `given sku, when view model init, then display progress indicator`() {
+        testBlocking {
+            val navArgs = OrderCreateEditFormFragmentArgs(
+                OrderCreateEditViewModel.Mode.Creation, "123", BarcodeFormat.FormatUPCA,
+            ).initSavedStateHandle()
+            whenever(parameterRepository.getParameters("parameters_key", navArgs)).thenReturn(
+                SiteParameters(
+                    currencyCode = "",
+                    currencySymbol = null,
+                    currencyFormattingParameters = null,
+                    weightUnit = null,
+                    dimensionUnit = null,
+                    gmtOffset = 0F
+                )
+            )
+
+            createSut(navArgs)
+            var isUpdatingOrderDraft: Boolean? = null
+            sut.viewStateData.observeForever { _, viewState ->
+                isUpdatingOrderDraft = viewState.isUpdatingOrderDraft
+            }
+
+            assertTrue(isUpdatingOrderDraft!!)
+        }
+    }
+
+    @Test
     fun `given empty sku, when view model init, then do not fetch product information`() {
         testBlocking {
             val navArgs = OrderCreateEditFormFragmentArgs(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -1283,7 +1283,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `given scanning initiated from the order list screen, when product search via sku succeeds but contains no product, then track event with proper source`() {
         testBlocking {
             val navArgs = OrderCreateEditFormFragmentArgs(
-                OrderCreateEditViewModel.Mode.Creation, "12345", BarcodeFormat.FormatUPCA,
+                OrderCreateEditViewModel.Mode.Creation, "12345", BarcodeFormat.FormatQRCode,
             ).initSavedStateHandle()
             whenever(parameterRepository.getParameters("parameters_key", navArgs)).thenReturn(
                 SiteParameters(
@@ -1308,7 +1308,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
                 AnalyticsEvent.PRODUCT_SEARCH_VIA_SKU_FAILURE,
                 mapOf(
                     AnalyticsTracker.KEY_SCANNING_SOURCE to "order_list",
-                    KEY_SCANNING_BARCODE_FORMAT to BarcodeFormat.FormatUPCA.formatName,
+                    KEY_SCANNING_BARCODE_FORMAT to BarcodeFormat.FormatQRCode.formatName,
                     KEY_SCANNING_FAILURE_REASON to "Empty data response (no product found for the SKU)"
                 )
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UPCCheckDigitRemoverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UPCCheckDigitRemoverTest.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.ui.orders.creation
+
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class UPCCheckDigitRemoverTest : BaseUnitTest() {
+    private val checkDigitRemover = UPCCheckDigitRemover()
+
+    @Test
+    fun `given UPC format barcode SKU with check digit, then return SKU with check digit removed`() {
+        val sku = "12345678901"
+        assertThat(checkDigitRemover.getSKUWithoutCheckDigit(sku)).isEqualTo(
+            "1234567890"
+        )
+    }
+
+    @Test
+    fun `given alpha numeric UPC format barcode SKU with check digit, then return SKU with check digit removed`() {
+        val sku = "1a345Z78901"
+        assertThat(checkDigitRemover.getSKUWithoutCheckDigit(sku)).isEqualTo(
+            "1a345Z7890"
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -758,7 +758,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatQRCode))
                 }
             }
             whenever(
@@ -1217,7 +1217,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
-                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA))
+                    emit(CodeScannerStatus.Success("12345", BarcodeFormat.FormatQRCode))
                 }
             }
             whenever(
@@ -1233,7 +1233,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 PRODUCT_SEARCH_VIA_SKU_FAILURE,
                 mapOf(
                     KEY_SCANNING_SOURCE to "order_creation",
-                    KEY_SCANNING_BARCODE_FORMAT to BarcodeFormat.FormatUPCA.formatName,
+                    KEY_SCANNING_BARCODE_FORMAT to BarcodeFormat.FormatQRCode.formatName,
                     KEY_SCANNING_FAILURE_REASON to "Empty data response (no product found for the SKU)"
                 )
             )
@@ -1380,7 +1380,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given product search fails for UPC barcode format, when retrying, then do not handle the check digit on failing toe fetch product information second time`() {
+    fun `given product search fails for UPC barcode format, when retrying, then do not handle the check digit on failing to fetch product information second time`() {
         testBlocking {
             val sku = "12345678901"
             val skuWithCheckDigitRemoved = "1234567890"
@@ -1410,7 +1410,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
 
             sut.onScanClicked()
 
-            verify(checkDigitRemover, times(1)).getSKUWithoutCheckDigit(skuWithCheckDigitRemoved)
+            verify(checkDigitRemover, times(1)).getSKUWithoutCheckDigit(any())
             verify(productListRepository, times(1)).searchProductList(
                 skuWithCheckDigitRemoved,
                 WCProductStore.SkuSearchOptions.ExactSearch

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -66,6 +66,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     private lateinit var determineMultipleLinesContext: DetermineMultipleLinesContext
     protected lateinit var tracker: AnalyticsTrackerWrapper
     private lateinit var codeScanner: CodeScanner
+    private lateinit var checkDigitRemover: UPCCheckDigitRemover
     lateinit var productListRepository: ProductListRepository
 
     protected val defaultOrderValue = Order.EMPTY.copy(id = 123)
@@ -1328,7 +1329,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             autoSyncPriceModifier = autoSyncPriceModifier,
             tracker = tracker,
             codeScanner = codeScanner,
-            productRepository = productListRepository
+            productRepository = productListRepository,
+            checkDigitRemover = checkDigitRemover
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9168
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR implements a logic to handle UPC barcode formats. 

Whenever the barcode is scanned successfully and the product search API fails for any reason, we check the barcode format. If it's either UPC-A or UPC-E, we re-try the product search API with the newly calculated SKU. The new SKU is calculated by removing the check digit from the originally obtained SKU value.

More context: pdfdoF-2Zq-p2


<img width="600" alt="Screenshot 2023-06-05 at 9 56 17 AM" src="https://github.com/woocommerce/woocommerce-android/assets/1331230/f7ea2d38-1853-4c95-acaf-4f7de0eff279">



### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Test case 1
1. Add 2 products with UPC-A generated SKU where one product's SKU includes a check digit and the other does not. Example - `123456789012` and `12345678901`
2.  Generate the UPC-A barcode for `12345678901` online. Notice the barcode appends a check digit for the SKU. The SKU on the generated barcode will be `123456789012` (https://barcode.tec-it.com/en/UPCA?data=12345678901)
3. Scan the barcode from either the order listing or the order creation screen.
4. Ensure the product with the SKU `123456789012` gets added.

#### Test case 2
1. Add 1 product with UPC-A generated SKU `12345678901`
2. Generate the UPC-A barcode for `12345678901` online. Notice the barcode appends a check digit for the SKU. The SKU on the generated barcode will be `123456789012` (https://barcode.tec-it.com/en/UPCA?data=12345678901)
3. Scan the barcode from either the order listing or the order creation screen.
4. Ensure the product with the SKU `12345678901` gets added.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->