### PR TITLE
Analytics Performance: Improve analytics data store documentation and test coverage

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -21,6 +21,14 @@ class AnalyticsUpdateDataStore @Inject constructor(
     private val currentTimeProvider: CurrentTimeProvider,
     private val selectedSite: SelectedSite
 ) {
+    fun shouldUpdateAnalytics(
+        rangeSelection: StatsTimeRangeSelection,
+        maxOutdatedTime: Long = defaultMaxOutdatedTime,
+        analyticData: AnalyticData = AnalyticData.ALL
+    ) = dataStore.data
+        .map { prefs -> prefs[longPreferencesKey(getTimeStampKey(rangeSelection.identifier, analyticData))] }
+        .map { lastUpdateTime -> isElapsedTimeExpired(lastUpdateTime, maxOutdatedTime) }
+
     suspend fun storeLastAnalyticsUpdate(
         rangeSelection: StatsTimeRangeSelection,
         analyticData: AnalyticData = AnalyticData.ALL
@@ -66,14 +74,6 @@ class AnalyticsUpdateDataStore @Inject constructor(
     private fun observeLastUpdate(timestampKey: String): Flow<Long?> {
         return dataStore.data.map { prefs -> prefs[longPreferencesKey(timestampKey)] }
     }
-
-    fun shouldUpdateAnalytics(
-        rangeSelection: StatsTimeRangeSelection,
-        maxOutdatedTime: Long = defaultMaxOutdatedTime,
-        analyticData: AnalyticData = AnalyticData.ALL
-    ) = dataStore.data
-        .map { prefs -> prefs[longPreferencesKey(getTimeStampKey(rangeSelection.identifier, analyticData))] }
-        .map { lastUpdateTime -> isElapsedTimeExpired(lastUpdateTime, maxOutdatedTime) }
 
     private suspend fun storeLastAnalyticsUpdate(timestampKey: String) {
         dataStore.edit { preferences ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -42,6 +42,25 @@ class AnalyticsUpdateDataStore @Inject constructor(
         }
     }
 
+
+    /***
+     * Creates a flow that will emit the latest timestamp stored for a given [rangeSelection] and [analyticData]
+     *
+     * Useful for views that need to always display when the analytics data was last updated.
+     */
+    fun observeLastUpdate(
+        rangeSelection: StatsTimeRangeSelection,
+        analyticData: AnalyticData
+    ): Flow<Long?> {
+        val timestampKeys = getTimeStampKey(rangeSelection.identifier, analyticData)
+        return observeLastUpdate(timestampKeys)
+    }
+
+    /***
+     * Creates a flow that will emit the latest timestamp stored for a given [rangeSelection] and list of [analyticData]
+     *
+     * Useful for views that need to always display when the analytics data was last updated.
+     */
     fun observeLastUpdate(
         rangeSelection: StatsTimeRangeSelection,
         analyticData: List<AnalyticData>
@@ -49,14 +68,6 @@ class AnalyticsUpdateDataStore @Inject constructor(
         val timestampKeys = analyticData.map { data ->
             getTimeStampKey(rangeSelection.identifier, data)
         }
-        return observeLastUpdate(timestampKeys)
-    }
-
-    fun observeLastUpdate(
-        rangeSelection: StatsTimeRangeSelection,
-        analyticData: AnalyticData
-    ): Flow<Long?> {
-        val timestampKeys = getTimeStampKey(rangeSelection.identifier, analyticData)
         return observeLastUpdate(timestampKeys)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -16,6 +16,10 @@ import kotlinx.coroutines.flow.map
 import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import javax.inject.Inject
 
+/***
+ * Data store responsible for signaling when the analytics data should be updated
+ * through stored timestamp.
+ */
 class AnalyticsUpdateDataStore @Inject constructor(
     @DataStoreQualifier(DataStoreType.ANALYTICS) private val dataStore: DataStore<Preferences>,
     private val currentTimeProvider: CurrentTimeProvider,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -21,6 +21,13 @@ class AnalyticsUpdateDataStore @Inject constructor(
     private val currentTimeProvider: CurrentTimeProvider,
     private val selectedSite: SelectedSite
 ) {
+    /***
+     * Creates a flow that will emit true if the analytics data should be updated.
+     *
+     * The decision is based on the [rangeSelection] and [maxOutdatedTime] parameters.
+     *
+     * If no [maxOutdatedTime] is provided, the [defaultMaxOutdatedTime] value will be used.
+     */
     fun shouldUpdateAnalytics(
         rangeSelection: StatsTimeRangeSelection,
         maxOutdatedTime: Long = defaultMaxOutdatedTime,
@@ -29,6 +36,11 @@ class AnalyticsUpdateDataStore @Inject constructor(
         .map { prefs -> prefs[longPreferencesKey(getTimeStampKey(rangeSelection.identifier, analyticData))] }
         .map { lastUpdateTime -> isElapsedTimeExpired(lastUpdateTime, maxOutdatedTime) }
 
+    /***
+     * Stores the current timestamp for a given [rangeSelection] and [analyticData]
+     *
+     * Will trigger a update to anyone listening to [AnalyticsUpdateDataStore.observeLastUpdate]
+     */
     suspend fun storeLastAnalyticsUpdate(
         rangeSelection: StatsTimeRangeSelection,
         analyticData: AnalyticData = AnalyticData.ALL

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -58,7 +58,6 @@ class AnalyticsUpdateDataStore @Inject constructor(
         }
     }
 
-
     /***
      * Creates a flow that will emit the latest timestamp stored for a given [rangeSelection] and [analyticData]
      *

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
@@ -9,6 +9,8 @@ import com.woocommerce.android.ui.mystore.domain.asRangeSelection
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.single
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -22,8 +24,6 @@ import org.wordpress.android.fluxc.utils.CurrentTimeProvider
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 
 @ExperimentalCoroutinesApi
 class AnalyticsUpdateDataStoreTest : BaseUnitTest() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
@@ -141,26 +141,17 @@ class AnalyticsUpdateDataStoreTest : BaseUnitTest() {
             currentTimestamp = 2000
         )
 
+        // When
         sut.observeLastUpdate(
             rangeSelection = defaultSelectionData,
-            analyticData = AnalyticsUpdateDataStore.AnalyticData.ALL
+            analyticData = AnalyticsUpdateDataStore.AnalyticData.REVENUE
         ).onEach {
             timestampUpdate = it
         }.launchIn(this)
 
-        // When
-        sut.storeLastAnalyticsUpdate(
-            rangeSelection = defaultSelectionData,
-            analyticData = AnalyticsUpdateDataStore.AnalyticData.ALL
-        )
-
         // Then
         assertThat(timestampUpdate).isNotNull()
         assertThat(timestampUpdate).isEqualTo(2000)
-    }
-
-    @Test
-    fun `given a range selection timestamp is updated, then last update observation emits new value for all analyticData types`() = testBlocking {
     }
 
     private fun createAnalyticsUpdateScenarioWith(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
@@ -133,12 +133,10 @@ class AnalyticsUpdateDataStoreTest : BaseUnitTest() {
 
     @Test
     fun `given a range selection timestamp is updated, then last update observation emits new value`() = testBlocking {
-
     }
 
     @Test
     fun `given a range selection timestamp is updated, then last update observation emits new value for all analyticData types`() = testBlocking {
-
     }
 
     private fun createAnalyticsUpdateScenarioWith(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
@@ -195,20 +195,13 @@ class AnalyticsUpdateDataStoreTest : BaseUnitTest() {
             on { data } doReturn flowOf(analyticsPreferences)
         }
 
-        val mockDate = mock<Date> {
-            on { time } doReturn currentTimestamp
-        }
-        currentTimeProvider = mock {
-            on { currentDate() } doReturn mockDate
-        }
-
         val selectedSite: SelectedSite = mock {
             on { getSelectedSiteId() } doReturn 1
         }
 
         sut = AnalyticsUpdateDataStore(
             dataStore = dataStore,
-            currentTimeProvider = currentTimeProvider,
+            currentTimeProvider = mock(),
             selectedSite = selectedSite
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
@@ -131,6 +131,16 @@ class AnalyticsUpdateDataStoreTest : BaseUnitTest() {
         verify(dataStore, times(numberOfAnalyticsDataKeys)).edit(any())
     }
 
+    @Test
+    fun `given a range selection timestamp is updated, then last update observation emits new value`() = testBlocking {
+
+    }
+
+    @Test
+    fun `given a range selection timestamp is updated, then last update observation emits new value for all analyticData types`() = testBlocking {
+
+    }
+
     private fun createAnalyticsUpdateScenarioWith(
         lastUpdateTimestamp: Long?,
         currentTimestamp: Long


### PR DESCRIPTION
Summary
==========
A simple update of the recent Date Store adding documentation and a pending unit test, given how specific the Data Store purpose is.


How to Test
==========
1. Simply make sure the unit tests are green and the documentations makes sense.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.