### PR TITLE
Feature/9584 send app installation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -11,6 +11,9 @@ import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 
 class AppPrefsWrapper @Inject constructor() {
+
+    fun getAppInstallationDate() = AppPrefs.installationDate
+
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =
         AppPrefs.getReceiptUrl(localSiteId, remoteSiteId, selfHostedSiteId, orderId)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tracker/SendTelemetry.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tracker/SendTelemetry.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.tracker
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -15,6 +16,7 @@ class SendTelemetry @Inject constructor(
     private val trackerRepository: TrackerRepository,
     private val currentTimeProvider: CurrentTimeProvider,
     private val selectedSite: SelectedSite,
+    private val appsPrefsWrapper: AppPrefsWrapper
 ) {
     operator fun invoke(appVersion: String): Flow<Result> {
         return combine(
@@ -26,7 +28,11 @@ class SendTelemetry @Inject constructor(
                     val currentTime = currentTimeProvider.currentDate().time
 
                     if (lastUpdate == 0L || currentTime >= lastUpdate + UPDATE_INTERVAL) {
-                        trackerStore.sendTelemetry(appVersion, siteModel)
+                        trackerStore.sendTelemetry(
+                            appVersion,
+                            siteModel,
+                            appsPrefsWrapper.getAppInstallationDate()
+                        )
                         trackerRepository.updateLastSendingDate(siteModel, currentTime)
                         Result.SENT
                     } else {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/tracker/SendTelemetryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/tracker/SendTelemetryTest.kt
@@ -176,7 +176,7 @@ class SendTelemetryTest : BaseUnitTest() {
     private companion object {
         val site = SiteModel().apply { id = 123 }
         val siteB = SiteModel().apply { id = 321 }
-        val APP_INSTALLATION_DATE = Date(1692011562123) // 14 2023 11:12:42 UTC
+        val APP_INSTALLATION_DATE = Date(1692011562123) // 14 Aug 2023 11:12:42 UTC
         const val APP_INSTALLATION_DATE_ISO_8601 = "2023-08-14T11:12:42Z"
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/tracker/SendTelemetryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/tracker/SendTelemetryTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.tracker
 
 import app.cash.turbine.test
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tracker.SendTelemetry.Result.NOT_SENT
 import com.woocommerce.android.tracker.SendTelemetry.Result.SENT
@@ -39,6 +40,9 @@ class SendTelemetryTest : BaseUnitTest() {
     private val selectedSite = mock<SelectedSite> {
         on { observe() } doReturn flowOf(site)
     }
+    private val appsPrefsWrapper: AppPrefsWrapper = mock<AppPrefsWrapper> {
+        on { getAppInstallationDate() } doReturn SOME_APP_INSTALLATION_DATE
+    }
 
     @Before
     fun setUp() {
@@ -47,6 +51,7 @@ class SendTelemetryTest : BaseUnitTest() {
             trackerRepository = trackerRepository,
             currentTimeProvider = currentTimeProvider,
             selectedSite = selectedSite,
+            appsPrefsWrapper = appsPrefsWrapper
         )
     }
 
@@ -57,7 +62,11 @@ class SendTelemetryTest : BaseUnitTest() {
             // then
             .test {
                 assertThat(awaitItem()).isEqualTo(SENT)
-                verify(trackerStore).sendTelemetry("321", site)
+                verify(trackerStore).sendTelemetry(
+                    appVersion = "321",
+                    site = site,
+                    installationDate = SOME_APP_INSTALLATION_DATE
+                )
             }
     }
 
@@ -72,7 +81,7 @@ class SendTelemetryTest : BaseUnitTest() {
             // then
             .test {
                 assertThat(awaitItem()).isEqualTo(NOT_SENT)
-                verify(trackerStore, never()).sendTelemetry(any(), any())
+                verify(trackerStore, never()).sendTelemetry(any(), any(), any())
             }
     }
 
@@ -93,11 +102,19 @@ class SendTelemetryTest : BaseUnitTest() {
 
                 fakeSite.emit(site)
                 assertThat(awaitItem()).isEqualTo(SENT)
-                verify(trackerStore).sendTelemetry("123", site)
+                verify(trackerStore).sendTelemetry(
+                    appVersion = "123",
+                    site = site,
+                    installationDate = SOME_APP_INSTALLATION_DATE
+                )
 
                 fakeSite.emit(siteB)
                 assertThat(awaitItem()).isEqualTo(SENT)
-                verify(trackerStore).sendTelemetry("123", siteB)
+                verify(trackerStore).sendTelemetry(
+                    appVersion = "123",
+                    site = siteB,
+                    installationDate = SOME_APP_INSTALLATION_DATE
+                )
             }
     }
 
@@ -156,8 +173,9 @@ class SendTelemetryTest : BaseUnitTest() {
         assertThat(results).containsExactly(SENT, NOT_SENT, SENT)
     }
 
-    companion object {
+    private companion object {
         val site = SiteModel().apply { id = 123 }
         val siteB = SiteModel().apply { id = 321 }
+        val SOME_APP_INSTALLATION_DATE = Date(1692011562123) //14 2023 11:12:42 UTC
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/tracker/SendTelemetryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/tracker/SendTelemetryTest.kt
@@ -176,6 +176,6 @@ class SendTelemetryTest : BaseUnitTest() {
     private companion object {
         val site = SiteModel().apply { id = 123 }
         val siteB = SiteModel().apply { id = 321 }
-        val SOME_APP_INSTALLATION_DATE = Date(1692011562123) //14 2023 11:12:42 UTC
+        val SOME_APP_INSTALLATION_DATE = Date(1692011562123) // 14 2023 11:12:42 UTC
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/tracker/SendTelemetryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/tracker/SendTelemetryTest.kt
@@ -40,8 +40,8 @@ class SendTelemetryTest : BaseUnitTest() {
     private val selectedSite = mock<SelectedSite> {
         on { observe() } doReturn flowOf(site)
     }
-    private val appsPrefsWrapper: AppPrefsWrapper = mock<AppPrefsWrapper> {
-        on { getAppInstallationDate() } doReturn SOME_APP_INSTALLATION_DATE
+    private val appsPrefsWrapper = mock<AppPrefsWrapper> {
+        on { getAppInstallationDate() } doReturn APP_INSTALLATION_DATE
     }
 
     @Before
@@ -65,7 +65,7 @@ class SendTelemetryTest : BaseUnitTest() {
                 verify(trackerStore).sendTelemetry(
                     appVersion = "321",
                     site = site,
-                    installationDate = SOME_APP_INSTALLATION_DATE
+                    installationDateIso8601 = APP_INSTALLATION_DATE_ISO_8601
                 )
             }
     }
@@ -105,7 +105,7 @@ class SendTelemetryTest : BaseUnitTest() {
                 verify(trackerStore).sendTelemetry(
                     appVersion = "123",
                     site = site,
-                    installationDate = SOME_APP_INSTALLATION_DATE
+                    installationDateIso8601 = APP_INSTALLATION_DATE_ISO_8601
                 )
 
                 fakeSite.emit(siteB)
@@ -113,7 +113,7 @@ class SendTelemetryTest : BaseUnitTest() {
                 verify(trackerStore).sendTelemetry(
                     appVersion = "123",
                     site = siteB,
-                    installationDate = SOME_APP_INSTALLATION_DATE
+                    installationDateIso8601 = APP_INSTALLATION_DATE_ISO_8601
                 )
             }
     }
@@ -176,6 +176,7 @@ class SendTelemetryTest : BaseUnitTest() {
     private companion object {
         val site = SiteModel().apply { id = 123 }
         val siteB = SiteModel().apply { id = 321 }
-        val SOME_APP_INSTALLATION_DATE = Date(1692011562123) // 14 2023 11:12:42 UTC
+        val APP_INSTALLATION_DATE = Date(1692011562123) // 14 2023 11:12:42 UTC
+        const val APP_INSTALLATION_DATE_ISO_8601 = "2023-08-14T11:12:42Z"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2805-bb118e01ac818c4e39c93a8cf79a350f0e0c9889'
+    fluxCVersion = 'trunk-726ddcd38a9cd8fba85fc22fc922cea3fb422ce8'
     wooCommerceSharedVersion = 'trunk-09b36638186095b54a31aa3bdedac9d39e5438da'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2805-9dab2d09ef2de67391d95308ab573dddc595ed7a'
+    fluxCVersion = '2805-bb118e01ac818c4e39c93a8cf79a350f0e0c9889'
     wooCommerceSharedVersion = 'trunk-09b36638186095b54a31aa3bdedac9d39e5438da'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.40.0'
+    fluxCVersion = '2805-9dab2d09ef2de67391d95308ab573dddc595ed7a'
     wooCommerceSharedVersion = 'trunk-09b36638186095b54a31aa3bdedac9d39e5438da'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9584 
<!-- Id number of the GitHub issue this PR addresses. -->

~~⚠️ Don't merge this PR until Gradle has been updated with the latest FluxC `trunk` change set.~~

### Description
Adds app installation date to WcTracker telemetry. This PR works alongside these FluxC changes https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2805


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Fresh install the app
2. Log in a site 
3. Check the logs for the following: 
```
Sending Telemetry: appVersion=14.8, site=221713587, installationDate=2023-08-14T13:27:51Z
WCTracker telemetry result: SENT
```
Verify the installation Date and time (UTC) are correct. 
