### PR TITLE
[TTP] Change min required android version to 10

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatus.kt
@@ -22,7 +22,7 @@ class TapToPayAvailabilityStatus @Inject constructor(
     operator fun invoke() =
         when {
             !appPrefs.isTapToPayEnabled -> Result.NotAvailable.TapToPayDisabled
-            !systemVersionUtilsWrapper.isAtLeastP() -> Result.NotAvailable.SystemVersionNotSupported
+            !systemVersionUtilsWrapper.isAtLeastQ() -> Result.NotAvailable.SystemVersionNotSupported
             !deviceFeatures.isGooglePlayServicesAvailable() -> Result.NotAvailable.GooglePlayServicesNotAvailable
             !deviceFeatures.isNFCAvailable() -> Result.NotAvailable.NfcNotAvailable
             !isTppSupportedInCountry(wooStore.getStoreCountryCode(selectedSite.get())) ->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
@@ -17,7 +17,7 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 
 class TapToPayAvailabilityStatusTest {
     private val systemVersionUtilsWrapper = mock<SystemVersionUtilsWrapper> {
-        on { isAtLeastP() }.thenReturn(true)
+        on { isAtLeastQ() }.thenReturn(true)
     }
     private val appPrefs: AppPrefs = mock()
     private val cardReaderCountryConfigProvider: CardReaderCountryConfigProvider = mock {
@@ -39,7 +39,7 @@ class TapToPayAvailabilityStatusTest {
             whenever(it.isNFCAvailable()).thenReturn(false)
             whenever(it.isGooglePlayServicesAvailable()).thenReturn(true)
         }
-        whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
+        whenever(systemVersionUtilsWrapper.isAtLeastQ()).thenReturn(true)
         whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
 
         val result = TapToPayAvailabilityStatus(
@@ -60,7 +60,7 @@ class TapToPayAvailabilityStatusTest {
             whenever(it.isNFCAvailable()).thenReturn(true)
             whenever(it.isGooglePlayServicesAvailable()).thenReturn(false)
         }
-        whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
+        whenever(systemVersionUtilsWrapper.isAtLeastQ()).thenReturn(true)
         whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
 
         val result = TapToPayAvailabilityStatus(
@@ -81,7 +81,7 @@ class TapToPayAvailabilityStatusTest {
             whenever(it.isNFCAvailable()).thenReturn(true)
             whenever(it.isGooglePlayServicesAvailable()).thenReturn(true)
         }
-        whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(false)
+        whenever(systemVersionUtilsWrapper.isAtLeastQ()).thenReturn(false)
         whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
 
         val result = TapToPayAvailabilityStatus(
@@ -102,7 +102,7 @@ class TapToPayAvailabilityStatusTest {
             whenever(it.isNFCAvailable()).thenReturn(true)
             whenever(it.isGooglePlayServicesAvailable()).thenReturn(true)
         }
-        whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
+        whenever(systemVersionUtilsWrapper.isAtLeastQ()).thenReturn(true)
         whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
         whenever(wooStore.getStoreCountryCode(siteModel)).thenReturn("RU")
 
@@ -124,7 +124,7 @@ class TapToPayAvailabilityStatusTest {
             whenever(it.isNFCAvailable()).thenReturn(true)
             whenever(it.isGooglePlayServicesAvailable()).thenReturn(true)
         }
-        whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
+        whenever(systemVersionUtilsWrapper.isAtLeastQ()).thenReturn(true)
         whenever(appPrefs.isTapToPayEnabled).thenReturn(false)
 
         val result = TapToPayAvailabilityStatus(
@@ -145,7 +145,7 @@ class TapToPayAvailabilityStatusTest {
             whenever(it.isNFCAvailable()).thenReturn(true)
             whenever(it.isGooglePlayServicesAvailable()).thenReturn(true)
         }
-        whenever(systemVersionUtilsWrapper.isAtLeastP()).thenReturn(true)
+        whenever(systemVersionUtilsWrapper.isAtLeastQ()).thenReturn(true)
         whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
 
         val result = TapToPayAvailabilityStatus(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9321
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I found out that stripe changed min required android version to 10. This PR addresses it

https://stripe.com/docs/terminal/payments/setup-reader/tap-to-pay?platform=android#supported-devices

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Not sure if this can be tested unless you have a physical device with version 9. If not, then probably just take a look into the code



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
