### PR TITLE
[Release 15.1] Track completed orders count

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -175,6 +175,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val KEY_HAS_CHANGED_DATA = "has_changed_data"
         const val KEY_STATUS = "status"
         const val KEY_TOTAL_DURATION = "total_duration"
+        const val KEY_TOTAL_COMPLETED_ORDERS = "total_completed_orders"
         const val KEY_SEARCH = "search"
         const val KEY_SEARCH_FILTER = "filter"
         const val KEY_SEARCH_TYPE = "search_filter"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -73,6 +73,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.WCOrderAction.UPDATE_ORDER_STATUS
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.list.PagedListWrapper
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.ListStore
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
@@ -557,14 +558,19 @@ class OrderListViewModel @Inject constructor(
             return
         }
 
-        val totalDurationInSeconds = event.duration.toDouble() / 1_000
-        AnalyticsTracker.track(
-            AnalyticsEvent.ORDERS_LIST_LOADED,
-            mapOf(
-                AnalyticsTracker.KEY_TOTAL_DURATION to totalDurationInSeconds,
-                AnalyticsTracker.KEY_STATUS to event.listDescriptor.statusFilter
+        launch {
+            val totalDurationInSeconds = event.duration.toDouble() / 1_000
+            val totalCompletedOrders = orderListRepository
+                .getCachedOrderStatusOptions()[CoreOrderStatus.COMPLETED.value]?.statusCount
+            AnalyticsTracker.track(
+                AnalyticsEvent.ORDERS_LIST_LOADED,
+                mapOf(
+                    AnalyticsTracker.KEY_TOTAL_DURATION to totalDurationInSeconds,
+                    AnalyticsTracker.KEY_STATUS to event.listDescriptor.statusFilter,
+                    AnalyticsTracker.KEY_TOTAL_COMPLETED_ORDERS to totalCompletedOrders
+                )
             )
-        )
+        }
     }
 
     fun onFiltersButtonTapped() {


### PR DESCRIPTION
### Description
This PR just brings the change of #9664 to the release 15.1.

### Testing instructions
No testing is needed, the change was tested in #9664.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
