### PR TITLE
Subscription metadatada fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2810-7221c0b2c6a65efe8ebda2459d552954abbc5bb1'
+    fluxCVersion = 'trunk-f8d0bcf75c60827ac5df99d42a5a85bb95336c2c'
     wooCommerceSharedVersion = 'trunk-09b36638186095b54a31aa3bdedac9d39e5438da'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-726ddcd38a9cd8fba85fc22fc922cea3fb422ce8'
+    fluxCVersion = '2810-7221c0b2c6a65efe8ebda2459d552954abbc5bb1'
     wooCommerceSharedVersion = 'trunk-09b36638186095b54a31aa3bdedac9d39e5438da'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'


### PR DESCRIPTION
⚠️ This PR depends on this FluxC PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2810

### Why
As part of the Reliability project, we introduced a new metadata strip function to save only the allowed product's metadata keys in the database and optimize the app's memory usage. Unfortunately, this optimization broke the simple subscription read-only functionality by not saving the subscription metadata needed to display the subscription information.

### Description
This PR uses the fixed FluxC that adds the subscription metadata keys to the list of the supported private keys. This change prevents the strip function from removing the subscription metadata keys and restores the subscription's read-only functionality.

### Images/gif
| Before | After |
| ------------- | ------------- |
| <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/ff5d71f0-3389-44ef-8d42-cffa12ac5de8" />| <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/4bae0517-4edf-4159-8731-ad704e2c1d48" />  |


### Testing instruction
#### Prerequisites
- You need the subscription extension to be installed
- Create a simple subscription product if you don't have any

#### Testing
- Open the products tab
- Open a simple subscription
- Check that the simple subscription product contains a Subscription section with the subscription information

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->