### PR TITLE
Show only ai product description generation for WP.com stores

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.AIProductDescriptionBottomSheetFragment
+import com.woocommerce.android.ui.products.IsAIProductDescriptionEnabled
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.ToastUtils
@@ -45,6 +46,7 @@ class AztecEditorFragment :
     }
 
     @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
+    @Inject lateinit var isAIProductDescriptionEnabled: IsAIProductDescriptionEnabled
 
     private lateinit var aztec: Aztec
 
@@ -69,6 +71,7 @@ class AztecEditorFragment :
         }
 
         with(binding.aiButton) {
+            visibility = if (isAIProductDescriptionEnabled()) View.VISIBLE else View.GONE
             setOnClickListener {
                 onAIButtonClicked()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/IsAIProductDescriptionEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/IsAIProductDescriptionEnabled.kt
@@ -1,8 +1,13 @@
 package com.woocommerce.android.ui.products
 
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.FeatureFlag
 import javax.inject.Inject
 
-class IsAIProductDescriptionEnabled @Inject constructor() {
-    operator fun invoke(): Boolean = FeatureFlag.PRODUCT_DESCRIPTION_AI_GENERATOR.isEnabled()
+class IsAIProductDescriptionEnabled @Inject constructor(
+    private val selectedSite: SelectedSite
+) {
+    operator fun invoke(): Boolean =
+        FeatureFlag.PRODUCT_DESCRIPTION_AI_GENERATOR.isEnabled() &&
+            selectedSite.getIfExists()?.isWpComStore ?: false
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9214
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Ensure we only show the ai generation CTAs if the site is `WP.com`. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
WP.com site scenario
1. Navigate to product detail and check that generate product desc with AI is visible
2. Open the product description and check that AI description generation button is available in Aztec toolbar. 

Self-hosted site with Jetpack connection scenario
1. Navigate to product detail and check that generate product desc with AI is hidden
2. Open the product description and check that AI description generation button is hidden in Aztec toolbar. 

