### PR TITLE
Add proguard rules generated by AGP 8.1.0

### DIFF
--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -80,3 +80,59 @@
     fromSavedStateHandle(androidx.lifecycle.SavedStateHandle);
 }
 ###### SavedStateHandleExt - end
+
+# This is generated automatically by the Android Gradle plugin. (8.1.0)
+-dontwarn com.google.auto.service.AutoService
+-dontwarn com.squareup.kotlinpoet.FileSpec
+-dontwarn com.squareup.kotlinpoet.OriginatingElementsHolder$Builder
+-dontwarn com.squareup.kotlinpoet.OriginatingElementsHolder
+-dontwarn java.beans.ConstructorProperties
+-dontwarn java.beans.Transient
+-dontwarn javax.lang.model.SourceVersion
+-dontwarn javax.lang.model.element.AnnotationMirror
+-dontwarn javax.lang.model.element.AnnotationValue
+-dontwarn javax.lang.model.element.AnnotationValueVisitor
+-dontwarn javax.lang.model.element.Element
+-dontwarn javax.lang.model.element.ElementKind
+-dontwarn javax.lang.model.element.ElementVisitor
+-dontwarn javax.lang.model.element.ExecutableElement
+-dontwarn javax.lang.model.element.Modifier
+-dontwarn javax.lang.model.element.Name
+-dontwarn javax.lang.model.element.NestingKind
+-dontwarn javax.lang.model.element.PackageElement
+-dontwarn javax.lang.model.element.QualifiedNameable
+-dontwarn javax.lang.model.element.TypeElement
+-dontwarn javax.lang.model.element.TypeParameterElement
+-dontwarn javax.lang.model.element.VariableElement
+-dontwarn javax.lang.model.type.ArrayType
+-dontwarn javax.lang.model.type.DeclaredType
+-dontwarn javax.lang.model.type.ErrorType
+-dontwarn javax.lang.model.type.ExecutableType
+-dontwarn javax.lang.model.type.IntersectionType
+-dontwarn javax.lang.model.type.NoType
+-dontwarn javax.lang.model.type.NullType
+-dontwarn javax.lang.model.type.PrimitiveType
+-dontwarn javax.lang.model.type.TypeKind
+-dontwarn javax.lang.model.type.TypeMirror
+-dontwarn javax.lang.model.type.TypeVariable
+-dontwarn javax.lang.model.type.TypeVisitor
+-dontwarn javax.lang.model.type.UnionType
+-dontwarn javax.lang.model.type.WildcardType
+-dontwarn javax.lang.model.util.AbstractAnnotationValueVisitor8
+-dontwarn javax.lang.model.util.AbstractElementVisitor8
+-dontwarn javax.lang.model.util.AbstractTypeVisitor8
+-dontwarn javax.lang.model.util.ElementFilter
+-dontwarn javax.lang.model.util.Elements
+-dontwarn javax.lang.model.util.SimpleAnnotationValueVisitor6
+-dontwarn javax.lang.model.util.SimpleAnnotationValueVisitor7
+-dontwarn javax.lang.model.util.SimpleAnnotationValueVisitor8
+-dontwarn javax.lang.model.util.SimpleElementVisitor8
+-dontwarn javax.lang.model.util.SimpleTypeVisitor7
+-dontwarn javax.lang.model.util.SimpleTypeVisitor8
+-dontwarn javax.lang.model.util.Types
+-dontwarn javax.tools.Diagnostic$Kind
+-dontwarn javax.tools.JavaFileObject$Kind
+-dontwarn javax.tools.JavaFileObject
+-dontwarn javax.tools.SimpleJavaFileObject
+-dontwarn org.slf4j.impl.StaticLoggerBinder
+-dontwarn org.slf4j.impl.StaticMDCBinder


### PR DESCRIPTION
After the AGP `8.1.0` update, we started getting `missing classes detected` errors in `minifyVanillaReleaseWithR8` Gradle task. In order to address this failure, AGP generates a `missing_rules.txt` file which has the `dontwarn` statements as added in f480cf9361d6ce9d9e32c1b109e89c7638677ff7.

