### PR TITLE
Observe last update top performers

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -185,7 +185,7 @@ class MyStoreFragment :
             viewLifecycleOwner.lifecycleScope
         ) { myStoreViewModel.onViewAnalyticsClicked() }
 
-        binding.myStoreTopPerformers.initView(selectedSite,dateUtils)
+        binding.myStoreTopPerformers.initView(selectedSite, dateUtils)
 
         val contactUsText = getString(R.string.my_store_stats_availability_contact_us)
         binding.myStoreStatsAvailabilityMessage.setClickableText(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -185,7 +185,7 @@ class MyStoreFragment :
             viewLifecycleOwner.lifecycleScope
         ) { myStoreViewModel.onViewAnalyticsClicked() }
 
-        binding.myStoreTopPerformers.initView(selectedSite)
+        binding.myStoreTopPerformers.initView(selectedSite,dateUtils)
 
         val contactUsText = getString(R.string.my_store_stats_availability_contact_us)
         binding.myStoreStatsAvailabilityMessage.setClickableText(
@@ -398,8 +398,11 @@ class MyStoreFragment :
                 else -> event.isHandled = false
             }
         }
-        myStoreViewModel.lastUpdate.observe(viewLifecycleOwner) { lastUpdateMillis ->
+        myStoreViewModel.lastUpdateStats.observe(viewLifecycleOwner) { lastUpdateMillis ->
             binding.myStoreStats.showLastUpdate(lastUpdateMillis)
+        }
+        myStoreViewModel.lastUpdateTopPerformers.observe(viewLifecycleOwner) { lastUpdateMillis ->
+            binding.myStoreTopPerformers.showLastUpdate(lastUpdateMillis)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopPerformersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopPerformersView.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.databinding.MyStoreTopPerformersBinding
 import com.woocommerce.android.databinding.TopPerformersListItemBinding
 import com.woocommerce.android.di.GlideApp
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.widgets.SkeletonView
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import java.util.Locale
@@ -31,12 +32,19 @@ class MyStoreTopPerformersView @JvmOverloads constructor(
     private val binding = MyStoreTopPerformersBinding.inflate(LayoutInflater.from(ctx), this, true)
 
     private lateinit var selectedSite: SelectedSite
+    private lateinit var dateUtils: DateUtils
 
     private var skeletonView = SkeletonView()
 
-    fun initView(selectedSite: SelectedSite) {
-        this.selectedSite = selectedSite
+    private val lastUpdated
+        get() = binding.lastUpdatedTextView
 
+    fun initView(
+        selectedSite: SelectedSite,
+        dateUtils: DateUtils,
+    ) {
+        this.selectedSite = selectedSite
+        this.dateUtils = dateUtils
         binding.topPerformersRecycler.layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context)
         binding.topPerformersRecycler.adapter = TopPerformersAdapter()
         binding.topPerformersRecycler.itemAnimator = androidx.recyclerview.widget.DefaultItemAnimator()
@@ -85,6 +93,20 @@ class MyStoreTopPerformersView @JvmOverloads constructor(
         showEmptyView(false)
         binding.topPerformersEmptyViewLinearLayout.isVisible = show
         binding.topPerformersRecycler.isVisible = !show
+    }
+
+    fun showLastUpdate(lastUpdateMillis: Long?) {
+        if (lastUpdateMillis != null) {
+            val lastUpdateFormatted = dateUtils.getDateMillisInFriendlyTimeFormat(lastUpdateMillis)
+            lastUpdated.isVisible = true
+            lastUpdated.text = String.format(
+                Locale.getDefault(),
+                resources.getString(R.string.last_update),
+                lastUpdateFormatted
+            )
+        } else {
+            lastUpdated.isVisible = false
+        }
     }
 
     class TopPerformersViewHolder(val viewBinding: TopPerformersListItemBinding) :

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -109,8 +109,11 @@ class MyStoreViewModel @Inject constructor(
     private var _hasOrders = MutableLiveData<OrderState>()
     val hasOrders: LiveData<OrderState> = _hasOrders
 
-    private var _lastUpdate = MutableLiveData<Long?>()
-    val lastUpdate: LiveData<Long?> = _lastUpdate
+    private var _lastUpdateStats = MutableLiveData<Long?>()
+    val lastUpdateStats: LiveData<Long?> = _lastUpdateStats
+
+    private var _lastUpdateTopPerformers = MutableLiveData<Long?>()
+    val lastUpdateTopPerformers: LiveData<Long?> = _lastUpdateTopPerformers
 
     private var _appbarState = MutableLiveData<AppbarState>()
     val appbarState: LiveData<AppbarState> = _appbarState
@@ -241,13 +244,21 @@ class MyStoreViewModel @Inject constructor(
                 }
                 myStoreTransactionLauncher.onStoreStatisticsFetched()
             }
-        observeLastUpdate(
-            granularity,
-            listOf(
-                AnalyticsUpdateDataStore.AnalyticData.REVENUE,
-                AnalyticsUpdateDataStore.AnalyticData.VISITORS
-            )
-        ).collect { lastUpdateMillis -> _lastUpdate.value = lastUpdateMillis }
+        launch {
+            observeLastUpdate(
+                granularity,
+                listOf(
+                    AnalyticsUpdateDataStore.AnalyticData.REVENUE,
+                    AnalyticsUpdateDataStore.AnalyticData.VISITORS
+                )
+            ).collect { lastUpdateMillis -> _lastUpdateStats.value = lastUpdateMillis }
+        }
+        launch {
+            observeLastUpdate(
+                granularity,
+                AnalyticsUpdateDataStore.AnalyticData.TOP_PERFORMERS
+            ).collect { lastUpdateMillis -> _lastUpdateTopPerformers.value = lastUpdateMillis }
+        }
     }
 
     private fun onRevenueStatsSuccess(

--- a/WooCommerce/src/main/res/layout/my_store_top_performers.xml
+++ b/WooCommerce/src/main/res/layout/my_store_top_performers.xml
@@ -83,5 +83,14 @@
 
         </LinearLayout>
     </RelativeLayout>
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/lastUpdatedTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:layout_gravity="end"
+        android:textColor="@color/color_on_surface_medium"
+        tools:text="Last updated 11:25 AM"
+        android:layout_margin="@dimen/major_100"/>
 
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/my_store_top_performers.xml
+++ b/WooCommerce/src/main/res/layout/my_store_top_performers.xml
@@ -88,7 +88,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="?attr/textAppearanceBody2"
-        android:layout_gravity="end"
+        android:layout_gravity="center_horizontal"
         android:textColor="@color/color_on_surface_medium"
         tools:text="Last updated 11:25 AM"
         android:layout_margin="@dimen/major_100"/>


### PR DESCRIPTION
Closes: #9443

### Why
As part of the Reliability project, we are working on improving the app's performance and reducing the perceived time it takes to load. One of the ideas we are working on is introducing a timestamp as the web does and preventing redundant requests to the API. This PR is part of the timestamp introduction in the My Store screen.

This how the web looks like:
<img width="594" alt="Screenshot 2023-06-21 at 11 25 43" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/133b162b-f9f9-4344-bdb1-577f07cbbb43">

### Description
This PR adds the last update value to the My Store screen in the Top performers section. Now every time the last update value changes, the UI will be refreshed.

### Testing instructions
TC1
1. Open the App and open a granularity (ex. Today)
2. Wait until the screen finish loading
3. Check that the last update value is shown
4. Press on a different granularity (ex. This week)
5. Wait until the screen finish loading
6. Check that the last update value is shown
7. Change back to the first selection (Today)
8. Check that no request is made to the API and that data is presented from the cache
9. Check that the last update value is shown with the same value as in Step 3
10. Change to the second selection (This week)
11. Check that no request is made to the API and that data is presented from the cache
12. Check that the last update value is shown with the same value as Step 6

TC2
1. Open the App and open a granularity (ex. Today)
2. Wait until the screen finish loading
3. Check that the last update value is shown
4. Press on a different granularity (ex. This week)
5. Wait until the screen finish loading
6. Check that the last update value is shown
7. Change back to the first selection (Today)
8. Check that the last update value is shown as in Step 3
9. Check that no request is made to the API and that data is presented from the cache
10. Pull-To-Refresh and check that a call is made to the API and the data is refreshed
11. Check that last update value is updated to current time

### Images/gif

<img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/6e890b3b-8a41-4146-99ae-89d8fd7fc2cb" />

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->