### PR TITLE
Check metadataArray is not null

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailRepository.kt
@@ -292,9 +292,8 @@ class ProductDetailRepository @Inject constructor(
         val metadata = getCachedWCProductModel(remoteProductId)?.metadata ?: return null
         val metadataArray = gson.fromJson(metadata, Array<WCMetaData>::class.java)
 
-        return metadataArray
-            .filter { metadataItem -> metadataItem.key.isNullOrEmpty().not() }
-            .associate { metadataItem -> metadataItem.key!! to metadataItem.value }
+        return metadataArray?.filter { metadataItem -> metadataItem.key.isNullOrEmpty().not() }
+            ?.associate { metadataItem -> metadataItem.key!! to metadataItem.value }
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
Closes: #9161

### Description
This small PR adds a check to the `metadataArray` value to ensure it's not null, preventing the NPE.

### Testing instructions
No need

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
