### PR TITLE
Feature/9209 open blaze flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -17,8 +17,8 @@ class IsBlazeEnabled @Inject constructor(
 
     operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled()
 
-    fun buildUrlForCurrentSite(source: BlazeFlowSource): String {
-        val siteUrl = selectedSite.get().url
+    fun buildUrlForSite(source: BlazeFlowSource): String {
+        val siteUrl = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
         return BLAZE_CREATION_FLOW_SITE.format(siteUrl, source.trackingName)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -18,13 +18,13 @@ class IsBlazeEnabled @Inject constructor(
     operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled()
 
     fun buildUrlForSite(source: BlazeFlowSource): String {
-        val siteUrl = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
-        return BLAZE_CREATION_FLOW_SITE.format(siteUrl, source.trackingName)
+        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
+        return BLAZE_CREATION_FLOW_SITE.format(siteUrlWithoutProtocol, source.trackingName)
     }
 
     fun buildUrlForProduct(productId: Long, source: BlazeFlowSource): String {
-        val siteUrl = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
-        return BLAZE_CREATION_FLOW_PRODUCT.format(siteUrl, productId, source.trackingName)
+        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
+        return BLAZE_CREATION_FLOW_PRODUCT.format(siteUrlWithoutProtocol, productId, source.trackingName)
     }
 
     enum class BlazeFlowSource(val trackingName: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -1,8 +1,34 @@
 package com.woocommerce.android.ui.blaze
 
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.FeatureFlag
 import javax.inject.Inject
 
-class IsBlazeEnabled @Inject constructor() {
+class IsBlazeEnabled @Inject constructor(
+    private val selectedSite: SelectedSite
+) {
+    companion object {
+        private const val BASE_URL = "https://wordpress.com/advertising/"
+
+        const val BLAZE_CREATION_FLOW_PRODUCT = "$BASE_URL%s?blazepress-widget=post-%d&_source=%s"
+        const val BLAZE_CREATION_FLOW_SITE = "$BASE_URL%s?_source=%s"
+        const val HTTP_PATTERN = "(https?://)"
+    }
+
     operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled()
+
+    fun buildUrlForCurrentSite(source: BlazeFlowSource): String {
+        val siteUrl = selectedSite.get().url
+        return BLAZE_CREATION_FLOW_SITE.format(siteUrl, source.trackingName)
+    }
+
+    fun buildUrlForProduct(productId: Long, source: BlazeFlowSource): String {
+        val siteUrl = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
+        return BLAZE_CREATION_FLOW_PRODUCT.format(siteUrl, productId, source.trackingName)
+    }
+
+    enum class BlazeFlowSource(val trackingName: String) {
+        PRODUCT_DETAIL_OVERFLOW_MENU("product_more_menu"),
+        MORE_MENU_ITEM("menu"),
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -9,7 +9,9 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
+import com.woocommerce.android.R.string
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
@@ -89,9 +91,18 @@ class MoreMenuFragment : TopLevelFragment() {
                 is ViewInboxEvent -> navigateToInbox()
                 is ViewCouponsEvent -> navigateToCoupons()
                 is ViewPayments -> navigateToPayments()
-                is OpenBlazeEvent -> openInBrowser(event.url)
+                is OpenBlazeEvent -> openBlazeWebview(event)
             }
         }
+    }
+
+    private fun openBlazeWebview(event: OpenBlazeEvent) {
+        findNavController().navigateSafely(
+            NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+                urlToLoad = event.url,
+                title = getString(string.more_menu_button_blaze)
+            )
+        )
     }
 
     private fun navigateToPayments() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.NavigateToSettingsEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.NavigateToSubscriptionsEvent
+import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.OpenBlazeEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.StartSitePickerEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewAdminEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewCouponsEvent
@@ -88,6 +89,7 @@ class MoreMenuFragment : TopLevelFragment() {
                 is ViewInboxEvent -> navigateToInbox()
                 is ViewCouponsEvent -> navigateToCoupons()
                 is ViewPayments -> navigateToPayments()
+                is OpenBlazeEvent -> openInBrowser(event.url)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource.MORE_MENU_ITEM
 import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
 import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.payments.taptopay.isAvailable
@@ -196,7 +197,11 @@ class MoreMenuViewModel @Inject constructor(
     }
 
     private fun onPromoteProductsWithBlaze() {
-        triggerEvent(MoreMenuEvent.OpenBlazeEvent("TODO"))
+        triggerEvent(
+            MoreMenuEvent.OpenBlazeEvent(
+                url = isBlazeEnabled.buildUrlForSite(MORE_MENU_ITEM)
+            )
+        )
     }
 
     private fun onViewAdminButtonClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -23,7 +23,9 @@ import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.transition.MaterialContainerTransform
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
+import com.woocommerce.android.R.string
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -33,6 +35,7 @@ import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
@@ -46,6 +49,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.products.ProductDetailViewModel.HideImageUploadErrorSnackbar
 import com.woocommerce.android.ui.products.ProductDetailViewModel.MenuButtonsState
+import com.woocommerce.android.ui.products.ProductDetailViewModel.NavigateToBlazeProductWebView
 import com.woocommerce.android.ui.products.ProductDetailViewModel.OpenProductDetails
 import com.woocommerce.android.ui.products.ProductDetailViewModel.RefreshMenu
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ShowDuplicateProductError
@@ -309,6 +313,7 @@ class ProductDetailFragment :
                 is ShowLinkedProductPromoBanner -> showLinkedProductPromoBanner()
                 is OpenProductDetails -> openProductDetails(event.productRemoteId)
                 is ShowDuplicateProductError -> showDuplicateProductError()
+                is NavigateToBlazeProductWebView -> openBlazeProductWebView(event)
                 is ShowDuplicateProductInProgress -> showProgressDialog(
                     R.string.product_duplicate_progress_title,
                     R.string.product_duplicate_progress_body
@@ -317,6 +322,15 @@ class ProductDetailFragment :
                 else -> event.isHandled = false
             }
         }
+    }
+
+    private fun openBlazeProductWebView(event: NavigateToBlazeProductWebView) {
+        findNavController().navigateSafely(
+            NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+                urlToLoad = event.url,
+                title = getString(string.more_menu_button_blaze)
+            )
+        )
     }
 
     private fun showDuplicateProductError() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -292,10 +292,7 @@ class ProductDetailFragment :
     private fun observeEvents(viewModel: ProductDetailViewModel) {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is LaunchUrlInChromeTab -> {
-                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
-                }
-
+                is LaunchUrlInChromeTab -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 is RefreshMenu -> activity?.invalidateOptionsMenu()
                 is ExitWithResult<*> -> {
                     navigateBackWithResult(
@@ -464,6 +461,11 @@ class ProductDetailFragment :
 
             R.id.menu_trash_product -> {
                 viewModel.onTrashButtonClicked()
+                true
+            }
+
+            R.id.promote_with_blaze -> {
+                viewModel.onPromoteWithBlazeClicked()
                 true
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -46,6 +46,7 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.media.getMediaUploadErrorMessage
 import com.woocommerce.android.ui.products.AddProductSource.STORE_ONBOARDING
@@ -393,6 +394,19 @@ class ProductDetailViewModel @Inject constructor(
             viewState.productDraft?.let {
                 triggerEvent(ProductNavigationTarget.ShareProduct(it.permalink, it.name))
             }
+        }
+    }
+
+    fun onPromoteWithBlazeClicked() {
+        viewState.productDraft?.let {
+            triggerEvent(
+                LaunchUrlInChromeTab(
+                    url = isBlazeEnabled.buildUrlForProduct(
+                        productId = it.remoteId,
+                        source = BlazeFlowSource.PRODUCT_DETAIL_OVERFLOW_MENU
+                    )
+                )
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -400,7 +400,7 @@ class ProductDetailViewModel @Inject constructor(
     fun onPromoteWithBlazeClicked() {
         viewState.productDraft?.let {
             triggerEvent(
-                LaunchUrlInChromeTab(
+                NavigateToBlazeProductWebView(
                     url = isBlazeEnabled.buildUrlForProduct(
                         productId = it.remoteId,
                         source = BlazeFlowSource.PRODUCT_DETAIL_OVERFLOW_MENU
@@ -2331,6 +2331,8 @@ class ProductDetailViewModel @Inject constructor(
     object ShowDuplicateProductError : Event()
 
     object ShowDuplicateProductInProgress : Event()
+
+    data class NavigateToBlazeProductWebView(val url: String) : Event()
 
     /**
      * [productDraft] is used for the UI. Any updates to the fields in the UI would update this model.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9209 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Handles taps on Blaze CTAs
### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
On an atomic site store: 
- Open product detail -> overflow menu -> promote with Blaze. Check that the Blaze webview is loaded for the given product (like in the screencast below)
- Navigate to more menu -> Blaze. Check that Blaze general webview is open with a list of all the products or post you can Blaze
### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/2663464/ba8f2452-637c-4c3c-bfe8-0779a0522da1



- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
