### PR TITLE
Feature/9638 link profiler steps together

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerFragment.kt
@@ -48,14 +48,14 @@ class CountryListPickerFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is Exit -> findNavController().popBackStack()
-                is NavigateToSummaryStep -> navigateToInstallationStep()
+                is NavigateToSummaryStep -> navigateToStoreChallengesStep()
             }
         }
     }
 
-    private fun navigateToInstallationStep() {
+    private fun navigateToStoreChallengesStep() {
         findNavController().navigateSafely(
-            CountryListPickerFragmentDirections.actionCountryListPickerFragmentToSummaryFragment()
+            CountryListPickerFragmentDirections.actionCountryListPickerFragmentToChallengesFragment()
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerFragment.kt
@@ -49,7 +49,7 @@ class CountryPickerFragment : BaseFragment() {
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                 is MultiLiveEvent.Event.NavigateToHelpScreen -> navigateToHelpScreen(event.origin)
-                is NavigateToSummaryStep -> navigateToInstallationStep()
+                is NavigateToSummaryStep -> navigateToStoreChallengesStep()
                 is NavigateToDomainListPicker -> navigateToDomainListPicker(event.locationCode)
             }
         }
@@ -63,9 +63,9 @@ class CountryPickerFragment : BaseFragment() {
         )
     }
 
-    private fun navigateToInstallationStep() {
+    private fun navigateToStoreChallengesStep() {
         findNavController().navigateSafely(
-            CountryPickerFragmentDirections.actionCountryPickerFragmentToSummaryFragment()
+            CountryPickerFragmentDirections.actionCountryPickerFragmentToStoreProfilerChallengesFragment()
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerFeaturesFragment.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -41,10 +42,15 @@ class StoreProfilerFeaturesFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
-                is BaseStoreProfilerViewModel.NavigateToNextStep -> {
-                    TODO()
-                }
+                is BaseStoreProfilerViewModel.NavigateToNextStep -> navigateToStoreInstallationStep()
             }
         }
+    }
+
+    private fun navigateToStoreInstallationStep() {
+        findNavController().navigateSafely(
+            StoreProfilerFeaturesFragmentDirections
+                .actionStoreProfilerFeaturesFragmentToStoreCreationInstallationFragment()
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerFeaturesFragment.kt
@@ -11,6 +11,7 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.storecreation.profiler.BaseStoreProfilerViewModel.NavigateToNextStep
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
@@ -42,7 +43,7 @@ class StoreProfilerFeaturesFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
-                is BaseStoreProfilerViewModel.NavigateToNextStep -> navigateToStoreInstallationStep()
+                is NavigateToNextStep -> navigateToStoreInstallationStep()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerFeaturesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerFeaturesViewModel.kt
@@ -106,6 +106,6 @@ class StoreProfilerFeaturesViewModel @Inject constructor(
                 AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_STEP_STORE_PROFILER_FEATURES
             )
         )
-        // TODO("Navigate to store creation loading")
+        triggerEvent(NavigateToNextStep)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryFragment.kt
@@ -49,7 +49,7 @@ class StoreCreationSummaryFragment : BaseFragment() {
             when (event) {
                 is OnCancelPressed -> findNavController().popBackStack()
                 is OnStoreCreationSuccess -> findNavController().navigateSafely(
-                    StoreCreationSummaryFragmentDirections.actionSummaryFragmentToInstallationFragment()
+                    StoreCreationSummaryFragmentDirections.actionSummaryFragmentToStoreProfilerIndustriesFragment()
                 )
                 is OnStoreCreationFailure -> displayStoreCreationErrorDialog()
             }

--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
@@ -73,19 +73,16 @@
     <fragment
         android:id="@+id/storeProfilerFeaturesFragment"
         android:name="com.woocommerce.android.ui.login.storecreation.profiler.StoreProfilerFeaturesFragment"
-        android:label="fragment_store_profiler_features" />
+        android:label="fragment_store_profiler_features">
+        <action
+            android:id="@+id/action_storeProfilerFeaturesFragment_to_storeCreationInstallationFragment"
+            app:destination="@id/storeCreationInstallationFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/countryPickerFragment"
         android:name="com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerFragment"
         android:label="fragment_country_picker">
-        <action
-            android:id="@+id/action_countryPickerFragment_to_installationFragment"
-            app:destination="@id/installationFragment"
-            app:popUpTo="@id/nav_graph_store_creation" />
-        <action
-            android:id="@+id/action_countryPickerFragment_to_summaryFragment"
-            app:destination="@id/storeCreationSummaryFragment" />
         <action
             android:id="@+id/action_countryPickerFragment_to_storeProfilerChallengesFragment"
             app:destination="@id/storeProfilerChallengesFragment" />
@@ -121,12 +118,12 @@
         android:label="PlansFragment">
         <action
             android:id="@+id/action_plansFragment_to_installationFragment"
-            app:destination="@id/installationFragment"
+            app:destination="@id/storeCreationInstallationFragment"
             app:popUpTo="@id/nav_graph_store_creation" />
     </fragment>
 
     <fragment
-        android:id="@+id/installationFragment"
+        android:id="@+id/storeCreationInstallationFragment"
         android:name="com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationFragment"
         android:label="InstallationFragment" />
 
@@ -135,17 +132,16 @@
         android:name="com.woocommerce.android.ui.login.storecreation.summary.StoreCreationSummaryFragment"
         android:label="SummaryFragment">
         <action
-            android:id="@+id/action_summaryFragment_to_installationFragment"
-            app:destination="@id/installationFragment"
-            app:popUpTo="@id/nav_graph_store_creation" />
+            android:id="@+id/action_summaryFragment_to_storeProfilerIndustriesFragment"
+            app:destination="@id/storeProfilerIndustriesFragment" />
     </fragment>
     <fragment
         android:id="@+id/countryListPickerFragment"
         android:name="com.woocommerce.android.ui.login.storecreation.countrypicker.CountryListPickerFragment"
         android:label="CountryListPickerFragment">
         <action
-            android:id="@+id/action_countryListPickerFragment_to_summaryFragment"
-            app:destination="@id/storeCreationSummaryFragment" />
+            android:id="@+id/action_countryListPickerFragment_to_challengesFragment"
+            app:destination="@id/storeProfilerChallengesFragment" />
         <argument
             android:name="currentLocationCode"
             app:argType="string" />


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9638 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the following changes to store creation flow:
- Removes store name picker step from the flow
- Adds new Challenges and Features profiler steps
- Opens loading store step

Keep in mind the loading phase has not been updated yet. In a subsequent PR I'll adjust the loading screen to the new design and manually set the progress bar to 50% or 60% when the screen is opened. 

### Testing instructions

1. Trigger store creation flow and check the following order is match: 

https://github.com/woocommerce/woocommerce-android/assets/2663464/4e7ee9de-be81-496a-8d07-1fb28f5bbcc2

