### PR TITLE
[Data Sprint] Add a flag per site to save that site was tracked

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -508,4 +508,26 @@ class AppPrefsTest {
     fun givenIppWasNotUsedWhenGetCardReaderLastSuccessfulPaymentThenTimeReturnedZero() {
         assertThat(AppPrefs.getCardReaderLastSuccessfulPaymentTime()).isEqualTo(0L)
     }
+
+    @Test
+    fun givenSetApplicationStoreSnapshotTrackedForSiteNotCalledThenGetterReturnsFalse() {
+        assertThat(
+            AppPrefs.isApplicationStoreSnapshotTrackedForSite(
+                0, 0L, 0L
+            )
+        ).isFalse
+    }
+
+    @Test
+    fun givenSetApplicationStoreSnapshotTrackedForSiteCalledThenGetterReturnsTrue() {
+        AppPrefs.setApplicationStoreSnapshotTrackedForSite(
+            0, 0L, 0L
+        )
+
+        assertThat(
+            AppPrefs.isApplicationStoreSnapshotTrackedForSite(
+                0, 0L, 0L
+            )
+        ).isTrue
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -1065,7 +1065,7 @@ object AppPrefs {
     ) {
         setBoolean(
             key = PrefKeyString(
-                "${APPLICATION_STORE_SNAPSHOT_TRACKED_FOR_SITE}:$localSiteId:$remoteSiteId:$selfHostedSiteId"
+                "$APPLICATION_STORE_SNAPSHOT_TRACKED_FOR_SITE:$localSiteId:$remoteSiteId:$selfHostedSiteId"
             ),
             value = true
         )
@@ -1077,7 +1077,7 @@ object AppPrefs {
         selfHostedSiteId: Long
     ) = getBoolean(
         key = PrefKeyString(
-            "${APPLICATION_STORE_SNAPSHOT_TRACKED_FOR_SITE}:$localSiteId:$remoteSiteId:$selfHostedSiteId"
+            "$APPLICATION_STORE_SNAPSHOT_TRACKED_FOR_SITE:$localSiteId:$remoteSiteId:$selfHostedSiteId"
         ),
         default = false
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRODUCT_SORTING_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.RECEIPT_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.UPDATE_SIMULATED_READER_OPTION
+import com.woocommerce.android.AppPrefs.UndeletablePrefKey.APPLICATION_STORE_SNAPSHOT_TRACKED_FOR_SITE
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.ONBOARDING_CAROUSEL_DISPLAYED
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.STORE_ONBOARDING_SETTING_VISIBILITY
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.STORE_ONBOARDING_SHOWN_AT_LEAST_ONCE
@@ -199,6 +200,8 @@ object AppPrefs {
         USER_SEEN_NEW_FEATURE_MORE_SCREEN,
 
         USER_CLICKED_ON_PAYMENTS_MORE_SCREEN,
+
+        APPLICATION_STORE_SNAPSHOT_TRACKED_FOR_SITE,
     }
 
     fun init(context: Context) {
@@ -1054,6 +1057,30 @@ object AppPrefs {
             key = PrefKeyString("$siteId$localTimezone$storeTimezone"),
             default = false
         )
+
+    fun setApplicationStoreSnapshotTrackedForSite(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long
+    ) {
+        setBoolean(
+            key = PrefKeyString(
+                "${APPLICATION_STORE_SNAPSHOT_TRACKED_FOR_SITE}:$localSiteId:$remoteSiteId:$selfHostedSiteId"
+            ),
+            value = true
+        )
+    }
+
+    fun isApplicationStoreSnapshotTrackedForSite(
+        localSiteId: Int,
+        remoteSiteId: Long,
+        selfHostedSiteId: Long
+    ) = getBoolean(
+        key = PrefKeyString(
+            "${APPLICATION_STORE_SNAPSHOT_TRACKED_FOR_SITE}:$localSiteId:$remoteSiteId:$selfHostedSiteId"
+        ),
+        default = false
+    )
 
     /**
      * Remove all user and site-related preferences.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9585
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The initial PR adds a flag that will be used to track a site just once per login per site

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Nothing to test, just look in the code changes


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
