### PR TITLE
Fix for RTL on Select Payment Method screen

### DIFF
--- a/WooCommerce/src/main/res/layout/item_select_payment_method_single_row.xml
+++ b/WooCommerce/src/main/res/layout/item_select_payment_method_single_row.xml
@@ -1,34 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="wrap_content">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/tvSelectPaymentRowHeader"
         style="@style/Woo.Card.Body.Bold"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         android:layout_margin="0dp"
         android:background="?attr/selectableItemBackground"
         android:drawablePadding="@dimen/major_100"
         android:padding="@dimen/major_100"
+        android:textAlignment="viewStart"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:drawableEnd="@drawable/ic_arrow_right"
         tools:drawableStart="@drawable/ic_baseline_qr_code_scanner"
         tools:text="@string/card_reader_type_selection_scan_to_pay" />
 
     <View
         android:id="@+id/vSelectPaymentRowOverlay"
-        android:background="@color/color_on_primary_disabled"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
         android:layout_width="0dp"
-        android:layout_height="0dp" />
+        android:layout_height="0dp"
+        android:background="@color/color_on_primary_disabled"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9429
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes RTL Text behavior on Select Payment Method screen

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Payments -> Collect Payment -> Amount
* Notice Select payment screen
* Change locale to arrabic
* Notice that scan to pay text located on the right

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="348" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/4923871/5a4ad02b-c4de-4762-9956-4dce034229fe">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
