### PR TITLE
[UI Tests] Fix `e2eCreateOrderTest` in the customer note area.

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/UnifiedOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/UnifiedOrderScreen.kt
@@ -92,13 +92,9 @@ class UnifiedOrderScreen : Screen(ORDER_CREATION) {
     fun addCustomerNotes(note: String): UnifiedOrderScreen {
         Espresso.onView(withId(NOTES_SECTION))
             .perform(NestedScrollViewExtension())
-        Espresso.onView(withText("Add note"))
-            .perform(click())
 
-        waitForElementToBeDisplayed(CUSTOMER_NOTE_EDITOR)
-        Espresso.onView(withId(CUSTOMER_NOTE_EDITOR))
-            .perform((ViewActions.replaceText(note)))
-
+        clickOn(Espresso.onView(withText("Add note")))
+        typeTextInto(CUSTOMER_NOTE_EDITOR, note)
         clickOn(DONE_BUTTON)
         return this
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
@@ -49,7 +49,7 @@ class OrdersUITest : TestBase() {
 
     @Test
     fun e2eCreateOrderTest() {
-        val note = "Customer notes 123~"
+        val note = "Just a placeholder text"
         val status = "Processing"
         val ordersJSONArray = MocksReader().readOrderToArray()
 


### PR DESCRIPTION
### Description
This is a follow-up to #9416. `e2eCreateOrderTest` fails on `trunk` because when customer note is added on Customer Note screen, the `Done` button stays disabled, and the test becomes blocked:

https://github.com/woocommerce/woocommerce-android/assets/73365754/82b24b33-e1e4-4a13-9149-6f1d80b28328

The `Done` button was disabled because by the time the Customer Note screen was open, the mock file with the same customer note was already loaded. The test entered exactly the same customer note content (`Customer notes 123~`) as defined in the mock file, so there was nothing to save. I had three options:

- Change / remove the customer note defined in the mock file. This made no sense, because the final assertion `assertSingleOrderScreenWithProduct` fetches the data from the mock file. It really doesn’t matter what the test enters into the customer note field. After saving, the note from mock file will be shown anyway.
- Remove the step of entering the customer note. I didn’t go for it because I saw value in opening the screen, entering the text and tapping Done.
- Enter a different text for a customer note. Since the text is not really saved (fake API), it doesn’t matter which text it is, as long as it’s different from the existing note.

I went for 3.

### Testing instructions
- Instrumented Tests are 🟢. 