### PR TITLE
Restore _orderDraft state after process death in creation flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/coupon/edit/OrderCreateCouponEditFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/coupon/edit/OrderCreateCouponEditFragment.kt
@@ -79,7 +79,8 @@ class OrderCreateCouponEditFragment : BaseFragment() {
                         mode = args.orderCreationMode,
                         couponEditResult = OrderCreateCouponEditViewModel.CouponEditResult.UpdateCouponCode(
                             it.oldCode,
-                            it.newCode
+                            it.newCode,
+                            args.orderDraft
                         ),
                         sku = null,
                         barcodeFormat = null
@@ -89,7 +90,10 @@ class OrderCreateCouponEditFragment : BaseFragment() {
                 is OrderCreateCouponEditViewModel.CouponEditResult.RemoveCoupon -> {
                     val action = actionOrderCreationCouponEditFragmentToOrderCreationFragment(
                         mode = args.orderCreationMode,
-                        couponEditResult = OrderCreateCouponEditViewModel.CouponEditResult.RemoveCoupon(it.couponCode),
+                        couponEditResult = OrderCreateCouponEditViewModel.CouponEditResult.RemoveCoupon(
+                            it.couponCode,
+                            args.orderDraft
+                        ),
                         sku = null,
                         barcodeFormat = null
                     )
@@ -98,8 +102,10 @@ class OrderCreateCouponEditFragment : BaseFragment() {
                 is OrderCreateCouponEditViewModel.CouponEditResult.AddNewCouponCode -> {
                     val action = actionOrderCreationCouponEditFragmentToOrderCreationFragment(
                         mode = args.orderCreationMode,
-                        couponEditResult =
-                        OrderCreateCouponEditViewModel.CouponEditResult.AddNewCouponCode(it.couponCode),
+                        couponEditResult = OrderCreateCouponEditViewModel.CouponEditResult.AddNewCouponCode(
+                            it.couponCode,
+                            args.orderDraft
+                        ),
                         sku = null,
                         barcodeFormat = null
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/coupon/edit/OrderCreateCouponEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/coupon/edit/OrderCreateCouponEditViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.extensions.isNotNullOrEmpty
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
@@ -93,14 +94,20 @@ class OrderCreateCouponEditViewModel @Inject constructor(
     enum class ValidationState { IDLE, IN_PROGRESS, ERROR }
 
     @Parcelize
-    sealed class CouponEditResult : MultiLiveEvent.Event(), Parcelable {
+    sealed class CouponEditResult(
+        open val orderDraft: Order? = null
+    ) : MultiLiveEvent.Event(), Parcelable {
         @Parcelize
-        data class UpdateCouponCode(val oldCode: String, val newCode: String) : CouponEditResult()
+        data class UpdateCouponCode(
+            val oldCode: String,
+            val newCode: String,
+            override val orderDraft: Order? = null
+        ) : CouponEditResult()
 
         @Parcelize
-        data class AddNewCouponCode(val couponCode: String) : CouponEditResult()
+        data class AddNewCouponCode(val couponCode: String, override val orderDraft: Order? = null) : CouponEditResult()
 
         @Parcelize
-        data class RemoveCoupon(val couponCode: String) : CouponEditResult()
+        data class RemoveCoupon(val couponCode: String, override val orderDraft: Order? = null) : CouponEditResult()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/coupon/list/OrderCreateCouponListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/coupon/list/OrderCreateCouponListFragment.kt
@@ -46,14 +46,18 @@ class OrderCreateCouponListFragment : BaseFragment() {
                     findNavController().navigate(
                         actionOrderCreationCouponListFragmentToOrderCreationCouponEditFragment(
                             args.orderCreationMode,
-                            it.couponCode
+                            it.couponCode,
+                            args.orderDraft
                         )
                     )
                 }
 
                 is OrderCreateCouponListViewModel.AddCoupon -> {
                     findNavController().navigate(
-                        actionOrderCreationCouponListFragmentToOrderCreationCouponEditFragment(args.orderCreationMode)
+                        actionOrderCreationCouponListFragmentToOrderCreationCouponEditFragment(
+                            args.orderCreationMode,
+                            orderDraft = args.orderDraft
+                        )
                     )
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigationTarget.kt
@@ -24,11 +24,13 @@ sealed class OrderCreateEditNavigationTarget : Event() {
 
     data class EditCoupon(
         val orderCreationMode: OrderCreateEditViewModel.Mode,
-        val couponCode: String? = null
+        val couponCode: String? = null,
+        val orderDraft: Order? = null
     ) : OrderCreateEditNavigationTarget()
 
     data class CouponList(
         val orderCreationMode: OrderCreateEditViewModel.Mode,
-        val couponLines: Collection<Order.CouponLine>
+        val couponLines: Collection<Order.CouponLine>,
+        val orderDraft: Order? = null
     ) : OrderCreateEditNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt
@@ -45,12 +45,14 @@ object OrderCreateEditNavigator {
             is EditCoupon ->
                 OrderCreateEditFormFragmentDirections.actionOrderCreationFragmentToOrderCreationCouponEditFragment(
                     orderCreationMode = target.orderCreationMode,
-                    couponCode = target.couponCode
+                    couponCode = target.couponCode,
+                    orderDraft = target.orderDraft
                 )
             is OrderCreateEditNavigationTarget.CouponList -> {
                 OrderCreateEditFormFragmentDirections.actionOrderCreationFragmentToOrderCreationCouponListFragment(
                     orderCreationMode = target.orderCreationMode,
-                    couponLines = target.couponLines.toTypedArray()
+                    couponLines = target.couponLines.toTypedArray(),
+                    orderDraft = target.orderDraft
                 )
             }
         }

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -88,9 +88,6 @@
             app:exitAnim="@anim/default_exit_anim"
             app:popEnterAnim="@anim/default_pop_enter_anim"
             app:popExitAnim="@anim/default_pop_exit_anim">
-            <argument
-                android:name="couponLines"
-                app:argType="com.woocommerce.android.model.Order$CouponLine[]" />
         </action>
         <action
             android:id="@+id/action_orderCreationFragment_to_orderCreationCouponEditFragment"
@@ -101,11 +98,6 @@
             app:exitAnim="@anim/default_exit_anim"
             app:popEnterAnim="@anim/default_pop_enter_anim"
             app:popExitAnim="@anim/default_pop_exit_anim">
-            <argument
-                android:name="couponCode"
-                app:argType="string"
-                app:nullable="true"
-                android:defaultValue="@null"/>
         </action>
         <argument
             android:name="mode"
@@ -220,6 +212,11 @@
         <argument
             android:name="orderCreationMode"
             app:argType="com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel$Mode" />
+        <argument
+            android:name="orderDraft"
+            app:argType="com.woocommerce.android.model.Order"
+            app:nullable="true"
+            android:defaultValue="@null"/>
         <action
             android:id="@+id/action_orderCreationCouponListFragment_to_orderCreationCouponEditFragment"
             app:destination="@id/orderCreationCouponEditFragment"
@@ -243,6 +240,11 @@
         <argument
             android:name="orderCreationMode"
             app:argType="com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel$Mode" />
+        <argument
+            android:name="orderDraft"
+            app:argType="com.woocommerce.android.model.Order"
+            app:nullable="true"
+            android:defaultValue="@null"/>
         <action
             android:id="@+id/action_orderCreationCouponEditFragment_to_orderCreationFragment"
             app:destination="@id/orderCreationFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -1074,7 +1074,6 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
 
     @Test
     fun `when create button tapped, send track event`() {
-        initMocksForAnalyticsWithOrder(defaultOrderValue)
         createSut()
 
         sut.onCreateOrderClicked(defaultOrderValue)
@@ -1093,7 +1092,6 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
 
     @Test
     fun `when coupon added should track event`() {
-        initMocksForAnalyticsWithOrder(defaultOrderValue)
         createSut()
 
         val couponEditResult = OrderCreateCouponEditViewModel.CouponEditResult.AddNewCouponCode("code")
@@ -1107,7 +1105,6 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
 
     @Test
     fun `when coupon removed should track event`() {
-        initMocksForAnalyticsWithOrder(defaultOrderValue)
         createSut()
 
         val couponEditResult = OrderCreateCouponEditViewModel.CouponEditResult.RemoveCoupon("abc")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
@@ -216,22 +216,23 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
 
     @Test
     fun `given no coupon added to order when add new coupon clicked, then should redirect to coupon form`() {
-        initMocksForAnalyticsWithOrder(defaultOrderValue)
         createSut()
         var latestEvent: Event? = null
         sut.event.observeForever {
             latestEvent = it
         }
-
+        var orderDraft: Order? = null
+        sut.orderDraft.observeForever {
+            orderDraft = it
+        }
         sut.onCouponButtonClicked()
 
-        assertEquals(OrderCreateEditNavigationTarget.EditCoupon(sut.mode, null), latestEvent)
+        assertEquals(OrderCreateEditNavigationTarget.EditCoupon(sut.mode, null, orderDraft), latestEvent)
     }
 
     @Test
     fun `given coupon line present in order, when coupon button clicked, then should redirect to coupon list screen`() {
         // given
-        initMocksForAnalyticsWithOrder(defaultOrderValue)
         createSut()
         var latestEvent: Event? = null
         sut.event.observeForever {
@@ -247,7 +248,14 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
         sut.onCouponButtonClicked()
 
         // then
-        assertEquals(OrderCreateEditNavigationTarget.CouponList(sut.mode, orderDraft!!.couponLines), latestEvent)
+        assertEquals(
+            OrderCreateEditNavigationTarget.CouponList(
+                sut.mode,
+                orderDraft!!.couponLines,
+                sut.orderDraft.value
+            ),
+            latestEvent
+        )
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
