### PR TITLE
AI Product Sharing: Refactor logic for showing or hiding Share button on Product details.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -190,6 +190,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_CUSTOM_FIELDS_COUNT = "custom_fields_count"
         const val KEY_CUSTOM_FIELDS_SIZE = "custom_fields_size"
         const val KEY_WAITING_TIME = "waiting_time"
+        const val KEY_IS_ATOMIC = "is_atomic"
         const val KEY_IS_NON_ATOMIC = "is_non_atomic"
         const val KEY_INDUSTRY_SLUG = "industry_slug"
         const val KEY_USER_COMMERCE_JOURNEY = "user_commerce_journey"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -190,7 +190,6 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_CUSTOM_FIELDS_COUNT = "custom_fields_count"
         const val KEY_CUSTOM_FIELDS_SIZE = "custom_fields_size"
         const val KEY_WAITING_TIME = "waiting_time"
-        const val KEY_IS_ATOMIC = "is_atomic"
         const val KEY_IS_NON_ATOMIC = "is_non_atomic"
         const val KEY_INDUSTRY_SLUG = "industry_slug"
         const val KEY_USER_COMMERCE_JOURNEY = "user_commerce_journey"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -407,7 +407,8 @@ class ProductDetailViewModel @Inject constructor(
             tracker.track(
                 AnalyticsEvent.PRODUCT_DETAIL_SHARE_BUTTON_TAPPED,
                 mapOf(
-                    AnalyticsTracker.KEY_SOURCE to source
+                    AnalyticsTracker.KEY_SOURCE to source,
+                    AnalyticsTracker.KEY_IS_ATOMIC to selectedSite.get().isWPComAtomic
                 )
             )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -277,9 +277,14 @@ class ProductDetailViewModel @Inject constructor(
             val isProductPublished = productDraft.status == ProductStatus.PUBLISH
             val isProductPublishedOrPrivate = isProductPublished || productDraft.status == ProductStatus.PRIVATE
             val showPublishOption = !isProductPublishedOrPrivate || isProductUnderCreation
-            val showShareOption = !isProductUnderCreation
 
-            // Show as action with text if "Save" or "Publish" is not currently shown as action with text.
+            // Show sharing option only if the product isn't being created.
+            // Additionally, for WPCom atomic sites, ensure the site is public.
+            // (`isSitePublic` applies only to WordPress.com sites, not self-hosted ones).
+            val showShareOption = !isProductUnderCreation &&
+                (!selectedSite.get().isWPComAtomic || selectedSite.get().isSitePublic)
+
+            // Show "Share" as action with text only if "Save" or "Publish" is not currently shown as action with text.
             val showShareOptionAsActionWithText =
                 showShareOption && !showSaveOptionAsActionWithText && !showPublishOption
 
@@ -424,7 +429,6 @@ class ProductDetailViewModel @Inject constructor(
 
     private fun canSiteUseSharingWithAI(): Boolean {
         return FeatureFlag.SHARING_PRODUCT_AI.isEnabled() &&
-            selectedSite.get().isSitePublic &&
             selectedSite.get().isWPComAtomic
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -407,8 +407,7 @@ class ProductDetailViewModel @Inject constructor(
             tracker.track(
                 AnalyticsEvent.PRODUCT_DETAIL_SHARE_BUTTON_TAPPED,
                 mapOf(
-                    AnalyticsTracker.KEY_SOURCE to source,
-                    AnalyticsTracker.KEY_IS_ATOMIC to selectedSite.get().isWPComAtomic
+                    AnalyticsTracker.KEY_SOURCE to source
                 )
             )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -54,6 +54,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
@@ -80,7 +81,10 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     private val productTagsRepository: ProductTagsRepository = mock()
     private val mediaFilesRepository: MediaFilesRepository = mock()
     private val variationRepository: VariationRepository = mock()
-    private val selectedSite: SelectedSite = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { get() } doReturn SiteModel()
+    }
+
     private val isAIProductDescriptionEnabled: IsAIProductDescriptionEnabled = mock()
     private val resources: ResourceProvider = mock {
         on(it.getString(any())).thenAnswer { i -> i.arguments[0].toString() }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As the Product Sharing with AI was released on version 14.1 / June 26, 2023, I checked the data and found that there's a discrepancy between:
1) the number of `is_wpcom_store` sites that tap the share button,
2) the number of `is_wpcom_store` sites that see the AI sharing dialog.

These numbers should be similar or nearly so, but at the moment only about 60% sees the AI sharing dialog. My guess is that the rest are WPCom sites that are not public, thus can't see the AI share dialog due to the check in `canSiteUseSharingWithAI()`.

Another (admittedly wild) guess is that perhaps not all `is_wpcom_store` sites are `is_atomic` sites, somehow (since I don't really understand the difference between the two). Thus I'm adding a `is_atomic` key to the tap event just to make sure.

I'm adding these two items to help check why the difference happens:

1. Improving the logic for showing or hiding share button. The previous check for `isSitePublic()` in  `canSiteUseSharingWithAI()` was inaccurate because a non-public site shouldn't see the Share option in the first place. Thus now I move the check for `isSitePublic` at `showShareOption` in the beginning instead, to decide whether to show or hide the Share button.

2. Add a `is_atomic` key to the tap tracking just to check further whether all atomic sites indeed could see the AI sharing dialog after tapping.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Test the AI sharing functionality both on WPCom site, and self hosted site, and make sure it still works on the former and not available on the latter.
2. Test with a private WPCom site and make sure the "Share" option on top right of Product Details (or inside its more menu, depending on the editing state of the product) is not shown.
4. Check `is_atomic` key for the `PRODUCT_DETAIL_SHARE_BUTTON_TAPPED` event.

### Additional question to reviewer
Since this is an update to logic and tracking, and it's probably better to get data sooner, do you think it's worth pushing it to 14.3 beta instead of 14.4?