### PR TITLE
Feature/9209 blaze remote feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -4,11 +4,14 @@ import com.woocommerce.android.model.UserRole.Administrator
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
 import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
+import com.woocommerce.android.util.RemoteFeatureFlag.WOO_BLAZE
 import javax.inject.Inject
 
 class IsBlazeEnabled @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val userEligibilityFetcher: UserEligibilityFetcher
+    private val userEligibilityFetcher: UserEligibilityFetcher,
+    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
 ) {
     companion object {
         private const val BASE_URL = "https://wordpress.com/advertising/"
@@ -17,9 +20,10 @@ class IsBlazeEnabled @Inject constructor(
         const val HTTP_PATTERN = "(https?://)"
     }
 
-    operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled() &&
+    suspend operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled() &&
         hasAdministratorRole() &&
-        selectedSite.getIfExists()?.canBlaze ?: false
+        selectedSite.getIfExists()?.canBlaze ?: false &&
+        isRemoteFeatureFlagEnabled(WOO_BLAZE)
 
     fun buildUrlForSite(source: BlazeFlowSource): String {
         val siteUrl = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -21,7 +21,7 @@ class IsBlazeEnabled @Inject constructor(
     }
 
     suspend operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled() &&
-        hasAdministratorRole() &&
+        userIsAdminForCurrentSite() &&
         selectedSite.getIfExists()?.canBlaze ?: false &&
         isRemoteFeatureFlagEnabled(WOO_BLAZE)
 
@@ -35,7 +35,7 @@ class IsBlazeEnabled @Inject constructor(
         return BLAZE_CREATION_FLOW_PRODUCT.format(siteUrl, productId, source.trackingName)
     }
 
-    private fun hasAdministratorRole() =
+    private fun userIsAdminForCurrentSite() =
         selectedSite.exists() &&
             userEligibilityFetcher.getUser()?.roles?.any { it is Administrator } ?: false
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -51,6 +51,7 @@ import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.media.getMediaUploadErrorMessage
 import com.woocommerce.android.ui.products.AddProductSource.STORE_ONBOARDING
 import com.woocommerce.android.ui.products.ProductDetailBottomSheetBuilder.ProductDetailBottomSheetUiItem
+import com.woocommerce.android.ui.products.ProductStatus.DRAFT
 import com.woocommerce.android.ui.products.addons.AddonRepository
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.categories.ProductCategoryItemUiModel
@@ -274,9 +275,7 @@ class ProductDetailViewModel @Inject constructor(
                 shareOption = showShareOption,
                 showShareOptionAsActionWithText = showShareOptionAsActionWithText,
                 trashOption = !isProductUnderCreation && navArgs.isTrashEnabled,
-                showPromoteWithBlaze = isBlazeEnabled() &&
-                    getProductVisibility() == PUBLIC &&
-                    productDraft.status != ProductStatus.DRAFT
+                showPromoteWithBlaze = shouldShowBlaze(productDraft)
             )
         }.asLiveData()
 
@@ -2285,6 +2284,11 @@ class ProductDetailViewModel @Inject constructor(
         if (FeatureFlag.COMPOSITE_PRODUCTS_READ_ONLY_SUPPORT.isEnabled().not()) return null
         return getComponentProducts(remoteId)
     }
+
+    private suspend fun shouldShowBlaze(productDraft: Product) =
+        getProductVisibility() == PUBLIC &&
+            productDraft.status != DRAFT &&
+            isBlazeEnabled()
 
     /**
      * Sealed class that handles the back navigation for the product detail screens while providing a common

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -52,12 +52,12 @@ enum class FeatureFlag {
             STORE_CREATION_PROFILER,
             COMPOSITE_PRODUCTS_READ_ONLY_SUPPORT,
             EU_SHIPPING_NOTIFICATION,
-            PRIVACY_CHOICES -> true
+            PRIVACY_CHOICES,
+            BLAZE -> true
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
-            IPP_TAP_TO_PAY,
-            BLAZE -> PackageUtils.isDebugBuild()
+            IPP_TAP_TO_PAY -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_1D_AFTE
 import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES
 import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D
 import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_STORE_CREATION_READY
+import com.woocommerce.android.util.RemoteFeatureFlag.WOO_BLAZE
 import javax.inject.Inject
 
 class IsRemoteFeatureFlagEnabled @Inject constructor(
@@ -15,7 +16,8 @@ class IsRemoteFeatureFlagEnabled @Inject constructor(
             LOCAL_NOTIFICATION_STORE_CREATION_READY,
             LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D,
             LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES,
-            LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES ->
+            LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES,
+            WOO_BLAZE ->
                 PackageUtils.isDebugBuild() ||
                     wpComRemoteFeatureFlagRepository.isRemoteFeatureFlagEnabled(featureFlag.remoteKey)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/RemoteFeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/RemoteFeatureFlag.kt
@@ -4,5 +4,6 @@ enum class RemoteFeatureFlag(val remoteKey: String) {
     LOCAL_NOTIFICATION_STORE_CREATION_READY("woo_notification_store_creation_ready"),
     LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D("woo_notification_nudge_free_trial_after_1d"),
     LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES("woo_notification_1d_before_free_trial_expires"),
-    LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES("woo_notification_1d_after_free_trial_expires")
+    LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES("woo_notification_1d_after_free_trial_expires"),
+    WOO_BLAZE("woo_blaze")
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -69,7 +69,9 @@ class MoreMenuViewModelTests : BaseUnitTest() {
     }
 
     private val appPrefsWrapper: AppPrefsWrapper = mock()
-    private val isBlazeEnabled: IsBlazeEnabled = mock()
+    private val isBlazeEnabled: IsBlazeEnabled = mock {
+        onBlocking { invoke() } doReturn false
+    }
 
     private lateinit var viewModel: MoreMenuViewModel
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.media.ProductImagesServiceWrapper
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.media.MediaFileUploadHandler.ProductImageUploadData
 import com.woocommerce.android.ui.media.MediaFileUploadHandler.UploadStatus
@@ -95,6 +96,10 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     }
     private val addonRepository: AddonRepository = mock {
         onBlocking { hasAnyProductSpecificAddons(any()) } doReturn false
+    }
+
+    private val isBlazeEnabled: IsBlazeEnabled = mock {
+        onBlocking { invoke() } doReturn false
     }
 
     private var savedState: SavedStateHandle =
@@ -254,7 +259,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                 mock(),
                 mock(),
                 mock(),
-                mock()
+                isBlazeEnabled
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.media.ProductImagesServiceWrapper
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.products.ProductDetailViewModel.MenuButtonsState
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductDetailViewState
@@ -78,7 +79,9 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         on { it.observeCurrentUploads(any()) } doReturn flowOf(emptyList())
         on { it.observeSuccessfulUploads(any()) } doReturn emptyFlow()
     }
-
+    private val isBlazeEnabled: IsBlazeEnabled = mock {
+        onBlocking { invoke() } doReturn false
+    }
     private var savedState: SavedStateHandle =
         ProductDetailFragmentArgs(remoteProductId = PRODUCT_REMOTE_ID, isAddProduct = true).initSavedStateHandle()
 
@@ -181,7 +184,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 mock(),
                 mock(),
                 mock(),
-                mock()
+                isBlazeEnabled
             )
         )
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9209

⚠️ Don't merge until base branch is `trunk`
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Checks new `woo_blaze` remove feature flag to show or hide Blaze options. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Apply this patch to the app to upgrade the apps version to `14.1` and test if remote feature flag is enabled for that version onwards: 

```diff
Subject: [PATCH] Increase app version number to test remote feature flag
---
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt	(revision 9649b009259e3c6cf1a2c220609c8510517cfb52)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt	(date 1686842800317)
@@ -17,9 +17,7 @@
             LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D,
             LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES,
             LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES,
-            WOO_BLAZE ->
-                PackageUtils.isDebugBuild() ||
-                    wpComRemoteFeatureFlagRepository.isRemoteFeatureFlagEnabled(featureFlag.remoteKey)
+            WOO_BLAZE -> wpComRemoteFeatureFlagRepository.isRemoteFeatureFlagEnabled(featureFlag.remoteKey)
         }
     }
 }
Index: WooCommerce/build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/build.gradle b/WooCommerce/build.gradle
--- a/WooCommerce/build.gradle	(revision 9649b009259e3c6cf1a2c220609c8510517cfb52)
+++ b/WooCommerce/build.gradle	(date 1686842800325)
@@ -79,9 +79,9 @@
         if (project.hasProperty("versionName")) {
             versionName project.property("versionName")
         } else {
-            versionName "14.0-rc-1"
+            versionName "14.1"
         }
-        versionCode 424
+        versionCode 425
 
         minSdkVersion gradle.ext.minSdkVersion
         // Update targetSdkVersion only after reviewing all the OS changes (developer.android.com/about/versions/[ENTER_ANDROID_VERSION]/migration)

```

After applying the patch, open a public/launched atomic store and check the 2 Blaze entry points are displayed in: 
- More Menu tab as a menu item
- Product detail as an overflow menu item
