### PR TITLE
Feature/9435 still exploring notification

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -785,6 +785,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     LOCAL_NOTIFICATION_TAPPED,
     LOCAL_NOTIFICATION_DISMISSED,
     FREE_TRIAL_SURVEY_SENT,
+    FREE_TRIAL_SURVEY_DISPLAYED,
 
     // Widgets
     WIDGET_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -521,11 +521,12 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_USE_DOMAIN_CREDIT = "use_domain_credit"
 
         // -- Free Trial
+        const val KEY_FREE_TRIAL_SOURCE = "source"
+        const val KEY_SURVEY_OPTION = "survey_option"
+        const val KEY_SURVEY_FREE_TEXT = "free_text"
         const val VALUE_BANNER = "banner"
         const val VALUE_UPGRADES_SCREEN = "upgrades_screen"
         const val VALUE_NOTIFICATION = "notification"
-        const val SURVEY_KEY = "survey_option"
-        const val FREE_TEXT_KEY = "free_text"
 
         // -- Store Onboarding
         const val ONBOARDING_TASK_KEY = "task"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -104,4 +104,18 @@ sealed class LocalNotification(
             return resourceProvider.getString(description)
         }
     }
+
+    data class StillExploringNotification(val siteId: Long) : LocalNotification(
+        title = R.string.local_notification_still_exploring_title,
+        description = R.string.local_notification_still_exploring_description,
+        type = LocalNotificationType.THREE_DAYS_AFTER_STILL_EXPLORING,
+        delay = 3,
+        delayUnit = TimeUnit.DAYS
+    ) {
+        override val data: String = siteId.toString()
+
+        override fun getDescriptionString(resourceProvider: ResourceProvider): String {
+            return resourceProvider.getString(description)
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
@@ -6,7 +6,8 @@ enum class LocalNotificationType(val value: String) {
     FREE_TRIAL_EXPIRING("one_day_before_free_trial_expires"),
     FREE_TRIAL_EXPIRED("one_day_after_free_trial_expires"),
     SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED("six_hours_after_free_trial_subscribed"),
-    FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED("free_trial_survey_24h_after_free_trial_subscribed");
+    FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED("free_trial_survey_24h_after_free_trial_subscribed"),
+    THREE_DAYS_AFTER_STILL_EXPLORING("three_days_after_still_exploring");
 
     override fun toString() = value
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TR
 import com.woocommerce.android.notifications.local.LocalNotificationType.SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED
 import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_FINISHED
 import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_INCOMPLETE
+import com.woocommerce.android.notifications.local.LocalNotificationType.THREE_DAYS_AFTER_STILL_EXPLORING
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
 import com.woocommerce.android.util.WooLogWrapper
@@ -42,7 +43,8 @@ class PreconditionCheckWorker @AssistedInject constructor(
             FREE_TRIAL_EXPIRING,
             FREE_TRIAL_EXPIRED,
             SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED,
-            FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED -> proceedIfFreeTrialAndMatchesSite(data?.toLongOrNull())
+            FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED,
+            THREE_DAYS_AFTER_STILL_EXPLORING -> proceedIfFreeTrialAndMatchesSite(data?.toLongOrNull())
 
             null -> cancelWork("Notification type is null. Cancelling work.")
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/freetrial/FreeTrialSurveyViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/freetrial/FreeTrialSurveyViewModel.kt
@@ -5,12 +5,15 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent.FREE_TRIAL_SURVEY_DISPLAYED
 import com.woocommerce.android.analytics.AnalyticsEvent.FREE_TRIAL_SURVEY_SENT
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.FREE_TEXT_KEY
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.SURVEY_KEY
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FREE_TRIAL_SOURCE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SURVEY_FREE_TEXT
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SURVEY_OPTION
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.notifications.local.LocalNotification.StillExploringNotification
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler
+import com.woocommerce.android.notifications.local.LocalNotificationType
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.feedback.freetrial.FreeTrialSurveyViewModel.SurveyOptionType.COLLECTIVE_DECISION
 import com.woocommerce.android.ui.feedback.freetrial.FreeTrialSurveyViewModel.SurveyOptionType.COMPARING_WITH_OTHER_PLATFORMS
@@ -67,6 +70,15 @@ class FreeTrialSurveyViewModel @Inject constructor(
     )
     val surveyState = _surveyState.asLiveData()
 
+    init {
+        analyticsTrackerWrapper.track(
+            stat = FREE_TRIAL_SURVEY_DISPLAYED,
+            properties = mutableMapOf(
+                KEY_FREE_TRIAL_SOURCE to LocalNotificationType.FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED.value,
+            )
+        )
+    }
+
     fun onArrowBackPressed() {
         triggerEvent(Exit)
     }
@@ -96,8 +108,9 @@ class FreeTrialSurveyViewModel @Inject constructor(
         analyticsTrackerWrapper.track(
             stat = FREE_TRIAL_SURVEY_SENT,
             properties = mutableMapOf(
-                SURVEY_KEY to selectedOption.optionType.name.lowercase()
-            ).putIfNotEmpty(FREE_TEXT_KEY to _surveyState.value.freeText)
+                KEY_SURVEY_OPTION to selectedOption.optionType.name.lowercase(),
+                KEY_FREE_TRIAL_SOURCE to LocalNotificationType.FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED.value,
+            ).putIfNotEmpty(KEY_SURVEY_FREE_TEXT to _surveyState.value.freeText)
         )
         if (selectedOption.optionType == STILL_EXPLORING) {
             notificationScheduler.scheduleNotification(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/freetrial/FreeTrialSurveyViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/freetrial/FreeTrialSurveyViewModel.kt
@@ -9,6 +9,9 @@ import com.woocommerce.android.analytics.AnalyticsEvent.FREE_TRIAL_SURVEY_SENT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.FREE_TEXT_KEY
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.SURVEY_KEY
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.notifications.local.LocalNotification.StillExploringNotification
+import com.woocommerce.android.notifications.local.LocalNotificationScheduler
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.feedback.freetrial.FreeTrialSurveyViewModel.SurveyOptionType.COLLECTIVE_DECISION
 import com.woocommerce.android.ui.feedback.freetrial.FreeTrialSurveyViewModel.SurveyOptionType.COMPARING_WITH_OTHER_PLATFORMS
 import com.woocommerce.android.ui.feedback.freetrial.FreeTrialSurveyViewModel.SurveyOptionType.OTHER_REASONS
@@ -26,7 +29,9 @@ import javax.inject.Inject
 @HiltViewModel
 class FreeTrialSurveyViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val notificationScheduler: LocalNotificationScheduler,
+    private val selectedSite: SelectedSite
 ) : ScopedViewModel(savedStateHandle) {
     private val _surveyState = savedState.getStateFlow(
         scope = this,
@@ -94,6 +99,11 @@ class FreeTrialSurveyViewModel @Inject constructor(
                 SURVEY_KEY to selectedOption.optionType.name.lowercase()
             ).putIfNotEmpty(FREE_TEXT_KEY to _surveyState.value.freeText)
         )
+        if (selectedOption.optionType == STILL_EXPLORING) {
+            notificationScheduler.scheduleNotification(
+                StillExploringNotification(selectedSite.get().siteId)
+            )
+        }
         triggerEvent(Exit)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TR
 import com.woocommerce.android.notifications.local.LocalNotificationType.SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED
 import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_FINISHED
 import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_INCOMPLETE
+import com.woocommerce.android.notifications.local.LocalNotificationType.THREE_DAYS_AFTER_STILL_EXPLORING
 import com.woocommerce.android.notifications.push.NotificationMessageHandler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType.Jetpack
@@ -277,7 +278,9 @@ class MainActivityViewModel @Inject constructor(
 
                 FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED -> triggerEvent(OpenFreeTrialSurvey)
 
-                STORE_CREATION_FINISHED -> {}
+                STORE_CREATION_FINISHED,
+                THREE_DAYS_AFTER_STILL_EXPLORING -> {
+                }
             }
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3381,7 +3381,8 @@
     <string name="local_notification_survey_after_24_hours_title">💡Help Us Understand Your Subscription Decision</string>
     <string name="local_notification_survey_after_24_hours_description">We’re interested in your decision-making journey. Could you please tell us about your current status?</string>
     <string name="free_trial_survey_screen_title">Help Us Understand Your Subscription Decision</string>
-
+    <string name="local_notification_still_exploring_title">🧭 Still Exploring WooCommerce?</string>
+    <string name="local_notification_still_exploring_description">No rush, take your time! If you have any questions or need assistance, we\'re always here to help. Happy exploring!</string>
     <!--
     First product published congratulatory feature
     -->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
⚠️ Do not merge until base branch is merged


Part of #9435
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
If the user selects "Still exploring" option in the free trial survey we show after 24h from subscribing to Free trial, then we schedule an additional local notification to be shown 3 days after the survey is sent. 

Additionally this PR adds a couple of small changes to tracking for the free trial survey to match iOS. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Go to[ LocalNotifications.kt](https://github.com/woocommerce/woocommerce-android/pull/9444/files#diff-74c116a16145d5ea7d01758d98557b5a20c465d60e70c9e45b59373b810b057bR97) and change HOURS for SECONDS in both `FreeTrialSurveyNotification` and `StillExploringNotification`
2. Run the app and create a new store.  
3. Wait until the new store is ready for the notification to be shown. Check it displays the correct title and body. Like in the screen recording below.
4. Tap on it and check the survey is displayed. 
5. Select "Still exploring" option and send your answer
6. Wait a few seconds for the new "Still exploring" notification to be shown.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/d9983470-5f7f-438b-ac79-af38fece9ad7

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
