### PR TITLE
Android CameraX version 

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -390,11 +390,11 @@ dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.8'
 
     // CameraX
-    implementation "androidx.camera:camera-camera2:$camerax"
-    implementation "androidx.camera:camera-lifecycle:$cameraLifecycle"
-    implementation "androidx.camera:camera-view:$cameraView"
+    implementation "androidx.camera:camera-camera2:$androidxCameraVersion"
+    implementation "androidx.camera:camera-lifecycle:$androidxCameraVersion"
+    implementation "androidx.camera:camera-view:$androidxCameraVersion"
 
-    implementation "com.google.guava:guava:$guava"
+    implementation "com.google.guava:guava:$guavaVersion"
 }
 
 task copyGoogleServicesExampleFile(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -119,10 +119,8 @@ ext {
     billingVersion = '5.0.0'
     stripeTerminalVersion = '2.21.1'
     mlkitVersion = '17.1.0'
-    camerax = '1.2.3'
-    cameraLifecycle = '1.2.3'
-    cameraView = '1.2.3'
-    guava = '31.0.1-android'
+    androidxCameraVersion = '1.2.3'
+    guavaVersion = '31.0.1-android'
 
     // Apache
     commonsText = '1.10.0'


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: #9316 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Replace 3 different constants into a single one for cameraX dependencies since all of them pointed to the same version number.

### Before this PR
```
camerax = '1.2.3'
cameraLifecycle = '1.2.3'
cameraView = '1.2.3'
```

### After this PR

```
androidxCameraVersion = '1.2.3'
```

This PR also changes the dependency constant used for the Gauva library from `guava` to `guavaVersion` to remain consistent with other dependency constants.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just ensure CI is happy


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
