### PR TITLE
Disconnect card reader and clear reader cached credentials when we switch payment gateway

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+14.8
+-----
+- [*] [Internal] Fix crash happening while collecting IPP when switching payment gateways [https://github.com/woocommerce/woocommerce-android/pull/9492]
+
 14.7
 -----
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
@@ -364,7 +364,7 @@ class CardReaderHubViewModel @Inject constructor(
     }
 
     private fun disconnectCardReader() {
-        viewModelScope.launch {
+        launch {
             cardReaderDataAction()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.map
-import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.AppUrls

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModel.kt
@@ -354,7 +354,6 @@ class CardReaderHubViewModel @Inject constructor(
 
     private fun onCardReaderPaymentProviderClicked() {
         disconnectCardReader()
-        cardReaderChecker.invalidateCache()
         trackEvent(AnalyticsEvent.SETTINGS_CARD_PRESENT_SELECT_PAYMENT_GATEWAY_TAPPED)
         clearPluginExplicitlySelectedFlag()
         triggerEvent(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -546,6 +546,27 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given multiple plugins installed, when change payment provider clicked, then remove last connected card reader id`() {
+        testBlocking {
+            val site = selectedSite.get()
+            whenever(
+                appPrefsWrapper.isCardReaderPluginExplicitlySelected(
+                    localSiteId = site.id,
+                    remoteSiteId = site.siteId,
+                    selfHostedSiteId = site.selfHostedSiteId
+                )
+            ).thenReturn(true)
+
+            initViewModel()
+            (viewModel.viewStateData.getOrAwaitValue()).rows.find {
+                it.label == UiStringRes(R.string.card_reader_manage_payment_provider)
+            }!!.onClick!!.invoke()
+
+            verify(appPrefsWrapper).removeLastConnectedCardReaderId()
+        }
+    }
+
+    @Test
     fun `given onboarding error, when view model init, then show error message`() =
         testBlocking {
             whenever(cardReaderChecker.getOnboardingState()).thenReturn(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -407,25 +407,6 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given multiple plugins installed, when change payment provider clicked, then invalidate cache invoked`() {
-        val site = selectedSite.get()
-        whenever(
-            appPrefsWrapper.isCardReaderPluginExplicitlySelected(
-                localSiteId = site.id,
-                remoteSiteId = site.siteId,
-                selfHostedSiteId = site.selfHostedSiteId
-            )
-        ).thenReturn(true)
-
-        initViewModel()
-        (viewModel.viewStateData.getOrAwaitValue()).rows.find {
-            it.label == UiStringRes(R.string.card_reader_manage_payment_provider)
-        }!!.onClick!!.invoke()
-
-        verify(cardReaderChecker).invalidateCache()
-    }
-
-    @Test
     fun `given multiple plugins installed, when payment provider clicked, then clear plugin selected flag`() {
         val site = selectedSite.get()
         whenever(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -524,6 +524,28 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given multiple plugins installed, when change payment provider clicked, then clear cached card reader credentials`() {
+        testBlocking {
+            val site = selectedSite.get()
+            whenever(
+                appPrefsWrapper.isCardReaderPluginExplicitlySelected(
+                    localSiteId = site.id,
+                    remoteSiteId = site.siteId,
+                    selfHostedSiteId = site.selfHostedSiteId
+                )
+            ).thenReturn(true)
+            whenever(cardReaderManager.initialized).thenReturn(true)
+
+            initViewModel()
+            (viewModel.viewStateData.getOrAwaitValue()).rows.find {
+                it.label == UiStringRes(R.string.card_reader_manage_payment_provider)
+            }!!.onClick!!.invoke()
+
+            verify(cardReaderManager).clearCachedCredentials()
+        }
+    }
+
+    @Test
     fun `given onboarding error, when view model init, then show error message`() =
         testBlocking {
             whenever(cardReaderChecker.getOnboardingState()).thenReturn(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/hub/CardReaderHubViewModelTest.kt
@@ -567,6 +567,27 @@ class CardReaderHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given multiple plugins installed, when change payment provider clicked, then invalidate onboarding cache`() {
+        testBlocking {
+            val site = selectedSite.get()
+            whenever(
+                appPrefsWrapper.isCardReaderPluginExplicitlySelected(
+                    localSiteId = site.id,
+                    remoteSiteId = site.siteId,
+                    selfHostedSiteId = site.selfHostedSiteId
+                )
+            ).thenReturn(true)
+
+            initViewModel()
+            (viewModel.viewStateData.getOrAwaitValue()).rows.find {
+                it.label == UiStringRes(R.string.card_reader_manage_payment_provider)
+            }!!.onClick!!.invoke()
+
+            verify(cardReaderOnboardingChecker).invalidateCache()
+        }
+    }
+
+    @Test
     fun `given onboarding error, when view model init, then show error message`() =
         testBlocking {
             whenever(cardReaderChecker.getOnboardingState()).thenReturn(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9490 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a crash that was happening when we tried to make IPP after switching the payment gateway.

#### Reason for the crash
When the payment gateway is switched, ideally, we need to disconnect the card reader. If not, the card reader will use the cached credentials of the old gateway and this causes errors while making IPP

There was also a crash happening when we follow the below steps:
1. Have 2 payment gateway on your site
2. In the payments hub screen, select any one of them
3. Continue to collect the payment
4. IPP finishes successfully
5. In the hub screen, click on the "change payment provider" option
6. Do nothing on this screen. Just press back
7. Try collecting the payment again
8. While collecting the payment, it crashes

The reason for the crash is that the plugin type will be null. Ideally, we should be running the onboarding check again while collecting the IPP since the onboarding state becomes `not_completed` in step 5.

#### Fix
Disconnect the card reader every time the user tries to switch payment gateway.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Switching payment gateways and trying IPP
1. Have 2 payment gateway on your site
2. Select one of them and make IPP
3. Ensure IPP works
4. Switch payment gateway and make IPP
5. Ensure IPP works
6. Repeat steps 4-5 several times and ensure IPP works without any errors.

#### Not selecting any of the payment gateways
1. Have 2 payment gateway on your site
2. In the payments hub screen, select any one of them
3. Continue to collect the payment
4. IPP finishes successfully
5. In the hub screen, click on the "change payment provider" option
6. Do nothing on this screen. Just press back
7. Try collecting the payment again
8. Ensure IPP works

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
