### PR TITLE
[Store Profiler] Handle storing and uploading store profiler answers

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.login.storecreation.NewStore
+import com.woocommerce.android.ui.login.storecreation.profiler.StoreProfilerRepository
 import com.woocommerce.android.util.EmojiUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -23,7 +24,8 @@ class CountryPickerViewModel @Inject constructor(
     analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val newStore: NewStore,
     private val localCountriesRepository: LocalCountriesRepository,
-    private val emojiUtils: EmojiUtils
+    private val emojiUtils: EmojiUtils,
+    private val storeProfilerRepository: StoreProfilerRepository
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         const val DEFAULT_LOCATION_CODE = "US"
@@ -78,9 +80,15 @@ class CountryPickerViewModel @Inject constructor(
     }
 
     fun onContinueClicked() {
-        launch {
-            triggerEvent(NavigateToSummaryStep)
+        newStore.data.profilerData?.let {
+            storeProfilerRepository.storeAnswers(
+                siteId = newStore.data.siteId ?: 0L,
+                countryCode = newStore.data.country?.code.orEmpty(),
+                profilerAnswers = it
+            )
         }
+
+        triggerEvent(NavigateToSummaryStep)
     }
 
     fun onCurrentCountryClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
@@ -80,13 +80,11 @@ class CountryPickerViewModel @Inject constructor(
     }
 
     fun onContinueClicked() {
-        newStore.data.profilerData?.let {
-            storeProfilerRepository.storeAnswers(
-                siteId = newStore.data.siteId ?: 0L,
-                countryCode = newStore.data.country?.code.orEmpty(),
-                profilerAnswers = it
-            )
-        }
+        storeProfilerRepository.storeAnswers(
+            siteId = newStore.data.siteId ?: 0L,
+            countryCode = newStore.data.country?.code,
+            profilerAnswers = newStore.data.profilerData
+        )
 
         triggerEvent(NavigateToSummaryStep)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/BaseStoreProfilerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/BaseStoreProfilerViewModel.kt
@@ -65,13 +65,11 @@ abstract class BaseStoreProfilerViewModel(
 
     fun onMainButtonClicked() {
         saveStepAnswer()
-        newStore.data.profilerData?.let {
-            storeProfilerRepository.storeAnswers(
-                siteId = newStore.data.siteId ?: 0L,
-                countryCode = newStore.data.country?.code.orEmpty(),
-                profilerAnswers = it
-            )
-        }
+        storeProfilerRepository.storeAnswers(
+            siteId = newStore.data.siteId ?: 0L,
+            countryCode = newStore.data.country?.code,
+            profilerAnswers = newStore.data.profilerData
+        )
 
         moveForward()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/BaseStoreProfilerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/BaseStoreProfilerViewModel.kt
@@ -12,7 +12,8 @@ import kotlinx.coroutines.flow.update
 
 abstract class BaseStoreProfilerViewModel(
     savedStateHandle: SavedStateHandle,
-    private val newStore: NewStore
+    private val newStore: NewStore,
+    private val storeProfilerRepository: StoreProfilerRepository,
 ) : ScopedViewModel(savedStateHandle) {
     abstract val hasSearchableContent: Boolean
     protected val profilerOptions = MutableStateFlow(emptyList<StoreProfilerOptionUi>())
@@ -46,7 +47,9 @@ abstract class BaseStoreProfilerViewModel(
 
     protected abstract fun getMainButtonText(): String
 
-    abstract fun onMainButtonClicked()
+    protected abstract fun saveStepAnswer()
+
+    protected abstract fun moveForward()
 
     fun onSearchQueryChanged(query: String) {
         searchQuery.value = query
@@ -58,6 +61,19 @@ abstract class BaseStoreProfilerViewModel(
 
     fun onArrowBackPressed() {
         triggerEvent(MultiLiveEvent.Event.Exit)
+    }
+
+    fun onMainButtonClicked() {
+        saveStepAnswer()
+        newStore.data.profilerData?.let {
+            storeProfilerRepository.storeAnswers(
+                siteId = newStore.data.siteId ?: 0L,
+                countryCode = newStore.data.country?.code.orEmpty(),
+                profilerAnswers = it
+            )
+        }
+
+        moveForward()
     }
 
     open fun onOptionSelected(option: StoreProfilerOptionUi) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerChallengesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerChallengesViewModel.kt
@@ -24,7 +24,8 @@ class StoreProfilerChallengesViewModel @Inject constructor(
     private val newStore: NewStore,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val resourceProvider: ResourceProvider,
-) : BaseStoreProfilerViewModel(savedStateHandle, newStore) {
+    storeProfilerRepository: StoreProfilerRepository
+) : BaseStoreProfilerViewModel(savedStateHandle, newStore, storeProfilerRepository) {
 
     override val hasSearchableContent: Boolean
         get() = false
@@ -81,12 +82,16 @@ class StoreProfilerChallengesViewModel @Inject constructor(
     override fun getMainButtonText(): String =
         resourceProvider.getString(R.string.continue_button)
 
-    override fun onMainButtonClicked() {
+    override fun saveStepAnswer() {
         val selectedOption = profilerOptions.value.firstOrNull { it.isSelected }
+
         newStore.update(
             profilerData = (newStore.data.profilerData ?: ProfilerData())
                 .copy(challengeKey = selectedOption?.key)
         )
+    }
+
+    override fun moveForward() {
         triggerEvent(NavigateToNextStep)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerCommerceJourneyViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerCommerceJourneyViewModel.kt
@@ -19,7 +19,7 @@ class StoreProfilerCommerceJourneyViewModel @Inject constructor(
     private val newStore: NewStore,
     private val storeProfilerRepository: StoreProfilerRepository,
     private val resourceProvider: ResourceProvider,
-) : BaseStoreProfilerViewModel(savedStateHandle, newStore) {
+) : BaseStoreProfilerViewModel(savedStateHandle, newStore, storeProfilerRepository) {
     private companion object {
         const val STARTING_BUSINESS_KEY = "im_just_starting_my_business"
         const val NOT_SELLING_ONLINE_KEY = "im_already_selling_but_not_online"
@@ -57,13 +57,16 @@ class StoreProfilerCommerceJourneyViewModel @Inject constructor(
     override fun getProfilerStepTitle(): String =
         resourceProvider.getString(R.string.store_creation_store_profiler_journey_title)
 
-    override fun onMainButtonClicked() {
+    override fun saveStepAnswer() {
         newStore.update(
             profilerData = (newStore.data.profilerData ?: NewStore.ProfilerData())
                 .copy(
                     userCommerceJourneyKey = profilerOptions.value.firstOrNull { it.isSelected }?.key
                 )
         )
+    }
+
+    override fun moveForward() {
         when (alreadySellingOnlineSelected()) {
             true -> triggerEvent(NavigateToEcommercePlatformsStep)
             false -> triggerEvent(NavigateToNextStep)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerEcommercePlatformsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerEcommercePlatformsViewModel.kt
@@ -19,7 +19,7 @@ class StoreProfilerEcommercePlatformsViewModel @Inject constructor(
     private val newStore: NewStore,
     private val storeProfilerRepository: StoreProfilerRepository,
     private val resourceProvider: ResourceProvider,
-) : BaseStoreProfilerViewModel(savedStateHandle, newStore) {
+) : BaseStoreProfilerViewModel(savedStateHandle, newStore, storeProfilerRepository) {
     override val hasSearchableContent: Boolean
         get() = false
 
@@ -66,7 +66,7 @@ class StoreProfilerEcommercePlatformsViewModel @Inject constructor(
         }
     }
 
-    override fun onMainButtonClicked() {
+    override fun saveStepAnswer() {
         newStore.update(
             profilerData = (newStore.data.profilerData ?: NewStore.ProfilerData())
                 .copy(
@@ -75,6 +75,9 @@ class StoreProfilerEcommercePlatformsViewModel @Inject constructor(
                         .map { it.key }
                 )
         )
+    }
+
+    override fun moveForward() {
         triggerEvent(NavigateToNextStep)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerFeaturesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerFeaturesViewModel.kt
@@ -19,7 +19,8 @@ class StoreProfilerFeaturesViewModel @Inject constructor(
     private val newStore: NewStore,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val resourceProvider: ResourceProvider,
-) : BaseStoreProfilerViewModel(savedStateHandle, newStore) {
+    storeProfilerRepository: StoreProfilerRepository
+) : BaseStoreProfilerViewModel(savedStateHandle, newStore, storeProfilerRepository) {
     override val hasSearchableContent: Boolean
         get() = false
 
@@ -90,12 +91,16 @@ class StoreProfilerFeaturesViewModel @Inject constructor(
     override fun getMainButtonText(): String =
         resourceProvider.getString(R.string.store_profiler_features_main_button)
 
-    override fun onMainButtonClicked() {
+    override fun saveStepAnswer() {
         val selectedOption = profilerOptions.value.firstOrNull { it.isSelected }
         newStore.update(
             profilerData = (newStore.data.profilerData ?: ProfilerData())
                 .copy(featuresKey = selectedOption?.key)
         )
+    }
+
+    override fun moveForward() {
+        // TODO("Navigate to store creation loading")
     }
 
     override fun onSkipPressed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerIndustriesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerIndustriesViewModel.kt
@@ -20,7 +20,7 @@ class StoreProfilerIndustriesViewModel @Inject constructor(
     private val newStore: NewStore,
     private val storeProfilerRepository: StoreProfilerRepository,
     private val resourceProvider: ResourceProvider,
-) : BaseStoreProfilerViewModel(savedStateHandle, newStore) {
+) : BaseStoreProfilerViewModel(savedStateHandle, newStore, storeProfilerRepository) {
     private companion object {
         const val DEFAULT_INDUSTRY_STRING_KEY_PREFIX = "store_creation_profiler_industry_"
     }
@@ -54,7 +54,7 @@ class StoreProfilerIndustriesViewModel @Inject constructor(
     override fun getProfilerStepTitle(): String =
         resourceProvider.getString(R.string.store_creation_store_profiler_industries_title)
 
-    override fun onMainButtonClicked() {
+    override fun saveStepAnswer() {
         val selectedOption = profilerOptions.value.firstOrNull { it.isSelected }
         val selectedIndustry = industries.firstOrNull { selectedOption?.key == it.key }
         newStore.update(
@@ -64,6 +64,9 @@ class StoreProfilerIndustriesViewModel @Inject constructor(
                     industryKey = selectedIndustry?.key
                 )
         )
+    }
+
+    override fun moveForward() {
         triggerEvent(NavigateToNextStep)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerRepository.kt
@@ -23,8 +23,8 @@ class StoreProfilerRepository @Inject constructor(
 
     fun storeAnswers(
         siteId: Long,
-        countryCode: String,
-        profilerAnswers: NewStore.ProfilerData
+        countryCode: String?,
+        profilerAnswers: NewStore.ProfilerData?
     ) {
         appPrefs.storeCreationProfilerAnswers = gson.toJson(
             ProfilerAnswersCache(
@@ -44,15 +44,22 @@ class StoreProfilerRepository @Inject constructor(
 
         wooAdminStore.updateOptions(
             site = selectedSite.get(),
-            options = mapOf(
-                "woocommerce_default_country" to storedAnswers.countryCode,
-                "woocommerce_onboarding_profile" to mapOf(
-                    "business_choice" to storedAnswers.answers.userCommerceJourneyKey,
-                    "selling_platforms" to storedAnswers.answers.eCommercePlatformKeys,
-                    "industry" to storedAnswers.answers.industryKey?.let { listOf(it) },
-                    "is_store_country_set" to true,
-                )
-            )
+            options = buildMap {
+                storedAnswers.countryCode?.let {
+                    put("woocommerce_default_country", it)
+                }
+                storedAnswers.answers?.let {
+                    put(
+                        key = "woocommerce_onboarding_profile",
+                        value = mapOf(
+                            "business_choice" to storedAnswers.answers.userCommerceJourneyKey,
+                            "selling_platforms" to storedAnswers.answers.eCommercePlatformKeys,
+                            "industry" to storedAnswers.answers.industryKey?.let { listOf(it) },
+                            "is_store_country_set" to (storedAnswers.countryCode != null),
+                        )
+                    )
+                }
+            }
         ).let { result ->
             when {
                 result.isError -> {
@@ -72,8 +79,8 @@ class StoreProfilerRepository @Inject constructor(
 
     private data class ProfilerAnswersCache(
         val siteId: Long,
-        val countryCode: String,
-        val answers: NewStore.ProfilerData
+        val countryCode: String?,
+        val answers: NewStore.ProfilerData?
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerRepository.kt
@@ -46,17 +46,6 @@ class StoreProfilerRepository @Inject constructor(
             ?.takeIf { selectedSite.get().siteId == it.siteId }
             ?: return
 
-        tracker.track(
-            stat = AnalyticsEvent.SITE_CREATION_PROFILER_DATA,
-            properties = mapOf(
-                AnalyticsTracker.KEY_INDUSTRY_SLUG to storedAnswers.answers?.industryKey,
-                AnalyticsTracker.KEY_USER_COMMERCE_JOURNEY to storedAnswers.answers?.userCommerceJourneyKey,
-                AnalyticsTracker.KEY_ECOMMERCE_PLATFORMS to
-                    storedAnswers.answers?.eCommercePlatformKeys?.joinToString(),
-                AnalyticsTracker.KEY_COUNTRY_CODE to storedAnswers.countryCode,
-            )
-        )
-
         wooAdminStore.updateOptions(
             site = selectedSite.get(),
             options = buildMap {
@@ -86,6 +75,16 @@ class StoreProfilerRepository @Inject constructor(
 
                 else -> {
                     WooLog.d(WooLog.T.STORE_CREATION, "Profiler Answers uploaded successfully")
+                    tracker.track(
+                        stat = AnalyticsEvent.SITE_CREATION_PROFILER_DATA,
+                        properties = mapOf(
+                            AnalyticsTracker.KEY_INDUSTRY_SLUG to storedAnswers.answers?.industryKey,
+                            AnalyticsTracker.KEY_USER_COMMERCE_JOURNEY to storedAnswers.answers?.userCommerceJourneyKey,
+                            AnalyticsTracker.KEY_ECOMMERCE_PLATFORMS to
+                                storedAnswers.answers?.eCommercePlatformKeys?.joinToString(),
+                            AnalyticsTracker.KEY_COUNTRY_CODE to storedAnswers.countryCode,
+                        )
+                    )
                     appPrefs.storeCreationProfilerAnswers = null
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerRepository.kt
@@ -125,32 +125,32 @@ private const val PROFILER_OPTIONS_JSON = """{
     {
       "id": 0,
       "label": "Clothing and accessories",
-      "key": "clothing_accessories"
+      "key": "clothing_and_accessories"
     },
     {
       "id": 1,
       "label": "Health and beauty",
-      "key": "health_beauty"
+      "key": "health_and_beauty"
     },
     {
       "id": 2,
       "label": "Food and drink",
-      "key": "food_drink"
+      "key": "food_and_drink"
     },
     {
       "id": 3,
       "label": "Home, furniture, and garden",
-      "key": "home_furniture_garden"
+      "key": "home_furniture_and_garden"
     },
     {
       "id": 4,
       "label": "Education and learning",
-      "key": "education_learning"
+      "key": "education_and_learning"
     },
     {
       "id": 5,
       "label": "Electronics and computers",
-      "key": "electronic_computers"
+      "key": "electronics_and_computers"
     },
     {
       "id": 6,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -45,17 +45,6 @@ class StoreCreationSummaryViewModel @Inject constructor(
                 AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_STEP_STORE_SUMMARY
             )
         )
-
-        val newStoreProfilerData = newStore.data.profilerData
-        tracker.track(
-            stat = AnalyticsEvent.SITE_CREATION_PROFILER_DATA,
-            properties = mapOf(
-                AnalyticsTracker.KEY_INDUSTRY_SLUG to newStoreProfilerData?.industryKey,
-                AnalyticsTracker.KEY_USER_COMMERCE_JOURNEY to newStoreProfilerData?.userCommerceJourneyKey,
-                AnalyticsTracker.KEY_ECOMMERCE_PLATFORMS to newStoreProfilerData?.eCommercePlatformKeys?.joinToString(),
-                AnalyticsTracker.KEY_COUNTRY_CODE to newStore.data.country?.code,
-            )
-        )
     }
 
     fun onCancelPressed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -48,6 +48,7 @@ import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -48,7 +48,6 @@ import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -42,12 +42,12 @@ import com.woocommerce.android.ui.prefs.RequestedAnalyticsValue
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
@@ -79,6 +79,7 @@ class MainActivityViewModel @Inject constructor(
         }
 
         launch(dispatchers.io) {
+            if (!FeatureFlag.OPTIMIZE_PROFILER_QUESTIONS.isEnabled()) return@launch
             if (selectedSite.exists()) {
                 // Upload any pending store profiler answers
                 storeProfilerRepository.uploadAnswers()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/networking/SitePlanRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/plans/networking/SitePlanRestClient.kt
@@ -122,7 +122,9 @@ class SitePlanRestClient @Inject constructor(
             .plan_slug("ecommerce-trial-bundle-monthly")
             .urlV1_1
 
-        val body = if (FeatureFlag.STORE_CREATION_PROFILER.isEnabled()) {
+        val body = if (FeatureFlag.STORE_CREATION_PROFILER.isEnabled() &&
+            !FeatureFlag.OPTIMIZE_PROFILER_QUESTIONS.isEnabled()
+        ) {
             siteData.toAPIBody()
         } else {
             emptyMap()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -31,7 +31,8 @@ enum class FeatureFlag {
     SHIPPING_ZONES,
     BETTER_CUSTOMER_SEARCH_M2,
     HAZMAT_SHIPPING,
-    NAME_YOUR_STORE_DIALOG;
+    NAME_YOUR_STORE_DIALOG,
+    OPTIMIZE_PROFILER_QUESTIONS;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -63,7 +64,8 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             HAZMAT_SHIPPING,
-            NAME_YOUR_STORE_DIALOG
+            NAME_YOUR_STORE_DIALOG,
+            OPTIMIZE_PROFILER_QUESTIONS
             -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.notifications.WooNotificationType
 import com.woocommerce.android.notifications.push.NotificationMessageHandler
 import com.woocommerce.android.notifications.push.NotificationTestUtils
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.storecreation.profiler.StoreProfilerRepository
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.Hidden
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.UnseenReviews
 import com.woocommerce.android.ui.main.MainActivityViewModel.RestartActivityForNotification
@@ -113,6 +114,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
     private val unseenReviewsCountHandler: UnseenReviewsCountHandler = mock {
         on { observeUnseenCount() } doReturn MutableStateFlow(1)
     }
+    private val storeProfilerRepository: StoreProfilerRepository = mock()
 
     private val testAnnouncement = FeatureAnnouncement(
         appVersionName = "14.2",
@@ -526,19 +528,21 @@ class MainActivityViewModelTest : BaseUnitTest() {
     private fun createViewModel() {
         viewModel = spy(
             MainActivityViewModel(
-                savedStateHandle,
-                siteStore,
-                selectedSite,
-                notificationMessageHandler,
-                featureAnnouncementRepository,
-                buildConfigWrapper,
-                prefs,
-                analyticsTrackerWrapper,
-                resolveAppLink,
-                mock(),
-                moreMenuNewFeatureHandler,
-                unseenReviewsCountHandler,
-                mock {
+                savedState = savedStateHandle,
+                dispatchers = coroutinesTestRule.testDispatchers,
+                siteStore = siteStore,
+                selectedSite = selectedSite,
+                notificationHandler = notificationMessageHandler,
+                featureAnnouncementRepository = featureAnnouncementRepository,
+                buildConfigWrapper = buildConfigWrapper,
+                prefs = prefs,
+                analyticsTrackerWrapper = analyticsTrackerWrapper,
+                resolveAppLink = resolveAppLink,
+                privacyRepository = mock(),
+                storeProfilerRepository = storeProfilerRepository,
+                moreMenuNewFeatureHandler = moreMenuNewFeatureHandler,
+                unseenReviewsCountHandler = unseenReviewsCountHandler,
+                determineTrialStatusBarState = mock {
                     onBlocking { invoke(any()) } doReturn emptyFlow()
                 }
             )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9630
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR is building on top of what we added in #9629, it adds the following:
1. Updates the Profiler screens with a logic to separate saving from the navigation, which allows the parent class to handle saving their data before navigating.
2. Updates the CountryPicker to update the profiler data as well.
3. Updates the industry keys to match the Core values.
4. Adds a FeatureFlag, and use it for sending the data on app launch.

### Testing instructions
1. Apply the patch from below, it's needed to save the correct site ID, but we won't need when we re-order the flow.
2. Create a free trial site.
3. Once the site creation finishes, confirm that the following line is printed in the log: `Profiler Answers uploaded successfully`


```patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt	(revision 80d2e64271e7355ea1f8e504d4dde6792768e358)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt	(date 1692797915465)
@@ -9,12 +9,14 @@
 import com.woocommerce.android.ui.login.storecreation.StoreCreationResult.Success
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_LANGUAGE_ID
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_THEME
+import com.woocommerce.android.ui.login.storecreation.profiler.StoreProfilerRepository
 import kotlinx.coroutines.flow.flow
 import java.util.TimeZone
 import javax.inject.Inject
 
 class CreateFreeTrialStore @Inject constructor(
-    private val repository: StoreCreationRepository
+    private val repository: StoreCreationRepository,
+    private val storeProfilerRepository: StoreProfilerRepository
 ) {
     /**
      * Triggers the creation of a new free trial site given a domain and a name.
@@ -46,7 +48,14 @@
         ).recoverIfSiteExists(storeDomain)
 
         when (result) {
-            is Success -> emit(Finished(result.data))
+            is Success -> {
+                storeProfilerRepository.storeAnswers(
+                    siteId = result.data,
+                    profilerAnswers = profilerData!!,
+                    countryCode = countryCode.orEmpty()
+                )
+                emit(Finished(result.data))
+            }
             is Failure -> emit(Failed(result.type))
         }
     }

```

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
