### PR TITLE
Remove FAB from coupon removal screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/coupon/list/OrderCouponListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/coupon/list/OrderCouponListScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.Divider
-import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -17,7 +16,6 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -35,13 +33,11 @@ import com.woocommerce.android.model.Order
 @Composable
 fun OrderCouponListScreen(
     onNavigateBackClicked: () -> Unit = {},
-    onAddCouponClicked: () -> Unit = {},
     onCouponClicked: (Order.CouponLine) -> Unit = {},
     couponsState: State<List<Order.CouponLine>>,
 ) {
     Scaffold(
         topBar = { TopBar(onNavigateBackClicked) },
-        floatingActionButton = { FAB(onAddCouponClicked) }
     ) { padding ->
         CouponList(padding, couponsState, onCouponClicked)
     }
@@ -62,16 +58,6 @@ private fun TopBar(onNavigateBackClicked: () -> Unit) {
         backgroundColor = colorResource(id = R.color.color_toolbar),
         elevation = dimensionResource(id = R.dimen.appbar_elevation),
     )
-}
-
-@Composable
-private fun FAB(onClick: () -> Unit) {
-    FloatingActionButton(
-        onClick = onClick,
-        backgroundColor = colorResource(id = R.color.color_primary),
-    ) {
-        Icon(imageVector = Icons.Filled.Add, contentDescription = "Add coupon")
-    }
 }
 
 @Composable
@@ -112,12 +98,6 @@ private fun CouponList(
             }
         }
     }
-}
-
-@Composable
-@Preview
-private fun FABPreview() {
-    FAB(onClick = {})
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/coupon/list/OrderCreateCouponListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/coupon/list/OrderCreateCouponListFragment.kt
@@ -31,7 +31,6 @@ class OrderCreateCouponListFragment : BaseFragment() {
             WooThemeWithBackground {
                 OrderCouponListScreen(
                     onNavigateBackClicked = viewModel::onNavigateBack,
-                    onAddCouponClicked = viewModel::onAddCouponClicked,
                     onCouponClicked = viewModel::onCouponClicked,
                     couponsState = viewModel.coupons.observeAsState(emptyList()),
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/coupon/list/OrderCreateCouponListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/coupon/list/OrderCreateCouponListViewModel.kt
@@ -22,10 +22,6 @@ class OrderCreateCouponListViewModel @Inject constructor(
         "key_coupons"
     ).asLiveData()
 
-    fun onAddCouponClicked() {
-        triggerEvent(AddCoupon)
-    }
-
     fun onCouponClicked(coupon: Order.CouponLine) {
         triggerEvent(EditCoupon(coupon.code))
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Please do not merge until target base is Trunk

Closes: #9552 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When the user clicks on `+Add Coupon` in order creation they go to the coupon selector screen now. Once they click on a coupon they are sent back to the order creation screen where they can click on `+Add Coupon`  again to add another coupon. So the FAB became redundant.

Context: https://github.com/woocommerce/woocommerce-android/pull/9510#issuecomment-1669567743

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Log into a store that has coupons
2. Go to the orders tab
3. click on add order
4. add a product
5. click on `+Add Coupon`
6. select a coupon (this will send you back to the order creation screen
7. click on the added coupon in the order creation screen 
8. Make sure the FAB in the Applied coupons screen is not displayed anymore

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
| ---- | ---- |
| <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/8e788a21-4db3-4eff-b4bb-bacfd0f5f88f" width="350"/> | <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/07d9ca40-e2ed-4585-b5f1-5c43dbc86cbf" width="350"/> |

<img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/ec0319fd-b761-463e-8dc4-122cead9405f" width="350"/> 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
