### PR TITLE
[TTP] Improve TTP pin required error handling

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
@@ -14,8 +14,10 @@ import androidx.activity.ComponentDialog
 import androidx.activity.addCallback
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.CardReaderPaymentDialogBinding
@@ -95,6 +97,7 @@ class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_paym
                 ).show()
                 is PlayChaChing -> playChaChing()
                 is ContactSupport -> openSupportRequestScreen()
+                is PurchaseCardReader -> openPurchaseCardReaderScreen(event.url)
                 else -> event.isHandled = false
             }
         }
@@ -134,6 +137,12 @@ class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_paym
                 }
             }
         }
+    }
+
+    private fun openPurchaseCardReaderScreen(url: String) {
+        findNavController().navigate(
+            NavGraphMainDirections.actionGlobalWPComWebViewFragment(urlToLoad = url)
+        )
     }
 
     private fun openSupportRequestScreen() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -766,8 +766,10 @@ class CardReaderPaymentViewModel
     private fun onPurchaseCardReaderClicked() {
         onCancelPaymentFlow()
         val storeCountryCode = wooStore.getStoreCountryCode(selectedSite.get())
-        triggerEvent(PurchaseCardReader(
-            "${AppUrls.WOOCOMMERCE_PURCHASE_CARD_READER_IN_COUNTRY}$storeCountryCode")
+        triggerEvent(
+            PurchaseCardReader(
+                "${AppUrls.WOOCOMMERCE_PURCHASE_CARD_READER_IN_COUNTRY}$storeCountryCode"
+            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -572,7 +572,9 @@ class CardReaderPaymentViewModel
                     errorType = errorType,
                     amountLabel = amountLabel,
                     primaryLabel = R.string.card_reader_payment_payment_failed_purchase_hardware_reader,
-                    onPrimaryActionClicked = { onPurchaseCardReaderClicked() }
+                    onPrimaryActionClicked = { onPurchaseCardReaderClicked() },
+                    secondaryLabel = R.string.cancel,
+                    onSecondaryActionClicked = { onBackPressed() }
                 )
 
             else ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
@@ -535,7 +536,11 @@ class CardReaderPaymentViewModel
             "State mismatch: received unsupported country config"
         }
 
-        val errorType = errorMapper.mapPaymentErrorToUiError(error.type, config)
+        val errorType = errorMapper.mapPaymentErrorToUiError(
+            error.type,
+            config,
+            arguments.cardReaderType == CardReaderType.BUILT_IN
+        )
         viewState.postValue(buildFailedPaymentState(errorType, amountLabel, onRetryClicked))
     }
 
@@ -559,6 +564,15 @@ class CardReaderPaymentViewModel
                     amountLabel = amountLabel,
                     primaryLabel = R.string.card_reader_payment_payment_failed_ok,
                     onPrimaryActionClicked = { onBackPressed() }
+                )
+
+            is PaymentFlowError.PurchaseHardwareReaderError ->
+                cardReaderPaymentReaderTypeStateProvider.provideFailedPaymentState(
+                    cardReaderType = arguments.cardReaderType,
+                    errorType = errorType,
+                    amountLabel = amountLabel,
+                    primaryLabel = R.string.card_reader_payment_payment_failed_purchase_hardware_reader,
+                    onPrimaryActionClicked = { onPurchaseCardReaderClicked() }
                 )
 
             else ->
@@ -747,6 +761,14 @@ class CardReaderPaymentViewModel
         tracker.trackPaymentFailedContactSupportTapped()
         onCancelPaymentFlow()
         triggerEvent(ContactSupport)
+    }
+
+    private fun onPurchaseCardReaderClicked() {
+        onCancelPaymentFlow()
+        val storeCountryCode = wooStore.getStoreCountryCode(selectedSite.get())
+        triggerEvent(PurchaseCardReader(
+            "${AppUrls.WOOCOMMERCE_PURCHASE_CARD_READER_IN_COUNTRY}$storeCountryCode")
+        )
     }
 
     private fun onCancelPaymentFlow() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModelEvent.kt