I don't have much experience with Proguard, but I checked the classes in the list and I couldn't find any usages of them by grepping the names in the code base. This makes sense because I believe AGP's suggestion will keep behavior we had before the update.

Although I am suggesting we merge this PR, I don't have full confidence in it. So if there is anyone with Proguard experience, it'd be good if they check this out. 🤷 

_P.S:_ We had to make similar changes in https://github.com/Automattic/pocket-casts-android/pull/1208 and we did not find any issues with it during testing.

**To Test**

* Verify that `./gradlew bundleVanillaRelease` is successful

_**Full error log:**_
```
[2023-07-31T04:04:46Z] [04:04:46]: â–¸ [35m> Task :WooCommerce:minifyVanillaReleaseWithR8[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mERROR: Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in /var/lib/buildkite-agent/builds/ci-android-i-0cca5055f30ad4db1-1/automattic/woocommerce-android/WooCommerce/build/outputs/mapping/vanillaRelease/missing_rules.txt.[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mERROR: R8: Missing class com.google.auto.service.AutoService (referenced from: dagger.hilt.android.processor.internal.androidentrypoint.AndroidEntryPointProcessor and 14 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class com.squareup.kotlinpoet.FileSpec (referenced from: void dagger.spi.shaded.androidx.room.compiler.processing.XFiler.write(com.squareup.kotlinpoet.FileSpec, dagger.spi.shaded.androidx.room.compiler.processing.XFiler$Mode) and 5 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class com.squareup.kotlinpoet.OriginatingElementsHolder$Builder (referenced from: com.squareup.kotlinpoet.OriginatingElementsHolder$Builder dagger.spi.shaded.androidx.room.compiler.processing.KotlinPoetExtKt.addOriginatingElement(com.squareup.kotlinpoet.OriginatingElementsHolder$Builder, dagger.spi.shaded.androidx.room.compiler.processing.XElement))[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class com.squareup.kotlinpoet.OriginatingElementsHolder (referenced from: void dagger.spi.shaded.androidx.room.compiler.processing.ksp.KspFiler.write(com.squareup.kotlinpoet.FileSpec, dagger.spi.shaded.androidx.room.compiler.processing.XFiler$Mode))[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class java.beans.ConstructorProperties (referenced from: void com.fasterxml.jackson.databind.ext.Java7SupportImpl.<init>() and 2 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class java.beans.Transient (referenced from: void com.fasterxml.jackson.databind.ext.Java7SupportImpl.<init>() and 1 other context)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.SourceVersion (referenced from: com.squareup.javapoet.AnnotationSpec$Builder com.squareup.javapoet.AnnotationSpec$Builder.addMemberForValue(java.lang.String, java.lang.Object) and 34 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.AnnotationMirror (referenced from: javax.lang.model.element.AnnotationMirror dagger.spi.shaded.androidx.room.compiler.processing.javac.JavacAnnotation.mirror and 216 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.AnnotationValue (referenced from: javax.lang.model.element.AnnotationValue dagger.spi.shaded.androidx.room.compiler.processing.javac.JavacAnnotationValue$1.$annotationValue and 264 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.AnnotationValueVisitor (referenced from: javax.lang.model.element.AnnotationValueVisitor dagger.hilt.android.shaded.auto.common.AnnotationOutput.ARRAY_VISITOR and 47 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.Element (referenced from: javax.lang.model.element.Element dagger.hilt.android.shaded.auto.common.MoreTypes$ComparedElements.a and 480 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.ElementKind (referenced from: javax.lang.model.element.ElementKind dagger.hilt.android.shaded.auto.common.Visibility.MODULE and 64 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.ElementVisitor (referenced from: javax.lang.model.element.ElementVisitor dagger.hilt.android.shaded.auto.common.SuperficialValidation.ELEMENT_VALIDATING_VISITOR and 25 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.ExecutableElement (referenced from: javax.lang.model.element.ExecutableElement dagger.hilt.processor.internal.definecomponent.AutoValue_DefineComponentBuilderMetadatas_DefineComponentBuilderMetadata.buildMethod and 239 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.Modifier (referenced from: void com.squareup.javapoet.CodeWriter.emitModifiers(java.util.Set, java.util.Set) and 171 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.Name (referenced from: com.squareup.javapoet.AnnotationSpec$Builder com.squareup.javapoet.AnnotationSpec$Visitor.visitEnumConstant(javax.lang.model.element.VariableElement, java.lang.String) and 126 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.NestingKind (referenced from: dagger.hilt.android.processor.internal.viewmodel.ViewModelMetadata dagger.hilt.android.processor.internal.viewmodel.ViewModelMetadata$Companion.create$java_dagger_hilt_android_processor_internal_viewmodel_processor_lib(javax.annotation.processing.ProcessingEnvironment, javax.lang.model.element.TypeElement) and 9 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.PackageElement (referenced from: com.squareup.javapoet.ClassName com.squareup.javapoet.ClassName$1.visitPackage(javax.lang.model.element.PackageElement, java.lang.Void) and 45 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.QualifiedNameable (referenced from: com.google.common.base.Optional dagger.hilt.android.shaded.auto.common.BasicAnnotationProcessor$ElementName.getElement(javax.lang.model.util.Elements) and 4 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.TypeElement (referenced from: javax.lang.model.element.TypeElement com.squareup.javapoet.ClassName$1.val$element and 609 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.TypeParameterElement (referenced from: com.squareup.javapoet.MethodSpec$Builder com.squareup.javapoet.MethodSpec.overriding(javax.lang.model.element.ExecutableElement) and 34 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.element.VariableElement (referenced from: javax.lang.model.element.VariableElement dagger.hilt.android.processor.internal.bindvalue.AutoValue_BindValueMetadata_BindValueElement.variableElement and 111 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.type.ArrayType (referenced from: javax.lang.model.type.ArrayType dagger.spi.shaded.androidx.room.compiler.processing.javac.JavacArrayType.typeMirror and 92 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.type.DeclaredType (referenced from: javax.lang.model.type.DeclaredType dagger.spi.shaded.androidx.room.compiler.processing.javac.JavacDeclaredType.typeMirror and 205 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.type.ErrorType (referenced from: com.squareup.javapoet.TypeName com.squareup.javapoet.TypeName$1.visitError(javax.lang.model.type.ErrorType, java.lang.Void) and 35 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.type.ExecutableType (referenced from: javax.lang.model.type.ExecutableType dagger.spi.shaded.androidx.room.compiler.processing.javac.JavacExecutableType.executableType and 65 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.type.IntersectionType (referenced from: java.lang.Boolean dagger.hilt.android.shaded.auto.common.MoreTypes$EqualVisitor.visitIntersection(javax.lang.model.type.IntersectionType, dagger.hilt.android.shaded.auto.common.MoreTypes$EqualVisitorParam) and 16 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.type.NoType (referenced from: com.squareup.javapoet.TypeName com.squareup.javapoet.TypeName$1.visitNoType(javax.lang.model.type.NoType, java.lang.Void) and 26 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.type.NullType (referenced from: java.lang.Object dagger.hilt.android.shaded.auto.common.MoreTypes$NullTypeVisitor.visitNull(javax.lang.model.type.NullType, java.lang.Object) and 9 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.type.PrimitiveType (referenced from: com.squareup.javapoet.TypeName com.squareup.javapoet.TypeName$1.visitPrimitive(javax.lang.model.type.PrimitiveType, java.lang.Void) and 34 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.type.TypeKind (referenced from: com.squareup.javapoet.TypeName com.squareup.javapoet.TypeName$1.visitDeclared(javax.lang.model.type.DeclaredType, java.lang.Void) and 107 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.type.TypeMirror (referenced from: javax.lang.model.type.TypeMirror dagger.hilt.android.shaded.auto.common.MoreTypes$EqualVisitorParam.type and 589 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.type.TypeVariable (referenced from: com.squareup.javapoet.MethodSpec$Builder com.squareup.javapoet.MethodSpec.overriding(javax.lang.model.element.ExecutableElement) and 45 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.type.TypeVisitor (referenced from: javax.lang.model.type.TypeVisitor dagger.hilt.android.shaded.auto.common.SuperficialValidation.TYPE_VALIDATING_VISITOR and 69 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.type.UnionType (referenced from: java.lang.Object dagger.spi.shaded.androidx.room.compiler.processing.javac.kotlin.JvmDescriptorTypeVisitor.visitUnion(javax.lang.model.type.UnionType, java.lang.Object) and 1 other context)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.type.WildcardType (referenced from: com.squareup.javapoet.TypeName com.squareup.javapoet.TypeName$1.visitWildcard(javax.lang.model.type.WildcardType, java.lang.Void) and 41 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.util.AbstractAnnotationValueVisitor8 (referenced from: void dagger.spi.shaded.androidx.room.compiler.processing.javac.JavacAnnotationValueKt$UNWRAP_VISITOR$1.<init>() and 1 other context)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.util.AbstractElementVisitor8 (referenced from: void dagger.hilt.android.shaded.auto.common.SuperficialValidation$1.<init>() and 5 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.util.AbstractTypeVisitor8 (referenced from: void dagger.spi.shaded.androidx.room.compiler.processing.javac.kotlin.JvmDescriptorTypeVisitor.<init>() and 1 other context)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.util.ElementFilter (referenced from: com.squareup.javapoet.TypeSpec$Builder com.squareup.javapoet.TypeSpec$Builder.avoidClashesWithNestedClasses(javax.lang.model.element.TypeElement) and 31 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.util.Elements (referenced from: javax.lang.model.util.Elements dagger.hilt.android.shaded.auto.common.BasicAnnotationProcessor.elements and 167 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.util.SimpleAnnotationValueVisitor6 (referenced from: void dagger.spi.shaded.androidx.room.compiler.processing.javac.AnnotationClassVisitor.<init>(dagger.spi.shaded.androidx.room.compiler.processing.javac.JavacProcessingEnv, java.lang.Class) and 47 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.util.SimpleAnnotationValueVisitor7 (referenced from: javax.lang.model.util.SimpleAnnotationValueVisitor7 dagger.hilt.processor.internal.Processors.ENUM_ANNOTATION_VALUE_VISITOR and 18 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.util.SimpleAnnotationValueVisitor8 (referenced from: void com.squareup.javapoet.AnnotationSpec$Visitor.<init>(com.squareup.javapoet.AnnotationSpec$Builder) and 61 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.util.SimpleElementVisitor8 (referenced from: void com.squareup.javapoet.ClassName$1.<init>(java.lang.String, javax.lang.model.element.TypeElement) and 11 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.util.SimpleTypeVisitor7 (referenced from: void dagger.hilt.android.processor.internal.MoreTypes$1.<init>() and 9 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.util.SimpleTypeVisitor8 (referenced from: javax.lang.model.util.SimpleTypeVisitor8 dagger.hilt.processor.internal.ElementDescriptors.JVM_DESCRIPTOR_TYPE_VISITOR and 52 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.lang.model.util.Types (referenced from: javax.lang.model.util.Types dagger.hilt.android.shaded.auto.common.Overrides$ExplicitOverrides.typeUtils and 79 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.tools.Diagnostic$Kind (referenced from: javax.tools.Diagnostic$Kind dagger.internal.codegen.validation.AutoValue_ValidationReport_Item.kind and 105 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.tools.JavaFileObject$Kind (referenced from: void com.squareup.javapoet.JavaFile$2.<init>(com.squareup.javapoet.JavaFile, java.net.URI, javax.tools.JavaFileObject$Kind) and 1 other context)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.tools.JavaFileObject (referenced from: javax.tools.JavaFileObject com.squareup.javapoet.JavaFile.toJavaFileObject() and 2 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class javax.tools.SimpleJavaFileObject (referenced from: void com.squareup.javapoet.JavaFile$2.<init>(com.squareup.javapoet.JavaFile, java.net.URI, javax.tools.JavaFileObject$Kind) and 1 other context)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class org.slf4j.impl.StaticLoggerBinder (referenced from: void org.slf4j.LoggerFactory.bind() and 3 other contexts)[0m
[2023-07-31T04:05:46Z] [04:05:46]: â–¸ [35mMissing class org.slf4j.impl.StaticMDCBinder (referenced from: org.slf4j.spi.MDCAdapter org.slf4j.MDC.bwCompatibleGetMDCAdapterFromBinder())[0m
```
