### PR TITLE
Add go to coupon list tracker

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -315,6 +315,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     ORDER_COUPON_ADD,
     ORDER_COUPON_REMOVE,
     ORDER_COUPON_UPDATE,
+    ORDER_GO_TO_COUPON_LIST_TAPPED,
 
     // -- Order discount
     ORDER_PRODUCT_DISCOUNT_ADD,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -315,7 +315,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     ORDER_COUPON_ADD,
     ORDER_COUPON_REMOVE,
     ORDER_COUPON_UPDATE,
-    ORDER_GO_TO_COUPON_LIST_TAPPED,
+    ORDER_GO_TO_COUPON_BUTTON_TAPPED,
 
     // -- Order discount
     ORDER_PRODUCT_DISCOUNT_ADD,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorFragment.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
@@ -50,6 +52,7 @@ class CouponSelectorFragment : BaseFragment() {
                     findNavController().navigateSafely(
                         CouponSelectorFragmentDirections.actionCouponSelectorFragmentToCouponListFragment()
                     )
+                    AnalyticsTracker.track(AnalyticsEvent.ORDER_GO_TO_COUPON_LIST_TAPPED)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorFragment.kt
@@ -50,7 +50,6 @@ class CouponSelectorFragment : BaseFragment() {
                     findNavController().navigateSafely(
                         CouponSelectorFragmentDirections.actionCouponSelectorFragmentToCouponListFragment()
                     )
-//                    AnalyticsTracker.track(AnalyticsEvent.ORDER_GO_TO_COUPON_LIST_TAPPED)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorFragment.kt
@@ -9,8 +9,6 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
-import com.woocommerce.android.analytics.AnalyticsEvent
-import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
@@ -52,7 +50,7 @@ class CouponSelectorFragment : BaseFragment() {
                     findNavController().navigateSafely(
                         CouponSelectorFragmentDirections.actionCouponSelectorFragmentToCouponListFragment()
                     )
-                    AnalyticsTracker.track(AnalyticsEvent.ORDER_GO_TO_COUPON_LIST_TAPPED)
+//                    AnalyticsTracker.track(AnalyticsEvent.ORDER_GO_TO_COUPON_LIST_TAPPED)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorViewModel.kt
@@ -107,7 +107,7 @@ class CouponSelectorViewModel @Inject constructor(
 
     fun onEmptyScreenButtonClicked() {
         triggerEvent(NavigateToCouponList)
-        analyticsTrackerWrapper.track(AnalyticsEvent.ORDER_GO_TO_COUPON_LIST_TAPPED)
+        analyticsTrackerWrapper.track(AnalyticsEvent.ORDER_GO_TO_COUPON_BUTTON_TAPPED)
     }
     private fun fetchCoupons() = launch {
         loadingState.value = LoadingState.Loading

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.coupons.CouponListHandler
@@ -33,6 +35,7 @@ class CouponSelectorViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     private val couponListHandler: CouponListHandler,
     private val couponUtils: CouponUtils,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedState) {
 
     companion object {
@@ -104,6 +107,7 @@ class CouponSelectorViewModel @Inject constructor(
 
     fun onEmptyScreenButtonClicked() {
         triggerEvent(NavigateToCouponList)
+        analyticsTrackerWrapper.track(AnalyticsEvent.ORDER_GO_TO_COUPON_LIST_TAPPED)
     }
     private fun fetchCoupons() = launch {
         loadingState.value = LoadingState.Loading

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.coupons.CouponListHandler
 import com.woocommerce.android.ui.coupons.CouponListItem


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Please do not merge until target base is `Trunk` 

Closes: #9523
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Add tracker for the Go To Coupon List Event button tapped from the empty coupon selector list

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Log into a store that has no coupons added
2. go to the orders tab
3. add new order
4. add a product
5. tap on Add coupon
6. Tap the Go to Coupon List button
7. make sure the event is tracked

```
Tracked: order_go_to_coupon_list_tapped, Properties: {"blog_id":221646855,"is_wpcom_store":true,"was_ecommerce_trial":false,"plan_product_slug":"business-bundle","is_debug":true}
```

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="1253" alt="Screenshot 2023-08-04 at 1 16 34 PM" src="https://github.com/woocommerce/woocommerce-android/assets/30724184/eb5cd05f-a314-4afc-9c05-57fce9e40efc">

I'll add all the tests on a separate PR
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
