### PR TITLE
Feature/9435 schedule 6h local notification

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -82,7 +82,7 @@ sealed class LocalNotification(
         description = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_description,
         type = LocalNotificationType.UPGRADE_TO_PAID_PLAN,
         delay = 6,
-        delayUnit = TimeUnit.SECONDS
+        delayUnit = TimeUnit.HOURS
     ) {
         override val data: String = siteId.toString()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -76,4 +76,16 @@ sealed class LocalNotification(
             return resourceProvider.getString(description, name)
         }
     }
+
+    object UpgradeToPaidPlanNotification : LocalNotification(
+        title = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_title,
+        description = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_description,
+        type = LocalNotificationType.UPGRADE_TO_PAID_PLAN,
+        delay = 6,
+        delayUnit = TimeUnit.HOURS
+    ) {
+        override fun getDescriptionString(resourceProvider: ResourceProvider): String {
+            return resourceProvider.getString(description)
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -77,13 +77,15 @@ sealed class LocalNotification(
         }
     }
 
-    object UpgradeToPaidPlanNotification : LocalNotification(
+    data class UpgradeToPaidPlanNotification(val siteId: Long) : LocalNotification(
         title = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_title,
         description = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_description,
         type = LocalNotificationType.UPGRADE_TO_PAID_PLAN,
         delay = 6,
-        delayUnit = TimeUnit.HOURS
+        delayUnit = TimeUnit.SECONDS
     ) {
+        override val data: String = siteId.toString()
+
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
@@ -5,5 +5,12 @@ enum class LocalNotificationType(val value: String) {
     STORE_CREATION_INCOMPLETE("one_day_after_store_creation_name_without_free_trial"),
     FREE_TRIAL_EXPIRING("one_day_before_free_trial_expires"),
     FREE_TRIAL_EXPIRED("one_day_after_free_trial_expires"),
-    UPGRADE_TO_PAID_PLAN("upgrade_to_paid_plan_reminder"),
+    UPGRADE_TO_PAID_PLAN("upgrade_to_paid_plan_reminder");
+
+    override fun toString() = value
+
+    companion object {
+        fun fromString(source: String?): LocalNotificationType? =
+            values().firstOrNull { it.value.equals(source, ignoreCase = true) }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
@@ -4,5 +4,6 @@ enum class LocalNotificationType(val value: String) {
     STORE_CREATION_FINISHED("store_creation_complete"),
     STORE_CREATION_INCOMPLETE("one_day_after_store_creation_name_without_free_trial"),
     FREE_TRIAL_EXPIRING("one_day_before_free_trial_expires"),
-    FREE_TRIAL_EXPIRED("one_day_after_free_trial_expires")
+    FREE_TRIAL_EXPIRED("one_day_after_free_trial_expires"),
+    UPGRADE_TO_PAID_PLAN("upgrade_to_paid_plan"),
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
@@ -5,5 +5,5 @@ enum class LocalNotificationType(val value: String) {
     STORE_CREATION_INCOMPLETE("one_day_after_store_creation_name_without_free_trial"),
     FREE_TRIAL_EXPIRING("one_day_before_free_trial_expires"),
     FREE_TRIAL_EXPIRED("one_day_after_free_trial_expires"),
-    UPGRADE_TO_PAID_PLAN("upgrade_to_paid_plan"),
+    UPGRADE_TO_PAID_PLAN("upgrade_to_paid_plan_reminder"),
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -39,7 +39,7 @@ class PreconditionCheckWorker @AssistedInject constructor(
             STORE_CREATION_INCOMPLETE -> Result.success()
             FREE_TRIAL_EXPIRING -> proceedIfFreeMatchingSite(data?.toLongOrNull())
             FREE_TRIAL_EXPIRED -> proceedIfFreeMatchingSite(data?.toLongOrNull())
-            UPGRADE_TO_PAID_PLAN -> Result.success()
+            UPGRADE_TO_PAID_PLAN -> proceedIfFreeMatchingSite(data?.toLongOrNull())
             null -> cancelWork("Notification type is null. Cancelling work.")
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
@@ -170,7 +170,9 @@ class StoreInstallationViewModel @Inject constructor(
                 )
             }
 
-            localNotificationScheduler.scheduleNotification(UpgradeToPaidPlanNotification)
+            localNotificationScheduler.scheduleNotification(
+                UpgradeToPaidPlanNotification(selectedSite.get().siteId)
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.notifications.local.LocalNotification.FreeTrialExpiredNotification
 import com.woocommerce.android.notifications.local.LocalNotification.FreeTrialExpiringNotification
+import com.woocommerce.android.notifications.local.LocalNotification.UpgradeToPaidPlanNotification
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.NewStore
@@ -168,6 +169,8 @@ class StoreInstallationViewModel @Inject constructor(
                     FreeTrialExpiredNotification(name, selectedSite.get().siteId)
                 )
             }
+
+            localNotificationScheduler.scheduleNotification(UpgradeToPaidPlanNotification)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -17,6 +17,11 @@ import com.woocommerce.android.model.Notification
 import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
 import com.woocommerce.android.notifications.local.LocalNotificationType
+import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TRIAL_EXPIRED
+import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TRIAL_EXPIRING
+import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_FINISHED
+import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_INCOMPLETE
+import com.woocommerce.android.notifications.local.LocalNotificationType.UPGRADE_TO_PAID_PLAN
 import com.woocommerce.android.notifications.push.NotificationMessageHandler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType.Jetpack
@@ -262,16 +267,14 @@ class MainActivityViewModel @Inject constructor(
             AnalyticsEvent.LOCAL_NOTIFICATION_TAPPED,
             mapOf(AnalyticsTracker.KEY_TYPE to notification.tag)
         )
+        LocalNotificationType.fromString(notification.tag)?.let {
+            when (it) {
+                STORE_CREATION_INCOMPLETE -> triggerEvent(ShortcutOpenStoreCreation(storeName = notification.data))
+                FREE_TRIAL_EXPIRED,
+                FREE_TRIAL_EXPIRING,
+                UPGRADE_TO_PAID_PLAN -> triggerEvent(ViewStorePlanUpgrade(NOTIFICATION))
 
-        when (notification.tag) {
-            LocalNotificationType.STORE_CREATION_INCOMPLETE.value -> {
-                triggerEvent(ShortcutOpenStoreCreation(storeName = notification.data))
-            }
-
-            LocalNotificationType.FREE_TRIAL_EXPIRED.value,
-            LocalNotificationType.FREE_TRIAL_EXPIRING.value,
-            LocalNotificationType.UPGRADE_TO_PAID_PLAN.value -> {
-                triggerEvent(ViewStorePlanUpgrade(NOTIFICATION))
+                STORE_CREATION_FINISHED -> {}
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -92,6 +92,7 @@ class MainActivityViewModel @Inject constructor(
                 )
                 triggerEvent(ShortcutOpenPayments)
             }
+
             SHORTCUT_OPEN_ORDER_CREATION -> {
                 analyticsTrackerWrapper.track(
                     AnalyticsEvent.SHORTCUT_ORDERS_ADD_NEW
@@ -131,21 +132,27 @@ class MainActivityViewModel @Inject constructor(
             is ResolveAppLink.Action.ChangeSiteAndRestart -> {
                 changeSiteAndRestart(event.siteId, RestartActivityForAppLink(event.uri))
             }
+
             is ResolveAppLink.Action.ViewOrderDetail -> {
                 triggerEvent(ViewOrderDetail(uniqueId = event.orderId, remoteNoteId = 0L))
             }
+
             ResolveAppLink.Action.ViewStats -> {
                 triggerEvent(ViewMyStoreStats)
             }
+
             ResolveAppLink.Action.ViewPayments -> {
                 triggerEvent(ViewPayments)
             }
+
             ResolveAppLink.Action.ViewTapToPay -> {
                 triggerEvent(ViewTapToPay)
             }
+
             is ResolveAppLink.Action.ViewUrlInWebView -> {
                 triggerEvent(ViewUrlInWebView(event.url))
             }
+
             ResolveAppLink.Action.DoNothing -> {
                 // no-op
             }
@@ -260,8 +267,10 @@ class MainActivityViewModel @Inject constructor(
             LocalNotificationType.STORE_CREATION_INCOMPLETE.value -> {
                 triggerEvent(ShortcutOpenStoreCreation(storeName = notification.data))
             }
+
             LocalNotificationType.FREE_TRIAL_EXPIRED.value,
-            LocalNotificationType.FREE_TRIAL_EXPIRING.value -> {
+            LocalNotificationType.FREE_TRIAL_EXPIRING.value,
+            LocalNotificationType.UPGRADE_TO_PAID_PLAN.value -> {
                 triggerEvent(ViewStorePlanUpgrade(NOTIFICATION))
             }
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3376,6 +3376,8 @@
     <string name="local_notification_one_day_before_free_trial_expires_description">Your free trial of Woo Express ends tomorrow (%1$s). Now’s the time to own your future – pick a plan and get ready to grow.</string>
     <string name="local_notification_one_day_after_free_trial_expires_title">🌟 Keep your business going with our plan!</string>
     <string name="local_notification_one_day_after_free_trial_expires_description">%1$s, we have paused your store, but you can continue by picking a plan that suits you best.</string>
+    <string name="local_notification_upgrade_to_paid_plan_after_6_hours_title">🌟 Keep your business going!</string>
+    <string name="local_notification_upgrade_to_paid_plan_after_6_hours_description">Discover advanced features and personalized recommendations for your store! Tap to pick a plan that suits you best.</string>
 
     <!--
     First product published congratulatory feature


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9435 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Schedule a notification 6h after the user creates a free trial site. When clicking on the notification, the web view to upgrade to the `eCommerce` plan will be shown. 

Expected notification content: 
```
Title: 🌟  Keep your business going!
Description: “Discover advanced features and personalized recommendations for your store! Tap to pick a plan that suits you best.”
```

Additionally, this PR adds a small refactor to use `LocalNotificationType` as an enum rather than the `String` value in `when` expressions. This allows the `when` expressions to be exhaustive. 

We decided no feature flag is needed for this notification. 
Tracking for notification schedules, displayed, tapped or dismissed is handled automagically.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Go to[ line 85 from LocalNotifications.kt](https://github.com/woocommerce/woocommerce-android/pull/9438/files#diff-74c116a16145d5ea7d01758d98557b5a20c465d60e70c9e45b59373b810b057bR85) and change `HOURS` for `SECONDS`. 
2. Run the app and create a new store.
3. Send the app to the background.
4. Wait until the store is fully created and you land on my store tab
5. Wait 6 seconds for the notification to show
6. Tap on the notification and check how the web view for upgrading the plan is opened.

### Demo

https://github.com/woocommerce/woocommerce-android/assets/2663464/80243be4-6c0d-406c-91bb-3825d882e7f2



