### PR TITLE
Store Creation: Name Your Store Functionality

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,8 @@
 - [*] Fix a crash that occurs when using Magic Link to login during the Jetpack installation flow [https://github.com/woocommerce/woocommerce-android/pull/9642]
 - [**] [Internal] Handle "enabled" WCPay account status the same way as "completed" [https://github.com/woocommerce/woocommerce-android/pull/9637]
 - [*] Onboarding: A new onboarding item, "Name Your Store", is added. Also, changing store name is now possible in Settings. [https://github.com/woocommerce/woocommerce-android/issues/9621]
+- [**] Store creation: Store creation flow has been revamped and now profiler steps are shown while the site is being created [https://github.com/woocommerce/woocommerce-android/issues/9587]
+
 15.0
 -----
 - [*] Store creation: Country selector screen is now more intuitive and easier to use. [https://github.com/woocommerce/woocommerce-android/issues/9606]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 - [*] [Internal] Add application_store_snapshot event tracking with fetching of orders and products count and payment gateways [https://github.com/woocommerce/woocommerce-android/pull/9597]
 - [*] Fix a crash that occurs when using Magic Link to login during the Jetpack installation flow [https://github.com/woocommerce/woocommerce-android/pull/9642]
 - [**] [Internal] Handle "enabled" WCPay account status the same way as "completed" [https://github.com/woocommerce/woocommerce-android/pull/9637]
-
+- [*] Onboarding: A new onboarding item, "Name Your Store", is added. Also, changing store name is now possible in Settings. [https://github.com/woocommerce/woocommerce-android/issues/9621]
 15.0
 -----
 - [*] Store creation: Country selector screen is now more intuitive and easier to use. [https://github.com/woocommerce/woocommerce-android/issues/9606]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -34,15 +34,19 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.onboarding.NameYourStoreViewModel.NameYourStoreDialogState
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class NameYourStoreDialogFragment : DialogFragment() {
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     private val viewModel: NameYourStoreViewModel by viewModels()
 
@@ -72,6 +76,7 @@ class NameYourStoreDialogFragment : DialogFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
+                is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -32,7 +32,7 @@ class NameYourStoreDialogFragment : DialogFragment() {
         builder.setTitle(resources.getString(R.string.store_onboarding_name_your_store_dialog_title))
             .setView(frameLayout)
             .setPositiveButton(resources.getString(R.string.dialog_ok)) { dialog, _ ->
-                viewModel.saveSiteTitle(inputField.text.toString())
+                viewModel.saveSiteTitle(inputField.text.toString(), fromOnboarding = false)
                 dialog.dismiss()
             }
             .setNegativeButton(resources.getString(R.string.cancel)) { dialog, _ ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -109,9 +109,10 @@ class NameYourStoreDialogFragment : DialogFragment() {
             Row(
                 modifier = Modifier
                     .padding(
-                    start = dimensionResource(id = R.dimen.major_100),
-                    end = dimensionResource(id = R.dimen.major_100),
-                    bottom = dimensionResource(id = R.dimen.minor_100))
+                        start = dimensionResource(id = R.dimen.major_100),
+                        end = dimensionResource(id = R.dimen.major_100),
+                        bottom = dimensionResource(id = R.dimen.minor_100)
+                    )
                     .fillMaxWidth(),
                 horizontalArrangement = Arrangement.End,
                 verticalAlignment = Alignment.CenterVertically

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -5,11 +5,13 @@ import android.os.Bundle
 import android.widget.EditText
 import android.widget.FrameLayout
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 
 class NameYourStoreDialogFragment : DialogFragment() {
+    private val viewModel: StoreOnboardingViewModel by viewModels()
     companion object {
         const val TAG: String = "NameYourStoreDialogFragment"
     }
@@ -28,7 +30,7 @@ class NameYourStoreDialogFragment : DialogFragment() {
         builder.setTitle(resources.getString(R.string.store_onboarding_name_your_store_dialog_title))
             .setView(frameLayout)
             .setPositiveButton(resources.getString(R.string.dialog_ok)) { dialog, _ ->
-                // todo handle the inputText
+                viewModel.saveSiteTitle(inputField.text.toString())
                 dialog.dismiss()
             }
             .setNegativeButton(resources.getString(R.string.cancel)) { dialog, _ ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -86,46 +86,42 @@ class NameYourStoreDialogFragment : DialogFragment() {
             Text(
                 text = stringResource(id = R.string.store_onboarding_name_your_store_dialog_title),
                 style = MaterialTheme.typography.h6,
-                modifier = Modifier.padding(dimensionResource(id = R.dimen.major_150))
+                modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))
             )
-            Spacer(modifier = Modifier.size(size = dimensionResource(id = R.dimen.major_150)))
             WCOutlinedTextField(
                 modifier = Modifier
                     .focusRequester(focusRequester)
-                    .padding(top = dimensionResource(id = R.dimen.minor_100)),
+                    .padding(dimensionResource(id = R.dimen.major_100)),
                 value = state.enteredSiteTitle,
                 onValueChange = { viewModel.onSiteTitleInputChanged(it) },
                 label = stringResource(id = R.string.store_onboarding_name_your_store_dialog_title),
                 singleLine = true
             )
-            Spacer(modifier = Modifier.size(size = dimensionResource(id = R.dimen.major_150)))
 
             Text(
                 text = stringResource(id = R.string.store_onboarding_name_your_store_dialog_failure),
-                style = MaterialTheme.typography.body1,
+                style = MaterialTheme.typography.subtitle1,
                 modifier = Modifier
-                    .padding(dimensionResource(id = R.dimen.major_100))
+                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
                     .alpha(if (isError) 1f else 0f)
             )
 
             Row(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(dimensionResource(id = R.dimen.major_150)),
-                horizontalArrangement = Arrangement.SpaceBetween
+                    .padding(
+                    start = dimensionResource(id = R.dimen.major_100),
+                    end = dimensionResource(id = R.dimen.major_100),
+                    bottom = dimensionResource(id = R.dimen.minor_100))
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 WCTextButton(
                     text = stringResource(id = R.string.cancel),
-                    modifier = Modifier
-                        .weight(weight = 1f)
-                        .padding(end = dimensionResource(id = R.dimen.major_150)),
                     onClick = viewModel::onNameYourStoreDismissed
                 )
                 WCTextButton(
                     text = stringResource(id = R.string.dialog_ok),
-                    modifier = Modifier
-                        .weight(weight = 1f)
-                        .padding(start = dimensionResource(id = R.dimen.major_150)),
                     onClick = {
                         viewModel.saveSiteTitle(state.enteredSiteTitle)
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -68,15 +68,13 @@ class NameYourStoreDialogFragment : DialogFragment() {
         }
     }
 
-
-        override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
             }
         }
     }
-
 
     @Composable
     private fun NameYourStoreDialog(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -125,7 +125,7 @@ class NameYourStoreDialogFragment : DialogFragment() {
                         .weight(weight = 1f)
                         .padding(start = dimensionResource(id = R.dimen.major_150)),
                     onClick = {
-                        viewModel.saveSiteTitle(state.enteredSiteTitle, fromOnboarding = false)
+                        viewModel.saveSiteTitle(state.enteredSiteTitle)
                     }
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -9,7 +9,9 @@ import androidx.fragment.app.viewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class NameYourStoreDialogFragment : DialogFragment() {
     private val viewModel: StoreOnboardingViewModel by viewModels()
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -2,8 +2,11 @@ package com.woocommerce.android.ui.login.storecreation.onboarding
 
 import android.app.Dialog
 import android.os.Bundle
+import android.view.View
 import android.widget.EditText
 import android.widget.FrameLayout
+import android.widget.ProgressBar
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -19,32 +22,80 @@ class NameYourStoreDialogFragment : DialogFragment() {
     internal lateinit var selectedSite: SelectedSite
 
     private val viewModel: StoreOnboardingViewModel by viewModels()
+
+    private lateinit var dialog: AlertDialog
+    private lateinit var layout: FrameLayout
+    private lateinit var inputField: EditText
+    private lateinit var progressBar: ProgressBar
+
+
     companion object {
         const val TAG: String = "NameYourStoreDialogFragment"
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val inputField = EditText(context)
 
-        val frameLayout = FrameLayout(requireContext()).apply {
+        inputField = EditText(context)
+        progressBar = ProgressBar(context)
+
+        progressBar.visibility = ProgressBar.GONE
+
+        layout = FrameLayout(requireContext()).apply {
             val verticalPadding = resources.getDimensionPixelSize(R.dimen.major_150)
             val horizontalPadding = resources.getDimensionPixelSize(R.dimen.major_100)
             setPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding)
             addView(inputField)
             inputField.setText(selectedSite.get().name)
+            addView(progressBar)
         }
 
         val builder = MaterialAlertDialogBuilder(requireContext())
         builder.setTitle(resources.getString(R.string.store_onboarding_name_your_store_dialog_title))
-            .setView(frameLayout)
-            .setPositiveButton(resources.getString(R.string.dialog_ok)) { dialog, _ ->
-                viewModel.saveSiteTitle(inputField.text.toString(), fromOnboarding = false)
-                dialog.dismiss()
-            }
+            .setView(layout)
+            .setPositiveButton(resources.getString(R.string.dialog_ok), null)
             .setNegativeButton(resources.getString(R.string.cancel)) { dialog, _ ->
                 dialog.cancel()
             }
-        return builder.create()
+
+        dialog = builder.create()
+
+        dialog.setOnShowListener {
+            // Setting here to prevent automatic dismissal
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                viewModel.saveSiteTitle(inputField.text.toString(), fromOnboarding = false)
+            }
+        }
+        return dialog
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewModel.isSavingSiteTitle.observe(viewLifecycleOwner) { isSavingSiteTitle ->
+            when (isSavingSiteTitle) {
+                StoreOnboardingViewModel.NameYourStoreDialogState.START,
+                StoreOnboardingViewModel.NameYourStoreDialogState.FAILURE,
+                null -> {
+                    progressBar.visibility = ProgressBar.INVISIBLE
+                    inputField.visibility = EditText.VISIBLE
+                    dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = true
+                    dialog.getButton(AlertDialog.BUTTON_NEGATIVE).isEnabled = true
+                    dialog.setCancelable(true)
+                }
+
+                StoreOnboardingViewModel.NameYourStoreDialogState.LOADING -> {
+                    progressBar.visibility = ProgressBar.VISIBLE
+                    inputField.visibility = EditText.INVISIBLE
+                    dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = false
+                    dialog.getButton(AlertDialog.BUTTON_NEGATIVE).isEnabled = false
+                    dialog.setCancelable(false)
+                }
+
+                StoreOnboardingViewModel.NameYourStoreDialogState.SUCCESS -> {
+                    dialog.dismiss()
+                }
+            }
+        }
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -31,14 +31,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.onboarding.NameYourStoreViewModel.NameYourStoreDialogState
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class NameYourStoreDialogFragment : DialogFragment() {
@@ -66,6 +67,16 @@ class NameYourStoreDialogFragment : DialogFragment() {
             }
         }
     }
+
+
+        override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
+            }
+        }
+    }
+
 
     @Composable
     private fun NameYourStoreDialog(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -9,10 +9,15 @@ import androidx.fragment.app.viewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.tools.SelectedSite
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class NameYourStoreDialogFragment : DialogFragment() {
+    @Inject
+    internal lateinit var selectedSite: SelectedSite
+
     private val viewModel: StoreOnboardingViewModel by viewModels()
     companion object {
         const val TAG: String = "NameYourStoreDialogFragment"
@@ -26,6 +31,7 @@ class NameYourStoreDialogFragment : DialogFragment() {
             val horizontalPadding = resources.getDimensionPixelSize(R.dimen.major_100)
             setPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding)
             addView(inputField)
+            inputField.setText(selectedSite.get().name)
         }
 
         val builder = MaterialAlertDialogBuilder(requireContext())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -33,7 +33,6 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -43,14 +42,8 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class NameYourStoreDialogFragment : DialogFragment() {
-    @Inject
-    internal lateinit var selectedSite: SelectedSite
 
     private val viewModel: NameYourStoreViewModel by viewModels()
-
-    companion object {
-        const val TAG: String = "NameYourStoreDialogFragment"
-    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         dialog?.window?.attributes?.windowAnimations = R.style.Woo_Animations_Dialog

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreDialogFragment.kt
@@ -94,7 +94,7 @@ class NameYourStoreDialogFragment : DialogFragment() {
                     .padding(dimensionResource(id = R.dimen.major_100)),
                 value = state.enteredSiteTitle,
                 onValueChange = { viewModel.onSiteTitleInputChanged(it) },
-                label = stringResource(id = R.string.store_onboarding_name_your_store_dialog_title),
+                label = stringResource(id = R.string.store_onboarding_name_your_store_dialog_label),
                 singleLine = true
             )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreViewModel.kt
@@ -23,8 +23,7 @@ class NameYourStoreViewModel @Inject constructor(
 
     private val _viewState = MutableLiveData(
         NameYourStoreDialogState(
-            currentSiteTitle = selectedSite.get().name,
-            enteredSiteTitle = "",
+            enteredSiteTitle = selectedSite.get().name,
             isLoading = false,
             isError = false
         )
@@ -62,7 +61,6 @@ class NameYourStoreViewModel @Inject constructor(
     }
 
     data class NameYourStoreDialogState(
-        val currentSiteTitle: String,
         val enteredSiteTitle: String,
         val isLoading: Boolean,
         val isError: Boolean

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreViewModel.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -18,6 +19,8 @@ class NameYourStoreViewModel @Inject constructor(
     selectedSite: SelectedSite,
     private val onboardingRepository: StoreOnboardingRepository
 ) : ScopedViewModel(savedStateHandle) {
+    private val navArgs: NameYourStoreDialogFragmentArgs by savedStateHandle.navArgs()
+
     private val _viewState = MutableLiveData(
         NameYourStoreDialogState(
             currentSiteTitle = selectedSite.get().name,
@@ -28,12 +31,12 @@ class NameYourStoreViewModel @Inject constructor(
     )
     val viewState = _viewState
 
-    fun saveSiteTitle(siteTitle: String, fromOnboarding: Boolean = true) {
+    fun saveSiteTitle(siteTitle: String) {
         launch {
             _viewState.value = _viewState.value?.copy(isLoading = true, isError = false)
             onboardingRepository.saveSiteTitle(siteTitle).fold(
                 onSuccess = {
-                    if (fromOnboarding) {
+                    if (navArgs.fromOnboarding) {
                         triggerEvent(ShowSnackbar(R.string.store_onboarding_name_your_store_dialog_success))
                     } else {
                         triggerEvent(ShowSnackbar(R.string.settings_name_your_store_dialog_success))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -41,7 +40,7 @@ class NameYourStoreViewModel @Inject constructor(
                         triggerEvent(ShowSnackbar(R.string.settings_name_your_store_dialog_success))
                     }
 
-                    triggerEvent(OnSiteTitleSaved)
+                    triggerEvent(Exit)
                 },
                 onFailure = {
                     triggerEvent(ShowSnackbar(R.string.store_onboarding_name_your_store_dialog_failure))
@@ -65,6 +64,4 @@ class NameYourStoreViewModel @Inject constructor(
         val isLoading: Boolean,
         val isError: Boolean
     )
-
-    object OnSiteTitleSaved : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/NameYourStoreViewModel.kt
@@ -1,0 +1,69 @@
+package com.woocommerce.android.ui.login.storecreation.onboarding
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class NameYourStoreViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    selectedSite: SelectedSite,
+    private val onboardingRepository: StoreOnboardingRepository
+) : ScopedViewModel(savedStateHandle) {
+    private val _viewState = MutableLiveData(
+        NameYourStoreDialogState(
+            currentSiteTitle = selectedSite.get().name,
+            enteredSiteTitle = "",
+            isLoading = false,
+            isError = false
+        )
+    )
+    val viewState = _viewState
+
+    fun saveSiteTitle(siteTitle: String, fromOnboarding: Boolean = true) {
+        launch {
+            _viewState.value = _viewState.value?.copy(isLoading = true, isError = false)
+            onboardingRepository.saveSiteTitle(siteTitle).fold(
+                onSuccess = {
+                    if (fromOnboarding) {
+                        triggerEvent(ShowSnackbar(R.string.store_onboarding_name_your_store_dialog_success))
+                    } else {
+                        triggerEvent(ShowSnackbar(R.string.settings_name_your_store_dialog_success))
+                    }
+
+                    triggerEvent(OnSiteTitleSaved)
+                },
+                onFailure = {
+                    triggerEvent(ShowSnackbar(R.string.store_onboarding_name_your_store_dialog_failure))
+                    _viewState.value = _viewState.value?.copy(isError = true)
+                }
+            )
+            _viewState.value = _viewState.value?.copy(isLoading = false)
+        }
+    }
+
+    fun onNameYourStoreDismissed() {
+        triggerEvent(Exit)
+    }
+
+    fun onSiteTitleInputChanged(input: String) {
+        _viewState.value = _viewState.value?.copy(enteredSiteTitle = input, isError = false)
+    }
+
+    data class NameYourStoreDialogState(
+        val currentSiteTitle: String,
+        val enteredSiteTitle: String,
+        val isLoading: Boolean,
+        val isError: Boolean
+    )
+
+    object OnSiteTitleSaved : MultiLiveEvent.Event()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.login.storecreation.onboarding
 
+import com.woocommerce.android.WooException
 import com.woocommerce.android.extensions.isFreeTrial
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LAUNCH_YOUR_STORE
@@ -106,6 +107,22 @@ class StoreOnboardingRepository @Inject constructor(
             else -> {
                 WooLog.d(WooLog.T.ONBOARDING, "Site launched successfully")
                 Success
+            }
+        }
+    }
+
+    suspend fun saveSiteTitle(siteTitle: String): Result<Boolean> {
+        val site = selectedSite.get()
+        val result = onboardingStore.saveSiteTitle(site, siteTitle)
+        return when {
+            result.isError -> {
+                WooLog.w(WooLog.T.ONBOARDING, "Error while saving site title. Message: ${result.error.message} ")
+                Result.failure(WooException(result.error))
+            }
+
+            else -> {
+                WooLog.d(WooLog.T.ONBOARDING, "Site title saved successfully")
+                Result.success(true)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboarding
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.LOCAL_NAME_STORE
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.MOBILE_UNSUPPORTED
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.values
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -71,16 +70,14 @@ class StoreOnboardingRepository @Inject constructor(
                 )
             )
         }
-        if (FeatureFlag.NAME_YOUR_STORE_DIALOG.isEnabled()) {
-            onboardingTasks.add(
-                OnboardingTask(
-                    type = LOCAL_NAME_STORE,
-                    isComplete = isLocalTaskNameYourStoreCompleted(),
-                    isVisible = true,
-                    isVisited = false
-                )
+        onboardingTasks.add(
+            OnboardingTask(
+                type = LOCAL_NAME_STORE,
+                isComplete = isLocalTaskNameYourStoreCompleted(),
+                isVisible = true,
+                isVisited = false
             )
-        }
+        )
     }
 
     private fun shouldMarkLaunchStoreAsCompleted(task: OnboardingTask) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -119,6 +119,12 @@ class StoreOnboardingRepository @Inject constructor(
 
             else -> {
                 WooLog.d(WooLog.T.ONBOARDING, "Site title saved successfully")
+
+                // Update selectedSite to reflect the newly saved store name.
+                siteStore.getSiteByLocalId(selectedSite.get().id)?.let { updatedSite ->
+                    selectedSite.set(updatedSite)
+                }
+
                 Result.success(true)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -57,6 +57,9 @@ class StoreOnboardingViewModel @Inject constructor(
     )
     val viewState = _viewState
 
+    private val _isSavingSiteTitle = MutableLiveData(NameYourStoreDialogState.START)
+    val isSavingSiteTitle = _isSavingSiteTitle
+
     init {
         launch {
             onboardingRepository.observeOnboardingTasks()
@@ -169,6 +172,7 @@ class StoreOnboardingViewModel @Inject constructor(
 
     fun saveSiteTitle(siteTitle: String, fromOnboarding: Boolean = true) {
         launch {
+            _isSavingSiteTitle.value = NameYourStoreDialogState.LOADING
             onboardingRepository.saveSiteTitle(siteTitle).fold(
                 onSuccess = {
                     if (fromOnboarding) {
@@ -177,9 +181,11 @@ class StoreOnboardingViewModel @Inject constructor(
                     } else {
                         triggerEvent(ShowSnackbar(R.string.settings_name_your_store_dialog_success))
                     }
+                    _isSavingSiteTitle.value = NameYourStoreDialogState.SUCCESS
                 },
                 onFailure = {
                     triggerEvent(ShowSnackbar(R.string.store_onboarding_name_your_store_dialog_failure))
+                    _isSavingSiteTitle.value = NameYourStoreDialogState.FAILURE
                 }
             )
         }
@@ -251,4 +257,11 @@ class StoreOnboardingViewModel @Inject constructor(
     object NavigateToAboutYourStore : MultiLiveEvent.Event()
     object NavigateToAddProduct : MultiLiveEvent.Event()
     object ShowNameYourStoreDialog : MultiLiveEvent.Event()
+
+    enum class NameYourStoreDialogState {
+        START,
+        LOADING,
+        SUCCESS,
+        FAILURE
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -28,12 +28,14 @@ import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboarding
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.WC_PAYMENTS
 import com.woocommerce.android.ui.products.IsAIProductDescriptionEnabled
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@Suppress("TooManyFunctions")
 @HiltViewModel
 class StoreOnboardingViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -162,6 +164,20 @@ class StoreOnboardingViewModel @Inject constructor(
             }
         } else {
             _viewState.value = _viewState.value?.copy(show = false)
+        }
+    }
+
+    fun saveSiteTitle(siteTitle: String) {
+        launch {
+            onboardingRepository.saveSiteTitle(siteTitle).fold(
+                onSuccess = {
+                    refreshOnboardingList()
+                    triggerEvent(ShowSnackbar(R.string.store_onboarding_name_your_store_dialog_success))
+                },
+                onFailure = {
+                    triggerEvent(ShowSnackbar(R.string.store_onboarding_name_your_store_dialog_failure))
+                }
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -34,7 +34,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@Suppress("TooManyFunctions")
 @HiltViewModel
 class StoreOnboardingViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -171,11 +171,10 @@ class StoreOnboardingViewModel @Inject constructor(
         launch {
             onboardingRepository.saveSiteTitle(siteTitle).fold(
                 onSuccess = {
-                    if(fromOnboarding) {
+                    if (fromOnboarding) {
                         refreshOnboardingList()
                         triggerEvent(ShowSnackbar(R.string.store_onboarding_name_your_store_dialog_success))
-                    }
-                    else {
+                    } else {
                         triggerEvent(ShowSnackbar(R.string.settings_name_your_store_dialog_success))
                     }
                 },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -28,7 +28,6 @@ import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboarding
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.WC_PAYMENTS
 import com.woocommerce.android.ui.products.IsAIProductDescriptionEnabled
 import com.woocommerce.android.viewmodel.MultiLiveEvent
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
@@ -56,9 +55,6 @@ class StoreOnboardingViewModel @Inject constructor(
         )
     )
     val viewState = _viewState
-
-    private val _isSavingSiteTitle = MutableLiveData(NameYourStoreDialogState.START)
-    val isSavingSiteTitle = _isSavingSiteTitle
 
     init {
         launch {
@@ -170,27 +166,6 @@ class StoreOnboardingViewModel @Inject constructor(
         }
     }
 
-    fun saveSiteTitle(siteTitle: String, fromOnboarding: Boolean = true) {
-        launch {
-            _isSavingSiteTitle.value = NameYourStoreDialogState.LOADING
-            onboardingRepository.saveSiteTitle(siteTitle).fold(
-                onSuccess = {
-                    if (fromOnboarding) {
-                        refreshOnboardingList()
-                        triggerEvent(ShowSnackbar(R.string.store_onboarding_name_your_store_dialog_success))
-                    } else {
-                        triggerEvent(ShowSnackbar(R.string.settings_name_your_store_dialog_success))
-                    }
-                    _isSavingSiteTitle.value = NameYourStoreDialogState.SUCCESS
-                },
-                onFailure = {
-                    triggerEvent(ShowSnackbar(R.string.store_onboarding_name_your_store_dialog_failure))
-                    _isSavingSiteTitle.value = NameYourStoreDialogState.FAILURE
-                }
-            )
-        }
-    }
-
     data class OnboardingState(
         val show: Boolean,
         @StringRes val title: Int,
@@ -257,11 +232,4 @@ class StoreOnboardingViewModel @Inject constructor(
     object NavigateToAboutYourStore : MultiLiveEvent.Event()
     object NavigateToAddProduct : MultiLiveEvent.Event()
     object ShowNameYourStoreDialog : MultiLiveEvent.Event()
-
-    enum class NameYourStoreDialogState {
-        START,
-        LOADING,
-        SUCCESS,
-        FAILURE
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -167,12 +167,17 @@ class StoreOnboardingViewModel @Inject constructor(
         }
     }
 
-    fun saveSiteTitle(siteTitle: String) {
+    fun saveSiteTitle(siteTitle: String, fromOnboarding: Boolean = true) {
         launch {
             onboardingRepository.saveSiteTitle(siteTitle).fold(
                 onSuccess = {
-                    refreshOnboardingList()
-                    triggerEvent(ShowSnackbar(R.string.store_onboarding_name_your_store_dialog_success))
+                    if(fromOnboarding) {
+                        refreshOnboardingList()
+                        triggerEvent(ShowSnackbar(R.string.store_onboarding_name_your_store_dialog_success))
+                    }
+                    else {
+                        triggerEvent(ShowSnackbar(R.string.settings_name_your_store_dialog_success))
+                    }
                 },
                 onFailure = {
                     triggerEvent(ShowSnackbar(R.string.store_onboarding_name_your_store_dialog_failure))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -51,7 +51,6 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.jitm.JitmFragment
 import com.woocommerce.android.ui.jitm.JitmMessagePathsProvider
-import com.woocommerce.android.ui.login.storecreation.onboarding.NameYourStoreDialogFragment
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingCollapsed
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -307,7 +306,7 @@ class MyStoreFragment :
                     )
 
                 is StoreOnboardingViewModel.ShowNameYourStoreDialog -> {
-                    NameYourStoreDialogFragment().show(childFragmentManager, NameYourStoreDialogFragment.TAG)
+                    // todo replace with navigation to NameYourStoreDialogFragment
                 }
 
                 is ShowDialog -> event.showDialog()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -578,6 +578,8 @@ class MyStoreFragment :
 
     override fun getFragmentTitle() = getString(R.string.my_store)
 
+    override fun getFragmentSubtitle(): String = myStoreViewModel.storeName.value ?: ""
+
     override fun scrollToTop() {
         binding.statsScrollView.smoothScrollTo(0, 0)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -246,6 +246,7 @@ class MyStoreFragment :
         )
     }
 
+    @Suppress("LongMethod")
     private fun setupOnboardingView() {
         storeOnboardingViewModel.viewState.observe(viewLifecycleOwner) { state ->
             when (state.show) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -411,6 +411,9 @@ class MyStoreFragment :
         myStoreViewModel.lastUpdateTopPerformers.observe(viewLifecycleOwner) { lastUpdateMillis ->
             binding.myStoreTopPerformers.showLastUpdate(lastUpdateMillis)
         }
+        myStoreViewModel.storeName.observe(viewLifecycleOwner) { storeName ->
+            ((activity) as MainActivity).setSubtitle(storeName)
+        }
     }
 
     private fun onVisitorStatsUnavailable(state: VisitorStatsViewState.Unavailable) {
@@ -574,8 +577,6 @@ class MyStoreFragment :
     }
 
     override fun getFragmentTitle() = getString(R.string.my_store)
-
-    override fun getFragmentSubtitle(): String = myStoreViewModel.getSelectedSiteName()
 
     override fun scrollToTop() {
         binding.statsScrollView.smoothScrollTo(0, 0)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -306,7 +306,10 @@ class MyStoreFragment :
                     )
 
                 is StoreOnboardingViewModel.ShowNameYourStoreDialog -> {
-                    // todo replace with navigation to NameYourStoreDialogFragment
+                    findNavController()
+                        .navigateSafely(
+                            NavGraphMainDirections.actionGlobalNameYourStoreDialogFragment(fromOnboarding = true)
+                        )
                 }
 
                 is ShowDialog -> event.showDialog()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -309,7 +309,7 @@ class MyStoreFragment :
                 is StoreOnboardingViewModel.ShowNameYourStoreDialog -> {
                     findNavController()
                         .navigateSafely(
-                            NavGraphMainDirections.actionGlobalNameYourStoreDialogFragment(fromOnboarding = true)
+                            MyStoreFragmentDirections.actionMyStoreToNameYourStoreDialogFragment(fromOnboarding = true)
                         )
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.update
@@ -124,6 +125,14 @@ class MyStoreViewModel @Inject constructor(
     val activeStatsGranularity = _activeStatsGranularity.asLiveData()
 
     private var jetpackMonitoringJob: Job? = null
+
+    val storeName = selectedSite.observe().map { site ->
+        if (!site?.displayName.isNullOrBlank()) {
+            site?.displayName
+        } else {
+            site?.name
+        } ?: resourceProvider.getString(R.string.store_creation_store_name_default)
+    }.asLiveData()
 
     init {
         ConnectionChangeReceiver.getEventBus().register(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -242,6 +242,10 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             binding.optionDomain.isVisible ||
             binding.optionStoreOnboardingListVisibility.isVisible ||
             binding.shippingClasses.isVisible
+
+        binding.optionStoreName.setOnClickListener {
+            // implementation coming soon
+        }
     }
 
     private fun showDomainDashboard() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -16,7 +16,6 @@ import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
-import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.SETTINGS_ABOUT_OPEN_SOURCE_LICENSES_LINK_TAPPED
@@ -247,7 +246,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         binding.optionStoreName.setOnClickListener {
             findNavController()
                 .navigateSafely(
-                    NavGraphMainDirections.actionGlobalNameYourStoreDialogFragment()
+                    MainSettingsFragmentDirections.actionMainSettingsFragmentToNameYourStoreDialogFragment()
                 )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -16,6 +16,7 @@ import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppUrls
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.SETTINGS_ABOUT_OPEN_SOURCE_LICENSES_LINK_TAPPED
@@ -244,7 +245,10 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             binding.shippingClasses.isVisible
 
         binding.optionStoreName.setOnClickListener {
-            // todo replace with navigation to NameYourStoreDialogFragment
+            findNavController()
+                .navigateSafely(
+                    NavGraphMainDirections.actionGlobalNameYourStoreDialogFragment()
+                )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -38,7 +38,6 @@ import com.woocommerce.android.model.FeatureAnnouncement
 import com.woocommerce.android.support.help.HelpActivity
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.OpenReactNative
-import com.woocommerce.android.ui.login.storecreation.onboarding.NameYourStoreDialogFragment
 import com.woocommerce.android.util.AnalyticsUtils
 import com.woocommerce.android.util.AppThemeUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -245,7 +244,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             binding.shippingClasses.isVisible
 
         binding.optionStoreName.setOnClickListener {
-            NameYourStoreDialogFragment().show(childFragmentManager, NameYourStoreDialogFragment.TAG)
+            // todo replace with navigation to NameYourStoreDialogFragment
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -38,6 +38,7 @@ import com.woocommerce.android.model.FeatureAnnouncement
 import com.woocommerce.android.support.help.HelpActivity
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.OpenReactNative
+import com.woocommerce.android.ui.login.storecreation.onboarding.NameYourStoreDialogFragment
 import com.woocommerce.android.util.AnalyticsUtils
 import com.woocommerce.android.util.AppThemeUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -244,7 +245,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             binding.shippingClasses.isVisible
 
         binding.optionStoreName.setOnClickListener {
-            // implementation coming soon
+            NameYourStoreDialogFragment().show(childFragmentManager, NameYourStoreDialogFragment.TAG)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -27,7 +27,6 @@ enum class FeatureFlag {
     SHIPPING_ZONES,
     BETTER_CUSTOMER_SEARCH_M2,
     HAZMAT_SHIPPING,
-    NAME_YOUR_STORE_DIALOG,
     OPTIMIZE_PROFILER_QUESTIONS;
 
     fun isEnabled(context: Context? = null): Boolean {
@@ -56,7 +55,6 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             HAZMAT_SHIPPING,
-            NAME_YOUR_STORE_DIALOG,
             OPTIMIZE_PROFILER_QUESTIONS
             -> PackageUtils.isDebugBuild()
 

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -46,6 +46,14 @@
                 android:layout_height="wrap_content"
                 android:text="@string/settings_store" />
 
+            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                android:id="@+id/option_store_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="visible"
+                app:optionTitle="@string/store_creation_store_name_settings_option"
+                tools:visibility="visible" />
+
             <!--
                 Install Jetpack
             -->

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -74,6 +74,9 @@
         <action
             android:id="@+id/action_dashboard_to_AIProductDescriptionDialogFragment"
             app:destination="@id/AIProductDescriptionDialogFragment" />
+        <action
+            android:id="@+id/action_myStore_to_nameYourStoreDialogFragment"
+            app:destination="@id/nameYourStoreDialogFragment" />
     </fragment>
     <fragment
         android:id="@+id/orders"
@@ -615,7 +618,4 @@
             app:argType="boolean"
             android:defaultValue="false" />
     </dialog>
-    <action
-        android:id="@+id/action_global_nameYourStoreDialogFragment"
-        app:destination="@id/nameYourStoreDialogFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -606,4 +606,16 @@
             app:argType="string"
             app:nullable="false" />
     </dialog>
+    <dialog
+        android:id="@+id/nameYourStoreDialogFragment"
+        android:name="com.woocommerce.android.ui.login.storecreation.onboarding.NameYourStoreDialogFragment"
+        android:label="NameYourStoreDialogFragment" >
+        <argument
+            android:name="fromOnboarding"
+            app:argType="boolean"
+            android:defaultValue="false" />
+    </dialog>
+    <action
+        android:id="@+id/action_global_nameYourStoreDialogFragment"
+        app:destination="@id/nameYourStoreDialogFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -44,6 +44,10 @@
         <action
             android:id="@+id/action_mainSettingsFragment_to_closeAccountDialogFragment"
             app:destination="@id/closeAccountDialogFragment" />
+
+        <action
+            android:id="@+id/action_mainSettingsFragment_to_nameYourStoreDialogFragment"
+            app:destination="@id/nameYourStoreDialogFragment" />
     </fragment>
     <fragment
         android:id="@+id/privacySettingsFragment"
@@ -159,4 +163,14 @@
         android:id="@+id/closeAccountDialogFragment"
         android:name="com.woocommerce.android.ui.prefs.CloseAccountDialogFragment"
         android:label="CloseAccountDialogFragment" />
+    <dialog
+        android:id="@+id/nameYourStoreDialogFragment"
+        android:name="com.woocommerce.android.ui.login.storecreation.onboarding.NameYourStoreDialogFragment"
+        android:label="NameYourStoreDialogFragment" >
+        <argument
+            android:name="fromOnboarding"
+            app:argType="boolean"
+            android:defaultValue="false" />
+    </dialog>
+
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3255,7 +3255,7 @@
     <string name="store_onboarding_get_paid_loading_label">Loading…</string>
     <string name="store_onboarding_setting_title">Store Setup List</string>
     <string name="store_onboarding_setting_description">Show or hide store setup list</string>
-    <string name="store_onboarding_name_your_store_dialog_title">Site Title</string>
+    <string name="store_onboarding_name_your_store_dialog_title">Store name</string>
     <string name="store_onboarding_name_your_store_dialog_success">Store name set! \n To change again, visit Store Settings.</string>
     <string name="settings_name_your_store_dialog_success">Store name set!</string>
     <string name="store_onboarding_name_your_store_dialog_failure">Unable to save store name. Please try again.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3257,6 +3257,7 @@
     <string name="store_onboarding_setting_description">Show or hide store setup list</string>
     <string name="store_onboarding_name_your_store_dialog_title">Site Title</string>
     <string name="store_onboarding_name_your_store_dialog_success">Store name set! \n To change again, visit Store Settings.</string>
+    <string name="settings_name_your_store_dialog_success">Store name set!</string>
     <string name="store_onboarding_name_your_store_dialog_failure">Unable to save store name. Please try again.</string>
 
     <!--

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3255,7 +3255,7 @@
     <string name="store_onboarding_get_paid_loading_label">Loading…</string>
     <string name="store_onboarding_setting_title">Store Setup List</string>
     <string name="store_onboarding_setting_description">Show or hide store setup list</string>
-    <string name="store_onboarding_name_your_store_dialog_title">Store name</string>
+    <string name="store_onboarding_name_your_store_dialog_title">Update store name</string>
     <string name="store_onboarding_name_your_store_dialog_success">Store name set! \n To change again, visit Store Settings.</string>
     <string name="settings_name_your_store_dialog_success">Store name set!</string>
     <string name="settings_name_your_store_dialog_loading">Saving new store name…</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3255,6 +3255,8 @@
     <string name="store_onboarding_setting_title">Store Setup List</string>
     <string name="store_onboarding_setting_description">Show or hide store setup list</string>
     <string name="store_onboarding_name_your_store_dialog_title">Site Title</string>
+    <string name="store_onboarding_name_your_store_dialog_success">Site title saved successfully.</string>
+    <string name="store_onboarding_name_your_store_dialog_failure">Unable to save site title. Please try again.</string>
 
     <!--
     Support Request

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3156,6 +3156,7 @@
     <string name="store_creation_store_name_subtitle">Don’t worry, you can always change it later. </string>
     <string name="store_creation_store_name_hint">Store name</string>
     <string name="store_creation_store_name_default">Store name</string>
+    <string name="store_creation_store_name_settings_option">Store name</string>
 
     <string name="store_creation_store_profiler_industries_header">About your store</string>
     <string name="store_creation_store_profiler_industries_title">What do you plan to sell\nin your store?</string>
@@ -3255,8 +3256,8 @@
     <string name="store_onboarding_setting_title">Store Setup List</string>
     <string name="store_onboarding_setting_description">Show or hide store setup list</string>
     <string name="store_onboarding_name_your_store_dialog_title">Site Title</string>
-    <string name="store_onboarding_name_your_store_dialog_success">Site title saved successfully.</string>
-    <string name="store_onboarding_name_your_store_dialog_failure">Unable to save site title. Please try again.</string>
+    <string name="store_onboarding_name_your_store_dialog_success">Store name set! \n To change again, visit Store Settings.</string>
+    <string name="store_onboarding_name_your_store_dialog_failure">Unable to save store name. Please try again.</string>
 
     <!--
     Support Request

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3256,6 +3256,7 @@
     <string name="store_onboarding_setting_title">Store Setup List</string>
     <string name="store_onboarding_setting_description">Show or hide store setup list</string>
     <string name="store_onboarding_name_your_store_dialog_title">Update store name</string>
+    <string name="store_onboarding_name_your_store_dialog_label">Store name</string>
     <string name="store_onboarding_name_your_store_dialog_success">Store name set! \n To change again, visit Store Settings.</string>
     <string name="settings_name_your_store_dialog_success">Store name set!</string>
     <string name="settings_name_your_store_dialog_loading">Saving new store name…</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3258,6 +3258,7 @@
     <string name="store_onboarding_name_your_store_dialog_title">Store name</string>
     <string name="store_onboarding_name_your_store_dialog_success">Store name set! \n To change again, visit Store Settings.</string>
     <string name="settings_name_your_store_dialog_success">Store name set!</string>
+    <string name="settings_name_your_store_dialog_loading">Saving new store name…</string>
     <string name="store_onboarding_name_your_store_dialog_failure">Unable to save store name. Please try again.</string>
 
     <!--

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2820-d9d3373771da684da97aab34e130c526f86d6a7c'
+    fluxCVersion = 'trunk-316568ff30fc54bd4fae97a60df7ed40fea48c67'
     wooCommerceSharedVersion = '0.6.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-2a36587d9cff7099f2039f6bd853914bf06f6f5c'
+    fluxCVersion = '2820-6f3160c3a3d0fe0846283f54ab663f2d8a879291'
     wooCommerceSharedVersion = '0.6.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2820-6f3160c3a3d0fe0846283f54ab663f2d8a879291'
+    fluxCVersion = '2820-d9d3373771da684da97aab34e130c526f86d6a7c'
     wooCommerceSharedVersion = '0.6.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-316568ff30fc54bd4fae97a60df7ed40fea48c67'
+    fluxCVersion = '2.43.0'
     wooCommerceSharedVersion = '0.6.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR does three main things:
1. Make the saving store name dialog work (actually saves the input) in the onboarding task,
2. Make the saving store name dialog work in the Settings area,
3. Removes feature flag for this feature as everything's done.

Please note that I just realized the existence of the second task above quite late, so the code structure is not optimized for that. Specifically, the code to save store name is still in `StoreOnboardingViewModel` even though the context is not for onboarding. I aim to refactor this in the next sprint, it doesn't affect the functionality. **Update**: nevermind, it ended up being refactored already in this PR.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

This one is easiest to test from Settings first. Please use a free trial WooExpress site.

**Settings:**
1. Go to More Menu > Settings,
2. Tap "Store name",
3. Enter a new name and tap OK,
4. Site title should be saved properly.
5. Tap "Store name" again, then change the store name back to "Store name". This is needed to reset the Onboarding status, then continue below.


**Onboarding:**
1. Once site is created, tap the "Name Your Store" task on the onboarding task on My Store,
2. Make sure the dialog is shown, change the name to something else and tap OK.
3. Site title should be saved properly.
4. The "Name Your Store" task should now be checked and not usable anymore.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
