### PR TITLE
[Instrumented Tests] Added support for Buildkite Test Analytics

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,12 +44,6 @@ steps:
     artifact_paths:
       - "**/build/test-results/*/*.xml"
 
-  - label: "Instrumented tests"
-    command: .buildkite/commands/run-instrumented-tests.sh
-    plugins: *common_plugins
-    artifact_paths:
-      - "**/build/instrumented-tests/**/*"
-
   - label: "Ensure Screenshot Tests Build"
     command: |
       echo "--- ⚒️ Building"
@@ -61,3 +55,19 @@ steps:
     command: ".buildkite/commands/installable-build.sh"
     if: build.pull_request.id != null
     plugins: *common_plugins
+
+  - label: "Instrumented tests"
+    command: .buildkite/commands/run-instrumented-tests.sh
+    plugins: *common_plugins
+    artifact_paths:
+      - "**/build/instrumented-tests/**/*"
+
+  - wait
+
+  - label: "🔍 Test Analytics"
+    command: buildkite-agent artifact download '**/test_result_1.xml' .
+    plugins:
+      - test-collector#v1.8.0:
+          files: "**/test_result_1.xml"
+          format: "junit"
+          api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS"


### PR DESCRIPTION
### Description
Adds a new `Test Analytics` step to `pipeline.yml`. 

In this step, a test report `test_result_1.xml` created during `Instrumented tests` step (stored in `Artifacts`) is passed to Test Analytics plugin together with a unique token, which is used to locate a corresponding test suite.

### Testing instructions
- The `Test Analytics` step is 🟢 
- Test data is available at `WooCommerce Android - Instrumented Tests` test suite in Buildkite Test Analytics:

<img width="1157" alt="Screenshot 2023-07-04 at 16 00 20" src="https://github.com/woocommerce/woocommerce-android/assets/73365754/19ba7117-c1de-484b-9320-340a19127659">