### PR TITLE
[Customer Search] Tracking of the new customer search screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -248,6 +248,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     ORDERS_ADD_NEW,
     ORDER_PRODUCT_ADD,
     ORDER_CUSTOMER_ADD,
+    ORDER_CUSTOMER_DELETE,
     ORDER_FEE_ADD,
     ORDER_SHIPPING_METHOD_ADD,
     ORDER_CREATE_BUTTON_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_FAILED
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_PRODUCT_BARCODE_SCANNING_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CUSTOMER_ADD
+import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CUSTOMER_DELETE
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_FEE_ADD
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_FEE_REMOVE
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_NOTE_ADD
@@ -622,6 +623,11 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     fun onCustomerAddressDeleted() {
+        tracker.track(
+            ORDER_CUSTOMER_DELETE,
+            mapOf(KEY_FLOW to flow)
+        )
+
         _orderDraft.update { order ->
             order.copy(
                 customerId = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListFragment.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -70,5 +71,10 @@ class CustomerListFragment : BaseFragment() {
                 }
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AnalyticsTracker.trackViewShown(this)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModel.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.fluxc.model.customer.WCCustomerModel
 import javax.inject.Inject
 
 @HiltViewModel
-@Suppress("EmptyFunctionBlock")
 class CustomerListViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val repository: CustomerListRepository,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -214,6 +214,16 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when customer address deleted, then delete event tracked`() {
+        sut.onCustomerAddressDeleted()
+
+        verify(tracker).track(
+            AnalyticsEvent.ORDER_CUSTOMER_DELETE,
+            mapOf(AnalyticsTracker.KEY_FLOW to tracksFlow)
+        )
+    }
+
+    @Test
     fun `when fee edited, send tracks event`() {
         sut.onFeeEdited(BigDecimal.TEN)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlistnew/CustomerListViewModelTest.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.orders.creation.customerlistnew
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Location
 import com.woocommerce.android.ui.orders.creation.customerlist.CustomerListRepository
@@ -59,6 +61,7 @@ class CustomerListViewModelTest : BaseUnitTest() {
             )
         )
     }
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
 
     @Test
     fun `when viewmodel init, then viewstate is updated with customers`() = testBlocking {
@@ -148,7 +151,7 @@ class CustomerListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given search query, when onSearchQueryChanged is called, then update search query is updated`() =
+    fun `given search query, when onSearchQueryChanged is called, then update search query is updated and tracked`() =
         testBlocking {
             // GIVEN
             val searchQuery = "customer"
@@ -160,6 +163,74 @@ class CustomerListViewModelTest : BaseUnitTest() {
             // THEN
             assertThat(viewModel.viewState.value?.searchQuery).isEqualTo(searchQuery)
         }
+
+    @Test
+    fun `when onSearchQueryChanged is called, then tracked with all`() = testBlocking {
+        // GIVEN
+        val viewModel = initViewModel()
+
+        // WHEN
+        viewModel.onSearchQueryChanged("customer")
+
+        // THEN
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.ORDER_CREATION_CUSTOMER_SEARCH,
+            mapOf(
+                "search_type" to "all"
+            )
+        )
+    }
+
+    @Test
+    fun `when onSearchTypeChanged is called with email, then tracked with email`() = testBlocking {
+        // GIVEN
+        val viewModel = initViewModel()
+
+        // WHEN
+        viewModel.onSearchTypeChanged(R.string.order_creation_customer_search_email)
+
+        // THEN
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.ORDER_CREATION_CUSTOMER_SEARCH,
+            mapOf(
+                "search_type" to "email"
+            )
+        )
+    }
+
+    @Test
+    fun `when onSearchTypeChanged is called with name, then tracked with name`() = testBlocking {
+        // GIVEN
+        val viewModel = initViewModel()
+
+        // WHEN
+        viewModel.onSearchTypeChanged(R.string.order_creation_customer_search_name)
+
+        // THEN
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.ORDER_CREATION_CUSTOMER_SEARCH,
+            mapOf(
+                "search_type" to "name"
+            )
+        )
+    }
+
+    @Test
+    fun `when onSearchTypeChanged is called with username, then tracked with username`() = testBlocking {
+        // GIVEN
+        val viewModel = initViewModel()
+
+        // WHEN
+        viewModel.onSearchTypeChanged(R.string.order_creation_customer_search_username)
+
+        // THEN
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.ORDER_CREATION_CUSTOMER_SEARCH,
+            mapOf(
+                "search_type" to "username"
+            )
+        )
+    }
 
     @Test
     fun `given search query, when onSearchQueryChanged is called, then search is invoked and viewstate updated with customers`() =
@@ -358,6 +429,7 @@ class CustomerListViewModelTest : BaseUnitTest() {
                     shippingAddress = address,
                 )
             )
+            verify(analyticsTrackerWrapper).track(AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED)
         }
 
     @Test
@@ -407,6 +479,7 @@ class CustomerListViewModelTest : BaseUnitTest() {
             // THEN
             assertThat(states[0].partialLoading).isFalse()
             assertThat(states[1].partialLoading).isTrue()
+            verify(analyticsTrackerWrapper).track(AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED)
         }
 
     @Test
@@ -457,6 +530,7 @@ class CustomerListViewModelTest : BaseUnitTest() {
                     shippingAddress = address,
                 )
             )
+            verify(analyticsTrackerWrapper).track(AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED)
         }
 
     @Test
@@ -514,6 +588,7 @@ class CustomerListViewModelTest : BaseUnitTest() {
                     shippingAddress = address,
                 )
             )
+            verify(analyticsTrackerWrapper).track(AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED)
         }
 
     @Test
@@ -561,6 +636,7 @@ class CustomerListViewModelTest : BaseUnitTest() {
                     shippingAddress = address,
                 )
             )
+            verify(analyticsTrackerWrapper).track(AnalyticsEvent.ORDER_CREATION_CUSTOMER_ADDED)
         }
 
     @Test
@@ -592,5 +668,6 @@ class CustomerListViewModelTest : BaseUnitTest() {
         customerListRepository,
         customerListViewModelMapper,
         getSupportedSearchModes,
+        analyticsTrackerWrapper,
     )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9391
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR Adds:
* `ORDER_CUSTOMER_DELETE` event
* Uses existing `ORDER_CREATION_CUSTOMER_ADDED` event
* Uses existing `ORDER_CREATION_CUSTOMER_SEARCH` with `search_type` param

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Go via order creation -> Customer details flow + Editing and deleting added customer
* Notice all 3 events using logcat with the `track` filter


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
