### PR TITLE
[UI Tests] Moved test data for real API tests to a separate file.

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersRealAPI.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersRealAPI.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.e2e.helpers.InitializationRule
 import com.woocommerce.android.e2e.helpers.TestBase
 import com.woocommerce.android.e2e.helpers.useMockedAPI
-import com.woocommerce.android.e2e.helpers.util.OrderData
 import com.woocommerce.android.e2e.screens.TabNavComponent
 import com.woocommerce.android.e2e.screens.login.WelcomeScreen
 import com.woocommerce.android.e2e.screens.orders.OrderListScreen
@@ -77,24 +76,6 @@ class OrdersRealAPI : TestBase() {
             .logoutIfNeeded(composeTestRule)
     }
 
-    private val order40 = OrderData(
-        customerName = "Samuel Ayala",
-        id = 40,
-        productsTotalRaw = "10.00",
-        taxesRaw = "0.00",
-        shippingRaw = "0.00",
-        totalRaw = "10.00",
-        statusRaw = "pending",
-        customerNoteRaw = "Cappuccino is made on doppio, free of charge. Enjoy!"
-    )
-
-    private val order41 = OrderData(
-        customerName = "Samara Montes",
-        id = 41,
-        totalRaw = "7.00",
-        statusRaw = "completed"
-    )
-
     @Test
     fun e2eRealApiOrdersFilter() {
         OrderListScreen()
@@ -145,8 +126,8 @@ class OrdersRealAPI : TestBase() {
                 .assertOrderId(order40.id)
                 .assertCustomerName(order40.customerName)
                 .assertOrderStatus(order40.status)
-                .assertOrderHasProduct(ProductsRealAPI().productSalad)
-                .assertOrderHasProduct(ProductsRealAPI().productCappuccinoCocoMedium)
+                .assertOrderHasProduct(productSalad)
+                .assertOrderHasProduct(productCappuccinoCocoMedium)
                 .assertPayments(order40)
                 .assertCustomerNote(order40.customerNote)
         } finally {

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductsRealAPI.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductsRealAPI.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.e2e.helpers.InitializationRule
 import com.woocommerce.android.e2e.helpers.TestBase
 import com.woocommerce.android.e2e.helpers.useMockedAPI
-import com.woocommerce.android.e2e.helpers.util.ProductData
 import com.woocommerce.android.e2e.screens.TabNavComponent
 import com.woocommerce.android.e2e.screens.login.WelcomeScreen
 import com.woocommerce.android.e2e.screens.products.ProductListScreen
@@ -75,42 +74,6 @@ class ProductsRealAPI : TestBase() {
         WelcomeScreen
             .logoutIfNeeded(composeTestRule)
     }
-
-    val productSalad = ProductData(
-        name = "Chicken Teriyaki Salad",
-        stockStatusRaw = "instock",
-        priceDiscountedRaw = "7",
-        sku = "SLD-CHK-TRK"
-    )
-
-    private val productCappuccino = ProductData(
-        name = "Cappuccino",
-        stockStatusRaw = "instock",
-        variations = " • 6 variations",
-        priceDiscountedRaw = "2",
-        sku = "CF-CPC"
-    )
-
-    private val productCappuccinoAlmondMedium = ProductData(
-        name = productCappuccino.name,
-        stockStatusRaw = productCappuccino.stockStatusRaw,
-        priceDiscountedRaw = "3",
-        sku = productCappuccino.sku + "-ALM-M"
-    )
-
-    private val productCappuccinoAlmondLarge = ProductData(
-        name = productCappuccino.name,
-        stockStatusRaw = productCappuccino.stockStatusRaw,
-        priceDiscountedRaw = "4",
-        sku = productCappuccino.sku + "-ALM-L"
-    )
-
-    val productCappuccinoCocoMedium = ProductData(
-        name = productCappuccino.name,
-        stockStatusRaw = productCappuccino.stockStatusRaw,
-        priceDiscountedRaw = "3",
-        sku = productCappuccino.sku + "-COCO-M"
-    )
 
     @Test
     fun e2eRealApiProductsSearchUsual() {

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/TestData.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/TestData.kt
@@ -1,0 +1,62 @@
+package com.woocommerce.android.e2e.tests.ui
+
+import com.woocommerce.android.e2e.helpers.util.OrderData
+import com.woocommerce.android.e2e.helpers.util.ProductData
+
+// Test data for Orders used in E2E (real API) tests
+
+val order40 = OrderData(
+    customerName = "Samuel Ayala",
+    id = 40,
+    productsTotalRaw = "10.00",
+    taxesRaw = "0.00",
+    shippingRaw = "0.00",
+    totalRaw = "10.00",
+    statusRaw = "pending",
+    customerNoteRaw = "Cappuccino is made on doppio, free of charge. Enjoy!"
+)
+
+val order41 = OrderData(
+    customerName = "Samara Montes",
+    id = 41,
+    totalRaw = "7.00",
+    statusRaw = "completed"
+)
+
+// Test data for Products used in E2E (real API) tests
+
+val productSalad = ProductData(
+    name = "Chicken Teriyaki Salad",
+    stockStatusRaw = "instock",
+    priceDiscountedRaw = "7",
+    sku = "SLD-CHK-TRK"
+)
+
+val productCappuccino = ProductData(
+    name = "Cappuccino",
+    stockStatusRaw = "instock",
+    variations = " • 6 variations",
+    priceDiscountedRaw = "2",
+    sku = "CF-CPC"
+)
+
+val productCappuccinoAlmondMedium = ProductData(
+    name = productCappuccino.name,
+    stockStatusRaw = productCappuccino.stockStatusRaw,
+    priceDiscountedRaw = "3",
+    sku = productCappuccino.sku + "-ALM-M"
+)
+
+val productCappuccinoAlmondLarge = ProductData(
+    name = productCappuccino.name,
+    stockStatusRaw = productCappuccino.stockStatusRaw,
+    priceDiscountedRaw = "4",
+    sku = productCappuccino.sku + "-ALM-L"
+)
+
+val productCappuccinoCocoMedium = ProductData(
+    name = productCappuccino.name,
+    stockStatusRaw = productCappuccino.stockStatusRaw,
+    priceDiscountedRaw = "3",
+    sku = productCappuccino.sku + "-COCO-M"
+)


### PR DESCRIPTION
Closes: #9142

### Description
No changes to UI tests logic. All test data used in real API UI tests is now placed in one file (as was suggested by @jostnes some time ago).

### Testing instructions
- Seeing 🟢 CI should be (K)enough.