### PR TITLE
Issue/9254 filter products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1091,6 +1091,6 @@ private fun ModelProduct.isVariable() =
         productType == ProductType.VARIATION
 
 private fun ModelProduct.isRestricted() = status != ProductStatus.PUBLISH ||
-    (price?.compareTo(BigDecimal.ZERO) == 0 || price != null)
+    (price?.compareTo(BigDecimal.ZERO) == 0 || price == null)
 
 fun Order.Item.isSynced() = this.itemId != 0L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -530,12 +530,12 @@ class OrderCreateEditViewModel @Inject constructor(
             }
             product.hasNoPrice() -> {
                 sendAddingProductsViaScanningFailedEvent(
-                    message = string.order_creation_barcode_scanning_unable_to_add_draft_product
+                    message = string.order_creation_barcode_scanning_unable_to_add_product_with_invalid_price
                 )
                 trackProductSearchViaSKUFailureEvent(
                     source,
                     barcodeFormat,
-                    "Failed to add a product that is not published"
+                    "Failed to add a product whose price is not specified"
                 )
                 return
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1107,6 +1107,6 @@ private fun ModelProduct.isVariable() =
 
 private fun ModelProduct.isNotPublished() = status != ProductStatus.PUBLISH
 
-private fun ModelProduct.hasNoPrice() = price?.compareTo(BigDecimal.ZERO) == 0 || price == null
+private fun ModelProduct.hasNoPrice() = price == null
 
 fun Order.Item.isSynced() = this.itemId != 0L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1105,9 +1105,6 @@ private fun ModelProduct.isVariable() =
         productType == ProductType.VARIABLE_SUBSCRIPTION ||
         productType == ProductType.VARIATION
 
-private fun ModelProduct.isRestricted() = status != ProductStatus.PUBLISH ||
-    (price?.compareTo(BigDecimal.ZERO) == 0 || price == null)
-
 private fun ModelProduct.isNotPublished() = status != ProductStatus.PUBLISH
 
 private fun ModelProduct.hasNoPrice() = price?.compareTo(BigDecimal.ZERO) == 0 || price == null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -510,6 +510,7 @@ class OrderCreateEditViewModel @Inject constructor(
         barcodeOptions.barcodeFormat == BarcodeFormat.FormatEAN13 ||
             barcodeOptions.barcodeFormat == BarcodeFormat.FormatEAN8
 
+    @Suppress("LongMethod", "ReturnCount")
     private fun addScannedProduct(
         product: ModelProduct,
         selectedItems: List<SelectedItem>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1090,6 +1090,7 @@ private fun ModelProduct.isVariable() =
         productType == ProductType.VARIABLE_SUBSCRIPTION ||
         productType == ProductType.VARIATION
 
-private fun ModelProduct.isRestricted() = status != ProductStatus.PUBLISH
+private fun ModelProduct.isRestricted() = status != ProductStatus.PUBLISH ||
+    (price?.compareTo(BigDecimal.ZERO) == 0 || price != null)
 
 fun Order.Item.isSynced() = this.itemId != 0L

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -576,6 +576,7 @@
     <string name="order_creation_barcode_scanning_scanning_failed">Scanning failed. Please try again later</string>
     <string name="order_creation_barcode_scanning_unable_to_add_variable_product">You cannot add variable product directly. Please select a specific variation</string>
     <string name="order_creation_barcode_scanning_unable_to_add_draft_product">You cannot add product that are not published</string>
+    <string name="order_creation_barcode_scanning_unable_to_add_product_with_invalid_price">You cannot add product that has no price specified</string>
     <string name="order_creation_barcode_scanning_process_death">The system terminated the Woo app while it was running in the background. You may attempt to use it again.</string>
     <string name="order_creation_coupon_invalid_code">We couldn\'t find a coupon with that code. Please try again</string>
     <string name="order_creation_coupon_network_error">Something went wrong when validating your coupon code. Please try again</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -575,8 +575,8 @@
     <string name="order_creation_barcode_scanning_unable_to_add_product">Product not found. Unable to add to new order</string>
     <string name="order_creation_barcode_scanning_scanning_failed">Scanning failed. Please try again later</string>
     <string name="order_creation_barcode_scanning_unable_to_add_variable_product">You cannot add variable product directly. Please select a specific variation</string>
-    <string name="order_creation_barcode_scanning_unable_to_add_draft_product">You cannot add product that are not published</string>
-    <string name="order_creation_barcode_scanning_unable_to_add_product_with_invalid_price">You cannot add product that has no price specified</string>
+    <string name="order_creation_barcode_scanning_unable_to_add_draft_product">You cannot add products that are not published</string>
+    <string name="order_creation_barcode_scanning_unable_to_add_product_with_invalid_price">You cannot add products with no price specified</string>
     <string name="order_creation_barcode_scanning_process_death">The system terminated the Woo app while it was running in the background. You may attempt to use it again.</string>
     <string name="order_creation_coupon_invalid_code">We couldn\'t find a coupon with that code. Please try again</string>
     <string name="order_creation_coupon_network_error">Something went wrong when validating your coupon code. Please try again</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -575,6 +575,7 @@
     <string name="order_creation_barcode_scanning_unable_to_add_product">Product not found. Unable to add to new order</string>
     <string name="order_creation_barcode_scanning_scanning_failed">Scanning failed. Please try again later</string>
     <string name="order_creation_barcode_scanning_unable_to_add_variable_product">You cannot add variable product directly. Please select a specific variation</string>
+    <string name="order_creation_barcode_scanning_unable_to_add_draft_product">You cannot add product that are not published</string>
     <string name="order_creation_barcode_scanning_process_death">The system terminated the Woo app while it was running in the background. You may attempt to use it again.</string>
     <string name="order_creation_coupon_invalid_code">We couldn\'t find a coupon with that code. Please try again</string>
     <string name="order_creation_coupon_network_error">Something went wrong when validating your coupon code. Please try again</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -754,6 +754,35 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             )
         }
     }
