### PR TITLE
Download the scanning module during app install time

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -218,7 +218,7 @@
 
         <meta-data
             android:name="com.google.mlkit.vision.DEPENDENCIES"
-            android:value="barcode" />
+            android:value="barcode_ui" />
 
         <meta-data android:name="io.sentry.traces.activity.enable" android:value="false" />
     </application>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9195 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes a typo in manifest meta-data that would help us in downloading the scanning module during the app install time.

Documentation: https://developers.google.com/ml-kit/vision/barcode-scanning/code-scanner#configure_your_app


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Since this PR just fixes a typo, there's nothing to test. Just ensure that the CI is happy.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
