### PR TITLE
[Mobile Payments] Rounded corners to the payment dialogs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+14.2
+-----
+- [*] [Internal] Rounded corners to the payments dialogs [https://github.com/woocommerce/woocommerce-android/pull/9231]
+
 14.1
 -----
 - [*][Internal] Fixed database access race condition in Product Selector affecting local search performance and featured products selection [https://github.com/woocommerce/woocommerce-android/pull/9202]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/PaymentsBaseDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/PaymentsBaseDialogFragment.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.payments
+
+import android.os.Bundle
+import androidx.annotation.LayoutRes
+import androidx.fragment.app.DialogFragment
+import com.woocommerce.android.R
+
+abstract class PaymentsBaseDialogFragment(@LayoutRes val contentLayoutId: Int) : DialogFragment(contentLayoutId) {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(STYLE_NO_TITLE, R.style.Theme_Woo_Dialog_RoundedCorners)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -12,11 +12,9 @@ import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.Window
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
@@ -29,6 +27,7 @@ import com.woocommerce.android.databinding.CardReaderConnectDialogBinding
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.ui.payments.PaymentsBaseDialogFragment
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.CheckBluetoothEnabled
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.CheckBluetoothPermissionsGiven
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectEvent.CheckLocationEnabled
@@ -55,7 +54,7 @@ import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_connect_dialog) {
+class CardReaderConnectDialogFragment : PaymentsBaseDialogFragment(R.layout.card_reader_connect_dialog) {
     val viewModel: CardReaderConnectViewModel by viewModels()
 
     @Inject lateinit var locationUtils: LocationUtils
@@ -83,10 +82,7 @@ class CardReaderConnectDialogFragment : DialogFragment(R.layout.card_reader_conn
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        dialog?.let {
-            it.setCanceledOnTouchOutside(false)
-            it.requestWindowFeature(Window.FEATURE_NO_TITLE)
-        }
+        dialog?.setCanceledOnTouchOutside(false)
         return super.onCreateView(inflater, container, savedInstanceState)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderWelcomeDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderWelcomeDialogFragment.kt
@@ -1,28 +1,20 @@
 package com.woocommerce.android.ui.payments.cardreader.onboarding
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import android.view.Window
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.CardReaderWelcomeDialogBinding
+import com.woocommerce.android.ui.payments.PaymentsBaseDialogFragment
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderWelcomeViewModel.CardReaderWelcomeDialogEvent.NavigateToOnboardingFlow
 import com.woocommerce.android.util.UiHelpers
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class CardReaderWelcomeDialogFragment : DialogFragment(R.layout.card_reader_welcome_dialog) {
+class CardReaderWelcomeDialogFragment : PaymentsBaseDialogFragment(R.layout.card_reader_welcome_dialog) {
     val viewModel: CardReaderWelcomeViewModel by viewModels()
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        dialog?.requestWindowFeature(Window.FEATURE_NO_TITLE)
-        return super.onCreateView(inflater, container, savedInstanceState)
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         val binding = CardReaderWelcomeDialogBinding.bind(view)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
@@ -9,10 +9,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.Window
 import androidx.activity.ComponentDialog
 import androidx.activity.addCallback
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
@@ -24,6 +22,7 @@ import com.woocommerce.android.model.UiString
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.requests.SupportRequestFormActivity
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.payments.PaymentsBaseDialogFragment
 import com.woocommerce.android.ui.payments.cardreader.payment.ViewState.BuiltInReaderPaymentSuccessfulReceiptSentAutomaticallyState
 import com.woocommerce.android.ui.payments.cardreader.payment.ViewState.BuiltInReaderPaymentSuccessfulState
 import com.woocommerce.android.ui.payments.cardreader.payment.ViewState.ExternalReaderPaymentSuccessfulReceiptSentAutomaticallyState
@@ -41,7 +40,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_payment_dialog) {
+class CardReaderPaymentDialogFragment : PaymentsBaseDialogFragment(R.layout.card_reader_payment_dialog) {
     val viewModel: CardReaderPaymentViewModel by viewModels()
 
     @Inject
@@ -51,10 +50,7 @@ class CardReaderPaymentDialogFragment : DialogFragment(R.layout.card_reader_paym
     lateinit var uiMessageResolver: UIMessageResolver
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        dialog?.let {
-            it.setCanceledOnTouchOutside(false)
-            it.requestWindowFeature(Window.FEATURE_NO_TITLE)
-        }
+        dialog?.setCanceledOnTouchOutside(false)
         return super.onCreateView(inflater, container, savedInstanceState)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerDialogFragment.kt
@@ -4,23 +4,19 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.Window
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.exhaustive
+import com.woocommerce.android.ui.payments.PaymentsBaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class CardReaderStatusCheckerDialogFragment : DialogFragment(R.layout.card_reader_status_checker_dialog) {
+class CardReaderStatusCheckerDialogFragment : PaymentsBaseDialogFragment(R.layout.card_reader_status_checker_dialog) {
     val viewModel: CardReaderStatusCheckerViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        dialog?.let {
-            it.setCanceledOnTouchOutside(false)
-            it.requestWindowFeature(Window.FEATURE_NO_TITLE)
-        }
+        dialog?.setCanceledOnTouchOutside(false)
         return super.onCreateView(inflater, container, savedInstanceState)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/tutorial/CardReaderTutorialDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/tutorial/CardReaderTutorialDialogFragment.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.Window
-import androidx.fragment.app.DialogFragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.viewpager2.widget.ViewPager2
@@ -14,13 +12,14 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.CardReaderTutorialDialogBinding
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.ui.payments.PaymentsBaseDialogFragment
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType.BUILT_IN
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class CardReaderTutorialDialogFragment : DialogFragment(R.layout.card_reader_tutorial_dialog) {
+class CardReaderTutorialDialogFragment : PaymentsBaseDialogFragment(R.layout.card_reader_tutorial_dialog) {
     private val args: CardReaderTutorialDialogFragmentArgs by navArgs()
     @Inject lateinit var appPrefs: AppPrefs
 
@@ -28,7 +27,6 @@ class CardReaderTutorialDialogFragment : DialogFragment(R.layout.card_reader_tut
         dialog?.let {
             it.setCancelable(false)
             it.setCanceledOnTouchOutside(false)
-            it.requestWindowFeature(Window.FEATURE_NO_TITLE)
         }
 
         if (!appPrefs.getShowCardReaderConnectedTutorial() || args.cardReaderType == BUILT_IN) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/update/CardReaderUpdateDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/update/CardReaderUpdateDialogFragment.kt
@@ -5,16 +5,15 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.Window
 import androidx.activity.ComponentDialog
 import androidx.activity.addCallback
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.CardReaderUpdateDialogBinding
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.model.UiString
+import com.woocommerce.android.ui.payments.PaymentsBaseDialogFragment
 import com.woocommerce.android.ui.payments.cardreader.update.CardReaderUpdateViewModel.CardReaderUpdateEvent.SoftwareUpdateAboutToStart
 import com.woocommerce.android.ui.payments.cardreader.update.CardReaderUpdateViewModel.CardReaderUpdateEvent.SoftwareUpdateProgress
 import com.woocommerce.android.ui.payments.cardreader.update.CardReaderUpdateViewModel.UpdateResult
@@ -23,14 +22,11 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class CardReaderUpdateDialogFragment : DialogFragment(R.layout.card_reader_update_dialog) {
+class CardReaderUpdateDialogFragment : PaymentsBaseDialogFragment(R.layout.card_reader_update_dialog) {
     val viewModel: CardReaderUpdateViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        with(requireDialog()) {
-            this.setCanceledOnTouchOutside(false)
-            this.requestWindowFeature(Window.FEATURE_NO_TITLE)
-        }
+        requireDialog().setCanceledOnTouchOutside(false)
         return super.onCreateView(inflater, container, savedInstanceState)
     }
 
@@ -50,39 +46,40 @@ class CardReaderUpdateDialogFragment : DialogFragment(R.layout.card_reader_updat
 
     private fun initObservers(binding: CardReaderUpdateDialogBinding) {
         viewModel.event.observe(
-            viewLifecycleOwner,
-            { event ->
-                when (event) {
-                    is ExitWithResult<*> -> navigateBackWithResult(
-                        KEY_READER_UPDATE_RESULT,
-                        event.data as UpdateResult
-                    )
-                    is SoftwareUpdateProgress ->
-                        announceSoftwareUpdateProgress(event.progress, binding)
-                    is SoftwareUpdateAboutToStart ->
-                        binding.root.announceForAccessibility(getString(event.accessibilityText))
-                    else -> event.isHandled = false
-                }
+            viewLifecycleOwner
+        ) { event ->
+            when (event) {
+                is ExitWithResult<*> -> navigateBackWithResult(
+                    KEY_READER_UPDATE_RESULT,
+                    event.data as UpdateResult
+                )
+
+                is SoftwareUpdateProgress ->
+                    announceSoftwareUpdateProgress(event.progress, binding)
+
+                is SoftwareUpdateAboutToStart ->
+                    binding.root.announceForAccessibility(getString(event.accessibilityText))
+
+                else -> event.isHandled = false
             }
-        )
+        }
 
         viewModel.viewStateData.observe(
-            viewLifecycleOwner,
-            { state ->
-                with(binding) {
-                    UiHelpers.setTextOrHide(titleTextView, state.title)
-                    UiHelpers.setTextOrHide(descriptionTextView, state.description)
-                    UiHelpers.setTextOrHide(progressTextView, state.progressText)
-                    UiHelpers.setTextOrHide(actionButton, state.button?.text)
-                    with(progressCircleProgressOverlayView) {
-                        UiHelpers.updateVisibility(this, state.progress != null)
-                        currentProgressPercentage = state.progress ?: 0
-                    }
-                    UiHelpers.setImageOrHideInLandscape(progressImageView, state.illustration)
-                    actionButton.setOnClickListener { state.button?.onActionClicked?.invoke() }
+            viewLifecycleOwner
+        ) { state ->
+            with(binding) {
+                UiHelpers.setTextOrHide(titleTextView, state.title)
+                UiHelpers.setTextOrHide(descriptionTextView, state.description)
+                UiHelpers.setTextOrHide(progressTextView, state.progressText)
+                UiHelpers.setTextOrHide(actionButton, state.button?.text)
+                with(progressCircleProgressOverlayView) {
+                    UiHelpers.updateVisibility(this, state.progress != null)
+                    currentProgressPercentage = state.progress ?: 0
                 }
+                UiHelpers.setImageOrHideInLandscape(progressImageView, state.illustration)
+                actionButton.setOnClickListener { state.button?.onActionClicked?.invoke() }
             }
-        )
+        }
     }
 
     private fun announceSoftwareUpdateProgress(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsDialog.kt
@@ -6,7 +6,6 @@ import android.view.View
 import androidx.activity.ComponentDialog
 import androidx.activity.addCallback
 import androidx.core.view.isVisible
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
@@ -16,6 +15,7 @@ import com.woocommerce.android.extensions.filterNotNull
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.payments.PaymentsBaseDialogFragment
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -25,18 +25,13 @@ import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class SimplePaymentsDialog : DialogFragment(R.layout.dialog_simple_payments) {
+class SimplePaymentsDialog : PaymentsBaseDialogFragment(R.layout.dialog_simple_payments) {
     @Inject
     lateinit var currencyFormatter: CurrencyFormatter
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
 
     private val viewModel: SimplePaymentsDialogViewModel by viewModels()
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setStyle(STYLE_NO_TITLE, R.style.Theme_Woo_Dialog)
-    }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = ComponentDialog(requireContext(), theme)

--- a/WooCommerce/src/main/res/values/themes.xml
+++ b/WooCommerce/src/main/res/values/themes.xml
@@ -126,6 +126,12 @@
         <item name="android:buttonBarStyle">@style/Woo.Dialog.ButtonBar</item>
     </style>
 
+    <style name="Theme.Woo.Dialog.RoundedCorners" parent="Theme.Woo.Dialog">
+        <item name="dialogCornerRadius">8dp</item>
+        <item name="android:windowMinWidthMajor">0%</item>
+        <item name="android:windowMinWidthMinor">0%</item>
+    </style>
+
     <style name="Woo.Dialog"/>
     <style name="Woo.Dialog.ButtonBar">
         <item name="android:paddingStart">@dimen/minor_100</item>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9037
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds rounded corners to all payments dialogs as per design request

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Run TPP and IPP both dark and light mode
* Notice that each dialog has rounded corners now

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/ad9f25a5-3bfb-4b7f-802c-00d26fed1b64





- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
