### PR TITLE
Upload unit tests results as Buildkite artifacts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,6 +47,8 @@ steps:
       ./gradlew jacocoTestReport
       .buildkite/commands/upload-code-coverage.sh
     plugins: *common_plugins
+    artifact_paths:
+      - "**/build/test-results/*/*.xml"
 
   - label: "Instrumented tests"
     command: |


### PR DESCRIPTION
Uploads the unit test results as Buildkite artifacts, so we can further process them:

<img width="1430" alt="Screenshot 2023-06-09 at 2 18 24 PM" src="https://github.com/woocommerce/woocommerce-android/assets/662023/29d42b73-5389-41d1-b592-7a63ac494925">
