### PR TITLE
[UI Tests] Added a `woocommerce_tax_based_on` mock

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/settings/tax_based_on.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/settings/tax_based_on.json
@@ -1,0 +1,46 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+    "queryParameters": {
+      "json": {
+        "equalTo": "true"
+      },
+      "path": {
+        "equalTo": "/wc/v3/settings/tax/woocommerce_tax_based_on/&_method=get"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "data": {
+        "id": "woocommerce_tax_based_on",
+        "label": "Calculate tax based on",
+        "description": "",
+        "type": "select",
+        "default": "shipping",
+        "options": {
+          "shipping": "Customer shipping address",
+          "billing": "Customer billing address",
+          "base": "Shop base address"
+        },
+        "tip": "This option determines which address is used to calculate tax.",
+        "value": "shipping",
+        "group_id": "tax",
+        "_links": {
+          "self": [{
+            "href": "https:\/\/test.blog\/wp-json\/wc\/v3\/settings\/tax\/woocommerce_tax_based_on"
+          }],
+          "collection": [{
+            "href": "https:\/\/test.blog\/wp-json\/wc\/v3\/settings\/tax"
+          }]
+        }
+      }
+    },
+    "headers": {
+      "Content-Type": "application/json",
+      "Connection": "keep-alive"
+    }
+  }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
@@ -22,7 +22,7 @@ import org.junit.Rule
 import org.junit.Test
 
 @HiltAndroidTest
-class OrdersUITest : TestBase(failOnUnmatchedWireMockRequests = false) {
+class OrdersUITest : TestBase() {
     @get:Rule(order = 0)
     val rule = HiltAndroidRule(this)
 


### PR DESCRIPTION
### Description
The functionality implemented in #9625 resulted in a new API call being made during order creation. The related `e2eCreateOrderTest` started failing in the mentioned PR, and the unmatched request warning was supressed by disabling `failOnUnmatchedWireMockRequests`. 

Current PR sets the setting back to default (`true`), and adds a missing mock.

### Testing instructions
CI is 🟢, the `e2eCreateOrderTest` test passes.