### PR TITLE
Improve QR code quality

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/QRCode.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/QRCode.kt
@@ -8,6 +8,9 @@ import android.graphics.Matrix
 import android.graphics.Paint
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -46,6 +49,15 @@ fun QRCode(
     @DrawableRes overlayId: Int? = null,
 ) {
     Image(
+        modifier = Modifier
+            .size(size)
+            .border(
+                width = 5.dp,
+                color = colorResource(id = R.color.woo_white),
+            )
+            .padding(4.dp)
+            .background(color = colorResource(id = R.color.woo_white)
+            ),
         painter = rememberQrBitmapPainter(
             content,
             size = size,
@@ -53,7 +65,6 @@ fun QRCode(
         ),
         contentDescription = "QR Code",
         contentScale = ContentScale.FillBounds,
-        modifier = Modifier.size(size),
     )
 }
 
@@ -68,7 +79,7 @@ private fun rememberQrBitmapPainter(
 
     var bitmap by remember(content) { mutableStateOf<Bitmap?>(null) }
 
-    val pixelColor = colorResource(id = R.color.color_on_surface_medium).toArgb()
+    val pixelColor = colorResource(id = R.color.woo_black_90).toArgb()
 
     LaunchedEffect(bitmap) {
         if (bitmap != null) return@LaunchedEffect

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/QRCode.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/QRCode.kt
@@ -56,7 +56,8 @@ fun QRCode(
                 color = colorResource(id = R.color.woo_white),
             )
             .padding(4.dp)
-            .background(color = colorResource(id = R.color.woo_white)
+            .background(
+                color = colorResource(id = R.color.woo_white)
             ),
         painter = rememberQrBitmapPainter(
             content,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9266
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR hardcodes the colour (R.color.woo_black_90) to the QR code so it does not shift to the theme's default colour on dark mode. It also adds a white background so it's visible on dark mode. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. click on Collect payment 
2. click on scan to pay
3. test it on light and dark mode. 
4. make sure the QR code is black on both modes
5. make sure there's a border around the code on dark mode
6. make sure the code is not being cut off in light mode

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

#### Dark mode 
| Before | After |
| ---- | ---- |
| <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/1d27193e-67eb-4fd9-9273-44f299403292" width="350"/> | <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/851583e1-b54e-490d-879b-29bef0f77897" width="350"/> |

#### Light mode
| Before | After |
| ---- | ---- |
| <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/25fd334c-1d03-4e79-a041-0b16a86644c0" width="350"/> | <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/8a6e52f1-479a-404f-ae60-85e100ca1664" width="350"/> |


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
