### PR TITLE
Analytics Performance: Introduce last update info to Analytics Hub

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
@@ -110,7 +110,7 @@ class AnalyticsHubFragment :
         binding.analyticsDateSelectorCard.updateSelectionTitle(viewState.analyticsDateRangeSelectorState.selectionType)
         binding.analyticsDateSelectorCard.updatePreviousRange(viewState.analyticsDateRangeSelectorState.previousRange)
         binding.analyticsDateSelectorCard.updateCurrentRange(viewState.analyticsDateRangeSelectorState.currentRange)
-        binding.analyticsDateSelectorCard.updateLastUpdateTimestamp(viewState.lastUpdateTimestamp.toString())
+        binding.analyticsDateSelectorCard.updateLastUpdateTimestamp(viewState.lastUpdateTimestamp)
         binding.analyticsRevenueCard.updateInformation(viewState.revenueState)
         binding.analyticsOrdersCard.updateInformation(viewState.ordersState)
         binding.analyticsProductsCard.updateInformation(viewState.productsState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
@@ -110,6 +110,7 @@ class AnalyticsHubFragment :
         binding.analyticsDateSelectorCard.updateSelectionTitle(viewState.analyticsDateRangeSelectorState.selectionType)
         binding.analyticsDateSelectorCard.updatePreviousRange(viewState.analyticsDateRangeSelectorState.previousRange)
         binding.analyticsDateSelectorCard.updateCurrentRange(viewState.analyticsDateRangeSelectorState.currentRange)
+        binding.analyticsDateSelectorCard.updateLastUpdateTimestamp(viewState.lastUpdateTimestamp.toString())
         binding.analyticsRevenueCard.updateInformation(viewState.revenueState)
         binding.analyticsOrdersCard.updateInformation(viewState.ordersState)
         binding.analyticsProductsCard.updateInformation(viewState.productsState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -275,11 +275,12 @@ class AnalyticsHubViewModel @Inject constructor(
     }
 
     private fun observeLastUpdateTimestamp() {
-        observeLastUpdate(timeRangeSelection = rangeSelectionState.value)
-            .filterNotNull()
-            .map { dateUtils.getDateMillisInFriendlyTimeFormat(it) }
-            .onEach { mutableState.value = viewState.value.copy(lastUpdateTimestamp = it) }
-            .launchIn(viewModelScope)
+        rangeSelectionState.onEach {
+            observeLastUpdate(timeRangeSelection = rangeSelectionState.value)
+                .filterNotNull()
+                .map { dateUtils.getDateMillisInFriendlyTimeFormat(it) }
+                .onEach { mutableState.value = viewState.value.copy(lastUpdateTimestamp = it) }
+        }.launchIn(viewModelScope)
     }
 
     private fun updateDateSelector() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -271,7 +271,7 @@ class AnalyticsHubViewModel @Inject constructor(
 
     private fun observeLastUpdateTimestamp() {
         observeLastUpdate(timeRangeSelection = rangeSelectionState.value)
-            .onEach {  }
+            .onEach { mutableState.value = viewState.value.copy(lastUpdateTimestamp = it) }
             .launchIn(viewModelScope)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -173,6 +173,7 @@ class AnalyticsHubViewModel @Inject constructor(
 
     private fun observeRangeSelectionChanges() {
         rangeSelectionState.onEach {
+            observeLastUpdateTimestamp()
             updateDateSelector()
             trackSelectedDateRange()
             updateStats(
@@ -275,12 +276,12 @@ class AnalyticsHubViewModel @Inject constructor(
     }
 
     private fun observeLastUpdateTimestamp() {
-        rangeSelectionState.onEach {
-            observeLastUpdate(timeRangeSelection = rangeSelectionState.value)
-                .filterNotNull()
-                .map { dateUtils.getDateMillisInFriendlyTimeFormat(it) }
-                .onEach { mutableState.value = viewState.value.copy(lastUpdateTimestamp = it) }
-        }.launchIn(viewModelScope)
+        mutableState.value = viewState.value.copy(lastUpdateTimestamp = "")
+        observeLastUpdate(timeRangeSelection = rangeSelectionState.value)
+            .filterNotNull()
+            .map { dateUtils.getDateMillisInFriendlyTimeFormat(it) }
+            .onEach { mutableState.value = viewState.value.copy(lastUpdateTimestamp = it) }
+            .launchIn(viewModelScope)
     }
 
     private fun updateDateSelector() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -30,7 +30,9 @@ import com.woocommerce.android.ui.analytics.hub.sync.UpdateAnalyticsHubStats
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
 import com.woocommerce.android.ui.feedback.FeedbackRepository
 import com.woocommerce.android.ui.mystore.MyStoreStatsUsageTracksEventEmitter
+import com.woocommerce.android.ui.mystore.domain.ObserveLastUpdate
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.locale.LocaleProvider
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -42,7 +44,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -53,10 +57,6 @@ import javax.inject.Inject
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState as ProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.LoadingViewState as LoadingProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.NoDataState as ProductsNoDataState
-import com.woocommerce.android.ui.mystore.domain.ObserveLastUpdate
-import com.woocommerce.android.util.DateUtils
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.map
 
 @HiltViewModel
 class AnalyticsHubViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -270,7 +270,9 @@ class AnalyticsHubViewModel @Inject constructor(
     }
 
     private fun observeLastUpdateTimestamp() {
-        TODO("Not yet implemented")
+        observeLastUpdate(timeRangeSelection = rangeSelectionState.value)
+            .onEach {  }
+            .launchIn(viewModelScope)
     }
 
     private fun updateDateSelector() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -53,6 +53,7 @@ import javax.inject.Inject
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState as ProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.LoadingViewState as LoadingProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.NoDataState as ProductsNoDataState
+import com.woocommerce.android.ui.mystore.domain.ObserveLastUpdate
 
 @HiltViewModel
 class AnalyticsHubViewModel @Inject constructor(
@@ -61,6 +62,7 @@ class AnalyticsHubViewModel @Inject constructor(
     private val transactionLauncher: AnalyticsHubTransactionLauncher,
     private val usageTracksEventEmitter: MyStoreStatsUsageTracksEventEmitter,
     private val updateStats: UpdateAnalyticsHubStats,
+    private val observeLastUpdate: ObserveLastUpdate,
     private val localeProvider: LocaleProvider,
     private val feedbackRepository: FeedbackRepository,
     private val tracker: AnalyticsTrackerWrapper,
@@ -104,6 +106,7 @@ class AnalyticsHubViewModel @Inject constructor(
         observeProductsChanges()
         observeRevenueChanges()
         observeRangeSelectionChanges()
+        observeLastUpdateTimestamp()
         if (FeatureFlag.ANALYTICS_HUB_FEEDBACK_BANNER.isEnabled()) {
             shouldAskForFeedback()
         }
@@ -264,6 +267,10 @@ class AnalyticsHubViewModel @Inject constructor(
             .filter { state -> state is RevenueState.Available }
             .onEach { transactionLauncher.onRevenueFetched() }
             .launchIn(viewModelScope)
+    }
+
+    private fun observeLastUpdateTimestamp() {
+        TODO("Not yet implemented")
     }
 
     private fun updateDateSelector() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -54,6 +54,9 @@ import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewSta
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.LoadingViewState as LoadingProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.NoDataState as ProductsNoDataState
 import com.woocommerce.android.ui.mystore.domain.ObserveLastUpdate
+import com.woocommerce.android.util.DateUtils
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
 
 @HiltViewModel
 class AnalyticsHubViewModel @Inject constructor(
@@ -66,6 +69,7 @@ class AnalyticsHubViewModel @Inject constructor(
     private val localeProvider: LocaleProvider,
     private val feedbackRepository: FeedbackRepository,
     private val tracker: AnalyticsTrackerWrapper,
+    private val dateUtils: DateUtils,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
 
@@ -272,6 +276,8 @@ class AnalyticsHubViewModel @Inject constructor(
 
     private fun observeLastUpdateTimestamp() {
         observeLastUpdate(timeRangeSelection = rangeSelectionState.value)
+            .filterNotNull()
+            .map { dateUtils.getDateMillisInFriendlyTimeFormat(it) }
             .onEach { mutableState.value = viewState.value.copy(lastUpdateTimestamp = it) }
             .launchIn(viewModelScope)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -80,13 +80,14 @@ class AnalyticsHubViewModel @Inject constructor(
 
     private val mutableState = MutableStateFlow(
         AnalyticsViewState(
-            NotShowIndicator,
-            AnalyticsHubDateRangeSelectorViewState.EMPTY,
-            LoadingViewState,
-            LoadingViewState,
-            LoadingProductsViewState,
-            LoadingViewState,
-            false
+            refreshIndicator = NotShowIndicator,
+            analyticsDateRangeSelectorState = AnalyticsHubDateRangeSelectorViewState.EMPTY,
+            revenueState = LoadingViewState,
+            ordersState = LoadingViewState,
+            productsState = LoadingProductsViewState,
+            sessionState = LoadingViewState,
+            showFeedBackBanner = false,
+            lastUpdateTimestamp = ""
         )
     )
     val viewState: StateFlow<AnalyticsViewState> = mutableState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewState.kt
@@ -12,7 +12,8 @@ data class AnalyticsViewState(
     val ordersState: AnalyticsHubInformationViewState,
     val productsState: AnalyticsHubListViewState,
     val sessionState: AnalyticsHubInformationViewState,
-    val showFeedBackBanner: Boolean
+    val showFeedBackBanner: Boolean,
+    val lastUpdateTimestamp: Long? = null
 )
 
 sealed class AnalyticsViewEvent : MultiLiveEvent.Event() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewState.kt
@@ -13,7 +13,7 @@ data class AnalyticsViewState(
     val productsState: AnalyticsHubListViewState,
     val sessionState: AnalyticsHubInformationViewState,
     val showFeedBackBanner: Boolean,
-    val lastUpdateTimestamp: Long? = null
+    val lastUpdateTimestamp: String
 )
 
 sealed class AnalyticsViewEvent : MultiLiveEvent.Event() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/daterangeselector/AnalyticsHubDateRangeCardView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/daterangeselector/AnalyticsHubDateRangeCardView.kt
@@ -26,6 +26,10 @@ class AnalyticsHubDateRangeCardView @JvmOverloads constructor(
         binding.selectionTitle.text = context.getString(selectionType.localizedResourceId)
     }
 
+    fun updateLastUpdateTimestamp(lastUpdateTimestamp: String) {
+        binding.lastUpdateTimestamp.text = lastUpdateTimestamp
+    }
+
     fun updatePreviousRange(previousRange: String) {
         SpannableStringBuilder()
             .append(resources.getString(R.string.date_compared_to))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/daterangeselector/AnalyticsHubDateRangeCardView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/daterangeselector/AnalyticsHubDateRangeCardView.kt
@@ -11,7 +11,6 @@ import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.AnalyticsDateRangeCardViewBinding
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
-import java.util.Locale
 
 class AnalyticsHubDateRangeCardView @JvmOverloads constructor(
     ctx: Context,
@@ -32,7 +31,10 @@ class AnalyticsHubDateRangeCardView @JvmOverloads constructor(
         with(binding.lastUpdateTimestamp) {
             lastUpdateTimestamp
                 .takeIf { it.isNotEmpty() }
-                ?.let { text = lastUpdateTimestamp }
+                ?.let {
+                    isVisible = true
+                    text = lastUpdateTimestamp
+                }
                 ?: apply { isVisible = false }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/daterangeselector/AnalyticsHubDateRangeCardView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/daterangeselector/AnalyticsHubDateRangeCardView.kt
@@ -11,6 +11,7 @@ import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.AnalyticsDateRangeCardViewBinding
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import java.util.Locale
 
 class AnalyticsHubDateRangeCardView @JvmOverloads constructor(
     ctx: Context,
@@ -33,7 +34,11 @@ class AnalyticsHubDateRangeCardView @JvmOverloads constructor(
                 .takeIf { it.isNotEmpty() }
                 ?.let {
                     isVisible = true
-                    text = lastUpdateTimestamp
+                    text = String.format(
+                        Locale.getDefault(),
+                        resources.getString(R.string.last_update),
+                        lastUpdateTimestamp
+                    )
                 }
                 ?: apply { isVisible = false }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/daterangeselector/AnalyticsHubDateRangeCardView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/daterangeselector/AnalyticsHubDateRangeCardView.kt
@@ -6,10 +6,12 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import androidx.core.text.bold
+import androidx.core.view.isVisible
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.AnalyticsDateRangeCardViewBinding
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import java.util.Locale
 
 class AnalyticsHubDateRangeCardView @JvmOverloads constructor(
     ctx: Context,
@@ -27,7 +29,12 @@ class AnalyticsHubDateRangeCardView @JvmOverloads constructor(
     }
 
     fun updateLastUpdateTimestamp(lastUpdateTimestamp: String) {
-        binding.lastUpdateTimestamp.text = lastUpdateTimestamp
+        with(binding.lastUpdateTimestamp) {
+            lastUpdateTimestamp
+                .takeIf { it.isNotEmpty() }
+                ?.let { text = lastUpdateTimestamp }
+                ?: apply { isVisible = false }
+        }
     }
 
     fun updatePreviousRange(previousRange: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/daterangeselector/AnalyticsHubDateRangeCardView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/daterangeselector/AnalyticsHubDateRangeCardView.kt
@@ -36,7 +36,7 @@ class AnalyticsHubDateRangeCardView @JvmOverloads constructor(
                     isVisible = true
                     text = String.format(
                         Locale.getDefault(),
-                        resources.getString(R.string.last_update),
+                        resources.getString(R.string.last_update_with_frequency),
                         lastUpdateTimestamp
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/domain/ObserveLastUpdate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/domain/ObserveLastUpdate.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.mystore.domain
 
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsUpdateDataStore
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.util.locale.LocaleProvider
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.store.WCStatsStore
@@ -29,6 +30,15 @@ class ObserveLastUpdate @Inject constructor(
         return analyticsUpdateDataStore.observeLastUpdate(
             rangeSelection = rangeSelection,
             analyticData = analyticData
+        )
+    }
+
+    operator fun invoke(
+        timeRangeSelection: StatsTimeRangeSelection
+    ) : Flow<Long?> {
+        return analyticsUpdateDataStore.observeLastUpdate(
+            rangeSelection = timeRangeSelection,
+            analyticData = AnalyticsUpdateDataStore.AnalyticData.ALL
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/domain/ObserveLastUpdate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/domain/ObserveLastUpdate.kt
@@ -35,7 +35,7 @@ class ObserveLastUpdate @Inject constructor(
 
     operator fun invoke(
         timeRangeSelection: StatsTimeRangeSelection
-    ) : Flow<Long?> {
+    ): Flow<Long?> {
         return analyticsUpdateDataStore.observeLastUpdate(
             rangeSelection = timeRangeSelection,
             analyticData = AnalyticsUpdateDataStore.AnalyticData.ALL

--- a/WooCommerce/src/main/res/layout/analytics_date_range_card_view.xml
+++ b/WooCommerce/src/main/res/layout/analytics_date_range_card_view.xml
@@ -71,24 +71,28 @@
             android:layout_height="1dp"
             android:background="@color/divider_color" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/previous_range_description"
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             style="@style/Woo.Card.Body"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_100"
-            android:maxLines="1"
-            tools:text="Compared to Jan 1 - Dec 31, 2021" />
+            android:layout_margin="@dimen/major_100"
+            android:orientation="vertical">
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/last_update_timestamp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_100"
-            android:layout_marginTop="@dimen/minor_50"
-            tools:text="Last update: 9:35 AM (Updates every 30 minutes)" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/previous_range_description"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:maxLines="1"
+                tools:text="Compared to Jan 1 - Dec 31, 2021" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/last_update_timestamp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/minor_50"
+                tools:text="Last update: 9:35 AM (Updates every 30 minutes)" />
+
+        </LinearLayout>
 
     </androidx.appcompat.widget.LinearLayoutCompat>
 

--- a/WooCommerce/src/main/res/layout/analytics_date_range_card_view.xml
+++ b/WooCommerce/src/main/res/layout/analytics_date_range_card_view.xml
@@ -76,9 +76,19 @@
             style="@style/Woo.Card.Body"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/major_100"
+            android:layout_marginHorizontal="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_100"
             android:maxLines="1"
             tools:text="Compared to Jan 1 - Dec 31, 2021" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/last_update_timestamp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
+            android:layout_marginBottom="@dimen/major_100"
+            android:layout_marginTop="@dimen/minor_50"
+            tools:text="Last update: 9:35 AM (Updates every 30 minutes)" />
 
     </androidx.appcompat.widget.LinearLayoutCompat>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -150,6 +150,7 @@
     <string name="hide_password_content_description">Hide password</string>
     <string name="show_password_content_description">Show password</string>
     <string name="last_update">Last update %s</string>
+    <string name="last_update_with_frequency">Last update %s (Updates every 30 minutes)</string>
 
     <!--
         Date/Time Labels
@@ -3453,7 +3454,7 @@
     <string name="free_trial_survey_option4">I am part of a team, and we need to make the decision collectively.</string>
     <string name="free_trial_survey_free_text">Other reason (please specify)</string>
 
-    <!--  
+    <!--
     Shipping zones
     -->
     <string name="shipping_classes_zones">Shipping classes &amp; zones</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
@@ -42,6 +42,7 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
@@ -63,7 +64,6 @@ import java.util.TimeZone
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlinx.coroutines.flow.flowOf
 
 @ExperimentalCoroutinesApi
 class AnalyticsHubViewModelTest : BaseUnitTest() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
@@ -63,6 +63,7 @@ import java.util.TimeZone
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.flowOf
 
 @ExperimentalCoroutinesApi
 class AnalyticsHubViewModelTest : BaseUnitTest() {
@@ -654,6 +655,14 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
         sut.onRefreshRequested()
 
         verify(tracker).track(AnalyticsEvent.ANALYTICS_HUB_PULL_TO_REFRESH_TRIGGERED)
+    }
+
+    @Test
+    fun `when last information changes, then update view state as expected`() = testBlocking {
+        whenever(observeLastUpdate.invoke(any())).thenReturn(flowOf(123456789L))
+        sut = givenAViewModel()
+
+        assertThat(sut.viewState.value.lastUpdateTimestamp).isEqualTo(123456789L)
     }
 
     private fun givenAResourceProvider(): ResourceProvider = mock {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
@@ -658,11 +658,19 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when last information changes, then update view state as expected`() = testBlocking {
+    fun `when last update information changes, then update view state as expected`() = testBlocking {
         whenever(observeLastUpdate.invoke(any())).thenReturn(flowOf(123456789L))
         sut = givenAViewModel()
 
         assertThat(sut.viewState.value.lastUpdateTimestamp).isEqualTo(123456789L)
+    }
+
+    @Test
+    fun `when last update information is not initialized, then update view state field is null`() = testBlocking {
+        whenever(observeLastUpdate.invoke(any())).thenReturn(flowOf())
+        sut = givenAViewModel()
+
+        assertThat(sut.viewState.value.lastUpdateTimestamp).isEqualTo(null)
     }
 
     private fun givenAResourceProvider(): ResourceProvider = mock {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
@@ -670,8 +670,16 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when last update information is not initialized, then update view state field is null`() = testBlocking {
+    fun `when last update information is not initialized, then update view state field is empty`() = testBlocking {
         whenever(observeLastUpdate.invoke(any())).thenReturn(flowOf())
+        sut = givenAViewModel()
+
+        assertThat(sut.viewState.value.lastUpdateTimestamp).isEmpty()
+    }
+
+    @Test
+    fun `when last update information is null, then update view state field is empty`() = testBlocking {
+        whenever(observeLastUpdate.invoke(any())).thenReturn(flowOf(null))
         sut = givenAViewModel()
 
         assertThat(sut.viewState.value.lastUpdateTimestamp).isEmpty()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.Selec
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.TODAY
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.WEEK_TO_DATE
 import com.woocommerce.android.ui.feedback.FeedbackRepository
+import com.woocommerce.android.ui.mystore.domain.ObserveLastUpdate
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.locale.LocaleProvider
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -78,6 +79,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
     }
 
     private val updateStats: UpdateAnalyticsHubStats = mock()
+    private val observeLastUpdate: ObserveLastUpdate = mock()
     private val savedState = AnalyticsHubFragmentArgs(targetGranularity = TODAY).initSavedStateHandle()
     private val transactionLauncher = mock<AnalyticsHubTransactionLauncher>()
     private val feedbackRepository: FeedbackRepository = mock()
@@ -666,6 +668,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
             transactionLauncher,
             mock(),
             updateStats,
+            observeLastUpdate,
             localeProvider,
             feedbackRepository,
             tracker,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
@@ -37,6 +37,7 @@ import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.Selec
 import com.woocommerce.android.ui.feedback.FeedbackRepository
 import com.woocommerce.android.ui.mystore.domain.ObserveLastUpdate
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.locale.LocaleProvider
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -85,6 +86,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
     private val transactionLauncher = mock<AnalyticsHubTransactionLauncher>()
     private val feedbackRepository: FeedbackRepository = mock()
     private val tracker: AnalyticsTrackerWrapper = mock()
+    private val dateUtils: DateUtils = mock()
 
     private lateinit var localeProvider: LocaleProvider
     private lateinit var testLocale: Locale
@@ -659,10 +661,12 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when last update information changes, then update view state as expected`() = testBlocking {
-        whenever(observeLastUpdate.invoke(any())).thenReturn(flowOf(123456789L))
+        val lastUpdateTimestamp = 123456789L
+        whenever(observeLastUpdate.invoke(any())).thenReturn(flowOf(lastUpdateTimestamp))
+        whenever(dateUtils.getDateMillisInFriendlyTimeFormat(lastUpdateTimestamp)).thenReturn("9:35 AM")
         sut = givenAViewModel()
 
-        assertThat(sut.viewState.value.lastUpdateTimestamp).isEqualTo(123456789L)
+        assertThat(sut.viewState.value.lastUpdateTimestamp).isEqualTo("9:35 AM")
     }
 
     @Test
@@ -670,7 +674,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
         whenever(observeLastUpdate.invoke(any())).thenReturn(flowOf())
         sut = givenAViewModel()
 
-        assertThat(sut.viewState.value.lastUpdateTimestamp).isEqualTo(null)
+        assertThat(sut.viewState.value.lastUpdateTimestamp).isEmpty()
     }
 
     private fun givenAResourceProvider(): ResourceProvider = mock {
@@ -689,6 +693,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
             localeProvider,
             feedbackRepository,
             tracker,
+            dateUtils,
             savedState
         )
     }


### PR DESCRIPTION
Summary
==========
Fix issue #9268 by introducing the last update info to the Analytics Hub date range selector. The implementation uses the same strategy introduced inside the My Store view.

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20230728_103959](https://github.com/woocommerce/woocommerce-android/assets/5920403/e93f5176-3ff1-4e54-85ec-51aff16a6089) | ![Screenshot_20230728_102148](https://github.com/woocommerce/woocommerce-android/assets/5920403/464e2351-faaa-4203-af02-7dfe6635ff59) |

How to Test
==========
1. Start a fresh app install and open the Analytics Hub
2. Verify that no last update information is displayed until the first load shows up
3. Verify that the last update is correctly displayed
4. Change the time range selection, verify that again the last update is hidden until the load finishes
5. Verify that the last update is correctly displayed
6. Go back to the previous range selection
7. Verify that the last update is still the one verified in step 3, not step 5.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.