### PR TITLE
[Mobile Payments] Country unsupported error copy change

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1448,7 +1448,7 @@
     <string name="card_reader_onboarding_title">In-Person Payments</string>
     <string name="card_reader_onboarding_loading">Connecting to your account</string>
 
-    <string name="card_reader_onboarding_country_not_supported_header">We don\'t support In-Person Payments in %1$s</string>
+    <string name="card_reader_onboarding_country_not_supported_header">We don\'t support Card In-Person Payments in %1$s</string>
     <string name="card_reader_onboarding_country_not_supported_hint">You can still accept In-Person Cash Payments by enabling the \"cash on delivery\" payment method on your store</string>
     <string name="card_reader_onboarding_country_not_supported_contact_support">Need some help? &lt;a href=\'\'&gt;Contact support&lt;/a&gt;</string>
     <string name="card_reader_onboarding_country_not_supported_learn_more">&lt;a href=\'\'&gt;Learn more&lt;/a&gt; about accepting payments with your mobile device and ordering card readers</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9558 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In the case of the unsupported country the title and the message a bit misleading. It may sound that enabling cash on deliver will allow a merchant to collect card IPP as well.  Especially that is missing that we have "Pay in person" toggle on the screen before that

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Change country of the website to IPP non supported 
* Go to payments -> click on error
* Notice changed the title

@malinajirka @samiuelson Wdyt, does this change make sense? I personally was confused when I was trying AUS integration - thought that something was wrong with my site, e.g., cash on delivery option was off

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="308" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/4923871/4b1ca81b-c861-4303-ac5f-baeff2f744f6">


<img width="308" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/4923871/15211d11-dd31-4a6e-875c-296ebd40838e">

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