@@ -10,3 +10,5 @@ object PlayChaChing : Event()
 object InteracRefundSuccessful : Event()
 
 object ContactSupport : Event()
+
+data class PurchaseCardReader(val url: String) : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewState.kt
@@ -348,11 +348,16 @@ sealed class PaymentFlowError(val message: UiString) {
         object AppKilledWhileInBackground :
             BuiltInReader(R.string.card_reader_payment_vm_killed_when_tpp_in_foreground),
             ContactSupportError
+
+        object PinRequired : Declined(UiStringRes(R.string.card_reader_payment_failed_pin_required_tap_to_pay)),
+            PurchaseHardwareReaderError
     }
 
     interface NonRetryableError
 
     interface ContactSupportError
+
+    interface PurchaseHardwareReaderError
 }
 
 sealed class InteracRefundFlowError(val message: UiString) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewState.kt
@@ -349,7 +349,8 @@ sealed class PaymentFlowError(val message: UiString) {
             BuiltInReader(R.string.card_reader_payment_vm_killed_when_tpp_in_foreground),
             ContactSupportError
 
-        object PinRequired : Declined(UiStringRes(R.string.card_reader_payment_failed_pin_required_tap_to_pay)),
+        object PinRequired :
+            Declined(UiStringRes(R.string.card_reader_payment_failed_pin_required_tap_to_pay)),
             PurchaseHardwareReaderError
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1283,7 +1283,7 @@
     <string name="card_reader_payment_failed_insufficient_funds">Payment declined due to insufficient funds</string>
     <string name="card_reader_payment_failed_invalid_amount">The payment amount is not allowed for the card presented</string>
     <string name="card_reader_payment_failed_pin_required">This card requires a PIN code and thus cannot be processed</string>
-    <string name="card_reader_payment_failed_pin_required_tap_to_pay">A PIN code is required for payment, but Tap To Pay doesn\'t support it yet. Consider getting an external card reader</string>
+    <string name="card_reader_payment_failed_pin_required_tap_to_pay">A PIN code is required, but Tap To Pay doesn\'t support it yet. Consider using an external card reader</string>
     <string name="card_reader_payment_failed_too_many_pin_tries">An incorrect PIN has been entered too many times</string>
     <string name="card_reader_payment_failed_test_card">System test cards are not permitted for payment</string>
     <string name="card_reader_payment_failed_test_mode_live_card">A live card was used on a site in test mode</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1283,7 +1283,7 @@
     <string name="card_reader_payment_failed_insufficient_funds">Payment declined due to insufficient funds</string>
     <string name="card_reader_payment_failed_invalid_amount">The payment amount is not allowed for the card presented</string>
     <string name="card_reader_payment_failed_pin_required">This card requires a PIN code and thus cannot be processed</string>
-    <string name="card_reader_payment_failed_pin_required_tap_to_pay">A PIN code is required for payment, but Tap To Pay doesn't support it yet. Consider getting an external card reader</string>
+    <string name="card_reader_payment_failed_pin_required_tap_to_pay">A PIN code is required for payment, but Tap To Pay doesn\'t support it yet. Consider getting an external card reader</string>
     <string name="card_reader_payment_failed_too_many_pin_tries">An incorrect PIN has been entered too many times</string>
     <string name="card_reader_payment_failed_test_card">System test cards are not permitted for payment</string>
     <string name="card_reader_payment_failed_test_mode_live_card">A live card was used on a site in test mode</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1260,6 +1260,7 @@
     <string name="card_reader_payment_completed_payment_header">Payment successful</string>
     <string name="card_reader_payment_payment_failed_header">Payment failed</string>
     <string name="card_reader_payment_payment_failed_ok">OK</string>
+    <string name="card_reader_payment_payment_failed_purchase_hardware_reader">Buy a card reader</string>
 
     <string name="card_reader_payment_collect_payment_state">Reader is ready</string>
     <string name="card_reader_payment_collect_payment_built_in_state">Built-in reader is ready</string>
@@ -1282,6 +1283,7 @@
     <string name="card_reader_payment_failed_insufficient_funds">Payment declined due to insufficient funds</string>
     <string name="card_reader_payment_failed_invalid_amount">The payment amount is not allowed for the card presented</string>
     <string name="card_reader_payment_failed_pin_required">This card requires a PIN code and thus cannot be processed</string>
+    <string name="card_reader_payment_failed_pin_required_tap_to_pay">A PIN code is required for payment, but Tap To Pay doesn't support it yet. Consider getting an external card reader</string>
     <string name="card_reader_payment_failed_too_many_pin_tries">An incorrect PIN has been entered too many times</string>
     <string name="card_reader_payment_failed_test_card">System test cards are not permitted for payment</string>
     <string name="card_reader_payment_failed_test_mode_live_card">A live card was used on a site in test mode</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentErrorMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentErrorMapperTest.kt
@@ -32,7 +32,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.CardReadTimeOut
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Generic)
@@ -46,7 +46,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.NoNetwork
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.NoNetwork)
@@ -60,7 +60,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.Server("")
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Server)
@@ -74,7 +74,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.Generic
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Generic)
@@ -94,7 +94,7 @@ class CardReaderPaymentErrorMapperTest {
             )
         ).thenReturn("£0.30")
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(
@@ -117,7 +117,7 @@ class CardReaderPaymentErrorMapperTest {
         ).thenReturn("US$0.50")
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(
@@ -140,7 +140,7 @@ class CardReaderPaymentErrorMapperTest {
         ).thenReturn("CA$0.50")
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(
@@ -156,7 +156,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.Temporary
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Declined.Temporary)
@@ -170,7 +170,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.Fraud
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Declined.Fraud)
@@ -184,7 +184,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.Generic
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Declined.Generic)
@@ -198,7 +198,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.InvalidAccount
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Declined.InvalidAccount)
@@ -212,7 +212,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.CardNotSupported
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Declined.CardNotSupported)
@@ -226,7 +226,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.CurrencyNotSupported
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Declined.CurrencyNotSupported)
@@ -240,7 +240,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.DuplicateTransaction
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Declined.DuplicateTransaction)
@@ -254,7 +254,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.ExpiredCard
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Declined.ExpiredCard)
@@ -268,7 +268,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.IncorrectPostalCode
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Declined.IncorrectPostalCode)
@@ -282,7 +282,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.InvalidAmount
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Declined.InvalidAmount)
@@ -291,12 +291,12 @@ class CardReaderPaymentErrorMapperTest {
     }
 
     @Test
