### PR TITLE
Add the "feature" parameter to AI completion calls

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
@@ -14,12 +14,40 @@ import javax.inject.Singleton
 class AIRepository @Inject constructor(
     private val jetpackAIStore: JetpackAIStore
 ) {
-    suspend fun fetchJetpackAICompletionsForSite(
+    companion object {
+        const val PRODUCT_SHARING_FEATURE = "woo_android_share_product"
+        const val PRODUCT_DESCRIPTION_FEATURE = "woo_android_product_description"
+    }
+
+    suspend fun generateProductSharingText(
+        site: SiteModel,
+        productName: String,
+        permalink: String,
+        productDescription: String?
+    ): Result<String> {
+        val prompt = AIPrompts.generateProductSharingPrompt(
+            productName,
+            permalink,
+            productDescription.orEmpty()
+        )
+        return fetchJetpackAICompletionsForSite(site, prompt, PRODUCT_SHARING_FEATURE)
+    }
+
+    suspend fun generateProductDescription(site: SiteModel, productName: String, features: String): Result<String> {
+        val prompt = AIPrompts.generateProductDescriptionPrompt(
+            productName,
+            features
+        )
+        return fetchJetpackAICompletionsForSite(site, prompt, PRODUCT_DESCRIPTION_FEATURE)
+    }
+
+    private suspend fun fetchJetpackAICompletionsForSite(
         site: SiteModel,
         prompt: String,
+        feature: String,
         skipCache: Boolean = false
     ): Result<String> = withContext(Dispatchers.IO) {
-        jetpackAIStore.fetchJetpackAICompletionsForSite(site, prompt, skipCache).run {
+        jetpackAIStore.fetchJetpackAICompletionsForSite(site, prompt, feature, skipCache).run {
             when (this) {
                 is JetpackAICompletionsResponse.Success -> {
                     WooLog.d(WooLog.T.AI, "Fetching Jetpack AI completions succeeded")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
-import com.woocommerce.android.ai.AIPrompts
 import com.woocommerce.android.ai.AIRepository
 import com.woocommerce.android.ai.AIRepository.JetpackAICompletionsException
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -25,7 +24,7 @@ import javax.inject.Inject
 class ProductSharingViewModel @Inject constructor(
     private val aiRepository: AIRepository,
     private val tracker: AnalyticsTrackerWrapper,
-    private val resourceProvider: ResourceProvider,
+    resourceProvider: ResourceProvider,
     private val selectedSite: SelectedSite,
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
@@ -66,13 +65,11 @@ class ProductSharingViewModel @Inject constructor(
         }
 
         launch {
-            val result = aiRepository.fetchJetpackAICompletionsForSite(
+            val result = aiRepository.generateProductSharingText(
                 site = selectedSite.get(),
-                prompt = AIPrompts.generateProductSharingPrompt(
-                    navArgs.productName,
-                    navArgs.permalink,
-                    navArgs.productDescription.orEmpty()
-                )
+                navArgs.productName,
+                navArgs.permalink,
+                navArgs.productDescription.orEmpty()
             )
             result.fold(
                 onSuccess = { completions ->

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-9037aa3c964116d7ee5629f87859a63257fff43c'
+    fluxCVersion = '2755-628b07c4997ab9ef336c98db82cd129727e4f322'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Fixes #9249.

This PR adds the `feature` parameter to the Jetpack AI completion API call that identifies the caller for cost-tracking purposes.

<img width="353" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/1522856/ee9c484c-2253-4c4a-ba41-f0e05da07388">

**To test:**

1. Go to Products -> Select a product
2. Tap on Share
3. Tap on Write with AI button
4. Verify a text is generated
5. Open Flipper and verify the API request executed with the correct `feature` parameter (`woo_android_share_product`)

**Note:** Before merging this PR, please merge the [associated FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2755) and update the hash reference.