### PR TITLE
Feature/ai share description design polishes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TextFields.kt
@@ -165,6 +165,65 @@ fun WCOutlinedTextField(
     }
 }
 
+/**
+ * An [OutlinedTextField] that displays an optional helper text below the field.
+ * [textFieldModifier] is added to allow adding modifier to the actual [OutlinedTextField]
+ */
+@Composable
+fun WCOutlinedTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    textFieldModifier: Modifier = Modifier,
+    helperText: String? = null,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = Int.MAX_VALUE,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors(),
+    placeholderText: String? = null
+) {
+    WCOutlinedTextFieldLayout(
+        modifier = modifier,
+        helperText = helperText,
+        isError = isError
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = {
+                Text(text = label)
+            },
+            enabled = enabled,
+            readOnly = readOnly,
+            modifier = textFieldModifier.fillMaxWidth(),
+            leadingIcon = leadingIcon,
+            trailingIcon = trailingIcon,
+            isError = isError,
+            colors = colors,
+            visualTransformation = visualTransformation,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            singleLine = singleLine,
+            maxLines = maxLines,
+            interactionSource = interactionSource,
+            placeholder = {
+                placeholderText?.let {
+                    Text(text = it)
+                }
+            }
+        )
+    }
+}
+
 @Composable
 private fun WCOutlinedTextFieldLayout(
     helperText: String? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,7 +15,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
@@ -31,6 +32,7 @@ import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.products.ProductSharingViewModel.AIButtonState
 import com.woocommerce.android.ui.products.ProductSharingViewModel.AIButtonState.Generating
@@ -93,10 +95,12 @@ fun ProductShareWithAI(
             }
 
             Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
                 modifier = Modifier
                     .padding(
                         vertical = dimensionResource(id = R.dimen.minor_100)
                     )
+                    .fillMaxWidth()
             ) {
                 WCOutlinedButton(
                     onClick = onGenerateButtonClick,
@@ -105,16 +109,15 @@ fun ProductShareWithAI(
                     AIButtonContent(buttonState = viewState.buttonState)
                 }
 
-                IconButton(
+                WCTextButton(
                     onClick = onInfoButtonClick,
                     enabled = !viewState.isGenerating
                 ) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_info_outline_20dp),
-                        contentDescription = stringResource(
-                            id = R.string.product_sharing_ai_info_label
-                        ),
-                        tint = colorResource(id = R.color.color_on_surface)
+                    Text(
+                        text = stringResource(id = R.string.learn_more),
+                        style = MaterialTheme.typography.body2,
+                        color = colorResource(id = R.color.color_primary),
+                        textAlign = TextAlign.End
                     )
                 }
             }
@@ -213,8 +216,8 @@ fun AIButtonContent(buttonState: AIButtonState) {
 
 @Preview(name = "Light mode")
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
-@Preview(name = "RTL mode", locale = "ar")
 @Preview(name = "Smaller screen", device = Devices.NEXUS_5)
+@Preview(name = "RTL mode", locale = "ar")
 @Composable
 fun DefaultUIWithSharingContent() {
     val shareMessage =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
@@ -86,9 +86,9 @@ fun ProductShareWithAI(
                     value = viewState.shareMessage,
                     onValueChange = { onShareMessageEdit(it) },
                     label = stringResource(id = R.string.product_sharing_optional_message_label),
-                    maxLines = 5,
                     isError = isError,
-                    helperText = if (isError) viewState.errorMessage else null
+                    helperText = if (isError) viewState.errorMessage else null,
+                    textFieldModifier = Modifier.height(dimensionResource(id = R.dimen.product_sharing_message_height))
                 )
             }
 
@@ -132,19 +132,19 @@ fun ProductShareWithAI(
 
 @Composable
 fun SharingMessageSkeletonView() {
-    Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_85)))
+    Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_75)))
     Column(
         modifier = Modifier
             .background(
                 color = MaterialTheme.colors.background,
                 shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_50))
             )
