### PR TITLE
Feature/9209 add blaze entry points

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.ui.blaze
+
+import com.woocommerce.android.util.FeatureFlag
+
+class IsBlazeEnabled {
+    operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -1,7 +1,8 @@
 package com.woocommerce.android.ui.blaze
 
 import com.woocommerce.android.util.FeatureFlag
+import javax.inject.Inject
 
-class IsBlazeEnabled {
+class IsBlazeEnabled @Inject constructor() {
     operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.notifications.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.tools.connectionType
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled
 import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
 import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.payments.taptopay.isAvailable
@@ -48,6 +49,7 @@ class MoreMenuViewModel @Inject constructor(
     private val moreMenuNewFeatureHandler: MoreMenuNewFeatureHandler,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
+    private val isBlazeEnabled: IsBlazeEnabled,
     unseenReviewsCountHandler: UnseenReviewsCountHandler
 ) : ScopedViewModel(savedState) {
     val moreMenuViewState =
@@ -91,6 +93,7 @@ class MoreMenuViewModel @Inject constructor(
             description = R.string.more_menu_button_blaze_description,
             icon = R.drawable.ic_more_menu_blaze,
             onClick = ::onPromoteProductsWithBlaze,
+            isEnabled = isBlazeEnabled()
         ),
         MenuUiButton(
             title = R.string.more_menu_button_wс_admin,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -42,6 +42,7 @@ import javax.inject.Inject
 class MoreMenuViewModel @Inject constructor(
     savedState: SavedStateHandle,
     accountStore: AccountStore,
+    unseenReviewsCountHandler: UnseenReviewsCountHandler,
     private val selectedSite: SelectedSite,
     private val moreMenuRepository: MoreMenuRepository,
     private val planRepository: SitePlanRepository,
@@ -50,7 +51,6 @@ class MoreMenuViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
     private val isBlazeEnabled: IsBlazeEnabled,
-    unseenReviewsCountHandler: UnseenReviewsCountHandler
 ) : ScopedViewModel(savedState) {
     val moreMenuViewState =
         combine(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -87,6 +87,12 @@ class MoreMenuViewModel @Inject constructor(
             onClick = ::onPaymentsButtonClick,
         ),
         MenuUiButton(
+            title = R.string.more_menu_button_blaze,
+            description = R.string.more_menu_button_blaze_description,
+            icon = R.drawable.ic_more_menu_blaze,
+            onClick = ::onPromoteProductsWithBlaze,
+        ),
+        MenuUiButton(
             title = R.string.more_menu_button_wс_admin,
             description = R.string.more_menu_button_wc_admin_description,
             icon = R.drawable.ic_more_menu_wp_admin,
@@ -186,6 +192,10 @@ class MoreMenuViewModel @Inject constructor(
         triggerEvent(MoreMenuEvent.ViewPayments)
     }
 
+    private fun onPromoteProductsWithBlaze() {
+        triggerEvent(MoreMenuEvent.OpenBlazeEvent("TODO"))
+    }
+
     private fun onViewAdminButtonClick() {
         trackMoreMenuOptionSelected(VALUE_MORE_MENU_ADMIN_MENU)
         triggerEvent(MoreMenuEvent.ViewAdminEvent(selectedSite.get().adminUrlOrDefault))
@@ -258,6 +268,7 @@ class MoreMenuViewModel @Inject constructor(
         object NavigateToSubscriptionsEvent : MoreMenuEvent()
         object StartSitePickerEvent : MoreMenuEvent()
         object ViewPayments : MoreMenuEvent()
+        data class OpenBlazeEvent(val url: String) : MoreMenuEvent()
         data class ViewAdminEvent(val url: String) : MoreMenuEvent()
         data class ViewStoreEvent(val url: String) : MoreMenuEvent()
         object ViewReviewsEvent : MoreMenuEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -233,6 +233,7 @@ class ProductDetailFragment :
                 RequestCodes.AZTEC_EDITOR_PRODUCT_DESCRIPTION -> {
                     viewModel.updateProductDraft(description = result.getString(ARG_AZTEC_EDITOR_TEXT))
                 }
+
                 RequestCodes.AZTEC_EDITOR_PRODUCT_SHORT_DESCRIPTION -> {
                     viewModel.updateProductDraft(shortDescription = result.getString(ARG_AZTEC_EDITOR_TEXT))
                 }
@@ -294,6 +295,7 @@ class ProductDetailFragment :
                 is LaunchUrlInChromeTab -> {
                     ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 }
+
                 is RefreshMenu -> activity?.invalidateOptionsMenu()
                 is ExitWithResult<*> -> {
                     navigateBackWithResult(
@@ -304,6 +306,7 @@ class ProductDetailFragment :
                         }
                     )
                 }
+
                 is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(event.message, event.action)
                 is HideImageUploadErrorSnackbar -> imageUploadErrorsSnackbar?.dismiss()
                 is ShowLinkedProductPromoBanner -> showLinkedProductPromoBanner()
@@ -313,6 +316,7 @@ class ProductDetailFragment :
                     R.string.product_duplicate_progress_title,
                     R.string.product_duplicate_progress_body
                 )
+
                 else -> event.isHandled = false
             }
         }
@@ -452,10 +456,12 @@ class ProductDetailFragment :
                 viewModel.onSettingsButtonClicked()
                 true
             }
+
             R.id.menu_duplicate -> {
                 viewModel.onDuplicateProduct()
                 true
             }
+
             R.id.menu_trash_product -> {
                 viewModel.onTrashButtonClicked()
                 true
@@ -568,6 +574,7 @@ class ProductDetailFragment :
             )
         }
         findItem(R.id.menu_trash_product)?.isVisible = state.trashOption
+        findItem(R.id.promote_with_blaze)?.isVisible = state.showPromoteWithBlaze
     }
 
     override fun getFragmentTitle(): String = productName

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -273,7 +273,9 @@ class ProductDetailViewModel @Inject constructor(
                 shareOption = showShareOption,
                 showShareOptionAsActionWithText = showShareOptionAsActionWithText,
                 trashOption = !isProductUnderCreation && navArgs.isTrashEnabled,
-                showPromoteWithBlaze = isBlazeEnabled() && getProductVisibility() == PUBLIC
+                showPromoteWithBlaze = isBlazeEnabled() &&
+                    getProductVisibility() == PUBLIC &&
+                    productDraft.status != ProductStatus.DRAFT
             )
         }.asLiveData()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -27,7 +27,8 @@ enum class FeatureFlag {
     COMPOSITE_PRODUCTS_READ_ONLY_SUPPORT,
     STORE_CREATION_PROFILER,
     EU_SHIPPING_NOTIFICATION,
-    PRIVACY_CHOICES;
+    PRIVACY_CHOICES,
+    BLAZE;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -55,7 +56,8 @@ enum class FeatureFlag {
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
-            IPP_TAP_TO_PAY -> PackageUtils.isDebugBuild()
+            IPP_TAP_TO_PAY,
+            BLAZE -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false
         }

--- a/WooCommerce/src/main/res/drawable/ic_more_menu_blaze.xml
+++ b/WooCommerce/src/main/res/drawable/ic_more_menu_blaze.xml
@@ -1,0 +1,25 @@
+<vector android:autoMirrored="true"
+    android:height="20dp"
+    android:viewportHeight="20"
+    android:viewportWidth="19"
+    android:width="19dp"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:pathData="M19,11.409C19,12.564 18.755,13.702 18.276,14.769C17.796,15.836 17.1,16.804 16.214,17.62C15.334,18.435 14.286,19.081 13.133,19.524C12.587,19.732 12.024,19.891 11.45,20L11.706,19.863C11.706,19.863 13.924,18.594 14.364,15.748C14.57,13.209 12.464,12.099 12.464,12.099C12.464,12.099 11.394,13.455 9.873,13.455C7.483,13.455 7.917,9.474 7.917,9.474C7.917,9.474 4.29,11.343 4.29,15.415C4.29,17.959 6.853,19.836 6.853,19.836V19.841C6.519,19.754 6.19,19.644 5.867,19.518C4.714,19.075 3.666,18.43 2.786,17.614C1.906,16.799 1.204,15.83 0.724,14.763C0.245,13.696 0,12.558 0,11.404C0,7.497 4.558,3.71 4.558,3.71C4.558,3.71 4.992,6.681 7.216,6.681C11.394,6.681 9.873,0 9.873,0C9.873,0 13.673,2.227 14.816,8.164C16.889,7.895 16.715,5.193 16.715,5.193C16.715,5.193 19,8.164 19,11.436">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:endX="9.5"
+                android:endY="20"
+                android:startX="9.5"
+                android:startY="0"
+                android:type="linear">
+                <item
+                    android:color="#FFE94338"
+                    android:offset="0" />
+                <item
+                    android:color="#FFFFB800"
+                    android:offset="1" />
+            </gradient>
+        </aapt:attr>
+    </path>
+</vector>

--- a/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_product_detail_fragment.xml
@@ -33,6 +33,12 @@
         app:showAsAction="withText" />
 
     <item
+        android:id="@+id/promote_with_blaze"
+        android:title="@string/product_detail_menu_item_promote_with_blaze"
+        android:visible="false"
+        app:showAsAction="withText" />
+
+    <item
         android:id="@+id/menu_product_settings"
         android:title="@string/product_settings"
         app:showAsAction="withText" />

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3278,6 +3278,9 @@
     <string name="more_menu_button_payments">Payments</string>
     <string name="more_menu_button_payments_description">Join the mobile payments</string>
 
+    <string name="more_menu_button_blaze">Blaze</string>
+    <string name="more_menu_button_blaze_description">Promote products with Blaze</string>
+
     <string name="more_menu_button_inbox">Inbox</string>
     <string name="more_menu_button_inbox_description">Stay up-to-date</string>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1781,6 +1781,7 @@
     <string name="product_category_selector_loading_failed">Loading product categories failed</string>
     <string name="product_category_selector_search_failed">Searching product categories failed</string>
     <string name="product_list_multiselect">Select multiple</string>
+    <string name="product_detail_menu_item_promote_with_blaze">Promote with Blaze</string>
     <!--
         Product Add more details Bottom sheet
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled
 import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
 import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.plans.domain.SitePlan
@@ -68,6 +69,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
     }
 
     private val appPrefsWrapper: AppPrefsWrapper = mock()
+    private val isBlazeEnabled: IsBlazeEnabled = mock()
 
     private lateinit var viewModel: MoreMenuViewModel
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()
@@ -77,14 +79,15 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         viewModel = MoreMenuViewModel(
             savedState = SavedStateHandle(),
             accountStore = accountStore,
+            unseenReviewsCountHandler = unseenReviewsCountHandler,
             selectedSite = selectedSite,
             moreMenuRepository = moreMenuRepository,
             moreMenuNewFeatureHandler = moreMenuNewFeatureHandler,
             planRepository = planRepository,
             resourceProvider = resourceProvider,
-            unseenReviewsCountHandler = unseenReviewsCountHandler,
             tapToPayAvailabilityStatus = tapToPayAvailabilityStatus,
-            appPrefsWrapper = appPrefsWrapper
+            appPrefsWrapper = appPrefsWrapper,
+            isBlazeEnabled = isBlazeEnabled
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelGenerateVariationFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelGenerateVariationFlowTest.kt
@@ -111,6 +111,7 @@ class ProductDetailViewModelGenerateVariationFlowTest : BaseUnitTest() {
                 mock(),
                 mock(),
                 mock(),
+                mock(),
                 mock()
             )
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -253,6 +253,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                 mock(),
                 mock(),
                 mock(),
+                mock(),
                 mock()
             )
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -180,6 +180,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 mock(),
                 mock(),
                 mock(),
+                mock(),
                 mock()
             )
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9209 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds new entry points for blaze from: 
- Product detail overflow menu
- More Menu new option

Keep in mind clicking on the items won't do anything for now.
These new CTAs are hidden by a feature flag enabled for `debug` version. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Navigate to a published product detail and check that there's an option in the overflow menu to promote the product with Blaze. This option should not be visible if the product is "draft" 
- Navigate to More Menu and check there's an option to Blaze the site

