### PR TITLE
Fix: Use coroutine when getting feature flag value from DB.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepository.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.config
 
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.util.WooLog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.mobile.FeatureFlagsStore
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -39,6 +41,7 @@ class WPComRemoteFeatureFlagRepository @Inject constructor(
         }
     }
 
-    fun isRemoteFeatureFlagEnabled(key: String): Boolean =
+    suspend fun isRemoteFeatureFlagEnabled(key: String): Boolean = withContext(Dispatchers.IO) {
         featureFlagsStore.getFeatureFlagsByKey(key).firstOrNull()?.value ?: false
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
@@ -148,24 +148,26 @@ class StoreInstallationViewModel @Inject constructor(
     }
 
     private fun scheduleDeferredNotifications() {
-        if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES)) {
-            val in14days = LocalDateTime.now()
-                .plusDays(TRIAL_LENGTH_IN_DAYS)
-                .format(DateTimeFormatter.ofPattern("EEEE, MMMM d"))
-            localNotificationScheduler.scheduleNotification(
-                FreeTrialExpiringNotification(in14days, selectedSite.get().siteId)
-            )
-        }
+        launch {
+            if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES)) {
+                val in14days = LocalDateTime.now()
+                    .plusDays(TRIAL_LENGTH_IN_DAYS)
+                    .format(DateTimeFormatter.ofPattern("EEEE, MMMM d"))
+                localNotificationScheduler.scheduleNotification(
+                    FreeTrialExpiringNotification(in14days, selectedSite.get().siteId)
+                )
+            }
 
-        if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES)) {
-            val name = if (accountStore.account.firstName.isNotNullOrEmpty())
-                accountStore.account.firstName
-            else
-                accountStore.account.userName
+            if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES)) {
+                val name = if (accountStore.account.firstName.isNotNullOrEmpty())
+                    accountStore.account.firstName
+                else
+                    accountStore.account.userName
 
-            localNotificationScheduler.scheduleNotification(
-                FreeTrialExpiredNotification(name, selectedSite.get().siteId)
-            )
+                localNotificationScheduler.scheduleNotification(
+                    FreeTrialExpiredNotification(name, selectedSite.get().siteId)
+                )
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.store.AccountStore
 import javax.inject.Inject
@@ -117,18 +118,20 @@ class StoreNamePickerViewModel @Inject constructor(
     }
 
     private fun scheduleDeferredNotification() {
-        if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D)) {
-            val name = if (accountStore.account.firstName.isNotNullOrEmpty())
-                accountStore.account.firstName
-            else
-                accountStore.account.userName
+        launch {
+            if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D)) {
+                val name = if (accountStore.account.firstName.isNotNullOrEmpty())
+                    accountStore.account.firstName
+                else
+                    accountStore.account.userName
 
-            localNotificationScheduler.scheduleNotification(
-                StoreCreationIncompleteNotification(
-                    name,
-                    _viewState.value.storeName
+                localNotificationScheduler.scheduleNotification(
+                    StoreCreationIncompleteNotification(
+                        name,
+                        _viewState.value.storeName
+                    )
                 )
-            )
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -86,16 +86,18 @@ class StoreCreationSummaryViewModel @Inject constructor(
     }
 
     private fun manageDeferredNotifications() {
-        if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_STORE_CREATION_READY)) {
-            val name = if (accountStore.account.firstName.isNotNullOrEmpty())
-                accountStore.account.firstName
-            else
-                accountStore.account.userName
-            localNotificationScheduler.scheduleNotification(StoreCreationFinishedNotification(name))
-        }
+        launch {
+            if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_STORE_CREATION_READY)) {
+                val name = if (accountStore.account.firstName.isNotNullOrEmpty())
+                    accountStore.account.firstName
+                else
+                    accountStore.account.userName
+                localNotificationScheduler.scheduleNotification(StoreCreationFinishedNotification(name))
+            }
 
-        // No need to display a notification to complete store creation anymore
-        localNotificationScheduler.cancelScheduledNotification(STORE_CREATION_INCOMPLETE)
+            // No need to display a notification to complete store creation anymore
+            localNotificationScheduler.cancelScheduledNotification(STORE_CREATION_INCOMPLETE)
+        }
     }
 
     object OnCancelPressed : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 class IsRemoteFeatureFlagEnabled @Inject constructor(
     private val wpComRemoteFeatureFlagRepository: WPComRemoteFeatureFlagRepository
 ) {
-    operator fun invoke(featureFlag: RemoteFeatureFlag): Boolean {
+    suspend operator fun invoke(featureFlag: RemoteFeatureFlag): Boolean {
         return when (featureFlag) {
             LOCAL_NOTIFICATION_STORE_CREATION_READY,
             LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: https://github.com/woocommerce/woocommerce-android/issues/9186

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This puts the database call for getting the local notification flag value into a coroutine, to make sure the it is not called in the main thread.

It also updates existing usages of the `IsRemoteFeatureFlagEnabled` use case to use coroutine.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

A way to test this is to ensure the local notification added in https://github.com/woocommerce/woocommerce-android/pull/9094 still works:

> **Note**
> If you want to make the testing go quicker, you can change the notification units to seconds [here](https://github.com/woocommerce/woocommerce-android/blob/77b6b03116d9d25274484f336fe10f7a1e1739f0/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt#L43). 🙂 

#### Test 1

1. From a logged-out state, tap on Get Started CTA and begin the store creation process
2. When you enter the store name and tap Continue, minimize the app
3. Wait for 24 hours (or seconds if you do the change above)
4. Verify that a notification is displayed
5. Tap on it
6. Verify that the store name picker is shown with the original name pre-filled
7. Tap on the back button and make sure the back stack is looking normal (no duplicates or anything weird)

#### Test 2
1. Log in
2. Go to More menu -> Settings -> Site picker
3. Repeat steps 1-7 from Test 1
4. Verify that everything is working


Ensure the error below doesn't show up:

```
Sentry Issue: [WOOCOMMERCE-ANDROID-6ZC](https://a8c.sentry.io/issues/4215176459/?referrer=github_integration)

IllegalStateException: Cannot access database on the main thread since it may potentially lock the UI for a long period of time.
    at com.woocommerce.android.config.WPComRemoteFeatureFlagRepository.isRemoteFeatureFlagEnabled(WPComRemoteFeatureFlagRepository.kt:43)
    at com.woocommerce.android.util.IsRemoteFeatureFlagEnabled.invoke(IsRemoteFeatureFlagEnabled.kt:20)
    at com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.scheduleDeferredNotification(StoreNamePickerViewModel.kt:120)
    at com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.onContinueClicked(StoreNamePickerViewModel.kt:108)
    at com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerScreenKt$StoreNamePickerScreen$1$4.invoke(StoreNamePickerScreen.kt:45)
...
(86 additional frame(s) were not displayed)
```

[device-2023-05-24-010103.webm](https://github.com/woocommerce/woocommerce-android/assets/1522856/5799439e-5a9c-4290-a335-1232093726e4)
