### PR TITLE
AI: Save entered title in the product description dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
@@ -17,7 +17,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
-import com.woocommerce.android.ui.products.AIProductDescriptionBottomSheetFragment
+import com.woocommerce.android.ui.products.AIProductDescriptionBottomSheetFragment.Companion.KEY_AI_GENERATED_DESCRIPTION_RESULT
 import com.woocommerce.android.ui.products.IsAIProductDescriptionEnabled
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
@@ -125,8 +125,10 @@ class AztecEditorFragment :
     }
 
     private fun handleResults() {
-        handleResult<String>(AIProductDescriptionBottomSheetFragment.KEY_AI_GENERATED_DESCRIPTION_RESULT) {
-            aztec.visualEditor.setText(it)
+        handleResult<Pair<String,String>>(KEY_AI_GENERATED_DESCRIPTION_RESULT) { pairResult ->
+            aztec.visualEditor.setText(pairResult.first)
+
+            // todo handle product title in pairResult.second
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
@@ -42,6 +42,7 @@ class AztecEditorFragment :
         const val ARG_AZTEC_REQUEST_CODE = "aztec-request-code"
         const val ARG_AZTEC_EDITOR_TEXT = "editor-text"
         const val ARG_AZTEC_HAS_CHANGES = "editor-has-changes"
+        const val ARG_AZTEC_TITLE_FROM_AI_DESCRIPTION = "title-from-ai-description"
 
         private const val FIELD_IS_HTML_EDITOR_ENABLED = "is_html_editor_enabled"
     }
@@ -54,6 +55,8 @@ class AztecEditorFragment :
     private val navArgs: AztecEditorFragmentArgs by navArgs()
 
     private var isHtmlEditorEnabled: Boolean = false
+
+    private var titleFromProductAIDescriptionDialog: String? = null
 
     override fun getFragmentTitle() = navArgs.aztecTitle
 
@@ -125,10 +128,10 @@ class AztecEditorFragment :
     }
 
     private fun handleResults() {
-        handleResult<Pair<String,String>>(KEY_AI_GENERATED_DESCRIPTION_RESULT) { pairResult ->
+        handleResult<Pair<String, String>>(KEY_AI_GENERATED_DESCRIPTION_RESULT) { pairResult ->
             aztec.visualEditor.setText(pairResult.first)
 
-            // todo handle product title in pairResult.second
+            titleFromProductAIDescriptionDialog = pairResult.second
         }
     }
 
@@ -201,6 +204,9 @@ class AztecEditorFragment :
             it.putInt(ARG_AZTEC_REQUEST_CODE, navArgs.requestCode)
             it.putString(ARG_AZTEC_EDITOR_TEXT, getEditorText())
             it.putBoolean(ARG_AZTEC_HAS_CHANGES, hasChanges)
+            titleFromProductAIDescriptionDialog?.let { title ->
+                it.putString(ARG_AZTEC_TITLE_FROM_AI_DESCRIPTION, title)
+            }
         }
         navigateBackWithResult(AZTEC_EDITOR_RESULT, bundle)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/AIProductDescriptionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/AIProductDescriptionViewModel.kt
@@ -212,7 +212,7 @@ class AIProductDescriptionViewModel @Inject constructor(
         tracker.track(PRODUCT_DESCRIPTION_AI_APPLY_BUTTON_TAPPED)
 
         if (appPrefsWrapper.wasAIProductDescriptionCelebrationShown) {
-            triggerEvent(ExitWithResult(_viewState.value.description))
+            triggerEvent(ExitWithResult(Pair(_viewState.value.description, _viewState.value.productTitle)))
         } else {
             _viewState.update { _viewState.value.copy(generationState = Celebration) }
             appPrefsWrapper.wasAIProductDescriptionCelebrationShown = true
@@ -226,7 +226,7 @@ class AIProductDescriptionViewModel @Inject constructor(
     }
 
     fun onCelebrationButtonClicked() {
-        triggerEvent(ExitWithResult(_viewState.value.description))
+        triggerEvent(ExitWithResult(Pair(_viewState.value.description, _viewState.value.productTitle)))
     }
 
     fun onDescriptionFeedbackReceived(isUseful: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -42,6 +42,7 @@ import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.ui.aztec.AztecEditorFragment
 import com.woocommerce.android.ui.aztec.AztecEditorFragment.Companion.ARG_AZTEC_EDITOR_TEXT
+import com.woocommerce.android.ui.aztec.AztecEditorFragment.Companion.ARG_AZTEC_TITLE_FROM_AI_DESCRIPTION
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -243,6 +244,12 @@ class ProductDetailFragment :
                 RequestCodes.AZTEC_EDITOR_PRODUCT_SHORT_DESCRIPTION -> {
                     viewModel.updateProductDraft(shortDescription = result.getString(ARG_AZTEC_EDITOR_TEXT))
                 }
+            }
+
+            if (result.containsKey(ARG_AZTEC_TITLE_FROM_AI_DESCRIPTION)) {
+                viewModel.updateProductDraft(
+                    title = result.getString(ARG_AZTEC_TITLE_FROM_AI_DESCRIPTION)
+                )
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -46,6 +46,7 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainNavigationRouter
+import com.woocommerce.android.ui.products.AIProductDescriptionBottomSheetFragment.Companion.KEY_AI_GENERATED_DESCRIPTION_RESULT
 import com.woocommerce.android.ui.products.ProductDetailViewModel.HideImageUploadErrorSnackbar
 import com.woocommerce.android.ui.products.ProductDetailViewModel.MenuButtonsState
 import com.woocommerce.android.ui.products.ProductDetailViewModel.NavigateToBlazeWebView
@@ -253,8 +254,8 @@ class ProductDetailFragment :
             viewModel.refreshProduct()
         }
 
-        handleResult<String>(AIProductDescriptionBottomSheetFragment.KEY_AI_GENERATED_DESCRIPTION_RESULT) { desc ->
-            viewModel.updateProductDraft(description = desc)
+        handleResult<Pair<String, String>>(KEY_AI_GENERATED_DESCRIPTION_RESULT) { resultPair ->
+            viewModel.updateProductDraft(description = resultPair.first, title = resultPair.second)
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: https://github.com/woocommerce/woocommerce-android/issues/9608
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

PR https://github.com/woocommerce/woocommerce-android/pull/9522 makes it so that product title is required to be entered in the AI product description dialog, if the current product draft has no title.

This PR makes it so that the entered product title in the dialog is saved back into the product draft, once the generated description is applied.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

**Button flow**
1. Create a new product,
2. Tap "Write with AI",
3. Enter some values on both product title and some product features,
4. Tap "Write with AI",
5. Tap "Apply" once description is generated,
6. Ensure you're brought back to the Product Details screen,
7. Ensure that the entered product title from Step 3 is now shown in the Product Details's product title area.

**Aztec flow**
1. Create a new product,
2. Go into description field,
3. Tap the ✨  AI icon on the keyboard toolbar,
4. Ensure the AI product generation dialog is shown,
5. Enter some values on both product title and some product features,
6. Tap "Write with AI",
7. Tap "Apply" once description is generated,
8. Ensure you're brought back to the editor screen, then press back,
9. Ensure you're brought back to the Product Details screen,
10. Ensure that the entered product title from Step 5 is now shown in the Product Details's product title area.

Additionally, you can also test both button flow and Aztec flow on products that already has a title. They should still work as usual.
