### PR TITLE
feat: make OrderProduct not Parcelable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderProduct.kt
@@ -1,16 +1,11 @@
 package com.woocommerce.android.ui.orders.details
 
-import android.os.Parcelable
 import com.woocommerce.android.model.Order
-import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
-@Parcelize
-sealed class OrderProduct : Parcelable {
-    @Parcelize
+sealed class OrderProduct {
     data class ProductItem(val product: Order.Item) : OrderProduct()
 
-    @Parcelize
     data class GroupedProductItem(
         val product: Order.Item,
         val children: List<ProductItem>,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Relates to: #9535 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As rest of the solution I'd like to introduce rely on making `OrderProduct` not Parcelable, I'd like to discuss it with you @atorresveiga first - do you remember why we made `OrderProduct` Parcelable and if it's okay to remove this interface?

The build seems to work fine, but I'm worried if I'm missing something.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
