### PR TITLE
UI/UX improvements for search in product selector

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 14.0
 -----
-
+[*] Improved search UI in product selector [https://github.com/woocommerce/woocommerce-android/pull/9193]
 
 13.9
 -----

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/ProductSelectorScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/ProductSelectorScreen.kt
@@ -17,7 +17,7 @@ class ProductSelectorScreen : Screen(R.id.product_selector_compose_view) {
         composeTestRule: ComposeContentTestRule
     ): ProductSelectorScreen {
         val screenTitle = getTranslatedString(R.string.coupon_conditions_products_select_products_title)
-        Espresso.onView(ViewMatchers.withText(screenTitle)).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        composeTestRule.onNodeWithText(screenTitle).assertIsDisplayed()
 
         val searchHintText = getTranslatedString(R.string.product_selector_search_hint)
         composeTestRule.onNodeWithText(searchHintText).assertIsDisplayed()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
@@ -7,13 +7,13 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
-import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.ProductFilterResult
 import com.woocommerce.android.ui.products.ProductListFragment.Companion.PRODUCT_FILTER_RESULT_KEY
 import com.woocommerce.android.ui.products.ProductNavigationTarget
@@ -21,12 +21,13 @@ import com.woocommerce.android.ui.products.ProductNavigator
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorFragment
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorViewModel.VariationSelectionResult
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class ProductSelectorFragment : BaseFragment(), BackPressListener {
+class ProductSelectorFragment : BaseFragment() {
     companion object {
         const val PRODUCT_SELECTOR_RESULT = "product-selector-result"
     }
@@ -35,11 +36,7 @@ class ProductSelectorFragment : BaseFragment(), BackPressListener {
 
     private val viewModel: ProductSelectorViewModel by viewModels()
 
-    override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Visible(
-            navigationIcon = R.drawable.ic_gridicons_cross_24dp,
-            hasShadow = false
-        )
+    override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
@@ -73,6 +70,7 @@ class ProductSelectorFragment : BaseFragment(), BackPressListener {
                     )
                 }
                 is ProductNavigationTarget -> navigator.navigate(this, event)
+                is Exit -> findNavController().navigateUp()
             }
         }
     }
@@ -91,11 +89,5 @@ class ProductSelectorFragment : BaseFragment(), BackPressListener {
                 productCategoryName = result.productCategoryName
             )
         }
