### PR TITLE
Feature/new default properties site info

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 14.8
 - [*] [Internal] Fix crash happening while collecting IPP when switching payment gateways [https://github.com/woocommerce/woocommerce-android/pull/9492]
 - [*] Added coupon creation feature [https://github.com/woocommerce/woocommerce-android/pull/9474]
+- [*] [Internal] now add `was_ecommerce_trial` and `plan_product_slug` for default tracking on logged-in state [https://github.com/woocommerce/woocommerce-android/pull/9514]
 
 14.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -87,6 +87,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
             site?.let {
                 finalProperties[KEY_BLOG_ID] = it.siteId
                 finalProperties[KEY_IS_WPCOM_STORE] = it.isWpComStore
+                finalProperties[KEY_WAS_ECOMMERCE_TRIAL] = it.wasEcommerceTrial
+                finalProperties[KEY_PLAN_PRODUCT_SLUG] = it.planProductSlug
             }
         }
         finalProperties[IS_DEBUG] = BuildConfig.DEBUG
@@ -276,6 +278,9 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_TIME_ELAPSED_SINCE_CARD_COLLECT_PAYMENT_IN_MILLIS = "milliseconds_since_card_collect_payment_flow"
 
         const val KEY_COUPONS_COUNT = "coupons_count"
+
+        const val KEY_WAS_ECOMMERCE_TRIAL = "was_ecommerce_trial"
+        const val KEY_PLAN_PRODUCT_SLUG = "plan_product_slug"
 
         enum class OrderNoteType(val value: String) {
             CUSTOMER("customer"),

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2790-c519a369c40d0ae57fb1cc5e3300af02ecfd8c86'
+    fluxCVersion = 'trunk-c9c2b55e5b0a392a34acb2a5fc06d25c983d4ae6'
     wooCommerceSharedVersion = 'trunk-09b36638186095b54a31aa3bdedac9d39e5438da'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.39.0'
+    fluxCVersion = '2790-c519a369c40d0ae57fb1cc5e3300af02ecfd8c86'
     wooCommerceSharedVersion = 'trunk-09b36638186095b54a31aa3bdedac9d39e5438da'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: https://github.com/woocommerce/woocommerce-android/issues/9513
<!-- Id number of the GitHub issue this PR addresses. -->

Please do not merge until https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2790/ is merged, and the FluxC version here is updated.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds `was_ecommerce_trial` and `plan_product_slug` as a default tracked properties on logged in state.

Example in logcat:

```
🔵 Tracked: main_tab_orders_selected, Properties: {"blog_id":211272157,"is_wpcom_store":true,"was_ecommerce_trial":false,"plan_product_slug":"business-bundle","is_debug":true}
```

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in to a WooExpress store (free trial or already upgraded) - notice that there's a new property `was_ecommerce_trial` in every event with value `true` and `plan_product_slug` is `ecommerce-trial-bundle-monthly`
- Switch to a self-hosted or ordinary WPCom store, `was_ecommerce_trial` should be tracked as `false`.
- Log out of the app, `was_ecommerce_trial` and `plan_product_slug` should not be tracked at all.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
