### PR TITLE
[Customer Search] Customer search list with pagination

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListRepository.kt
@@ -66,7 +66,7 @@ class CustomerListRepository @Inject constructor(
             filterEmpty = listOf(FILTER_EMPTY_PARAM)
         )
 
-        return if (result.isError ) {
+        return if (result.isError) {
             Result.failure(WooException(result.error))
         } else if (result.model == null) {
             Result.failure(IllegalStateException("empty model returned"))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
@@ -139,7 +139,9 @@ fun CustomerListLoaded(
     LazyColumn(
         state = listState,
     ) {
-        itemsIndexed(body.customers) { _, customer ->
+        itemsIndexed(
+            items = body.customers,
+        ) { _, customer ->
             when (customer) {
                 is CustomerListViewState.CustomerList.Item.Customer -> {
                     CustomerListItem(
@@ -198,6 +200,7 @@ fun CustomerListItem(
             style = MaterialTheme.typography.subtitle2,
             color = MaterialTheme.colors.onSurface
         )
+        Spacer(modifier = Modifier.height(2.dp))
         Text(
             text = customer.email,
             style = MaterialTheme.typography.caption,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
@@ -1,9 +1,18 @@
 package com.woocommerce.android.ui.orders.creation.customerlistnew
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -17,9 +26,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.exhaustive
+import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.compose.component.SearchLayoutWithParams
 import com.woocommerce.android.ui.compose.component.SearchLayoutWithParamsState
 
@@ -46,8 +60,10 @@ fun CustomerListScreen(viewModel: CustomerListViewModel) {
             CustomerListScreen(
                 modifier = Modifier.padding(padding),
                 state = it,
+                onCustomerSelected = viewModel::onCustomerSelected,
                 onSearchQueryChanged = viewModel::onSearchQueryChanged,
-                onSearchTypeChanged = viewModel::onSearchTypeChanged
+                onSearchTypeChanged = viewModel::onSearchTypeChanged,
+                onEndOfListReached = viewModel::onEndOfListReached,
             )
         }
     }
@@ -57,8 +73,10 @@ fun CustomerListScreen(viewModel: CustomerListViewModel) {
 fun CustomerListScreen(
     modifier: Modifier = Modifier,
     state: CustomerListViewState,
+    onCustomerSelected: (Long) -> Unit,
     onSearchQueryChanged: (String) -> Unit,
     onSearchTypeChanged: (Int) -> Unit,
+    onEndOfListReached: () -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -81,5 +99,143 @@ fun CustomerListScreen(
             onSearchQueryChanged = onSearchQueryChanged,
             onSearchTypeSelected = onSearchTypeChanged,
         )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        when (val body = state.body) {
+            CustomerListViewState.CustomerList.Empty -> {
+                // todo
+            }
+
+            CustomerListViewState.CustomerList.Error -> {
+                // todo
+            }
+
+            CustomerListViewState.CustomerList.Loading -> {
+                // todo
+            }
+
+            is CustomerListViewState.CustomerList.Loaded -> {
+                CustomerListLoaded(
+                    body,
+                    onCustomerSelected,
+                    onEndOfListReached,
+                )
+            }
+        }.exhaustive
     }
+}
+
+@Composable
+fun CustomerListLoaded(
+    body: CustomerListViewState.CustomerList.Loaded,
+    onCustomerSelected: (Long) -> Unit,
+    onEndOfListReached: () -> Unit,
+) {
+    val listState = rememberLazyListState()
+
+    LazyColumn(
+        state = listState,
+    ) {
+        itemsIndexed(body.customers) { _, customer ->
+            when (customer) {
+                is CustomerListViewState.CustomerList.Item.Customer -> {
+                    CustomerListItem(
+                        customer = customer,
+                        onCustomerSelected = onCustomerSelected
+                    )
+                }
+
+                CustomerListViewState.CustomerList.Item.Loading -> {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .wrapContentWidth()
+                            .padding(vertical = dimensionResource(id = R.dimen.minor_100))
+                    )
+                }
+            }.exhaustive
+        }
+    }
+
+    InfiniteListHandler(listState = listState, buffer = 3) {
+        onEndOfListReached()
+    }
+}
+
+@Composable
+fun CustomerListItem(
+    customer: CustomerListViewState.CustomerList.Item.Customer,
+    onCustomerSelected: (Long) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(
+                enabled = true,
+                onClickLabel = stringResource(id = R.string.coupon_list_view_coupon),
+                role = Role.Button,
+                onClick = { onCustomerSelected(customer.remoteId) }
+            )
+            .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+    ) {
+        Text(
+            text = "${customer.firstName} ${customer.lastName}",
+            style = MaterialTheme.typography.subtitle1,
+            color = MaterialTheme.colors.onSurface
+        )
+        Text(
+            text = customer.email,
+            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.onSurface
+        )
+    }
+}
+
+@Preview
+@Composable
+fun CustomerListScreenPreview() {
+    CustomerListScreen(
+        modifier = Modifier,
+        state = CustomerListViewState(
+            searchQuery = "",
+            searchModes = listOf(
+                SearchMode(
+                    labelResId = R.string.order_creation_customer_search_everything,
+                    searchParam = "all",
+                    isSelected = true,
+                ),
+                SearchMode(
+                    labelResId = R.string.order_creation_customer_search_name,
+                    searchParam = "name",
+                    isSelected = false,
+                ),
+                SearchMode(
+                    labelResId = R.string.order_creation_customer_search_email,
+                    searchParam = "email",
+                    isSelected = false,
+                ),
+            ),
+            body = CustomerListViewState.CustomerList.Loaded(
+                customers = listOf(
+                    CustomerListViewState.CustomerList.Item.Customer(
+                        remoteId = 1,
+                        firstName = "John",
+                        lastName = "Doe",
+                        email = "John@gmail.com",
+                    ),
+                    CustomerListViewState.CustomerList.Item.Customer(
+                        remoteId = 2,
+                        firstName = "Andrei",
+                        lastName = "K",
+                        email = "blac@aaa.com",
+                    )
+                )
+            ),
+        ),
+        {},
+        {},
+        {},
+        {},
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.ui.compose.component.InfiniteListHandler
 import com.woocommerce.android.ui.compose.component.SearchLayoutWithParams
 import com.woocommerce.android.ui.compose.component.SearchLayoutWithParamsState
@@ -124,7 +123,7 @@ fun CustomerListScreen(
                     onEndOfListReached,
                 )
             }
-        }.exhaustive
+        }
     }
 }
 
@@ -167,7 +166,7 @@ fun CustomerListLoaded(
                             .padding(vertical = dimensionResource(id = R.dimen.minor_100))
                     )
                 }
-            }.exhaustive
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
@@ -7,12 +7,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -144,6 +146,15 @@ fun CustomerListLoaded(
                         customer = customer,
                         onCustomerSelected = onCustomerSelected
                     )
+                    if (customer != body.customers.last()) {
+                        Divider(
+                            modifier = Modifier.offset(x = dimensionResource(id = R.dimen.major_100)),
+                            color = colorResource(id = R.color.divider_color),
+                            thickness = dimensionResource(id = R.dimen.minor_10)
+                        )
+                    } else {
+                        Spacer(modifier = Modifier.height(0.dp))
+                    }
                 }
 
                 CustomerListViewState.CustomerList.Item.Loading -> {
@@ -177,16 +188,19 @@ fun CustomerListItem(
                 role = Role.Button,
                 onClick = { onCustomerSelected(customer.remoteId) }
             )
-            .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+            .padding(
+                horizontal = dimensionResource(id = R.dimen.major_100),
+                vertical = dimensionResource(id = R.dimen.minor_50)
+            )
     ) {
         Text(
             text = "${customer.firstName} ${customer.lastName}",
-            style = MaterialTheme.typography.subtitle1,
+            style = MaterialTheme.typography.subtitle2,
             color = MaterialTheme.colors.onSurface
         )
         Text(
             text = customer.email,
-            style = MaterialTheme.typography.body2,
+            style = MaterialTheme.typography.caption,
             color = MaterialTheme.colors.onSurface
         )
     }
@@ -229,7 +243,8 @@ fun CustomerListScreenPreview() {
                         firstName = "Andrei",
                         lastName = "K",
                         email = "blac@aaa.com",
-                    )
+                    ),
+                    CustomerListViewState.CustomerList.Item.Loading,
                 )
             ),
         ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListScreen.kt
