### PR TITLE
[UI Tests] Use `depends_on` instead of `wait` for test analytics.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -57,15 +57,16 @@ steps:
     plugins: *common_plugins
 
   - label: "Instrumented tests"
+    key: "instrumented_tests"
     command: .buildkite/commands/run-instrumented-tests.sh
     plugins: *common_plugins
     artifact_paths:
       - "**/build/instrumented-tests/**/*"
 
-  - wait
-
   - label: "🔍 Test Analytics"
     command: buildkite-agent artifact download '**/test_result_1.xml' .
+    depends_on:
+      - "instrumented_tests"
     plugins:
       - test-collector#v1.8.0:
           files: "**/test_result_1.xml"


### PR DESCRIPTION
### Description
This is a tiny follow-up to #9358. Instead of using [wait](https://buildkite.com/docs/pipelines/wait-step), the "Test Analytics" step now uses [depends_on](https://buildkite.com/docs/pipelines/dependencies#defining-explicit-dependencies). This makes things more robust, since `wait` will wait for _all steps_ listed above it to complete, whereas a step with `depends_on` will be executed only after a _specific step_.

### Testing instructions
- CI is green
- Test Analytics still works (the pic for this PR's commit):

<img width="1168" alt="Screenshot 2023-07-05 at 15 42 29" src="https://github.com/woocommerce/woocommerce-android/assets/73365754/092edcd4-1c10-4677-b5e8-2050cf4aa35b">


