### PR TITLE
[Hazmat Shipping] Connect hazmat submission to shipping label creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -158,6 +158,7 @@ class EditShippingLabelPackagesFragment :
                     findNavController().navigateSafely(action)
                 }
                 is OpenHazmatCategorySelector -> showHazmatCategoryPicker(
+                    event.packagePosition,
                     event.currentSelection,
                     event.onHazmatCategorySelected
                 )
@@ -183,6 +184,7 @@ class EditShippingLabelPackagesFragment :
     }
 
     private fun showHazmatCategoryPicker(
+        packagePosition: Int,
         currentSelection: ShippingLabelHazmatCategory?,
         onHazmatCategorySelected: OnHazmatCategorySelected
     ) {
@@ -190,7 +192,9 @@ class EditShippingLabelPackagesFragment :
             key = KEY_HAZMAT_CATEGORY_SELECTOR_RESULT,
             entryId = R.id.editShippingLabelPackagesFragment
         ) { hazmatSelection ->
-            onHazmatCategorySelected(ShippingLabelHazmatCategory.valueOf(hazmatSelection))
+            val selectedCategory = ShippingLabelHazmatCategory.valueOf(hazmatSelection)
+            viewModel.onHazmatCategorySelected(selectedCategory, packagePosition)
+            onHazmatCategorySelected(selectedCategory)
         }
         EditShippingLabelPackagesFragmentDirections
             .actionEditShippingLabelPaymentFragmentToHazmatCategorySelector(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -184,7 +184,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         packagePosition: Int,
         onHazmatCategorySelected: OnHazmatCategorySelected
     ) {
-        triggerEvent(OpenHazmatCategorySelector(currentSelection, onHazmatCategorySelected))
+        triggerEvent(OpenHazmatCategorySelector(packagePosition, currentSelection, onHazmatCategorySelected))
     }
 
     fun onHazmatCategorySelected(
@@ -390,6 +390,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
     ) : MultiLiveEvent.Event()
 
     data class OpenHazmatCategorySelector(
+        val packagePosition: Int,
         val currentSelection: ShippingLabelHazmatCategory?,
         val onHazmatCategorySelected: OnHazmatCategorySelected
     ) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -196,6 +196,8 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
             selectedPackage?.copy(hazmatCategory = newSelection)
                 ?.let { copy(selectedPackage = it) }
         }?.let { packages[packagePosition] = packages[packagePosition].copy(data = it) }
+        viewState = viewState.copy(packagesUiModels = packages)
+
     }
 
     // all the logic is inside local functions, so it should be OK, but detekt complains still

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -181,9 +181,21 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
 
     fun onHazmatCategoryClicked(
         currentSelection: ShippingLabelHazmatCategory?,
+        packagePosition: Int,
         onHazmatCategorySelected: OnHazmatCategorySelected
     ) {
         triggerEvent(OpenHazmatCategorySelector(currentSelection, onHazmatCategorySelected))
+    }
+
+    fun onHazmatCategorySelected(
+        newSelection: ShippingLabelHazmatCategory,
+        packagePosition: Int
+    ) {
+        val packages = viewState.packagesUiModels.toMutableList()
+        with(packages[packagePosition].data) {
+            selectedPackage?.copy(hazmatCategory = newSelection)
+                ?.let { copy(selectedPackage = it) }
+        }?.let { packages[packagePosition] = packages[packagePosition].copy(data = it) }
     }
 
     // all the logic is inside local functions, so it should be OK, but detekt complains still

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -197,7 +197,6 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
                 ?.let { copy(selectedPackage = it) }
         }?.let { packages[packagePosition] = packages[packagePosition].copy(data = it) }
         viewState = viewState.copy(packagesUiModels = packages)
-
     }
 
     // all the logic is inside local functions, so it should be OK, but detekt complains still

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -192,6 +192,11 @@ class ShippingLabelPackagesAdapter(
                 binding.expandIcon.rotation = 0f
                 binding.detailsLayout.isVisible = false
             }
+
+            shippingLabelPackage.selectedPackage?.hazmatCategory?.let {
+                binding.hazmatToggle.isChecked = true
+                binding.hazmatCategory.text = context.getString(it.stringResourceID)
+            }
         }
 
         private fun ShippingLabelPackage.adaptItemsForUi(): List<ShippingLabelPackage.Item> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelPackagesAdapter.kt
@@ -25,7 +25,7 @@ import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.StringUtils
 
