### PR TITLE
Avoid foreground services on API 34+

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -10,12 +10,13 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.RUN_USER_INITIATED_JOBS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACTION_OPEN_DOCUMENT" />
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
-    <uses-permission android:name="android.permission.CAMERA"></uses-permission>
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:name=".WooCommerce"
@@ -195,6 +196,11 @@
 
         <service
             android:name=".media.ProductImagesService"
+            android:exported="false" />
+
+        <service
+            android:name=".media.ProductImagesJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false" />
 
         <!-- Provider for exposing file URIs on Android 7+ (required for camera) -->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesJobService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesJobService.kt
@@ -1,0 +1,38 @@
+package com.woocommerce.android.media
+
+import android.app.job.JobParameters
+import android.app.job.JobService
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.work.Configuration
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+/**
+ * Service which uploads device images to the WP media library to be later assigned to a product.
+ * This service is used on devices running API 34 and above due to the restrictions on foreground services.
+ */
+@AndroidEntryPoint
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+class ProductImagesJobService : JobService() {
+    companion object {
+        private const val MIN_JOB_ID = 0
+        private const val MAX_JOB_ID = 10000
+    }
+    @Inject lateinit var notifHandler: ProductImagesNotificationHandler
+
+    init {
+        val builder: Configuration.Builder = Configuration.Builder()
+        builder.setJobSchedulerJobIdRange(MIN_JOB_ID, MAX_JOB_ID)
+    }
+
+    override fun onStartJob(params: JobParameters?): Boolean {
+        notifHandler.attachToService(this, params!!)
+        return true
+    }
+
+    override fun onStopJob(params: JobParameters?): Boolean {
+        jobFinished(params!!, false)
+        return true
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesNotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesNotificationHandler.kt
@@ -2,7 +2,11 @@ package com.woocommerce.android.media
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.job.JobParameters
+import android.app.job.JobService
 import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.navigation.NavDeepLinkBuilder
@@ -61,6 +65,17 @@ class ProductImagesNotificationHandler @Inject constructor(
         val notification = notificationBuilder.build()
         service.startForeground(FOREGROUND_NOTIFICATION_ID, notification)
         notificationManager.notify(FOREGROUND_NOTIFICATION_ID, notification)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    fun attachToService(service: ProductImagesJobService, params: JobParameters) {
+        val notification = notificationBuilder.build()
+        service.setNotification(
+            params,
+            FOREGROUND_NOTIFICATION_ID,
+            notification,
+            JobService.JOB_END_NOTIFICATION_POLICY_REMOVE
+        )
     }
 
     fun update(currentUpload: Int, totalUploads: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesServiceWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesServiceWrapper.kt
@@ -1,8 +1,16 @@
 package com.woocommerce.android.media
 
+import android.app.job.JobInfo
+import android.app.job.JobScheduler
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
+import com.woocommerce.android.util.SystemVersionUtils
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -11,15 +19,47 @@ import javax.inject.Singleton
  * to the [Context]
  */
 @Singleton
-class ProductImagesServiceWrapper
-@Inject constructor(
+class ProductImagesServiceWrapper @Inject constructor(
     private val context: Context
 ) {
+    companion object {
+        private const val JOB_ID = 112233
+    }
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun startJobService() {
+        val networkRequestBuilder = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+
+        val jobInfo = JobInfo.Builder(JOB_ID, ComponentName(context, ProductImagesJobService::class.java))
+            .setUserInitiated(true)
+            .setRequiredNetwork(networkRequestBuilder.build())
+            .build()
+
+        val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
+        jobScheduler.schedule(jobInfo)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun stopJobService() {
+        val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
+        jobScheduler.cancel(JOB_ID)
+    }
+
     fun startService() {
-        ContextCompat.startForegroundService(context, Intent(context, ProductImagesService::class.java))
+        // we can't use foreground services on devices running >API 34
+        if (SystemVersionUtils.isAtLeastU()) {
+            startJobService()
+        } else {
+            ContextCompat.startForegroundService(context, Intent(context, ProductImagesService::class.java))
+        }
     }
 
     fun stopService() {
-        context.stopService(Intent(context, ProductImagesService::class.java))
+        if (SystemVersionUtils.isAtLeastU()) {
+            stopJobService()
+        } else {
+            context.stopService(Intent(context, ProductImagesService::class.java))
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/SystemVersionUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/SystemVersionUtils.kt
@@ -4,6 +4,9 @@ import android.os.Build
 
 @Suppress("Unused", "TooManyFunctions")
 object SystemVersionUtils {
+    fun isAtLeastU() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+    fun isAtMostU() = Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+
     fun isAtLeastT() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
     fun isAtMostT() = Build.VERSION.SDK_INT <= Build.VERSION_CODES.TIRAMISU
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/SystemVersionUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/SystemVersionUtils.kt
@@ -1,9 +1,11 @@
 package com.woocommerce.android.util
 
 import android.os.Build
+import androidx.annotation.ChecksSdkIntAtLeast
 
 @Suppress("Unused", "TooManyFunctions")
 object SystemVersionUtils {
+    @ChecksSdkIntAtLeast(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
     fun isAtLeastU() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
     fun isAtMostU() = Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -58,7 +58,7 @@ gradle.ext.mediaPickerSourceGifBinaryPath = "org.wordpress.mediapicker:source-gi
 gradle.ext.mediaPickerSourceWordPressBinaryPath = "org.wordpress.mediapicker:source-wordpress"
 
 gradle.ext {
-    compileSdkVersion = 33
+    compileSdkVersion = 34
     targetSdkVersion = 33
     minSdkVersion = 24
 }


### PR DESCRIPTION
This PR implements [a new user-initiated data-transfer](https://developer.android.com/about/versions/14/changes/user-initiated-data-transfers) `JobService` that avoids using foreground services. This is a [new policy requirement](https://support.google.com/googleplay/android-developer/answer/13315670) for devices running API 34+ from August 31, 2023 (p8Qyks-5tZ). Although this requirement applies only after we update the `targetSdk` to 34, I already started looking into it and implemented the change, so we might as well use it.

**To test:**
1. Create a new emulator running Android 14 (API 34)
2. Run the app and log in
3. Enable the notifications permission
4. Go to Products -> select a product
5. Tap on the new image button
6. Take a picture with a camera and confirm
7. Notice the image upload is initiated and a notification is shown
8. After the upload finishes, notice the notification is removed