### PR TITLE
Fix disabling / enabling editable controls

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 14.8
 - [*] [Internal] Fix crash happening while collecting IPP when switching payment gateways [https://github.com/woocommerce/woocommerce-android/pull/9492]
 - [*] Added coupon creation feature [https://github.com/woocommerce/woocommerce-android/pull/9474]
+- [*] [Internal] Fixed logic disabling editable controls in order creation/edit form [https://github.com/woocommerce/woocommerce-android/pull/9515]
 
 14.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
@@ -28,8 +28,18 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
     var isEachAddButtonEnabled
         get() = binding.addButtonsLayout.children.all { it.isEnabled }
         set(value) {
+            fun View.adjustState(isEnabled: Boolean) {
+                if (this is ViewGroup) {
+                    this.children.forEach {
+                        it.adjustState(isEnabled)
+                    }
+                } else {
+                    this.isEnabled = isEnabled
+                }
+            }
+
             binding.addButtonsLayout.children.forEach {
-                it.isEnabled = value
+                it.adjustState(value)
             }
         }
 


### PR DESCRIPTION
### Fix for disabling / enabling editable controls in order create/edit form

When the "Scan" button was introduced next to the "+ Add products" a new container `ViewGroup` was created holding both buttons. However, the logic of updating the enabled/disabled state of the buttons was not updated. As a result, the container was being enabled/disabled instead of the buttons themselves.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Take the simple payment and go to the orders
2. Open the latest order and edit it
3. Observe it's not possible to add a product to the order anymore

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Before | After |
| ---- | ---- |
| <video src=https://github.com/woocommerce/woocommerce-android/assets/4527432/f4407d43-7adc-47d9-9f6e-c5ff2011a5fb/> | <video src=https://github.com/woocommerce/woocommerce-android/assets/4527432/af088d84-edb1-4ddc-a369-f6f9a4491bcf/> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
