### PR TITLE
Feature/9209 check if blaze enabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -2,20 +2,35 @@ package com.woocommerce.android.ui.blaze
 
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.FeatureFlag
+import kotlinx.coroutines.flow.map
+import org.wordpress.android.fluxc.store.blaze.BlazeStore
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class IsBlazeEnabled @Inject constructor(
-    private val selectedSite: SelectedSite
+    private val selectedSite: SelectedSite,
+    private val blazeStore: BlazeStore
 ) {
     companion object {
         private const val BASE_URL = "https://wordpress.com/advertising/"
-
         const val BLAZE_CREATION_FLOW_PRODUCT = "$BASE_URL%s?blazepress-widget=post-%d&_source=%s"
         const val BLAZE_CREATION_FLOW_SITE = "$BASE_URL%s?_source=%s"
         const val HTTP_PATTERN = "(https?://)"
     }
 
-    operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled()
+    private var blazeStatus = false
+
+    operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled() && blazeStatus
+
+    suspend fun fetchBlazeStatus() {
+        blazeStore.fetchBlazeStatus(selectedSite.get())
+        blazeStore.getBlazeStatus(selectedSite.get().siteId)
+            .map { it.model?.firstOrNull() }
+            .collect {
+                blazeStatus = it?.isEligible ?: false
+            }
+    }
 
     fun buildUrlForSite(source: BlazeFlowSource): String {
         val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.extensions.getSiteName
 import com.woocommerce.android.extensions.isSimpleWPComSite
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.UnifiedLoginTracker
@@ -64,7 +65,8 @@ class SitePickerViewModel @Inject constructor(
     private val unifiedLoginTracker: UnifiedLoginTracker,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val userEligibilityFetcher: UserEligibilityFetcher,
-    private val experimentTracker: ExperimentTracker
+    private val experimentTracker: ExperimentTracker,
+    private val isBlazeEnabled: IsBlazeEnabled,
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val WOOCOMMERCE_INSTALLATION_URL = "https://wordpress.com/plugins/woocommerce/"
@@ -501,7 +503,7 @@ class SitePickerViewModel @Inject constructor(
                             userEligibilityFetcher.fetchUserInfo().fold(
                                 onSuccess = {
                                     sitePickerViewState = sitePickerViewState.copy(isProgressDiaLogVisible = false)
-
+                                    launch { isBlazeEnabled.fetchBlazeStatus() }
                                     trackLoginEvent(currentStep = UnifiedLoginTracker.Step.SUCCESS)
                                     appPrefsWrapper.removeLoginSiteAddress()
                                     triggerEvent(SitePickerEvent.NavigateToMainActivityEvent)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9209 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Dynamically fetches Blaze status from endpoint `sites/$siteId/blaze/status/` to show or hide the different Blaze entry points for the given site. 
 
### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The easiest way to test this is to switch between 2 sites where one has blaze enabled and other doesn't. Possible options: 
- Switch between an atomic published site where you are and `admin` user and other site where you are a `shopManager`. In the `shopManager` role Blaze will be disabled. 
- Switch between a public atomic site and other atomic site that has not been published yet, like for example any free trial store. In the free trial store Blaze will be disabled. 

The screencast below shows where are the 2 entry points that should be verified are visible/hidden depending on the selected site. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/3b142da2-d8a7-4c82-99e0-605ce659093c



- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
