### PR TITLE
[UI Test] - Wait for customer notes screen to load before adding text

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/UnifiedOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/UnifiedOrderScreen.kt
@@ -95,6 +95,7 @@ class UnifiedOrderScreen : Screen(ORDER_CREATION) {
         Espresso.onView(withText("Add note"))
             .perform(click())
 
+        waitForElementToBeDisplayed(CUSTOMER_NOTE_EDITOR)
         Espresso.onView(withId(CUSTOMER_NOTE_EDITOR))
             .perform((ViewActions.replaceText(note)))
 


### PR DESCRIPTION
### Description
`e2eCreateOrderTest` UI Test started failing on the `addCustomerNotes` step. Looks like the `Done` button stayed disabled after the note was added. Added a wait before the action so that the page is fully loaded before the test adds the note. I wasn't able to reproduce the issue when running the test on my local machine.

### Testing instructions
`e2eCreateOrderTest` should pass in CI.

### Images/gif
Test failed because `Done` button is disabled:
![image](https://github.com/woocommerce/woocommerce-android/assets/17252150/b54179bf-2969-472c-82ba-e2f2656684e3)


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
