### PR TITLE
[JITM] Evict JITM from the cache when CTA clicked

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmStoreInMemoryCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmStoreInMemoryCache.kt
@@ -83,6 +83,10 @@ class JitmStoreInMemoryCache
         return jitmStore.dismissJitmMessage(selectedSite.get(), jitmId, featureClass)
     }
 
+    fun onCtaClicked(messagePath: String) {
+        evictFirstMessage(messagePath)
+    }
+
     private fun handleResponse(path: String, response: WooResult<Array<JITMApiResponse>>) {
         val utmSource = path.split(":")[1]
         if (!response.isError) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmViewModel.kt
@@ -83,6 +83,7 @@ class JitmViewModel @Inject constructor(
     }
 
     private fun onJitmCtaClicked(model: JITMApiResponse) {
+        jitmStoreCache.onCtaClicked(messagePath)
         jitmTracker.trackJitmCtaTapped(
             utmSource,
             model.id,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmStoreInMemoryCacheTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmStoreInMemoryCacheTest.kt
@@ -195,4 +195,22 @@ class JitmStoreInMemoryCacheTest : BaseUnitTest() {
         // THEN
         assertThat(cache.getMessagesForPath(messagePath = messagePath)).isEmpty()
     }
+
+    @Test
+    fun `when onCtaClicked, then message evicted from cache`() = testBlocking {
+        // GIVEN
+        val messagePath = "path:screen:1"
+        val jitmApiResponse1 = mock<JITMApiResponse>()
+        val jitmResponseArray = arrayOf(jitmApiResponse1)
+        whenever(selectedSite.exists()).thenReturn(true)
+        whenever(pathsProvider.paths).thenReturn(listOf(messagePath))
+        whenever(jitmStore.fetchJitmMessage(any(), any(), any())).thenReturn(WooResult(jitmResponseArray))
+        cache.init()
+
+        // WHEN
+        cache.onCtaClicked(messagePath)
+
+        // THEN
+        assertThat(cache.getMessagesForPath(messagePath = messagePath)).isEmpty()
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmViewModelTest.kt
@@ -412,6 +412,39 @@ class JitmViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given jitm displayed, when jitm cta clicked, then jitm click called from cache`() {
+        whenever(selectedSite.getIfExists()).thenReturn(SiteModel())
+        testBlocking {
+            val jitmCtaLink = "https://woocommerce.com/products/hardware/US"
+            whenever(
+                jitmStoreInMemoryCache.getMessagesForPath(any())
+            ).thenReturn(
+                listOf(
+                    provideJitmApiResponse(
+                        jitmCta = provideJitmCta(
+                            link = jitmCtaLink
+                        )
+                    )
+                )
+            )
+            whenever(
+                utmProvider.getUrlWithUtmParams(
+                    anyString(),
+                    anyString(),
+                    anyString(),
+                    any(),
+                    anyString(),
+                )
+            ).thenReturn(jitmCtaLink)
+
+            whenViewModelIsCreated()
+            (sut.jitmState.value as JitmState.Banner).onPrimaryActionClicked.invoke()
+
+            verify(jitmStoreInMemoryCache).onCtaClicked("woomobile:my_store:admin_notices")
+        }
+    }
+
+    @Test
     fun `given jitm displayed, when jitm cta clicked, then proper url is passedto OpenJITM event`() {
         val jitmCtaLink = "https://woocommerce.com/products/hardware/US"
         val jitmCtaLinkWithUtmParams = "https://woocommerce.com/products/hardware/US?utm_campaign=compaign"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9296
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In order to avoid showing the same JITM from the local cache, we decided that it will make sense to remove it from there when CTA used

p1687440393738639/1687337330.096909-slack-C025A8VV728

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Use either local (`jitm_testing_json_file_name = jitm_testing.json`) or remote JITM response
* Click on CTA
* Notice that when you come back next JITM is shown (if it was in the response)

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/bb3854da-8f9b-4f66-ac2a-a18659e5e842



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->