-    fun `given PinRequired error, when map to ui error, then PinRequired error returned`() {
+    fun `given PinRequired error and hw reader, when map to ui error, then PinRequired error returned`() {
         // GIVEN
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.PinRequired
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Declined.PinRequired)
@@ -305,12 +305,26 @@ class CardReaderPaymentErrorMapperTest {
     }
 
     @Test
+    fun `given PinRequired error and built in, when map to ui error, then PinRequired error returned`() {
+        // GIVEN
+        val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.PinRequired
+
+        // WHEN
+        val result = mapper.mapPaymentErrorToUiError(error, config, true)
+
+        // THEN
+        assertThat(result).isEqualTo(PaymentFlowError.BuiltInReader.PinRequired)
+        assertThat((result as PaymentFlowError.BuiltInReader.PinRequired).message)
+            .isEqualTo(UiStringRes(R.string.card_reader_payment_failed_pin_required_tap_to_pay))
+    }
+
+    @Test
     fun `given TooManyPinTries error, when map to ui error, then TooManyPinTries error returned`() {
         // GIVEN
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.TooManyPinTries
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Declined.TooManyPinTries)
@@ -324,7 +338,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.TestCard
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Declined.TestCard)
@@ -338,7 +352,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.CardDeclined.TestModeLiveCard
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Declined.TestModeLiveCard)
@@ -352,7 +366,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.DeclinedByBackendError.Unknown
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Unknown)
@@ -366,7 +380,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.Canceled
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.Canceled)
@@ -380,7 +394,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.BuiltInReader.NfcDisabled
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.BuiltInReader.NfcDisabled)
@@ -394,7 +408,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.BuiltInReader.DeviceIsNotSupported
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.BuiltInReader.DeviceIsNotSupported)
@@ -408,7 +422,7 @@ class CardReaderPaymentErrorMapperTest {
         val error = CardPaymentStatusErrorType.BuiltInReader.InvalidAppSetup
 
         // WHEN
-        val result = mapper.mapPaymentErrorToUiError(error, config)
+        val result = mapper.mapPaymentErrorToUiError(error, config, false)
 
         // THEN
         assertThat(result).isEqualTo(PaymentFlowError.BuiltInReader.InvalidAppSetup)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
@@ -67,6 +67,7 @@ import com.woocommerce.android.ui.payments.cardreader.payment.PaymentFlowError
 import com.woocommerce.android.ui.payments.cardreader.payment.PaymentFlowError.AmountTooSmall
 import com.woocommerce.android.ui.payments.cardreader.payment.PaymentFlowError.Unknown
 import com.woocommerce.android.ui.payments.cardreader.payment.PlayChaChing
+import com.woocommerce.android.ui.payments.cardreader.payment.PurchaseCardReader
 import com.woocommerce.android.ui.payments.cardreader.payment.ViewState.BuiltInReaderCapturingPaymentState
 import com.woocommerce.android.ui.payments.cardreader.payment.ViewState.BuiltInReaderCollectPaymentState
 import com.woocommerce.android.ui.payments.cardreader.payment.ViewState.BuiltInReaderFailedPaymentState
@@ -803,7 +804,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given external reader, when payment fails, then ui updated to external failed state`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -817,7 +818,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given external reader fails with Unknown error, when view model starts, then ui has contact support button`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(Unknown)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -833,7 +834,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given built in reader fails with Unknown error, when view model starts, then ui has contact support button`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, true))
                 .thenReturn(Unknown)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -850,7 +851,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given external reader fails with generic error, when contact support clicked, then contact support emitted and flow canceled`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Declined.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -869,7 +870,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `when contact support clicked, then contact support event tracked`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Declined.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -885,7 +886,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given built in reader fails with generic error, when contact support clicked, then contact support emitted and flow canceled`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, true))
                 .thenReturn(PaymentFlowError.Declined.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -905,7 +906,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given built in reader, when payment fails, then ui updated to built in failed state`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, true))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -920,7 +921,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `when payment fails, then invalidate onboarding cache`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -934,7 +935,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given external reader, when payment fails because of NoNetwork, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.NoNetwork)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithNoNetwork) }
