### PR TITLE
My Store revenue with revenue id

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsRepository.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.analytics.hub.sync
 
 import com.woocommerce.android.extensions.adminUrlOrDefault
-import com.woocommerce.android.extensions.formatToYYYYmmDD
 import com.woocommerce.android.extensions.formatToYYYYmmDDhhmmss
 import com.woocommerce.android.model.DeltaPercentage
 import com.woocommerce.android.model.OrdersStat
@@ -23,6 +22,7 @@ import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.Selec
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.WEEK_TO_DATE
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.YEAR_TO_DATE
 import com.woocommerce.android.ui.mystore.data.StatsRepository
+import com.woocommerce.android.ui.mystore.data.asRevenueRangeId
 import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
@@ -370,12 +370,6 @@ class AnalyticsRepository @Inject constructor(
         private val timeRange: AnalyticsHubTimeRange,
         private val selectionType: SelectionType
     ) {
-        val id: Int
-
-        init {
-            val startDateString = timeRange.start.formatToYYYYmmDD()
-            val endDateString = timeRange.end.formatToYYYYmmDD()
-            id = "${selectionType.identifier}$startDateString$endDateString".hashCode()
-        }
+        val id: Int = selectionType.identifier.asRevenueRangeId(timeRange.start, timeRange.end)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/data/StatsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/data/StatsRepository.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.mystore.data
 
 import com.woocommerce.android.AppConstants
 import com.woocommerce.android.WooException
+import com.woocommerce.android.extensions.formatToYYYYmmDD
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog
@@ -30,6 +31,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsError
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.utils.DateUtils
+import java.util.Date
 import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
@@ -365,4 +367,13 @@ class StatsRepository @Inject constructor(
             message = this.message
         )
     }
+}
+
+fun String.asRevenueRangeId(
+    startDate: Date,
+    endDate: Date
+): Int {
+    val startDateString = startDate.formatToYYYYmmDD()
+    val endDateString = endDate.formatToYYYYmmDD()
+    return "$this$startDateString$endDateString".hashCode()
 }


### PR DESCRIPTION
### Description
This PR introduces the use of the new revenue id to the GetStats Use Case. With this change the My Stats analytics will rely also on the DB cache and ensure making a fetch request only when necessary.

### Testing instructions
TC1
1. Open the My Store Screen
2. Open All stats tabs
3. Open All stats tabs for a second time
4. Check that all tab's revenue data is fetched from the cache and that no fetch request is made

TC2 
1. Run TC1
2. Close the app
3. Reopen the app
4. Open All stats tabs
5. Check that all tab's revenue data is fetched from the cache and that no fetch request is made

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/3d569480-1951-4613-b534-25012e49e5ca

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
