### PR TITLE
Fix: Selected site timezone crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.DASHBOARD_STORE_TIMEZONE_DIFFER_FROM_DEVICE
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.extensions.isSitePublic
 import com.woocommerce.android.extensions.offsetInHours
 import com.woocommerce.android.network.ConnectionChangeReceiver
@@ -331,26 +332,27 @@ class MyStoreViewModel @Inject constructor(
 
     private fun trackLocalTimezoneDifferenceFromStore() {
         val selectedSite = selectedSite.getIfExists() ?: return
+        val siteTimezone = selectedSite.timezone.takeIf { it.isNotNullOrEmpty() } ?: return
         val localTimeZoneOffset = timezoneProvider.deviceTimezone.offsetInHours.toString()
 
         val shouldTriggerTimezoneTrack = appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(
             siteId = selectedSite.siteId,
             localTimezone = localTimeZoneOffset,
-            storeTimezone = selectedSite.timezone
+            storeTimezone = siteTimezone
         ) && selectedSite.timezone != localTimeZoneOffset
 
         if (shouldTriggerTimezoneTrack) {
             analyticsTrackerWrapper.track(
                 stat = DASHBOARD_STORE_TIMEZONE_DIFFER_FROM_DEVICE,
                 properties = mapOf(
-                    AnalyticsTracker.KEY_STORE_TIMEZONE to selectedSite.timezone,
+                    AnalyticsTracker.KEY_STORE_TIMEZONE to siteTimezone,
                     AnalyticsTracker.KEY_LOCAL_TIMEZONE to localTimeZoneOffset
                 )
             )
             appPrefsWrapper.setTimezoneTrackEventTriggeredFor(
                 siteId = selectedSite.siteId,
                 localTimezone = localTimeZoneOffset,
-                storeTimezone = selectedSite.timezone
+                storeTimezone = siteTimezone
             )
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -611,6 +611,32 @@ class MyStoreViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `given the viewModel started, when the store timezone is null, then do nothing`() = testBlocking {
+        // Given
+        val testSite = SiteModel().apply {
+            timezone = null
+        }
+
+        val deviceTimezone = mock<TimeZone> {
+            on { rawOffset } doReturn 0
+        }
+
+        whenever(selectedSite.getIfExists()) doReturn testSite
+
+        // When
+        whenViewModelIsCreated()
+
+        // Then
+        verify(analyticsTrackerWrapper, never()).track(
+            stat = AnalyticsEvent.DASHBOARD_STORE_TIMEZONE_DIFFER_FROM_DEVICE,
+            properties = mapOf(
+                AnalyticsTracker.KEY_STORE_TIMEZONE to testSite.timezone,
+                AnalyticsTracker.KEY_LOCAL_TIMEZONE to deviceTimezone.offsetInHours.toString()
+            )
+        )
+    }
+
     private suspend fun givenStatsLoadingResult(result: GetStats.LoadStatsResult) {
         whenever(getStats.invoke(any(), any())).thenReturn(flow { emit(result) })
     }


### PR DESCRIPTION
Summary
==========
Fix issue #9232 by creating a check to the SelectedSite `timezone`, ensuring it's not null before operating its value.

It's unclear when the timezone can be nullified in a real scenario, but we should be resilient since the REST API can return null site data.

Steps to reproduce
==========
1. Force the `SiteModel` to contain a `null` timezone value
2. Open the app
3. Verify the app crashes in the My Store section


How to Test
==========
1. Force the `SiteModel` to contain a `null` timezone value
2. Open the app
3. Verify the app works as expected, and the timezone track is not triggered

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.