### PR TITLE
Move close account option to a new screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] [Internal] Add application_store_snapshot event tracking with fetching of orders and products count and payment gateways [https://github.com/woocommerce/woocommerce-android/pull/9597]
 - [*] Fix a crash that occurs when using Magic Link to login during the Jetpack installation flow [https://github.com/woocommerce/woocommerce-android/pull/9642]
 - [**] [Internal] Handle "enabled" WCPay account status the same way as "completed" [https://github.com/woocommerce/woocommerce-android/pull/9637]
+- [*] Settings: Close Account option is moved to a new section Account Settings. [https://github.com/woocommerce/woocommerce-android/pull/9659]
 
 15.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonColors
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.ButtonElevation
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
@@ -55,8 +56,11 @@ fun WCColoredButton(
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
-    colors: ButtonColors = ButtonDefaults.buttonColors(),
+    colors: ButtonColors = ButtonDefaults.buttonColors(
+        contentColor = colorResource(id = R.color.woo_white)
+    ),
     rippleColor: Color = MaterialTheme.colors.primaryVariant,
+    elevation: ButtonElevation? = null,
     content: @Composable RowScope.() -> Unit
 ) {
     val contentColor by colors.contentColor(enabled = enabled)
@@ -80,15 +84,13 @@ fun WCColoredButton(
             onClick = onClick,
             enabled = enabled,
             colors = colors,
-            elevation = null,
+            elevation = elevation,
             interactionSource = interactionSource,
             contentPadding = contentPadding,
             modifier = modifier
         ) {
             ProvideTextStyle(
-                value = MaterialTheme.typography.subtitle2.copy(
-                    color = colorResource(id = R.color.woo_white)
-                )
+                value = MaterialTheme.typography.subtitle2
             ) {
                 content()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -61,8 +61,10 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         private const val SETTING_NOTIFS_TONE = "notifications_tone"
     }
 
-    @Inject lateinit var presenter: MainSettingsContract.Presenter
-    @Inject lateinit var openReactNative: OpenReactNative
+    @Inject
+    lateinit var presenter: MainSettingsContract.Presenter
+    @Inject
+    lateinit var openReactNative: OpenReactNative
 
     private var _binding: FragmentSettingsMainBinding? = null
     private val binding get() = _binding!!
@@ -221,9 +223,11 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             }
         }
 
-        binding.containerOptionCloseAccount.isVisible = presenter.isCloseAccountOptionVisible
-        binding.btnOptionCloseAccount.setOnClickListener {
-            findNavController().navigateSafely(R.id.action_mainSettingsFragment_to_closeAccountDialogFragment)
+        binding.optionAccountSettings.isVisible = presenter.isCloseAccountOptionVisible
+        binding.optionAccountSettings.setOnClickListener {
+            findNavController().navigateSafely(
+                MainSettingsFragmentDirections.actionMainSettingsFragmentToAccountSettingsFragment()
+            )
         }
 
         presenter.setupAnnouncementOption()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/account/AccountSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/account/AccountSettingsFragment.kt
@@ -1,0 +1,44 @@
+package com.woocommerce.android.ui.prefs.account
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.navigation.findNavController
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class AccountSettingsFragment : BaseFragment() {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Visible(
+            navigationIcon = R.drawable.ic_gridicons_cross_24dp
+        )
+
+    override fun getFragmentTitle(): String = getString(R.string.settings_account)
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    AccountSettingsScreen(
+                        onCloseAccountClick = {
+                            findNavController().navigateSafely(
+                                AccountSettingsFragmentDirections
+                                    .actionAccountSettingsFragmentToCloseAccountDialogFragment()
+                            )
+                        }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/account/AccountSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/account/AccountSettingsScreen.kt
@@ -1,42 +1,86 @@
 package com.woocommerce.android.ui.prefs.account
 
 import android.content.res.Configuration
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Divider
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 fun AccountSettingsScreen(
     onCloseAccountClick: () -> Unit
 ) {
-    Box(
+    Column(
         modifier = Modifier
+            .background(MaterialTheme.colors.surface)
             .fillMaxSize()
-            .padding(dimensionResource(id = R.dimen.major_100))
     ) {
-        WCColoredButton(
+        Divider()
+        AccountSettingsItem(
+            title = stringResource(id = R.string.settings_close_account).uppercase(),
             onClick = onCloseAccountClick,
-            colors = ButtonDefaults.buttonColors(
-                backgroundColor = MaterialTheme.colors.surface,
-                contentColor = MaterialTheme.colors.error
-            ),
-            // The elevation is needed to give the button some contrast on dark mode
-            elevation = if (MaterialTheme.colors.isLight) null else ButtonDefaults.elevation(),
+            textColor = colorResource(id = R.color.woo_pink_50),
+            boldText = true,
             modifier = Modifier.fillMaxWidth()
-        ) {
-            Text(text = stringResource(id = R.string.settings_close_account))
+        )
+        Divider()
+    }
+}
+
+@Composable
+private fun AccountSettingsItem(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    enabled: Boolean = true,
+    boldText: Boolean = false,
+    textColor: Color = LocalContentColor.current
+) {
+    Column(
+        modifier = modifier
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(
+                start = dimensionResource(id = R.dimen.major_375),
+                top = dimensionResource(id = R.dimen.major_100),
+                bottom = dimensionResource(id = R.dimen.major_100),
+                end = dimensionResource(id = R.dimen.major_100)
+            )
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.subtitle1,
+            fontWeight = if (boldText) FontWeight.Medium else null,
+            color = textColor.let {
+                if (!enabled) it.copy(alpha = ContentAlpha.disabled) else it
+            }
+        )
+        subtitle?.let {
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.body2,
+                fontWeight = if (boldText) FontWeight.Medium else null,
+                color = textColor.let {
+                    if (!enabled) it.copy(alpha = ContentAlpha.disabled) else it
+                }
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/account/AccountSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/account/AccountSettingsScreen.kt
@@ -1,0 +1,51 @@
+package com.woocommerce.android.ui.prefs.account
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun AccountSettingsScreen(
+    onCloseAccountClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(dimensionResource(id = R.dimen.major_100))
+    ) {
+        WCColoredButton(
+            onClick = onCloseAccountClick,
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = MaterialTheme.colors.surface,
+                contentColor = MaterialTheme.colors.error
+            ),
+            // The elevation is needed to give the button some contrast on dark mode
+            elevation = if (MaterialTheme.colors.isLight) null else ButtonDefaults.elevation(),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(text = stringResource(id = R.string.settings_close_account))
+        }
+    }
+}
+
+@Composable
+@Preview(name = "Light mode")
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
+private fun AccountSettingsScreenPreview() {
+    WooThemeWithBackground {
+        AccountSettingsScreen(onCloseAccountClick = {})
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/account/CloseAccountDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/account/CloseAccountDialogFragment.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.prefs
+package com.woocommerce.android.ui.prefs.account
 
 import android.content.Intent
 import android.os.Bundle
@@ -43,9 +43,9 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.LoginActivity
-import com.woocommerce.android.ui.prefs.CloseAccountViewModel.CloseAccountState
-import com.woocommerce.android.ui.prefs.CloseAccountViewModel.ContactSupport
-import com.woocommerce.android.ui.prefs.CloseAccountViewModel.OnAccountClosed
+import com.woocommerce.android.ui.prefs.account.CloseAccountViewModel.CloseAccountState
+import com.woocommerce.android.ui.prefs.account.CloseAccountViewModel.ContactSupport
+import com.woocommerce.android.ui.prefs.account.CloseAccountViewModel.OnAccountClosed
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.login.LoginMode

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/account/CloseAccountViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/account/CloseAccountViewModel.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.prefs
+package com.woocommerce.android.ui.prefs.account
 
 import androidx.annotation.StringRes
 import androidx.lifecycle.MutableLiveData

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -233,6 +233,14 @@
 
         <View style="@style/Woo.Divider" />
 
+        <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+            android:id="@+id/option_account_settings"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:optionTitle="@string/settings_account" />
+
+        <View style="@style/Woo.Divider" />
+
         <com.woocommerce.android.ui.prefs.WCSettingsButton
             android:id="@+id/btn_option_logout"
             android:layout_width="match_parent"
@@ -240,23 +248,6 @@
             android:text="@string/settings_signout" />
 
         <View style="@style/Woo.Divider" />
-
-        <LinearLayout
-            android:id="@+id/container_option_close_account"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:visibility="gone">
-
-            <com.woocommerce.android.ui.prefs.WCSettingsButton
-                android:id="@+id/btn_option_close_account"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/settings_close_account"
-                android:textColor="@color/color_error" />
-
-            <View style="@style/Woo.Divider" />
-        </LinearLayout>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -157,6 +157,6 @@
     <include app:graph="@navigation/nav_graph_domain_change" />
     <dialog
         android:id="@+id/closeAccountDialogFragment"
-        android:name="com.woocommerce.android.ui.prefs.CloseAccountDialogFragment"
+        android:name="com.woocommerce.android.ui.prefs.account.CloseAccountDialogFragment"
         android:label="CloseAccountDialogFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -42,8 +42,8 @@
                 app:argType="com.woocommerce.android.ui.prefs.domain.DomainFlowSource" />
         </action>
         <action
-            android:id="@+id/action_mainSettingsFragment_to_closeAccountDialogFragment"
-            app:destination="@id/closeAccountDialogFragment" />
+            android:id="@+id/action_mainSettingsFragment_to_accountSettingsFragment"
+            app:destination="@id/accountSettingsFragment" />
     </fragment>
     <fragment
         android:id="@+id/privacySettingsFragment"
@@ -155,6 +155,14 @@
         android:name="com.woocommerce.android.ui.prefs.DeveloperOptionsFragment"
         android:label="DeveloperOptionsFragment" />
     <include app:graph="@navigation/nav_graph_domain_change" />
+    <fragment
+        android:id="@+id/accountSettingsFragment"
+        android:name="com.woocommerce.android.ui.prefs.account.AccountSettingsFragment"
+        android:label="AccountSettingsFragment" >
+        <action
+            android:id="@+id/action_accountSettingsFragment_to_closeAccountDialogFragment"
+            app:destination="@id/closeAccountDialogFragment" />
+    </fragment>
     <dialog
         android:id="@+id/closeAccountDialogFragment"
         android:name="com.woocommerce.android.ui.prefs.account.CloseAccountDialogFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_site_picker.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_site_picker.xml
@@ -89,6 +89,6 @@
     </dialog>
     <dialog
         android:id="@+id/closeAccountDialogFragment"
-        android:name="com.woocommerce.android.ui.prefs.CloseAccountDialogFragment"
+        android:name="com.woocommerce.android.ui.prefs.account.CloseAccountDialogFragment"
         android:label="CloseAccountDialogFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2108,6 +2108,7 @@
     <string name="settings_about_recommend_app_subject">WooCommerce</string>
     <string name="settings_about_recommend_app_message">Hey! Here is a link to download the WooCommerce app. I\'m really enjoying it and thought you might too. %1$s</string>
     <string name="dev_options">Developer Options</string>
+    <string name="settings_account">Account Settings</string>
 
     <!--
         Developer Options Screen


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9653
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR introduces a new screen "Account Settings", its sole role now is to hold the "Close account" button, but more functionality will be added later.
As explained in the ticket, we want to move the button to avoid accidental clicks.

### Testing instructions
1. Open the app and sign in using a WordPress.com account.
2. Navigate to the settings.
3. Notice the option: "Account Settings"
4. Click on the button and confirm it opens the new screen.
5. Click on "Close Account" and confirm that it opens the account closing dialog.

No need to test the rest of the flow, as it wasn't touched in this PR. 

### Images/gif
| | |
| - | - |
| ![Screenshot_20230824_175308](https://github.com/woocommerce/woocommerce-android/assets/1657201/87611737-9801-43e1-af8c-2f5a71b233f6) | ![Screenshot_20230824_174326](https://github.com/woocommerce/woocommerce-android/assets/1657201/b5c21232-1ed4-4c8a-b7ae-5985f67f0ffa) |
| ![Screenshot_20230825_102158](https://github.com/woocommerce/woocommerce-android/assets/1657201/c3444605-aeea-493d-b5b1-b5c2f9cbf4bc) | ![Screenshot_20230825_102214](https://github.com/woocommerce/woocommerce-android/assets/1657201/46fac736-6fb9-4650-81ef-e4b3ec9d7429) |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
