### PR TITLE
[Order Creation] Feature flag and skeleton for the new screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListFragment.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android.ui.orders.creation.customerlistnew
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class CustomerListFragment : BaseFragment() {
+    private val viewModel by viewModels<CustomerListViewModel>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                WooThemeWithBackground {
+                    CustomerListScreen(viewModel)
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
@@ -9,16 +9,5 @@ fun CustomerListScreen(
     viewModel: CustomerListViewModel
 ) {
     val state by viewModel.viewState.observeAsState(CustomerListViewModel.ViewState.Loading)
-    CustomerListScreen(
-        state,
-        viewModel::onCustomerClick
-    )
-}
-
-@Composable
-@Suppress("UnusedPrivateMember", "EmptyFunctionBlock")
-fun CustomerListScreen(
-    state: CustomerListViewModel.ViewState,
-    onCustomerClick: ((Long) -> Unit?)? = null
-) {
+    print(state)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
@@ -1,0 +1,24 @@
+package com.woocommerce.android.ui.orders.creation.customerlistnew
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+
+@Composable
+fun CustomerListScreen(
+    viewModel: CustomerListViewModel
+) {
+    val state by viewModel.viewState.observeAsState(CustomerListViewModel.ViewState.Loading)
+    CustomerListScreen(
+        state,
+        viewModel::onCustomerClick
+    )
+}
+
+@Composable
+@Suppress("UnusedPrivateMember", "EmptyFunctionBlock")
+fun CustomerListScreen(
+    state: CustomerListViewModel.ViewState,
+    onCustomerClick: ((Long) -> Unit?)? = null
+) {
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
@@ -9,12 +9,12 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-@Suppress("UnusedPrivateMember", "EmptyFunctionBlock")
+@Suppress("UnusedPrivateMember")
 class CustomerListViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val customerListRepository: CustomerListRepository
 ) : ScopedViewModel(savedState) {
-    private val _viewState = MutableLiveData<ViewState>(ViewState.Loading)
+    private val _viewState = MutableLiveData<ViewState>()
     val viewState: LiveData<ViewState> = _viewState
 
     private var searchQuery: String
@@ -27,9 +27,6 @@ class CustomerListViewModel @Inject constructor(
         set(value) {
             savedState[SEARCH_MODE_KEY] = value
         }
-
-    fun onCustomerClick(customerRemoteId: Long) {
-    }
 
     sealed class ViewState {
         object Loading : ViewState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
@@ -1,0 +1,59 @@
+package com.woocommerce.android.ui.orders.creation.customerlistnew
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.ui.orders.creation.customerlist.CustomerListRepository
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+@Suppress("UnusedPrivateMember", "EmptyFunctionBlock")
+class CustomerListViewModel @Inject constructor(
+    savedState: SavedStateHandle,
+    private val customerListRepository: CustomerListRepository
+) : ScopedViewModel(savedState) {
+    private val _viewState = MutableLiveData<ViewState>(ViewState.Loading)
+    val viewState: LiveData<ViewState> = _viewState
+
+    private var searchQuery: String
+        get() = savedState.get<String>(SEARCH_QUERY_KEY) ?: ""
+        set(value) {
+            savedState[SEARCH_QUERY_KEY] = value
+        }
+    private var searchMode: SearchMode
+        get() = savedState.get<SearchMode>(SEARCH_MODE_KEY) ?: SearchMode.ALL
+        set(value) {
+            savedState[SEARCH_MODE_KEY] = value
+        }
+
+    fun onCustomerClick(customerRemoteId: Long) {
+    }
+
+    sealed class ViewState {
+        object Loading : ViewState()
+        object Empty : ViewState()
+        object Error : ViewState()
+        data class Loaded(val customers: List<ListItem>) : ViewState()
+
+        data class ListItem(
+            val remoteId: Long,
+            val firstName: String,
+            val lastName: String,
+            val email: String,
+        )
+    }
+
+    enum class SearchMode(val value: String) {
+        ALL("all"),
+        EMAIL("email"),
+        NAME("name"),
+        USERNAME("username"),
+    }
+
+    private companion object {
+        private const val SEARCH_QUERY_KEY = "search_query"
+        private const val SEARCH_MODE_KEY = "search_mode"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt
@@ -12,14 +12,20 @@ import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavi
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.ShowCreatedOrder
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.ShowProductDetails
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
+import com.woocommerce.android.util.FeatureFlag
 
 object OrderCreateEditNavigator {
     fun navigate(fragment: Fragment, target: OrderCreateEditNavigationTarget) {
         val navController = fragment.findNavController()
 
         val action = when (target) {
-            is EditCustomer ->
-                OrderCreateEditFormFragmentDirections.actionOrderCreationFragmentToOrderCreationCustomerFragment()
+            is EditCustomer -> {
+                if (FeatureFlag.CUSTOMER_LIST_SEARCH_2.isEnabled()) {
+                    OrderCreateEditFormFragmentDirections.actionOrderCreationFragmentToCustomerListFragment()
+                } else {
+                    OrderCreateEditFormFragmentDirections.actionOrderCreationFragmentToOrderCreationCustomerFragment()
+                }
+            }
             is EditCustomerNote ->
                 OrderCreateEditFormFragmentDirections.actionOrderCreationFragmentToOrderCreationCustomerNoteFragment()
             is SelectItems ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -30,7 +30,8 @@ enum class FeatureFlag {
     PRIVACY_CHOICES,
     SHARING_PRODUCT_AI,
     BLAZE,
-    PRODUCT_DESCRIPTION_AI_GENERATOR;
+    PRODUCT_DESCRIPTION_AI_GENERATOR,
+    CUSTOMER_LIST_SEARCH_2;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -61,7 +62,8 @@ enum class FeatureFlag {
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             IPP_TAP_TO_PAY,
-            PRODUCT_DESCRIPTION_AI_GENERATOR -> PackageUtils.isDebugBuild()
+            PRODUCT_DESCRIPTION_AI_GENERATOR,
+            CUSTOMER_LIST_SEARCH_2 -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false
         }

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -37,6 +37,9 @@
             android:id="@+id/action_orderCreationFragment_to_orderCreationCustomerFragment"
             app:destination="@id/orderCreationCustomerFragment" />
         <action
+            android:id="@+id/action_orderCreationFragment_to_customerListFragment"
+            app:destination="@id/customerListFragmentNew" />
+        <action
             android:id="@+id/action_orderCreationFragment_to_orderCreationProductDetailsFragment"
             app:destination="@id/orderCreationProductDetailsFragment"
             app:enterAnim="@anim/default_enter_anim"
@@ -203,8 +206,11 @@
     <fragment
         android:id="@+id/customerListFragment"
         android:name="com.woocommerce.android.ui.orders.creation.customerlist.CustomerListFragment"
-        android:label="customerListFragment"
-        tools:layout="@layout/fragment_customer_list" />
+        android:label="customerListFragment" />
+    <fragment
+        android:id="@+id/customerListFragmentNew"
+        android:name="com.woocommerce.android.ui.orders.creation.customerlistnew.CustomerListFragment"
+        android:label="customerListFragment" />
 
     <include app:graph="@navigation/nav_graph_product_selector" />
 </navigation>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9303
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds feature flag and opens skeleton screen for the future customer search if the flag is on

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Run release build
* Follow order creation -> add customer flow 
* Notice that there are no changes
* Run debug build
* Follow order creation -> add customer flow 
* Notice that empty screen is open

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/fde76b9a-c61b-4d41-a831-517c9c74d0f1



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
