### PR TITLE
Issue/9622 update woo profiler questions

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -123,6 +123,7 @@ object AppPrefs {
         TRACKING_EXTENSION_AVAILABLE,
         JETPACK_BENEFITS_BANNER_DISMISSAL_DATE,
         AI_PRODUCT_DESCRIPTION_CELEBRATION_SHOWN,
+        STORE_CREATION_PROFILER_ANSWERS
     }
 
     /**
@@ -261,6 +262,16 @@ object AppPrefs {
     var isEUShippingNoticeDismissed: Boolean
         get() = getBoolean(DeletablePrefKey.IS_EU_SHIPPING_NOTICE_DISMISSED, false)
         set(value) = setBoolean(DeletablePrefKey.IS_EU_SHIPPING_NOTICE_DISMISSED, value)
+
+    var storeCreationProfilerAnswers: String?
+        get() = getString(DeletableSitePrefKey.STORE_CREATION_PROFILER_ANSWERS, "")
+        set(value) {
+            if (value != null) {
+                setString(DeletableSitePrefKey.STORE_CREATION_PROFILER_ANSWERS, value)
+            } else {
+                remove(DeletableSitePrefKey.STORE_CREATION_PROFILER_ANSWERS)
+            }
+        }
 
     fun setBlazeBannerHidden(currentSiteId: Int, hidden: Boolean) {
         setBoolean(getBlazeBannerKey(currentSiteId), hidden)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -114,6 +114,7 @@ object AppPrefs {
         BLAZE_BANNER_HIDDEN,
         IS_AI_DESCRIPTION_TOOLTIP_DISMISSED,
         NUMBER_OF_TIMES_AI_DESCRIPTION_TOOLTIP_SHOWN,
+        STORE_CREATION_PROFILER_ANSWERS,
     }
 
     /**
@@ -122,8 +123,7 @@ object AppPrefs {
     private enum class DeletableSitePrefKey : PrefKey {
         TRACKING_EXTENSION_AVAILABLE,
         JETPACK_BENEFITS_BANNER_DISMISSAL_DATE,
-        AI_PRODUCT_DESCRIPTION_CELEBRATION_SHOWN,
-        STORE_CREATION_PROFILER_ANSWERS
+        AI_PRODUCT_DESCRIPTION_CELEBRATION_SHOWN
     }
 
     /**
@@ -264,12 +264,12 @@ object AppPrefs {
         set(value) = setBoolean(DeletablePrefKey.IS_EU_SHIPPING_NOTICE_DISMISSED, value)
 
     var storeCreationProfilerAnswers: String?
-        get() = getString(DeletableSitePrefKey.STORE_CREATION_PROFILER_ANSWERS, "")
+        get() = getString(DeletablePrefKey.STORE_CREATION_PROFILER_ANSWERS, "")
         set(value) {
             if (value != null) {
-                setString(DeletableSitePrefKey.STORE_CREATION_PROFILER_ANSWERS, value)
+                setString(DeletablePrefKey.STORE_CREATION_PROFILER_ANSWERS, value)
             } else {
-                remove(DeletableSitePrefKey.STORE_CREATION_PROFILER_ANSWERS)
+                remove(DeletablePrefKey.STORE_CREATION_PROFILER_ANSWERS)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 
 class AppPrefsWrapper @Inject constructor() {
+    var storeCreationProfilerAnswers by AppPrefs::storeCreationProfilerAnswers
 
     fun getAppInstallationDate() = AppPrefs.installationDate
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt
@@ -32,6 +32,7 @@ object WooLog {
         JITM,
         PLUGINS,
         IAP,
+        STORE_CREATION,
         ONBOARDING,
         WOO_TRIAL,
         AI,

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.42.0'
+    fluxCVersion = '2815-f6a9893d8cbda5f8c5c6858282b360ee6786bd99'
     wooCommerceSharedVersion = '0.6.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-b490b0fee2de32f1cfe3d94320d78ee6e5e5ed79'
+    fluxCVersion = 'trunk-2a36587d9cff7099f2039f6bd853914bf06f6f5c'
     wooCommerceSharedVersion = '0.6.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9622 

### Description
This PR uses https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2815 to add support for uploading profiler questions using the endpoint `wc-admin/options`, it adds the needed work to handle this to the `StoreProfilerRepository`, but we don't use it yet, it'll be done in a future PR.

### Testing instructions
1. Apply the patch from below
2. Open flipper or use a breakpoint at this [line](https://github.com/woocommerce/woocommerce-android/blob/516a260632224e5c262ae53281667c9affdbb4b2/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerRepository.kt#L29) to monitor the network request. 
3. Run the app, then create a free trial site.
4. Wait until the dashboard is shown.
5. Confirm using the approach chosen for 3 that the app uploaded the profiler answers using `wc-admin/options`.
6. Optional: follow the testing instructions of https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2815 to fetch the keys `woocommerce_default_country` and `woocommerce_onboarding_profile` and confirm that they have been updated.

##### Patch
```patch
Subject: [PATCH] Save site_id along the profiler answers

This is needed to avoid sending them for the wrong site
---
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt	(revision 516a260632224e5c262ae53281667c9affdbb4b2)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt	(date 1692727238953)
@@ -9,12 +9,14 @@
 import com.woocommerce.android.ui.login.storecreation.StoreCreationResult.Success
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_LANGUAGE_ID
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_THEME
+import com.woocommerce.android.ui.login.storecreation.profiler.StoreProfilerRepository
 import kotlinx.coroutines.flow.flow
 import java.util.TimeZone
 import javax.inject.Inject
 
 class CreateFreeTrialStore @Inject constructor(
-    private val repository: StoreCreationRepository
+    private val repository: StoreCreationRepository,
+    private val storeProfilerRepository: StoreProfilerRepository
 ) {
     /**
      * Triggers the creation of a new free trial site given a domain and a name.
@@ -46,7 +48,10 @@
         ).recoverIfSiteExists(storeDomain)
 
         when (result) {
-            is Success -> emit(Finished(result.data))
+            is Success -> {
+                storeProfilerRepository.storeAnswers(result.data, countryCode!!, profilerData!!)
+                emit(Finished(result.data))
+            }
             is Failure -> emit(Failed(result.type))
         }
     }
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt	(revision 516a260632224e5c262ae53281667c9affdbb4b2)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt	(date 1692727238951)
@@ -25,6 +25,7 @@
 import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsUpdateDataStore
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.login.storecreation.profiler.StoreProfilerRepository
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.MyStoreEvent.ShowAIProductDescriptionDialog
 import com.woocommerce.android.ui.mystore.domain.GetStats
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.HasOrders
@@ -89,7 +90,8 @@
     private val isAIProductDescriptionEnabled: IsAIProductDescriptionEnabled,
     private val observeLastUpdate: ObserveLastUpdate,
     notificationScheduler: LocalNotificationScheduler,
-    shouldShowPrivacyBanner: ShouldShowPrivacyBanner
+    shouldShowPrivacyBanner: ShouldShowPrivacyBanner,
+    storeProfilerRepository: StoreProfilerRepository
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER = 5
@@ -164,6 +166,10 @@
         // A notification is only displayed when the store has never been opened before
         notificationScheduler.cancelScheduledNotification(STORE_CREATION_FINISHED)
         updateShareStoreButtonVisibility()
+
+        launch {
+            storeProfilerRepository.uploadAnswers()
+        }
     }
 
     private fun updateShareStoreButtonVisibility() {
```



### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
