### PR TITLE
Restore the logic to reset the selected site when it doesn't have Woo

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -26,6 +26,8 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.RateLimitedTask
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.tools.SiteConnectionType.ApplicationPasswords
+import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.tracker.SendTelemetry
 import com.woocommerce.android.tracker.TrackStoreSnapshot
 import com.woocommerce.android.ui.appwidgets.getWidgetName
@@ -133,7 +135,10 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
             selectedSite.getIfExists()?.let {
                 appCoroutineScope.launch {
                     wooCommerceStore.fetchWooCommerceSite(it).let {
-                        if (it.model?.hasWooCommerce == false) {
+                        if (it.model?.hasWooCommerce == false && it.model?.connectionType == ApplicationPasswords) {
+                            // The previously selected site doesn't have Woo anymore, take the user to the login screen
+                            WooLog.w(T.LOGIN, "Selected site no longer has WooCommerce")
+                            selectedSite.reset()
                             restartMainActivity()
                         }
                     }


### PR DESCRIPTION
### Description
In the PR #9529, we updated the logic of `updateSelectedSite` to avoid resetting the SelectedSite, and while this might fix the crash https://github.com/woocommerce/woocommerce-android/issues/9528, it has a downside of breaking a functionally we need for sites accessed using Application Passwords.
For more details, please check the discussion: https://href.li/?https://wp.me/peaMlT-6L#comment-376

As agreed in the linked discussion above, this PR restores the logic of resetting the SelectedSite but only if the current site is using Application Passwords.
Later we'll monitor the situation, and if we find that the number of crashes remain high, we'll think about a different approach for fixing it.

### Testing instructions
1. Sign in using Application Passwords (non-Jetpack site).
2. Go to the site, then disable WooCommerce.
3. Restart the app.
4. Confirm the app shows the login screen.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
