### PR TITLE
Add new Blaze banner for product list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
@@ -23,12 +23,18 @@ class BlazeBannerViewModel @Inject constructor(
     private val _isBlazeBannerVisible = MutableLiveData(false)
     val isBlazeBannerVisible = _isBlazeBannerVisible
 
+    private var blazeBannerSource: BlazeFlowSource = MY_STORE_BANNER
+
     init {
         launch {
             if (isBlazeEnabled()) {
                 _isBlazeBannerVisible.value = true
             }
         }
+    }
+
+    fun setBlazeBannerSource(source: BlazeFlowSource) {
+        blazeBannerSource = source
     }
 
     fun onBlazeBannerDismissed() {
@@ -38,12 +44,12 @@ class BlazeBannerViewModel @Inject constructor(
     fun onTryBlazeBannerClicked() {
         analyticsTrackerWrapper.track(
             stat = BLAZE_ENTRY_POINT_TAPPED,
-            properties = mapOf(AnalyticsTracker.KEY_BLAZE_SOURCE to MY_STORE_BANNER.trackingName)
+            properties = mapOf(AnalyticsTracker.KEY_BLAZE_SOURCE to blazeBannerSource.trackingName)
         )
         triggerEvent(
             OpenBlazeEvent(
                 url = isBlazeEnabled.buildUrlForSite(MY_STORE_BANNER),
-                source = MY_STORE_BANNER
+                source = blazeBannerSource
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -39,5 +39,6 @@ class IsBlazeEnabled @Inject constructor(
         PRODUCT_DETAIL_OVERFLOW_MENU("product_more_menu"),
         MORE_MENU_ITEM("menu"),
         MY_STORE_BANNER("my_store_banner"),
+        PRODUCT_LIST_BANNER("product_list_banner"),
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -45,6 +45,7 @@ import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.blaze.BlazeBanner
 import com.woocommerce.android.ui.blaze.BlazeBannerViewModel
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource.MY_STORE_BANNER
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.jitm.JitmFragment
@@ -208,6 +209,7 @@ class MyStoreFragment :
     }
 
     private fun setUpBlazeBanner() {
+        blazeViewModel.setBlazeBannerSource(MY_STORE_BANNER)
         blazeViewModel.isBlazeBannerVisible.observe(viewLifecycleOwner) { isVisible ->
             if (!isVisible) binding.blazeBannerView.hide()
             else {

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -49,6 +49,17 @@
             app:layout_constraintTop_toBottomOf="@+id/products_wip_card"
             tools:visibility="visible" />
 
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/blaze_banner_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/empty_state_bg_color"
+            android:paddingBottom="@dimen/minor_100"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/products_sort_filter_card" />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/productsRecycler"
             android:layout_width="match_parent"
@@ -57,7 +68,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/products_sort_filter_card"
+            app:layout_constraintTop_toBottomOf="@+id/blaze_banner_view"
             tools:itemCount="5"
             tools:listitem="@layout/product_list_item" />
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Do not merge until base branch is `trunk`

Part of: #9332
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds Blaze banner to product list. The ideal behavior of this component for product list is that it should scroll as if it was part of the list. The problem is that would require to add the banner component to the `ProductListAdapter` and create a new item for the list. Adopting this approach (which I initially started implementing) would force me to add all the Blaze banner logic inside, the already huge `ProductListViewModel`. Going down this path also required a big refactor/effort. I don't think it's worth it. What I ended up doing is adding the banner as an independent component outside the list. Keep in mind this banner is a temporary UI element that the user will dismiss once they know what it is about. It shouldn't be a issue if it doesn't completely scroll on as part of the list. 

PS: Tried a workaround to make everything scrollable without having to add new elements to the product list. But the scrolling experience with the swipe to refresh on top was a mess, so I discarded this option: 

https://github.com/woocommerce/woocommerce-android/assets/2663464/cc23cb70-19d5-4f78-adb2-96bfbe949c6f

### Testing
1. Log into a site that is Blaze eligible (user `isAdmin`, site is atomic and Jetpack connected) 
2. Check the Blaze banner is displayed in Product list tab. For now, the banner will always be displayed event if the product list is empty. I'll address that in the next PR. 
3. Click on "Try Blaze now" and check the Blaze webview is opened and the following events are logged:
- `Tracked: blaze_entry_point_tapped, Properties: {"source":"product_list_banner","blog_id":205513046,"is_wpcom_store":false,"is_debug":true}`
-`Tracked: blaze_flow_started, Properties: {"source":"product_list_banner","blog_id":205513046,"is_wpcom_store":false,"is_debug":true}`

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/2663464/2cee3333-bf81-44b3-a60c-113060a68393


