### PR TITLE
UI: update text alignment in more menu button description.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuScreen.kt
@@ -359,12 +359,12 @@ private fun MoreMenuButton(
                 ) {
                     Text(
                         text = stringResource(id = title),
-                        textAlign = TextAlign.Center,
+                        textAlign = TextAlign.Start,
                     )
                     Text(
                         text = stringResource(id = description),
                         style = MaterialTheme.typography.caption,
-                        textAlign = TextAlign.Center,
+                        textAlign = TextAlign.Start,
                     )
                 }
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

A minor PR 🐤 

While testing on a device with the largest font and display size, I found that the more menu button description's text alignment is centered, making it look odd if the text overflows to more than one line. This PR fixes that by making the text aligned to start instead.

This is targeted to `14.2` but it's not a rush for the current code freeze, and can be pushed to later milestone if needed.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Set device to use largest font size and display size. These are both in Settings app > "Accessibility" > "Text and display"
2. Run app, go to More menu,
3. Check the more menu button description's alignment, make sure it matches the screenshot below.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
|--------|--------|
| ![alignment-before](https://github.com/woocommerce/woocommerce-android/assets/266376/d5a112e7-9dbd-408d-ae7d-7484ded98fab) | ![alignment-after](https://github.com/woocommerce/woocommerce-android/assets/266376/a1c62e04-ad0b-4f0a-835b-61f7405368c2) |


