### PR TITLE
[Customer Search] Fix for a bug when customer selected from the list and then edited then the details are not prefilled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomerAddFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomerAddFragment.kt
@@ -273,7 +273,9 @@ class OrderCreateEditCustomerAddFragment :
     override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()
 
-        if (editingOfAddedCustomer.editingOfAddedCustomer) {
+        if (editingOfAddedCustomer.editingOfAddedCustomer &&
+            sharedViewModel.mode == OrderCreateEditViewModel.Mode.Creation
+        ) {
             menu.add(
                 Menu.NONE,
                 MENU_ITEM_DELETE_ID,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomerAddFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomerAddFragment.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.ui.orders.details.editing.address.AddressViewMode
 import com.woocommerce.android.ui.orders.details.editing.address.AddressViewModel.ShowStateSelector
 import com.woocommerce.android.ui.orders.details.editing.address.LocationCode
 import com.woocommerce.android.ui.searchfilter.SearchFilterItem
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -274,7 +275,7 @@ class OrderCreateEditCustomerAddFragment :
         menu.clear()
 
         if (editingOfAddedCustomer.editingOfAddedCustomer &&
-            sharedViewModel.mode == OrderCreateEditViewModel.Mode.Creation
+            FeatureFlag.BETTER_CUSTOMER_SEARCH_M2.isEnabled()
         ) {
             menu.add(
                 Menu.NONE,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListFragment.kt
@@ -52,6 +52,11 @@ class CustomerListFragment : BaseFragment() {
                         billingAddress = event.billingAddress,
                         shippingAddress = event.shippingAddress
                     )
+                    addressViewModel.onAddressesChanged(
+                        customerId = event.customerId,
+                        billingAddress = event.billingAddress,
+                        shippingAddress = event.shippingAddress
+                    )
 
                     findNavController().popBackStack(R.id.orderCreationFragment, false)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -245,7 +245,7 @@ class AddressViewModel @Inject constructor(
         billingAddress: Address,
         shippingAddress: Address
     ) {
-        clearSelectedAddress()
+        hasStarted = true
         viewState = viewState.copy(
             customerId = customerId,
             addressSelectionStates = mapOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -245,7 +245,7 @@ class AddressViewModel @Inject constructor(
         billingAddress: Address,
         shippingAddress: Address
     ) {
-        hasStarted = true
+        clearSelectedAddress()
         viewState = viewState.copy(
             customerId = customerId,
             addressSelectionStates = mapOf(
@@ -267,6 +267,7 @@ class AddressViewModel @Inject constructor(
             AddressType.BILLING to Address.EMPTY,
             AddressType.SHIPPING to Address.EMPTY,
         )
+        viewState = ViewState()
         initialize(initialState)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -30,7 +30,8 @@ enum class FeatureFlag {
     BLAZE,
     PRODUCT_DESCRIPTION_AI_GENERATOR,
     ORDER_CREATION_PRODUCT_DISCOUNTS,
-    SHIPPING_ZONES;
+    SHIPPING_ZONES,
+    BETTER_CUSTOMER_SEARCH_M2;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -61,7 +62,9 @@ enum class FeatureFlag {
             SHIPPING_ZONES -> true
 
             MORE_MENU_INBOX,
-            WC_SHIPPING_BANNER -> PackageUtils.isDebugBuild()
+            WC_SHIPPING_BANNER,
+            BETTER_CUSTOMER_SEARCH_M2,
+            -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModelTest.kt
@@ -289,11 +289,12 @@ class AddressViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when clearSelectedAddress, then initialise with empty address`() {
+    fun `when clearSelectedAddress, then initialise with empty address`() = testBlocking {
         addressViewModel.clearSelectedAddress()
 
         assertThat(addressViewModel.viewStateData.liveData.value).isEqualTo(
             ViewState(
+                customerId = null,
                 addressSelectionStates = mapOf(
                     BILLING to AddressSelectionState(
                         address = Address.EMPTY,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9517
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes 2 issues:
* If "add manually details" screen visited, then when you "edit" added customer then fields are not prefilled
* Removes "delete" button from the customer details screen as Fluxc doesn't support fully removing customer (it replaces empty email with null so it won't be updated with empty field)

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
**Before**

https://github.com/woocommerce/woocommerce-android/assets/4923871/4079ba96-bbd7-405e-9993-8e432b966ebb

**After**

https://github.com/woocommerce/woocommerce-android/assets/4923871/8e759fab-5681-4386-95e3-d55af99abd8a



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