-typealias OnHazmatCategoryClicked = (ShippingLabelHazmatCategory?, OnHazmatCategorySelected) -> Unit
+typealias OnHazmatCategoryClicked = (ShippingLabelHazmatCategory?, Int, OnHazmatCategorySelected) -> Unit
 
 class ShippingLabelPackagesAdapter(
     val siteParameters: SiteParameters,
@@ -134,7 +134,7 @@ class ShippingLabelPackagesAdapter(
             }
 
             binding.hazmatCategoryContainer.setOnClickListener {
-                onHazmatCategoryClicked(currentHazmatSelection) {
+                onHazmatCategoryClicked(currentHazmatSelection, bindingAdapterPosition) {
                     currentHazmatSelection = it
                     binding.hazmatCategory.text = binding.root.context.getString(it.stringResourceID)
                 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.OpenHazmatCategorySelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.ViewState
+import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelHazmatCategory.AIR_ELIGIBLE_ETHANOL
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.ui.products.ProductTestUtils
@@ -314,7 +315,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         viewModel.event.observeForever { event = it }
 
         viewModel.onHazmatCategoryClicked(
-            currentSelection = ShippingLabelHazmatCategory.AIR_ELIGIBLE_ETHANOL,
+            currentSelection = AIR_ELIGIBLE_ETHANOL,
             packagePosition = 0,
             onHazmatCategorySelected = onHazmatCategorySelected
         )
@@ -322,7 +323,7 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
         assertThat(event).isEqualTo(
             OpenHazmatCategorySelector(
                 packagePosition = 0,
-                currentSelection = ShippingLabelHazmatCategory.AIR_ELIGIBLE_ETHANOL,
+                currentSelection = AIR_ELIGIBLE_ETHANOL,
                 onHazmatCategorySelected = onHazmatCategorySelected
             )
         )
@@ -340,11 +341,11 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
 
         viewModel.onHazmatCategorySelected(
             packagePosition = 0,
-            newSelection = ShippingLabelHazmatCategory.AIR_ELIGIBLE_ETHANOL
+            newSelection = AIR_ELIGIBLE_ETHANOL
         )
 
         val newPackages = viewModel.viewStateData.liveData.value!!.packages
         assertThat(newPackages.size).isEqualTo(1)
-        assertThat(newPackages[0].selectedPackage?.hazmatCategory).isEqualTo(ShippingLabelHazmatCategory.AIR_ELIGIBLE_ETHANOL)
+        assertThat(newPackages[0].selectedPackage?.hazmatCategory).isEqualTo(AIR_ELIGIBLE_ETHANOL)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -327,4 +327,24 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
             )
         )
     }
+
+    @Test
+    fun `when onHazmatCategorySelected, then update the packages info`() = testBlocking {
+        val currentShippingPackages = arrayOf(
+            CreateShippingLabelTestUtils.generateShippingLabelPackage(
+                position = 1,
+                items = listOf(defaultItem)
+            )
+        )
+        setup(currentShippingPackages)
+
+        viewModel.onHazmatCategorySelected(
+            packagePosition = 0,
+            newSelection = ShippingLabelHazmatCategory.AIR_ELIGIBLE_ETHANOL
+        )
+
+        val newPackages = viewModel.viewStateData.liveData.value!!.packages
+        assertThat(newPackages.size).isEqualTo(1)
+        assertThat(newPackages[0].selectedPackage?.hazmatCategory).isEqualTo(ShippingLabelHazmatCategory.AIR_ELIGIBLE_ETHANOL)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.model.ShippingLabelPackage
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.shippinglabels.ShippingLabelRepository
+import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.OpenHazmatCategorySelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelPackagesViewModel.ViewState
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductDetailRepository
@@ -303,5 +304,27 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
             assertThat(length).isEqualTo(testProduct.length)
             assertThat(height).isEqualTo(testProduct.height)
         }
+    }
+
+    @Test
+    fun `when select hazmat category is clicked, then trigger hazmat dialog event`() = testBlocking {
+        setup(emptyArray())
+        var event: MultiLiveEvent.Event? = null
+        val onHazmatCategorySelected: OnHazmatCategorySelected = { _ -> }
+        viewModel.event.observeForever { event = it }
+
+        viewModel.onHazmatCategoryClicked(
+            currentSelection = ShippingLabelHazmatCategory.AIR_ELIGIBLE_ETHANOL,
+            packagePosition = 0,
+            onHazmatCategorySelected = onHazmatCategorySelected
+        )
+
+        assertThat(event).isEqualTo(
+            OpenHazmatCategorySelector(
+                packagePosition = 0,
+                currentSelection = ShippingLabelHazmatCategory.AIR_ELIGIBLE_ETHANOL,
+                onHazmatCategorySelected = onHazmatCategorySelected
+            )
+        )
     }
 }


### PR DESCRIPTION
Summary
==========
Fix issue #9575 by effectively connecting the Hazmat UI work with the network layer, making possible to submit a shipping label with hazmat instructions.

### ⚠️ Testing the shipping label creation can be tricky, in case you don't have a store configuration with the staging scenario for the shipping label creation flow, proceed with the instructions in `PbTz5e-11v` or contact me in slack.

Captures
==========
https://github.com/woocommerce/woocommerce-android/assets/5920403/c911c31f-8bf5-493d-81a6-834b8645f6fc

| Shipping Label package HTTP body  | Shipping Label with Hazmat declaration |
| ------------- | ------------- |
| ![hazmat_package](https://github.com/woocommerce/woocommerce-android/assets/5920403/286cd78a-3a5e-4409-9b59-8c28531c3d16) | ![screenshot-1693318430784](https://github.com/woocommerce/woocommerce-android/assets/5920403/adbb1488-8beb-4512-b168-f803ad52c84b) |

How to Test
==========
1. Open the order details of an order eligible for Shipping label creation
2. Start the shipping label creation flow with valid US address options until you reach the Package details section
3. Inside the package details view, make sure the Contains hazardous materials toggle is visible and interactable
4. Make sure the toggle expands and collapses a basic view that will serve as the main control options for the HAZMAT declaration
5. Select a hazmat option, make sure the Package Details are complete
6. Continue to the shipping rates calculation displays a USPS option, select that one and create the Shipping Label
7. Verify that the shipping label contains the `HAZMAT` info in the bottom section

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.