@@ -951,7 +952,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given built in reader, when payment fails because of NoNetwork, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig, true))
                 .thenReturn(PaymentFlowError.NoNetwork)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithNoNetwork) }
@@ -969,7 +970,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given external reader, when payment fails because of Unknown, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.Unknown, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.Unknown, cardReaderConfig, false))
                 .thenReturn(Unknown)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithPaymentDeclined) }
@@ -986,7 +987,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given built in reader, when payment fails because of Unknown, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.Unknown, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.Unknown, cardReaderConfig, true))
                 .thenReturn(Unknown)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithPaymentDeclined) }
@@ -1004,7 +1005,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given external reader, when payment fails because of CARD_READ_TIMEOUT, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithCardReadTimeOut) }
@@ -1021,7 +1022,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given built in reader, when payment fails because of CARD_READ_TIMEOUT, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, true))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithCardReadTimeOut) }
@@ -1051,7 +1052,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given external reader, when payment fails because of NO_NETWORK, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.NoNetwork)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithNoNetwork) }
@@ -1068,7 +1069,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given built in reader, when payment fails because of NO_NETWORK, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig, true))
                 .thenReturn(PaymentFlowError.NoNetwork)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithNoNetwork) }
@@ -1086,7 +1087,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given external reader, when payment fails because of declined Unknown, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.Unknown, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.Unknown, cardReaderConfig, false))
                 .thenReturn(Unknown)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithPaymentDeclined) }
