### PR TITLE
Feature/improve polling strategy new stores

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationConst.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/InstallationConst.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.login.storecreation.installation
 
 object InstallationConst {
-    const val STORE_LOAD_RETRIES_LIMIT = 10
-    const val INITIAL_STORE_CREATION_DELAY = 30000L
+    const val STORE_LOAD_RETRIES_LIMIT = 15
+    const val INITIAL_STORE_CREATION_DELAY = 40000L
     const val SITE_CHECK_DEBOUNCE = 5000L
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/ObserveSiteInstallation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/ObserveSiteInstallation.kt
@@ -66,7 +66,10 @@ class ObserveSiteInstallation @Inject constructor(
     }
 
     private val SiteModel?.isReadyToUse: Boolean
-        get() = this?.isJetpackInstalled == true && this.isJetpackConnected
+        get() = this?.isJetpackInstalled == true &&
+            this.isJetpackConnected &&
+            this.isWpComStore &&
+            this.hasWooCommerce
 
     private fun SiteModel?.isDesynced(expectedName: String): Boolean =
         this?.isJetpackInstalled == true && this.isJetpackConnected &&


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After the Jetpack Sync issues were resolved: pe5sF9-1xN-p2. We decided we can rely back on the values for fields: 
`jetpack/jetpack_connection/woocommerce_is_active/is_wpcom_store` to check if a site is ready. 
Moreover, now that we have a notification in place that will inform the user when their store is ready, and given we want to ensure all the previous fields have the expected value before taking the user to My Store tab, we'll increase the timeout threshold to provide more time for the Atomic transfer to run successfully. 

Note that after several tests with these new checks, from the moment you tap on "Start Free Trial" button to landing on My Store tab, the user will roughly wait 1 min 10secs. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Create a few stores using the store creation flow and check that after around 1 min from loading, you are taken to the My store tab and the free trial banner is displayed correctly.