### PR TITLE
Analytics Performance: Improve last update for old timestamps

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.drop
@@ -57,8 +58,6 @@ import javax.inject.Inject
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState as ProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.LoadingViewState as LoadingProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.NoDataState as ProductsNoDataState
-import com.woocommerce.android.extensions.formatToYYYYmmDDhhmmss
-import kotlinx.coroutines.Job
 
 @HiltViewModel
 class AnalyticsHubViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -284,11 +284,7 @@ class AnalyticsHubViewModel @Inject constructor(
         mutableState.value = viewState.value.copy(lastUpdateTimestamp = "")
         lastUpdateObservationJob = observeLastUpdate(timeRangeSelection = rangeSelectionState.value)
             .filterNotNull()
-            .map {
-                val lastUpdate = Date(it)
-                if (dateUtils.isToday(lastUpdate)) dateUtils.getDateMillisInFriendlyTimeFormat(it)
-                else dateUtils.getDayMonthDateString(lastUpdate.formatToYYYYmmDDhhmmss())
-            }
+            .map { dateUtils.getDateOrTimeFromMillis(it) }
             .onEach { mutableState.value = viewState.value.copy(lastUpdateTimestamp = it.orEmpty()) }
             .launchIn(viewModelScope)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -57,6 +57,7 @@ import javax.inject.Inject
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState as ProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.LoadingViewState as LoadingProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.NoDataState as ProductsNoDataState
+import com.woocommerce.android.extensions.formatToYYYYmmDDhhmmss
 import kotlinx.coroutines.Job
 
 @HiltViewModel
@@ -283,8 +284,11 @@ class AnalyticsHubViewModel @Inject constructor(
         mutableState.value = viewState.value.copy(lastUpdateTimestamp = "")
         lastUpdateObservationJob = observeLastUpdate(timeRangeSelection = rangeSelectionState.value)
             .filterNotNull()
-            .map { dateUtils.getDateMillisInFriendlyTimeFormat(it) }
-            .onEach { mutableState.value = viewState.value.copy(lastUpdateTimestamp = it) }
+            .map {
+                if (dateUtils.isToday(Date(it))) dateUtils.getDateMillisInFriendlyTimeFormat(it)
+                else dateUtils.getDayMonthDateString(Date(it).formatToYYYYmmDDhhmmss())
+            }
+            .onEach { mutableState.value = viewState.value.copy(lastUpdateTimestamp = it.orEmpty()) }
             .launchIn(viewModelScope)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -285,8 +285,9 @@ class AnalyticsHubViewModel @Inject constructor(
         lastUpdateObservationJob = observeLastUpdate(timeRangeSelection = rangeSelectionState.value)
             .filterNotNull()
             .map {
-                if (dateUtils.isToday(Date(it))) dateUtils.getDateMillisInFriendlyTimeFormat(it)
-                else dateUtils.getDayMonthDateString(Date(it).formatToYYYYmmDDhhmmss())
+                val lastUpdate = Date(it)
+                if (dateUtils.isToday(lastUpdate)) dateUtils.getDateMillisInFriendlyTimeFormat(it)
+                else dateUtils.getDayMonthDateString(lastUpdate.formatToYYYYmmDDhhmmss())
             }
             .onEach { mutableState.value = viewState.value.copy(lastUpdateTimestamp = it.orEmpty()) }
             .launchIn(viewModelScope)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -57,6 +57,7 @@ import javax.inject.Inject
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState as ProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.LoadingViewState as LoadingProductsViewState
 import com.woocommerce.android.ui.analytics.hub.listcard.AnalyticsHubListViewState.NoDataState as ProductsNoDataState
+import kotlinx.coroutines.Job
 
 @HiltViewModel
 class AnalyticsHubViewModel @Inject constructor(
@@ -104,6 +105,8 @@ class AnalyticsHubViewModel @Inject constructor(
 
     private val ranges
         get() = rangeSelectionState.value
+
+    private var lastUpdateObservationJob: Job? = null
 
     init {
         observeOrdersStatChanges()
@@ -276,8 +279,9 @@ class AnalyticsHubViewModel @Inject constructor(
     }
 
     private fun observeLastUpdateTimestamp() {
+        lastUpdateObservationJob?.cancel()
         mutableState.value = viewState.value.copy(lastUpdateTimestamp = "")
-        observeLastUpdate(timeRangeSelection = rangeSelectionState.value)
+        lastUpdateObservationJob = observeLastUpdate(timeRangeSelection = rangeSelectionState.value)
             .filterNotNull()
             .map { dateUtils.getDateMillisInFriendlyTimeFormat(it) }
             .onEach { mutableState.value = viewState.value.copy(lastUpdateTimestamp = it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -432,7 +432,7 @@ class MyStoreStatsView @JvmOverloads constructor(
 
     fun showLastUpdate(lastUpdateMillis: Long?) {
         if (lastUpdateMillis != null) {
-            val lastUpdateFormatted = dateUtils.getDateMillisInFriendlyTimeFormat(lastUpdateMillis)
+            val lastUpdateFormatted = dateUtils.getDateOrTimeFromMillis(lastUpdateMillis)
             lastUpdated.isVisible = true
             fadeInLabelValue(
                 lastUpdated,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopPerformersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopPerformersView.kt
@@ -97,7 +97,7 @@ class MyStoreTopPerformersView @JvmOverloads constructor(
 
     fun showLastUpdate(lastUpdateMillis: Long?) {
         if (lastUpdateMillis != null) {
-            val lastUpdateFormatted = dateUtils.getDateMillisInFriendlyTimeFormat(lastUpdateMillis)
+            val lastUpdateFormatted = dateUtils.getDateOrTimeFromMillis(lastUpdateMillis)
             lastUpdated.isVisible = true
             lastUpdated.text = String.format(
                 Locale.getDefault(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.text.format.DateFormat
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.extensions.formatToYYYYmmDD
-import com.woocommerce.android.extensions.formatToYYYYmmDDhhmmss
 import com.woocommerce.android.util.WooLog.T.UTILS
 import org.apache.commons.lang3.time.DateUtils
 import java.text.DateFormatSymbols
@@ -375,7 +374,7 @@ class DateUtils @Inject constructor(
         return if (isToday(date)) {
             getDateMillisInFriendlyTimeFormat(millis)
         } else {
-            getDayMonthDateString(date.formatToYYYYmmDDhhmmss())
+            getDayMonthDateString(date.formatToYYYYmmDD())
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -364,6 +364,13 @@ class DateUtils @Inject constructor(
             null
         }
 
+    fun isToday(date: Date): Boolean {
+        val todayStart = getDateForTodayAtTheStartOfTheDay()
+        return isSameDay(date, Date(todayStart))
+    }
+
+    fun isSameDay(date1: Date, date2: Date) = DateUtils.isSameDay(date1,date2)
+
     companion object {
         const val ZERO = 0
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.text.format.DateFormat
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.extensions.formatToYYYYmmDD
+import com.woocommerce.android.extensions.formatToYYYYmmDDhhmmss
 import com.woocommerce.android.util.WooLog.T.UTILS
 import org.apache.commons.lang3.time.DateUtils
 import java.text.DateFormatSymbols
@@ -370,6 +371,15 @@ class DateUtils @Inject constructor(
     }
 
     fun isSameDay(date1: Date, date2: Date) = DateUtils.isSameDay(date1,date2)
+
+    fun getDateOrTimeFromMillis(millis: Long): String? {
+        val date = Date(millis)
+        return if (isToday(date)) {
+            getDateMillisInFriendlyTimeFormat(millis)
+        } else {
+            getDayMonthDateString(date.formatToYYYYmmDDhhmmss())
+        }
+    }
 
     companion object {
         const val ZERO = 0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -365,13 +365,11 @@ class DateUtils @Inject constructor(
             null
         }
 
-    fun isToday(date: Date): Boolean {
-        val todayStart = getDateForTodayAtTheStartOfTheDay()
-        return isSameDay(date, Date(todayStart))
-    }
-
-    fun isSameDay(date1: Date, date2: Date) = DateUtils.isSameDay(date1,date2)
-
+    /***
+     * Will generate a formatted date string in two possible formats:
+     * 1. If the date is today, it will return the time in the format h:mm a
+     * 2. If the date is not today, it will return the date in the format MMM dd, yyyy
+     */
     fun getDateOrTimeFromMillis(millis: Long): String? {
         val date = Date(millis)
         return if (isToday(date)) {
@@ -379,6 +377,11 @@ class DateUtils @Inject constructor(
         } else {
             getDayMonthDateString(date.formatToYYYYmmDDhhmmss())
         }
+    }
+
+    private fun isToday(date: Date): Boolean {
+        val todayStart = getDateForTodayAtTheStartOfTheDay()
+        return DateUtils.isSameDay(date, Date(todayStart))
     }
 
     companion object {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -149,7 +149,7 @@
     <string name="tip">Tip</string>
     <string name="hide_password_content_description">Hide password</string>
     <string name="show_password_content_description">Show password</string>
-    <string name="last_update">Last update %s</string>
+    <string name="last_update">Last update: %s</string>
     <string name="last_update_with_frequency">Last update %s (Updates every 30 minutes)</string>
 
     <!--

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
@@ -663,7 +663,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
     fun `when last update information changes, then update view state as expected`() = testBlocking {
         val lastUpdateTimestamp = 123456789L
         whenever(observeLastUpdate.invoke(any())).thenReturn(flowOf(lastUpdateTimestamp))
-        whenever(dateUtils.getDateMillisInFriendlyTimeFormat(lastUpdateTimestamp)).thenReturn("9:35 AM")
+        whenever(dateUtils.getDateOrTimeFromMillis(lastUpdateTimestamp)).thenReturn("9:35 AM")
         sut = givenAViewModel()
 
         assertThat(sut.viewState.value.lastUpdateTimestamp).isEqualTo("9:35 AM")


### PR DESCRIPTION
Summary
==========
Fix the scenario where the last update info is from one day ago or more and can be misleading by showing just the time. This way, when the app is reopened only in the next day or more, the `last update` label will display the date instead of the time while the new stats are loading from the network request. With that said, the last update timestamp is from today's date, we still show the time. Otherwise, we display the date.

This change covers both My Store and Analytics Hub last update labels.

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20230802_164000](https://github.com/woocommerce/woocommerce-android/assets/5920403/d6aa9a75-1885-4d0e-872c-a93d7e85726f) | ![Screenshot_20230802_163423](https://github.com/woocommerce/woocommerce-android/assets/5920403/1102f6fb-f191-4f04-9270-c7c944177e96) |

How to Test
==========
This is a hard-to-reproduce test scenario, to reproduce it naturally, it would require waiting a full day to reopen the app and check the `last update` label displaying the day before the date as the `last update` info. So to make things easier, I recommend doing the following:
1. Open the My Store and Analytics Hub, and wait for the stats to load and the `last update` label to be updated with the current time. Verify everything works as before.
2. Close the app.
3. Go to the device settings and manually set the device time to tomorrow.
4. Go back to the app My Store and Analytics Hub, verify that the `last update` label now shows the Date instead of time, correctly telling to our users that the current data is very old (and will be under a refresh already).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
