### PR TITLE
Analytics Performance: adjust analytics hub to use stored data

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
@@ -38,7 +38,7 @@ class DataStoreModule {
     fun provideAnalyticsDataStore(
         appContext: Context,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
-    ) : DataStore<Preferences> = PreferenceDataStoreFactory.create(
+    ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = {
             appContext.preferencesDataStoreFile("analytics")
         },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
@@ -38,7 +38,7 @@ class DataStoreModule {
     fun provideAnalyticsDataStore(
         appContext: Context,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
-    ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
+    ) : DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = {
             appContext.preferencesDataStoreFile("analytics")
         },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -53,8 +53,6 @@ import javax.inject.Inject
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState as ProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.LoadingViewState as LoadingProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.NoDataState as ProductsNoDataState
-import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.FetchStrategy.ForceNew
-import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.FetchStrategy.Saved
 
 @HiltViewModel
 class AnalyticsHubViewModel @Inject constructor(
@@ -143,7 +141,6 @@ class AnalyticsHubViewModel @Inject constructor(
         viewModelScope.launch {
             updateStats(
                 rangeSelection = ranges,
-                fetchStrategy = getFetchStrategy(isRefreshing = true),
                 scope = viewModelScope
             ).collect {
                 mutableState.update { viewState ->
@@ -164,15 +161,12 @@ class AnalyticsHubViewModel @Inject constructor(
     private fun formatValue(value: String, currencyCode: String?) =
         currencyCode?.let { currencyFormatter.formatCurrency(value, it) } ?: value
 
-    private fun getFetchStrategy(isRefreshing: Boolean) = if (isRefreshing) ForceNew else Saved
-
     private fun observeRangeSelectionChanges() {
         rangeSelectionState.onEach {
             updateDateSelector()
             trackSelectedDateRange()
             updateStats(
                 rangeSelection = it,
-                fetchStrategy = getFetchStrategy(isRefreshing = false),
                 scope = viewModelScope
             )
         }.launchIn(viewModelScope)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -22,8 +22,6 @@ import com.woocommerce.android.ui.analytics.hub.informationcard.AnalyticsHubInfo
 import com.woocommerce.android.ui.analytics.hub.informationcard.AnalyticsHubInformationViewState.NoDataState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListCardItemViewState
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsHubUpdateState.Finished
-import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.FetchStrategy.ForceNew
-import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.FetchStrategy.Saved
 import com.woocommerce.android.ui.analytics.hub.sync.OrdersState
 import com.woocommerce.android.ui.analytics.hub.sync.ProductsState
 import com.woocommerce.android.ui.analytics.hub.sync.RevenueState
@@ -55,6 +53,8 @@ import javax.inject.Inject
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState as ProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.LoadingViewState as LoadingProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.NoDataState as ProductsNoDataState
+import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.FetchStrategy.ForceNew
+import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.FetchStrategy.Saved
 
 @HiltViewModel
 class AnalyticsHubViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -7,10 +7,10 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
+import javax.inject.Inject
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
-import javax.inject.Inject
 
 class AnalyticsUpdateDataStore @Inject constructor(
     @DataStoreQualifier(DataStoreType.ANALYTICS) private val dataStore: DataStore<Preferences>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -7,10 +7,10 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
-import javax.inject.Inject
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
+import javax.inject.Inject
 
 class AnalyticsUpdateDataStore @Inject constructor(
     @DataStoreQualifier(DataStoreType.ANALYTICS) private val dataStore: DataStore<Preferences>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -43,6 +43,6 @@ class AnalyticsUpdateDataStore @Inject constructor(
         get() = currentTimeProvider.currentDate().time
 
     companion object {
-        const val defaultMaxOutdatedTime = 1000 * 30L // 30 seconds
+        const val defaultMaxOutdatedTime = 1000 * 60 * 30L // 30 minutes
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -19,15 +19,14 @@ class AnalyticsUpdateDataStore @Inject constructor(
     suspend fun shouldUpdateAnalytics(
         rangeSelection: StatsTimeRangeSelection,
         maxOutdatedTime: Long = defaultMaxOutdatedTime
-    ) = flow {
-        rangeSelection.lastUpdateTimestamp.collect { lastUpdateTimestamp ->
+    ) = rangeSelection.lastUpdateTimestamp
+        .map { lastUpdateTimestamp ->
             lastUpdateTimestamp
                 ?.let { currentTime - it }
                 ?.let { timeElapsedSinceLastUpdate ->
-                    emit(timeElapsedSinceLastUpdate > maxOutdatedTime)
-                } ?: emit(true)
+                    timeElapsedSinceLastUpdate > maxOutdatedTime
+                } ?: true
         }
-    }
 
     suspend fun storeLastAnalyticsUpdate(rangeSelection: StatsTimeRangeSelection) {
         dataStore.edit { preferences ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -7,7 +7,6 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import javax.inject.Inject
@@ -16,7 +15,7 @@ class AnalyticsUpdateDataStore @Inject constructor(
     @DataStoreQualifier(DataStoreType.ANALYTICS) private val dataStore: DataStore<Preferences>,
     private val currentTimeProvider: CurrentTimeProvider
 ) {
-    suspend fun shouldUpdateAnalytics(
+    fun shouldUpdateAnalytics(
         rangeSelection: StatsTimeRangeSelection,
         maxOutdatedTime: Long = defaultMaxOutdatedTime
     ) = rangeSelection.lastUpdateTimestamp

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -7,14 +7,10 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.singleOrNull
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import javax.inject.Inject
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.mapNotNull
 
 class AnalyticsUpdateDataStore @Inject constructor(
     @DataStoreQualifier(DataStoreType.ANALYTICS) private val dataStore: DataStore<Preferences>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
@@ -46,8 +46,8 @@ class UpdateAnalyticsHubStats @Inject constructor(
         _productsState.update { ProductsState.Loading }
         visitorsCountState.update { VisitorsState.Loading }
 
-        withFetchStrategy(rangeSelection) {
-            updateStatsData(scope, rangeSelection, it)
+        withFetchStrategyFrom(rangeSelection) { fetchStrategy ->
+            updateStatsData(scope, rangeSelection, fetchStrategy)
         }
 
         return fullStatsRequestState
@@ -70,7 +70,7 @@ class UpdateAnalyticsHubStats @Inject constructor(
         }
     }
 
-    private suspend fun withFetchStrategy(
+    private suspend fun withFetchStrategyFrom(
         rangeSelection: StatsTimeRangeSelection,
         action: suspend (FetchStrategy) -> Unit
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
@@ -68,12 +68,17 @@ class UpdateAnalyticsHubStats @Inject constructor(
         }
     }
 
-    private suspend fun generateFetchStrategy(rangeSelection: StatsTimeRangeSelection) =
-        if (analyticsUpdateDataStore.shouldUpdateAnalytics(rangeSelection)) {
+    private suspend fun generateFetchStrategy(rangeSelection: StatsTimeRangeSelection): FetchStrategy {
+        if (rangeSelection.selectionType == StatsTimeRangeSelection.SelectionType.CUSTOM) {
+            return FetchStrategy.ForceNew
+        }
+
+        return if (analyticsUpdateDataStore.shouldUpdateAnalytics(rangeSelection)) {
             FetchStrategy.ForceNew
         } else {
             FetchStrategy.Saved
         }
+    }
 
     private fun combineFullUpdateState() =
         combine(_revenueState, _productsState, _ordersState, sessionState) { revenue, products, orders, session ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
@@ -15,10 +15,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
-import kotlinx.coroutines.flow.firstOrNull
 
 class UpdateAnalyticsHubStats @Inject constructor(
     private val analyticsUpdateDataStore: AnalyticsUpdateDataStore,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 
 class UpdateAnalyticsHubStats @Inject constructor(
     private val analyticsUpdateDataStore: AnalyticsUpdateDataStore,
@@ -79,12 +79,12 @@ class UpdateAnalyticsHubStats @Inject constructor(
             action(FetchStrategy.ForceNew)
         }
 
-        val strategy = analyticsUpdateDataStore
+        analyticsUpdateDataStore
             .shouldUpdateAnalytics(rangeSelection)
             .map { if (it) FetchStrategy.ForceNew else FetchStrategy.Saved }
-            .first()
-
-        action(strategy)
+            .firstOrNull()
+            ?.let { action(it) }
+            ?: action(FetchStrategy.ForceNew)
     }
 
     private fun combineFullUpdateState() =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
+import kotlinx.coroutines.flow.first
 
 class UpdateAnalyticsHubStats @Inject constructor(
     private val analyticsUpdateDataStore: AnalyticsUpdateDataStore,
@@ -78,10 +79,12 @@ class UpdateAnalyticsHubStats @Inject constructor(
             action(FetchStrategy.ForceNew)
         }
 
-        analyticsUpdateDataStore
+        val strategy = analyticsUpdateDataStore
             .shouldUpdateAnalytics(rangeSelection)
             .map { if (it) FetchStrategy.ForceNew else FetchStrategy.Saved }
-            .collect { action(it) }
+            .first()
+
+        action(strategy)
     }
 
     private fun combineFullUpdateState() =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
@@ -68,6 +68,13 @@ class UpdateAnalyticsHubStats @Inject constructor(
         }
     }
 
+    private suspend fun generateFetchStrategy(rangeSelection: StatsTimeRangeSelection) =
+        if (analyticsUpdateDataStore.shouldUpdateAnalytics(rangeSelection)) {
+            FetchStrategy.ForceNew
+        } else {
+            FetchStrategy.Saved
+        }
+
     private fun combineFullUpdateState() =
         combine(_revenueState, _productsState, _ordersState, sessionState) { revenue, products, orders, session ->
             revenue.isIdle && products.isIdle && orders.isIdle && session.isIdle
@@ -123,11 +130,4 @@ class UpdateAnalyticsHubStats @Inject constructor(
             ?.let { _productsState.value = ProductsState.Available(it.productsStat) }
             ?: _productsState.update { ProductsState.Error }
     }
-
-    private suspend fun generateFetchStrategy(rangeSelection: StatsTimeRangeSelection) =
-        if (analyticsUpdateDataStore.shouldUpdateAnalytics(rangeSelection)) {
-            FetchStrategy.ForceNew
-        } else {
-            FetchStrategy.Saved
-        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubTestFixtures.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubTestFixtures.kt
@@ -13,11 +13,17 @@ import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.Revenue
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.RevenueResult.RevenueData
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.VisitorsResult
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.VisitorsResult.VisitorsData
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.CUSTOM
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.TODAY
 import java.util.Calendar
 import java.util.Locale
 
 val testRangeSelection = TODAY.generateSelectionData(
+    calendar = Calendar.getInstance(),
+    locale = Locale.getDefault()
+)
+
+val testCustomRangeSelection = CUSTOM.generateSelectionData(
     calendar = Calendar.getInstance(),
     locale = Locale.getDefault()
 )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
@@ -410,7 +410,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
     fun `given a view, when refresh is requested, then show indicator is the expected`() = testBlocking {
         configureSuccessfulStatsResponse()
         updateStats.stub {
-            onBlocking { invoke(any(), any(), any()) } doReturn flow {
+            onBlocking { invoke(any(), any()) } doReturn flow {
                 emit(AnalyticsHubUpdateState.Finished)
                 emit(AnalyticsHubUpdateState.Loading)
             }
@@ -744,7 +744,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
                 emit(SessionState.Loading)
                 emit(SessionState.Available(testSessionStat))
             }
-            onBlocking { invoke(any(), any(), any()) } doReturn flow {
+            onBlocking { invoke(any(), any()) } doReturn flow {
                 emit(AnalyticsHubUpdateState.Finished)
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -276,7 +276,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
     fun `when selection type is CUSTOM, then ignore the data store and request data with ForceNew strategy`() = testBlocking {
         // Given
         analyticsDataStore = mock {
-            onBlocking { shouldUpdateAnalytics(testRangeSelection) } doReturn false
+            onBlocking { shouldUpdateAnalytics(testCustomRangeSelection) } doReturn false
         }
         sut = UpdateAnalyticsHubStats(
             analyticsUpdateDataStore = analyticsDataStore,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -236,15 +236,8 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when syncing stats data starts, then store the expected timestamp`() = testBlocking {
-    }
+    fun `when syncing stats data starts with ForceNew strategy, then store the expected timestamp`() = testBlocking {
 
-    @Test
-    fun `when syncing stats data starts under the cache interval, then request data from cache`() = testBlocking {
-    }
-
-    @Test
-    fun `when syncing stats data starts outside the cache interval, then request data from network`() = testBlocking {
     }
 
     private fun configureSuccessResponseStub() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.model.ProductsStat
 import com.woocommerce.android.model.RevenueStat
 import com.woocommerce.android.model.SessionStat
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository
+import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.FetchStrategy.ForceNew
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.FetchStrategy.Saved
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.OrdersResult
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.ProductsResult
@@ -232,19 +233,19 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
     private fun configureSuccessResponseStub() {
         repository.stub {
             onBlocking {
-                repository.fetchRevenueData(testRangeSelection, Saved)
+                repository.fetchRevenueData(testRangeSelection, ForceNew)
             } doReturn testRevenueResult
 
             onBlocking {
-                repository.fetchOrdersData(testRangeSelection, Saved)
+                repository.fetchOrdersData(testRangeSelection, ForceNew)
             } doReturn testOrdersResult
 
             onBlocking {
-                repository.fetchProductsData(testRangeSelection, Saved)
+                repository.fetchProductsData(testRangeSelection, ForceNew)
             } doReturn testProductsResult
 
             onBlocking {
-                repository.fetchVisitorsData(testRangeSelection, Saved)
+                repository.fetchVisitorsData(testRangeSelection, ForceNew)
             } doReturn testVisitorsResult
         }
     }
@@ -252,19 +253,19 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
     private fun configureErrorResponseStub() {
         repository.stub {
             onBlocking {
-                repository.fetchRevenueData(testRangeSelection, Saved)
+                repository.fetchRevenueData(testRangeSelection, ForceNew)
             } doReturn RevenueResult.RevenueError
 
             onBlocking {
-                repository.fetchOrdersData(testRangeSelection, Saved)
+                repository.fetchOrdersData(testRangeSelection, ForceNew)
             } doReturn OrdersResult.OrdersError
 
             onBlocking {
-                repository.fetchProductsData(testRangeSelection, Saved)
+                repository.fetchProductsData(testRangeSelection, ForceNew)
             } doReturn ProductsResult.ProductsError
 
             onBlocking {
-                repository.fetchVisitorsData(testRangeSelection, Saved)
+                repository.fetchVisitorsData(testRangeSelection, ForceNew)
             } doReturn VisitorsResult.VisitorsError
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.ui.analytics.hub.sync.SessionState
 import com.woocommerce.android.ui.analytics.hub.sync.UpdateAnalyticsHubStats
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -42,7 +43,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
     @Before
     fun setUp() {
         analyticsDataStore = mock {
-            onBlocking { shouldUpdateAnalytics(testRangeSelection) } doReturn true
+            onBlocking { shouldUpdateAnalytics(testRangeSelection) } doReturn flowOf(true)
         }
         repository = mock()
         sut = UpdateAnalyticsHubStats(
@@ -255,7 +256,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
     fun `when data store does NOT allows net stats fetch, then request data with Saved strategy`() = testBlocking {
         // Given
         analyticsDataStore = mock {
-            onBlocking { shouldUpdateAnalytics(testRangeSelection) } doReturn false
+            onBlocking { shouldUpdateAnalytics(testRangeSelection) } doReturn flowOf(false)
         }
         sut = UpdateAnalyticsHubStats(
             analyticsUpdateDataStore = analyticsDataStore,
@@ -276,7 +277,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
     fun `when selection type is CUSTOM, then ignore the data store and request data with ForceNew strategy`() = testBlocking {
         // Given
         analyticsDataStore = mock {
-            onBlocking { shouldUpdateAnalytics(testCustomRangeSelection) } doReturn false
+            onBlocking { shouldUpdateAnalytics(testCustomRangeSelection) } doReturn flowOf(false)
         }
         sut = UpdateAnalyticsHubStats(
             analyticsUpdateDataStore = analyticsDataStore,
@@ -310,7 +311,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
         // Given
         configureSuccessResponseStub()
         analyticsDataStore = mock {
-            onBlocking { shouldUpdateAnalytics(testRangeSelection) } doReturn false
+            onBlocking { shouldUpdateAnalytics(testRangeSelection) } doReturn flowOf(false)
         }
         sut = UpdateAnalyticsHubStats(
             analyticsUpdateDataStore = analyticsDataStore,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -27,6 +27,8 @@ import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 
 @ExperimentalCoroutinesApi
 internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
@@ -237,7 +239,14 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
 
     @Test
     fun `when syncing stats data starts with ForceNew strategy, then store the expected timestamp`() = testBlocking {
+        // Given
+        configureSuccessResponseStub()
 
+        // When
+        sut(testRangeSelection, this)
+
+        // Then
+        verify(analyticsDataStore, times(1)).storeLastAnalyticsUpdate(testRangeSelection)
     }
 
     private fun configureSuccessResponseStub() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -26,6 +26,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -247,6 +248,25 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
 
         // Then
         verify(analyticsDataStore, times(1)).storeLastAnalyticsUpdate(testRangeSelection)
+    }
+
+    @Test
+    fun `when syncing stats data stats with Stored strategy, then do not store the timestamp`() = testBlocking {
+        // Given
+        configureSuccessResponseStub()
+        analyticsDataStore = mock {
+            onBlocking { shouldUpdateAnalytics(testRangeSelection) } doReturn false
+        }
+        sut = UpdateAnalyticsHubStats(
+            analyticsUpdateDataStore = analyticsDataStore,
+            analyticsRepository = repository
+        )
+
+        // When
+        sut(testRangeSelection, this)
+
+        // Then
+        verify(analyticsDataStore, never()).storeLastAnalyticsUpdate(testRangeSelection)
     }
 
     private fun configureSuccessResponseStub() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -30,7 +30,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 
 @ExperimentalCoroutinesApi
@@ -246,10 +245,10 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
         sut(testRangeSelection, this)
 
         // Then
-        verify(repository, times(1)).fetchRevenueData(testRangeSelection, ForceNew)
-        verify(repository, times(1)).fetchOrdersData(testRangeSelection, ForceNew)
-        verify(repository, times(1)).fetchVisitorsData(testRangeSelection, ForceNew)
-        verify(repository, times(1)).fetchProductsData(testRangeSelection, ForceNew)
+        verify(repository).fetchRevenueData(testRangeSelection, ForceNew)
+        verify(repository).fetchOrdersData(testRangeSelection, ForceNew)
+        verify(repository).fetchVisitorsData(testRangeSelection, ForceNew)
+        verify(repository).fetchProductsData(testRangeSelection, ForceNew)
     }
 
     @Test
@@ -267,10 +266,10 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
         sut(testRangeSelection, this)
 
         // Then
-        verify(repository, times(1)).fetchRevenueData(testRangeSelection, Saved)
-        verify(repository, times(1)).fetchOrdersData(testRangeSelection, Saved)
-        verify(repository, times(1)).fetchVisitorsData(testRangeSelection, Saved)
-        verify(repository, times(1)).fetchProductsData(testRangeSelection, Saved)
+        verify(repository).fetchRevenueData(testRangeSelection, Saved)
+        verify(repository).fetchOrdersData(testRangeSelection, Saved)
+        verify(repository).fetchVisitorsData(testRangeSelection, Saved)
+        verify(repository).fetchProductsData(testRangeSelection, Saved)
     }
 
     @Test
@@ -288,10 +287,10 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
         sut(testCustomRangeSelection, this)
 
         // Then
-        verify(repository, times(1)).fetchRevenueData(testCustomRangeSelection, ForceNew)
-        verify(repository, times(1)).fetchOrdersData(testCustomRangeSelection, ForceNew)
-        verify(repository, times(1)).fetchVisitorsData(testCustomRangeSelection, ForceNew)
-        verify(repository, times(1)).fetchProductsData(testCustomRangeSelection, ForceNew)
+        verify(repository).fetchRevenueData(testCustomRangeSelection, ForceNew)
+        verify(repository).fetchOrdersData(testCustomRangeSelection, ForceNew)
+        verify(repository).fetchVisitorsData(testCustomRangeSelection, ForceNew)
+        verify(repository).fetchProductsData(testCustomRangeSelection, ForceNew)
     }
 
     @Test
@@ -303,7 +302,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
         sut(testRangeSelection, this)
 
         // Then
-        verify(analyticsDataStore, times(1)).storeLastAnalyticsUpdate(testRangeSelection)
+        verify(analyticsDataStore).storeLastAnalyticsUpdate(testRangeSelection)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -6,11 +6,11 @@ import com.woocommerce.android.model.RevenueStat
 import com.woocommerce.android.model.SessionStat
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.FetchStrategy.ForceNew
-import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.FetchStrategy.Saved
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.OrdersResult
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.ProductsResult
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.RevenueResult
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsRepository.VisitorsResult
+import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsUpdateDataStore
 import com.woocommerce.android.ui.analytics.hub.sync.OrdersState
 import com.woocommerce.android.ui.analytics.hub.sync.ProductsState
 import com.woocommerce.android.ui.analytics.hub.sync.RevenueState
@@ -30,14 +30,19 @@ import org.mockito.kotlin.stub
 
 @ExperimentalCoroutinesApi
 internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
+    private lateinit var analyticsDataStore: AnalyticsUpdateDataStore
     private lateinit var repository: AnalyticsRepository
 
     private lateinit var sut: UpdateAnalyticsHubStats
 
     @Before
     fun setUp() {
+        analyticsDataStore = mock {
+            onBlocking { shouldUpdateAnalytics(testRangeSelection) } doReturn true
+        }
         repository = mock()
         sut = UpdateAnalyticsHubStats(
+            analyticsUpdateDataStore = analyticsDataStore,
             analyticsRepository = repository
         )
     }
@@ -52,7 +57,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
             .launchIn(this)
 
         // When
-        sut(testRangeSelection, Saved, this)
+        sut(testRangeSelection, this)
 
         advanceUntilIdle()
 
@@ -75,7 +80,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
             .launchIn(this)
 
         // When
-        sut(testRangeSelection, Saved, this)
+        sut(testRangeSelection, this)
 
         advanceUntilIdle()
 
@@ -98,7 +103,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
             .launchIn(this)
 
         // When
-        sut(testRangeSelection, Saved, this)
+        sut(testRangeSelection, this)
 
         advanceUntilIdle()
 
@@ -121,7 +126,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
             .launchIn(this)
 
         // When
-        sut(testRangeSelection, Saved, this)
+        sut(testRangeSelection, this)
 
         advanceUntilIdle()
 
@@ -144,7 +149,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
             .launchIn(this)
 
         // When
-        sut(testRangeSelection, Saved, this)
+        sut(testRangeSelection, this)
 
         advanceUntilIdle()
 
@@ -167,7 +172,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
             .launchIn(this)
 
         // When
-        sut(testRangeSelection, Saved, this)
+        sut(testRangeSelection, this)
 
         advanceUntilIdle()
 
@@ -194,7 +199,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
             .launchIn(this)
 
         // When
-        sut(testRangeSelection, Saved, this)
+        sut(testRangeSelection, this)
 
         advanceUntilIdle()
 
@@ -217,7 +222,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
             .launchIn(this)
 
         // When
-        sut(testRangeSelection, Saved, this)
+        sut(testRangeSelection, this)
 
         advanceUntilIdle()
 
@@ -228,6 +233,21 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
         assertThat(sessionStatsUpdates[2]).isEqualTo(SessionState.Error)
 
         job.cancel()
+    }
+
+    @Test
+    fun `when syncing stats data starts, then store the expected timestamp`() = testBlocking {
+
+    }
+
+    @Test
+    fun `when syncing stats data starts under the cache interval, then request data from cache`() = testBlocking {
+
+    }
+
+    @Test
+    fun `when syncing stats data starts outside the cache interval, then request data from network`() = testBlocking {
+
     }
 
     private fun configureSuccessResponseStub() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -327,7 +327,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
 
     @Test
     fun `when syncing stats with empty DataStore flow response, then use ForceNew strategy`() = testBlocking {
-        //Given
+        // Given
         configureSuccessResponseStub()
         analyticsDataStore = mock {
             onBlocking { shouldUpdateAnalytics(testRangeSelection) } doReturn emptyFlow()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -237,17 +237,14 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
 
     @Test
     fun `when syncing stats data starts, then store the expected timestamp`() = testBlocking {
-
     }
 
     @Test
     fun `when syncing stats data starts under the cache interval, then request data from cache`() = testBlocking {
-
     }
 
     @Test
     fun `when syncing stats data starts outside the cache interval, then request data from network`() = testBlocking {
-
     }
 
     private fun configureSuccessResponseStub() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -273,6 +273,27 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when selection type is CUSTOM, then ignore the data store and request data with ForceNew strategy`() = testBlocking {
+        // Given
+        analyticsDataStore = mock {
+            onBlocking { shouldUpdateAnalytics(testRangeSelection) } doReturn false
+        }
+        sut = UpdateAnalyticsHubStats(
+            analyticsUpdateDataStore = analyticsDataStore,
+            analyticsRepository = repository
+        )
+
+        // When
+        sut(testCustomRangeSelection, this)
+
+        // Then
+        verify(repository, times(1)).fetchRevenueData(testCustomRangeSelection, ForceNew)
+        verify(repository, times(1)).fetchOrdersData(testCustomRangeSelection, ForceNew)
+        verify(repository, times(1)).fetchVisitorsData(testCustomRangeSelection, ForceNew)
+        verify(repository, times(1)).fetchProductsData(testCustomRangeSelection, ForceNew)
+    }
+
+    @Test
     fun `when syncing stats data starts with ForceNew strategy, then store the expected timestamp`() = testBlocking {
         // Given
         configureSuccessResponseStub()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.ui.analytics.hub.sync.SessionState
 import com.woocommerce.android.ui.analytics.hub.sync.UpdateAnalyticsHubStats
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -322,6 +323,28 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
 
         // Then
         verify(analyticsDataStore, never()).storeLastAnalyticsUpdate(testRangeSelection)
+    }
+
+    @Test
+    fun `when syncing stats with empty DataStore flow response, then use ForceNew strategy`() = testBlocking {
+        //Given
+        configureSuccessResponseStub()
+        analyticsDataStore = mock {
+            onBlocking { shouldUpdateAnalytics(testRangeSelection) } doReturn emptyFlow()
+        }
+        sut = UpdateAnalyticsHubStats(
+            analyticsUpdateDataStore = analyticsDataStore,
+            analyticsRepository = repository
+        )
+
+        // When
+        sut(testRangeSelection, this)
+
+        // Then
+        verify(repository).fetchRevenueData(testRangeSelection, ForceNew)
+        verify(repository).fetchOrdersData(testRangeSelection, ForceNew)
+        verify(repository).fetchVisitorsData(testRangeSelection, ForceNew)
+        verify(repository).fetchProductsData(testRangeSelection, ForceNew)
     }
 
     private fun configureSuccessResponseStub() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
@@ -5,9 +5,6 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.longPreferencesKey
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.LAST_MONTH
 import com.woocommerce.android.viewmodel.BaseUnitTest
-import java.util.Calendar
-import java.util.Date
-import java.util.Locale
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
@@ -15,6 +12,9 @@ import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
 
 @ExperimentalCoroutinesApi
 class AnalyticsUpdateDataStoreTest : BaseUnitTest() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
@@ -5,6 +5,9 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.longPreferencesKey
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.LAST_MONTH
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
@@ -12,9 +15,6 @@ import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
-import java.util.Calendar
-import java.util.Date
-import java.util.Locale
 
 @ExperimentalCoroutinesApi
 class AnalyticsUpdateDataStoreTest : BaseUnitTest() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.Selec
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.single
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.doReturn
@@ -15,7 +16,6 @@ import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
-import kotlinx.coroutines.flow.single
 
 @ExperimentalCoroutinesApi
 class AnalyticsUpdateDataStoreTest : BaseUnitTest() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import kotlinx.coroutines.flow.single
 
 @ExperimentalCoroutinesApi
 class AnalyticsUpdateDataStoreTest : BaseUnitTest() {
@@ -41,7 +42,7 @@ class AnalyticsUpdateDataStoreTest : BaseUnitTest() {
         val result = sut.shouldUpdateAnalytics(
             rangeSelection = defaultSelectionData,
             maxOutdatedTime = maxOutdatedTime
-        )
+        ).single()
 
         // Then
         assertThat(result).isTrue
@@ -60,7 +61,7 @@ class AnalyticsUpdateDataStoreTest : BaseUnitTest() {
         val result = sut.shouldUpdateAnalytics(
             rangeSelection = defaultSelectionData,
             maxOutdatedTime = maxOutdatedTime
-        )
+        ).single()
 
         // Then
         assertThat(result).isFalse
@@ -79,7 +80,7 @@ class AnalyticsUpdateDataStoreTest : BaseUnitTest() {
         val result = sut.shouldUpdateAnalytics(
             rangeSelection = defaultSelectionData,
             maxOutdatedTime = maxOutdatedTime
-        )
+        ).single()
 
         // Then
         assertThat(result).isTrue


### PR DESCRIPTION
Summary
==========
Partially fix issue #9269 by connecting the newly introduced `AnalyticsUpdateDataStore` with the `UpdateAnalyticsHubStats` use case, effectively connecting the expected logic for updating the stats inside the Analytics Hub.

How to Test
==========
1. Open the app and enter the Analytics Hub
2. Once the data is loaded, exit and reenter the Hub with the same range selection, and verify that no network operation is triggered.
3. Wait 30 seconds, exit the Hub, and enter again. Now verify that a new request was made fetching the stats data inside the Hub again for that specific selection range.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
