### PR TITLE
Store Creation: New default store name

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -22,6 +23,7 @@ import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_NUDGE_F
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.SingleLiveEvent
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -41,6 +43,7 @@ class StoreNamePickerViewModel @Inject constructor(
     private val prefsWrapper: AppPrefsWrapper,
     private val localNotificationScheduler: LocalNotificationScheduler,
     private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
+    private val resourceProvider: ResourceProvider,
     private val accountStore: AccountStore
 ) : ScopedViewModel(savedStateHandle) {
     override val _event = SingleLiveEvent<Event>()
@@ -70,6 +73,8 @@ class StoreNamePickerViewModel @Inject constructor(
 
         if (navArgs.storeName != null) {
             onStoreNameChanged(navArgs.storeName!!)
+        } else {
+            onStoreNameChanged(resourceProvider.getString(R.string.store_creation_store_name_default))
         }
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3126,6 +3126,7 @@
     <string name="store_creation_store_name_title">What’s your store name?</string>
     <string name="store_creation_store_name_subtitle">Don’t worry, you can always change it later. </string>
     <string name="store_creation_store_name_hint">Store name</string>
+    <string name="store_creation_store_name_default">Store name</string>
 
     <string name="store_creation_store_profiler_industries_header">About your store</string>
     <string name="store_creation_store_profiler_industries_title">What do you plan to sell\nin your store?</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3124,7 +3124,7 @@
     <string name="store_creation_installation_rendering_preview_label">Rendering preview…</string>
     <string name="store_creation_store_name_caption">About your store</string>
     <string name="store_creation_store_name_title">What’s your store name?</string>
-    <string name="store_creation_store_name_subtitle">Don’t worry you can always change it later. </string>
+    <string name="store_creation_store_name_subtitle">Don’t worry, you can always change it later. </string>
     <string name="store_creation_store_name_hint">Store name</string>
 
     <string name="store_creation_store_profiler_industries_header">About your store</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
@@ -12,10 +12,13 @@ import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -30,6 +33,9 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
     private val localNotificationScheduler: LocalNotificationScheduler = mock()
     private val accountStore: AccountStore = mock()
     private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled = mock()
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(any()) } doAnswer { it.arguments[0].toString() }
+    }
 
     @Before
     fun setUp() {
@@ -42,6 +48,7 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
             prefsWrapper = prefsWrapper,
             localNotificationScheduler,
             isRemoteFeatureFlagEnabled,
+            resourceProvider,
             accountStore
         )
     }
@@ -76,6 +83,7 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
             prefsWrapper = prefsWrapper,
             localNotificationScheduler,
             isRemoteFeatureFlagEnabled,
+            resourceProvider,
             accountStore
         )
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #9621

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This tiny PR sets "Store name" as the default store name during store creation.

Also adds a bit of copy fix.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Start the process of creating a new site,
2. On the "What's your store name?" step, make sure the text "Don't worry" now has comma on it.
2. On the "What's your store name?" step, make sure the input field is pre-filled with "Store name",
3. Make sure the field is still editable and usable as usual


Note: the PR checks seem to be breaking intermittently but I believe at least this should be good to review.