### PR TITLE
Fix/remove feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [*] Fix a crash that occurs when using Magic Link to login during the Jetpack installation flow [https://github.com/woocommerce/woocommerce-android/pull/9642]
 - [**] [Internal] Handle "enabled" WCPay account status the same way as "completed" [https://github.com/woocommerce/woocommerce-android/pull/9637]
 - [*] Onboarding: A new onboarding item, "Name Your Store", is added. Also, changing store name is now possible in Settings. [https://github.com/woocommerce/woocommerce-android/issues/9621]
+- [**] Store creation: Store creation flow has been revamped and now profiler steps are shown while the site is being created [https://github.com/woocommerce/woocommerce-android/issues/9587]
 15.0
 -----
 - [*] Store creation: Country selector screen is now more intuitive and easier to use. [https://github.com/woocommerce/woocommerce-android/issues/9606]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -49,13 +49,13 @@ enum class FeatureFlag {
             SHARING_PRODUCT_AI,
             PRODUCT_DESCRIPTION_AI_GENERATOR,
             ORDER_CREATION_PRODUCT_DISCOUNTS,
-            SHIPPING_ZONES -> true
+            SHIPPING_ZONES,
+            OPTIMIZE_PROFILER_QUESTIONS -> true
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
-            HAZMAT_SHIPPING,
-            OPTIMIZE_PROFILER_QUESTIONS
+            HAZMAT_SHIPPING
             -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Updates feature flag value to enable sending new profiler data after the store is created instead of sending it as part of subscribing to free trial.
Additionally it updated release notes for this latest version

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Trigger store creation flow and verify that the profiler data is sent correctly once the store is fully created and you land in MyStore tab. To do that check for the following logs: 
```
Profiler Answers uploaded successfully

🔵 Tracked: site_creation_profiler_data, Properties: {"industry_slug":"electronics_and_computers","user_commerce_journey":"im_just_starting_my_business","ecommerce_platforms":"","country_code":"AD","is_debug":true}
```