### PR TITLE
Analytics Performance: Analytics pull to refresh force update

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -141,7 +141,8 @@ class AnalyticsHubViewModel @Inject constructor(
         viewModelScope.launch {
             updateStats(
                 rangeSelection = ranges,
-                scope = viewModelScope
+                scope = viewModelScope,
+                forceUpdate = true
             ).collect {
                 mutableState.update { viewState ->
                     viewState.copy(refreshIndicator = if (it is Finished) NotShowIndicator else ShowIndicator)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -46,6 +46,6 @@ class AnalyticsUpdateDataStore @Inject constructor(
         get() = currentTimeProvider.currentDate().time
 
     companion object {
-        const val defaultMaxOutdatedTime = 1000 * 30L // 30 seconds
+        const val defaultMaxOutdatedTime = 1000 * 60 * 30L // 30 minutes
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
@@ -39,8 +39,8 @@ class UpdateAnalyticsHubStats @Inject constructor(
 
     suspend operator fun invoke(
         rangeSelection: StatsTimeRangeSelection,
-        forceUpdate: Boolean,
-        scope: CoroutineScope
+        scope: CoroutineScope,
+        forceUpdate: Boolean = false
     ): Flow<AnalyticsHubUpdateState> {
         _ordersState.update { OrdersState.Loading }
         _revenueState.update { RevenueState.Loading }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
@@ -410,7 +410,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
     fun `given a view, when refresh is requested, then show indicator is the expected`() = testBlocking {
         configureSuccessfulStatsResponse()
         updateStats.stub {
-            onBlocking { invoke(any(), any()) } doReturn flow {
+            onBlocking { invoke(any(), any(), any()) } doReturn flow {
                 emit(AnalyticsHubUpdateState.Finished)
                 emit(AnalyticsHubUpdateState.Loading)
             }
@@ -744,7 +744,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
                 emit(SessionState.Loading)
                 emit(SessionState.Available(testSessionStat))
             }
-            onBlocking { invoke(any(), any()) } doReturn flow {
+            onBlocking { invoke(any(), any(), any()) } doReturn flow {
                 emit(AnalyticsHubUpdateState.Finished)
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -308,10 +308,10 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
         sut(testRangeSelection, this, true)
 
         // Then
-        verify(repository, times(1)).fetchRevenueData(testRangeSelection, ForceNew)
-        verify(repository, times(1)).fetchOrdersData(testRangeSelection, ForceNew)
-        verify(repository, times(1)).fetchVisitorsData(testRangeSelection, ForceNew)
-        verify(repository, times(1)).fetchProductsData(testRangeSelection, ForceNew)
+        verify(repository).fetchRevenueData(testRangeSelection, ForceNew)
+        verify(repository).fetchOrdersData(testRangeSelection, ForceNew)
+        verify(repository).fetchVisitorsData(testRangeSelection, ForceNew)
+        verify(repository).fetchProductsData(testRangeSelection, ForceNew)
 
         verify(analyticsDataStore, never()).shouldUpdateAnalytics(testRangeSelection)
     }
@@ -331,12 +331,12 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
         sut(testRangeSelection, this, false)
 
         // Then
-        verify(repository, times(1)).fetchRevenueData(testRangeSelection, Saved)
-        verify(repository, times(1)).fetchOrdersData(testRangeSelection, Saved)
-        verify(repository, times(1)).fetchVisitorsData(testRangeSelection, Saved)
-        verify(repository, times(1)).fetchProductsData(testRangeSelection, Saved)
+        verify(repository).fetchRevenueData(testRangeSelection, Saved)
+        verify(repository).fetchOrdersData(testRangeSelection, Saved)
+        verify(repository).fetchVisitorsData(testRangeSelection, Saved)
+        verify(repository).fetchProductsData(testRangeSelection, Saved)
 
-        verify(analyticsDataStore, times(1)).shouldUpdateAnalytics(testRangeSelection)
+        verify(analyticsDataStore).shouldUpdateAnalytics(testRangeSelection)
     }
 
     @Test


### PR DESCRIPTION
Summary
==========
Fix #9363 by adjusting the Analytics Hub Pull to refresh action to always force a new refresh, completely ignoring the time constraint introduced for stats refresh.

How to Test
==========
1. Open the app and enter the Analytics Hub
2. Once the data is loaded, exit and reenter the Hub with the same range selection, and verify that no network operation is triggered.
3. Trigger a pull-to-refresh action. Now verify that a new request was made fetching the stats data inside the Hub again for that specific selection range.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
