### PR TITLE
Feature/9332 my store blaze banner

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBanner.kt
@@ -33,8 +33,8 @@ fun BlazeBanner(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(dimensionResource(id = R.dimen.major_100))
             .background(MaterialTheme.colors.surface)
+            .padding(dimensionResource(id = R.dimen.major_100))
     ) {
         IconButton(
             modifier = Modifier.align(Alignment.TopEnd),
@@ -74,9 +74,8 @@ fun BlazeBanner(
                 onClick = onTryBlazeClicked
             ) {
                 Text(
-                    text = stringResource(R.string.blaze_banner_button),
+                    text = stringResource(R.string.blaze_banner_button).uppercase(),
                     style = MaterialTheme.typography.subtitle1,
-                    fontWeight = FontWeight.Bold,
                 )
             }
         }
@@ -94,4 +93,3 @@ private fun BlazeBannerPreview() {
         onTryBlazeClicked = {}
     )
 }
-

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource.MORE_MENU_ITEM
-import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource.MY_STORE_BANNER
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -34,9 +34,9 @@ class BlazeBannerViewModel @Inject constructor(
 
     fun onTryBlazeBannerClicked() {
         triggerEvent(
-            MoreMenuEvent.OpenBlazeEvent(
+            OpenBlazeEvent(
                 url = isBlazeEnabled.buildUrlForSite(MORE_MENU_ITEM),
-                source = MORE_MENU_ITEM
+                source = MY_STORE_BANNER
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
@@ -1,0 +1,45 @@
+package com.woocommerce.android.ui.blaze
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource.MORE_MENU_ITEM
+import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class BlazeBannerViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val isBlazeEnabled: IsBlazeEnabled
+) : ScopedViewModel(savedStateHandle) {
+
+    private val _isBlazeBannerVisible = MutableLiveData(false)
+    val isBlazeBannerVisible = _isBlazeBannerVisible
+
+    init {
+        launch {
+            if (isBlazeEnabled()) {
+                _isBlazeBannerVisible.value = true
+            }
+        }
+    }
+
+    fun onBlazeBannerDismissed() {
+        TODO()
+    }
+
+    fun onTryBlazeBannerClicked() {
+        triggerEvent(
+            MoreMenuEvent.OpenBlazeEvent(
+                url = isBlazeEnabled.buildUrlForSite(MORE_MENU_ITEM),
+                source = MORE_MENU_ITEM
+            )
+        )
+    }
+
+    data class OpenBlazeEvent(val url: String, val source: BlazeFlowSource) : MultiLiveEvent.Event()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
@@ -2,8 +2,10 @@ package com.woocommerce.android.ui.blaze
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_ENTRY_POINT_TAPPED
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource.MORE_MENU_ITEM
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource.MY_STORE_BANNER
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -14,7 +16,8 @@ import javax.inject.Inject
 @HiltViewModel
 class BlazeBannerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val isBlazeEnabled: IsBlazeEnabled
+    private val isBlazeEnabled: IsBlazeEnabled,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
 
     private val _isBlazeBannerVisible = MutableLiveData(false)
@@ -33,9 +36,13 @@ class BlazeBannerViewModel @Inject constructor(
     }
 
     fun onTryBlazeBannerClicked() {
+        analyticsTrackerWrapper.track(
+            stat = BLAZE_ENTRY_POINT_TAPPED,
+            properties = mapOf(AnalyticsTracker.KEY_BLAZE_SOURCE to MY_STORE_BANNER.trackingName)
+        )
         triggerEvent(
             OpenBlazeEvent(
-                url = isBlazeEnabled.buildUrlForSite(MORE_MENU_ITEM),
+                url = isBlazeEnabled.buildUrlForSite(MY_STORE_BANNER),
                 source = MY_STORE_BANNER
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -38,5 +38,6 @@ class IsBlazeEnabled @Inject constructor(
     enum class BlazeFlowSource(val trackingName: String) {
         PRODUCT_DETAIL_OVERFLOW_MENU("product_more_menu"),
         MORE_MENU_ITEM("menu"),
+        MY_STORE_BANNER("my_store_banner"),
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -43,6 +43,8 @@ import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.blaze.BlazeBanner
+import com.woocommerce.android.ui.blaze.BlazeBannerViewModel
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.jitm.JitmFragment
@@ -96,6 +98,7 @@ class MyStoreFragment :
 
     private val myStoreViewModel: MyStoreViewModel by viewModels()
     private val storeOnboardingViewModel: StoreOnboardingViewModel by activityViewModels()
+    private val blazeViewModel: BlazeBannerViewModel by viewModels()
 
     @Inject lateinit var selectedSite: SelectedSite
     @Inject lateinit var currencyFormatter: CurrencyFormatter
@@ -199,8 +202,28 @@ class MyStoreFragment :
 
         setupStateObservers()
         setupOnboardingView()
+        setUpBlazeBanner()
 
         initJitm(savedInstanceState)
+    }
+
+    private fun setUpBlazeBanner() {
+        blazeViewModel.isBlazeBannerVisible.observe(viewLifecycleOwner) { isVisible ->
+            if (!isVisible) binding.blazeBannerView.hide()
+            else {
+                binding.blazeBannerView.apply {
+                    show()
+                    setContent {
+                        WooThemeWithBackground {
+                            BlazeBanner(
+                                onClose = blazeViewModel::onBlazeBannerDismissed,
+                                onTryBlazeClicked = blazeViewModel::onTryBlazeBannerClicked
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private fun setupOnboardingView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -224,6 +224,21 @@ class MyStoreFragment :
                 }
             }
         }
+
+        blazeViewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is BlazeBannerViewModel.OpenBlazeEvent -> openBlazeWebView(event)
+            }
+        }
+    }
+
+    private fun openBlazeWebView(event: BlazeBannerViewModel.OpenBlazeEvent) {
+        findNavController().navigateSafely(
+            NavGraphMainDirections.actionGlobalBlazeWebViewFragment(
+                urlToLoad = event.url,
+                source = event.source
+            )
+        )
     }
 
     private fun setupOnboardingView() {

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -47,6 +47,13 @@
                         android:transitionName="@string/store_onboarding_collapsed_transition_name"
                         android:visibility="gone" />
 
+                    <androidx.compose.ui.platform.ComposeView
+                        android:id="@+id/blaze_banner_view"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/minor_100"
+                        android:visibility="gone" />
+
                     <com.woocommerce.android.widgets.WCEmptyView
                         android:id="@+id/empty_view"
                         android:layout_width="match_parent"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9332 
<!-- Id number of the GitHub issue this PR addresses. -->
Don't merge until base branch is `trunk`

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds the new Blaze banner UI component to My store tab

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Log into a site that is Blaze eligible (user `isAdmin`, site is atomic and Jetpack connected) 
2. Check the Blaze banner is displayed in My store tab
3. Click on "Try Blaze now" and check the Blaze webview is opened and the following events are logged:
-  `Tracked: blaze_entry_point_tapped, Properties: {"source":"my_store_banner","blog_id":205513046,"is_wpcom_store":false,"is_debug":true}`
- `Tracked: blaze_flow_started, Properties: {"source":"my_store_banner","blog_id":205513046,"is_wpcom_store":false,"is_debug":true}`
