### PR TITLE
[TTP] Add learn more link to the TTP summary screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 14.6
 -----
+- [*] [Internal] In-Person Payments: learn more link to the Tap To Pay Summary screen. [https://github.com/woocommerce/woocommerce-android/pull/9426]
 
 
 14.5

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -63,7 +63,8 @@ object AppUrls {
         "https://docs.woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/"
     const val STRIPE_TAP_TO_PAY_DEVICE_REQUIREMENTS =
         "https://stripe.com/docs/terminal/payments/setup-reader/tap-to-pay?platform=android#supported-devices"
-    const val LEARN_MORE_ABOUT_TAP_TO_PAY = "https://woocommerce.com/document/woocommerce-payments/in-person-payments/tap-to-pay-android/"
+    const val LEARN_MORE_ABOUT_TAP_TO_PAY =
+        "https://woocommerce.com/document/woocommerce-payments/in-person-payments/tap-to-pay-android/"
 
     const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY =
         "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/" +

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -63,6 +63,7 @@ object AppUrls {
         "https://docs.woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/"
     const val STRIPE_TAP_TO_PAY_DEVICE_REQUIREMENTS =
         "https://stripe.com/docs/terminal/payments/setup-reader/tap-to-pay?platform=android#supported-devices"
+    const val LEARN_MORE_ABOUT_TAP_TO_PAY = "https://woocommerce.com/document/woocommerce-payments/in-person-payments/tap-to-pay-android/"
 
     const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY =
         "https://docs.woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/" +

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryFragment.kt
@@ -18,8 +18,10 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType
 import com.woocommerce.android.ui.payments.taptopay.summary.TapToPaySummaryViewModel.NavigateToOrderDetails
+import com.woocommerce.android.ui.payments.taptopay.summary.TapToPaySummaryViewModel.NavigateToUrlInGenericWebView
 import com.woocommerce.android.ui.payments.taptopay.summary.TapToPaySummaryViewModel.ShowSuccessfulRefundNotification
 import com.woocommerce.android.ui.payments.taptopay.summary.TapToPaySummaryViewModel.StartTryPaymentFlow
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -80,6 +82,10 @@ class TapToPaySummaryFragment : BaseFragment() {
                         )
                     )
                 }
+                is NavigateToUrlInGenericWebView ->
+                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url,
+                        ChromeCustomTabUtils.Height.Partial.ThreeQuarters
+                    )
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryFragment.kt
@@ -83,7 +83,9 @@ class TapToPaySummaryFragment : BaseFragment() {
                     )
                 }
                 is NavigateToUrlInGenericWebView ->
-                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url,
+                    ChromeCustomTabUtils.launchUrl(
+                        requireContext(),
+                        event.url,
                         ChromeCustomTabUtils.Height.Partial.ThreeQuarters
                     )
                 else -> event.isHandled = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryScreen.kt
@@ -1,6 +1,9 @@
 package com.woocommerce.android.ui.payments.taptopay.summary
 
 import android.content.res.Configuration
+import android.text.method.LinkMovementMethod
+import android.view.LayoutInflater
+import android.widget.TextView
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement.SpaceBetween
@@ -26,6 +29,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign.Companion.Center
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.text.HtmlCompat
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
@@ -38,7 +43,8 @@ fun TapToPaySummaryScreen(viewModel: TapToPaySummaryViewModel) {
         TapToPaySummaryScreen(
             uiState = state,
             onTryPaymentClicked = viewModel::onTryPaymentClicked,
-            onBackClick = viewModel::onBackClicked
+            onBackClick = viewModel::onBackClicked,
+            onLearnMoreClicked = viewModel::onLearnMoreClicked,
         )
     }
 }
