### PR TITLE
build: include shared repo in quicklogin config

### DIFF
--- a/config/gradle/include_builds.gradle
+++ b/config/gradle/include_builds.gradle
@@ -48,7 +48,7 @@ if (localBuilds.exists()) {
         includeBuild(ext.localWooCommerceSharedPath) {
             dependencySubstitution {
                 println "Substituting WooCommerce-Shared with the local build"
-                substitute module("$gradle.ext.wooCommerceSharedBinaryPath") with project(':library')
+                substitute module("$gradle.ext.wooCommerceSharedBinaryPath") using project(':library')
             }
         }
     }

--- a/quicklogin/build.gradle
+++ b/quicklogin/build.gradle
@@ -14,6 +14,7 @@ repositories {
             includeGroup "org.wordpress.mediapicker"
             includeGroup "com.automattic"
             includeGroup "com.automattic.tracks"
+            includeGroup "com.woocommerce.shared"
         }
     }
     maven {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. --> 
This PR adjusts build configuration to work correctly with Shared library.

For now, the configuration works as I believe the `quicklogin` module is loaded from cache on majority of local machines. But if you try to build it, there's an error:

`./gradlew :quicklogin:assemble`

```
* What went wrong:
Could not determine the dependencies of task ':quicklogin:processDebugResources'.
> Could not resolve all task dependencies for configuration ':quicklogin:debugTestedApks'.
   > Could not find com.woocommerce.shared:library:0.6.0.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/com/woocommerce/shared/library/0.6.0/library-0.6.0.pom
       - https://repo.maven.apache.org/maven2/com/woocommerce/shared/library/0.6.0/library-0.6.0.pom
     Required by:
         project :quicklogin > project :WooCommerce
```

which is expected.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Not needed


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
