### PR TITLE
Add new chrome client to support picking images from authenticated we…

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeWebViewFragment.kt
@@ -30,6 +30,7 @@ class BlazeWebViewFragment : BaseFragment() {
                         viewModel.viewState,
                         viewModel.userAgent,
                         viewModel.wpComWebViewAuthenticator,
+                        requireActivity().activityResultRegistry,
                         viewModel::onPageFinished,
                         viewModel::onClose
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeWebViewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeWebViewScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.blaze
 
 import androidx.activity.compose.BackHandler
+import androidx.activity.result.ActivityResultRegistry
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
@@ -21,6 +22,7 @@ fun BlazeWebViewScreen(
     viewState: BlazeWebViewState,
     userAgent: UserAgent,
     wpcomWebViewAuthenticator: WPComWebViewAuthenticator,
+    activityRegistry: ActivityResultRegistry,
     onPageFinished: (String) -> Unit,
     onClose: () -> Unit,
 ) {
@@ -39,6 +41,7 @@ fun BlazeWebViewScreen(
             userAgent = userAgent,
             wpComAuthenticator = wpcomWebViewAuthenticator,
             onPageFinished = onPageFinished,
+            activityRegistry = activityRegistry,
             modifier = Modifier
                 .padding(paddingValues)
                 .fillMaxSize()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WebChromeClientWithImageChooser.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WebChromeClientWithImageChooser.kt
@@ -1,0 +1,43 @@
+package com.woocommerce.android.ui.compose.component
+
+import android.content.ActivityNotFoundException
+import android.net.Uri
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.contract.ActivityResultContracts.GetContent
+
+class WebChromeClientWithImageChooser(
+    registry: ActivityResultRegistry,
+    private val onProgressChanged: (Int) -> Unit
+) : WebChromeClient() {
+    companion object {
+        private const val FILE_CHOOSER_RESULT_KEY = "file_chooser_result_key"
+    }
+
+    private lateinit var fileChooserValueCallback: ValueCallback<Array<Uri>>
+    private val getImageContent = registry.register(FILE_CHOOSER_RESULT_KEY, GetContent()) { uri ->
+        uri?.let {
+            fileChooserValueCallback.onReceiveValue(arrayOf(uri))
+        } ?: fileChooserValueCallback.onReceiveValue(null)
+    }
+
+    override fun onShowFileChooser(
+        webView: WebView?,
+        filePathCallback: ValueCallback<Array<Uri>>,
+        fileChooserParams: FileChooserParams
+    ): Boolean {
+        try {
+            fileChooserValueCallback = filePathCallback;
+            getImageContent.launch("image/*")
+        } catch (e: ActivityNotFoundException) {
+            // You may handle "No activity found to handle intent" error
+        }
+        return true
+    }
+
+    override fun onProgressChanged(view: WebView?, newProgress: Int) {
+        onProgressChanged(newProgress)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WebChromeClientWithImageChooser.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WebChromeClientWithImageChooser.kt
@@ -7,6 +7,8 @@ import android.webkit.WebChromeClient
 import android.webkit.WebView
 import androidx.activity.result.ActivityResultRegistry
 import androidx.activity.result.contract.ActivityResultContracts.GetContent
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
 
 class WebChromeClientWithImageChooser(
     registry: ActivityResultRegistry,
@@ -29,10 +31,13 @@ class WebChromeClientWithImageChooser(
         fileChooserParams: FileChooserParams
     ): Boolean {
         try {
-            fileChooserValueCallback = filePathCallback;
+            fileChooserValueCallback = filePathCallback
             getImageContent.launch("image/*")
         } catch (e: ActivityNotFoundException) {
-            // You may handle "No activity found to handle intent" error
+            WooLog.d(
+                T.UTILS,
+                "WebChromeClientWithImageChooser. No activity found to handle image selection: ${e.message}"
+            )
         }
         return true
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WebView.kt
@@ -8,6 +8,7 @@ import android.webkit.WebStorage
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.compose.BackHandler
+import androidx.activity.result.ActivityResultRegistry
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -47,6 +48,7 @@ fun WCWebView(
     captureBackPresses: Boolean = true,
     wpComAuthenticator: WPComWebViewAuthenticator? = null,
     webViewNavigator: WebViewNavigator = rememberWebViewNavigator(),
+    activityRegistry: ActivityResultRegistry? = null,
     loadWithOverviewMode: Boolean = false,
     isJavaScriptEnabled: Boolean = true,
     isDomStorageEnabled: Boolean = true,
@@ -109,9 +111,14 @@ fun WCWebView(
                         }
                     }
 
-                    this.webChromeClient = object : WebChromeClient() {
-                        override fun onProgressChanged(view: WebView?, newProgress: Int) {
-                            progress = newProgress
+                    if (activityRegistry != null) {
+                        this.webChromeClient =
+                            WebChromeClientWithImageChooser(activityRegistry) { newProgress -> progress = newProgress }
+                    } else {
+                        this.webChromeClient = object : WebChromeClient() {
+                            override fun onProgressChanged(view: WebView?, newProgress: Int) {
+                                progress = newProgress
+                            }
                         }
                     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9256 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In order to be able to open file android file picker to get select an image for Blaze campaigns we need to add a custom `FileChooser` to the chrome client the Web view uses so that we can react to click to opening the photo picker. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open an atomic site that is launched/published and has at least one product published
2. Navigate to product detail -> Overflow menu -> Promote with Blaze
3. Click on on the "Upload" button next to the product image and select and alternative image
4. Check the image is updated correctly.

See the screen recording below for reference

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
**Before**

https://github.com/woocommerce/woocommerce-android/assets/2663464/51db6ef9-729b-4a90-855c-19e178fedc54

**After **

https://github.com/woocommerce/woocommerce-android/assets/2663464/92c41b9c-7228-4caa-b4c6-7eb6ca877c6a

