### PR TITLE
Show Blaze banner only if orders are empty

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.store.WCOrderStore
 import javax.inject.Inject
 
 @HiltViewModel
@@ -29,6 +30,7 @@ class BlazeBannerViewModel @Inject constructor(
     private val productRepository: ProductListRepository,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val selectedSite: SelectedSite,
+    private val orderStore: WCOrderStore,
 ) : ScopedViewModel(savedStateHandle) {
 
     private val _isBlazeBannerVisible = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = false)
@@ -40,8 +42,10 @@ class BlazeBannerViewModel @Inject constructor(
         launch {
             val publishedProducts = productRepository.getProductList()
                 .filter { it.status == PUBLISH }
+            val orderList = orderStore.getOrdersForSite(selectedSite.get())
             _isBlazeBannerVisible.value = !appPrefsWrapper.isBlazeBannerHidden(selectedSite.getSelectedSiteId()) &&
                 publishedProducts.isNotEmpty() &&
+                orderList.isEmpty() &&
                 isBlazeEnabled()
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9536 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Show Blaze banner only when the store has 0 orders

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Log into a site that is Blaze eligible. Creating a jurassic ninja jetpack connected should be enough. The following conditions must be satisfied: 
  - user `isAdmin`
  - the site is public,
  - the site is atomic/jetpack connected
  - the site has 0 orders
  - the site has at least 1 product
3. Check the Blaze banner is displayed in My store tab and Products tab
4. Create a new order and check how the Blaze banner is gone. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/dcf49d45-94fd-4fc3-9143-db3533d35e39

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
