### PR TITLE
[Hazmat Shipping] Introduce Hazmat complete category selection UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -157,7 +157,10 @@ class EditShippingLabelPackagesFragment :
 
                     findNavController().navigateSafely(action)
                 }
-                is OpenHazmatCategorySelector -> showHazmatCategoryPicker(event.onHazmatCategorySelected)
+                is OpenHazmatCategorySelector -> showHazmatCategoryPicker(
+                    event.currentSelection,
+                    event.onHazmatCategorySelected
+                )
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ExitWithResult<*> -> navigateBackWithResult(EDIT_PACKAGES_RESULT, event.data)
                 is Exit -> navigateBackWithNotice(EDIT_PACKAGES_CLOSED)
@@ -179,7 +182,10 @@ class EditShippingLabelPackagesFragment :
         return false
     }
 
-    private fun showHazmatCategoryPicker(onHazmatCategorySelected: OnHazmatCategorySelected) {
+    private fun showHazmatCategoryPicker(
+        currentSelection: ShippingLabelHazmatCategory?,
+        onHazmatCategorySelected: OnHazmatCategorySelected
+    ) {
         handleDialogResult<String>(
             key = KEY_HAZMAT_CATEGORY_SELECTOR_RESULT,
             entryId = R.id.editShippingLabelPackagesFragment
@@ -196,7 +202,7 @@ class EditShippingLabelPackagesFragment :
                 values = ShippingLabelHazmatCategory.values()
                     .map { it.toString() }
                     .toTypedArray(),
-                selectedItem = null
+                selectedItem = currentSelection.toString()
             ).let { findNavController().navigateSafely(it) }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -43,6 +43,7 @@ class EditShippingLabelPackagesFragment :
     companion object {
         const val EDIT_PACKAGES_CLOSED = "edit_packages_closed"
         const val EDIT_PACKAGES_RESULT = "edit_packages_result"
+        const val KEY_HAZMAT_CATEGORY_SELECTOR_RESULT = "hazmat_category_selector_result"
     }
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
@@ -180,15 +181,15 @@ class EditShippingLabelPackagesFragment :
 
     private fun showHazmatCategoryPicker(onHazmatCategorySelected: OnHazmatCategorySelected) {
         handleDialogResult<String>(
-            key = "test",
+            key = KEY_HAZMAT_CATEGORY_SELECTOR_RESULT,
             entryId = R.id.editShippingLabelPackagesFragment
         ) { hazmatSelection ->
             onHazmatCategorySelected(ShippingLabelHazmatCategory.valueOf(hazmatSelection))
         }
         EditShippingLabelPackagesFragmentDirections
             .actionEditShippingLabelPaymentFragmentToHazmatCategorySelector(
-                title = "Select Category",
-                requestKey = "test",
+                title = getString(R.string.shipping_label_package_details_hazmat_select_category_action),
+                requestKey = KEY_HAZMAT_CATEGORY_SELECTOR_RESULT,
                 keys = ShippingLabelHazmatCategory.values()
                     .map { getString(it.stringResourceID) }
                     .toTypedArray(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -190,10 +190,10 @@ class EditShippingLabelPackagesFragment :
                 title = "Select Category",
                 requestKey = "test",
                 keys = ShippingLabelHazmatCategory.values()
-                    .map { it.toString() }
+                    .map { getString(it.stringResourceID) }
                     .toTypedArray(),
                 values = ShippingLabelHazmatCategory.values()
-                    .map { getString(it.stringResourceID) }
+                    .map { it.toString() }
                     .toTypedArray(),
                 selectedItem = null
             ).let { findNavController().navigateSafely(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -172,4 +172,15 @@ class EditShippingLabelPackagesFragment :
         viewModel.onBackButtonClicked()
         return false
     }
+
+    private fun showHazmatCategoryPicker() {
+        EditShippingLabelPackagesFragmentDirections
+            .actionEditShippingLabelPaymentFragmentToHazmatCategorySelector(
+                title = "",
+                requestKey = "",
+                keys = emptyArray(),
+                values = emptyArray(),
+                selectedItem = ""
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -52,7 +52,8 @@ class EditShippingLabelPackagesFragment :
             viewModel::onWeightEdited,
             viewModel::onExpandedChanged,
             viewModel::onPackageSpinnerClicked,
-            viewModel::onMoveButtonClicked
+            viewModel::onMoveButtonClicked,
+            viewModel::onHazmatCategoryClicked
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.OpenHazmatCategorySelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.OpenPackageCreatorEvent
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.OpenPackageSelectorEvent
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.ShowMoveItemDialog
@@ -152,6 +153,7 @@ class EditShippingLabelPackagesFragment :
 
                     findNavController().navigateSafely(action)
                 }
+                is OpenHazmatCategorySelector -> showHazmatCategoryPicker()
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ExitWithResult<*> -> navigateBackWithResult(EDIT_PACKAGES_RESULT, event.data)
                 is Exit -> navigateBackWithNotice(EDIT_PACKAGES_CLOSED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -156,7 +156,7 @@ class EditShippingLabelPackagesFragment :
 
                     findNavController().navigateSafely(action)
                 }
-                is OpenHazmatCategorySelector -> showHazmatCategoryPicker()
+                is OpenHazmatCategorySelector -> showHazmatCategoryPicker(event.onHazmatCategorySelected)
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ExitWithResult<*> -> navigateBackWithResult(EDIT_PACKAGES_RESULT, event.data)
                 is Exit -> navigateBackWithNotice(EDIT_PACKAGES_CLOSED)
@@ -180,18 +180,22 @@ class EditShippingLabelPackagesFragment :
 
     private fun showHazmatCategoryPicker(onHazmatCategorySelected: OnHazmatCategorySelected) {
         handleDialogResult<String>(
-            key = "",
+            key = "test",
             entryId = R.id.editShippingLabelPackagesFragment
         ) { hazmatSelection ->
             onHazmatCategorySelected(ShippingLabelHazmatCategory.valueOf(hazmatSelection))
         }
         EditShippingLabelPackagesFragmentDirections
             .actionEditShippingLabelPaymentFragmentToHazmatCategorySelector(
-                title = "",
-                requestKey = "",
-                keys = emptyArray(),
-                values = emptyArray(),
-                selectedItem = ""
+                title = "Select Category",
+                requestKey = "test",
+                keys = ShippingLabelHazmatCategory.values()
+                    .map { it.toString() }
+                    .toTypedArray(),
+                values = ShippingLabelHazmatCategory.values()
+                    .map { getString(it.stringResourceID) }
+                    .toTypedArray(),
+                selectedItem = null
             )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -196,6 +196,6 @@ class EditShippingLabelPackagesFragment :
                     .map { getString(it.stringResourceID) }
                     .toTypedArray(),
                 selectedItem = null
-            )
+            ).let { findNavController().navigateSafely(it) }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentEditShippingLabelPackagesBinding
+import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.navigateBackWithResult
@@ -178,6 +179,12 @@ class EditShippingLabelPackagesFragment :
     }
 
     private fun showHazmatCategoryPicker(onHazmatCategorySelected: OnHazmatCategorySelected) {
+        handleDialogResult<String>(
+            key = "",
+            entryId = R.id.editShippingLabelPackagesFragment
+        ) { hazmatSelection ->
+            onHazmatCategorySelected(ShippingLabelHazmatCategory.valueOf(hazmatSelection))
+        }
         EditShippingLabelPackagesFragmentDirections
             .actionEditShippingLabelPaymentFragmentToHazmatCategorySelector(
                 title = "",
@@ -185,6 +192,6 @@ class EditShippingLabelPackagesFragment :
                 keys = emptyArray(),
                 values = emptyArray(),
                 selectedItem = ""
-        )
+            )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -32,6 +32,8 @@ import com.woocommerce.android.widgets.SkeletonView
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
+typealias OnHazmatCategorySelected = (ShippingLabelHazmatCategory) -> Unit
+
 @AndroidEntryPoint
 class EditShippingLabelPackagesFragment :
     BaseFragment(R.layout.fragment_edit_shipping_label_packages),
@@ -175,7 +177,7 @@ class EditShippingLabelPackagesFragment :
         return false
     }
 
-    private fun showHazmatCategoryPicker() {
+    private fun showHazmatCategoryPicker(onHazmatCategorySelected: OnHazmatCategorySelected) {
         EditShippingLabelPackagesFragmentDirections
             .actionEditShippingLabelPaymentFragmentToHazmatCategorySelector(
                 title = "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -376,5 +376,5 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
 
     data class OpenHazmatCategorySelector(
         val onHazmatCategorySelected: OnHazmatCategorySelected
-    ): MultiLiveEvent.Event()
+    ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -179,9 +179,8 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         triggerEvent(ShowMoveItemDialog(item, shippingPackage, viewState.packages))
     }
 
-    fun onHazmatCategoryClicked(): ShippingLabelHazmatCategory {
-        triggerEvent(OpenHazmatCategorySelector)
-        return ShippingLabelHazmatCategory.AIR_ELIGIBLE_ETHANOL
+    fun onHazmatCategoryClicked(onHazmatCategorySelected: OnHazmatCategorySelected) {
+        triggerEvent(OpenHazmatCategorySelector(onHazmatCategorySelected))
     }
 
     // all the logic is inside local functions, so it should be OK, but detekt complains still
@@ -375,5 +374,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         val packagesList: List<ShippingLabelPackage>
     ) : MultiLiveEvent.Event()
 
-    object OpenHazmatCategorySelector: MultiLiveEvent.Event()
+    data class OpenHazmatCategorySelector(
+        val onHazmatCategorySelected: OnHazmatCategorySelected
+    ): MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -180,6 +180,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
     }
 
     fun onHazmatCategoryClicked(): ShippingLabelHazmatCategory {
+        triggerEvent(OpenHazmatCategorySelector)
         return ShippingLabelHazmatCategory.AIR_ELIGIBLE_ETHANOL
     }
 
@@ -373,4 +374,6 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         val currentPackage: ShippingLabelPackage,
         val packagesList: List<ShippingLabelPackage>
     ) : MultiLiveEvent.Event()
+
+    object OpenHazmatCategorySelector: MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -179,8 +179,11 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         triggerEvent(ShowMoveItemDialog(item, shippingPackage, viewState.packages))
     }
 
-    fun onHazmatCategoryClicked(onHazmatCategorySelected: OnHazmatCategorySelected) {
-        triggerEvent(OpenHazmatCategorySelector(onHazmatCategorySelected))
+    fun onHazmatCategoryClicked(
+        currentSelection: ShippingLabelHazmatCategory?,
+        onHazmatCategorySelected: OnHazmatCategorySelected
+    ) {
+        triggerEvent(OpenHazmatCategorySelector(currentSelection, onHazmatCategorySelected))
     }
 
     // all the logic is inside local functions, so it should be OK, but detekt complains still
@@ -375,6 +378,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
     ) : MultiLiveEvent.Event()
 
     data class OpenHazmatCategorySelector(
+        val currentSelection: ShippingLabelHazmatCategory?,
         val onHazmatCategorySelected: OnHazmatCategorySelected
     ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -179,6 +179,10 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         triggerEvent(ShowMoveItemDialog(item, shippingPackage, viewState.packages))
     }
 
+    fun onHazmatCategoryClicked(): ShippingLabelHazmatCategory {
+        return ShippingLabelHazmatCategory.AIR_ELIGIBLE_ETHANOL
+    }
+
     // all the logic is inside local functions, so it should be OK, but detekt complains still
     @Suppress("ComplexMethod")
     fun handleMoveItemResult(result: MoveItemResult) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.extensions.collapse
 import com.woocommerce.android.extensions.expand
 import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.extensions.getColorCompat
+import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.model.getTitle
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.ShippingLabelPackageUiModel
@@ -25,13 +26,15 @@ import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 
+typealias OnHazmatCategoryClicked = (ShippingLabelHazmatCategory?, OnHazmatCategorySelected) -> Unit
+
 class ShippingLabelPackagesAdapter(
     val siteParameters: SiteParameters,
     val onWeightEdited: (Int, Float) -> Unit,
     val onExpandedChanged: (Int, Boolean) -> Unit,
     val onPackageSpinnerClicked: (Int) -> Unit,
     val onMoveItemClicked: (ShippingLabelPackage.Item, ShippingLabelPackage) -> Unit,
-    val onHazmatCategoryClicked: (OnHazmatCategorySelected) -> Unit,
+    val onHazmatCategoryClicked: OnHazmatCategoryClicked,
 ) : RecyclerView.Adapter<ShippingLabelPackageViewHolder>() {
     var uiModels: List<ShippingLabelPackageUiModel> = emptyList()
         set(value) {
@@ -130,7 +133,10 @@ class ShippingLabelPackagesAdapter(
             }
 
             binding.hazmatCategoryContainer.setOnClickListener {
-                onHazmatCategoryClicked {
+                val currentCategory = binding.hazmatCategory.text.toString()
+                    .takeIf { it.isNotNullOrEmpty() }
+                    ?.let { ShippingLabelHazmatCategory.valueOf(it) }
+                onHazmatCategoryClicked(currentCategory) {
                     binding.hazmatCategory.text = binding.root.context.getString(it.stringResourceID)
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.extensions.collapse
 import com.woocommerce.android.extensions.expand
 import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.extensions.getColorCompat
-import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.model.getTitle
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.ShippingLabelPackageUiModel
@@ -85,7 +84,7 @@ class ShippingLabelPackagesAdapter(
         val isExpanded
             get() = binding.expandIcon.rotation == 180f
 
-        var currentHazmatSelection: ShippingLabelHazmatCategory? = null
+        private var currentHazmatSelection: ShippingLabelHazmatCategory? = null
 
         init {
             with(binding.itemsList) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -85,6 +85,8 @@ class ShippingLabelPackagesAdapter(
         val isExpanded
             get() = binding.expandIcon.rotation == 180f
 
+        var currentHazmatSelection: ShippingLabelHazmatCategory? = null
+
         init {
             with(binding.itemsList) {
                 layoutManager =
@@ -133,10 +135,8 @@ class ShippingLabelPackagesAdapter(
             }
 
             binding.hazmatCategoryContainer.setOnClickListener {
-                val currentCategory = binding.hazmatCategory.text.toString()
-                    .takeIf { it.isNotNullOrEmpty() }
-                    ?.let { ShippingLabelHazmatCategory.valueOf(it) }
-                onHazmatCategoryClicked(currentCategory) {
+                onHazmatCategoryClicked(currentHazmatSelection) {
+                    currentHazmatSelection = it
                     binding.hazmatCategory.text = binding.root.context.getString(it.stringResourceID)
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -31,7 +31,7 @@ class ShippingLabelPackagesAdapter(
     val onExpandedChanged: (Int, Boolean) -> Unit,
     val onPackageSpinnerClicked: (Int) -> Unit,
     val onMoveItemClicked: (ShippingLabelPackage.Item, ShippingLabelPackage) -> Unit,
-    val onHazmatCategoryClicked: () -> ShippingLabelHazmatCategory,
+    val onHazmatCategoryClicked: (OnHazmatCategorySelected) -> Unit,
 ) : RecyclerView.Adapter<ShippingLabelPackageViewHolder>() {
     var uiModels: List<ShippingLabelPackageUiModel> = emptyList()
         set(value) {
@@ -130,9 +130,9 @@ class ShippingLabelPackagesAdapter(
             }
 
             binding.hazmatCategoryContainer.setOnClickListener {
-                onHazmatCategoryClicked()
-                    .let { binding.root.context.getString(it.stringResourceID) }
-                    .let { binding.hazmatCategory.text = it }
+                onHazmatCategoryClicked {
+                    binding.hazmatCategory.text = binding.root.context.getString(it.stringResourceID)
+                }
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -30,7 +30,8 @@ class ShippingLabelPackagesAdapter(
     val onWeightEdited: (Int, Float) -> Unit,
     val onExpandedChanged: (Int, Boolean) -> Unit,
     val onPackageSpinnerClicked: (Int) -> Unit,
-    val onMoveItemClicked: (ShippingLabelPackage.Item, ShippingLabelPackage) -> Unit
+    val onMoveItemClicked: (ShippingLabelPackage.Item, ShippingLabelPackage) -> Unit,
+    val onHazmatCategoryClicked: () -> Unit,
 ) : RecyclerView.Adapter<ShippingLabelPackageViewHolder>() {
     var uiModels: List<ShippingLabelPackageUiModel> = emptyList()
         set(value) {
@@ -126,6 +127,10 @@ class ShippingLabelPackagesAdapter(
             binding.hazmatToggle.setOnCheckedChangeListener { _, isChecked ->
                 TransitionManager.beginDelayedTransition(binding.root)
                 binding.hazmatContent.isVisible = isChecked
+            }
+
+            binding.hazmatCategoryContainer.setOnClickListener {
+                onHazmatCategoryClicked()
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -31,7 +31,7 @@ class ShippingLabelPackagesAdapter(
     val onExpandedChanged: (Int, Boolean) -> Unit,
     val onPackageSpinnerClicked: (Int) -> Unit,
     val onMoveItemClicked: (ShippingLabelPackage.Item, ShippingLabelPackage) -> Unit,
-    val onHazmatCategoryClicked: () -> Unit,
+    val onHazmatCategoryClicked: () -> ShippingLabelHazmatCategory,
 ) : RecyclerView.Adapter<ShippingLabelPackageViewHolder>() {
     var uiModels: List<ShippingLabelPackageUiModel> = emptyList()
         set(value) {
@@ -131,6 +131,8 @@ class ShippingLabelPackagesAdapter(
 
             binding.hazmatCategoryContainer.setOnClickListener {
                 onHazmatCategoryClicked()
+                    .let { binding.root.context.getString(it.stringResourceID) }
+                    .let { binding.hazmatCategory.text = it }
             }
         }
 

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -210,7 +210,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/major_100"
                 android:orientation="vertical"
-                android:visibility="visible">
+                android:visibility="gone">
 
                 <LinearLayout
                     android:id="@+id/hazmat_category_container"

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -208,7 +208,6 @@
                 android:id="@+id/hazmat_content"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
                 android:orientation="vertical"
                 android:visibility="gone">
 
@@ -217,16 +216,20 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/minor_100"
+                    android:background="?attr/selectableItemBackground"
                     android:clickable="true"
                     android:focusable="true"
                     android:orientation="vertical">
 
-                    <View style="@style/Woo.Divider" />
+                    <View
+                        style="@style/Woo.Divider"
+                        android:layout_marginStart="@dimen/major_100" />
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginVertical="@dimen/minor_100"
+                        android:layout_marginStart="@dimen/major_100"
                         android:orientation="horizontal">
 
                         <LinearLayout
@@ -262,19 +265,20 @@
 
                     </LinearLayout>
 
-                    <View style="@style/Woo.Divider" />
+                    <View
+                        style="@style/Woo.Divider"
+                        android:layout_marginStart="@dimen/major_100" />
 
                 </LinearLayout>
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/major_100"
                     android:layout_marginVertical="@dimen/major_100"
-                    android:layout_marginEnd="@dimen/major_100"
                     android:text="@string/shipping_label_package_details_hazmat_content_description" />
 
             </LinearLayout>
-
         </LinearLayout>
     </LinearLayout>
 </androidx.cardview.widget.CardView>

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -208,7 +208,7 @@
                 android:id="@+id/hazmat_content"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/major_100"
+                android:layout_marginStart="@dimen/major_100"
                 android:orientation="vertical"
                 android:visibility="visible">
 
@@ -261,8 +261,8 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:layout_marginBottom="@dimen/major_100"
+                    android:layout_marginVertical="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
                     android:text="@string/shipping_label_package_details_hazmat_content_description" />
 
             </LinearLayout>

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/Woo.Card.WithoutPadding"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    style="@style/Woo.Card.WithoutPadding">
+    android:layout_height="wrap_content">
 
     <LinearLayout xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
@@ -212,51 +212,58 @@
                 android:orientation="vertical"
                 android:visibility="visible">
 
-                <View
-                    style="@style/Woo.Divider"
-                    android:layout_marginTop="@dimen/minor_100" />
-
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginVertical="@dimen/minor_100"
-                    android:orientation="horizontal">
+                    android:layout_marginTop="@dimen/minor_100"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:orientation="vertical">
+
+                    <View style="@style/Woo.Divider" />
 
                     <LinearLayout
-                        android:layout_width="0dp"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_weight="5"
-                        android:orientation="vertical">
+                        android:layout_marginVertical="@dimen/minor_100"
+                        android:orientation="horizontal">
 
-                        <com.google.android.material.textview.MaterialTextView
-                            style="@style/Woo.ListItem.Title"
-                            android:layout_width="match_parent"
+                        <LinearLayout
+                            android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_margin="0dp"
-                            android:text="@string/shipping_label_package_details_hazmat_selection_title" />
+                            android:layout_weight="5"
+                            android:orientation="vertical">
 
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/hazmat_category"
-                            style="@style/Woo.ListItem.Body"
-                            android:layout_width="match_parent"
+                            <com.google.android.material.textview.MaterialTextView
+                                style="@style/Woo.ListItem.Title"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_margin="0dp"
+                                android:text="@string/shipping_label_package_details_hazmat_selection_title" />
+
+                            <com.google.android.material.textview.MaterialTextView
+                                android:id="@+id/hazmat_category"
+                                style="@style/Woo.ListItem.Body"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_margin="0dp"
+                                android:text="@string/shipping_label_package_details_hazmat_select_category_action" />
+
+                        </LinearLayout>
+
+                        <ImageView
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_margin="0dp"
-                            android:text="@string/shipping_label_package_details_hazmat_select_category_action" />
+                            android:layout_gravity="center_vertical"
+                            android:layout_marginEnd="@dimen/major_75"
+                            android:contentDescription="@string/product_property_edit"
+                            android:src="@drawable/ic_arrow_right" />
 
                     </LinearLayout>
 
-                    <ImageView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_vertical"
-                        android:layout_marginEnd="@dimen/major_75"
-                        android:contentDescription="@string/product_property_edit"
-                        android:src="@drawable/ic_arrow_right" />
+                    <View style="@style/Woo.Divider" />
 
                 </LinearLayout>
-
-                <View
-                    style="@style/Woo.Divider" />
 
                 <TextView
                     android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -213,6 +213,7 @@
                 android:visibility="visible">
 
                 <LinearLayout
+                    android:id="@+id/hazmat_category_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/minor_100"

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -233,14 +233,15 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_margin="0dp"
-                            android:text="Hazardous material category" />
+                            android:text="@string/shipping_label_package_details_hazmat_selection_title" />
 
                         <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/hazmat_category"
                             style="@style/Woo.ListItem.Body"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_margin="0dp"
-                            android:text="select a category" />
+                            android:text="@string/shipping_label_package_details_hazmat_select_category_action" />
 
                     </LinearLayout>
 

--- a/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
+++ b/WooCommerce/src/main/res/layout/shipping_label_package_details_list_item.xml
@@ -210,7 +210,52 @@
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="@dimen/major_100"
                 android:orientation="vertical"
-                android:visibility="gone">
+                android:visibility="visible">
+
+                <View
+                    style="@style/Woo.Divider"
+                    android:layout_marginTop="@dimen/minor_100" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="@dimen/minor_100"
+                    android:orientation="horizontal">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="5"
+                        android:orientation="vertical">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            style="@style/Woo.ListItem.Title"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_margin="0dp"
+                            android:text="Hazardous material category" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            style="@style/Woo.ListItem.Body"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_margin="0dp"
+                            android:text="select a category" />
+
+                    </LinearLayout>
+
+                    <ImageView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:layout_marginEnd="@dimen/major_75"
+                        android:contentDescription="@string/product_property_edit"
+                        android:src="@drawable/ic_arrow_right" />
+
+                </LinearLayout>
+
+                <View
+                    style="@style/Woo.Divider" />
 
                 <TextView
                     android:layout_width="wrap_content"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -394,6 +394,9 @@
         <action
             android:id="@+id/action_editShippingLabelPackagesFragment_to_shippingLabelCreatePackageFragment"
             app:destination="@id/shippingLabelCreatePackageFragment" />
+        <action
+            android:id="@+id/action_editShippingLabelPaymentFragment_to_hazmatCategorySelector"
+            app:destination="@id/hazmatCategorySelectorDialog" />
     </fragment>
     <fragment
         android:id="@+id/shippingPackageSelectorFragment"
@@ -420,11 +423,7 @@
         android:id="@+id/editShippingLabelPaymentFragment"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPaymentFragment"
         android:label="EditShippingLabelPaymentFragment"
-        tools:layout="@layout/fragment_edit_shipping_label_payment">
-        <action
-            android:id="@+id/action_editShippingLabelPaymentFragment_to_hazmatCategorySelector"
-            app:destination="@id/hazmatCategorySelectorDialog" />
-    </fragment>
+        tools:layout="@layout/fragment_edit_shipping_label_payment"/>
     <fragment
         android:id="@+id/shippingCarrierRatesFragment"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -420,7 +420,11 @@
         android:id="@+id/editShippingLabelPaymentFragment"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPaymentFragment"
         android:label="EditShippingLabelPaymentFragment"
-        tools:layout="@layout/fragment_edit_shipping_label_payment" />
+        tools:layout="@layout/fragment_edit_shipping_label_payment">
+        <action
+            android:id="@+id/action_editShippingLabelPaymentFragment_to_hazmatCategorySelector"
+            app:destination="@id/hazmatCategorySelectorDialog" />
+    </fragment>
     <fragment
         android:id="@+id/shippingCarrierRatesFragment"
         android:name="com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingCarrierRatesFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -599,4 +599,27 @@
         android:id="@+id/installWcShippingFlowFragment"
         android:name="com.woocommerce.android.ui.shipping.InstallWCShippingFragment"
         android:label="InstallWcShippingFlowFragment" />
+    <dialog
+        android:id="@+id/hazmatCategorySelectorDialog"
+        android:name="com.woocommerce.android.ui.ItemSelectorDialog"
+        android:label="ItemSelectorDialog">
+        <argument
+            android:name="selectedItem"
+            app:argType="string"
+            app:nullable="true" />
+        <argument
+            android:name="keys"
+            app:argType="string[]" />
+        <argument
+            android:name="values"
+            app:argType="string[]" />
+        <argument
+            android:name="requestKey"
+            app:argType="string" />
+        <argument
+            android:name="title"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
+    </dialog>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -963,6 +963,8 @@
     <string name="shipping_label_package_details_individual_package_dimensions_error">Package dimensions must be greater than zero. Please update your item’s dimensions in the Shipping section of your product page to continue.</string>
     <string name="shipping_label_package_details_hazmat_content_checkbox_title">Contains Hazardous Materials</string>
     <string name="shipping_label_package_details_hazmat_content_description">Potentially hazardous material includes items such as batteries, dry ice, flammable liquids, aerosols, ammunition, fireworks, nail polish, perfume, paint, solvents, and more. Hazardous items must ship in separate packages.</string>
+    <string name="shipping_label_package_details_hazmat_selection_title">Hazardous material category</string>
+    <string name="shipping_label_package_details_hazmat_select_category_action">Select a category</string>
     <string name="shipping_label_items_count_placeholder">Items count</string>
     <string name="shipping_label_package_details_title_template">Package %1$d</string>
     <string name="shipping_label_packages_loading_title">Loading Packages!</string>


### PR DESCRIPTION
Summary
==========
Partially fix issue #9575 by creating the Hazmat category selection view with the expected Dialog detailing each category. This PR does not connect the selected Hazmat category with the Shipping Label creation yet. This will be introduced in the next PR. This one is just UI work.

Captures
==========
https://github.com/woocommerce/woocommerce-android/assets/5920403/a41a520e-a389-493f-bee2-68fb1670ba4b


How to Test
==========
1. Open the order details of an order eligible for Shipping label creation
2. Start the shipping label creation flow until you reach the Package details section
3. Inside the package details view, make sure the Contains hazardous materials toggle is visible and interactable
4. Make sure the toggle expands and collapses a basic view that will serve as the main control options for the HAZMAT declaration
5. Hit the `Hazardous material category` section, make sure it works as expected from a selection field

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.