### PR TITLE
Store Creation: Better country selector part II: Functionality

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 15.0
 -----
+- [*] Store creation: Country selector screen is now more intuitive and easier to use. [https://github.com/woocommerce/woocommerce-android/issues/9606]
 
 
 14.9

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerFragment.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryListPickerViewModel.NavigateToDomainPickerStep
+import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryListPickerViewModel.NavigateToSummaryStep
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
@@ -49,8 +50,15 @@ class CountryListPickerFragment : BaseFragment() {
             when (event) {
                 is Exit -> findNavController().popBackStack()
                 is NavigateToDomainPickerStep -> navigateToDomainPickerStep()
+                is NavigateToSummaryStep -> navigateToInstallationStep()
             }
         }
+    }
+
+    private fun navigateToInstallationStep() {
+        findNavController().navigateSafely(
+            CountryListPickerFragmentDirections.actionCountryListPickerFragmentToSummaryFragment()
+        )
     }
 
     private fun navigateToDomainPickerStep() {
@@ -61,4 +69,3 @@ class CountryListPickerFragment : BaseFragment() {
         )
     }
 }
-

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerFragment.kt
@@ -8,16 +8,20 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.storecreation.NewStore
+import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryListPickerViewModel.NavigateToDomainPickerStep
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class CountryListPickerFragment : BaseFragment() {
-
     private val viewModel: CountryListPickerViewModel by viewModels()
+    @Inject lateinit var newStore: NewStore
 
     override
     val activityAppBarStatus: AppBarStatus
@@ -44,7 +48,17 @@ class CountryListPickerFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is Exit -> findNavController().popBackStack()
+                is NavigateToDomainPickerStep -> navigateToDomainPickerStep()
             }
         }
     }
+
+    private fun navigateToDomainPickerStep() {
+        findNavController().navigateSafely(
+            CountryListPickerFragmentDirections.actionCountryListPickerFragmentToDomainPickerFragment(
+                initialQuery = newStore.data.name ?: ""
+            )
+        )
+    }
 }
+

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerScreen.kt
@@ -41,50 +41,63 @@ fun CountryListPickerScreen(viewModel: CountryListPickerViewModel) {
                 onNavigationButtonClick = viewModel::onArrowBackPressed,
             )
         }) { padding ->
-            Column(
+            CountryListPickerForm(
+                countries = viewState.countries,
+                onCountrySelected = viewModel::onCountrySelected,
+                onContinueClicked = viewModel::onContinueClicked,
                 modifier = Modifier
                     .background(MaterialTheme.colors.surface)
                     .padding(padding)
-            ) {
-                val configuration = LocalConfiguration.current
-                if (configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
-                    CountryListPickerHeader(viewState.countries.first { it.isSelected })
-                }
-                LazyColumn(
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(horizontal = dimensionResource(id = R.dimen.major_100))
-                ) {
-                    if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                        item {
-                            CountryListPickerHeader(viewState.countries.first { it.isSelected })
-                        }
-                    }
+            )
+        }
+    }
+}
 