@@ -1103,7 +1104,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given built in reader, when payment fails because of declined Unknown, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.Unknown, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.Unknown, cardReaderConfig, true))
                 .thenReturn(Unknown)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithPaymentDeclined) }
@@ -1121,7 +1122,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given external reader, when payment fails because of CARD_READ_TIME_OUT, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithCardReadTimeOut) }
@@ -1138,7 +1139,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given built in reader, when payment fails because of CARD_READ_TIME_OUT, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, true))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithCardReadTimeOut) }
@@ -1156,7 +1157,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given external reader, when payment fails because of GENERIC_ERROR, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithValidDataForRetry) }
@@ -1173,7 +1174,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given built in reader, when payment fails because of GENERIC_ERROR, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, true))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithValidDataForRetry) }
@@ -1191,7 +1192,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given external reader, when payment fails because of SERVER_ERROR, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Server(""), cardReaderConfig)).thenReturn(
+            whenever(errorMapper.mapPaymentErrorToUiError(Server(""), cardReaderConfig, false)).thenReturn(
                 PaymentFlowError.Server
             )
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -1209,9 +1210,8 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given built in reader, when payment fails because of SERVER_ERROR, then error is mapped correctly`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Server(""), cardReaderConfig)).thenReturn(
-                PaymentFlowError.Server
-            )
+            whenever(errorMapper.mapPaymentErrorToUiError(Server(""), cardReaderConfig, true))
+                .thenReturn(PaymentFlowError.Server)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithServerError) }
             }
@@ -1229,8 +1229,13 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     fun `given external reader, when payment fails because of AMOUNT_TOO_SMALL, then error is mapped correctly`() =
         testBlocking {
             val error = AmountTooSmall(UiStringText("Amount must be at least US$0.50"))
-            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.AmountTooSmall, cardReaderConfig))
-                .thenReturn(error)
+            whenever(
+                errorMapper.mapPaymentErrorToUiError(
+                    DeclinedByBackendError.AmountTooSmall,
+                    cardReaderConfig,
+                    false
+                )
+            ).thenReturn(error)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithAmountTooSmall) }
             }
@@ -1247,8 +1252,13 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     fun `given built in reader, when payment fails because of AMOUNT_TOO_SMALL, then error is mapped correctly`() =
         testBlocking {
             val error = AmountTooSmall(UiStringText("Amount must be at least US$0.50"))
-            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.AmountTooSmall, cardReaderConfig))
-                .thenReturn(error)
+            whenever(
+                errorMapper.mapPaymentErrorToUiError(
+                    DeclinedByBackendError.AmountTooSmall,
+                    cardReaderConfig,
+                    true
+                )
+            ).thenReturn(error)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithAmountTooSmall) }
             }
@@ -1266,8 +1276,13 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     fun `given external reader, when payment fails because of AMOUNT_TOO_SMALL, then failed state has ok button`() =
         testBlocking {
             val error = AmountTooSmall(UiStringText("Amount must be at least US$0.50"))
-            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.AmountTooSmall, cardReaderConfig))
-                .thenReturn(error)
+            whenever(
+                errorMapper.mapPaymentErrorToUiError(
+                    DeclinedByBackendError.AmountTooSmall,
+                    cardReaderConfig,
+                    false
+                )
+            ).thenReturn(error)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithAmountTooSmall) }
             }
@@ -1284,8 +1299,13 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     fun `given built in reader, when payment fails because of AMOUNT_TOO_SMALL, then failed state has ok button`() =
         testBlocking {
             val error = AmountTooSmall(UiStringText("Amount must be at least US$0.50"))
-            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.AmountTooSmall, cardReaderConfig))
-                .thenReturn(error)
+            whenever(
+                errorMapper.mapPaymentErrorToUiError(
+                    DeclinedByBackendError.AmountTooSmall,
+                    cardReaderConfig,
+                    true
+                )
+            ).thenReturn(error)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithAmountTooSmall) }
             }
@@ -1302,7 +1322,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given external reader, when payment fails not because of AMOUNT_TOO_SMALL, then failed state has Try again button`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Server(""), cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Server(""), cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Server)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithServerError) }
@@ -1319,7 +1339,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given built in reader, when payment fails not because of AMOUNT_TOO_SMALL, then failed state has Try again button`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Server(""), cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Server(""), cardReaderConfig, true))
                 .thenReturn(PaymentFlowError.Server)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithServerError) }
@@ -1335,11 +1355,64 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given built in reader, when payment fails PIN_REQUIRED, then failed state has purchase card reader`() =
+        testBlocking {
+            whenever(
+                errorMapper.mapPaymentErrorToUiError(
+                    DeclinedByBackendError.CardDeclined.PinRequired,
+                    cardReaderConfig,
+                    true
+                )
+            ).thenReturn(PaymentFlowError.BuiltInReader.PinRequired)
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(PaymentFailed(DeclinedByBackendError.CardDeclined.PinRequired, mock(), "dummy msg")) }
+            }
+            initViewModel(BUILT_IN)
+
+            viewModel.start()
+
+            assertEquals(
+                (viewModel.viewStateData.value as BuiltInReaderFailedPaymentState).primaryActionLabel,
+                R.string.card_reader_payment_payment_failed_purchase_hardware_reader
+            )
+        }
+
+    @Test
+    fun `given built in reader, when purchase button clicked, then purchase even emmited`() =
+        testBlocking {
+            whenever(
+                errorMapper.mapPaymentErrorToUiError(
+                    DeclinedByBackendError.CardDeclined.PinRequired,
+                    cardReaderConfig,
+                    true
+                )
+            ).thenReturn(PaymentFlowError.BuiltInReader.PinRequired)
+            whenever(cardReaderManager.collectPayment(any())).thenAnswer {
+                flow { emit(PaymentFailed(DeclinedByBackendError.CardDeclined.PinRequired, mock(), "dummy msg")) }
+            }
+            whenever(wooStore.getStoreCountryCode(siteModel)).thenReturn("US")
+            initViewModel(BUILT_IN)
+
+            viewModel.start()
+            (viewModel.viewStateData.value as BuiltInReaderFailedPaymentState).onPrimaryActionClicked.invoke()
+
+            assertThat(viewModel.event.value).isInstanceOf(PurchaseCardReader::class.java)
+            assertThat((viewModel.event.value as PurchaseCardReader).url).isEqualTo(
+                "https://woocommerce.com/products/hardware/US"
+            )
+        }
+
+    @Test
     fun `given external reader, when payment fails because of AMOUNT_TOO_SMALL, then clicking on ok button triggers exit event`() =
         testBlocking {
             val error = AmountTooSmall(UiStringText("Amount must be at least US$0.50"))
-            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.AmountTooSmall, cardReaderConfig))
-                .thenReturn(error)
+            whenever(
+                errorMapper.mapPaymentErrorToUiError(
+                    DeclinedByBackendError.AmountTooSmall,
+                    cardReaderConfig,
+                    false
+                )
+            ).thenReturn(error)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithAmountTooSmall) }
             }
