### PR TITLE
Fix/9262 tracking free trial created

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -804,6 +804,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     SITE_CREATION_TRY_FOR_FREE_TAPPED(siteless = true),
     SITE_CREATION_TIMED_OUT(siteless = true),
     SITE_CREATION_PROPERTIES_OUT_OF_SYNC(siteless = true),
+    SITE_CREATION_FREE_TRIAL_CREATED_SUCCESS,
 
     // Domain change
     CUSTOM_DOMAINS_STEP,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -486,6 +486,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_STEP_PLAN_PURCHASE = "plan_purchase"
         const val VALUE_STEP_WEB_CHECKOUT = "web_checkout"
         const val VALUE_STEP_STORE_INSTALLATION = "store_installation"
+        const val KEY_INITIAL_DOMAIN = "initial_domain"
 
         // -- Products bulk update
         const val KEY_PROPERTY = "property"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/StoreCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/StoreCreationRepository.kt
@@ -176,9 +176,6 @@ class StoreCreationRepository @Inject constructor(
 
         return when (createSiteResult) {
             is Success -> {
-                val site = siteStore.getSiteBySiteId(createSiteResult.data)
-                val domain = Uri.parse(site?.url.orEmpty()).host.orEmpty()
-                newStore.update(domain = domain)
                 sitePlanRestClient.addEcommercePlanTrial(createSiteResult.data, siteData)
                     .let { addTrialResult ->
                         return when (addTrialResult) {
@@ -252,7 +249,10 @@ class StoreCreationRepository @Inject constructor(
                 }
             }
 
-            else -> Success(result.newSiteRemoteId)
+            else -> {
+                newStore.update(domain = Uri.parse(result.url.orEmpty()).host.orEmpty())
+                Success(result.newSiteRemoteId)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -58,7 +58,9 @@ class StoreCreationSummaryViewModel @Inject constructor(
         )
     }
 
-    fun onCancelPressed() { triggerEvent(OnCancelPressed) }
+    fun onCancelPressed() {
+        triggerEvent(OnCancelPressed)
+    }
 
     fun onTryForFreeButtonPressed() {
         tracker.track(AnalyticsEvent.SITE_CREATION_TRY_FOR_FREE_TAPPED)
@@ -74,12 +76,21 @@ class StoreCreationSummaryViewModel @Inject constructor(
                 when (creationState) {
                     is Finished -> {
                         newStore.update(siteId = creationState.siteId)
+                        tracker.track(
+                            stat = AnalyticsEvent.SITE_CREATION_FREE_TRIAL_CREATED_SUCCESS,
+                            properties = mapOf(
+                                AnalyticsTracker.KEY_BLOG_ID to newStore.data.siteId,
+                                AnalyticsTracker.KEY_INITIAL_DOMAIN to newStore.data.domain
+                            )
+                        )
                         triggerEvent(OnStoreCreationSuccess)
 
                         manageDeferredNotifications()
                     }
+
                     is Failed -> triggerEvent(OnStoreCreationFailure)
-                    else -> { /* no op */ }
+                    else -> { /* no op */
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9262 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We need a straightforward way to measure how many free trial stores are created from mobile apps. When measuring this, we also want to have an easy way to know what stores exactly have been created from the apps. For that we are adding a new dedicated event with the following properties and behavior: 

- **Name:** `_site_creation_free_trial_created_success`
- **Triggered** when requests /sites/new/ and /sites/$siteId/ecommerce-trial/add/ecommerce-trial-bundle-monthly/ are successful after the user clicked on “Try for free” CTA on store creation flow.
- **Properties:** `new_site_id`: new site’s blog Id value `initial_domain`: the default domain added to the site upon creation


We want to release this ASAP to start gathering data. Thus, we are merging this to the current `release/14.1` branch.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Trigger store creation flow and check the following event is tracked: `Tracked: site_creation_free_trial_created_success, Properties: {"blog_id":220392323,"initial_domain":"woo-usually-zany-basement.wordpress.com","is_wpcom_store":true,"is_debug":true}`
