### PR TITLE
Feature/9332 show dialog when dismissing blaze banner

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 14.4
 -----
+- [*] Blaze: New Blaze banners added to My Store tab and product list tab. [https://github.com/woocommerce/woocommerce-android/issues/9332]
 
 
 14.3

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_BANNER_DISMISSED
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_ENTRY_POINT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -57,6 +58,14 @@ class BlazeBannerViewModel @Inject constructor(
         )
         appPrefsWrapper.shouldHideBlazeBanner = true
         triggerEvent(DismissBlazeBannerEvent)
+        triggerEvent(
+            MultiLiveEvent.Event.ShowDialog(
+                titleId = R.string.blaze_banner_dismiss_dialog_title,
+                messageId = R.string.blaze_banner_dismiss_dialog_description,
+                positiveButtonId = R.string.blaze_banner_dismiss_dialog_button,
+                positiveBtnAction = { dialog, _ -> dialog.dismiss() },
+            )
+        )
     }
 
     fun onTryBlazeBannerClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -232,6 +232,7 @@ class MyStoreFragment :
             when (event) {
                 is BlazeBannerViewModel.OpenBlazeEvent -> openBlazeWebView(event)
                 is BlazeBannerViewModel.DismissBlazeBannerEvent -> binding.blazeBannerView.collapse()
+                is ShowDialog -> event.showDialog()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -61,6 +61,7 @@ import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent
 import com.woocommerce.android.ui.products.ProductSortAndFiltersCard.ProductSortAndFilterListener
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
@@ -200,6 +201,8 @@ class ProductListFragment :
                         )
                     )
                 }
+
+                is ShowDialog -> event.showDialog()
             }
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3390,4 +3390,8 @@
     <string name="blaze_banner_description">Turn your products into ads that run across millions of sites on WordPress.com and Tumblr.</string>
     <string name="blaze_banner_button">Try Blaze now</string>
     <string name="blaze_banner_close_button_content_description">Close Blaze banner button</string>
+    <string name="blaze_banner_dismiss_dialog_title">Blaze ads</string>
+    <string name="blaze_banner_dismiss_dialog_description">No worries! Blaze is accessible from the Menu and the product detail menu for your convenience.</string>
+    <string name="blaze_banner_dismiss_dialog_button">Got it</string>
+
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9332

⚠️ Don't merge until [this PR](https://github.com/woocommerce/woocommerce-android/pull/9367) is merged

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Display an informative dialog after dismissing Blaze banner. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Log into a site that is Blaze eligible (user isAdmin, site is atomic and Jetpack connected)
2. Dismiss Blaze banner
3. Check the informative dialog is displayed.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/862cb61e-cfca-4f91-9619-119717aaaa31

