### PR TITLE
Add couponSelector tests

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorViewModelTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.coupons.CouponListHandler
+import com.woocommerce.android.ui.coupons.CouponListItem
 import com.woocommerce.android.util.CouponUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.captureValues
@@ -140,6 +141,27 @@ class CouponSelectorViewModelTest : BaseUnitTest() {
         // THEN
         assertThat(event.message).isEqualTo(R.string.coupon_list_loading_failed)
     }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun `given non-empty coupon list, when a coupon is tapped, then screen returns with a correct result`() =
+        testBlocking {
+            // GIVEN
+            setup()
+            val coupon = CouponListItem(1, "Coupon", "10", true)
+            var event: MultiLiveEvent.Event.ExitWithResult<String>? = null
+            viewModel.event.observeForever {
+                event = it as? MultiLiveEvent.Event.ExitWithResult<String>
+            }
+
+            // WHEN
+            viewModel.onCouponClicked(coupon)
+
+            // THEN
+            assertThat(event).isInstanceOf(MultiLiveEvent.Event.ExitWithResult::class.java)
+            val couponCode = (event as MultiLiveEvent.Event.ExitWithResult<String>).data
+            assertThat(couponCode).isEqualTo(coupon.code)
+        }
 
     @Test
     fun `given coupon list empty, when user click on Go to Coupons List, then event is tracked`() = testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/selector/CouponSelectorViewModelTest.kt
@@ -1,0 +1,157 @@
+package com.woocommerce.android.ui.coupons.selector
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.Coupon
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.coupons.CouponListHandler
+import com.woocommerce.android.util.CouponUtils
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.captureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.store.WooCommerceStore
+
+@ExperimentalCoroutinesApi
+class CouponSelectorViewModelTest : BaseUnitTest() {
+    private val wooCommerceStore: WooCommerceStore = mock()
+    private val selectedSite: SelectedSite = mock()
+    private val couponsStateFlow = MutableStateFlow(emptyList<Coupon>())
+    private val couponListHandler: CouponListHandler = mock {
+        on { couponsFlow } doReturn couponsStateFlow
+    }
+    private val currencyFormatter: CurrencyFormatter = mock()
+    private val resourceProvider: ResourceProvider = mock()
+    private val couponUtils = CouponUtils(
+        currencyFormatter = currencyFormatter,
+        resourceProvider = resourceProvider
+    )
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+
+    private lateinit var viewModel: CouponSelectorViewModel
+
+    suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
+        prepareMocks()
+        viewModel = CouponSelectorViewModel(
+            couponListHandler = couponListHandler,
+            wooCommerceStore = wooCommerceStore,
+            selectedSite = selectedSite,
+            couponUtils = couponUtils,
+            analyticsTrackerWrapper = analyticsTrackerWrapper,
+            savedState = SavedStateHandle()
+        )
+    }
+
+    @Test
+    fun `when screen is loaded, then fetch coupons`() = testBlocking {
+        // WHEN
+        setup {
+            whenever(couponListHandler.fetchCoupons(forceRefresh = true)).doSuspendableAnswer {
+                delay(1L)
+                return@doSuspendableAnswer Result.success(Unit)
+            }
+        }
+
+        val fetchingState = viewModel.couponSelectorState.captureValues().last()
+
+        // THEN
+
+        verify(couponListHandler).fetchCoupons(forceRefresh = true)
+        assertThat(fetchingState.loadingState).isEqualTo(LoadingState.Loading)
+    }
+
+    @Test
+    fun `when load more is requested, then load next page`() = testBlocking {
+        setup()
+
+        // WHEN
+        viewModel.onLoadMore()
+
+        // THEN
+
+        verify(couponListHandler).loadMore()
+    }
+
+    @Test
+    fun `when list is swiped down, then force refresh coupon lists`() = testBlocking {
+        setup()
+        clearInvocations(couponListHandler)
+
+        // WHEN
+        viewModel.onRefresh()
+
+        // THEN
+        verify(couponListHandler).fetchCoupons(forceRefresh = true)
+    }
+
+    @Test
+    fun `when fetching coupons fails, then show an error`() = testBlocking {
+        // WHEN
+        setup {
+            whenever(couponListHandler.fetchCoupons(forceRefresh = true)).thenReturn(Result.failure(Exception()))
+        }
+
+        val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
+
+        // THEN
+        assertThat(event.message).isEqualTo(R.string.coupon_list_loading_failed)
+    }
+
+    @Test
+    fun `when loading next page fails, then show an error`() = testBlocking {
+        // WHEN
+        setup {
+            whenever(couponListHandler.loadMore()).thenReturn(Result.failure(Exception()))
+        }
+        viewModel.onLoadMore()
+        advanceUntilIdle()
+        val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
+
+        // THEN
+        assertThat(event.message).isEqualTo(R.string.coupon_list_loading_failed)
+    }
+
+    @Test
+    fun `when refreshing fails, then show an error`() = testBlocking {
+        // WHEN
+        setup {
+            whenever(couponListHandler.fetchCoupons(forceRefresh = true)).thenReturn(Result.failure(Exception()))
+        }
+
+        viewModel.onRefresh()
+        advanceUntilIdle()
+        val event = viewModel.event.captureValues().filterIsInstance<MultiLiveEvent.Event.ShowSnackbar>().last()
+
+        // THEN
+        assertThat(event.message).isEqualTo(R.string.coupon_list_loading_failed)
+    }
+
+    @Test
+    fun `given coupon list empty, when user click on Go to Coupons List, then event is tracked`() = testBlocking {
+        // GIVEN
+        setup {
+            whenever(couponListHandler.couponsFlow).thenReturn(couponsStateFlow)
+        }
+
+        // WHEN
+        viewModel.onEmptyScreenButtonClicked()
+
+        // THEN
+        verify(analyticsTrackerWrapper).track(AnalyticsEvent.ORDER_GO_TO_COUPON_BUTTON_TAPPED)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9547 

### Please do not merge until target base is Trunk

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR add the tests for the CouponSelector VM

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

green CI and running the tests on CouponSelectorViewModelTest.kt

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