-    }
-
-    override fun getFragmentTitle() = getString(R.string.coupon_conditions_products_select_products_title)
-
-    override fun onRequestAllowBackPress(): Boolean {
-        return viewModel.onExternalBackPressInterceptRequest()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -23,9 +23,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
@@ -52,7 +55,6 @@ import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
-import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCSearchField
 import com.woocommerce.android.ui.compose.component.WCSelectableChip
@@ -79,10 +81,20 @@ fun ProductSelectorScreen(viewModel: ProductSelectorViewModel) {
     BackHandler(onBack = viewModel::onNavigateBack)
     viewState?.let { state ->
         Scaffold(topBar = {
-            Toolbar(
-                onNavigationButtonClick = viewModel::onNavigateBack,
-                navigationIcon = if (state.searchState.isActive) Icons.Filled.ArrowBack else Icons.Filled.Close,
-                title = stringResource(id = string.coupon_conditions_products_select_products_title)
+            TopAppBar(
+                title = { Text(stringResource(id = string.coupon_conditions_products_select_products_title)) },
+                navigationIcon = {
+                    IconButton(viewModel::onNavigateBack) {
+                        Icon(
+                            imageVector = if (state.searchState.isActive) {
+                                Icons.Filled.ArrowBack
+                            } else {
+                                Icons.Filled.Close
+                            },
+                            contentDescription = stringResource(id = string.back)
+                        )
+                    }
+                }
             )
         }) { padding ->
             ProductSelectorScreen(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products.selector
 
 import android.content.res.Configuration
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -23,7 +24,11 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -47,6 +52,7 @@ import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
+import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCSearchField
 import com.woocommerce.android.ui.compose.component.WCSelectableChip
@@ -70,23 +76,34 @@ import com.woocommerce.android.util.StringUtils
 @Composable
 fun ProductSelectorScreen(viewModel: ProductSelectorViewModel) {
     val viewState by viewModel.viewState.observeAsState()
-    viewState?.let {
-        ProductSelectorScreen(
-            state = it,
-            onDoneButtonClick = viewModel::onDoneButtonClick,
-            onClearButtonClick = viewModel::onClearButtonClick,
-            onFilterButtonClick = viewModel::onFilterButtonClick,
-            onProductClick = viewModel::onProductClick,
-            onLoadMore = viewModel::onLoadMore,
-            onSearchQueryChanged = viewModel::onSearchQueryChanged,
-            onClearFiltersButtonClick = viewModel::onClearFiltersButtonClick,
-            onSearchTypeChanged = viewModel::onSearchTypeChanged
-        )
+    BackHandler(onBack = viewModel::onNavigateBack)
+    viewState?.let { state ->
+        Scaffold(topBar = {
+            Toolbar(
+                onNavigationButtonClick = viewModel::onNavigateBack,
+                navigationIcon = if (state.searchState.isActive) Icons.Filled.ArrowBack else Icons.Filled.Close,
+                title = stringResource(id = string.coupon_conditions_products_select_products_title)
+            )
+        }) { padding ->
+            ProductSelectorScreen(
+                modifier = Modifier.padding(padding),
+                state = state,
+                onDoneButtonClick = viewModel::onDoneButtonClick,
+                onClearButtonClick = viewModel::onClearButtonClick,
+                onFilterButtonClick = viewModel::onFilterButtonClick,
+                onProductClick = viewModel::onProductClick,
+                onLoadMore = viewModel::onLoadMore,
+                onSearchQueryChanged = viewModel::onSearchQueryChanged,
+                onClearFiltersButtonClick = viewModel::onClearFiltersButtonClick,
+                onSearchTypeChanged = viewModel::onSearchTypeChanged
+            )
+        }
     }
 }
 
 @Composable
 fun ProductSelectorScreen(
+    modifier: Modifier = Modifier,
     state: ViewState,
     onDoneButtonClick: () -> Unit,
     onClearButtonClick: () -> Unit,
@@ -98,7 +115,7 @@ fun ProductSelectorScreen(
     onClearFiltersButtonClick: () -> Unit
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colors.surface)
     ) {
@@ -709,9 +726,8 @@ fun ProductListEmptyPreview() {
             searchState = ProductSelectorViewModel.SearchState(),
             popularProducts = emptyList(),
             recentProducts = emptyList(),
-        ),
-        {}
-    )
+        )
+    ) {}
 }
 
 @Preview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -30,6 +30,7 @@ import com.woocommerce.android.ui.products.variations.selector.VariationSelector
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.util.getStockText
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -379,6 +380,14 @@ class ProductSelectorViewModel @Inject constructor(
         triggerEvent(ExitWithResult(selectedItems.value))
     }
 
+    fun onNavigateBack() {
+        if (searchState.value.isActive) {
+            searchState.value = SearchState.EMPTY
+        } else {
+            triggerEvent(Exit)
+        }
+    }
+
     private fun isFilterActive() = filterState.value.filterOptions.isNotEmpty()
 
     fun onSearchQueryChanged(query: String) {
@@ -513,15 +522,6 @@ class ProductSelectorViewModel @Inject constructor(
     fun onSearchTypeChanged(searchType: SearchType) {
         this.searchState.update {
             it.copy(searchType = searchType)
-        }
-    }
-
-    fun onExternalBackPressInterceptRequest(): Boolean {
-        return if (searchState.value.isActive) {
-            searchState.value = SearchState.EMPTY
-            false
-        } else {
-            true
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -526,6 +526,8 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
             event = it
         }
 
+        sut.onNavigateBack()
+
         assertThat(event!!).isEqualTo(MultiLiveEvent.Event.Exit)
     }
 


### PR DESCRIPTION
### UI/UX improvements for search in product selector
<!-- Remember about a good descriptive title. -->
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
* Cleaned up back press handling code. Using Compose `BackHandler` instead of MainActivity's interface type check.
* Adjusted Toolbar navigation icons in active search and default modes. Now the toolbar's nav icon is "back" in active search mode and "close" in default mode.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open the product selector and enter a search phrase
2. Observe that the toolbar's nav icon changed to the back arrow
3. Tap the toolbar nav icon or click the OS "back" button
4. Verify that the search mode is closed - the product selector is open and in default mode, the toolbar's nav icon is the "close" icon, keyboard and cursor are hidden

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
