### PR TITLE
Store Creation: UI for "Name your store" local onboarding task

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -1,0 +1,35 @@
+package com.woocommerce.android.ui.login.storecreation.onboarding
+
+import android.app.Dialog
+import android.os.Bundle
+import android.widget.EditText
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.woocommerce.android.analytics.AnalyticsTracker
+
+class NameYourStoreDialogFragment : DialogFragment() {
+    companion object {
+        const val TAG: String = "NameYourStoreDialogFragment"
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val inputField = EditText(context)
+
+        val builder = MaterialAlertDialogBuilder(requireContext())
+        builder.setTitle("Site title")
+            .setView(inputField)
+            .setPositiveButton("OK") { dialog, _ ->
+                // todo handle the inputText
+                dialog.dismiss()
+            }
+            .setNegativeButton("Cancel") { dialog, _ ->
+                dialog.cancel()
+            }
+        return builder.create()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AnalyticsTracker.trackViewShown(this)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -3,8 +3,10 @@ package com.woocommerce.android.ui.login.storecreation.onboarding
 import android.app.Dialog
 import android.os.Bundle
 import android.widget.EditText
+import android.widget.FrameLayout
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 
 class NameYourStoreDialogFragment : DialogFragment() {
@@ -15,14 +17,21 @@ class NameYourStoreDialogFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val inputField = EditText(context)
 
+        val frameLayout = FrameLayout(requireContext()).apply {
+            val verticalPadding = resources.getDimensionPixelSize(R.dimen.major_150)
+            val horizontalPadding = resources.getDimensionPixelSize(R.dimen.major_100)
+            setPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding)
+            addView(inputField)
+        }
+
         val builder = MaterialAlertDialogBuilder(requireContext())
-        builder.setTitle("Site title")
-            .setView(inputField)
-            .setPositiveButton("OK") { dialog, _ ->
+        builder.setTitle(resources.getString(R.string.store_onboarding_name_your_store_dialog_title))
+            .setView(frameLayout)
+            .setPositiveButton(resources.getString(R.string.dialog_ok)) { dialog, _ ->
                 // todo handle the inputText
                 dialog.dismiss()
             }
-            .setNegativeButton("Cancel") { dialog, _ ->
+            .setNegativeButton(resources.getString(R.string.cancel)) { dialog, _ ->
                 dialog.cancel()
             }
         return builder.create()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboarding
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LOCAL_NAME_STORE
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.MOBILE_UNSUPPORTED
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.values
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -69,14 +70,16 @@ class StoreOnboardingRepository @Inject constructor(
                 )
             )
         }
-        onboardingTasks.add(
-            OnboardingTask(
-                type = LOCAL_NAME_STORE,
-                isComplete = isLocalTaskNameYourStoreCompleted(),
-                isVisible = true,
-                isVisited = false
+        if (FeatureFlag.NAME_YOUR_STORE_DIALOG.isEnabled()) {
+            onboardingTasks.add(
+                OnboardingTask(
+                    type = LOCAL_NAME_STORE,
+                    isComplete = isLocalTaskNameYourStoreCompleted(),
+                    isVisible = true,
+                    isVisited = false
+                )
             )
-        )
+        }
     }
 
     private fun shouldMarkLaunchStoreAsCompleted(task: OnboardingTask) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_ADD_DOMAIN
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_LAUNCH_SITE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_LOCAL_NAME_STORE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PAYMENTS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUCTS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STORE_DETAILS
@@ -129,6 +130,7 @@ class StoreOnboardingViewModel @Inject constructor(
             is AddProductTaskRes -> triggerEvent(NavigateToAddProduct)
             CustomizeDomainTaskRes -> triggerEvent(NavigateToDomains)
             LaunchStoreTaskRes -> triggerEvent(NavigateToLaunchStore)
+            NameYourStoreTaskRes -> triggerEvent(ShowNameYourStoreDialog)
             SetupPaymentsTaskRes -> triggerEvent(NavigateToSetupPayments)
         }
         analyticsTrackerWrapper.track(
@@ -144,6 +146,7 @@ class StoreOnboardingViewModel @Inject constructor(
             CustomizeDomainTaskRes -> VALUE_ADD_DOMAIN
             LaunchStoreTaskRes -> VALUE_LAUNCH_SITE
             SetupPaymentsTaskRes -> VALUE_PAYMENTS
+            NameYourStoreTaskRes -> VALUE_LOCAL_NAME_STORE
         }
 
     fun onPullToRefresh() {
@@ -178,6 +181,12 @@ class StoreOnboardingViewModel @Inject constructor(
         @StringRes val description: Int,
         @StringRes val labelText: Int = 0,
         @DrawableRes val labelIcon: Int = 0
+    )
+
+    object NameYourStoreTaskRes : OnboardingTaskUiResources(
+        icon = R.drawable.ic_onboarding_name_your_store,
+        title = R.string.store_onboarding_task_name_store_title,
+        description = R.string.store_onboarding_task_name_store_description
     )
 
     object AboutYourStoreTaskRes : OnboardingTaskUiResources(
@@ -219,4 +228,5 @@ class StoreOnboardingViewModel @Inject constructor(
     object NavigateToSetupPayments : MultiLiveEvent.Event()
     object NavigateToAboutYourStore : MultiLiveEvent.Event()
     object NavigateToAddProduct : MultiLiveEvent.Event()
+    object ShowNameYourStoreDialog : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -62,9 +62,7 @@ class StoreOnboardingViewModel @Inject constructor(
                     _viewState.value = OnboardingState(
                         show = shouldShowOnboarding.showForTasks(tasks),
                         title = R.string.store_onboarding_title,
-                        tasks = tasks
-                            .filter { it.type != LOCAL_NAME_STORE } // temporary, to hide it from UI.
-                            .map { mapToOnboardingTaskState(it) },
+                        tasks = tasks.map { mapToOnboardingTaskState(it) },
                     )
                 }
         }
@@ -88,7 +86,11 @@ class StoreOnboardingViewModel @Inject constructor(
                 isLabelVisible = isAIProductDescriptionEnabled()
             )
 
-            LOCAL_NAME_STORE,
+            LOCAL_NAME_STORE -> OnboardingTaskUi(
+                NameYourStoreTaskRes,
+                isCompleted = task.isComplete
+            )
+
             MOBILE_UNSUPPORTED -> error("Unknown task type is not allowed in UI layer")
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -51,6 +51,7 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.jitm.JitmFragment
 import com.woocommerce.android.ui.jitm.JitmMessagePathsProvider
+import com.woocommerce.android.ui.login.storecreation.onboarding.NameYourStoreDialogFragment
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingCollapsed
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -304,6 +305,10 @@ class MyStoreFragment :
                     findNavController().navigateSafely(
                         MyStoreFragmentDirections.actionMyStoreToAboutYourStoreFragment()
                     )
+
+                is StoreOnboardingViewModel.ShowNameYourStoreDialog -> {
+                    NameYourStoreDialogFragment().show(childFragmentManager, NameYourStoreDialogFragment.TAG)
+                }
 
                 is ShowDialog -> event.showDialog()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -31,7 +31,9 @@ enum class FeatureFlag {
     ORDER_CREATION_PRODUCT_DISCOUNTS,
     SHIPPING_ZONES,
     BETTER_CUSTOMER_SEARCH_M2,
-    HAZMAT_SHIPPING;
+    HAZMAT_SHIPPING,
+    NAME_YOUR_STORE_DIALOG;
+
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -63,7 +65,8 @@ enum class FeatureFlag {
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
-            HAZMAT_SHIPPING
+            HAZMAT_SHIPPING,
+            NAME_YOUR_STORE_DIALOG
             -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -34,7 +34,6 @@ enum class FeatureFlag {
     HAZMAT_SHIPPING,
     NAME_YOUR_STORE_DIALOG;
 
-
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
             DB_DOWNGRADE -> {

--- a/WooCommerce/src/main/res/drawable/ic_onboarding_name_your_store.xml
+++ b/WooCommerce/src/main/res/drawable/ic_onboarding_name_your_store.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group>
+        <clip-path
+            android:pathData="M0,0h24v24h-24z"/>
+        <path
+            android:pathData="M14.06,9.02L14.98,9.94L5.92,19H5V18.08L14.06,9.02ZM17.66,3C17.41,3 17.15,3.1 16.96,3.29L15.13,5.12L18.88,8.87L20.71,7.04C21.1,6.65 21.1,6.02 20.71,5.63L18.37,3.29C18.17,3.09 17.92,3 17.66,3ZM14.06,6.19L3,17.25V21H6.75L17.81,9.94L14.06,6.19Z"
+            android:fillColor="#000000"/>
+    </group>
+</vector>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="continue_button">Continue</string>
     <string name="refresh_button">Refresh</string>
     <string name="untitled">Untitled</string>
+    <string name="dialog_ok">OK</string>
     <string name="cancel">Cancel</string>
     <string name="cancel_anyway">Cancel anyway</string>
     <string name="keep_editing">Keep editing</string>
@@ -3213,6 +3214,7 @@
     <string name="store_onboarding_get_paid_loading_label">Loading…</string>
     <string name="store_onboarding_setting_title">Store Setup List</string>
     <string name="store_onboarding_setting_description">Show or hide store setup list</string>
+    <string name="store_onboarding_name_your_store_dialog_title">Site Title</string>
 
     <!--
     Support Request

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3184,6 +3184,8 @@
     <string name="store_onboarding_task_change_domain_description">Have a custom URL to host your store.</string>
     <string name="store_onboarding_task_payments_setup_title">Get paid</string>
     <string name="store_onboarding_task_payments_setup_description">Give your customers an easy and convenient way to pay!</string>
+    <string name="store_onboarding_task_name_store_title">Name your store</string>
+    <string name="store_onboarding_task_name_store_description">Customizing your store name can also help your store\'s search engine optimization.</string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d completed</string>
     <string name="store_onboarding_completed_tasks_full_screen_status">%1$d of %2$d tasks completed</string>
     <string name="store_onboarding_task_view_all">View all (%1$d)</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of https://github.com/woocommerce/woocommerce-android/issues/9621
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the UI for the store local onboarding task:
1. It shows the "Name your store" task on the Onboarding item list.
2. It shows the "Name your store" dialog if the "Name your store" task is tapped.

This PR is just UI and does not have functionalities to save site title and check the task yet.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Start a new site, make sure to use the default store name ("Store name") during store creation,
2. Once site is created and My Store is loaded, make sure "Name your store" task is shown at the top of the "Store setup" section.
3. Tap it, ensure the "Site title" dialog is shown.

Check video below for demo:

[Screen_recording_20230823_113155.webm](https://github.com/woocommerce/woocommerce-android/assets/266376/9ed7890c-7f99-4002-ae1c-cfbfb7d5bf75)
