### PR TITLE
Fix/UI glitches blaze banner

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -264,9 +264,15 @@ object AppPrefs {
         get() = getBoolean(DeletablePrefKey.IS_EU_SHIPPING_NOTICE_DISMISSED, false)
         set(value) = setBoolean(DeletablePrefKey.IS_EU_SHIPPING_NOTICE_DISMISSED, value)
 
-    var shouldHideBlazeBanner: Boolean
-        get() = getBoolean(DeletablePrefKey.BLAZE_BANNER_HIDDEN, false)
-        set(value) = setBoolean(DeletablePrefKey.BLAZE_BANNER_HIDDEN, value)
+    fun setBlazeBannerHidden(currentSiteId: Int, hidden: Boolean) {
+        setBoolean(getBlazeBannerKey(currentSiteId), hidden)
+    }
+
+    fun isBlazeBannerHidden(currentSiteId: Int) =
+        getBoolean(getBlazeBannerKey(currentSiteId), default = false)
+
+    private fun getBlazeBannerKey(currentSiteId: Int) =
+        PrefKeyString("${DeletablePrefKey.BLAZE_BANNER_HIDDEN}:$currentSiteId")
 
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -358,5 +358,9 @@ class AppPrefsWrapper @Inject constructor() {
 
     var wasAIProductDescriptionCelebrationShown by AppPrefs::wasAIProductDescriptionCelebrationShown
 
-    var shouldHideBlazeBanner by AppPrefs::shouldHideBlazeBanner
+    fun isBlazeBannerHidden(siteId: Int): Boolean = AppPrefs.isBlazeBannerHidden(siteId)
+
+    fun setBlazeBannerHidden(siteId: Int, hide: Boolean) {
+        AppPrefs.setBlazeBannerHidden(siteId, hide)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBanner.kt
@@ -3,11 +3,12 @@ package com.woocommerce.android.ui.blaze
 import android.content.res.Configuration
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -21,7 +22,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import com.woocommerce.android.R
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R.dimen
+import com.woocommerce.android.R.drawable
+import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.compose.component.WCTextButton
 
 @Composable
@@ -29,49 +33,52 @@ fun BlazeBanner(
     onClose: () -> Unit,
     onTryBlazeClicked: () -> Unit,
 ) {
-    Column(
+    Card(
         modifier = Modifier
             .fillMaxWidth()
-            .wrapContentHeight()
-            .background(MaterialTheme.colors.surface)
-            .padding(dimensionResource(id = R.dimen.major_100)),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .wrapContentHeight(),
+        shape = RoundedCornerShape(0.dp)
     ) {
-        IconButton(
-            modifier = Modifier.align(Alignment.End),
-            onClick = onClose
+        Column(
+            modifier = Modifier.padding(dimensionResource(id = dimen.major_100)),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Icon(
-                painter = painterResource(R.drawable.ic_gridicons_cross_grey_24dp),
-                contentDescription = stringResource(R.string.blaze_banner_close_button_content_description),
+            IconButton(
+                modifier = Modifier.align(Alignment.End),
+                onClick = onClose
+            ) {
+                Icon(
+                    painter = painterResource(drawable.ic_gridicons_cross_grey_24dp),
+                    contentDescription = stringResource(string.blaze_banner_close_button_content_description),
+                )
+            }
+            Image(
+                painter = painterResource(drawable.ic_blaze_banner_flame),
+                contentDescription = ""
             )
-        }
-        Image(
-            painter = painterResource(R.drawable.ic_blaze_banner_flame),
-            contentDescription = ""
-        )
-        Text(
-            modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100)),
-            text = stringResource(id = R.string.blaze_banner_title),
-            style = MaterialTheme.typography.h6,
-            textAlign = TextAlign.Center,
-            fontWeight = FontWeight.Bold
-        )
-        Text(
-            modifier = Modifier.padding(top = dimensionResource(id = R.dimen.minor_100)),
-            text = stringResource(id = R.string.blaze_banner_description),
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.subtitle1,
-        )
-        WCTextButton(
-            modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100)),
-            onClick = onTryBlazeClicked
-        ) {
             Text(
-                text = stringResource(R.string.blaze_banner_button).uppercase(),
-                style = MaterialTheme.typography.subtitle1,
+                modifier = Modifier.padding(top = dimensionResource(id = dimen.major_100)),
+                text = stringResource(id = string.blaze_banner_title),
+                style = MaterialTheme.typography.h6,
+                textAlign = TextAlign.Center,
                 fontWeight = FontWeight.Bold
             )
+            Text(
+                modifier = Modifier.padding(top = dimensionResource(id = dimen.minor_100)),
+                text = stringResource(id = string.blaze_banner_description),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.subtitle1,
+            )
+            WCTextButton(
+                modifier = Modifier.padding(top = dimensionResource(id = dimen.major_100)),
+                onClick = onTryBlazeClicked
+            ) {
+                Text(
+                    text = stringResource(string.blaze_banner_button).uppercase(),
+                    style = MaterialTheme.typography.subtitle1,
+                    fontWeight = FontWeight.Bold
+                )
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_BANNER_DISMISSED
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_ENTRY_POINT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource.MY_STORE_BANNER
 import com.woocommerce.android.ui.products.ProductListRepository
@@ -26,7 +27,8 @@ class BlazeBannerViewModel @Inject constructor(
     private val isBlazeEnabled: IsBlazeEnabled,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val productRepository: ProductListRepository,
-    private val appPrefsWrapper: AppPrefsWrapper
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val selectedSite: SelectedSite,
 ) : ScopedViewModel(savedStateHandle) {
 
     private val _isBlazeBannerVisible = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = false)
@@ -40,7 +42,7 @@ class BlazeBannerViewModel @Inject constructor(
                 .filter { it.status == PUBLISH }
             if (isBlazeEnabled() &&
                 publishedProducts.isNotEmpty() &&
-                !appPrefsWrapper.shouldHideBlazeBanner
+                !appPrefsWrapper.isBlazeBannerHidden(selectedSite.getSelectedSiteId())
             ) {
                 _isBlazeBannerVisible.value = true
             }
@@ -56,7 +58,7 @@ class BlazeBannerViewModel @Inject constructor(
             stat = BLAZE_BANNER_DISMISSED,
             properties = mapOf(AnalyticsTracker.KEY_BLAZE_SOURCE to blazeBannerSource.trackingName)
         )
-        appPrefsWrapper.shouldHideBlazeBanner = true
+        appPrefsWrapper.setBlazeBannerHidden(selectedSite.getSelectedSiteId(), hide = true)
         triggerEvent(DismissBlazeBannerEvent)
         triggerEvent(
             MultiLiveEvent.Event.ShowDialog(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
@@ -36,16 +36,13 @@ class BlazeBannerViewModel @Inject constructor(
 
     private var blazeBannerSource: BlazeFlowSource = MY_STORE_BANNER
 
-    init {
+    fun updateBlazeBannerStatus() {
         launch {
             val publishedProducts = productRepository.getProductList()
                 .filter { it.status == PUBLISH }
-            if (isBlazeEnabled() &&
+            _isBlazeBannerVisible.value = !appPrefsWrapper.isBlazeBannerHidden(selectedSite.getSelectedSiteId()) &&
                 publishedProducts.isNotEmpty() &&
-                !appPrefsWrapper.isBlazeBannerHidden(selectedSite.getSelectedSiteId())
-            ) {
-                _isBlazeBannerVisible.value = true
-            }
+                isBlazeEnabled()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeWebViewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeWebViewViewModel.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_FLOW_COMPLETED
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_FLOW_STARTED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled.Companion.BLAZEPRESS_WIDGET
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
@@ -24,7 +25,8 @@ class BlazeWebViewViewModel @Inject constructor(
     val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
     val userAgent: UserAgent,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    private val appPrefsWrapper: AppPrefsWrapper
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val selectedSite: SelectedSite
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: BlazeWebViewFragmentArgs by savedStateHandle.navArgs()
 
@@ -56,7 +58,7 @@ class BlazeWebViewViewModel @Inject constructor(
                     AnalyticsTracker.KEY_BLAZE_STEP to currentBlazeStep.label
                 )
             )
-            appPrefsWrapper.shouldHideBlazeBanner = true
+            appPrefsWrapper.setBlazeBannerHidden(selectedSite.getSelectedSiteId(), hide = true)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -459,7 +459,7 @@ class MyStoreFragment :
         super.onResume()
         handleFeedbackRequestCardState()
         AnalyticsTracker.trackViewShown(this)
-
+        blazeViewModel.updateBlazeBannerStatus()
         // Avoid executing interacted() on first load. Only when the user navigated away from the fragment.
         if (wasPreviouslyStopped) {
             usageTracksEventEmitter.interacted()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -158,6 +158,7 @@ class ProductListFragment :
         initAddProductFab(binding.addProductButton)
 
         addSelectionTracker()
+        setUpBlazeBanner()
 
         when {
             productListViewModel.isSearching() -> {
@@ -453,9 +454,7 @@ class ProductListFragment :
 
         viewModel.productList.observe(viewLifecycleOwner) {
             showProductList(it)
-            if (it.isNotEmpty()) {
-                setUpBlazeBanner()
-            }
+            blazeViewModel.updateBlazeBannerStatus()
         }
 
         viewModel.event.observe(viewLifecycleOwner) { event ->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes several small issues with Blaze banner. Thanks @itsmeichigo for the great feedback here: p1689131287021789-slack-C03L1NF1EA3
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Many subtle small changes to support the following:

- Banner background color in dark mode should match android card style
- Blaze banner site dismissal should be site-specific
- Update show/hide banner in "real time" (without having to kill the app or switch site) in the following scenarios: 
  - When adding or removing a single product
  - When creating a Blaze campaign successfully

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in into a Blaze compatible site (atomic site where you are admin) with 0 products published
- Add a product and check Blaze banner is displayed
- Remove the product and check Blaze banner is gone
- Dismiss Blaze banner and switch into a different site where the banner should be displayed. Check that the banner is displayed after loading Product tabs at least once. When login in for the first time into a site that is Blaza banner compatible and has products already publishes the banner won't be displayed the first time My Store tab is opened. Not until the product list has been fetched at least once from the server, and that happens when opening products tab. 
- Complete/Purchase a Blaze campaign and notice how the Blaze banner is gone for the current selected site. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/2663464/5d8f5999-c800-4919-9457-4c25124de64e

