### PR TITLE
Fix logout crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.prefs
 
-import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
@@ -23,13 +22,14 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.appwidgets.WidgetUpdater
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.main.AppBarStatus
-import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.prefs.MainSettingsFragment.AppSettingsListener
 import com.woocommerce.android.util.AnalyticsUtils
 import com.woocommerce.android.util.parcelable
 import dagger.android.DispatchingAndroidInjector
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.login.LoginMode
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -148,15 +148,12 @@ class AppSettingsActivity :
         notificationMessageHandler.removeAllNotificationsFromSystemsBar()
         statsWidgetUpdaters.updateTodayWidget()
 
-        val mainIntent = Intent(this, MainActivity::class.java)
-        mainIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-        startActivity(mainIntent)
-        setResult(Activity.RESULT_OK)
+        val intent = Intent(this, LoginActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            LoginMode.WOO_LOGIN_MODE.putInto(this)
+        }
 
-        close()
-    }
-
-    override fun close() {
+        startActivity(intent)
         finish()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsContract.kt
@@ -11,7 +11,6 @@ interface AppSettingsContract {
     }
 
     interface View : BaseView<Presenter> {
-        fun close()
         fun finishLogout()
         fun confirmLogout()
     }


### PR DESCRIPTION
### Description
The change introduced in #9285, is causing a crash during logout in a specific scenario: when the MainActivity was destroyed by the system in the meantime (p1692721445097719/1687876204.530329-slack-C6H8C3G23)
This PR fixes this.

### Testing instructions
1. Enable "Don't keep activities" in the developer options.
2. Open the app and sign in.
3. Open settings and tap logout.
4. Confirm the  app doesn't crash.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->