-            .padding(dimensionResource(id = R.dimen.major_100))
+            .padding(dimensionResource(id = R.dimen.major_110))
             .fillMaxWidth()
     ) {
         SkeletonView(
             modifier = Modifier
-                .width(dimensionResource(id = R.dimen.skeleton_text_extra_large_width))
+                .fillMaxWidth()
                 .height(dimensionResource(id = R.dimen.major_100))
         )
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
@@ -259,7 +259,7 @@ fun Generating() {
             viewState = ProductSharingViewState(
                 productTitle = "Music Album",
                 shareMessage = "",
-                buttonState = Generating(stringResource(id = R.string.product_sharing_regenerate)),
+                buttonState = Generating(stringResource(id = R.string.product_sharing_generating)),
                 isGenerating = true
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
@@ -186,7 +186,8 @@ fun AIButtonContent(buttonState: AIButtonState) {
                 CircularProgressIndicator(
                     modifier = Modifier
                         .size(dimensionResource(id = R.dimen.major_100)),
-                    strokeWidth = dimensionResource(id = R.dimen.minor_25)
+                    strokeWidth = dimensionResource(id = R.dimen.minor_25),
+                    color = colorResource(id = R.color.color_on_surface_disabled)
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
@@ -132,9 +133,13 @@ fun ProductShareWithAI(
 
 @Composable
 fun SharingMessageSkeletonView() {
+    Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_85)))
     Column(
         modifier = Modifier
-            .background(MaterialTheme.colors.background)
+            .background(
+                color = MaterialTheme.colors.background,
+                shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_50))
+            )
             .padding(dimensionResource(id = R.dimen.major_100))
             .fillMaxWidth()
     ) {
@@ -159,6 +164,12 @@ fun SharingMessageSkeletonView() {
         SkeletonView(
             modifier = Modifier
                 .width(dimensionResource(id = R.dimen.skeleton_text_large_width))
+                .height(dimensionResource(id = R.dimen.major_100))
+        )
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+        SkeletonView(
+            modifier = Modifier
+                .width(dimensionResource(id = R.dimen.skeleton_text_extra_large_width))
                 .height(dimensionResource(id = R.dimen.major_100))
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
@@ -109,6 +109,11 @@ fun ProductShareWithAI(
                     AIButtonContent(buttonState = viewState.buttonState)
                 }
 
+                val learnMoreButtonColor = if (viewState.isGenerating) {
+                    colorResource(id = R.color.color_on_surface_disabled)
+                } else {
+                    colorResource(id = R.color.color_primary)
+                }
                 WCTextButton(
                     onClick = onInfoButtonClick,
                     enabled = !viewState.isGenerating
@@ -116,7 +121,7 @@ fun ProductShareWithAI(
                     Text(
                         text = stringResource(id = R.string.learn_more),
                         style = MaterialTheme.typography.body2,
-                        color = colorResource(id = R.color.color_primary),
+                        color = learnMoreButtonColor,
                         textAlign = TextAlign.End
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -177,7 +176,7 @@ fun SharingMessageSkeletonView() {
 
 @Composable
 fun AIButtonContent(buttonState: AIButtonState) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
+    Row {
         when (buttonState) {
             is WriteWithAI -> {
                 Icon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -184,7 +185,9 @@ fun SharingMessageSkeletonView() {
 
 @Composable
 fun AIButtonContent(buttonState: AIButtonState) {
-    Row {
+    Row(
+        verticalAlignment = Alignment.CenterVertically
+    ) {
         when (buttonState) {
             is WriteWithAI -> {
                 Icon(

--- a/WooCommerce/src/main/res/drawable/ic_ai_share_button.xml
+++ b/WooCommerce/src/main/res/drawable/ic_ai_share_button.xml
@@ -1,18 +1,15 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-  <group>
-    <clip-path android:pathData="M2,0L22,0A2,2 0,0 1,24 2L24,22A2,2 0,0 1,22 24L2,24A2,2 0,0 1,0 22L0,2A2,2 0,0 1,2 0z" />
-    <path
-        android:pathData="M14,5L15.891,10.109L21,12L15.891,13.891L14,19L12.109,13.891L7,12L12.109,10.109L14,5Z"
-        android:fillColor="#1E1E1E" />
-    <path
-        android:pathData="M7,3.5L7.81,5.69L10,6.5L7.81,7.31L7,9.5L6.19,7.31L4,6.5L6.19,5.69L7,3.5Z"
-        android:fillColor="#1E1E1E" />
-    <path
-        android:pathData="M7,14.5L7.81,16.69L10,17.5L7.81,18.31L7,20.5L6.19,18.31L4,17.5L6.19,16.69L7,14.5Z"
-        android:fillColor="#1E1E1E" />
-  </group>
+    android:width="17dp"
+    android:height="18dp"
+    android:viewportWidth="17"
+    android:viewportHeight="18">
+  <path
+      android:pathData="M10,2L11.891,7.109L17,9L11.891,10.891L10,16L8.109,10.891L3,9L8.109,7.109L10,2Z"
+      android:fillColor="#674399"/>
+  <path
+      android:pathData="M3,0.5L3.81,2.69L6,3.5L3.81,4.31L3,6.5L2.19,4.31L0,3.5L2.19,2.69L3,0.5Z"
+      android:fillColor="#674399"/>
+  <path
+      android:pathData="M3,11.5L3.81,13.69L6,14.5L3.81,15.31L3,17.5L2.19,15.31L0,14.5L2.19,13.69L3,11.5Z"
+      android:fillColor="#674399"/>
 </vector>

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -139,6 +139,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="prologue_button_wide">300dp</dimen>
     <dimen name="support_request_message_height">400dp</dimen>
     <dimen name="free_trial_summary_title_top_padding">140dp</dimen>
+    <dimen name="product_sharing_message_height">155dp</dimen>
 
     <!-- More Menu dimens -->
     <dimen name="more_menu_button_height">190dp</dimen>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3346,7 +3346,7 @@
     Product sharing with AI
     -->
     <string name="product_sharing_write_with_ai">Write with AI</string>
-    <string name="product_sharing_regenerate">Regenerate</string>
+    <string name="product_sharing_regenerate">Write again</string>
     <string name="product_sharing_generating">Generating…</string>
     <string name="product_sharing_optional_message_label">Add an optional message</string>
     <string name="product_sharing_ai_info_label">Learn more about our AI feature</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3347,7 +3347,7 @@
     -->
     <string name="product_sharing_write_with_ai">Write with AI</string>
     <string name="product_sharing_regenerate">Write again</string>
-    <string name="product_sharing_generating">Generating…</string>
+    <string name="product_sharing_generating">Writing…</string>
     <string name="product_sharing_optional_message_label">Add an optional message</string>
     <string name="product_sharing_ai_info_label">Learn more about our AI feature</string>
     <string name="product_sharing_ai_generating_failure">Unable to generate sharing message. Please try again!</string>


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR brought the following design changes to the Product Sharing feature:

1. The (i) icon is now a `Learn More` Text button that is aligned to the right.
2. "Regenerate" button text is now replaced with "Write again"
3. "Generating..." button text is now replaced with "Writing..."
4. Spinner is now gray colored to match the disabled state.
5. Learn more button text is now gray colored to match the disabled state.
6. Skeleton loading now has rounded corner (small, to match the text box).
7. The share message textbox now share the same height in empty, loading, and filled state. Technically speaking the loading state shows the skeleton view, not textbox, but the skeleton now also has the same height.
8. The end result for the point above is that now the bottom sheet height stays the same during empty, loading, and filled state.
9. Icon alignment is now corrected in the Write with AI button.

In graphics form, here are the revisions (click for zoomed in version):

![Screenshot 2023-06-23 at 11 54 14](https://github.com/woocommerce/woocommerce-android/assets/266376/982b4f84-1c20-47e5-99b1-3b223a25e017)


![Screenshot 2023-06-23 at 11 54 07](https://github.com/woocommerce/woocommerce-android/assets/266376/d16a0c90-14a4-4746-a913-2b3310a565d1)



### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Run app, go to a product, tap Share,
2. Please check the design elements mentioned above.

### Quick video walkthrough:
<!-- Include before and after images or gifs when appropriate. -->
[device-2023-06-23-120848.webm](https://github.com/woocommerce/woocommerce-android/assets/266376/1e32898b-8449-43ff-9d26-534fba40641a)


<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
