### PR TITLE
Handle EAN-13, EAN-8 barcode formats

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 14.2
 -----
 - [*] [Internal] Rounded corners to the payments dialogs [https://github.com/woocommerce/woocommerce-android/pull/9231]
+- [*] [Internal] Adding products via barcode scanning - Handle EAN-13, EAN-8 barcode formats [https://github.com/woocommerce/woocommerce-android/pull/9240]
 
 14.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemover.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemover.kt
@@ -8,18 +8,18 @@ interface CheckDigitRemover {
 
 class UPCCheckDigitRemover @Inject constructor() : CheckDigitRemover {
     override fun getSKUWithoutCheckDigit(sku: String): String {
-        return sku.substring(0, sku.length - 1)
+        return sku.dropLast(1)
     }
 }
 
 class EAN13CheckDigitRemover @Inject constructor() : CheckDigitRemover {
     override fun getSKUWithoutCheckDigit(sku: String): String {
-        return sku.substring(0, sku.length - 1)
+        return sku.dropLast(1)
     }
 }
 
 class EAN8CheckDigitRemover @Inject constructor() : CheckDigitRemover {
     override fun getSKUWithoutCheckDigit(sku: String): String {
-        return sku.substring(0, sku.length - 1)
+        return sku.dropLast(1)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemover.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemover.kt
@@ -11,3 +11,15 @@ class UPCCheckDigitRemover @Inject constructor() : CheckDigitRemover {
         return sku.substring(0, sku.length - 1)
     }
 }
+
+class EAN13CheckDigitRemover @Inject constructor() : CheckDigitRemover {
+    override fun getSKUWithoutCheckDigit(sku: String): String {
+        return sku.substring(0, sku.length - 1)
+    }
+}
+
+class EAN8CheckDigitRemover @Inject constructor() : CheckDigitRemover {
+    override fun getSKUWithoutCheckDigit(sku: String): String {
+        return sku.substring(0, sku.length - 1)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactory.kt
@@ -1,0 +1,18 @@
+package com.woocommerce.android.ui.orders.creation
+
+import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
+import javax.inject.Inject
+
+class CheckDigitRemoverFactory @Inject constructor() {
+    fun getCheckDigitRemoverFor(barcodeFormat: BarcodeFormat) : CheckDigitRemover {
+        return when (barcodeFormat) {
+            BarcodeFormat.FormatEAN13 -> EAN13CheckDigitRemover()
+            BarcodeFormat.FormatEAN8 -> EAN8CheckDigitRemover()
+            BarcodeFormat.FormatUPCA -> UPCCheckDigitRemover()
+            BarcodeFormat.FormatUPCE -> UPCCheckDigitRemover()
+            else -> throw IllegalStateException(
+                "Cannot remove check digit for this barcode format: ${barcodeFormat.formatName}"
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactory.kt
@@ -4,7 +4,7 @@ import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.Barc
 import javax.inject.Inject
 
 class CheckDigitRemoverFactory @Inject constructor() {
-    fun getCheckDigitRemoverFor(barcodeFormat: BarcodeFormat) : CheckDigitRemover {
+    fun getCheckDigitRemoverFor(barcodeFormat: BarcodeFormat): CheckDigitRemover {
         return when (barcodeFormat) {
             BarcodeFormat.FormatEAN13 -> EAN13CheckDigitRemover()
             BarcodeFormat.FormatEAN8 -> EAN8CheckDigitRemover()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -383,6 +383,7 @@ class OrderCreateEditViewModel @Inject constructor(
     private fun trackBarcodeScanningTapped() {
         tracker.track(ORDER_CREATION_PRODUCT_BARCODE_SCANNING_TAPPED)
     }
+
     private fun startScan() {
         scanningJob = viewModelScope.launch {
             isScanningInProgress = true
@@ -498,9 +499,7 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     private fun shouldWeRetryProductSearchByRemovingTheCheckDigitFor(barcodeOptions: BarcodeOptions) =
-        (isBarcodeFormatUPC(barcodeOptions) ||
-            isBarcodeFormatEAN(barcodeOptions)
-            ) &&
+        (isBarcodeFormatUPC(barcodeOptions) || isBarcodeFormatEAN(barcodeOptions)) &&
             barcodeOptions.shouldHandleCheckDigitOnFailure
 
     private fun isBarcodeFormatUPC(barcodeOptions: BarcodeOptions) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -123,7 +123,7 @@ class OrderCreateEditViewModel @Inject constructor(
     private val tracker: AnalyticsTrackerWrapper,
     private val codeScanner: CodeScanner,
     private val productRepository: ProductListRepository,
-    private val checkDigitRemover: UPCCheckDigitRemover,
+    private val checkDigitRemoverFactory: CheckDigitRemoverFactory,
     autoSyncOrder: AutoSyncOrder,
     autoSyncPriceModifier: AutoSyncPriceModifier,
     parameterRepository: ParameterRepository
@@ -489,18 +489,27 @@ class OrderCreateEditViewModel @Inject constructor(
         viewState = viewState.copy(isUpdatingOrderDraft = true)
         fetchProductBySKU(
             barcodeOptions.copy(
-                sku = checkDigitRemover.getSKUWithoutCheckDigit(barcodeOptions.sku),
+                sku = checkDigitRemoverFactory.getCheckDigitRemoverFor(
+                    barcodeOptions.barcodeFormat
+                ).getSKUWithoutCheckDigit(barcodeOptions.sku),
                 shouldHandleCheckDigitOnFailure = false
             )
         )
     }
 
     private fun shouldWeRetryProductSearchByRemovingTheCheckDigitFor(barcodeOptions: BarcodeOptions) =
-        isBarcodeFormatUPC(barcodeOptions) && barcodeOptions.shouldHandleCheckDigitOnFailure
+        (isBarcodeFormatUPC(barcodeOptions) ||
+            isBarcodeFormatEAN(barcodeOptions)
+            ) &&
+            barcodeOptions.shouldHandleCheckDigitOnFailure
 
     private fun isBarcodeFormatUPC(barcodeOptions: BarcodeOptions) =
         barcodeOptions.barcodeFormat == BarcodeFormat.FormatUPCA ||
             barcodeOptions.barcodeFormat == BarcodeFormat.FormatUPCE
+
+    private fun isBarcodeFormatEAN(barcodeOptions: BarcodeOptions) =
+        barcodeOptions.barcodeFormat == BarcodeFormat.FormatEAN13 ||
+            barcodeOptions.barcodeFormat == BarcodeFormat.FormatEAN8
 
     private fun addScannedProduct(
         product: ModelProduct,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactoryTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.Barc
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.Before
 import org.junit.Test
 
@@ -50,5 +51,14 @@ class CheckDigitRemoverFactoryTest : BaseUnitTest() {
                 BarcodeFormat.FormatEAN8
             )
         ).isInstanceOf(EAN8CheckDigitRemover::class.java)
+    }
+
+    @Test
+    fun `given non-supported barcode format, when factory is called, then throw illegal state exception` () {
+        assertThatIllegalStateException().isThrownBy {
+            checkDigitRemoverFactory.getCheckDigitRemoverFor(
+                BarcodeFormat.FormatQRCode
+            )
+        }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactoryTest.kt
@@ -42,4 +42,13 @@ class CheckDigitRemoverFactoryTest : BaseUnitTest() {
             )
         ).isInstanceOf(EAN13CheckDigitRemover::class.java)
     }
+
+    @Test
+    fun `given EAN-8 barcode format, when factory is called, then return UPCA check digit remover` () {
+        assertThat(
+            checkDigitRemoverFactory.getCheckDigitRemoverFor(
+                BarcodeFormat.FormatEAN8
+            )
+        ).isInstanceOf(EAN8CheckDigitRemover::class.java)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactoryTest.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.ui.orders.creation
+
+import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class CheckDigitRemoverFactoryTest : BaseUnitTest() {
+    private lateinit var checkDigitRemoverFactory: CheckDigitRemoverFactory
+
+    @Before
+    fun setup() {
+        checkDigitRemoverFactory = CheckDigitRemoverFactory()
+    }
+
+    @Test
+    fun `given UPC-A barcode format, when factory is called, then return UPCA check digit remover` () {
+        assertThat(
+            checkDigitRemoverFactory.getCheckDigitRemoverFor(
+                BarcodeFormat.FormatUPCA
+            )
+        ).isInstanceOf(UPCCheckDigitRemover::class.java)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactoryTest.kt
@@ -24,4 +24,13 @@ class CheckDigitRemoverFactoryTest : BaseUnitTest() {
             )
         ).isInstanceOf(UPCCheckDigitRemover::class.java)
     }
+
+    @Test
+    fun `given UPC-E barcode format, when factory is called, then return UPCA check digit remover` () {
+        assertThat(
+            checkDigitRemoverFactory.getCheckDigitRemoverFor(
+                BarcodeFormat.FormatUPCE
+            )
+        ).isInstanceOf(UPCCheckDigitRemover::class.java)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactoryTest.kt
@@ -33,4 +33,13 @@ class CheckDigitRemoverFactoryTest : BaseUnitTest() {
             )
         ).isInstanceOf(UPCCheckDigitRemover::class.java)
     }
+
+    @Test
+    fun `given EAN-13 barcode format, when factory is called, then return UPCA check digit remover` () {
+        assertThat(
+            checkDigitRemoverFactory.getCheckDigitRemoverFor(
+                BarcodeFormat.FormatEAN13
+            )
+        ).isInstanceOf(EAN13CheckDigitRemover::class.java)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CheckDigitRemoverFactoryTest.kt
@@ -18,7 +18,7 @@ class CheckDigitRemoverFactoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given UPC-A barcode format, when factory is called, then return UPCA check digit remover` () {
+    fun `given UPC-A barcode format, when factory is called, then return UPCA check digit remover`() {
         assertThat(
             checkDigitRemoverFactory.getCheckDigitRemoverFor(
                 BarcodeFormat.FormatUPCA
@@ -27,7 +27,7 @@ class CheckDigitRemoverFactoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given UPC-E barcode format, when factory is called, then return UPCA check digit remover` () {
+    fun `given UPC-E barcode format, when factory is called, then return UPCA check digit remover`() {
         assertThat(
             checkDigitRemoverFactory.getCheckDigitRemoverFor(
                 BarcodeFormat.FormatUPCE
@@ -36,7 +36,7 @@ class CheckDigitRemoverFactoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given EAN-13 barcode format, when factory is called, then return UPCA check digit remover` () {
+    fun `given EAN-13 barcode format, when factory is called, then return UPCA check digit remover`() {
         assertThat(
             checkDigitRemoverFactory.getCheckDigitRemoverFor(
                 BarcodeFormat.FormatEAN13
@@ -45,7 +45,7 @@ class CheckDigitRemoverFactoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given EAN-8 barcode format, when factory is called, then return UPCA check digit remover` () {
+    fun `given EAN-8 barcode format, when factory is called, then return UPCA check digit remover`() {
         assertThat(
             checkDigitRemoverFactory.getCheckDigitRemoverFor(
                 BarcodeFormat.FormatEAN8
@@ -54,7 +54,7 @@ class CheckDigitRemoverFactoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given non-supported barcode format, when factory is called, then throw illegal state exception` () {
+    fun `given non-supported barcode format, when factory is called, then throw illegal state exception`() {
         assertThatIllegalStateException().isThrownBy {
             checkDigitRemoverFactory.getCheckDigitRemoverFor(
                 BarcodeFormat.FormatQRCode

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EAN13CheckDigitRemoverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EAN13CheckDigitRemoverTest.kt
@@ -11,9 +11,17 @@ class EAN13CheckDigitRemoverTest : BaseUnitTest() {
 
     @Test
     fun `given EAN-13 format barcode SKU with check digit, then return SKU with check digit removed`() {
-        val sku = "12345678901"
+        val sku = "1234567890123"
         Assertions.assertThat(checkDigitRemover.getSKUWithoutCheckDigit(sku)).isEqualTo(
-            "1234567890"
+            "123456789012"
+        )
+    }
+
+    @Test
+    fun `given alpha numeric EAN-13 format barcode SKU with check digit, then return SKU with check digit removed`() {
+        val sku = "1a345Z7890123"
+        Assertions.assertThat(checkDigitRemover.getSKUWithoutCheckDigit(sku)).isEqualTo(
+            "1a345Z789012"
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EAN13CheckDigitRemoverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EAN13CheckDigitRemoverTest.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.ui.orders.creation
+
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class EAN13CheckDigitRemoverTest : BaseUnitTest() {
+    private val checkDigitRemover = EAN13CheckDigitRemover()
+
+    @Test
+    fun `given EAN-13 format barcode SKU with check digit, then return SKU with check digit removed`() {
+        val sku = "12345678901"
+        Assertions.assertThat(checkDigitRemover.getSKUWithoutCheckDigit(sku)).isEqualTo(
+            "1234567890"
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EAN8CheckDigitRemoverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EAN8CheckDigitRemoverTest.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.ui.orders.creation
+
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class EAN8CheckDigitRemoverTest : BaseUnitTest() {
+    private val checkDigitRemover = EAN8CheckDigitRemover()
+
+    @Test
+    fun `given EAN-8 format barcode SKU with check digit, then return SKU with check digit removed`() {
+        val sku = "12345678"
+        Assertions.assertThat(checkDigitRemover.getSKUWithoutCheckDigit(sku)).isEqualTo(
+            "1234567"
+        )
+    }
+
+    @Test
+    fun `given alpha numeric EAN-8 format barcode SKU with check digit, then return SKU with check digit removed`() {
+        val sku = "1a345Z78"
+        Assertions.assertThat(checkDigitRemover.getSKUWithoutCheckDigit(sku)).isEqualTo(
+            "1a345Z7"
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -1628,6 +1628,52 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given product search fails for EAN-13 barcode format, when retrying, then do not track any failure event`() {
+        testBlocking {
+            val sku = "12345678901"
+            val skuWithCheckDigitRemoved = "1234567890"
+            val mockEAN13CheckDigitRemover = mock<EAN13CheckDigitRemover> {
+                on { getSKUWithoutCheckDigit(sku) }.thenReturn(skuWithCheckDigitRemoved)
+            }
+            createSut()
+            whenever(codeScanner.startScan()).thenAnswer {
+                flow<CodeScannerStatus> {
+                    emit(CodeScannerStatus.Success(sku, BarcodeFormat.FormatEAN13))
+                }
+            }
+            whenever(
+                checkDigitRemoverFactory.getCheckDigitRemoverFor(BarcodeFormat.FormatEAN13)
+            ).thenReturn(
+                mockEAN13CheckDigitRemover
+            )
+            whenever(
+                productListRepository.searchProductList(
+                    sku,
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(emptyList())
+
+            whenever(
+                productListRepository.searchProductList(
+                    skuWithCheckDigitRemoved,
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(
+                listOf(
+                    ProductTestUtils.generateProduct(1L)
+                )
+            )
+
+            sut.onScanClicked()
+
+            verify(tracker, never()).track(
+                eq(PRODUCT_SEARCH_VIA_SKU_FAILURE),
+                any()
+            )
+        }
+    }
+
+    @Test
     fun `given product search fails for UPC barcode format, when retrying, then do not trigger failure event`() {
         testBlocking {
             val sku = "12345678901"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -1498,6 +1498,48 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given product search fails for EAN-13 barcode format, when retrying, then do not handle the check digit on failing to fetch product information second time`() {
+        testBlocking {
+            val sku = "12345678901"
+            val skuWithCheckDigitRemoved = "1234567890"
+            val mockEAN13CheckDigitRemover = mock<EAN13CheckDigitRemover> {
+                on { getSKUWithoutCheckDigit(sku) }.thenReturn(skuWithCheckDigitRemoved)
+            }
+            createSut()
+            whenever(codeScanner.startScan()).thenAnswer {
+                flow<CodeScannerStatus> {
+                    emit(CodeScannerStatus.Success(sku, BarcodeFormat.FormatEAN13))
+                }
+            }
+            whenever(
+                checkDigitRemoverFactory.getCheckDigitRemoverFor(BarcodeFormat.FormatEAN13)
+            ).thenReturn(
+                mockEAN13CheckDigitRemover
+            )
+            whenever(
+                productListRepository.searchProductList(
+                    sku,
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(emptyList())
+            whenever(
+                productListRepository.searchProductList(
+                    skuWithCheckDigitRemoved,
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(emptyList())
+
+            sut.onScanClicked()
+
+            verify(checkDigitRemoverFactory, times(1)).getCheckDigitRemoverFor(BarcodeFormat.FormatEAN13)
+            verify(productListRepository, times(1)).searchProductList(
+                skuWithCheckDigitRemoved,
+                WCProductStore.SkuSearchOptions.ExactSearch
+            )
+        }
+    }
+
+    @Test
     fun `given product search fails for UPC barcode format, when retrying, then do not track any failure event`() {
         testBlocking {
             val sku = "12345678901"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -1763,6 +1763,49 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given product search fails for EAN-13 barcode format, when retrying, then do not trigger failure event`() {
+        testBlocking {
+            val sku = "12345678901"
+            val skuWithCheckDigitRemoved = "1234567890"
+            val mockEAN13CheckDigitRemover = mock<EAN13CheckDigitRemover> {
+                on { getSKUWithoutCheckDigit(sku) }.thenReturn(skuWithCheckDigitRemoved)
+            }
+            createSut()
+            whenever(codeScanner.startScan()).thenAnswer {
+                flow<CodeScannerStatus> {
+                    emit(CodeScannerStatus.Success(sku, BarcodeFormat.FormatEAN13))
+                }
+            }
+            whenever(
+                checkDigitRemoverFactory.getCheckDigitRemoverFor(BarcodeFormat.FormatEAN13)
+            ).thenReturn(
+                mockEAN13CheckDigitRemover
+            )
+            whenever(
+                productListRepository.searchProductList(
+                    sku,
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(emptyList())
+
+            whenever(
+                productListRepository.searchProductList(
+                    skuWithCheckDigitRemoved,
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(
+                listOf(
+                    ProductTestUtils.generateProduct(1L)
+                )
+            )
+
+            sut.onScanClicked()
+
+            assertThat(sut.event.value).isNull()
+        }
+    }
+
+    @Test
     fun `given product search fails for non UPC barcode format, then do not do any checksum operation`() {
         testBlocking {
             val sku = "12345678901"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -1806,6 +1806,49 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given product search fails for EAN-8 barcode format, when retrying, then do not trigger failure event`() {
+        testBlocking {
+            val sku = "12345678901"
+            val skuWithCheckDigitRemoved = "1234567890"
+            val mockEAN8CheckDigitRemover = mock<EAN8CheckDigitRemover> {
+                on { getSKUWithoutCheckDigit(sku) }.thenReturn(skuWithCheckDigitRemoved)
+            }
+            createSut()
+            whenever(codeScanner.startScan()).thenAnswer {
+                flow<CodeScannerStatus> {
+                    emit(CodeScannerStatus.Success(sku, BarcodeFormat.FormatEAN8))
+                }
+            }
+            whenever(
+                checkDigitRemoverFactory.getCheckDigitRemoverFor(BarcodeFormat.FormatEAN8)
+            ).thenReturn(
+                mockEAN8CheckDigitRemover
+            )
+            whenever(
+                productListRepository.searchProductList(
+                    sku,
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(emptyList())
+
+            whenever(
+                productListRepository.searchProductList(
+                    skuWithCheckDigitRemoved,
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(
+                listOf(
+                    ProductTestUtils.generateProduct(1L)
+                )
+            )
+
+            sut.onScanClicked()
+
+            assertThat(sut.event.value).isNull()
+        }
+    }
+
+    @Test
     fun `given product search fails for non UPC barcode format, then do not do any checksum operation`() {
         testBlocking {
             val sku = "12345678901"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -67,7 +67,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     private lateinit var determineMultipleLinesContext: DetermineMultipleLinesContext
     protected lateinit var tracker: AnalyticsTrackerWrapper
     private lateinit var codeScanner: CodeScanner
-    private lateinit var checkDigitRemover: UPCCheckDigitRemover
+    private lateinit var checkDigitRemoverFactory: CheckDigitRemoverFactory
     lateinit var productListRepository: ProductListRepository
 
     protected val defaultOrderValue = Order.EMPTY.copy(id = 123)
@@ -130,7 +130,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         }
         tracker = mock()
         codeScanner = mock()
-        checkDigitRemover = mock()
+        checkDigitRemoverFactory = mock()
         productListRepository = mock()
     }
 
@@ -1319,6 +1319,9 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         testBlocking {
             val sku = "12345678901"
             val skuWithCheckDigitRemoved = "1234567890"
+            val mockUPCCheckDigitRemover = mock<UPCCheckDigitRemover> {
+                on { getSKUWithoutCheckDigit(sku) }.thenReturn(skuWithCheckDigitRemoved)
+            }
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
@@ -1326,9 +1329,9 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 }
             }
             whenever(
-                checkDigitRemover.getSKUWithoutCheckDigit(sku)
+                checkDigitRemoverFactory.getCheckDigitRemoverFor(any())
             ).thenReturn(
-                skuWithCheckDigitRemoved
+                mockUPCCheckDigitRemover
             )
             whenever(
                 productListRepository.searchProductList(
@@ -1351,6 +1354,9 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         testBlocking {
             val sku = "12345678901"
             val skuWithCheckDigitRemoved = "1234567890"
+            val mockUPCCheckDigitRemover = mock<UPCCheckDigitRemover> {
+                on { getSKUWithoutCheckDigit(sku) }.thenReturn(skuWithCheckDigitRemoved)
+            }
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
@@ -1358,9 +1364,9 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 }
             }
             whenever(
-                checkDigitRemover.getSKUWithoutCheckDigit(sku)
+                checkDigitRemoverFactory.getCheckDigitRemoverFor(any())
             ).thenReturn(
-                skuWithCheckDigitRemoved
+                mockUPCCheckDigitRemover
             )
             whenever(
                 productListRepository.searchProductList(
@@ -1384,6 +1390,9 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         testBlocking {
             val sku = "12345678901"
             val skuWithCheckDigitRemoved = "1234567890"
+            val mockUPCCheckDigitRemover = mock<UPCCheckDigitRemover> {
+                on { getSKUWithoutCheckDigit(sku) }.thenReturn(skuWithCheckDigitRemoved)
+            }
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
@@ -1391,9 +1400,9 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 }
             }
             whenever(
-                checkDigitRemover.getSKUWithoutCheckDigit(sku)
+                checkDigitRemoverFactory.getCheckDigitRemoverFor(any())
             ).thenReturn(
-                skuWithCheckDigitRemoved
+                mockUPCCheckDigitRemover
             )
             whenever(
                 productListRepository.searchProductList(
@@ -1410,7 +1419,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
 
             sut.onScanClicked()
 
-            verify(checkDigitRemover, times(1)).getSKUWithoutCheckDigit(any())
+            verify(checkDigitRemoverFactory, times(1)).getCheckDigitRemoverFor(any())
             verify(productListRepository, times(1)).searchProductList(
                 skuWithCheckDigitRemoved,
                 WCProductStore.SkuSearchOptions.ExactSearch
@@ -1423,6 +1432,9 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         testBlocking {
             val sku = "12345678901"
             val skuWithCheckDigitRemoved = "1234567890"
+            val mockUPCCheckDigitRemover = mock<UPCCheckDigitRemover> {
+                on { getSKUWithoutCheckDigit(sku) }.thenReturn(skuWithCheckDigitRemoved)
+            }
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
@@ -1430,9 +1442,9 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 }
             }
             whenever(
-                checkDigitRemover.getSKUWithoutCheckDigit(sku)
+                checkDigitRemoverFactory.getCheckDigitRemoverFor(any())
             ).thenReturn(
-                skuWithCheckDigitRemoved
+                mockUPCCheckDigitRemover
             )
             whenever(
                 productListRepository.searchProductList(
@@ -1466,6 +1478,9 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         testBlocking {
             val sku = "12345678901"
             val skuWithCheckDigitRemoved = "1234567890"
+            val mockUPCCheckDigitRemover = mock<UPCCheckDigitRemover> {
+                on { getSKUWithoutCheckDigit(sku) }.thenReturn(skuWithCheckDigitRemoved)
+            }
             createSut()
             whenever(codeScanner.startScan()).thenAnswer {
                 flow<CodeScannerStatus> {
@@ -1473,9 +1488,9 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 }
             }
             whenever(
-                checkDigitRemover.getSKUWithoutCheckDigit(sku)
+                checkDigitRemoverFactory.getCheckDigitRemoverFor(any())
             ).thenReturn(
-                skuWithCheckDigitRemoved
+                mockUPCCheckDigitRemover
             )
             whenever(
                 productListRepository.searchProductList(
@@ -1521,7 +1536,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
 
             sut.onScanClicked()
 
-            verify(checkDigitRemover, never()).getSKUWithoutCheckDigit(any())
+            verify(checkDigitRemoverFactory, never()).getCheckDigitRemoverFor(any())
             verify(productListRepository, never()).searchProductList(
                 skuWithCheckDigitRemoved,
                 WCProductStore.SkuSearchOptions.ExactSearch
@@ -1631,7 +1646,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             tracker = tracker,
             codeScanner = codeScanner,
             productRepository = productListRepository,
-            checkDigitRemover = checkDigitRemover
+            checkDigitRemoverFactory = checkDigitRemoverFactory
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9238 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR implements a logic to handle EAN-13 and EAN-8 barcode formats.

Whenever the barcode is scanned successfully and the product search API fails for any reason, we check the barcode format. If it's either EAN-13, EAN-8, UPC-A, or UPC-E we re-try the product search API with the newly calculated SKU. The new SKU is calculated by removing the check digit from the originally obtained SKU value.

More context: pdfdoF-2Zq-p2

<img width="600" alt="Screenshot 2023-06-05 at 9 56 17 AM" src="https://github.com/woocommerce/woocommerce-android/assets/1331230/f7ea2d38-1853-4c95-acaf-4f7de0eff279">

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Test case 1
1. Add 2 products where one product's SKU includes EAN-13 format with the check digit and the other does not. Example - `9780201379624` and `978020137962`
2.  Generate the EAN-13 barcode for `978020137962` online. Notice the barcode appends a check digit for the SKU. The SKU on the generated barcode will be `9780201379624` (https://barcode.tec-it.com/en/EAN13?data=978020137962)
3. Scan the barcode from either the order listing or the order creation screen.
4. Ensure the product with the SKU `9780201379624` gets added.

#### Test case 2
1. Add 1 product with EAN-13 generated SKU `978020137962`
2. Generate the EAN-13 barcode for `978020137962` online. Notice the barcode appends a check digit for the SKU. The SKU on the generated barcode will be `9780201379624` (https://barcode.tec-it.com/en/EAN13?data=978020137962)
3. Scan the barcode from either the order listing or the order creation screen.
4. Ensure the product with the SKU `978020137962` gets added.

#### Test case 3
1. Add 2 products where one product's SKU includes EAN-8 format with the check digit and the other does not. Example - `90311017` and `9031101`
2.  Generate the EAN-8 barcode for `9031101` online. Notice the barcode appends a check digit for the SKU. The SKU on the generated barcode will be `90311017` (https://barcode.tec-it.com/en/EAN8?data=9031101)
3. Scan the barcode from either the order listing or the order creation screen.
4. Ensure the product with the SKU `90311017` gets added.

#### Test case 4
1. Add 1 product with EAN-8 generated SKU `9031101`
2. Generate the EAN-13 barcode for `9031101` online. Notice the barcode appends a check digit for the SKU. The SKU on the generated barcode will be `90311017` (https://barcode.tec-it.com/en/EAN8?data=9031101)
3. Scan the barcode from either the order listing or the order creation screen.
4. Ensure the product with the SKU `9031101` gets added.




### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->