### PR TITLE
Store Creation: Add "Name your store" local onboarding task

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -570,6 +570,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_ADD_DOMAIN = "add_domain"
         const val VALUE_LAUNCH_SITE = "launch_site"
         const val VALUE_PAYMENTS = "payments"
+        const val VALUE_LOCAL_NAME_STORE = "store_name"
 
         // -- Product Selector
         const val VALUE_PRODUCT_SELECTOR = "product_selector"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/IsLocalTaskNameYourStoreCompleted.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/IsLocalTaskNameYourStoreCompleted.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.android.ui.login.storecreation.onboarding
+
+import com.woocommerce.android.R
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.ResourceProvider
+import javax.inject.Inject
+
+class IsLocalTaskNameYourStoreCompleted @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val resourceProvider: ResourceProvider
+) {
+    operator fun invoke(): Boolean {
+        val defaultStoreName = resourceProvider.getString(R.string.store_creation_store_name_default)
+        return selectedSite.getIfExists()?.name != defaultStoreName
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/ShouldShowOnboarding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/ShouldShowOnboarding.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboarding
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.ADD_FIRST_PRODUCT
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.CUSTOMIZE_DOMAIN
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LAUNCH_YOUR_STORE
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LOCAL_NAME_STORE
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.MOBILE_UNSUPPORTED
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.PAYMENTS
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.WC_PAYMENTS
@@ -77,6 +78,7 @@ class ShouldShowOnboarding @Inject constructor(
             CUSTOMIZE_DOMAIN -> AnalyticsTracker.VALUE_ADD_DOMAIN
             WC_PAYMENTS,
             PAYMENTS -> AnalyticsTracker.VALUE_PAYMENTS
+            LOCAL_NAME_STORE -> AnalyticsTracker.VALUE_LOCAL_NAME_STORE
 
             MOBILE_UNSUPPORTED -> null
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -22,14 +22,15 @@ import javax.inject.Singleton
 class StoreOnboardingRepository @Inject constructor(
     private val onboardingStore: OnboardingStore,
     private val selectedSite: SelectedSite,
-    private val siteStore: SiteStore
+    private val siteStore: SiteStore,
+    private val isLocalTaskNameYourStoreCompleted: IsLocalTaskNameYourStoreCompleted
 ) {
 
     private val onboardingTasksCacheFlow: MutableSharedFlow<List<OnboardingTask>> = MutableSharedFlow()
 
     private val localNameStoreTask = OnboardingTask(
         type = OnboardingTaskType.LOCAL_NAME_STORE,
-        isComplete = false,
+        isComplete = isLocalTaskNameYourStoreCompleted(),
         isVisible = true,
         isVisited = false
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -27,6 +27,13 @@ class StoreOnboardingRepository @Inject constructor(
 
     private val onboardingTasksCacheFlow: MutableSharedFlow<List<OnboardingTask>> = MutableSharedFlow()
 
+    private val localNameStoreTask = OnboardingTask(
+        type = OnboardingTaskType.LOCAL_NAME_STORE,
+        isComplete = false,
+        isVisible = true,
+        isVisited = false
+    )
+
     fun observeOnboardingTasks(): SharedFlow<List<OnboardingTask>> = onboardingTasksCacheFlow
 
     suspend fun fetchOnboardingTasks() {
@@ -113,12 +120,13 @@ class StoreOnboardingRepository @Inject constructor(
     )
 
     enum class OnboardingTaskType(val id: String, val order: Int) {
-        ABOUT_YOUR_STORE(id = "store_details", order = 1),
-        ADD_FIRST_PRODUCT(id = "products", order = 2),
-        LAUNCH_YOUR_STORE(id = "launch_site", order = 3),
-        CUSTOMIZE_DOMAIN(id = "add_domain", order = 4),
-        WC_PAYMENTS(id = "woocommerce-payments", order = 5),
-        PAYMENTS(id = "payments", order = 5), // WC_PAYMENT and PAYMENTS are considered the same task on mobile
+        LOCAL_NAME_STORE(id = "local_name_store", order = 1),
+        ABOUT_YOUR_STORE(id = "store_details", order = 2),
+        ADD_FIRST_PRODUCT(id = "products", order = 3),
+        LAUNCH_YOUR_STORE(id = "launch_site", order = 4),
+        CUSTOMIZE_DOMAIN(id = "add_domain", order = 5),
+        WC_PAYMENTS(id = "woocommerce-payments", order = 6),
+        PAYMENTS(id = "payments", order = 6), // WC_PAYMENT and PAYMENTS are considered the same task on mobile
         MOBILE_UNSUPPORTED(id = "mobile-unsupported", order = -1)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -44,10 +44,8 @@ class StoreOnboardingRepository @Inject constructor(
                     ?.filter { it.type != MOBILE_UNSUPPORTED }
                     ?.toMutableList()
                     ?.apply {
-                        if (
-                            selectedSite.get().isFreeTrial &&
-                            !this.any { it.type == LAUNCH_YOUR_STORE }
-                        ) {
+                        if (!selectedSite.get().isFreeTrial) return@apply
+                        if (!this.any { it.type == LAUNCH_YOUR_STORE }) {
                             add(
                                 OnboardingTask(
                                     type = LAUNCH_YOUR_STORE,
@@ -57,17 +55,14 @@ class StoreOnboardingRepository @Inject constructor(
                                 )
                             )
                         }
-
-                        if (!isLocalTaskNameYourStoreCompleted()) {
-                            add(
-                                OnboardingTask(
-                                    type = LOCAL_NAME_STORE,
-                                    isComplete = false,
-                                    isVisible = true,
-                                    isVisited = false
-                                )
+                        add(
+                            OnboardingTask(
+                                type = LOCAL_NAME_STORE,
+                                isComplete = isLocalTaskNameYourStoreCompleted(),
+                                isVisible = true,
+                                isVisited = false
                             )
-                        }
+                        )
                     }
                     ?.map {
                         if (shouldMarkLaunchStoreAsCompleted(it)) it.copy(isComplete = true)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -43,27 +43,7 @@ class StoreOnboardingRepository @Inject constructor(
                 val mobileSupportedTasks = result.model?.map { it.toOnboardingTask() }
                     ?.filter { it.type != MOBILE_UNSUPPORTED }
                     ?.toMutableList()
-                    ?.apply {
-                        if (!selectedSite.get().isFreeTrial) return@apply
-                        if (!this.any { it.type == LAUNCH_YOUR_STORE }) {
-                            add(
-                                OnboardingTask(
-                                    type = LAUNCH_YOUR_STORE,
-                                    isComplete = false,
-                                    isVisible = true,
-                                    isVisited = false
-                                )
-                            )
-                        }
-                        add(
-                            OnboardingTask(
-                                type = LOCAL_NAME_STORE,
-                                isComplete = isLocalTaskNameYourStoreCompleted(),
-                                isVisible = true,
-                                isVisited = false
-                            )
-                        )
-                    }
+                    ?.apply { addLocalOnboardingTasks(this) }
                     ?.map {
                         if (shouldMarkLaunchStoreAsCompleted(it)) it.copy(isComplete = true)
                         else it
@@ -75,6 +55,28 @@ class StoreOnboardingRepository @Inject constructor(
                 onboardingTasksCacheFlow.emit(mobileSupportedTasks)
             }
         }
+    }
+
+    private fun addLocalOnboardingTasks(onboardingTasks: MutableList<OnboardingTask>) {
+        if (!selectedSite.get().isFreeTrial) return
+        if (!onboardingTasks.any { it.type == LAUNCH_YOUR_STORE }) {
+            onboardingTasks.add(
+                OnboardingTask(
+                    type = LAUNCH_YOUR_STORE,
+                    isComplete = false,
+                    isVisible = true,
+                    isVisited = false
+                )
+            )
+        }
+        onboardingTasks.add(
+            OnboardingTask(
+                type = LOCAL_NAME_STORE,
+                isComplete = isLocalTaskNameYourStoreCompleted(),
+                isVisible = true,
+                isVisited = false
+            )
+        )
     }
 
     private fun shouldMarkLaunchStoreAsCompleted(task: OnboardingTask) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.login.storecreation.onboarding
 import com.woocommerce.android.extensions.isFreeTrial
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LAUNCH_YOUR_STORE
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LOCAL_NAME_STORE
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.MOBILE_UNSUPPORTED
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.values
 import com.woocommerce.android.util.WooLog
@@ -28,13 +29,6 @@ class StoreOnboardingRepository @Inject constructor(
 
     private val onboardingTasksCacheFlow: MutableSharedFlow<List<OnboardingTask>> = MutableSharedFlow()
 
-    private val localNameStoreTask = OnboardingTask(
-        type = OnboardingTaskType.LOCAL_NAME_STORE,
-        isComplete = isLocalTaskNameYourStoreCompleted(),
-        isVisible = true,
-        isVisited = false
-    )
-
     fun observeOnboardingTasks(): SharedFlow<List<OnboardingTask>> = onboardingTasksCacheFlow
 
     suspend fun fetchOnboardingTasks() {
@@ -57,6 +51,17 @@ class StoreOnboardingRepository @Inject constructor(
                             add(
                                 OnboardingTask(
                                     type = LAUNCH_YOUR_STORE,
+                                    isComplete = false,
+                                    isVisible = true,
+                                    isVisited = false
+                                )
+                            )
+                        }
+
+                        if (!isLocalTaskNameYourStoreCompleted()) {
+                            add(
+                                OnboardingTask(
+                                    type = LOCAL_NAME_STORE,
                                     isComplete = false,
                                     isVisible = true,
                                     isVisited = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -61,7 +61,9 @@ class StoreOnboardingViewModel @Inject constructor(
                     _viewState.value = OnboardingState(
                         show = shouldShowOnboarding.showForTasks(tasks),
                         title = R.string.store_onboarding_title,
-                        tasks = tasks.map { mapToOnboardingTaskState(it) },
+                        tasks = tasks
+                            .filter { it.type != LOCAL_NAME_STORE } // temporary, to hide it from UI.
+                            .map { mapToOnboardingTaskState(it) },
                     )
                 }
         }
@@ -84,8 +86,8 @@ class StoreOnboardingViewModel @Inject constructor(
                 isCompleted = task.isComplete,
                 isLabelVisible = isAIProductDescriptionEnabled()
             )
-            LOCAL_NAME_STORE -> TODO()
 
+            LOCAL_NAME_STORE,
             MOBILE_UNSUPPORTED -> error("Unknown task type is not allowed in UI layer")
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboarding
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.ADD_FIRST_PRODUCT
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.CUSTOMIZE_DOMAIN
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LAUNCH_YOUR_STORE
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LOCAL_NAME_STORE
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.MOBILE_UNSUPPORTED
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.PAYMENTS
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.WC_PAYMENTS
@@ -83,6 +84,7 @@ class StoreOnboardingViewModel @Inject constructor(
                 isCompleted = task.isComplete,
                 isLabelVisible = isAIProductDescriptionEnabled()
             )
+            LOCAL_NAME_STORE -> TODO()
 
             MOBILE_UNSUPPORTED -> error("Unknown task type is not allowed in UI layer")
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of https://github.com/woocommerce/woocommerce-android/issues/9621
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds a local onboarding task for "Name your store", which completion logic solely depends on whether a store name currently uses the default name ("Store name", or its translated equivalent), or not.

This is just an internal change and has no effect on UI/usage yet.

**Please do not merge** until target branch is `trunk`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

There is no visible change for this in the UI, but a way to do this is to set a breakpoint on **line 80** on `StoreOnboardingRepository`. This line:

`onboardingTasksCacheFlow.emit(mobileSupportedTasks)`

Then run the debugger, and:

1. Create a new store, make sure to keep the default name "Store name".
2. Wait until the store is created and "My store" is loaded,
3. The debug breakpoint should be triggered. In the debugger, check for the value of `mobileSupportedTask` and make sure it includes 

```
OnboardingTask(type = LOCAL_NAME_STORE, isComplete = false, isVisible = true, isVisited = false)
```

![Screenshot 2023-08-22 at 14 02 29](https://github.com/woocommerce/woocommerce-android/assets/266376/436621dc-d4d8-44b1-9e12-d23c0a691a31)

4. Continue the debugging step, and ensure "My store" is loaded completely without error.
5. Ensure that "Name your store" is not added. yet into the onboarding list.