### PR TITLE
Refactor `updateSelectedSite` task - don't reset site data

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -36,6 +36,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboa
 import com.woocommerce.android.util.AppThemeUtils
 import com.woocommerce.android.util.ApplicationLifecycleMonitor
 import com.woocommerce.android.util.ApplicationLifecycleMonitor.ApplicationLifecycleListener
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.REGEX_API_JETPACK_TUNNEL_METHOD
 import com.woocommerce.android.util.REGEX_API_NUMERIC_PARAM
@@ -204,7 +205,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         }
 
         if (networkStatus.isConnected()) {
-            updateSelectedSite.runIfNotLimited()
+            if (FeatureFlag.SITE_CHECK_TASK.isEnabled()) updateSelectedSite.runIfNotLimited()
 
             appCoroutineScope.launch {
                 registerDevice(IF_NEEDED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -131,8 +131,6 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
                     wooCommerceStore.fetchWooCommerceSite(it).let {
                         if (it.model?.hasWooCommerce == false) {
                             // The previously selected site is not connected anymore, take the user to the site picker
-                            WooLog.w(T.LOGIN, "Selected site no longer has WooCommerce")
-                            selectedSite.reset()
                             restartMainActivity()
                         }
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -130,7 +130,6 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
                 appCoroutineScope.launch {
                     wooCommerceStore.fetchWooCommerceSite(it).let {
                         if (it.model?.hasWooCommerce == false) {
-                            // The previously selected site is not connected anymore, take the user to the site picker
                             restartMainActivity()
                         }
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -36,7 +36,6 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboa
 import com.woocommerce.android.util.AppThemeUtils
 import com.woocommerce.android.util.ApplicationLifecycleMonitor
 import com.woocommerce.android.util.ApplicationLifecycleMonitor.ApplicationLifecycleListener
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.REGEX_API_JETPACK_TUNNEL_METHOD
 import com.woocommerce.android.util.REGEX_API_NUMERIC_PARAM
@@ -205,7 +204,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         }
 
         if (networkStatus.isConnected()) {
-            if (FeatureFlag.SITE_CHECK_TASK.isEnabled()) updateSelectedSite.runIfNotLimited()
+            updateSelectedSite.runIfNotLimited()
 
             appCoroutineScope.launch {
                 registerDevice(IF_NEEDED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -31,7 +31,8 @@ enum class FeatureFlag {
     PRODUCT_DESCRIPTION_AI_GENERATOR,
     ORDER_CREATION_PRODUCT_DISCOUNTS,
     SHIPPING_ZONES,
-    BETTER_CUSTOMER_SEARCH_M2;
+    BETTER_CUSTOMER_SEARCH_M2,
+    SITE_CHECK_TASK;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -66,7 +67,8 @@ enum class FeatureFlag {
             BETTER_CUSTOMER_SEARCH_M2,
             -> PackageUtils.isDebugBuild()
 
-            IAP_FOR_STORE_CREATION -> false
+            IAP_FOR_STORE_CREATION,
+            SITE_CHECK_TASK -> false
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -31,8 +31,7 @@ enum class FeatureFlag {
     PRODUCT_DESCRIPTION_AI_GENERATOR,
     ORDER_CREATION_PRODUCT_DISCOUNTS,
     SHIPPING_ZONES,
-    BETTER_CUSTOMER_SEARCH_M2,
-    SITE_CHECK_TASK;
+    BETTER_CUSTOMER_SEARCH_M2;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -67,8 +66,7 @@ enum class FeatureFlag {
             BETTER_CUSTOMER_SEARCH_M2,
             -> PackageUtils.isDebugBuild()
 
-            IAP_FOR_STORE_CREATION,
-            SITE_CHECK_TASK -> false
+            IAP_FOR_STORE_CREATION -> false
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9528 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR modifies `updateSelectedSite` in `AppInitializer`. As discussed (here: peaMlT-6L-p2), we observe that it makes more problems than benefits when resetting site data, while there are ongoing async jobs that use that data.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Override `AppInitializer.SECONDS_BETWEEN_SITE_UPDATE` to 1
2. Move the app to the background and disable the WooCommerce plugin
3. Resume the app and observe it doesn't crash, just displays error snackbars

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->