### PR TITLE
[UI Tests] Fix a flaky point in "e2eCreateOrderTest"

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/UnifiedOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/UnifiedOrderScreen.kt
@@ -89,10 +89,9 @@ class UnifiedOrderScreen : Screen(ORDER_CREATION) {
         return this
     }
 
-    fun addCustomerNotes(note: String): UnifiedOrderScreen {
-        Espresso.onView(withId(NOTES_SECTION))
-            .perform(NestedScrollViewExtension())
-
+    fun addCustomerNote(note: String): UnifiedOrderScreen {
+        waitForElementToBeDisplayedWithoutFailure(NOTES_SECTION)
+        scrollTo(NOTES_SECTION)
         clickOn(Espresso.onView(withText("Add note")))
         typeTextInto(CUSTOMER_NOTE_EDITOR, note)
         clickOn(DONE_BUTTON)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/UnifiedOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/UnifiedOrderScreen.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.e2e.helpers.util.NestedScrollViewExtension
 import com.woocommerce.android.e2e.helpers.util.Screen
 import org.hamcrest.CoreMatchers.endsWith
+import org.hamcrest.Matchers
 import org.hamcrest.core.AllOf.allOf
 
 class UnifiedOrderScreen : Screen(ORDER_CREATION) {
@@ -62,15 +63,18 @@ class UnifiedOrderScreen : Screen(ORDER_CREATION) {
     }
 
     fun addShipping(): UnifiedOrderScreen {
+        scrollTo(PAYMENT_SECTION)
         waitForElementToBeDisplayed(PAYMENT_SECTION)
         clickOn(SHIPPING_BUTTON)
         waitForElementToBeDisplayed(SHIPPING_AMOUNT_INPUT)
+
         Espresso.onView(
             allOf(
                 isDescendantOfA(withId(SHIPPING_AMOUNT_INPUT)),
                 withClassName(endsWith("EditText"))
             )
         ).perform(ViewActions.replaceText("3.30"))
+
         clickOn(DONE_BUTTON)
         return this
     }
@@ -89,10 +93,18 @@ class UnifiedOrderScreen : Screen(ORDER_CREATION) {
         return this
     }
 
-    fun addCustomerNote(note: String): UnifiedOrderScreen {
+    fun editCustomerNote(note: String): UnifiedOrderScreen {
         waitForElementToBeDisplayedWithoutFailure(NOTES_SECTION)
         scrollTo(NOTES_SECTION)
-        clickOn(Espresso.onView(withText("Add note")))
+
+        val editNoteButton = Espresso.onView(
+            Matchers.allOf(
+                isDescendantOfA(withId(NOTES_SECTION)),
+                withId(R.id.edit_button)
+            )
+        )
+
+        clickOn(editNoteButton)
         typeTextInto(CUSTOMER_NOTE_EDITOR, note)
         clickOn(DONE_BUTTON)
         return this

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
@@ -65,7 +65,7 @@ class OrdersUITest : TestBase() {
                 .addProductTap()
                 .assertProductsSelectorScreen(composeTestRule)
                 .selectProduct(composeTestRule, orderData.productName)
-                .addCustomerNotes(note)
+                .addCustomerNote(note)
                 .addShipping()
                 .addFee()
                 .createOrder()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
@@ -65,7 +65,7 @@ class OrdersUITest : TestBase() {
                 .addProductTap()
                 .assertProductsSelectorScreen(composeTestRule)
                 .selectProduct(composeTestRule, orderData.productName)
-                .addCustomerNote(note)
+                .editCustomerNote(note)
                 .addShipping()
                 .addFee()
                 .createOrder()


### PR DESCRIPTION
### Description
There's an increase of flakiness of `e2eCreateOrderTest ` ([example](https://buildkite.com/automattic/woocommerce-android/builds/13768#0189779f-40f4-40af-a447-1b9feae09ae5)) on CI, in the area of adding a customer note.

I'm not providing a video of the fail, since the thing in question happens in a split second, and it's very hard to notice. But what happens is:

1. _Right_ after the product is added to the order, the mock is not loaded yet, the customer note is absent, and the UI shows `Add note` button, and does not have an `Edit` button next to `Customer Note` screen area. Previously, the tests were on time to tap the `Add note` button.
2. It takes less than a second for the mock to load and affect the screen. Once this happens, `Add note` button disappears and `Edit` button appears. The test will still try to tap the `Add note` button.

The time interval between `1` and `2` is flexible, and it looks like FTL became faster a bit, with `2` taking place before the test has a chance to tap the button. Actually, we were just lucky not to notice this flaky point before, because the emulator was slow enough.

What the PR does is tapping the `Edit` button instead, as a part of `clickOn` method, which will wait for an element to appear before tapping it. This ensures that the test will wait for `Edit` button to appear, and then tap it, which hopefully removes the flakiness in this place.

### Testing instructions
- CI is 🟢.