### PR TITLE
AI Product Description: Highlight Tooltips Functionality

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 14.4
 -----
-
+- [***] AI: WordPress.com-hosted sites now has access to an experimental AI feature that generates product description for you. [https://github.com/woocommerce/woocommerce-android/issues/9214]
 
 14.3
 -----

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
@@ -62,6 +62,9 @@ open class Screen {
 
         // hide the promo dialog because it breaks the tests
         AppPrefs.wasAIProductDescriptionPromoDialogShown = true
+
+        // also hide AI description tooltip to make test more simple
+        AppPrefs.isAIProductDescriptionTooltipDismissed = true
     }
 
     open fun recover() = Unit
@@ -392,23 +395,6 @@ open class Screen {
                 atLeastOneElementIsDisplayed(elementId)
             }
         )
-    }
-
-    fun waitForAnyElementToBeDisplayed(vararg elementIds: Int): Int? {
-        var displayedElementId: Int? = null
-        waitForConditionToBeTrue(
-            Supplier {
-                elementIds.any { id ->
-                    if (isElementDisplayed(id)) {
-                        displayedElementId = id
-                        true
-                    } else {
-                        false
-                    }
-                }
-            }
-        )
-        return displayedElementId
     }
 
     // MATCHERS

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
@@ -394,6 +394,14 @@ open class Screen {
         )
     }
 
+    fun waitForAnyElementToBeDisplayed(vararg elementIDs: Int) {
+        waitForConditionToBeTrue(
+            Supplier {
+                elementIDs.any { isElementDisplayed(it) }
+            }
+        )
+    }
+
     // MATCHERS
     private fun first(): FirstMatcher {
         return FirstMatcher()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
@@ -394,12 +394,21 @@ open class Screen {
         )
     }
 