@@ -1354,8 +1427,13 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     fun `given built in reader, when payment fails because of AMOUNT_TOO_SMALL, then clicking on ok button triggers exit event`() =
         testBlocking {
             val error = AmountTooSmall(UiStringText("Amount must be at least US$0.50"))
-            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.AmountTooSmall, cardReaderConfig))
-                .thenReturn(error)
+            whenever(
+                errorMapper.mapPaymentErrorToUiError(
+                    DeclinedByBackendError.AmountTooSmall,
+                    cardReaderConfig,
+                    true
+                )
+            ).thenReturn(error)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithAmountTooSmall) }
             }
@@ -1370,7 +1448,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given user clicks on retry and external, when payment fails and retryData are null, then flow restarted from scratch`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -1387,7 +1465,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given user clicks on retry and built in, when payment fails and retryData are null, then flow restarted from scratch`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, true))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -1405,7 +1483,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given user clicks on retry and external, when payment fails, then retryCollectPayment invoked`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithValidDataForRetry) }
@@ -1421,7 +1499,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given user clicks on retry and built in, when payment fails, then retryCollectPayment invoked`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, true))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithValidDataForRetry) }
@@ -1438,7 +1516,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given user clicks on retry and external, when payment fails, then flow retried with provided PaymentData`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Generic)
             val paymentData = mock<PaymentData>()
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -1455,7 +1533,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given user clicks on retry and built in, when payment fails, then flow retried with provided PaymentData`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, true))
                 .thenReturn(PaymentFlowError.Generic)
             val paymentData = mock<PaymentData>()
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -1473,7 +1551,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given external failed payment, when user clicks on secondary button, then exit event is triggered`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Generic)
             val paymentData = mock<PaymentData>()
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -1490,7 +1568,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given built in failed payment, when user clicks on secondary button, then exit event is triggered`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, true))
                 .thenReturn(PaymentFlowError.Generic)
             val paymentData = mock<PaymentData>()
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
@@ -1648,7 +1726,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `when payment fails, then progress and secondary button is visible`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -1665,7 +1743,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given external reader, when payment fails, then correct labels, illustration and button are shown`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -1691,7 +1769,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given built in reader, when payment fails, then correct labels, illustration and button are shown`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, true))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(paymentFailedWithEmptyDataForRetry) }
@@ -1720,7 +1798,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `when payment fails with no network error, then correct paymentStateLabel is shown`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.NoNetwork)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentFailed(NoNetwork, null, "")) }
@@ -1736,7 +1814,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `when payment fails with payment unknown error, then correct paymentStateLabel is shown`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.Unknown, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(DeclinedByBackendError.Unknown, cardReaderConfig, false))
                 .thenReturn(Unknown)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentFailed(DeclinedByBackendError.Unknown, null, "")) }
