### PR TITLE
Fix variable subscription description

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
@@ -11,7 +11,7 @@ enum class ProductType(@StringRes val stringResource: Int = 0, val value: String
     EXTERNAL(R.string.product_type_external, CoreProductType.EXTERNAL.value),
     VARIABLE(R.string.product_type_variable, CoreProductType.VARIABLE.value),
     SUBSCRIPTION(R.string.product_type_subscription, "subscription"),
-    VARIABLE_SUBSCRIPTION(R.string.product_type_subscription, "variable-subscription"),
+    VARIABLE_SUBSCRIPTION(R.string.product_type_variable_subscription, "variable-subscription"),
     BUNDLE(R.string.product_type_bundle, CoreProductType.BUNDLE.value),
     COMPOSITE(R.string.product_type_composite, "composite"),
     VARIATION(R.string.product_type_variation, "variation"),

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2318,6 +2318,7 @@
     <string name="product_type_virtual">Virtual</string>
     <string name="product_type_downloadable">Downloadable</string>
     <string name="product_type_subscription">Subscription</string>
+    <string name="product_type_variable_subscription">Variable subscription</string>
     <string name="product_type_bundle">Bundle</string>
     <string name="product_type_composite">Composite product</string>
     <string name="product_type_variation">Variation product</string>


### PR DESCRIPTION
Closes: #9530

### Description
This small PR fixes the variable subscription description to match how `wp-admin` displays the product-type filter for variable subscriptions.

<img width="208" alt="Screenshot 2023-08-08 at 17 21 00" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/b6891370-2f36-4155-aa76-fea7110a9605">


### Testing instructions

1. Open the products screen
2. Tap on Filters
3. Tap on Product type
4. Check that now the app displays **Variable subscription**

### Images/gif

| Before  | After |
| ------------- | ------------- |
|  <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/530869c8-901c-4d3c-aa49-e472f2726788" /> | <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/4738342d-9443-45bc-90bb-473900e385b5" />  |


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
