### PR TITLE
Fix crashes in Jetpack Activation flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 -----
 - [*] [Internal] Tap To Pay: Enable NFC button to the NFC disabled error state to help merchants to enable NFC on their devices [https://github.com/woocommerce/woocommerce-android/pull/9611]
 - [*] [Internal] Add application_store_snapshot event tracking with fetching of orders and products count and payment gateways [https://github.com/woocommerce/woocommerce-android/pull/9597]
-
+- [*] Fix a crash that occurs when using Magic Link to login during the Jetpack installation flow [https://github.com/woocommerce/woocommerce-android/pull/9642]
 
 15.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainFragment.kt
@@ -96,12 +96,10 @@ class JetpackActivationMainFragment : BaseFragment() {
     }
 
     private fun goToStore() {
-        (requireActivity() as? MainActivity)?.handleSitePickerResult() ?: run {
-            val intent = Intent(requireActivity(), MainActivity::class.java).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-            }
-            startActivity(intent)
+        val intent = Intent(requireActivity(), MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
         }
+        startActivity(intent)
     }
 
     private fun showWooNotInstalledScreen(siteUrl: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -145,7 +145,7 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
 
     private suspend fun startSiteDiscovery() {
         // If the site is already connected to the account, go back to site picker
-        if (sitePickRepository.getSiteBySiteUrl(siteAddressFlow.value) != null) {
+        if (sitePickRepository.getSiteBySiteUrl(urlUtils.sanitiseUrl(siteAddressFlow.value)) != null) {
             fetchedSiteUrl = siteAddressFlow.value
             navigateBackToSitePicker()
             return


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8049
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes two scenarios that led to the crash we get in the ticket above:
1. The first case happens during Magic link connection, and I believe this has been happening since releasing the feature, as we shipped this [part](https://github.com/woocommerce/woocommerce-android/pull/8470), the Jetpack installation wasn't implemented yet, and we probably missed re-testing the whole flow later.
2. The second case happens when the user enters the address of an already connected site.

### Testing instructions
Optional: It would be great if you can reproduce the crashes first on `trunk` before testing with this branch.

##### Case 1:
1. Prepare a site where Jetpack is not connected (or not installed)
2. Connect to the site in the app using site credentials.
3. In the Dashboard, click on the Jetpack benefits banner.
4. Start the installation, then enter your WordPress.com email.
5. Use the magic link login.
6. Finish the installation.
7. The app would crash on trunk and wouldn't on this branch.

##### Case 2:
1. Sign in using WordPress.com email.
2. Open the site picker, then click on Add a store, then connect an existing store.
3. Enter the address while using `wp-admin` as suffix of a site already connected to the WordPress.com email.
4. 
    - On trunk, the app would attempt to start the Jetpack installation, and later would crash.
    - On this branch, the app would identify the site as already connected and select it as the active site.


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