@@ -1752,7 +1830,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `when payment fails with server error, then correct paymentStateLabel is shown`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Server(""), cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Server(""), cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Server)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentFailed(Server(""), null, "")) }
@@ -2369,7 +2447,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given payment flow is payment failed, when user presses back button, then cancel event is not tracked`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.NoNetwork)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentFailed(NoNetwork, null, "")) }
@@ -2620,7 +2698,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             whenever(cardReaderManager.readerStatus).thenReturn(
                 MutableStateFlow(CardReaderStatus.Connected(cardReader))
             )
-            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig, true))
                 .thenReturn(PaymentFlowError.NoNetwork)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentFailed(NoNetwork, null, "")) }
@@ -2642,7 +2720,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             whenever(cardReaderManager.readerStatus).thenReturn(
                 MutableStateFlow(CardReaderStatus.Connected(cardReader))
             )
-            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(NoNetwork, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.NoNetwork)
             whenever(cardReaderManager.collectPayment(any())).thenAnswer {
                 flow { emit(PaymentFailed(NoNetwork, null, "")) }
@@ -2713,7 +2791,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `given user leaves the screen, when payment succeeded on retry, then payment NOT canceled`() =
         testBlocking {
-            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig))
+            whenever(errorMapper.mapPaymentErrorToUiError(Generic, cardReaderConfig, false))
                 .thenReturn(PaymentFlowError.Generic)
             whenever(cardReaderManager.collectPayment(any()))
                 .thenAnswer {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9221
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds specific text and action button that leads to the HW reader purchase page when PIN is required during TTP payment

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Try to collect the 1.02 payment with TTP
* Notice the new screen
* Click on the "purchase a reader" button
* Notice a web page

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/bfe1b8d0-1f95-45c2-b573-db8c4b07591e



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
