### PR TITLE
change minus button click behaviour

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+14.3
+-----
+- [*] Payments: Products are removed directly from an order when its count is below one, instead of opening an extra screen to remove it. [https://github.com/woocommerce/woocommerce-android/pull/9280]
 
 14.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -272,10 +272,22 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     fun onDecreaseProductsQuantity(id: Long) {
-        tracker.track(
-            ORDER_PRODUCT_QUANTITY_CHANGE,
-            mapOf(KEY_FLOW to flow)
-        )
+        _orderDraft.value.items
+            .find { it.itemId == id }
+            ?.let {
+                if (it.quantity == 1F) {
+                    tracker.track(
+                        ORDER_PRODUCT_REMOVE,
+                        mapOf(KEY_FLOW to flow)
+                    )
+                } else {
+                    tracker.track(
+                        ORDER_PRODUCT_QUANTITY_CHANGE,
+                        mapOf(KEY_FLOW to flow)
+                    )
+                }
+            }
+
         _orderDraft.update { it.adjustProductQuantity(id, -1) }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -272,17 +272,11 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     fun onDecreaseProductsQuantity(id: Long) {
-        _orderDraft.value.items
-            .find { it.itemId == id }
-            ?.takeIf { it.quantity == 1F }
-            ?.let { onProductClicked(it) }
-            ?: run {
-                tracker.track(
-                    ORDER_PRODUCT_QUANTITY_CHANGE,
-                    mapOf(KEY_FLOW to flow)
-                )
-                _orderDraft.update { it.adjustProductQuantity(id, -1) }
-            }
+        tracker.track(
+            ORDER_PRODUCT_QUANTITY_CHANGE,
+            mapOf(KEY_FLOW to flow)
+        )
+        _orderDraft.update { it.adjustProductQuantity(id, -1) }
     }
 
     fun onOrderStatusChanged(status: Order.Status) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -247,7 +247,6 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
             ?.find { it.variationId == 123L && it.itemId == addedProductItemId }
             ?.let { assertThat(it.quantity).isEqualTo(0f) }
             ?: fail("Expected an item with productId 123 with quantity set as 0")
-
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -251,7 +251,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when product quantity decreased, send tracks event`() {
+    fun `given product qt greater than 1, when product quantity decreased, send tracks event`() {
         val productId = 1L
         val products = OrderTestUtils.generateTestOrderItems(count = 1, productId = productId, quantity = 3F)
         val order = defaultOrderValue.copy(items = products)
@@ -265,15 +265,15 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when product quantity decreased but quantity 1, don't send tracks event`() {
+    fun `given product qt equals to 1, when product quantity decreased, send tracks event`() {
         val productId = 1L
         val products = OrderTestUtils.generateTestOrderItems(count = 1, productId = productId, quantity = 1F)
         val order = defaultOrderValue.copy(items = products)
         initMocksForAnalyticsWithOrder(order)
         createSut()
         sut.onDecreaseProductsQuantity(productId)
-        verify(tracker, never()).track(
-            AnalyticsEvent.ORDER_PRODUCT_QUANTITY_CHANGE,
+        verify(tracker).track(
+            AnalyticsEvent.ORDER_PRODUCT_REMOVE,
             mapOf(AnalyticsTracker.KEY_FLOW to tracksFlow)
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9265 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Android/iOS parity:
[iOS issue]( https://github.com/woocommerce/woocommerce-ios/pull/9624)
Context: pdfdoF-2PQ-p2

With this PR we remove the product item directly from an order when its quantity count is only 1, instead of opening an extra screen with a button to remove it. 
The option to remove the product regardless of the quantity is in place when the user taps on the product row, as it might be useful to remove the product directly when the quantity count is high -instead of having to press the `- ` button several times.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to the Orders Screen
2. Click on the `+` button to add a new order
3. click on `+ Add Product`
4. select one or more products
5. increase the products quantity to at least 2
6. test tapping on the `-` button to decrease the quantity of products
7. make sure when the quantity is 1 and you tap the - button, it gets deleted without going to the product screen with the `Remove product` button
8. add another product if needed
9. increase the product count
10. click on the product row to make sure you are taken to the product screen where there's a Remove Product button
11. tap on the button to make sure the product is removed as a whole

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
| ---- | ---- |
| <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/2e6d3e15-07de-4a48-b21c-28deb8c93dbe" width="350"/> | <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/7cd58aa3-25d4-428f-869c-7fbb47842092" width="350"/> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->