### PR TITLE
Feature/9435 schedule 24h survey notification

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -91,13 +91,15 @@ sealed class LocalNotification(
         }
     }
 
-    object FreeTrialSurveyNotification : LocalNotification(
+    data class FreeTrialSurveyNotification(val siteId: Long) : LocalNotification(
         title = R.string.local_notification_survey_after_24_hours_title,
         description = R.string.local_notification_survey_after_24_hours_description,
         type = LocalNotificationType.UPGRADE_TO_PAID_PLAN,
         delay = 24,
         delayUnit = TimeUnit.HOURS
     ) {
+        override val data: String = siteId.toString()
+
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -90,4 +90,16 @@ sealed class LocalNotification(
             return resourceProvider.getString(description)
         }
     }
+
+    object FreeTrialSurveyNotification : LocalNotification(
+        title = R.string.local_notification_survey_after_24_hours_title,
+        description = R.string.local_notification_survey_after_24_hours_description,
+        type = LocalNotificationType.UPGRADE_TO_PAID_PLAN,
+        delay = 24,
+        delayUnit = TimeUnit.HOURS
+    ) {
+        override fun getDescriptionString(resourceProvider: ResourceProvider): String {
+            return resourceProvider.getString(description)
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
@@ -5,7 +5,8 @@ enum class LocalNotificationType(val value: String) {
     STORE_CREATION_INCOMPLETE("one_day_after_store_creation_name_without_free_trial"),
     FREE_TRIAL_EXPIRING("one_day_before_free_trial_expires"),
     FREE_TRIAL_EXPIRED("one_day_after_free_trial_expires"),
-    UPGRADE_TO_PAID_PLAN("upgrade_to_paid_plan_reminder");
+    UPGRADE_TO_PAID_PLAN("upgrade_to_paid_plan_reminder"),
+    FREE_TRIAL_SURVEY("free_trial_survey");
 
     override fun toString() = value
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Co
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_TYPE
 import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TRIAL_EXPIRED
 import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TRIAL_EXPIRING
+import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TRIAL_SURVEY
 import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_FINISHED
 import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_INCOMPLETE
 import com.woocommerce.android.notifications.local.LocalNotificationType.UPGRADE_TO_PAID_PLAN
@@ -35,16 +36,19 @@ class PreconditionCheckWorker @AssistedInject constructor(
         val type = LocalNotificationType.fromString(inputData.getString(LOCAL_NOTIFICATION_TYPE))
         val data = inputData.getString(LOCAL_NOTIFICATION_DATA)
         return when (type) {
-            STORE_CREATION_FINISHED -> Result.success()
+            STORE_CREATION_FINISHED,
             STORE_CREATION_INCOMPLETE -> Result.success()
-            FREE_TRIAL_EXPIRING -> proceedIfFreeMatchingSite(data?.toLongOrNull())
-            FREE_TRIAL_EXPIRED -> proceedIfFreeMatchingSite(data?.toLongOrNull())
-            UPGRADE_TO_PAID_PLAN -> proceedIfFreeMatchingSite(data?.toLongOrNull())
+
+            FREE_TRIAL_EXPIRING,
+            FREE_TRIAL_EXPIRED,
+            UPGRADE_TO_PAID_PLAN,
+            FREE_TRIAL_SURVEY -> proceedIfFreeTrialAndMatchesSite(data?.toLongOrNull())
+
             null -> cancelWork("Notification type is null. Cancelling work.")
         }
     }
 
-    private fun proceedIfFreeMatchingSite(siteId: Long?): Result {
+    private fun proceedIfFreeTrialAndMatchesSite(siteId: Long?): Result {
         val site = selectedSite.get()
         return if (site.isFreeTrial && site.siteId == siteId) {
             Result.success()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.notifications.local.LocalNotification.FreeTrialExpiredNotification
 import com.woocommerce.android.notifications.local.LocalNotification.FreeTrialExpiringNotification
+import com.woocommerce.android.notifications.local.LocalNotification.FreeTrialSurveyNotification
 import com.woocommerce.android.notifications.local.LocalNotification.UpgradeToPaidPlanNotification
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.tools.SelectedSite
@@ -169,10 +170,10 @@ class StoreInstallationViewModel @Inject constructor(
                     FreeTrialExpiredNotification(name, selectedSite.get().siteId)
                 )
             }
-
             localNotificationScheduler.scheduleNotification(
                 UpgradeToPaidPlanNotification(selectedSite.get().siteId)
             )
+            localNotificationScheduler.scheduleNotification(FreeTrialSurveyNotification)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
@@ -173,7 +173,9 @@ class StoreInstallationViewModel @Inject constructor(
             localNotificationScheduler.scheduleNotification(
                 UpgradeToPaidPlanNotification(selectedSite.get().siteId)
             )
-            localNotificationScheduler.scheduleNotification(FreeTrialSurveyNotification)
+            localNotificationScheduler.scheduleNotification(
+                FreeTrialSurveyNotification(selectedSite.get().siteId)
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.notifications.UnseenReviewsCountHandler
 import com.woocommerce.android.notifications.local.LocalNotificationType
 import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TRIAL_EXPIRED
 import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TRIAL_EXPIRING
+import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TRIAL_SURVEY
 import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_FINISHED
 import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_INCOMPLETE
 import com.woocommerce.android.notifications.local.LocalNotificationType.UPGRADE_TO_PAID_PLAN
@@ -273,6 +274,8 @@ class MainActivityViewModel @Inject constructor(
                 FREE_TRIAL_EXPIRED,
                 FREE_TRIAL_EXPIRING,
                 UPGRADE_TO_PAID_PLAN -> triggerEvent(ViewStorePlanUpgrade(NOTIFICATION))
+
+                FREE_TRIAL_SURVEY -> TODO()
 
                 STORE_CREATION_FINISHED -> {}
             }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3378,6 +3378,8 @@
     <string name="local_notification_one_day_after_free_trial_expires_description">%1$s, we have paused your store, but you can continue by picking a plan that suits you best.</string>
     <string name="local_notification_upgrade_to_paid_plan_after_6_hours_title">🌟 Keep your business going!</string>
     <string name="local_notification_upgrade_to_paid_plan_after_6_hours_description">Discover advanced features and personalized recommendations for your store! Tap to pick a plan that suits you best.</string>
+    <string name="local_notification_survey_after_24_hours_title">💡Help Us Understand Your Subscription Decision</string>
+    <string name="local_notification_survey_after_24_hours_description">We’re interested in your decision-making journey. Could you please tell us about your current status?</string>
 
     <!--
     First product published congratulatory feature


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

⚠️ Do not merge until Base branch is `trunk`


Part of: #9435
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Schedule a local notification to display a survey asking for insights on why the user hasn't updated to a paid plan yet. Notification content should be the following: 

```
Title: 💡Help Us Understand Your Subscription Decision
Body: We’re interested in your decision-making journey. Could you please tell us about your current status?
```

Additionally, this PR checks that the site hasn't changed and the site is still on free trial by the time the notification should be displayed.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Go to[ line 85 from LocalNotifications.kt](https://github.com/woocommerce/woocommerce-android/pull/9444/files#diff-74c116a16145d5ea7d01758d98557b5a20c465d60e70c9e45b59373b810b057bR97) and change HOURS for SECONDS.
2. As soon as the store creation finished loading, send the app to the background.
3. Wait until the notification is shown. Check it displays the correct title and body. 
4. Click handling is still on TODO() so clicking on the notification will crash the app. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/88a200ba-9c0f-41b1-be54-091b54ff17fa



- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
