### PR TITLE
Avoid null pointer exception crash when tracking Blaze cta visible

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -2318,13 +2318,11 @@ class ProductDetailViewModel @Inject constructor(
             isBlazeEnabled()
 
     fun trackBlazeDisplayed() {
-        launch {
-            if (shouldShowBlaze(draftChanges.value!!))
-                tracker.track(
-                    stat = BLAZE_ENTRY_POINT_DISPLAYED,
-                    properties = mapOf(KEY_BLAZE_SOURCE to PRODUCT_DETAIL_OVERFLOW_MENU.trackingName)
-                )
-        }
+        if (menuButtonsState.value?.showPromoteWithBlaze == true)
+            tracker.track(
+                stat = BLAZE_ENTRY_POINT_DISPLAYED,
+                properties = mapOf(KEY_BLAZE_SOURCE to PRODUCT_DETAIL_OVERFLOW_MENU.trackingName)
+            )
     }
 
     /**


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes: #9315
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fix npe exception crash when clicking on the overflow menu of product detail

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log into am Atomic site where you are admin 
- Open a published product detail
- Click on the overflow menu
- Check that "Promote with Blaze" option is displayed and the following event is tracked `Tracked: blaze_entry_point_displayed, Properties: {"source":"product_more_menu","blog_id":205513046,"is_wpcom_store":false,"is_debug":true}`

