### PR TITLE
Track coupon add to order failure

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] [Internal] Rounded corners to the payments dialogs [https://github.com/woocommerce/woocommerce-android/pull/9231]
 - [*] [Internal] Adding products via barcode scanning - Handle EAN-13, EAN-8 barcode formats [https://github.com/woocommerce/woocommerce-android/pull/9240]
 - [*] [Internal] Changes the endpoint use for customer search during order creation flow [https://github.com/woocommerce/woocommerce-android/pull/9212]
+- [*] Handle case when backend rejects discount coupon while creating an order [https://github.com/woocommerce/woocommerce-android/pull/9263]
 
 14.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
@@ -19,7 +19,7 @@ class AIRepository @Inject constructor(
         prompt: String,
         skipCache: Boolean = false
     ): Result<String> = withContext(Dispatchers.IO) {
-        jetpackAIStore.fetchJetpackAICompletionsForSite(site, prompt, skipCache).run {
+        jetpackAIStore.fetchJetpackAICompletionsForSite(site, prompt, skipCache = skipCache).run {
             when (this) {
                 is JetpackAICompletionsResponse.Success -> {
                     WooLog.d(WooLog.T.AI, "Fetching Jetpack AI completions succeeded")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -308,6 +308,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     // -- Order Coupon
     ORDER_COUPON_ADD,
     ORDER_COUPON_REMOVE,
+    ORDER_COUPON_ADD_FAILURE,
 
     // -- Shipping Labels
     SHIPPING_LABEL_API_REQUEST,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -471,6 +471,11 @@ class OrderCreateEditFormFragment :
                     event.message
                 )
             }
+            is OnCouponRejectedByBackend -> {
+                uiMessageResolver.getSnack(
+                    stringResId = event.message
+                ).show()
+            }
             is Exit -> findNavController().navigateUp()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -778,6 +778,7 @@ class OrderCreateEditViewModel @Inject constructor(
                             viewState = viewState.copy(willUpdateOrderDraft = false, isUpdatingOrderDraft = true)
                         is OrderUpdateStatus.Failed -> {
                             if (updateStatus.isInvalidCouponFailure()) {
+                                trackCouponAddFailure(updateStatus)
                                 _orderDraft.update { currentDraft -> currentDraft.copy(couponLines = emptyList()) }
                                 triggerEvent(OnCouponRejectedByBackend)
                             } else {
@@ -807,6 +808,15 @@ class OrderCreateEditViewModel @Inject constructor(
                     }
                 }
         }
+    }
+
+    private fun trackCouponAddFailure(updateStatus: OrderUpdateStatus.Failed) {
+        tracker.track(
+            AnalyticsEvent.ORDER_COUPON_ADD_FAILURE,
+            mapOf(
+                KEY_ERROR_TYPE to (updateStatus.throwable as? WooException)?.error?.type
+            )
+        )
     }
 
     private fun OrderUpdateStatus.Failed.isInvalidCouponFailure() =

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -610,6 +610,7 @@
     <string name="order_editing_non_editable_message">To edit Products or Payment Details, change the status to Pending Payment.</string>
     <string name="order_editing_locked_content_description">locked</string>
     <string name="order_sync_failed">Unable to save changes</string>
+    <string name="order_sync_coupon_removed">Coupon could not be applied and was removed from the order</string>
     <!--
         Order Filters
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -1159,16 +1159,16 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `given coupon code rejected by backend, then should track event`() {
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn
-                    flowOf(
-                        Failed(
-                            WooException(
-                                WooError(
-                                    WooErrorType.INVALID_COUPON,
-                                    BaseRequest.GenericErrorType.UNKNOWN
-                                )
+                flowOf(
+                    Failed(
+                        WooException(
+                            WooError(
+                                WooErrorType.INVALID_COUPON,
+                                BaseRequest.GenericErrorType.UNKNOWN
                             )
                         )
                     )
+                )
         }
         createSut()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -36,7 +36,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.advanceTimeBy
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
@@ -1127,11 +1126,20 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         )
     }
 
-
     @Test
     fun `given coupon code rejected by backend, then should display message`() {
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Failed(WooException(WooError(WooErrorType.INVALID_COUPON, BaseRequest.GenericErrorType.UNKNOWN))))
+            onBlocking { invoke(any(), any()) } doReturn
+                flowOf(
+                    Failed(
+                        WooException(
+                            WooError(
+                                WooErrorType.INVALID_COUPON,
+                                BaseRequest.GenericErrorType.UNKNOWN
+                            )
+                        )
+                    )
+                )
         }
         createSut()
         var lastReceivedEvent: Event? = null

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-245a94ea89652f71b672f8f7d2413fd0cbc4785f'
+    fluxCVersion = '2759-5950d6dd7e596922e2a7080acb6c462d027d99bf'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2759-ad9bb74b73777ff408a5d23b70e4c5280aa89cd0'
+    fluxCVersion = 'trunk-7912d2daabbf036b62e8243efec070daa1149b88'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2759-5950d6dd7e596922e2a7080acb6c462d027d99bf'
+    fluxCVersion = '2759-ad9bb74b73777ff408a5d23b70e4c5280aa89cd0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
⚠️ This PR should be updated (trunk merge) and reviewed after its parent PR is merged into trunk: 
https://github.com/woocommerce/woocommerce-android/pull/9263

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
It adds analytic event tracking for the case backend rejects coupon added to the order.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Reproduce test scenario from the parent PR: https://github.com/woocommerce/woocommerce-android/pull/9263
2. Verify the event is tracked - `ORDER_COUPON_ADD_FAILURE` { `error_type`: `woocommerce_rest_invalid_coupon`}

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
