### PR TITLE
[Customer Search] Adds bouncing on search query change

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
@@ -7,6 +7,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.orders.creation.customerlist.CustomerListRepository
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.customer.WCCustomerModel
 import javax.inject.Inject
@@ -40,6 +42,8 @@ class CustomerListViewModel @Inject constructor(
             savedState[SEARCH_MODE_KEY] = value
         }
 
+    private var loadingFirstPageJob: Job? = null
+
     init {
         launch { loadCustomers(1) }
     }
@@ -53,7 +57,8 @@ class CustomerListViewModel @Inject constructor(
             searchQuery = this
             _viewState.value = _viewState.value!!.copy(searchQuery = this)
         }
-        launch { loadCustomers(1) }
+
+        loadAfterSearchChanged()
     }
 
     fun onSearchTypeChanged(searchTypeId: Int) {
@@ -64,7 +69,14 @@ class CustomerListViewModel @Inject constructor(
             )
         }
 
-        if (searchQuery.isNotEmpty()) launch { loadCustomers(1) }
+        if (searchQuery.isNotEmpty()) loadAfterSearchChanged()
+    }
+
+    private fun loadAfterSearchChanged() {
+        loadingFirstPageJob?.cancel()
+        loadingFirstPageJob = launch {
+            loadCustomers(1)
+        }
     }
 
     fun onNavigateBack() {
@@ -78,6 +90,8 @@ class CustomerListViewModel @Inject constructor(
         if (page != 1 && !paginationState.hasNextPage) return
         if (page == 1) {
             _viewState.value = _viewState.value!!.copy(body = CustomerListViewState.CustomerList.Loading)
+            // Add a delay to avoid multiple requests when the user types fast or switches search types
+            delay(SEARCH_DELAY_MS)
         }
         val result = customerListRepository.searchCustomerListWithEmail(
             searchQuery = searchQuery,
@@ -162,6 +176,8 @@ class CustomerListViewModel @Inject constructor(
     private companion object {
         private const val SEARCH_QUERY_KEY = "search_query"
         private const val SEARCH_MODE_KEY = "search_mode"
+
+        private const val SEARCH_DELAY_MS = 500L
 
         private const val PAGE_SIZE = 30
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9354
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds bouncing on search query and search type change

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Simulate slow connection on emulator
*  User the new customer search normally
* Switch and/or change the search query
* Notice in Flipper that new requests are not fired if switching is done withing 0.5 second

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
