### PR TITLE
Fix crash when required userName is not available for closing an account

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.prefs
 
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.storecreation.onboarding.ShouldShowOnboarding
 import com.woocommerce.android.ui.login.storecreation.onboarding.ShouldShowOnboarding.Source.SETTINGS
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
@@ -22,7 +23,8 @@ class MainSettingsPresenter @Inject constructor(
     private val wooCommerceStore: WooCommerceStore,
     private val featureAnnouncementRepository: FeatureAnnouncementRepository,
     private val buildConfigWrapper: BuildConfigWrapper,
-    private val shouldShowOnboarding: ShouldShowOnboarding
+    private val shouldShowOnboarding: ShouldShowOnboarding,
+    private val accountRepository: AccountRepository,
 ) : MainSettingsContract.Presenter {
     private var appSettingsFragmentView: MainSettingsContract.View? = null
 
@@ -99,5 +101,6 @@ class MainSettingsPresenter @Inject constructor(
         get() = selectedSite.get().isWPComAtomic
 
     override val isCloseAccountOptionVisible: Boolean
-        get() = selectedSite.connectionType != SiteConnectionType.ApplicationPasswords
+        get() = selectedSite.connectionType != SiteConnectionType.ApplicationPasswords &&
+            accountRepository.getUserAccount()?.userName != null
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes #9198
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Avoid displaying close account from settings when `userName` for the current account is not available. This will prevent the app from crashing when the user taps on "Close account" setting. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
I was unable to reproduce the Sentry crash (linked in the issue). But looking at the stack trace and checking the user logs for those experiencing the crash it seems they are in some sort of unauthenticated state. Maybe they disabled Jetpack and then tried closing the account from the app? : 
```
API Volley error on https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/212554216/rest-api/?path=%2Fwc-analytics%2Fleaderboards%2Fproducts%2F%26_method%3Dget&json=true&query=%7B%22before%22%3A%222023-06-06T23%3A59%3A59%22%2C%22after%22%3A%222023-06-06T00%3A00%3A00%22%2C%22per_page%22%3A%225%22%2C%22force_cache_refresh%22%3A%22true%22%7D&locale=es_ES Status Code: 403 - exception: null
[Jun-06 16:19 WP e] API StackTrace: com.android.volley.AuthFailureError
	at com.android.volley.toolbox.NetworkUtility.shouldRetryException(NetworkUtility.java:189)
	at com.android.volley.toolbox.BasicNetwork.performRequest(BasicNetwork.java:145)
	at com.android.volley.NetworkDispatcher.processRequest(NetworkDispatcher.java:132)
	at com.android.volley.NetworkDispatcher.processRequest(NetworkDispatcher.java:111)
	at com.android.volley.NetworkDispatcher.run(NetworkDispatcher.java:90)
API Volley error on https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/212554216/rest-api/?path=%2Fwc-admin%2Fonboarding%2Ftasks%2F%26_method%3Dget&json=true&locale=es_ES Status Code: 403 - exception: null
[Jun-06 16:20 WP e] API StackTrace: com.android.volley.AuthFailureError
	at com.android.volley.toolbox.NetworkUtility.shouldRetryException(NetworkUtility.java:189)
	at com.android.volley.toolbox.BasicNetwork.performRequest(BasicNetwork.java:145)
	at com.android.volley.NetworkDispatcher.processRequest(NetworkDispatcher.java:132)
	at com.android.volley.NetworkDispatcher.processRequest(NetworkDispatcher.java:111)
	at com.android.volley.NetworkDispatcher.run(NetworkDispatcher.java:90)

```

In any case with the current change we'll hide the setting option for closing account as it is clear that in that scenario they won't be able to close anything. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
