### PR TITLE
[FIX] If IPP banner data is null then show other banners on the orders screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -416,15 +416,13 @@ class OrderListViewModel @Inject constructor(
 
     private fun displayIPPFeedbackOrOrdersBannerOrJitm() {
         viewModelScope.launch {
+            val bannerData = getIPPFeedbackBannerData()
             when {
-                shouldShowFeedbackBanner() -> {
-                    val bannerData = getIPPFeedbackBannerData()
-                    if (bannerData != null) {
-                        viewState = viewState.copy(
-                            ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(bannerData)
-                        )
-                        trackIPPBannerEvent(AnalyticsEvent.IPP_FEEDBACK_BANNER_SHOWN)
-                    }
+                shouldShowFeedbackBanner() && bannerData != null -> {
+                    viewState = viewState.copy(
+                        ippFeedbackBannerState = IPPSurveyFeedbackBannerState.Visible(bannerData)
+                    )
+                    trackIPPBannerEvent(AnalyticsEvent.IPP_FEEDBACK_BANNER_SHOWN)
                 }
                 !isSimplePaymentsAndOrderCreationFeedbackVisible -> {
                     viewState = viewState.copy(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -1118,6 +1118,30 @@ class OrderListViewModelTest : BaseUnitTest() {
             eq(CodeScanningErrorType.CodeScannerGooglePlayServicesVersionTooOld)
         )
     }
+
+    @Test
+    fun `given should show feedback banner but the banner data is null, when ViewModel init, then JITM shown instead`() =
+        testBlocking {
+            // given
+            whenever(shouldShowFeedbackBanner()).thenReturn(true)
+            whenever(getIPPFeedbackBannerData()).thenReturn(null)
+            val featureFeedbackSettings = mock<FeatureFeedbackSettings> {
+                on { feedbackState }.thenReturn(FeatureFeedbackSettings.FeedbackState.DISMISSED)
+            }
+            whenever(
+                feedbackPrefs.getFeatureFeedbackSettings(
+                    FeatureFeedbackSettings.Feature.SIMPLE_PAYMENTS_AND_ORDER_CREATION
+                )
+            ).thenReturn(featureFeedbackSettings)
+            whenever(appPrefs.isTapToPayEnabled).thenReturn(true)
+
+            // when
+            viewModel = createViewModel()
+
+            // then
+            assertThat(viewModel.viewState.jitmEnabled).isEqualTo(true)
+        }
+
     //endregion
 
     private companion object {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -1139,6 +1139,7 @@ class OrderListViewModelTest : BaseUnitTest() {
             viewModel = createViewModel()
 
             // then
+            assertThat(viewModel.viewState.ippFeedbackBannerState).isEqualTo(IPPSurveyFeedbackBannerState.Hidden)
             assertThat(viewModel.viewState.jitmEnabled).isEqualTo(true)
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I noticed that with the current code we may do not show any banner (even when conditions allow that) because the code goes inside `shouldShowFeedbackBanner` block and then there is a dead end when `bannerData` is null

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Probably not really possible to test or worth it, but run order list on a fresh installation. Notice IPP feedback banner

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
