### PR TITLE
[Data Sprint] Track selected site url in the all events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -319,13 +319,9 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     }
 
     private fun initAnalytics() {
-        AnalyticsTracker.init(application)
+        AnalyticsTracker.init(application, selectedSite)
 
-        if (selectedSite.exists()) {
-            AnalyticsTracker.refreshMetadata(accountStore.account?.userName, selectedSite.get())
-        } else {
-            AnalyticsTracker.refreshMetadata(accountStore.account?.userName)
-        }
+        AnalyticsTracker.refreshMetadata(accountStore.account?.userName)
     }
 
     private fun trackStartupAnalytics() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -84,8 +84,9 @@ class AnalyticsTracker private constructor(
 
         val finalProperties = properties.toMutableMap()
 
+        val selectedSiteModel = selectedSite.getOrNull()
         if (!isSiteless) {
-            selectedSite.getIfExists()?.let {
+            selectedSiteModel?.let {
                 finalProperties[KEY_BLOG_ID] = it.siteId
                 finalProperties[KEY_IS_WPCOM_STORE] = it.isWpComStore
                 finalProperties[KEY_WAS_ECOMMERCE_TRIAL] = it.wasEcommerceTrial
@@ -93,7 +94,7 @@ class AnalyticsTracker private constructor(
             }
         }
         finalProperties[IS_DEBUG] = BuildConfig.DEBUG
-        selectedSite.getIfExists()?.url?.let { finalProperties[KEY_SITE_URL] = it }
+        selectedSiteModel?.url?.let { finalProperties[KEY_SITE_URL] = it }
 
         val propertiesJson = JSONObject(finalProperties)
         tracksClient?.track(EVENTS_PREFIX + eventName, propertiesJson, user, userType)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -7,19 +7,20 @@ import com.automattic.android.tracks.TracksClient
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.analytics.AnalyticsEvent.BACK_PRESSED
 import com.woocommerce.android.analytics.AnalyticsEvent.VIEW_SHOWN
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import org.json.JSONObject
-import org.wordpress.android.fluxc.model.SiteModel
 import java.util.Locale
 import java.util.UUID
 
-class AnalyticsTracker private constructor(private val context: Context) {
+class AnalyticsTracker private constructor(
+    private val context: Context,
+    private val selectedSite: SelectedSite,
+) {
     private var tracksClient: TracksClient? = TracksClient.getClient(context)
     private var username: String? = null
     private var anonymousID: String? = null
-
-    private var site: SiteModel? = null
 
     private fun clearAllData() {
         clearAnonID()
@@ -84,7 +85,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         val finalProperties = properties.toMutableMap()
 
         if (!isSiteless) {
-            site?.let {
+            selectedSite.getIfExists()?.let {
                 finalProperties[KEY_BLOG_ID] = it.siteId
                 finalProperties[KEY_IS_WPCOM_STORE] = it.isWpComStore
                 finalProperties[KEY_WAS_ECOMMERCE_TRIAL] = it.wasEcommerceTrial
@@ -92,6 +93,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
             }
         }
         finalProperties[IS_DEBUG] = BuildConfig.DEBUG
+        selectedSite.getIfExists()?.url?.let { finalProperties[KEY_SITE_URL] = it }
 
         val propertiesJson = JSONObject(finalProperties)
         tracksClient?.track(EVENTS_PREFIX + eventName, propertiesJson, user, userType)
@@ -107,12 +109,10 @@ class AnalyticsTracker private constructor(private val context: Context) {
         tracksClient?.flush()
     }
 
-    private fun refreshMetadata(newUsername: String?, site: SiteModel? = null) {
+    private fun refreshMetadata(newUsername: String?) {
         if (tracksClient == null) {
             return
         }
-
-        this.site = site
 
         if (!newUsername.isNullOrEmpty()) {
             username = newUsername
@@ -128,10 +128,6 @@ class AnalyticsTracker private constructor(private val context: Context) {
         }
     }
 
-    private fun refreshSiteMetadata(site: SiteModel) {
-        refreshMetadata(username, site)
-    }
-
     private fun storeUsagePref() {
         val prefs = PreferenceManager.getDefaultSharedPreferences(context)
         prefs.edit().putBoolean(PREFKEY_SEND_USAGE_STATS, sendUsageStats).apply()
@@ -144,6 +140,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
 
         private const val TRACKS_ANON_ID = "nosara_tracks_anon_id"
         private const val EVENTS_PREFIX = "woocommerceandroid_"
+        private const val KEY_SITE_URL = "site_url"
 
         const val IS_DEBUG = "is_debug"
         const val KEY_ALREADY_READ = "already_read"
@@ -616,8 +613,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
                 }
             }
 
-        fun init(context: Context) {
-            instance = AnalyticsTracker(context.applicationContext)
+        fun init(context: Context, selectedSite: SelectedSite) {
+            instance = AnalyticsTracker(context.applicationContext, selectedSite)
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
             sendUsageStats = prefs.getBoolean(PREFKEY_SEND_USAGE_STATS, true)
         }
@@ -702,12 +699,8 @@ class AnalyticsTracker private constructor(private val context: Context) {
             instance?.clearAllData()
         }
 
-        fun refreshMetadata(username: String?, site: SiteModel? = null) {
-            instance?.refreshMetadata(username, site)
-        }
-
-        fun refreshSiteMetadata(site: SiteModel) {
-            instance?.refreshSiteMetadata(site)
+        fun refreshMetadata(username: String?) {
+            instance?.refreshMetadata(username)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -32,6 +32,7 @@ class SelectedSite(
 
     fun observe(): Flow<SiteModel?> = state
 
+    @Suppress("SwallowedException")
     fun getOrNull(): SiteModel? =
         try {
             get()
@@ -39,6 +40,7 @@ class SelectedSite(
             null
         }
 
+    @Throws(IllegalStateException::class)
     fun get(): SiteModel {
         state.value?.let { return it }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -32,6 +32,13 @@ class SelectedSite(
 
     fun observe(): Flow<SiteModel?> = state
 
+    fun getOrNull(): SiteModel? =
+        try {
+            get()
+        } catch (e: IllegalStateException) {
+            null
+        }
+
     fun get(): SiteModel {
         state.value?.let { return it }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.tools
 
 import android.content.Context
 import androidx.preference.PreferenceManager
-import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.util.PreferenceUtils
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -58,8 +57,6 @@ class SelectedSite(
     fun set(siteModel: SiteModel) {
         state.value = siteModel
         PreferenceUtils.setInt(getPreferences(), SELECTED_SITE_LOCAL_ID, siteModel.id)
-
-        AnalyticsTracker.refreshSiteMetadata(siteModel)
 
         // Notify listeners
         getEventBus().post(SelectedSiteChangedEvent(siteModel))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -65,7 +65,6 @@ class AccountRepository @Inject constructor(
                 false
             } else {
                 AnalyticsTracker.track(AnalyticsEvent.ACCOUNT_LOGOUT)
-                selectedSite.reset()
                 cleanup()
                 true
             }
@@ -84,7 +83,6 @@ class AccountRepository @Inject constructor(
                 }
             }
 
-            selectedSite.reset()
             cleanup()
             true
         }
@@ -118,6 +116,7 @@ class AccountRepository @Inject constructor(
 
         // Wipe user-specific preferences
         prefs.resetUserPreferences()
+        selectedSite.reset()
 
         // Delete sites
         dispatcher.dispatch(SiteActionBuilder.newRemoveAllSitesAction())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -65,6 +65,7 @@ class AccountRepository @Inject constructor(
                 false
             } else {
                 AnalyticsTracker.track(AnalyticsEvent.ACCOUNT_LOGOUT)
+                selectedSite.reset()
                 cleanup()
                 true
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9699
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The PR adds tracking of the `site_url` URL  property for all the events. DO NOT MERGE till that clear peaMlT-aA-p2#comment-404

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Use logcat with "track" filtering
* Notice that all the events have correct, currently selected "site_url" property
* Notice that if a user in logged out state that we don't track "site_url"

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->