### PR TITLE
Fixes tracking for Blaze cta displayed from product detail

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -486,6 +486,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_STEP_PLAN_PURCHASE = "plan_purchase"
         const val VALUE_STEP_WEB_CHECKOUT = "web_checkout"
         const val VALUE_STEP_STORE_INSTALLATION = "store_installation"
+        const val KEY_NEW_SITE_ID = "new_site_id"
         const val KEY_INITIAL_DOMAIN = "initial_domain"
 
         // -- Products bulk update

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -79,7 +79,7 @@ class StoreCreationSummaryViewModel @Inject constructor(
                         tracker.track(
                             stat = AnalyticsEvent.SITE_CREATION_FREE_TRIAL_CREATED_SUCCESS,
                             properties = mapOf(
-                                AnalyticsTracker.KEY_BLOG_ID to newStore.data.siteId,
+                                AnalyticsTracker.KEY_NEW_SITE_ID to newStore.data.siteId,
                                 AnalyticsTracker.KEY_INITIAL_DOMAIN to newStore.data.domain
                             )
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -101,6 +101,7 @@ import com.woocommerce.android.ui.plans.di.TrialStatusBarFormatterFactory
 import com.woocommerce.android.ui.plans.trial.DetermineTrialStatusBarState.TrialStatusBarState
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
 import com.woocommerce.android.ui.prefs.RequestedAnalyticsValue
+import com.woocommerce.android.ui.products.ProductDetailFragment
 import com.woocommerce.android.ui.products.ProductListFragmentDirections
 import com.woocommerce.android.ui.reviews.ReviewListFragmentDirections
 import com.woocommerce.android.ui.sitepicker.SitePickerFragmentDirections
@@ -404,8 +405,15 @@ class MainActivity :
                 onBackPressed()
                 true
             }
+
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    override fun onMenuOpened(featureId: Int, menu: Menu): Boolean {
+        val currentFragment = getActiveChildFragment()
+        if (currentFragment is ProductDetailFragment) currentFragment.trackBlazeDisplayedIfVisible()
+        return true
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -593,4 +593,8 @@ class ProductDetailFragment :
     }
 
     override fun getFragmentTitle(): String = productName
+
+    fun trackBlazeDisplayedIfVisible() {
+        viewModel.trackBlazeDisplayed()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -2312,15 +2312,19 @@ class ProductDetailViewModel @Inject constructor(
         return getComponentProducts(remoteId)
     }
 
-    private suspend fun shouldShowBlaze(productDraft: Product): Boolean {
-        val showBlaze = getProductVisibility() == PUBLIC &&
+    private suspend fun shouldShowBlaze(productDraft: Product) =
+        getProductVisibility() == PUBLIC &&
             productDraft.status != DRAFT &&
             isBlazeEnabled()
-        if (showBlaze) tracker.track(
-            stat = BLAZE_ENTRY_POINT_DISPLAYED,
-            properties = mapOf(KEY_BLAZE_SOURCE to PRODUCT_DETAIL_OVERFLOW_MENU.trackingName)
-        )
-        return showBlaze
+
+    fun trackBlazeDisplayed() {
+        launch {
+            if (shouldShowBlaze(draftChanges.value!!))
+                tracker.track(
+                    stat = BLAZE_ENTRY_POINT_DISPLAYED,
+                    properties = mapOf(KEY_BLAZE_SOURCE to PRODUCT_DETAIL_OVERFLOW_MENU.trackingName)
+                )
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes: #9260
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Intercept clicks on the overflow menu inside the product detail screen to track `blaze_entry_point_displayed` properly. I'm not a big fan of the implementation of this tracking as it is a bit hacky, but it the "cleanest" way I found to track click on the overlflow button. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Log into a atomic public store
2. Open a published product
3. Check `blaze_entry_point_displayed` is NOT tracked
4. Click on the overflow menu and check the following event is tracked in the logs: `Tracked: blaze_entry_point_displayed, Properties: {"source":"product_more_menu","blog_id":205513046,"is_wpcom_store":false,"is_debug":true}`