@@ -48,6 +54,7 @@ fun TapToPaySummaryScreen(
     uiState: UiState,
     onTryPaymentClicked: () -> Unit,
     onBackClick: () -> Unit,
+    onLearnMoreClicked: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -126,11 +133,29 @@ fun TapToPaySummaryScreen(
                         Text(stringResource(id = R.string.card_reader_tap_to_pay_explanation_try_payment))
                     }
                 }
+
+                LearnMoreAboutTTP(onLearnMoreClicked = onLearnMoreClicked)
             }
 
-            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
         }
     }
+}
+
+@Composable
+fun LearnMoreAboutTTP(onLearnMoreClicked: () -> Unit) {
+    AndroidView(factory = { context ->
+        LayoutInflater.from(context).inflate(R.layout.card_reader_learn_more_section, null).apply {
+            with(this as TextView) {
+                text = HtmlCompat.fromHtml(
+                    context.getString(R.string.card_reader_tap_to_pay_learn_more),
+                    HtmlCompat.FROM_HTML_MODE_LEGACY
+                )
+                movementMethod = LinkMovementMethod.getInstance()
+                setOnClickListener { onLearnMoreClicked() }
+            }
+        }
+    })
 }
 
 @Preview(name = "Light mode")
@@ -142,6 +167,7 @@ fun TapToPaySummaryScreenPreview() {
             uiState = UiState(isProgressVisible = false),
             onTryPaymentClicked = {},
             onBackClick = {},
+            onLearnMoreClicked = {},
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
@@ -5,6 +5,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -133,6 +134,10 @@ class TapToPaySummaryViewModel @Inject constructor(
         )
     }
 
+    fun onLearnMoreClicked() {
+        triggerEvent(NavigateToUrlInGenericWebView(AppUrls.LEARN_MORE_ABOUT_TAP_TO_PAY))
+    }
+
     data class UiState(
         val isProgressVisible: Boolean = false
     )
@@ -146,6 +151,8 @@ class TapToPaySummaryViewModel @Inject constructor(
         @StringRes val actionLabel: Int,
         val action: () -> Unit
     ) : Event()
+
+    data class NavigateToUrlInGenericWebView(val url: String) : Event()
 
     companion object {
         private val TEST_ORDER_AMOUNT = BigDecimal.valueOf(0.5)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1233,6 +1233,7 @@
     <string name="card_reader_tap_to_pay_test_payment_note">Tap To Pay Test Payment</string>
     <string name="card_reader_tap_to_pay_successful_refund_message">Test Tap To Pay payment was successfully refunded</string>
     <string name="card_reader_tap_to_pay_successful_refund_action_label">View Order</string>
+    <string name="card_reader_tap_to_pay_learn_more">&lt;a href=\'\'&gt;Learn more&lt;/a&gt; about accepting payments with Tap To Pay on Android</string>
 
     <!--
             Card Reader Type Selection

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
@@ -429,6 +429,22 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
             assertThat(viewModel.event.value).isEqualTo(TapToPaySummaryViewModel.NavigateToOrderDetails(1))
         }
 
+    @Test
+    fun `when onLearnMoreClicked, then NavigateToUrlInGenericWebView emitted`() {
+        // GIVEN
+        val viewModel = initViewModel()
+
+        // WHEN
+        viewModel.onLearnMoreClicked()
+
+        // THEN
+        assertThat(viewModel.event.value).isEqualTo(
+            TapToPaySummaryViewModel.NavigateToUrlInGenericWebView(
+                "https://woocommerce.com/document/woocommerce-payments/in-person-payments/tap-to-pay-android/"
+            )
+        )
+    }
+
     private fun initViewModel(
         flow: TapToPaySummaryFragment.TestTapToPayFlow = TapToPaySummaryFragment.TestTapToPayFlow.BeforePayment
     ) =


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9407
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds "learn more" to the summary screen

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The doc is not published yet, so it's 404. Let's merge that when it is published

* More -> Payments -> Tap To Pay
* Notice "learn more" at the bottom

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/4923871/84daa7ad-3d53-4ebf-a390-71cea8bb9aa0


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