@@ -140,6 +140,12 @@ fun CustomerListLoaded(
     ) {
         itemsIndexed(
             items = body.customers,
+            key = { _, customer ->
+                when (customer) {
+                    is CustomerListViewState.CustomerList.Item.Customer -> customer.remoteId
+                    CustomerListViewState.CustomerList.Item.Loading -> -1L
+                }
+            },
         ) { _, customer ->
             when (customer) {
                 is CustomerListViewState.CustomerList.Item.Customer -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
@@ -92,7 +92,11 @@ class CustomerListViewModel @Inject constructor(
                 paginationState = PaginationState(page, customers.size == PAGE_SIZE)
 
                 _viewState.value = _viewState.value!!.copy(
-                    body = CustomerListViewState.CustomerList.Loaded(customers = customers.map { mapFromWCCustomer(it) })
+                    body = CustomerListViewState.CustomerList.Loaded(
+                        customers = customers.map {
+                            mapFromWCCustomer(it)
+                        }
+                    )
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
@@ -39,6 +39,10 @@ class CustomerListViewModel @Inject constructor(
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
+    fun onCustomerSelected(customerId: Long) {
+    }
+
     fun onSearchQueryChanged(query: String) {
         with(query) {
             searchQuery = this

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModelMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModelMapper.kt
@@ -1,0 +1,14 @@
+package com.woocommerce.android.ui.orders.creation.customerlistnew
+
+import org.wordpress.android.fluxc.model.customer.WCCustomerModel
+import javax.inject.Inject
+
+class CustomerListViewModelMapper @Inject constructor() {
+    fun mapFromWCCustomer(wcCustomerModel: WCCustomerModel) =
+        CustomerListViewState.CustomerList.Item.Customer(
+            remoteId = wcCustomerModel.remoteCustomerId,
+            firstName = wcCustomerModel.firstName,
+            lastName = wcCustomerModel.lastName,
+            email = wcCustomerModel.email,
+        )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewState.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.orders.creation.customerlistnew
 import android.os.Parcelable
 import androidx.annotation.StringRes
 import kotlinx.parcelize.Parcelize
-import org.wordpress.android.fluxc.model.customer.WCCustomerModel
 
 data class CustomerListViewState(
     val searchQuery: String = "",
@@ -25,14 +24,6 @@ data class CustomerListViewState(
             ) : Item()
 
             object Loading : Item()
-
-            fun mapFromWCCustomer(wcCustomerModel: WCCustomerModel) =
-                Customer(
-                    remoteId = wcCustomerModel.remoteCustomerId,
-                    firstName = wcCustomerModel.firstName,
-                    lastName = wcCustomerModel.lastName,
-                    email = wcCustomerModel.email,
-                )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewState.kt
@@ -3,11 +3,12 @@ package com.woocommerce.android.ui.orders.creation.customerlistnew
 import android.os.Parcelable
 import androidx.annotation.StringRes
 import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.model.customer.WCCustomerModel
 
 data class CustomerListViewState(
     val searchQuery: String = "",
     val searchModes: List<SearchMode>,
-    val customers: CustomerList = CustomerList.Loading,
+    val body: CustomerList = CustomerList.Loading,
 ) {
     sealed class CustomerList {
         object Loading : CustomerList()
@@ -15,12 +16,24 @@ data class CustomerListViewState(
         object Error : CustomerList()
         data class Loaded(val customers: List<Item>) : CustomerList()
 
-        data class Item(
-            val remoteId: Long,
-            val firstName: String,
-            val lastName: String,
-            val email: String,
-        )
+        sealed class Item {
+            data class Customer(
+                val remoteId: Long,
+                val firstName: String,
+                val lastName: String,
+                val email: String,
+            ) : Item()
+
+            object Loading : Item()
+
+            fun mapFromWCCustomer(wcCustomerModel: WCCustomerModel) =
+                Customer(
+                    remoteId = wcCustomerModel.remoteCustomerId,
+                    firstName = wcCustomerModel.firstName,
+                    lastName = wcCustomerModel.lastName,
+                    email = wcCustomerModel.email,
+                )
+        }
     }
 }
 
@@ -30,3 +43,8 @@ data class SearchMode(
     val searchParam: String,
     val isSelected: Boolean,
 ) : Parcelable
+
+data class PaginationState(
+    val currentPage: Int,
+    val hasNextPage: Boolean,
+)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModelMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModelMapperTest.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.ui.orders.creation.customerlistnew
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.model.customer.WCCustomerModel
+
+class CustomerListViewModelMapperTest {
+    @Test
+    fun `when mapFromWCCustomer, then return view model customer model`() {
+        // given
+        val wcCustomerModel: WCCustomerModel = mock {
+            on { remoteCustomerId }.thenReturn(1)
+            on { firstName }.thenReturn("firstName")
+            on { lastName }.thenReturn("lastName")
+            on { email }.thenReturn("email")
+        }
+
+        // when
+        val result = CustomerListViewModelMapper().mapFromWCCustomer(wcCustomerModel)
+
+        // then
+        assertThat(result.remoteId).isEqualTo(1)
+        assertThat(result.firstName).isEqualTo("firstName")
+        assertThat(result.lastName).isEqualTo("lastName")
+        assertThat(result.email).isEqualTo("email")
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModelMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModelMapperTest.kt
@@ -8,7 +8,7 @@ import org.wordpress.android.fluxc.model.customer.WCCustomerModel
 class CustomerListViewModelMapperTest {
     @Test
     fun `when mapFromWCCustomer, then return view model customer model`() {
-        // given
+        // GIVEN
         val wcCustomerModel: WCCustomerModel = mock {
             on { remoteCustomerId }.thenReturn(1)
             on { firstName }.thenReturn("firstName")
@@ -16,10 +16,10 @@ class CustomerListViewModelMapperTest {
             on { email }.thenReturn("email")
         }
 
-        // when
+        // WHEN
         val result = CustomerListViewModelMapper().mapFromWCCustomer(wcCustomerModel)
 
-        // then
+        // THEN
         assertThat(result.remoteId).isEqualTo(1)
         assertThat(result.firstName).isEqualTo("firstName")
         assertThat(result.lastName).isEqualTo("lastName")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModelTest.kt
@@ -1,0 +1,201 @@
+package com.woocommerce.android.ui.orders.creation.customerlistnew
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.orders.creation.customerlist.CustomerListRepository
+import com.woocommerce.android.util.captureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class CustomerListViewModelTest : BaseUnitTest() {
+    private val customerListRepository: CustomerListRepository = mock {
+        onBlocking {
+            searchCustomerListWithEmail(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        }.thenReturn(Result.success(listOf(mock())))
+    }
+    private val savedState: SavedStateHandle = SavedStateHandle()
+    private val mockCustomer: CustomerListViewState.CustomerList.Item.Customer = mock()
+    private val customerListViewModelMapper: CustomerListViewModelMapper = mock {
+        on { mapFromWCCustomer(any()) }.thenReturn(mockCustomer)
+    }
+
+    @Test
+    fun `when viewmodel init, then viewstate is updated with customers`() {
+        // GIVEN
+        val viewModel = initViewModel()
+        val states = viewModel.viewState.captureValues()
+
+        // THEN
+        assertThat(states.last().body).isInstanceOf(CustomerListViewState.CustomerList.Loaded::class.java)
+    }
+
+    @Test
+    fun `given search query, when onSearchQueryChanged is called, then update search query is updated`() =
+        testBlocking {
+            // GIVEN
+            val searchQuery = "customer"
+            val viewModel = initViewModel()
+
+            // WHEN
+            viewModel.onSearchQueryChanged(searchQuery)
+
+            // THEN
+            assertThat(viewModel.viewState.value?.searchQuery).isEqualTo(searchQuery)
+        }
+
+    @Test
+    fun `given search query, when onSearchQueryChanged is called, then search is invoked and viewstate updated with customers`() =
+        testBlocking {
+            // GIVEN
+            val searchQuery = "customer"
+            val viewModel = initViewModel()
+
+            val states = viewModel.viewState.captureValues()
+
+            // WHEN
+            viewModel.onSearchQueryChanged(searchQuery)
+
+            // THEN
+            assertThat((states.last().body as CustomerListViewState.CustomerList.Loaded).customers)
+                .isEqualTo(listOf(mockCustomer))
+        }
+
+    @Test
+    fun `given search type, when onSearchTypeChanged is called, then selected mode is changed`() =
+        testBlocking {
+            // GIVEN
+            val searchTypeId = R.string.order_creation_customer_search_email
+            val viewModel = initViewModel()
+
+            // WHEN
+            viewModel.onSearchTypeChanged(searchTypeId)
+
+            // THEN
+            assertThat(viewModel.viewState.value?.searchModes?.find { it.isSelected }?.labelResId).isEqualTo(
+                searchTypeId
+            )
+            assertThat(viewModel.viewState.value?.searchModes?.find { it.isSelected }?.labelResId).isNotEqualTo(
+                R.string.order_creation_customer_search_name
+            )
+        }
+
+    @Test
+    fun `given search type and empty search, when onSearchTypeChanged is called, then new customers are not loaded`() =
+        testBlocking {
+            // GIVEN
+            val searchTypeId = R.string.order_creation_customer_search_email
+            val viewModel = initViewModel()
+
+            val states = viewModel.viewState.captureValues()
+
+            // WHEN
+            viewModel.onSearchTypeChanged(searchTypeId)
+
+            // THEN
+            verify(customerListRepository, times(1)).searchCustomerListWithEmail(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+            assertThat(states.last().body).isInstanceOf(CustomerListViewState.CustomerList.Loaded::class.java)
+        }
+
+    @Test
+    fun `given search type and search is not empty, when onSearchTypeChanged is called, then new customers are loaded`() =
+        testBlocking {
+            // GIVEN
+            val searchTypeId = R.string.order_creation_customer_search_email
+            val viewModel = initViewModel()
+
+            val states = viewModel.viewState.captureValues()
+
+            // WHEN
+            viewModel.onSearchQueryChanged("customer")
+            viewModel.onSearchTypeChanged(searchTypeId)
+
+            // THEN
+            verify(customerListRepository, times(3)).searchCustomerListWithEmail(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+            assertThat(states.last().body).isInstanceOf(CustomerListViewState.CustomerList.Loaded::class.java)
+        }
+
+    @Test
+    fun `given less than page returned from repo, when onEndOfListReached, then next call doesnt load more customers`() =
+        testBlocking {
+            // GIVEN
+            val viewModel = initViewModel()
+
+            // WHEN
+            viewModel.onEndOfListReached()
+
+            // THEN
+            verify(customerListRepository, times(1)).searchCustomerListWithEmail(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        }
+
+    @Test
+    fun `given that one page size returned from repo, when onEndOfListReached, then next call load more customers`() =
+        testBlocking {
+            // GIVEN
+            whenever(customerListRepository.searchCustomerListWithEmail(any(), any(), any(), any()))
+                .thenReturn(Result.success((1..30).map { mock() }))
+            val viewModel = initViewModel()
+
+            // WHEN
+            viewModel.onEndOfListReached()
+
+            // THEN
+            verify(customerListRepository, times(2)).searchCustomerListWithEmail(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        }
+
+    @Test
+    fun `given that one page size returned from repo, when onEndOfListReached, then loading item appended`() =
+        testBlocking {
+            // GIVEN
+            whenever(customerListRepository.searchCustomerListWithEmail(any(), any(), any(), any()))
+                .thenReturn(Result.success((1..30).map { mock() }))
+            val viewModel = initViewModel()
+
+            val states = viewModel.viewState.captureValues()
+
+            // WHEN
+            viewModel.onEndOfListReached()
+
+            // THEN
+            assertThat((states.last().body as CustomerListViewState.CustomerList.Loaded).customers.last())
+                .isInstanceOf(CustomerListViewState.CustomerList.Item.Loading::class.java)
+        }
+
+    private fun initViewModel() = CustomerListViewModel(
+        savedState,
+        customerListRepository,
+        customerListViewModelMapper,
+    )
+}

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2761-131232f5d0ab2cf15c7c0aafc60954f1b2546137'
+    fluxCVersion = '2761-00f45a9be403131e6bcb5c348c05a22433648bf9'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.34.0'
+    fluxCVersion = '2761-131232f5d0ab2cf15c7c0aafc60954f1b2546137'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9305
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds a customer list with pagination

Notice:
* The UI is not final
* Scrolling performance is not final
* Empty/Error/Loading states are coming in the next PR
* DO NOT MERGE before I change the fluxc version. The hash I use is from the PR that can not be merged yet, as test do not pass due to the fact that WC version doesn't match

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Install nightly WC build https://github.com/woocommerce/woocommerce/releases as the current doesn't have an updated search endpoint
* Using the [plugin](https://github.com/woocommerce/wc-smooth-generator) generate customers for several pages (e.g. 100+)
* Using order creation flow, open the customers screen, scroll down and notice that more customers are loaded

OR

* Ask me to invite you to the store I used
* Using order creation flow, open the customers screen, scroll down and notice that more customers are loaded

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/541d753d-08cc-4914-9ea3-2dc38790c3c8



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