-    fun waitForAnyElementToBeDisplayed(vararg elementIDs: Int) {
+    fun waitForAnyElementToBeDisplayed(vararg elementIds: Int): Int? {
+        var displayedElementId: Int? = null
         waitForConditionToBeTrue(
             Supplier {
-                elementIDs.any { isElementDisplayed(it) }
+                elementIds.any { id ->
+                    if (isElementDisplayed(id)) {
+                        displayedElementId = id
+                        true
+                    } else {
+                        false
+                    }
+                }
             }
         )
+        return displayedElementId
     }
 
     // MATCHERS

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
@@ -27,7 +27,12 @@ class ProductListScreen : Screen {
 
     fun selectProductByName(productName: String): SingleProductScreen {
         selectListItem(productName, LIST_VIEW)
-        waitForAnyElementToBeDisplayed(R.id.highlights_tooltip_root, R.id.productDetail_root)
+        val displayedElement = waitForAnyElementToBeDisplayed(R.id.highlights_tooltip_root, R.id.productDetail_root)
+        displayedElement?.let {
+            if (it == R.id.highlights_tooltip_root) {
+                clickOn(R.id.tooltip_primary_button)
+            }
+        }
         return SingleProductScreen()
     }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
@@ -27,12 +27,7 @@ class ProductListScreen : Screen {
 
     fun selectProductByName(productName: String): SingleProductScreen {
         selectListItem(productName, LIST_VIEW)
-        val displayedElement = waitForAnyElementToBeDisplayed(R.id.highlights_tooltip_root, R.id.productDetail_root)
-        displayedElement?.let {
-            if (it == R.id.highlights_tooltip_root) {
-                clickOn(R.id.tooltip_primary_button)
-            }
-        }
+        waitForElementToBeDisplayed(R.id.productDetail_root)
         return SingleProductScreen()
     }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
@@ -27,9 +27,7 @@ class ProductListScreen : Screen {
 
     fun selectProductByName(productName: String): SingleProductScreen {
         selectListItem(productName, LIST_VIEW)
-        waitForElementToBeDisplayed(R.id.highlights_tooltip_root)
-        clickOn(R.id.tooltip_dismiss_button)
-        waitForElementToBeDisplayed(R.id.productDetail_root)
+        waitForAnyElementToBeDisplayed(R.id.highlights_tooltip_root, R.id.productDetail_root)
         return SingleProductScreen()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -111,6 +111,7 @@ object AppPrefs {
         IS_EU_SHIPPING_NOTICE_DISMISSED,
         HAS_SAVED_PRIVACY_SETTINGS,
         WAS_AI_DESCRIPTION_PROMO_DIALOG_SHOWN,
+        IS_AI_DESCRIPTION_TOOLTIP_DISMISSED
     }
 
     /**
@@ -1001,6 +1002,16 @@ object AppPrefs {
         )
         set(value) = setBoolean(
             key = DeletablePrefKey.WAS_AI_DESCRIPTION_PROMO_DIALOG_SHOWN,
+            value = value
+        )
+
+    var isAIProductDescriptionTooltipDismissed: Boolean
+        get() = getBoolean(
+            key = DeletablePrefKey.IS_AI_DESCRIPTION_TOOLTIP_DISMISSED,
+            default = false
+        )
+        set(value) = setBoolean(
+            key = DeletablePrefKey.IS_AI_DESCRIPTION_TOOLTIP_DISMISSED,
             value = value
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -111,7 +111,8 @@ object AppPrefs {
         IS_EU_SHIPPING_NOTICE_DISMISSED,
         HAS_SAVED_PRIVACY_SETTINGS,
         WAS_AI_DESCRIPTION_PROMO_DIALOG_SHOWN,
-        IS_AI_DESCRIPTION_TOOLTIP_DISMISSED
+        IS_AI_DESCRIPTION_TOOLTIP_DISMISSED,
+        NUMBER_OF_TIMES_AI_DESCRIPTION_TOOLTIP_SHOWN,
     }
 
     /**
@@ -1014,6 +1015,14 @@ object AppPrefs {
             key = DeletablePrefKey.IS_AI_DESCRIPTION_TOOLTIP_DISMISSED,
             value = value
         )
+
+    fun incrementAIDescriptionTooltipShownNumber() {
+        val currentTotal = getInt(DeletablePrefKey.NUMBER_OF_TIMES_AI_DESCRIPTION_TOOLTIP_SHOWN, 0)
+        return setInt(DeletablePrefKey.NUMBER_OF_TIMES_AI_DESCRIPTION_TOOLTIP_SHOWN, currentTotal + 1)
+    }
+
+    fun getAIDescriptionTooltipShownNumber() =
+        getInt(DeletablePrefKey.NUMBER_OF_TIMES_AI_DESCRIPTION_TOOLTIP_SHOWN, 0)
 
     fun setStorePhoneNumber(siteId: Int, phoneNumber: String) {
         setString(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -1018,7 +1018,7 @@ object AppPrefs {
 
     fun incrementAIDescriptionTooltipShownNumber() {
         val currentTotal = getInt(DeletablePrefKey.NUMBER_OF_TIMES_AI_DESCRIPTION_TOOLTIP_SHOWN, 0)
-        return setInt(DeletablePrefKey.NUMBER_OF_TIMES_AI_DESCRIPTION_TOOLTIP_SHOWN, currentTotal + 1)
+        setInt(DeletablePrefKey.NUMBER_OF_TIMES_AI_DESCRIPTION_TOOLTIP_SHOWN, currentTotal + 1)
     }
 
     fun getAIDescriptionTooltipShownNumber() =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -340,6 +340,9 @@ class AppPrefsWrapper @Inject constructor() {
 
     var isAIProductDescriptionTooltipDismissed by AppPrefs::isAIProductDescriptionTooltipDismissed
 
+    fun recordAIDescriptionTooltipShown() = AppPrefs.incrementAIDescriptionTooltipShownNumber()
+    fun getAIDescriptionTooltipShownNumber() = AppPrefs.getAIDescriptionTooltipShownNumber()
+
     fun isCrashReportingEnabled(): Boolean = AppPrefs.isCrashReportingEnabled()
 
     fun setCrashReportingEnabled(enabled: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -338,6 +338,8 @@ class AppPrefsWrapper @Inject constructor() {
 
     var wasAIProductDescriptionPromoDialogShown by AppPrefs::wasAIProductDescriptionPromoDialogShown
 
+    var isAIProductDescriptionTooltipDismissed by AppPrefs::isAIProductDescriptionTooltipDismissed
+
     fun isCrashReportingEnabled(): Boolean = AppPrefs.isCrashReportingEnabled()
 
     fun setCrashReportingEnabled(enabled: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -110,7 +110,7 @@ class ProductDetailCardBuilder(
     private fun getPrimaryCard(product: Product): ProductPropertyCard {
         val showTooltip = product.description.isEmpty() &&
             !appPrefsWrapper.isAIProductDescriptionTooltipDismissed &&
-            appPrefsWrapper.getAIDescriptionTooltipShownNumber() < MAXIMUM_TIMES_TO_SHOW_TOOLTIP
+            appPrefsWrapper.getAIDescriptionTooltipShownNumber() <= MAXIMUM_TIMES_TO_SHOW_TOOLTIP
         return ProductPropertyCard(
             type = PRIMARY,
             properties = (

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -79,6 +79,10 @@ class ProductDetailCardBuilder(
 ) {
     private lateinit var originalSku: String
 
+    companion object {
+        const val MAXIMUM_TIMES_TO_SHOW_TOOLTIP = 3
+    }
+
     suspend fun buildPropertyCards(product: Product, originalSku: String): List<ProductPropertyCard> {
 
         this.originalSku = originalSku
@@ -101,7 +105,9 @@ class ProductDetailCardBuilder(
     }
 
     private fun getPrimaryCard(product: Product): ProductPropertyCard {
-        val showTooltip = product.description.isEmpty() && !appPrefsWrapper.isAIProductDescriptionTooltipDismissed
+        val showTooltip = product.description.isEmpty() &&
+            !appPrefsWrapper.isAIProductDescriptionTooltipDismissed &&
+            appPrefsWrapper.getAIDescriptionTooltipShownNumber() < MAXIMUM_TIMES_TO_SHOW_TOOLTIP
         return ProductPropertyCard(
             type = PRIMARY,
             properties = (
@@ -619,6 +625,8 @@ class ProductDetailCardBuilder(
 
         if (showAIButton) {
             val tooltip = if (showTooltip) {
+                appPrefsWrapper.recordAIDescriptionTooltipShown()
+
                 Button.Tooltip(
                     title = string.ai_product_description_tooltip_title,
                     text = string.ai_product_description_tooltip_message,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products
 
 import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
@@ -73,7 +74,8 @@ class ProductDetailCardBuilder(
     private val parameters: SiteParameters,
     private val addonRepository: AddonRepository,
     private val variationRepository: VariationRepository,
-    private val isAIProductDescriptionEnabled: IsAIProductDescriptionEnabled
+    private val isAIProductDescriptionEnabled: IsAIProductDescriptionEnabled,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) {
     private lateinit var originalSku: String
 
@@ -620,6 +622,7 @@ class ProductDetailCardBuilder(
                     title = string.ai_product_description_tooltip_title,
                     text = string.ai_product_description_tooltip_message,
                     primaryButtonText = string.ai_product_description_tooltip_dismiss,
+                    onDismiss = { onTooltipDismiss() }
                 )
             } else {
                 null
@@ -638,6 +641,10 @@ class ProductDetailCardBuilder(
             )
         }
         return properties
+    }
+
+    private fun onTooltipDismiss() {
+        appPrefsWrapper.isAIProductDescriptionTooltipDismissed = true
     }
 
     // show product variations only if product type is variable and if there are variations for the product

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -630,7 +630,7 @@ class ProductDetailCardBuilder(
                 Button.Tooltip(
                     title = string.ai_product_description_tooltip_title,
                     text = string.ai_product_description_tooltip_message,
-                    primaryButtonText = string.ai_product_description_tooltip_dismiss,
+                    dismissButtonText = string.ai_product_description_tooltip_dismiss,
                     onDismiss = { onTooltipDismiss() }
                 )
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -104,9 +104,10 @@ class ProductDetailCardBuilder(
             properties = (
                 listOf(product.title()) +
                     product.description(
-                        isAIProductDescriptionEnabled(),
-                        viewModel::onWriteWithAIClicked,
-                        viewModel::onLearnMoreClicked
+                        showAIButton = isAIProductDescriptionEnabled(),
+                        showTooltip = product.description.isEmpty(),
+                        onWriteWithAIClicked = viewModel::onWriteWithAIClicked,
+                        onLearnMoreClicked = viewModel::onLearnMoreClicked
                     )
                 ).filterNotEmpty()
         )
@@ -584,6 +585,7 @@ class ProductDetailCardBuilder(
 
     private fun Product.description(
         showAIButton: Boolean,
+        showTooltip: Boolean,
         onWriteWithAIClicked: () -> Unit,
         onLearnMoreClicked: () -> Unit
     ): List<ProductProperty> {
@@ -613,11 +615,21 @@ class ProductDetailCardBuilder(
         )
 
         if (showAIButton) {
+            val tooltip = if (showTooltip) {
+                Button.Tooltip(
+                    title = string.ai_product_description_tooltip_title,
+                    text = string.ai_product_description_tooltip_message,
+                    primaryButtonText = string.ai_product_description_tooltip_dismiss,
+                )
+            } else {
+                null
+            }
             properties.add(
                 Button(
                     string.product_sharing_write_with_ai,
                     drawable.ic_ai,
                     onClick = onWriteWithAIClicked,
+                    tooltip = tooltip,
                     link = Link(
                         string.ai_product_description_learn_more_link,
                         onLearnMoreClicked

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -101,13 +101,14 @@ class ProductDetailCardBuilder(
     }
 
     private fun getPrimaryCard(product: Product): ProductPropertyCard {
+        val showTooltip = product.description.isEmpty() && !appPrefsWrapper.isAIProductDescriptionTooltipDismissed
         return ProductPropertyCard(
             type = PRIMARY,
             properties = (
                 listOf(product.title()) +
                     product.description(
                         showAIButton = isAIProductDescriptionEnabled(),
-                        showTooltip = product.description.isEmpty(),
+                        showTooltip = showTooltip,
                         onWriteWithAIClicked = viewModel::onWriteWithAIClicked,
                         onLearnMoreClicked = viewModel::onLearnMoreClicked
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -85,7 +85,6 @@ class ProductDetailCardBuilder(
 
     private val onTooltipDismiss = { appPrefsWrapper.isAIProductDescriptionTooltipDismissed = true }
 
-
     suspend fun buildPropertyCards(product: Product, originalSku: String): List<ProductPropertyCard> {
 
         this.originalSku = originalSku

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -83,6 +83,9 @@ class ProductDetailCardBuilder(
         const val MAXIMUM_TIMES_TO_SHOW_TOOLTIP = 3
     }
 
+    private val onTooltipDismiss = { appPrefsWrapper.isAIProductDescriptionTooltipDismissed = true }
+
+
     suspend fun buildPropertyCards(product: Product, originalSku: String): List<ProductPropertyCard> {
 
         this.originalSku = originalSku
@@ -631,7 +634,7 @@ class ProductDetailCardBuilder(
                     title = string.ai_product_description_tooltip_title,
                     text = string.ai_product_description_tooltip_message,
                     dismissButtonText = string.ai_product_description_tooltip_dismiss,
-                    onDismiss = { onTooltipDismiss() }
+                    onDismiss = onTooltipDismiss
                 )
             } else {
                 null
@@ -650,10 +653,6 @@ class ProductDetailCardBuilder(
             )
         }
         return properties
-    }
-
-    private fun onTooltipDismiss() {
-        appPrefsWrapper.isAIProductDescriptionTooltipDismissed = true
     }
 
     // show product variations only if product type is variable and if there are variations for the product

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -235,7 +235,8 @@ class ProductDetailViewModel @Inject constructor(
             parameters,
             addonRepository,
             variationRepository,
-            isAIProductDescriptionEnabled
+            isAIProductDescriptionEnabled,
+            appPrefsWrapper
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyButtonView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyButtonView.kt
@@ -65,7 +65,6 @@ class WCProductPropertyButtonView @JvmOverloads constructor(
                 tooltip.onDismiss?.invoke()
                 popupWindow.dismiss()
             }
-
         }
 
         // Make the popupWindow dismissible by clicking outside of it.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyButtonView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyButtonView.kt
@@ -61,7 +61,11 @@ class WCProductPropertyButtonView @JvmOverloads constructor(
         tooltip.onPrimaryButtonClick?.let {
             popupBinding.tooltipPrimaryButton.setOnClickListener { it() }
         } ?: run {
-            popupBinding.tooltipPrimaryButton.setOnClickListener { popupWindow.dismiss() }
+            popupBinding.tooltipPrimaryButton.setOnClickListener {
+                tooltip.onDismiss?.invoke()
+                popupWindow.dismiss()
+            }
+
         }
 
         // Make the popupWindow dismissible by clicking outside of it.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyButtonView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyButtonView.kt
@@ -2,13 +2,14 @@ package com.woocommerce.android.ui.products
 
 import android.content.Context
 import android.graphics.drawable.Drawable
-import android.text.Spanned
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.PopupWindow
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.text.HtmlCompat
 import com.woocommerce.android.databinding.HighlightsTooltipLayoutBinding
 import com.woocommerce.android.databinding.ProductPropertyButtonViewLayoutBinding
+import com.woocommerce.android.ui.products.models.ProductProperty
 import org.wordpress.android.util.DisplayUtils
 
 class WCProductPropertyButtonView @JvmOverloads constructor(
@@ -25,6 +26,8 @@ class WCProductPropertyButtonView @JvmOverloads constructor(
         text: String,
         icon: Drawable?,
         onClick: () -> Unit,
+        link: ProductProperty.Button.Link? = null,
+        tooltip: ProductProperty.Button.Tooltip? = null,
     ) {
         with(binding.productButton) {
             this.text = text
@@ -32,13 +35,34 @@ class WCProductPropertyButtonView @JvmOverloads constructor(
             setOnClickListener { onClick() }
         }
 
-        val popupBinding = HighlightsTooltipLayoutBinding.inflate(LayoutInflater.from(context), null, false)
-        showPopupWindow(popupBinding)
+        link?.let { linkData ->
+            with(binding.link) {
+                this.text = HtmlCompat.fromHtml(context.getString(linkData.text), HtmlCompat.FROM_HTML_MODE_LEGACY)
+                setOnClickListener {
+                    linkData.onClick()
+                }
+            }
+        }
+
+        tooltip?.let {
+            showPopupWindow(it)
+        }
     }
 
-    private fun showPopupWindow(popupBinding: HighlightsTooltipLayoutBinding) {
+    private fun showPopupWindow(tooltip: ProductProperty.Button.Tooltip) {
+        val popupBinding = HighlightsTooltipLayoutBinding.inflate(LayoutInflater.from(context), null, false)
+
         val popupWindow = PopupWindow(popupBinding.root, LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
-        popupBinding.tooltipDismissButton.setOnClickListener { popupWindow.dismiss() }
+
+        popupBinding.tooltipTitle.text = context.getString(tooltip.title)
+        popupBinding.tooltipMessage.text = context.getString(tooltip.text)
+        popupBinding.tooltipDismissButton.text = context.getString(tooltip.primaryButtonText)
+
+        tooltip.onPrimaryButtonClick?.let {
+            popupBinding.tooltipDismissButton.setOnClickListener { it() }
+        } ?: run {
+            popupBinding.tooltipDismissButton.setOnClickListener { popupWindow.dismiss() }
+        }
 
         // Make the popupWindow dismissible by clicking outside of it.
         popupWindow.isOutsideTouchable = true
@@ -51,27 +75,4 @@ class WCProductPropertyButtonView @JvmOverloads constructor(
             DisplayUtils.dpToPx(context, TOOLTIP_VERTICAL_OFFSET)
         )
     }
-
-    fun show(
-        text: String,
-        icon: Drawable?,
-        onClick: () -> Unit,
-        linkText: Spanned,
-        onLinkClick: () -> Unit,
-    ) {
-        with(binding.productButton) {
-            this.text = text
-            this.icon = icon
-            setOnClickListener { onClick() }
-        }
-
-        with(binding.link) {
-            this.text = linkText
-            setOnClickListener { onLinkClick() }
-        }
-
-        val popupBinding = HighlightsTooltipLayoutBinding.inflate(LayoutInflater.from(context), null, false)
-        showPopupWindow(popupBinding)
-    }
 }
-

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyButtonView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyButtonView.kt
@@ -9,12 +9,16 @@ import android.widget.PopupWindow
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.woocommerce.android.databinding.HighlightsTooltipLayoutBinding
 import com.woocommerce.android.databinding.ProductPropertyButtonViewLayoutBinding
+import org.wordpress.android.util.DisplayUtils
 
 class WCProductPropertyButtonView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyle: Int = 0
 ) : ConstraintLayout(context, attrs, defStyle) {
+    companion object {
+        const val TOOLTIP_VERTICAL_OFFSET = -8
+    }
     private val binding = ProductPropertyButtonViewLayoutBinding.inflate(LayoutInflater.from(context), this)
 
     fun show(
@@ -41,7 +45,11 @@ class WCProductPropertyButtonView @JvmOverloads constructor(
         popupWindow.isFocusable = true
 
         // Show the PopupWindow below the button
-        popupWindow.showAsDropDown(binding.productButton)
+        popupWindow.showAsDropDown(
+            binding.productButton,
+            0,
+            DisplayUtils.dpToPx(context, TOOLTIP_VERTICAL_OFFSET)
+        )
     }
 
     fun show(
@@ -66,3 +74,4 @@ class WCProductPropertyButtonView @JvmOverloads constructor(
         showPopupWindow(popupBinding)
     }
 }
+

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyButtonView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyButtonView.kt
@@ -56,12 +56,12 @@ class WCProductPropertyButtonView @JvmOverloads constructor(
 
         popupBinding.tooltipTitle.text = context.getString(tooltip.title)
         popupBinding.tooltipMessage.text = context.getString(tooltip.text)
-        popupBinding.tooltipDismissButton.text = context.getString(tooltip.primaryButtonText)
+        popupBinding.tooltipPrimaryButton.text = context.getString(tooltip.primaryButtonText)
 
         tooltip.onPrimaryButtonClick?.let {
-            popupBinding.tooltipDismissButton.setOnClickListener { it() }
+            popupBinding.tooltipPrimaryButton.setOnClickListener { it() }
         } ?: run {
-            popupBinding.tooltipDismissButton.setOnClickListener { popupWindow.dismiss() }
+            popupBinding.tooltipPrimaryButton.setOnClickListener { popupWindow.dismiss() }
         }
 
         // Make the popupWindow dismissible by clicking outside of it.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyButtonView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyButtonView.kt
@@ -56,15 +56,11 @@ class WCProductPropertyButtonView @JvmOverloads constructor(
 
         popupBinding.tooltipTitle.text = context.getString(tooltip.title)
         popupBinding.tooltipMessage.text = context.getString(tooltip.text)
-        popupBinding.tooltipPrimaryButton.text = context.getString(tooltip.primaryButtonText)
+        popupBinding.tooltipDismissButton.text = context.getString(tooltip.dismissButtonText)
 
-        tooltip.onPrimaryButtonClick?.let {
-            popupBinding.tooltipPrimaryButton.setOnClickListener { it() }
-        } ?: run {
-            popupBinding.tooltipPrimaryButton.setOnClickListener {
-                tooltip.onDismiss?.invoke()
-                popupWindow.dismiss()
-            }
+        popupBinding.tooltipDismissButton.setOnClickListener {
+            tooltip.onDismiss.invoke()
+            popupWindow.dismiss()
         }
 
         // Make the popupWindow dismissible by clicking outside of it.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
@@ -124,11 +124,14 @@ sealed class ProductProperty(val type: Type) {
         val link: Link? = null,
         val onClick: (() -> Unit)
     ) : ProductProperty(BUTTON) {
+        /**
+         * @param onPrimaryButtonClick Set as null for tooltip dismiss action.
+         */
         data class Tooltip(
             @StringRes val title: Int,
             @StringRes val text: Int,
-            @DrawableRes val primaryButtonText: Int,
-            val onPrimaryButtonClick: () -> Unit,
+            @StringRes val primaryButtonText: Int,
+            val onPrimaryButtonClick: (() -> Unit)? = null,
         )
 
         data class Link(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
@@ -126,13 +126,16 @@ sealed class ProductProperty(val type: Type) {
     ) : ProductProperty(BUTTON) {
         /**
          * @param onPrimaryButtonClick Set as null for tooltip dismiss action.
+         * @param onDismiss If `onPrimaryButtonClick` is null, this will be called on tooltip dismiss.
          */
         data class Tooltip(
             @StringRes val title: Int,
             @StringRes val text: Int,
             @StringRes val primaryButtonText: Int,
             val onPrimaryButtonClick: (() -> Unit)? = null,
+            val onDismiss: (() -> Unit)? = null
         )
+
 
         data class Link(
             @StringRes val text: Int,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
@@ -127,8 +127,8 @@ sealed class ProductProperty(val type: Type) {
         data class Tooltip(
             @StringRes val title: Int,
             @StringRes val text: Int,
-            @DrawableRes val icon: Int,
-            val onButtonClick: () -> Unit,
+            @DrawableRes val primaryButtonText: Int,
+            val onPrimaryButtonClick: () -> Unit,
         )
 
         data class Link(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
@@ -124,16 +124,11 @@ sealed class ProductProperty(val type: Type) {
         val link: Link? = null,
         val onClick: (() -> Unit)
     ) : ProductProperty(BUTTON) {
-        /**
-         * @param onPrimaryButtonClick Set as null for tooltip dismiss action.
-         * @param onDismiss If `onPrimaryButtonClick` is null, this will be called on tooltip dismiss.
-         */
         data class Tooltip(
             @StringRes val title: Int,
             @StringRes val text: Int,
-            @StringRes val primaryButtonText: Int,
-            val onPrimaryButtonClick: (() -> Unit)? = null,
-            val onDismiss: (() -> Unit)? = null
+            @StringRes val dismissButtonText: Int,
+            val onDismiss: (() -> Unit)
         )
 
         data class Link(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/models/ProductProperty.kt
@@ -136,7 +136,6 @@ sealed class ProductProperty(val type: Type) {
             val onDismiss: (() -> Unit)? = null
         )
 
-
         data class Link(
             @StringRes val text: Int,
             val onClick: () -> Unit,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/viewholders/ButtonViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/viewholders/ButtonViewHolder.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.products.viewholders
 
 import android.view.ViewGroup
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.text.HtmlCompat
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.products.WCProductPropertyButtonView
 import com.woocommerce.android.ui.products.models.ProductProperty.Button
@@ -18,17 +17,12 @@ class ButtonViewHolder(parent: ViewGroup) : ProductPropertyViewHolder(
         val text = context.getString(button.text)
         val icon = button.icon?.let { AppCompatResources.getDrawable(context, it) }
 
-        if (button.link != null) {
-            val linkText = HtmlCompat.fromHtml(context.getString(button.link.text), HtmlCompat.FROM_HTML_MODE_LEGACY)
-            buttonView.show(
-                text,
-                icon,
-                button.onClick,
-                linkText,
-                button.link.onClick
-            )
-        } else {
-            buttonView.show(text, icon, button.onClick)
-        }
+        buttonView.show(
+            text = text,
+            icon = icon,
+            onClick = button.onClick,
+            link = button.link,
+            tooltip = button.tooltip
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/viewholders/ButtonViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/viewholders/ButtonViewHolder.kt
@@ -17,9 +17,6 @@ class ButtonViewHolder(parent: ViewGroup) : ProductPropertyViewHolder(
 
         val text = context.getString(button.text)
         val icon = button.icon?.let { AppCompatResources.getDrawable(context, it) }
-//        val tooltipTitle = button.tooltip?.title?.let { context.getString(it) }
-//        val tooltipText = button.tooltip?.text?.let { context.getString(it) }
-//        val tooltipIcon = button.tooltip?.icon?.let { AppCompatResources.getDrawable(context, it) }
 
         if (button.link != null) {
             val linkText = HtmlCompat.fromHtml(context.getString(button.link.text), HtmlCompat.FROM_HTML_MODE_LEGACY)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -57,12 +57,12 @@ enum class FeatureFlag {
             EU_SHIPPING_NOTIFICATION,
             PRIVACY_CHOICES,
             BLAZE,
-            SHARING_PRODUCT_AI -> true
+            SHARING_PRODUCT_AI,
+            PRODUCT_DESCRIPTION_AI_GENERATOR -> true
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             IPP_TAP_TO_PAY,
-            PRODUCT_DESCRIPTION_AI_GENERATOR,
             CUSTOMER_LIST_SEARCH_2 -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false

--- a/WooCommerce/src/main/res/layout/highlights_tooltip_layout.xml
+++ b/WooCommerce/src/main/res/layout/highlights_tooltip_layout.xml
@@ -24,7 +24,7 @@
             android:id="@+id/tooltip_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/ai_product_description_tooltip_title"
+            android:text="@string/highlights_tooltip_title_hint"
             android:textColor="@color/highlights_tooltip_title"
             android:textAppearance="@style/TextAppearance.Woo.Subtitle1"
             android:layout_marginBottom="@dimen/minor_100"/>
@@ -33,7 +33,7 @@
             android:id="@+id/tooltip_message"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/ai_product_description_tooltip_message"
+            android:text="@string/highlights_tooltip_message_hint"
             android:textColor="@color/woo_purple_dark_secondary"
             android:textAppearance="@style/TextAppearance.Woo.Subtitle1"
             android:layout_below="@id/tooltip_title"/>
@@ -44,7 +44,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@color/woo_purple_40"
-            android:text="@string/ai_product_description_tooltip_dismiss"
+            android:text="@string/highlights_tooltip_button_hint"
             android:layout_alignParentEnd="true"
             android:layout_below="@id/tooltip_message"/>
     </RelativeLayout>

--- a/WooCommerce/src/main/res/layout/highlights_tooltip_layout.xml
+++ b/WooCommerce/src/main/res/layout/highlights_tooltip_layout.xml
@@ -40,7 +40,7 @@
 
         <com.google.android.material.button.MaterialButton
             style="@style/Woo.Button.TextButton"
-            android:id="@+id/tooltip_dismiss_button"
+            android:id="@+id/tooltip_primary_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@color/woo_purple_40"

--- a/WooCommerce/src/main/res/layout/highlights_tooltip_layout.xml
+++ b/WooCommerce/src/main/res/layout/highlights_tooltip_layout.xml
@@ -40,7 +40,7 @@
 
         <com.google.android.material.button.MaterialButton
             style="@style/Woo.Button.TextButton"
-            android:id="@+id/tooltip_primary_button"
+            android:id="@+id/tooltip_dismiss_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@color/woo_purple_40"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3402,4 +3402,11 @@
     <string name="blaze_banner_button">Try Blaze now</string>
     <string name="blaze_banner_close_button_content_description">Close Blaze banner button</string>
 
+    <!--
+    Highlights tooltip
+    -->
+    <string name="highlights_tooltip_title_hint">Tooltip title</string>
+    <string name="highlights_tooltip_message_hint">Tooltip message. \n This can be multiple lines.</string>
+    <string name="highlights_tooltip_button_hint">Button text</string>
+
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
@@ -40,7 +40,8 @@ class ProductDetailCardBuilderTest : BaseUnitTest() {
             parameters = mock(),
             addonRepository = addonRepo,
             variationRepository = mock(),
-            isAIProductDescriptionEnabled = mock()
+            isAIProductDescriptionEnabled = mock(),
+            appPrefsWrapper = mock(),
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9290
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Finally, now that the tasks are complete, this PR also releases the whole AI product description feature and updates the release note with it.

This PR shows or hides the tooltip based on these conditions, where all must be true:

1. Product description is empty
2. The tooltip is presented less than 3 times. (To avoid annoying the user)
3. Tooltip was not dismissed manually by tapping on the “Got it” button.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### a. test to ensure tooltip doesn't show up on product with existing description
1. Run app,
2. Go to products tab,
3. Open a product with existing description, ensure the highlights tooltip does not show up.

#### b. test to ensure tooltip only appears 3 times if not dismissed
1. Go back to products tab,
2. Open a product with no description, and ensure the highlights tooltip shows up,
3. Tap back, then go back into the same product above. Repeatedly do this and make sure the tooltip only shows up for two more times.

#### c. test to ensure tooltip does not appear once dismissed
1. Log out to reset preferences.
2. Log back in, go to products tab,
3. Open a product with no description, and ensure the highlights tooltip shows up,
4. Dismiss it using the "Got it" button,
5. Leave the product details, then go back to the same product. Make sure the highlight tooltip does not show up again.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-android/assets/266376/df4a0725-bf59-4430-addf-81ff78d83a6d" width="42%" />

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
