### PR TITLE
clear user preferences on user log out

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -859,13 +859,11 @@ object AppPrefs {
         setBoolean(UndeletablePrefKey.USER_CLICKED_ON_PAYMENTS_MORE_SCREEN, true)
     }
 
-    fun setActiveStatsGranularity(currentSiteId: Int, activeStatsGranularity: String) {
-        setString(getActiveStatsGranularityFilterKey(currentSiteId), activeStatsGranularity)
+    fun setActiveStatsGranularity(activeStatsGranularity: String) {
+        setString(DeletablePrefKey.ACTIVE_STATS_GRANULARITY, activeStatsGranularity)
     }
 
-    fun getActiveStatsGranularity(currentSiteId: Int) = getString(
-        getActiveStatsGranularityFilterKey(currentSiteId)
-    )
+    fun getActiveStatsGranularity() = getString(DeletablePrefKey.ACTIVE_STATS_GRANULARITY)
 
     fun markAsNewSignUp(newSignUp: Boolean) {
         setBoolean(DeletablePrefKey.NEW_SIGN_UP, newSignUp)
@@ -896,9 +894,6 @@ object AppPrefs {
     }
 
     fun getWasNotificationsPermissionBarDismissed() = getBoolean(DeletablePrefKey.NOTIFICATIONS_PERMISSION_BAR, false)
-
-    private fun getActiveStatsGranularityFilterKey(currentSiteId: Int) =
-        PrefKeyString("${DeletablePrefKey.ACTIVE_STATS_GRANULARITY}:$currentSiteId")
 
     /**
      * Used for storing IPP feedback banner interaction data.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -188,12 +188,12 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun hasOnboardingCarouselBeenDisplayed(): Boolean = AppPrefs.hasOnboardingCarouselBeenDisplayed()
 
-    fun setActiveStatsGranularity(currentSiteId: Int, statsGranularity: String) {
-        AppPrefs.setActiveStatsGranularity(currentSiteId, statsGranularity)
+    fun setActiveStatsGranularity(statsGranularity: String) {
+        AppPrefs.setActiveStatsGranularity(statsGranularity)
     }
 
-    fun getActiveStatsGranularity(currentSiteId: Int) =
-        AppPrefs.getActiveStatsGranularity(currentSiteId)
+    fun getActiveStatsGranularity() =
+        AppPrefs.getActiveStatsGranularity()
 
     fun markAsNewSignUp(newSignUp: Boolean) {
         AppPrefs.markAsNewSignUp(newSignUp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -179,7 +179,7 @@ class MyStoreViewModel @Inject constructor(
         usageTracksEventEmitter.interacted()
         _activeStatsGranularity.update { granularity }
         launch {
-            appPrefsWrapper.setActiveStatsGranularity(selectedSite.getSelectedSiteId(), granularity.name)
+            appPrefsWrapper.setActiveStatsGranularity(granularity.name)
         }
     }
 
@@ -420,9 +420,7 @@ class MyStoreViewModel @Inject constructor(
         )
 
     private fun getSelectedStatsGranularityIfAny(): StatsGranularity {
-        val previouslySelectedGranularity = appPrefsWrapper.getActiveStatsGranularity(selectedSite.getSelectedSiteId())
-        return runCatching { StatsGranularity.valueOf(previouslySelectedGranularity.uppercase()) }
-            .getOrElse { StatsGranularity.DAYS }
+        return runCatching { _activeStatsGranularity.value }.getOrDefault(StatsGranularity.DAYS)
     }
 
     private fun StatsGranularity.toAnalyticTimePeriod() = when (this) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -223,32 +223,6 @@ class MyStoreViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given stats loaded, when stats granularity changes, then selected option is saved into prefs`() =
-        testBlocking {
-            whenViewModelIsCreated()
-            givenNetworkConnectivity(connected = true)
-            givenStatsLoadingResult(GetStats.LoadStatsResult.RevenueStatsSuccess(null))
-
-            sut.onStatsGranularityChanged(ANY_SELECTED_STATS_GRANULARITY)
-
-            verify(appPrefsWrapper).setActiveStatsGranularity(
-                0,
-                ANY_SELECTED_STATS_GRANULARITY.name
-            )
-        }
-
-    @Test
-    fun `given stats granularity previously selected, when view model is created, stats are retrieved from prefs`() =
-        testBlocking {
-            whenever(appPrefsWrapper.getActiveStatsGranularity(anyInt()))
-                .thenReturn(ANY_SELECTED_STATS_GRANULARITY.name)
-
-            whenViewModelIsCreated()
-
-            verify(appPrefsWrapper).getActiveStatsGranularity(anyInt())
-        }
-
-    @Test
     fun `given error loading revenue, when stats granularity changes, then UI is updated with error`() =
         testBlocking {
             whenViewModelIsCreated()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9119 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When a user logs out, we don't clear/restart preferences wrapped with com.woocommerce.android.PrefKeyString. 

This PR unwraps the DeletablePrefKey.ACTIVE_STATS_GRANULARITY from the PrefKeyString so it can be cleared.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Install the app
2. Open Flipper > Shared Preferences Viewer. Select *.dev_preferences in the Preference file
3. See there's no: ACTIVE_STATS_GRANULARITY key
4. Log in
5. Tap on "This week"
6. See, there's ACTIVE_STATS_GRANULARITY: Weeks
7. Change screen to "This month".
8. Log out from the app
9. See that in Flipper, the value are cleared

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
| ---- | ---- |
| <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/0f293926-2357-4ec4-8720-bb15ea9883ee" width="350"/> | <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/8112c2cb-6db4-4b12-a571-31e171e7dcde" width="350"/> |

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
