### PR TITLE
[Manual Taxes M#1] Navigate to admin with WPComWebViewFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/TaxRatesInfoDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/TaxRatesInfoDialogFragment.kt
@@ -5,10 +5,11 @@ import android.os.Bundle
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.DialogFragment
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.util.ChromeCustomTabUtils
 
 class TaxRatesInfoDialogFragment : DialogFragment() {
     private val args: TaxRatesInfoDialogFragmentArgs by navArgs()
@@ -30,8 +31,10 @@ class TaxRatesInfoDialogFragment : DialogFragment() {
 
     private fun goToTaxRatesSettings() {
         args.dialogState.taxRatesSettingsUrl.let {
-            ChromeCustomTabUtils.launchUrl(requireContext(), it)
-            dismiss()
+            val directions = NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+                urlToLoad = it,
+            )
+            findNavController().navigate(directions)
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
This PR attempts to redirect from tax rates info dialog to wp-admin using WPComWebViewFragment
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
