### PR TITLE
Make coupon validator case insensitive

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 -----
 - [*][Internal] Fixed database access race condition in Product Selector affecting local search performance and featured products selection [https://github.com/woocommerce/woocommerce-android/pull/9202]
 - [*] [Internal] Added caching mechanism for JITMs [https://github.com/woocommerce/woocommerce-android/pull/9158]
+- [*] [Internal] Fixed coupon validation logic [https://github.com/woocommerce/woocommerce-android/pull/9210]
 
 14.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/coupon/CouponValidator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/coupon/CouponValidator.kt
@@ -10,6 +10,6 @@ class CouponValidator @Inject constructor(
 ) {
     suspend fun isCouponValid(code: String): Boolean {
         val result = store.searchCoupons(selectedSite.get(), code).model ?: return false
-        return result.coupons.find { code == it.coupon.code } != null
+        return result.coupons.find { code.lowercase() == it.coupon.code?.lowercase() } != null
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/coupon/CouponValidatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/coupon/CouponValidatorTest.kt
@@ -1,0 +1,71 @@
+package com.woocommerce.android.ui.orders.creation.coupon
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.persistence.entity.CouponEntity
+import org.wordpress.android.fluxc.persistence.entity.CouponWithEmails
+import org.wordpress.android.fluxc.store.CouponStore
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CouponValidatorTest : BaseUnitTest() {
+    private val selectedSite: SelectedSite = mock {
+        on { get() } doReturn SiteModel()
+    }
+    private val store: CouponStore = mock()
+
+    @Test
+    fun `given entered code, when coupon is found in store, then validator should mark coupon as valid`() = testBlocking {
+        whenever(store.searchCoupons(any(), any(), any(), any()))
+            .thenReturn(WooResult(generateSampleCouponSearchResponse("abc")))
+
+        val sut = CouponValidator(selectedSite, store)
+
+        assertThat(sut.isCouponValid("abc")).isTrue
+    }
+
+    @Test
+    fun `given entered code, when coupon is not found in store, then validator should mark coupon as invalid`() = testBlocking {
+        whenever(store.searchCoupons(any(), any(), any(), any()))
+            .thenReturn(WooResult())
+
+        val sut = CouponValidator(selectedSite, store)
+
+        assertThat(sut.isCouponValid("ABc")).isFalse
+    }
+
+    @Test
+    fun `given entered code, then validator should not be case sensitive`() = testBlocking {
+        whenever(store.searchCoupons(any(), any(), any(), any()))
+            .thenReturn(WooResult(generateSampleCouponSearchResponse("abc")))
+
+        val sut = CouponValidator(selectedSite, store)
+
+        assertThat(sut.isCouponValid("ABc")).isTrue
+    }
+
+    private fun generateSampleCouponSearchResponse(couponCode: String) =
+        CouponStore.CouponSearchResult(
+            coupons = listOf(
+                CouponWithEmails(
+                    coupon = CouponEntity(
+                        code = couponCode,
+                        id = LocalOrRemoteId.RemoteId(1L),
+                        localSiteId = LocalOrRemoteId.LocalId(1)
+                    ),
+                    listOf()
+                )
+
+            ),
+            canLoadMore = true
+        )
+}


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Coupons are converted to lowercase on the backend. We should check if the coupon code is valid by transforming it to lowercase. This PR modifies CouponValidator to be case insensitive.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Create a coupon code containing a capital letter, e.g. "Abc". Verify it's allowed to apply the coupon to an oder in different case variants - e.g. "abc", "ABC", "aBc". 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
