### PR TITLE
[Product Search] Remove new line symbols from the search

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
@@ -163,10 +164,20 @@ fun SearchLayout(
     val isFocused = remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
     val focusManager = LocalFocusManager.current
+
+    val searchQuery = remember { mutableStateOf(state.searchState.searchQuery) }
+    val newLineRegex = Regex("[\n\r]")
+
     Column {
         WCSearchField(
             value = state.searchState.searchQuery,
-            onValueChange = onSearchQueryChanged,
+            onValueChange = { newValue: String ->
+                if (newValue.contains(newLineRegex)) {
+                    searchQuery.value = newValue.replace(newLineRegex, "")
+                } else {
+                    onSearchQueryChanged(newValue)
+                }
+            },
             hint = stringResource(id = string.product_selector_search_hint),
             modifier = Modifier
                 .fillMaxWidth()
@@ -176,6 +187,7 @@ fun SearchLayout(
                 )
                 .onFocusChanged { isFocused.value = it.isFocused }
                 .focusRequester(focusRequester),
+            keyboardOptions = KeyboardOptions(autoCorrect = false),
         )
         if (isFocused.value) {
             Row(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9169 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Manually remove new line symbols from search input

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Start order creation
* Start adding a new product
* Try to enter a new line symbol (you can use emulator and enter from the hw keyboard)
* Notice that it's not entered anymore

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
