### PR TITLE
Feature/9209 use new canblaze field

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -9,13 +9,12 @@ class IsBlazeEnabled @Inject constructor(
 ) {
     companion object {
         private const val BASE_URL = "https://wordpress.com/advertising/"
-
         const val BLAZE_CREATION_FLOW_PRODUCT = "$BASE_URL%s?blazepress-widget=post-%d&_source=%s"
         const val BLAZE_CREATION_FLOW_SITE = "$BASE_URL%s?_source=%s"
         const val HTTP_PATTERN = "(https?://)"
     }
 
-    operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled()
+    operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled() && selectedSite.get().canBlaze ?: false
 
     fun buildUrlForSite(source: BlazeFlowSource): String {
         val siteUrl = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -31,7 +31,9 @@ class IsBlazeEnabled @Inject constructor(
         return BLAZE_CREATION_FLOW_PRODUCT.format(siteUrl, productId, source.trackingName)
     }
 
-    private fun hasAdministratorRole() = userEligibilityFetcher.getUser()?.roles?.any { it is Administrator } ?: false
+    private fun hasAdministratorRole() =
+        selectedSite.exists() &&
+            userEligibilityFetcher.getUser()?.roles?.any { it is Administrator } ?: false
 
     enum class BlazeFlowSource(val trackingName: String) {
         PRODUCT_DETAIL_OVERFLOW_MENU("product_more_menu"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -14,7 +14,7 @@ class IsBlazeEnabled @Inject constructor(
         const val HTTP_PATTERN = "(https?://)"
     }
 
-    operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled() && selectedSite.get().canBlaze ?: false
+    operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled() && selectedSite.getIfExists()?.canBlaze ?: false
 
     fun buildUrlForSite(source: BlazeFlowSource): String {
         val siteUrl = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-466e0b8f67bfb134682e4d03a408f4f25b7d3693'
+    fluxCVersion = '2753-68a84aff91bef1ce914948066ef425e3826af3af'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2753-68a84aff91bef1ce914948066ef425e3826af3af'
+    fluxCVersion = 'trunk-9037aa3c964116d7ee5629f87859a63257fff43c'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9209 
<!-- Id number of the GitHub issue this PR addresses. -->

~~On hold as we don't know how reliable the API values for `can_blaze` field are. Discussions are ongoing. For now, we'll rely on fetching blaze status using the endpoint `/wpcom/v2/sites/{blogId}/blaze/status`~~

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After further investigation and discussion it's reliable to use the new field `can_blaze`. One caveat is we need to check for the user role as only `administrator` roles are allowed to Blaze sites or products. 
This PR uses the `can_blaze` field as well as checks the current user role to determine if Blaze is enabled for a given site and user. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The easiest way to test this is to switch between 2 sites where one has blaze enabled and other doesn't. Possible options: 
- Switch between an atomic published site where you are and `administrator` user and another site where you are a `shopManager`. In the `shopManager` role Blaze CTAs will be gone. 
- Switch between a public atomic site and another atomic site that has not been published yet, like for example any free trial store. In the free trial store, Blaze will be disabled. 

The screencast below shows where are the 2 entry points that should be verified are visible/hidden depending on the selected site. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/3b142da2-d8a7-4c82-99e0-605ce659093c

