### PR TITLE
[Data Sprint] Fix keys nameing for "application_store_snapshot" event

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tracker/TrackStoreSnapshot.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tracker/TrackStoreSnapshot.kt
@@ -85,11 +85,13 @@ class TrackStoreSnapshot @Inject constructor(
             mapOf(
                 KEY_PRODUCTS_COUNT to productCounts.model,
                 KEY_ORDERS_COUNT to ordersCount.count,
-                KEY_WOOCOMMERCE to sitePlugins.model.getPlugin(KEY_WOOCOMMERCE).getPluginStatus(),
+                KEY_WOOCOMMERCE_PLUGIN to sitePlugins.model.getPlugin(KEY_WOOCOMMERCE_PLUGIN).getPluginStatus(),
                 KEY_STRIPE_PLUGIN to sitePlugins.model.getPlugin(KEY_STRIPE_PLUGIN).getPluginStatus(),
                 KEY_SQUARE_PLUGIN to sitePlugins.model.getPlugin(KEY_SQUARE_PLUGIN).getPluginStatus(),
                 KEY_PAYPAL_PLUGIN to sitePlugins.model.getPlugin(KEY_PAYPAL_PLUGIN).getPluginStatus(),
-            )
+            ).mapKeys {
+                it.key.replace("-", "_")
+            }
         )
     }
 
@@ -109,7 +111,7 @@ class TrackStoreSnapshot @Inject constructor(
         private const val KEY_PRODUCTS_COUNT = "products_count"
         private const val KEY_ORDERS_COUNT = "orders_count"
 
-        private const val KEY_WOOCOMMERCE = "woocommerce-payments"
+        private const val KEY_WOOCOMMERCE_PLUGIN = "woocommerce-payments"
         private const val KEY_STRIPE_PLUGIN = "woocommerce-gateway-stripe"
         private const val KEY_SQUARE_PLUGIN = "woocommerce-square"
         private const val KEY_PAYPAL_PLUGIN = "woocommerce-paypal-payments"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/tracker/TrackStoreSnapshotTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/tracker/TrackStoreSnapshotTest.kt
@@ -196,11 +196,11 @@ class TrackStoreSnapshotTest : BaseUnitTest() {
                 mapOf(
                     "products_count" to 1L,
                     "orders_count" to 2,
-                    "woocommerce-payments" to "not_installed",
-                    "woocommerce-gateway-stripe" to "not_installed",
-                    "woocommerce-gateway-stripe" to "not_installed",
-                    "woocommerce-square" to "not_installed",
-                    "woocommerce-paypal-payments" to "not_installed",
+                    "woocommerce_payments" to "not_installed",
+                    "woocommerce_gateway_stripe" to "not_installed",
+                    "woocommerce_gateway_stripe" to "not_installed",
+                    "woocommerce_square" to "not_installed",
+                    "woocommerce_paypal_payments" to "not_installed",
                 )
             )
         }
@@ -253,11 +253,11 @@ class TrackStoreSnapshotTest : BaseUnitTest() {
                 mapOf(
                     "products_count" to 1L,
                     "orders_count" to 2,
-                    "woocommerce-payments" to "installed_and_not_activated",
-                    "woocommerce-gateway-stripe" to "installed_and_not_activated",
-                    "woocommerce-gateway-stripe" to "installed_and_not_activated",
-                    "woocommerce-square" to "installed_and_not_activated",
-                    "woocommerce-paypal-payments" to "installed_and_not_activated",
+                    "woocommerce_payments" to "installed_and_not_activated",
+                    "woocommerce_gateway_stripe" to "installed_and_not_activated",
+                    "woocommerce_gateway_stripe" to "installed_and_not_activated",
+                    "woocommerce_square" to "installed_and_not_activated",
+                    "woocommerce_paypal_payments" to "installed_and_not_activated",
                 )
             )
         }
@@ -310,11 +310,11 @@ class TrackStoreSnapshotTest : BaseUnitTest() {
                 mapOf(
                     "products_count" to 1L,
                     "orders_count" to 2,
-                    "woocommerce-payments" to "installed_and_activated",
-                    "woocommerce-gateway-stripe" to "installed_and_activated",
-                    "woocommerce-gateway-stripe" to "installed_and_activated",
-                    "woocommerce-square" to "installed_and_activated",
-                    "woocommerce-paypal-payments" to "installed_and_activated",
+                    "woocommerce_payments" to "installed_and_activated",
+                    "woocommerce_gateway_stripe" to "installed_and_activated",
+                    "woocommerce_gateway_stripe" to "installed_and_activated",
+                    "woocommerce_square" to "installed_and_activated",
+                    "woocommerce_paypal_payments" to "installed_and_activated",
                 )
             )
         }
@@ -367,11 +367,11 @@ class TrackStoreSnapshotTest : BaseUnitTest() {
                 mapOf(
                     "products_count" to 1L,
                     "orders_count" to 2,
-                    "woocommerce-payments" to "installed_and_activated",
-                    "woocommerce-gateway-stripe" to "installed_and_activated",
-                    "woocommerce-gateway-stripe" to "installed_and_activated",
-                    "woocommerce-square" to "installed_and_activated",
-                    "woocommerce-paypal-payments" to "not_installed",
+                    "woocommerce_payments" to "installed_and_activated",
+                    "woocommerce_gateway_stripe" to "installed_and_activated",
+                    "woocommerce_gateway_stripe" to "installed_and_activated",
+                    "woocommerce_square" to "installed_and_activated",
+                    "woocommerce_paypal_payments" to "not_installed",
                 )
             )
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As we found out tracks filters the properties with char `-` in it. This PR fixes the keys

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Login in the app on fresh installation
* Find an event `woocommerceandroid_application_store_snapshot` in tracks
* Noticed that payments gateway are tracked:
```
"woocommerce_payments":"installed_and_activated","woocommerce_gateway_stripe":"not_installed","woocommerce_square":"not_installed","woocommerce_paypal_payments":"not_installed"
```

<img width="1215" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/4923871/3758daf9-fa38-4f62-8464-b0b9c6e73150">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