-                    itemsIndexed(viewState.countries) { _, country ->
-                        CountryItem(
-                            country = country,
-                            onCountrySelected = viewModel::onCountrySelected,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(bottom = dimensionResource(id = R.dimen.major_100))
-                        )
-                    }
-                }
-
-                Divider(
-                    color = colorResource(id = R.color.divider_color),
-                    thickness = dimensionResource(id = R.dimen.minor_10)
-                )
-                WCColoredButton(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(dimensionResource(id = R.dimen.major_100)),
-                    onClick = viewModel::onContinueClicked,
-                ) {
-                    Text(text = stringResource(id = R.string.continue_button))
+@Composable
+fun CountryListPickerForm(
+    countries: List<StoreCreationCountry>,
+    onCountrySelected: (StoreCreationCountry) -> Unit,
+    onContinueClicked: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        val configuration = LocalConfiguration.current
+        if (configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+            CountryListPickerHeader(countries.first { it.isSelected })
+        }
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+        ) {
+            if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                item {
+                    CountryListPickerHeader(countries.first { it.isSelected })
                 }
             }
+
+            itemsIndexed(countries) { _, country ->
+                CountryItem(
+                    country = country,
+                    onCountrySelected = onCountrySelected,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = dimensionResource(id = R.dimen.major_100))
+                )
+            }
+        }
+
+        Divider(
+            color = colorResource(id = R.color.divider_color),
+            thickness = dimensionResource(id = R.dimen.minor_10)
+        )
+        WCColoredButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(dimensionResource(id = R.dimen.major_100)),
+            onClick = onContinueClicked,
+        ) {
+            Text(text = stringResource(id = R.string.continue_button))
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerScreen.kt
@@ -80,7 +80,7 @@ fun CountryListPickerScreen(viewModel: CountryListPickerViewModel) {
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(dimensionResource(id = R.dimen.major_100)),
-                    onClick = { },
+                    onClick = viewModel::onContinueClicked,
                 ) {
                     Text(text = stringResource(id = R.string.continue_button))
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerScreen.kt
@@ -90,7 +90,7 @@ fun CountryListPickerScreen(viewModel: CountryListPickerViewModel) {
 }
 
 @Composable
-private fun CountryListPickerHeader(selectedCountry: CountryListPickerViewModel.StoreCreationCountry) {
+private fun CountryListPickerHeader(selectedCountry: StoreCreationCountry) {
     Column(
         modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
     ) {
@@ -117,8 +117,8 @@ private fun CountryListPickerHeader(selectedCountry: CountryListPickerViewModel.
 
 @Composable
 private fun CountryItem(
-    country: CountryListPickerViewModel.StoreCreationCountry,
-    onCountrySelected: (CountryListPickerViewModel.StoreCreationCountry) -> Unit,
+    country: StoreCreationCountry,
+    onCountrySelected: (StoreCreationCountry) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -165,7 +165,7 @@ private fun CountryItem(
 
 @Composable
 private fun CurrentCountryItem(
-    country: CountryListPickerViewModel.StoreCreationCountry,
+    country: StoreCreationCountry,
     modifier: Modifier = Modifier
 ) {
     Box(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerScreen.kt
@@ -262,11 +262,10 @@ fun CountryListPickerPreview() {
                     isSelected = false
                 )
             ),
-        onCountrySelected = {},
-        onContinueClicked = {},
-        modifier = Modifier
-            .background(MaterialTheme.colors.surface)
+            onCountrySelected = {},
+            onContinueClicked = {},
+            modifier = Modifier
+                .background(MaterialTheme.colors.surface)
         )
     }
-
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerScreen.kt
@@ -64,7 +64,7 @@ fun CountryListPickerScreen(viewModel: CountryListPickerViewModel) {
                     itemsIndexed(viewState.countries) { _, country ->
                         CountryItem(
                             country = country,
-                            onCountrySelected = { },
+                            onCountrySelected = viewModel::onCountrySelected,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(bottom = dimensionResource(id = R.dimen.major_100))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.login.storecreation.countrypicker
 
 import android.content.res.Configuration
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -27,9 +28,12 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 fun CountryListPickerScreen(viewModel: CountryListPickerViewModel) {
@@ -220,4 +224,49 @@ private fun CurrentCountryItem(
             )
         }
     }
+}
+
+@ExperimentalFoundationApi
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "small screen", device = Devices.PIXEL)
+@Preview(name = "mid screen", device = Devices.PIXEL_4)
+@Preview(name = "large screen", device = Devices.NEXUS_10)
+@Composable
+fun CountryListPickerPreview() {
+    WooThemeWithBackground {
+        CountryListPickerForm(
+            countries = listOf(
+                StoreCreationCountry(
+                    name = "Canada",
+                    code = "CA",
+                    emojiFlag = "\uD83C\uDDE8\uD83C\uDDE6",
+                    isSelected = false
+                ),
+                StoreCreationCountry(
+                    name = "Spain",
+                    code = "ES",
+                    emojiFlag = "\uD83C\uDDEA\uD83C\uDDF8",
+                    isSelected = true
+                ),
+                StoreCreationCountry(
+                    name = "United States",
+                    code = "US",
+                    emojiFlag = "\uD83C\uDDFA\uD83C\uDDF8",
+                    isSelected = false
+                ),
+                StoreCreationCountry(
+                    name = "Italy",
+                    code = "IT",
+                    emojiFlag = "\uD83C\uDDEE\uD83C\uDDF9",
+                    isSelected = false
+                )
+            ),
+        onCountrySelected = {},
+        onContinueClicked = {},
+        modifier = Modifier
+            .background(MaterialTheme.colors.surface)
+        )
+    }
+
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerViewModel.kt
@@ -47,6 +47,14 @@ class CountryListPickerViewModel @Inject constructor(
         triggerEvent(Exit)
     }
 
+    fun onCountrySelected(storeCreationCountry: StoreCreationCountry) {
+        availableCountries.update {
+            it.map { country ->
+                country.copy(isSelected = country.code == storeCreationCountry.code)
+            }
+        }
+    }
+
     data class CountryListPickerState(
         val countries: List<StoreCreationCountry>
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.login.storecreation.countrypicker
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.util.EmojiUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -17,6 +18,7 @@ import javax.inject.Inject
 class CountryListPickerViewModel @Inject constructor(
     private val localCountriesRepository: LocalCountriesRepository,
     private val emojiUtils: EmojiUtils,
+    private val newStore: NewStore,
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
     private val availableCountries = MutableStateFlow(emptyList<StoreCreationCountry>())
@@ -47,13 +49,26 @@ class CountryListPickerViewModel @Inject constructor(
         triggerEvent(Exit)
     }
 
-    fun onCountrySelected(storeCreationCountry: StoreCreationCountry) {
+    fun onCountrySelected(selectedCountry: StoreCreationCountry) {
         availableCountries.update {
             it.map { country ->
-                country.copy(isSelected = country.code == storeCreationCountry.code)
+                country.copy(isSelected = country.code == selectedCountry.code)
             }
         }
     }
+
+    fun onContinueClicked() {
+        val selectedCountry = availableCountries.value.first { it.isSelected }
+        newStore.update(
+            country = selectedCountry.toNewStoreCountry()
+        )
+    }
+
+    private fun StoreCreationCountry.toNewStoreCountry() =
+        NewStore.Country(
+            name = name,
+            code = code,
+        )
 
     data class CountryListPickerState(
         val countries: List<StoreCreationCountry>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.util.EmojiUtils
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -62,7 +64,19 @@ class CountryListPickerViewModel @Inject constructor(
         newStore.update(
             country = selectedCountry.toNewStoreCountry()
         )
+
+        launch {
+            if (FeatureFlag.FREE_TRIAL_M2.isEnabled()) {
+                triggerEvent(NavigateToSummaryStep)
+            } else {
+                triggerEvent(NavigateToDomainPickerStep)
+            }
+        }
     }
+
+    object NavigateToDomainPickerStep : MultiLiveEvent.Event()
+    object NavigateToSummaryStep : MultiLiveEvent.Event()
+
 
     private fun StoreCreationCountry.toNewStoreCountry() =
         NewStore.Country(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerViewModel.kt
@@ -77,21 +77,7 @@ class CountryListPickerViewModel @Inject constructor(
     object NavigateToDomainPickerStep : MultiLiveEvent.Event()
     object NavigateToSummaryStep : MultiLiveEvent.Event()
 
-
-    private fun StoreCreationCountry.toNewStoreCountry() =
-        NewStore.Country(
-            name = name,
-            code = code,
-        )
-
     data class CountryListPickerState(
         val countries: List<StoreCreationCountry>
-    )
-
-    data class StoreCreationCountry(
-        val name: String,
-        val code: String,
-        val emojiFlag: String,
-        val isSelected: Boolean = false
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
@@ -79,7 +79,7 @@ private fun CountryPickerForm(
                 .padding(dimensionResource(id = R.dimen.major_100)),
             onClick = onContinueClicked,
         ) {
-            Text(text = stringResource(id = R.string.continue_button))
+            Text(text = stringResource(id = R.string.next))
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerScreen.kt
@@ -28,7 +28,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.StoreCreationCountry
 
 @Composable
 fun CountryPickerScreen(viewModel: CountryPickerViewModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
@@ -97,7 +97,6 @@ class CountryPickerViewModel @Inject constructor(
     }
 
     private fun StoreCreationCountry.toNewStoreCountry() =
-
         NewStore.Country(
             name = name,
             code = code,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
@@ -96,20 +96,7 @@ class CountryPickerViewModel @Inject constructor(
         )
     }
 
-    private fun StoreCreationCountry.toNewStoreCountry() =
-        NewStore.Country(
-            name = name,
-            code = code,
-        )
-
     data class NavigateToDomainListPicker(val locationCode: String) : MultiLiveEvent.Event()
     object NavigateToDomainPickerStep : MultiLiveEvent.Event()
     object NavigateToSummaryStep : MultiLiveEvent.Event()
-
-    data class StoreCreationCountry(
-        val name: String,
-        val code: String,
-        val emojiFlag: String,
-        val isSelected: Boolean = false
-    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/StoreCreationCountry.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/StoreCreationCountry.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.android.ui.login.storecreation.countrypicker
+
+import com.woocommerce.android.ui.login.storecreation.NewStore
+
+data class StoreCreationCountry(
+    val name: String,
+    val code: String,
+    val emojiFlag: String,
+    val isSelected: Boolean = false
+) {
+    fun toNewStoreCountry() =
+        NewStore.Country(
+            name = name,
+            code = code,
+        )
+}

--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
@@ -149,6 +149,9 @@
         <action
             android:id="@+id/action_countryListPickerFragment_to_domainPickerFragment"
             app:destination="@id/domainPickerFragment" />
+        <action
+            android:id="@+id/action_countryListPickerFragment_to_summaryFragment"
+            app:destination="@id/summaryFragment" />
         <argument
             android:name="currentLocationCode"
             app:argType="string" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
@@ -146,6 +146,9 @@
         android:id="@+id/countryListPickerFragment"
         android:name="com.woocommerce.android.ui.login.storecreation.countrypicker.CountryListPickerFragment"
         android:label="CountryListPickerFragment">
+        <action
+            android:id="@+id/action_countryListPickerFragment_to_domainPickerFragment"
+            app:destination="@id/domainPickerFragment" />
         <argument
             android:name="currentLocationCode"
             app:argType="string" />


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9606 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR is a continuation from https://github.com/woocommerce/woocommerce-android/pull/9602

It adds a couple of functionalities on the Country List Picker screen:

1. If a country is selected, then it is recorded into `newStore` data and shown as the selected country at the top.
2. If "Continue" button is tapped, user is redirected to the Summary screen.
3. It also has conditional for point 2 above to go to the Domain Picker screen instead, to match the functionality of the old country picker flow.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

**A. First screen testing**
1. Create a new site, skip the profiler questions,
2. Ensure the first screen for the country picker is shown,
3. Tap Next, ensure that this opens the new store Summary screen.
4. Optionally, continue with creating the site and ensure that it's created properly.

**B. Second screen testing**
1. Create a new site, skip the profiler questions,
2. Ensure the first screen for the country picker is shown,
4. Tap the detected country, ensure that the second screen for the country picker (with the country list) is shown,
5. Select another country, ensure that this country is then shown at the top "Current Location" section,
6. Tap Continue, ensure that this opens the new store Summary screen.
7. Optionally, continue with creating the site and ensure that it's created properly.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