+
+    @Test
+    fun `when SKU search succeeds for a not published product, then do not track product search event`() {
+        testBlocking {
+            createSut()
+            val scannedStatus = CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA)
+            whenever(
+                productListRepository.searchProductList(
+                    "12345",
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(
+                listOf(
+                    ProductTestUtils.generateProduct(
+                        productId = 10L,
+                        customStatus = ProductStatus.PUBLISH.name,
+                        amount = ""
+                    )
+                )
+            )
+
+            sut.handleBarcodeScannedStatus(scannedStatus)
+
+            verify(tracker, never()).track(
+                eq(PRODUCT_SEARCH_VIA_SKU_SUCCESS),
+                any()
+            )
+        }
+    }
     @Test
     fun `when parent variable product is scanned, then trigger proper event`() {
         testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -492,6 +492,32 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when SKU search succeeds for a not published product, then trigger proper event`() {
+        testBlocking {
+            createSut()
+            val scannedStatus = CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA)
+            whenever(
+                productListRepository.searchProductList(
+                    "12345",
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(
+                listOf(
+                    ProductTestUtils.generateProduct(
+                        productId = 10L,
+                        customStatus = ProductStatus.PENDING.name
+                    )
+                )
+            )
+
+            sut.handleBarcodeScannedStatus(scannedStatus)
+
+            assertThat(sut.event.value).isInstanceOf(
+                OnAddingProductViaScanningFailed::class.java
+            )
+        }
+    }
+    @Test
     fun `when parent variable product is scanned, then trigger proper event`() {
         testBlocking {
             createSut()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -517,6 +517,33 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             )
         }
     }
+
+    @Test
+    fun `when SKU search succeeds for a not published product, then trigger event with proper message`() {
+        testBlocking {
+            createSut()
+            val scannedStatus = CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA)
+            whenever(
+                productListRepository.searchProductList(
+                    "12345",
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(
+                listOf(
+                    ProductTestUtils.generateProduct(
+                        productId = 10L,
+                        customStatus = ProductStatus.PENDING.name
+                    )
+                )
+            )
+
+            sut.handleBarcodeScannedStatus(scannedStatus)
+
+            assertThat(
+                (sut.event.value as OnAddingProductViaScanningFailed).message
+            ).isEqualTo(R.string.order_creation_barcode_scanning_unable_to_add_draft_product)
+        }
+    }
     @Test
     fun `when parent variable product is scanned, then trigger proper event`() {
         testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -695,6 +695,32 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             ).isEqualTo(R.string.order_creation_barcode_scanning_unable_to_add_product_with_invalid_price)
         }
     }
+
+    @Test
+    fun `when SKU search succeeds for a published product whose price is not specified, then track proper event`() {
+        testBlocking {
+            createSut()
+            val scannedStatus = CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA)
+            whenever(
+                productListRepository.searchProductList(
+                    "12345",
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(
+                listOf(
+                    ProductTestUtils.generateProduct(
+                        productId = 10L,
+                        customStatus = ProductStatus.PUBLISH.name,
+                        amount = ""
+                    )
+                )
+            )
+
+            sut.handleBarcodeScannedStatus(scannedStatus)
+
+            verify(tracker).track(eq(PRODUCT_SEARCH_VIA_SKU_FAILURE), any())
+        }
+    }
     @Test
     fun `when parent variable product is scanned, then trigger proper event`() {
         testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -667,6 +667,34 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             )
         }
     }
+
+    @Test
+    fun `when SKU search succeeds for a published product whose price is not specified, then trigger event with proper message`() {
+        testBlocking {
+            createSut()
+            val scannedStatus = CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA)
+            whenever(
+                productListRepository.searchProductList(
+                    "12345",
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(
+                listOf(
+                    ProductTestUtils.generateProduct(
+                        productId = 10L,
+                        customStatus = ProductStatus.PUBLISH.name,
+                        amount = ""
+                    )
+                )
+            )
+
+            sut.handleBarcodeScannedStatus(scannedStatus)
+
+            assertThat(
+                (sut.event.value as OnAddingProductViaScanningFailed).message
+            ).isEqualTo(R.string.order_creation_barcode_scanning_unable_to_add_product_with_invalid_price)
+        }
+    }
     @Test
     fun `when parent variable product is scanned, then trigger proper event`() {
         testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -544,6 +544,31 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             ).isEqualTo(R.string.order_creation_barcode_scanning_unable_to_add_draft_product)
         }
     }
+
+    @Test
+    fun `when SKU search succeeds for a not published product, then track proper event`() {
+        testBlocking {
+            createSut()
+            val scannedStatus = CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA)
+            whenever(
+                productListRepository.searchProductList(
+                    "12345",
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(
+                listOf(
+                    ProductTestUtils.generateProduct(
+                        productId = 10L,
+                        customStatus = ProductStatus.PENDING.name
+                    )
+                )
+            )
+
+            sut.handleBarcodeScannedStatus(scannedStatus)
+
+            verify(tracker).track(eq(PRODUCT_SEARCH_VIA_SKU_FAILURE), any())
+        }
+    }
     @Test
     fun `when parent variable product is scanned, then trigger proper event`() {
         testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -492,7 +492,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when SKU search succeeds for a product with price 0, then do not add that product`() {
+    fun `when SKU search succeeds for a product with price 0, then add that product`() {
         testBlocking {
             createSut()
             val scannedStatus = CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA)
@@ -520,7 +520,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
 
             sut.handleBarcodeScannedStatus(scannedStatus)
 
-            assertThat(newOrder?.getProductIds()?.any { it == 10L }).isFalse()
+            assertThat(newOrder?.getProductIds()?.any { it == 10L }).isTrue()
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -487,7 +487,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
 
             sut.handleBarcodeScannedStatus(scannedStatus)
 
-            assertThat(newOrder?.getProductIds()?.any { it == 10L }).isTrue()
+            assertThat(newOrder?.getProductIds()?.any { it == 10L }).isFalse()
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -525,6 +525,39 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when SKU search succeeds for a product with price null, then do not add that product`() {
+        testBlocking {
+            createSut()
+            val scannedStatus = CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA)
+            whenever(
+                productListRepository.searchProductList(
+                    "12345",
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(
+                listOf(
+                    ProductTestUtils.generateProduct(
+                        productId = 10L,
+                        customStatus = ProductStatus.PUBLISH.name,
+                        amount = ""
+                    )
+                )
+            )
+            whenever(createOrderItemUseCase.invoke(10L)).thenReturn(
+                createOrderItem(10L)
+            )
+            var newOrder: Order? = null
+            sut.orderDraft.observeForever { newOrderData ->
+                newOrder = newOrderData
+            }
+
+            sut.handleBarcodeScannedStatus(scannedStatus)
+
+            assertThat(newOrder?.getProductIds()?.any { it == 10L }).isFalse()
+        }
+    }
+
+    @Test
     fun `when SKU search succeeds for a not published product, then trigger proper event`() {
         testBlocking {
             createSut()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -754,9 +754,36 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             )
         }
     }
-
     @Test
     fun `when SKU search succeeds for a not published product, then do not track product search event`() {
+        testBlocking {
+            createSut()
+            val scannedStatus = CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA)
+            whenever(
+                productListRepository.searchProductList(
+                    "12345",
+                    WCProductStore.SkuSearchOptions.ExactSearch
+                )
+            ).thenReturn(
+                listOf(
+                    ProductTestUtils.generateProduct(
+                        productId = 10L,
+                        customStatus = ProductStatus.PENDING.name,
+                    )
+                )
+            )
+
+            sut.handleBarcodeScannedStatus(scannedStatus)
+
+            verify(tracker, never()).track(
+                eq(PRODUCT_SEARCH_VIA_SKU_SUCCESS),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `when SKU search succeeds for a published product whose price is not specified, then do not track product search event`() {
         testBlocking {
             createSut()
             val scannedStatus = CodeScannerStatus.Success("12345", BarcodeFormat.FormatUPCA)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -22,6 +22,7 @@ object ProductTestUtils {
         customStatus: String? = null,
         variationIds: String = if (isVariable) "[123]" else "[]",
         productType: String? = null,
+        amount: String = "20.00",
     ): Product {
         return WCProductModel(2).apply {
             dateCreated = "2018-01-05T05:14:30Z"
@@ -31,7 +32,7 @@ object ProductTestUtils {
             status = customStatus ?: "publish"
             type = productType ?: if (isVariable) "variable" else "simple"
             stockStatus = "instock"
-            price = "20.00"
+            price = amount
             salePrice = "10.00"
             regularPrice = "30.00"
             averageRating = "3.0"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9254 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR disallows adding the below products from the barcode scanning screen.
1. The product is **not** in the published status
2. The product does not have a price specified

The behavior should match what we already have when adding products manually (searching, multi-selection, filtering ...etc).



### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
#### Draft Product
1. Navigate to the order creation screen (Orders -> "+")
2. Click on the barcode icon.
3. Scan any product whose status is NOT `published`
4. Ensure you see an error message and the product doesn't get added.


#### Product with an unspecified price
1. Navigate to the order creation screen (Orders -> "+")
2. Click on the barcode icon.
3. Scan any product whose price is not specified
4. Ensure you see an error message and the product doesn't get added.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/1331230/ac28a60a-71eb-4864-abc7-505532edfa5d



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
