### PR TITLE
[Order Creation] UI of the search with selectable params

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/SearchLayoutWithParams.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/SearchLayoutWithParams.kt
@@ -1,0 +1,123 @@
+package com.woocommerce.android.ui.compose.component
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.woocommerce.android.R
+
+@Composable
+fun SearchLayoutWithParams(
+    state: SearchLayoutWithParamsState,
+    onSearchQueryChanged: (String) -> Unit,
+    onSearchTypeSelected: (Int) -> Unit
+) {
+    val isFocused = remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
+
+    val searchQuery = remember { mutableStateOf(state.initialSearchQuery) }
+    val newLineRegex = Regex("[\n\r]")
+
+    Column {
+        WCSearchField(
+            value = state.initialSearchQuery,
+            onValueChange = { newValue: String ->
+                if (newValue.contains(newLineRegex)) {
+                    searchQuery.value = newValue.replace(newLineRegex, "")
+                } else {
+                    onSearchQueryChanged(newValue)
+                }
+            },
+            hint = stringResource(id = state.hint),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = dimensionResource(id = R.dimen.major_100),
+                    vertical = dimensionResource(id = R.dimen.minor_100)
+                )
+                .onFocusChanged { isFocused.value = it.isFocused }
+                .focusRequester(focusRequester),
+            keyboardOptions = KeyboardOptions(autoCorrect = false),
+        )
+        if (isFocused.value) {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = dimensionResource(id = R.dimen.minor_100)),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                state.supportedSearchTypes.forEach { searchType ->
+                    WCSelectableChip(
+                        modifier = Modifier
+                            .padding(horizontal = dimensionResource(id = R.dimen.minor_100))
+                            .weight(1f),
+                        onClick = { onSearchTypeSelected(searchType.textId) },
+                        text = stringResource(id = searchType.textId),
+                        isSelected = searchType.isSelected
+                    )
+                }
+            }
+        }
+    }
+    LaunchedEffect(state.isActive) {
+        if (state.isActive) {
+            focusRequester.requestFocus()
+        } else {
+            focusManager.clearFocus()
+        }
+    }
+}
+
+data class SearchLayoutWithParamsState(
+    @StringRes val hint: Int,
+    val initialSearchQuery: String,
+    val isActive: Boolean,
+    val supportedSearchTypes: List<SearchType>,
+) {
+    data class SearchType(
+        @StringRes val textId: Int,
+        val isSelected: Boolean = false
+    )
+}
+
+@Preview
+@Composable
+fun SearchLayoutPreview() {
+    SearchLayoutWithParams(
+        state = SearchLayoutWithParamsState(
+            hint = R.string.product_selector_search_hint,
+            initialSearchQuery = "",
+            isActive = true,
+            supportedSearchTypes = listOf(
+                SearchLayoutWithParamsState.SearchType(
+                    textId = R.string.product_search_all,
+                ),
+                SearchLayoutWithParamsState.SearchType(
+                    textId = R.string.product_search_sku,
+                    isSelected = true,
+                ),
+                SearchLayoutWithParamsState.SearchType(
+                    textId = R.string.product_visibility_public,
+                ),
+            )
+        ),
+        onSearchQueryChanged = {},
+        onSearchTypeSelected = {},
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/SearchLayoutWithParams.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/SearchLayoutWithParams.kt
@@ -95,8 +95,8 @@ private fun SearchParamsRowScrollable(
     ) {
         supportedSearchTypes.forEach { searchType ->
             WCSelectableChip(
-                onClick = { onSearchTypeSelected(searchType.textId) },
-                text = stringResource(id = searchType.textId),
+                onClick = { onSearchTypeSelected(searchType.labelResId) },
+                text = stringResource(id = searchType.labelResId),
                 isSelected = searchType.isSelected
             )
         }
@@ -119,8 +119,8 @@ private fun SearchParamsRowFillWidth(
                 modifier = Modifier
                     .padding(horizontal = dimensionResource(id = R.dimen.minor_100))
                     .weight(1f),
-                onClick = { onSearchTypeSelected(searchType.textId) },
-                text = stringResource(id = searchType.textId),
+                onClick = { onSearchTypeSelected(searchType.labelResId) },
+                text = stringResource(id = searchType.labelResId),
                 isSelected = searchType.isSelected
             )
         }
@@ -134,7 +134,7 @@ data class SearchLayoutWithParamsState(
     val supportedSearchTypes: List<SearchType>,
 ) {
     data class SearchType(
-        @StringRes val textId: Int,
+        @StringRes val labelResId: Int,
         val isSelected: Boolean = false
     )
 }
@@ -149,17 +149,17 @@ fun SearchLayoutPreviewFillMaxWidth() {
             isActive = true,
             supportedSearchTypes = listOf(
                 SearchLayoutWithParamsState.SearchType(
-                    textId = R.string.product_search_all,
+                    labelResId = R.string.product_search_all,
                 ),
                 SearchLayoutWithParamsState.SearchType(
-                    textId = R.string.product_search_all,
+                    labelResId = R.string.product_search_all,
                 ),
                 SearchLayoutWithParamsState.SearchType(
-                    textId = R.string.product_search_sku,
+                    labelResId = R.string.product_search_sku,
                     isSelected = true,
                 ),
                 SearchLayoutWithParamsState.SearchType(
-                    textId = R.string.product_visibility_public,
+                    labelResId = R.string.product_visibility_public,
                 ),
             )
         ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/SearchLayoutWithParams.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/SearchLayoutWithParams.kt
@@ -89,7 +89,7 @@ private fun SearchParamsRowScrollable(
 ) {
     Row(
         Modifier
-            .padding(horizontal = dimensionResource(id = R.dimen.minor_100))
+            .padding(horizontal = dimensionResource(id = R.dimen.major_100))
             .horizontalScroll(rememberScrollState()),
         horizontalArrangement = spacedBy(dimensionResource(id = R.dimen.minor_100))
     ) {
@@ -163,7 +163,7 @@ fun SearchLayoutPreviewFillMaxWidth() {
                 ),
             )
         ),
-        paramsFillWidth = true,
+        paramsFillWidth = false,
         onSearchQueryChanged = {},
         onSearchTypeSelected = {},
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListFragment.kt
@@ -9,11 +9,14 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class CustomerListFragment : BaseFragment() {
     private val viewModel by viewModels<CustomerListViewModel>()
+
+    override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
@@ -1,13 +1,85 @@
 package com.woocommerce.android.ui.orders.creation.customerlistnew
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.SearchLayoutWithParams
+import com.woocommerce.android.ui.compose.component.SearchLayoutWithParamsState
+
+@Composable
+fun CustomerListScreen(viewModel: CustomerListViewModel) {
+    val state by viewModel.viewState.observeAsState()
+
+    state?.let {
+        Scaffold(topBar = {
+            TopAppBar(
+                title = { Text(stringResource(id = R.string.order_creation_fragment_title)) },
+                navigationIcon = {
+                    IconButton(viewModel::onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = stringResource(id = R.string.back)
+                        )
+                    }
+                },
+                backgroundColor = colorResource(id = R.color.color_toolbar),
+                elevation = 0.dp,
+            )
+        }) { padding ->
+            CustomerListScreen(
+                modifier = Modifier.padding(padding),
+                state = it,
+                onSearchQueryChanged = viewModel::onSearchQueryChanged,
+                onSearchTypeChanged = viewModel::onSearchTypeChanged
+            )
+        }
+    }
+}
 
 @Composable
 fun CustomerListScreen(
-    viewModel: CustomerListViewModel
+    modifier: Modifier = Modifier,
+    state: CustomerListViewState,
+    onSearchQueryChanged: (String) -> Unit,
+    onSearchTypeChanged: (Int) -> Unit,
 ) {
-    val state by viewModel.viewState.observeAsState(CustomerListViewModel.ViewState.Loading)
-    print(state)
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colors.surface)
+    ) {
+        SearchLayoutWithParams(
+            state = SearchLayoutWithParamsState(
+                hint = R.string.order_creation_customer_search_hint,
+                searchQuery = state.searchQuery,
+                isActive = true,
+                supportedSearchTypes = state.searchModes.map {
+                    SearchLayoutWithParamsState.SearchType(
+                        labelResId = it.labelResId,
+                        isSelected = it.isSelected,
+                    )
+                }
+            ),
+            paramsFillWidth = false,
+            onSearchQueryChanged = onSearchQueryChanged,
+            onSearchTypeSelected = onSearchTypeChanged,
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
@@ -67,7 +67,7 @@ fun CustomerListScreen(
     ) {
         SearchLayoutWithParams(
             state = SearchLayoutWithParamsState(
-                hint = R.string.order_creation_customer_search_hint,
+                hint = R.string.order_creation_customer_filter_hint,
                 searchQuery = state.searchQuery,
                 isActive = true,
                 supportedSearchTypes = state.searchModes.map {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
@@ -3,9 +3,11 @@ package com.woocommerce.android.ui.orders.creation.customerlistnew
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.orders.creation.customerlist.CustomerListRepository
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -14,43 +16,79 @@ class CustomerListViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val customerListRepository: CustomerListRepository
 ) : ScopedViewModel(savedState) {
-    private val _viewState = MutableLiveData<ViewState>()
-    val viewState: LiveData<ViewState> = _viewState
+    private val _viewState = MutableLiveData<CustomerListViewState>()
+    val viewState: LiveData<CustomerListViewState> = _viewState
 
     private var searchQuery: String
         get() = savedState.get<String>(SEARCH_QUERY_KEY) ?: ""
         set(value) {
             savedState[SEARCH_QUERY_KEY] = value
         }
-    private var searchMode: SearchMode
-        get() = savedState.get<SearchMode>(SEARCH_MODE_KEY) ?: SearchMode.ALL
+    private var selectedSearchMode: SearchMode?
+        get() = savedState.get<SearchMode>(SEARCH_MODE_KEY)
         set(value) {
             savedState[SEARCH_MODE_KEY] = value
         }
 
-    sealed class ViewState {
-        object Loading : ViewState()
-        object Empty : ViewState()
-        object Error : ViewState()
-        data class Loaded(val customers: List<ListItem>) : ViewState()
-
-        data class ListItem(
-            val remoteId: Long,
-            val firstName: String,
-            val lastName: String,
-            val email: String,
-        )
+    init {
+        launch {
+            _viewState.value = CustomerListViewState(
+                searchQuery = searchQuery,
+                searchModes = selectSearchMode(selectedSearchMode?.labelResId),
+                customers = CustomerListViewState.CustomerList.Loading
+            )
+        }
     }
 
-    enum class SearchMode(val value: String) {
-        ALL("all"),
-        EMAIL("email"),
-        NAME("name"),
-        USERNAME("username"),
+    fun onSearchQueryChanged(query: String) {
+        with(query) {
+            searchQuery = this
+            _viewState.value = _viewState.value!!.copy(searchQuery = this)
+        }
     }
+
+    fun onSearchTypeChanged(searchTypeId: Int) {
+        with(searchTypeId) {
+            selectedSearchMode = supportedSearchModes.first { it.labelResId == this }.copy(isSelected = true)
+            _viewState.value = _viewState.value!!.copy(
+                searchModes = selectSearchMode(this)
+            )
+        }
+    }
+
+    fun onNavigateBack() {
+    }
+
+    private fun selectSearchMode(searchTypeId: Int?) =
+        supportedSearchModes.map {
+            it.copy(isSelected = it.labelResId == searchTypeId)
+        }
 
     private companion object {
         private const val SEARCH_QUERY_KEY = "search_query"
         private const val SEARCH_MODE_KEY = "search_mode"
+
+        private val supportedSearchModes = listOf(
+            SearchMode(
+                labelResId = R.string.order_creation_customer_search_all,
+                searchParam = "all",
+                isSelected = false,
+            ),
+            SearchMode(
+                labelResId = R.string.order_creation_customer_search_email,
+                searchParam = "email",
+                isSelected = false,
+            ),
+            SearchMode(
+                labelResId = R.string.order_creation_customer_search_name,
+                searchParam = "name",
+                isSelected = false,
+            ),
+            SearchMode(
+                labelResId = R.string.order_creation_customer_search_username,
+                searchParam = "username",
+                isSelected = false,
+            ),
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-@Suppress("UnusedPrivateMember")
+@Suppress("UnusedPrivateMember", "EmptyFunctionBlock")
 class CustomerListViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val customerListRepository: CustomerListRepository
@@ -24,8 +24,8 @@ class CustomerListViewModel @Inject constructor(
         set(value) {
             savedState[SEARCH_QUERY_KEY] = value
         }
-    private var selectedSearchMode: SearchMode?
-        get() = savedState.get<SearchMode>(SEARCH_MODE_KEY)
+    private var selectedSearchMode: SearchMode
+        get() = savedState.get<SearchMode>(SEARCH_MODE_KEY) ?: supportedSearchModes.first()
         set(value) {
             savedState[SEARCH_MODE_KEY] = value
         }
@@ -34,7 +34,7 @@ class CustomerListViewModel @Inject constructor(
         launch {
             _viewState.value = CustomerListViewState(
                 searchQuery = searchQuery,
-                searchModes = selectSearchMode(selectedSearchMode?.labelResId),
+                searchModes = selectSearchMode(selectedSearchMode.labelResId),
                 customers = CustomerListViewState.CustomerList.Loading
             )
         }
@@ -49,7 +49,8 @@ class CustomerListViewModel @Inject constructor(
 
     fun onSearchTypeChanged(searchTypeId: Int) {
         with(searchTypeId) {
-            selectedSearchMode = supportedSearchModes.first { it.labelResId == this }.copy(isSelected = true)
+            selectedSearchMode = supportedSearchModes.first { it.labelResId == this }
+                .copy(isSelected = true)
             _viewState.value = _viewState.value!!.copy(
                 searchModes = selectSearchMode(this)
             )
@@ -59,7 +60,7 @@ class CustomerListViewModel @Inject constructor(
     fun onNavigateBack() {
     }
 
-    private fun selectSearchMode(searchTypeId: Int?) =
+    private fun selectSearchMode(searchTypeId: Int) =
         supportedSearchModes.map {
             it.copy(isSelected = it.labelResId == searchTypeId)
         }
@@ -70,7 +71,7 @@ class CustomerListViewModel @Inject constructor(
 
         private val supportedSearchModes = listOf(
             SearchMode(
-                labelResId = R.string.order_creation_customer_search_all,
+                labelResId = R.string.order_creation_customer_search_everything,
                 searchParam = "all",
                 isSelected = false,
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewState.kt
@@ -29,4 +29,4 @@ data class SearchMode(
     @StringRes val labelResId: Int,
     val searchParam: String,
     val isSelected: Boolean,
-): Parcelable
+) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewState.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android.ui.orders.creation.customerlistnew
+
+import android.os.Parcelable
+import androidx.annotation.StringRes
+import kotlinx.parcelize.Parcelize
+
+data class CustomerListViewState(
+    val searchQuery: String = "",
+    val searchModes: List<SearchMode>,
+    val customers: CustomerList = CustomerList.Loading,
+) {
+    sealed class CustomerList {
+        object Loading : CustomerList()
+        object Empty : CustomerList()
+        object Error : CustomerList()
+        data class Loaded(val customers: List<Item>) : CustomerList()
+
+        data class Item(
+            val remoteId: Long,
+            val firstName: String,
+            val lastName: String,
+            val email: String,
+        )
+    }
+}
+
+@Parcelize
+data class SearchMode(
+    @StringRes val labelResId: Int,
+    val searchParam: String,
+    val isSelected: Boolean,
+): Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductListHandler.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.products.selector
 
+import androidx.annotation.StringRes
+import com.woocommerce.android.R
 import com.woocommerce.android.model.Product
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -119,7 +121,11 @@ class ProductListHandler @Inject constructor(private val repository: ProductSele
     private fun updateSearchResult(list: List<Product>, loadedProducts: List<Product>) =
         (list + loadedProducts).distinctBy { it.remoteId }
 
-    enum class SearchType {
-        DEFAULT, SKU
+    enum class SearchType(@StringRes val labelResId: Int) {
+        DEFAULT(R.string.product_search_all), SKU(R.string.product_search_sku);
+
+        companion object {
+            fun fromLabelResId(@StringRes labelResId: Int) = values().firstOrNull { it.labelResId == labelResId }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -135,11 +135,11 @@ fun ProductSelectorScreen(
                     isActive = state.searchState.isActive,
                     supportedSearchTypes = listOf(
                         SearchLayoutWithParamsState.SearchType(
-                            textId = string.product_search_all,
+                            labelResId = string.product_search_all,
                             isSelected = state.searchState.searchType.labelResId == string.product_search_all
                         ),
                         SearchLayoutWithParamsState.SearchType(
-                            textId = string.product_search_sku,
+                            labelResId = string.product_search_sku,
                             isSelected = state.searchState.searchType.labelResId == string.product_search_sku
                         ),
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -131,7 +131,7 @@ fun ProductSelectorScreen(
             SearchLayoutWithParams(
                 state = SearchLayoutWithParamsState(
                     hint = string.product_selector_search_hint,
-                    initialSearchQuery = state.searchState.searchQuery,
+                    searchQuery = state.searchState.searchQuery,
                     isActive = state.searchState.isActive,
                     supportedSearchTypes = listOf(
                         SearchLayoutWithParamsState.SearchType(
@@ -144,6 +144,7 @@ fun ProductSelectorScreen(
                         ),
                     )
                 ),
+                paramsFillWidth = true,
                 onSearchQueryChanged = onSearchQueryChanged,
                 onSearchTypeSelected = onSearchTypeChanged,
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products.selector
 
 import android.os.Parcelable
+import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
@@ -517,9 +518,9 @@ class ProductSelectorViewModel @Inject constructor(
         }
     }
 
-    fun onSearchTypeChanged(searchType: SearchType) {
+    fun onSearchTypeChanged(@StringRes searchType: Int) {
         this.searchState.update {
-            it.copy(searchType = searchType)
+            it.copy(searchType = SearchType.fromLabelResId(searchType)!!)
         }
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -549,6 +549,10 @@
     <string name="order_creation_fee_percentage_calculated_amount">Calculated amount: %s</string>
     <string name="order_creation_customer_search_empty">No customers found</string>
     <string name="order_creation_customer_search_hint">Search customers</string>
+    <string name="order_creation_customer_search_all">All</string>
+    <string name="order_creation_customer_search_email">Email</string>
+    <string name="order_creation_customer_search_name">Name</string>
+    <string name="order_creation_customer_search_username">Username</string>
     <string name="order_creation_change_product_quantity">Change the product quantity from %1$d to %2$d</string>
     <string name="order_creation_barcode_scanning_unable_to_add_product">Product not found. Unable to add to new order</string>
     <string name="order_creation_barcode_scanning_scanning_failed">Scanning failed. Please try again later</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -549,7 +549,8 @@
     <string name="order_creation_fee_percentage_calculated_amount">Calculated amount: %s</string>
     <string name="order_creation_customer_search_empty">No customers found</string>
     <string name="order_creation_customer_search_hint">Search customers</string>
-    <string name="order_creation_customer_search_all">All</string>
+    <string name="order_creation_customer_filter_hint">Filter customers by</string>
+    <string name="order_creation_customer_search_everything">Everything</string>
     <string name="order_creation_customer_search_email">Email</string>
     <string name="order_creation_customer_search_name">Name</string>
     <string name="order_creation_customer_search_username">Username</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -392,7 +392,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
 
         val sut = createViewModel(navArgs)
 
-        sut.onSearchTypeChanged(ProductListHandler.SearchType.SKU)
+        sut.onSearchTypeChanged(ProductListHandler.SearchType.SKU.labelResId)
         sut.onSearchQueryChanged("test")
 
         advanceTimeBy(SEARCH_TYPING_DELAY_MS + 1)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9304
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds the UI of the search with selectable params. It extracts and reuses compose "SearchLayout" that is also used in Product Selection Search screen

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Start order creation
* Start adding a new customer
* Notice new search for UI
* Notice that search and type selection services activity death
* Make sure that Products Selection Search is not affected by the changes

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/cae5d59d-92c2-486a-b254-00c1e4808ce6



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
