### PR TITLE
Quick Fix: Product Selector backgroundColor and elevation of TopAppBar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -50,7 +50,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.compose.animations.SkeletonView
@@ -94,7 +96,9 @@ fun ProductSelectorScreen(viewModel: ProductSelectorViewModel) {
                             contentDescription = stringResource(id = string.back)
                         )
                     }
-                }
+                },
+                backgroundColor = colorResource(id = color.color_toolbar),
+                elevation = 0.dp,
             )
         }) { padding ->
             ProductSelectorScreen(
@@ -337,7 +341,7 @@ private fun displayProductsSection(
             if (index < productsList.size - 1) {
                 Divider(
                     modifier = Modifier.padding(start = dimensionResource(id = dimen.major_100)),
-                    color = colorResource(id = R.color.divider_color),
+                    color = colorResource(id = color.divider_color),
                     thickness = dimensionResource(id = dimen.minor_10)
                 )
             }
@@ -443,7 +447,7 @@ private fun ProductList(
                 }
                 Divider(
                     modifier = Modifier.padding(start = dimensionResource(id = dimen.major_100)),
-                    color = colorResource(id = R.color.divider_color),
+                    color = colorResource(id = color.divider_color),
                     thickness = dimensionResource(id = dimen.minor_10)
                 )
             }
@@ -464,7 +468,7 @@ private fun ProductList(
         }
 
         Divider(
-            color = colorResource(id = R.color.divider_color),
+            color = colorResource(id = color.divider_color),
             thickness = dimensionResource(id = dimen.minor_10)
         )
 
@@ -518,7 +522,7 @@ private fun ProductListSkeleton() {
                 Divider(
                     modifier = Modifier
                         .offset(x = dimensionResource(id = dimen.major_100)),
-                    color = colorResource(id = R.color.divider_color),
+                    color = colorResource(id = color.divider_color),
                     thickness = dimensionResource(id = dimen.minor_10)
                 )
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Quick Fix: Product Selector backgroundColor and elevation of TopAppBar. In the light theme, there was a wrong background color set to the app bar.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Verify that Product Selector's toolbar has correct background colors in light and dark themes.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
Light mode background of the app bar
| Before  | After |
| ------------- | ------------- |
|  ![Screenshot_20230608-152449](https://github.com/woocommerce/woocommerce-android/assets/4527432/303e34b6-d3c9-43ef-8f67-fc5fe7883bbf) | ![Screenshot_20230608-152206](https://github.com/woocommerce/woocommerce-android/assets/4527432/c186d92c-bd20-43ba-b8ea-7e2b4e4ce40d)  |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
