### PR TITLE
chore: bump Kotlin to 1.8.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ ext {
 
     // Compose and its module versions need to be consistent with each other (for example 'compose-theme-adapter')
     composeBOMVersion = "2022.12.00"
-    composeCompilerVersion = "1.4.4"
+    composeCompilerVersion = "1.4.7"
     composeAccompanistVersion = "0.23.1"
     composeThemeAdapterVersion = "1.1.17"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     gradle.ext.agpVersion = '7.2.1'
     gradle.ext.daggerVersion = '2.45'
     gradle.ext.detektVersion = '1.19.0'
-    gradle.ext.kotlinVersion = '1.8.10'
+    gradle.ext.kotlinVersion = '1.8.21'
     gradle.ext.navigationVersion = '2.5.3'
 
     repositories {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9180
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates Kotlin to 1.8.21 and Compose Compiler to 1.4.7. For reasons why this bump is needed, please see attached issue.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Smoke test the app.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
