### PR TITLE
[Customer Search] Optimise countries loading, to not show empty screen on the first screen stat

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListViewModel.kt
@@ -14,6 +14,8 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -53,12 +55,15 @@ class CustomerListViewModel @Inject constructor(
 
     init {
         launch {
-            repository.loadCountries()
             if (isAdvancedSearchSupported()) {
                 _viewState.value = advancedSearchSupportedInitState()
-                loadCustomers(1)
+                awaitAll(
+                    async { loadCustomers(1) },
+                    async { repository.loadCountries() },
+                )
             } else {
                 _viewState.value = advancedSearchNotSupportedInitState()
+                repository.loadCountries()
             }
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListViewModelTest.kt
@@ -92,7 +92,7 @@ class CustomerListViewModelTest : BaseUnitTest() {
     @Test
     fun `given non advanced search mode, when viewmodel init, then loadCountries is called`() = testBlocking {
         // GIVEN
-        whenever(isAdvancedSearchSupported.invoke()).thenReturn(true)
+        whenever(isAdvancedSearchSupported.invoke()).thenReturn(false)
 
         // WHEN
         initViewModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListViewModelTest.kt
@@ -77,6 +77,32 @@ class CustomerListViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given advanced search mode, when viewmodel init, then loadCountries is called`() = testBlocking {
+        // GIVEN
+        whenever(isAdvancedSearchSupported.invoke()).thenReturn(true)
+
+        // WHEN
+        initViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        verify(customerListRepository).loadCountries()
+    }
+
+    @Test
+    fun `given non advanced search mode, when viewmodel init, then loadCountries is called`() = testBlocking {
+        // GIVEN
+        whenever(isAdvancedSearchSupported.invoke()).thenReturn(true)
+
+        // WHEN
+        initViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        verify(customerListRepository).loadCountries()
+    }
+
+    @Test
     fun `when viewmodel init, then viewstate is updated with search modes`() = testBlocking {
         // WHEN
         val viewModel = initViewModel()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9500
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I noticed that if we start the customer search screen the first time on the clean app install and load countries - the screen is empty for some time. This PR fixes that by:
* On WC8+ we perform both (customer list and load countries calls) in parallel
* On WC8- I just show the search screen while loading countries in the background. This may cause issues by missing countries if a user manages to select a customer faster than counties are loaded. This is unlikely, and also this code should slowly be used less and less as people get new WC version, so for now, it should be fine

@rossanafmenezes this issue may be interesting for you to understand, as this touches on parallel work

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* To reproduce the issue everytime just adjust `CustomerListRepository` with
```
    suspend fun loadCountries() = withContext(dispatchers.io) {
        countries = dataStore.getCountries().map { it.toAppModel() }
//        if (countries.isEmpty()) {
            dataStore.fetchCountriesAndStates(selectedSite.get()).model?.let {
                countries = it.map { it.toAppModel() }
            }
//        }
    }
```
* Open the screen (order creation -> add customer details) on both wc8+ and wc8-
* Notice that the screen is interactive right away 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
