### PR TITLE
Handle INVALID_COUPON error

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] [Internal] Rounded corners to the payments dialogs [https://github.com/woocommerce/woocommerce-android/pull/9231]
 - [*] [Internal] Adding products via barcode scanning - Handle EAN-13, EAN-8 barcode formats [https://github.com/woocommerce/woocommerce-android/pull/9240]
 - [*] [Internal] Changes the endpoint use for customer search during order creation flow [https://github.com/woocommerce/woocommerce-android/pull/9212]
+- [*] Handle case when backend rejects discount coupon while creating an order [https://github.com/woocommerce/woocommerce-android/pull/9263]
 
 14.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
@@ -19,7 +19,7 @@ class AIRepository @Inject constructor(
         prompt: String,
         skipCache: Boolean = false
     ): Result<String> = withContext(Dispatchers.IO) {
-        jetpackAIStore.fetchJetpackAICompletionsForSite(site, prompt, skipCache).run {
+        jetpackAIStore.fetchJetpackAICompletionsForSite(site, prompt, skipCache = skipCache).run {
             when (this) {
                 is JetpackAICompletionsResponse.Success -> {
                     WooLog.d(WooLog.T.AI, "Fetching Jetpack AI completions succeeded")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -471,6 +471,11 @@ class OrderCreateEditFormFragment :
                     event.message
                 )
             }
+            is OnCouponRejectedByBackend -> {
+                uiMessageResolver.getSnack(
+                    stringResId = event.message
+                ).show()
+            }
             is Exit -> findNavController().navigateUp()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -781,9 +781,9 @@ class OrderCreateEditViewModel @Inject constructor(
                                 _orderDraft.update { currentDraft -> currentDraft.copy(couponLines = emptyList()) }
                                 triggerEvent(OnCouponRejectedByBackend)
                             } else {
-                                trackOrderSyncFailed(updateStatus.throwable)
                                 viewState = viewState.copy(isUpdatingOrderDraft = false, showOrderUpdateSnackbar = true)
                             }
+                            trackOrderSyncFailed(updateStatus.throwable)
                         }
                         is OrderUpdateStatus.Succeeded -> {
                             viewState = viewState.copy(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -610,6 +610,7 @@
     <string name="order_editing_non_editable_message">To edit Products or Payment Details, change the status to Pending Payment.</string>
     <string name="order_editing_locked_content_description">locked</string>
     <string name="order_sync_failed">Unable to save changes</string>
+    <string name="order_sync_coupon_removed">Coupon could not be applied and was removed from the order</string>
     <!--
         Order Filters
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -36,7 +36,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.advanceTimeBy
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
@@ -1127,11 +1126,20 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         )
     }
 
-
     @Test
     fun `given coupon code rejected by backend, then should display message`() {
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Failed(WooException(WooError(WooErrorType.INVALID_COUPON, BaseRequest.GenericErrorType.UNKNOWN))))
+            onBlocking { invoke(any(), any()) } doReturn
+                flowOf(
+                    Failed(
+                        WooException(
+                            WooError(
+                                WooErrorType.INVALID_COUPON,
+                                BaseRequest.GenericErrorType.UNKNOWN
+                            )
+                        )
+                    )
+                )
         }
         createSut()
         var lastReceivedEvent: Event? = null

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-245a94ea89652f71b672f8f7d2413fd0cbc4785f'
+    fluxCVersion = '2759-5950d6dd7e596922e2a7080acb6c462d027d99bf'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2759-ad9bb74b73777ff408a5d23b70e4c5280aa89cd0'
+    fluxCVersion = 'trunk-7912d2daabbf036b62e8243efec070daa1149b88'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2759-5950d6dd7e596922e2a7080acb6c462d027d99bf'
+    fluxCVersion = '2759-ad9bb74b73777ff408a5d23b70e4c5280aa89cd0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
#### ⚠️ Dependency: FluxC PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2759
##### ✅ ~~Before merging this PR make sure to merge the FluxC PR and update the FluxC version here.~~

This PR improves error handling in case a coupon code is rejected by the backend during the order update operation. 

### Description
This happens when a coupon is already added to an order and we remove the discount-eligible item from the order. In such cases, backend returns HTTP 400 and the following error code: `woocommerce_rest_invalid_coupon`. As a result order update (sync) operation fails and the merchant can't create the order.

To improve the UX, in case of the above error, we remove the invalid coupon from the order (this triggers order re-sync) and we display a snackbar to inform the user about this.

<!-- Remember about a good descriptive title. -->

Closes: #9258
<!-- Id number of the GitHub issue this PR addresses. -->


<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
You'll need to have a discount coupon restricted for use with a specific product(s). The coupon can be created in wp-admin/marketing/coupons.

1. Create a new order and add an item qualified for the discount
2. Add a coupon to the order and observe desired discount was added to the order's total
3. Remove the item from the order
4. Verify the order gets updated correctly (no error snackbars). Verify the coupon was removed and a proper information was displayed in a snackbar.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Before  | After |
| ------------- | ------------- |
| <video src=https://github.com/woocommerce/woocommerce-android/assets/4527432/b4482af7-f536-428c-8d5d-c863f20d68ab/>  |  <video src=https://github.com/woocommerce/woocommerce-android/assets/4527432/df656263-286d-4443-8413-1c58a427d12a/>  |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
