### PR TITLE
Analytics Performance: Support custom selection timestamps

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -19,14 +19,9 @@ class AnalyticsUpdateDataStore @Inject constructor(
     fun shouldUpdateAnalytics(
         rangeSelection: StatsTimeRangeSelection,
         maxOutdatedTime: Long = defaultMaxOutdatedTime
-    ) = rangeSelection.lastUpdateTimestamp
-        .map { lastUpdateTimestamp ->
-            lastUpdateTimestamp
-                ?.let { currentTime - it }
-                ?.let { timeElapsedSinceLastUpdate ->
-                    timeElapsedSinceLastUpdate > maxOutdatedTime
-                } ?: true
-        }
+    ) = dataStore.data
+        .map { prefs -> prefs[longPreferencesKey(rangeSelection.identifier)] }
+        .map { it?.let { (currentTime - it) > maxOutdatedTime } ?: true }
 
     suspend fun storeLastAnalyticsUpdate(rangeSelection: StatsTimeRangeSelection) {
         dataStore.edit { preferences ->
@@ -34,11 +29,6 @@ class AnalyticsUpdateDataStore @Inject constructor(
             preferences[longPreferencesKey(timestampKey)] = currentTime
         }
     }
-
-    private val StatsTimeRangeSelection.lastUpdateTimestamp
-        get() = dataStore.data.map { preferences ->
-            preferences[longPreferencesKey(identifier)]
-        }
 
     private val StatsTimeRangeSelection.identifier
         get() = if (selectionType == CUSTOM) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -21,7 +21,7 @@ class AnalyticsUpdateDataStore @Inject constructor(
         maxOutdatedTime: Long = defaultMaxOutdatedTime
     ) = dataStore.data
         .map { prefs -> prefs[longPreferencesKey(rangeSelection.identifier)] }
-        .map { it?.let { (currentTime - it) > maxOutdatedTime } ?: true }
+        .map { lastUpdateTime -> isElapsedTimeExpired(lastUpdateTime, maxOutdatedTime) }
 
     suspend fun storeLastAnalyticsUpdate(rangeSelection: StatsTimeRangeSelection) {
         dataStore.edit { preferences ->
@@ -29,6 +29,11 @@ class AnalyticsUpdateDataStore @Inject constructor(
             preferences[longPreferencesKey(timestampKey)] = currentTime
         }
     }
+
+    private fun isElapsedTimeExpired(lastUpdateTime: Long?, maxOutdatedTime: Long): Boolean =
+        lastUpdateTime?.let {
+            (currentTime - it) > maxOutdatedTime
+        } ?: true
 
     private val StatsTimeRangeSelection.identifier
         get() = if (selectionType == CUSTOM) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.CUSTOM
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
@@ -29,14 +30,21 @@ class AnalyticsUpdateDataStore @Inject constructor(
 
     suspend fun storeLastAnalyticsUpdate(rangeSelection: StatsTimeRangeSelection) {
         dataStore.edit { preferences ->
-            val timestampKey = rangeSelection.selectionType.identifier
+            val timestampKey = rangeSelection.identifier
             preferences[longPreferencesKey(timestampKey)] = currentTime
         }
     }
 
     private val StatsTimeRangeSelection.lastUpdateTimestamp
         get() = dataStore.data.map { preferences ->
-            preferences[longPreferencesKey(selectionType.identifier)]
+            preferences[longPreferencesKey(identifier)]
+        }
+
+    private val StatsTimeRangeSelection.identifier
+        get() = if (selectionType == CUSTOM) {
+            "${currentRange.start.time}-${currentRange.end.time}"
+        } else {
+            selectionType.identifier
         }
 
     private val currentTime

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
@@ -68,17 +68,12 @@ class UpdateAnalyticsHubStats @Inject constructor(
         }
     }
 
-    private suspend fun generateFetchStrategy(rangeSelection: StatsTimeRangeSelection): FetchStrategy {
-        if (rangeSelection.selectionType == StatsTimeRangeSelection.SelectionType.CUSTOM) {
-            return FetchStrategy.ForceNew
-        }
-
-        return if (analyticsUpdateDataStore.shouldUpdateAnalytics(rangeSelection)) {
+    private suspend fun generateFetchStrategy(rangeSelection: StatsTimeRangeSelection) =
+        if (analyticsUpdateDataStore.shouldUpdateAnalytics(rangeSelection)) {
             FetchStrategy.ForceNew
         } else {
             FetchStrategy.Saved
         }
-    }
 
     private fun combineFullUpdateState() =
         combine(_revenueState, _productsState, _ordersState, sessionState) { revenue, products, orders, session ->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -273,7 +273,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when selection type is CUSTOM, then ignore the data store and request data with ForceNew strategy`() = testBlocking {
+    fun `when selection type is CUSTOM, then follow the data store and request data with Stored strategy`() = testBlocking {
         // Given
         analyticsDataStore = mock {
             onBlocking { shouldUpdateAnalytics(testRangeSelection) } doReturn false

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -276,7 +276,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
     fun `when selection type is CUSTOM, then follow the data store and request data with Stored strategy`() = testBlocking {
         // Given
         analyticsDataStore = mock {
-            onBlocking { shouldUpdateAnalytics(testRangeSelection) } doReturn false
+            onBlocking { shouldUpdateAnalytics(testCustomRangeSelection) } doReturn false
         }
         sut = UpdateAnalyticsHubStats(
             analyticsUpdateDataStore = analyticsDataStore,
@@ -287,10 +287,10 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
         sut(testCustomRangeSelection, this)
 
         // Then
-        verify(repository, times(1)).fetchRevenueData(testCustomRangeSelection, ForceNew)
-        verify(repository, times(1)).fetchOrdersData(testCustomRangeSelection, ForceNew)
-        verify(repository, times(1)).fetchVisitorsData(testCustomRangeSelection, ForceNew)
-        verify(repository, times(1)).fetchProductsData(testCustomRangeSelection, ForceNew)
+        verify(repository, times(1)).fetchRevenueData(testCustomRangeSelection, Saved)
+        verify(repository, times(1)).fetchOrdersData(testCustomRangeSelection, Saved)
+        verify(repository, times(1)).fetchVisitorsData(testCustomRangeSelection, Saved)
+        verify(repository, times(1)).fetchProductsData(testCustomRangeSelection, Saved)
     }
 
     @Test


### PR DESCRIPTION
Summary
==========
Fix issue #9269 by introducing the same timed refresh constraint to Custom ranges selection inside the Hub. 

How to Test
==========
1. Open the app and enter the Analytics Hub
2. Once the data is loaded, select a Custom range selection, remember the one you selected and wait the loading to finish.
3. Once your custom range selection loading ends, leave the Hub, go back again and select the same Custom range you selected before, verify that now the cached data is used instead of a full triggering a full load.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
