### PR TITLE
WooPayments setup: update UI & setup URL

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -580,6 +580,7 @@ class AnalyticsTracker private constructor(private val context: Context) {
         const val VALUE_ADD_DOMAIN = "add_domain"
         const val VALUE_LAUNCH_SITE = "launch_site"
         const val VALUE_PAYMENTS = "payments"
+        const val VALUE_WOO_PAYMENTS = "woocommerce-payments"
         const val VALUE_LOCAL_NAME_STORE = "store_name"
 
         // -- Product Selector

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingFragment.kt
@@ -77,7 +77,9 @@ class StoreOnboardingFragment : BaseFragment() {
                     )
                 is StoreOnboardingViewModel.NavigateToSetupPayments ->
                     findNavController().navigateSafely(
-                        directions = StoreOnboardingFragmentDirections.actionStoreOnboardingFragmentToGetPaidFragment()
+                        directions = StoreOnboardingFragmentDirections.actionStoreOnboardingFragmentToGetPaidFragment(
+                            taskId = event.taskType.id
+                        )
                     )
                 is NavigateToAboutYourStore ->
                     findNavController().navigateSafely(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingFragment.kt
@@ -78,7 +78,13 @@ class StoreOnboardingFragment : BaseFragment() {
                 is StoreOnboardingViewModel.NavigateToSetupPayments ->
                     findNavController().navigateSafely(
                         directions = StoreOnboardingFragmentDirections.actionStoreOnboardingFragmentToGetPaidFragment(
-                            taskId = event.taskType.id
+                            taskId = event.taskId
+                        )
+                    )
+                is StoreOnboardingViewModel.NavigateToSetupWooPayments ->
+                    findNavController().navigateSafely(
+                        directions = StoreOnboardingFragmentDirections.actionStoreOnboardingFragmentToGetPaidFragment(
+                            taskId = event.taskId
                         )
                     )
                 is NavigateToAboutYourStore ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -128,11 +128,11 @@ class StoreOnboardingRepository @Inject constructor(
     enum class OnboardingTaskType(val id: String, val order: Int) {
         LOCAL_NAME_STORE(id = "local_name_store", order = 1),
         WC_PAYMENTS(id = "woocommerce-payments", order = 2),
-        PAYMENTS(id = "payments", order = 2), // PAYMENTS and WC_PAYMENTS are mutually exclusive
         ABOUT_YOUR_STORE(id = "store_details", order = 3),
         ADD_FIRST_PRODUCT(id = "products", order = 4),
         LAUNCH_YOUR_STORE(id = "launch_site", order = 5),
         CUSTOMIZE_DOMAIN(id = "add_domain", order = 6),
+        PAYMENTS(id = "payments", order = 7),
         MOBILE_UNSUPPORTED(id = "mobile-unsupported", order = -1)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -127,12 +127,12 @@ class StoreOnboardingRepository @Inject constructor(
 
     enum class OnboardingTaskType(val id: String, val order: Int) {
         LOCAL_NAME_STORE(id = "local_name_store", order = 1),
-        ABOUT_YOUR_STORE(id = "store_details", order = 2),
-        ADD_FIRST_PRODUCT(id = "products", order = 3),
-        LAUNCH_YOUR_STORE(id = "launch_site", order = 4),
-        CUSTOMIZE_DOMAIN(id = "add_domain", order = 5),
-        WC_PAYMENTS(id = "woocommerce-payments", order = 6),
-        PAYMENTS(id = "payments", order = 6), // WC_PAYMENT and PAYMENTS are considered the same task on mobile
+        WC_PAYMENTS(id = "woocommerce-payments", order = 2),
+        PAYMENTS(id = "payments", order = 2), // PAYMENTS and WC_PAYMENTS are mutually exclusive
+        ABOUT_YOUR_STORE(id = "store_details", order = 3),
+        ADD_FIRST_PRODUCT(id = "products", order = 4),
+        LAUNCH_YOUR_STORE(id = "launch_site", order = 5),
+        CUSTOMIZE_DOMAIN(id = "add_domain", order = 6),
         MOBILE_UNSUPPORTED(id = "mobile-unsupported", order = -1)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -57,7 +57,6 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.component.WcTag
-import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.AboutYourStoreTaskRes
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.Companion.NUMBER_ITEMS_IN_COLLAPSED_MODE
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.LaunchStoreTaskRes
@@ -401,17 +400,14 @@ private fun OnboardingPreview() {
             title = string.store_onboarding_title,
             tasks = listOf(
                 OnboardingTaskUi(
-                    type = OnboardingTaskType.ABOUT_YOUR_STORE,
                     taskUiResources = AboutYourStoreTaskRes,
                     isCompleted = false,
                 ),
                 OnboardingTaskUi(
-                    type = OnboardingTaskType.ABOUT_YOUR_STORE,
                     taskUiResources = AboutYourStoreTaskRes,
                     isCompleted = true,
                 ),
                 OnboardingTaskUi(
-                    type = OnboardingTaskType.ABOUT_YOUR_STORE,
                     taskUiResources = AboutYourStoreTaskRes,
                     isCompleted = false,
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -57,6 +57,7 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.component.WcTag
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.AboutYourStoreTaskRes
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.Companion.NUMBER_ITEMS_IN_COLLAPSED_MODE
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.LaunchStoreTaskRes
@@ -400,14 +401,17 @@ private fun OnboardingPreview() {
             title = string.store_onboarding_title,
             tasks = listOf(
                 OnboardingTaskUi(
+                    type = OnboardingTaskType.ABOUT_YOUR_STORE,
                     taskUiResources = AboutYourStoreTaskRes,
                     isCompleted = false,
                 ),
                 OnboardingTaskUi(
+                    type = OnboardingTaskType.ABOUT_YOUR_STORE,
                     taskUiResources = AboutYourStoreTaskRes,
                     isCompleted = true,
                 ),
                 OnboardingTaskUi(
+                    type = OnboardingTaskType.ABOUT_YOUR_STORE,
                     taskUiResources = AboutYourStoreTaskRes,
                     isCompleted = false,
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STORE_
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.login.storecreation.onboarding.ShouldShowOnboarding.Source.ONBOARDING_LIST
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTask
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.ABOUT_YOUR_STORE
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.ADD_FIRST_PRODUCT
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.CUSTOMIZE_DOMAIN
@@ -74,20 +75,22 @@ class StoreOnboardingViewModel @Inject constructor(
 
     private fun mapToOnboardingTaskState(task: OnboardingTask) =
         when (task.type) {
-            ABOUT_YOUR_STORE -> OnboardingTaskUi(AboutYourStoreTaskRes, isCompleted = task.isComplete)
-            LAUNCH_YOUR_STORE -> OnboardingTaskUi(LaunchStoreTaskRes, isCompleted = task.isComplete)
-            CUSTOMIZE_DOMAIN -> OnboardingTaskUi(CustomizeDomainTaskRes, isCompleted = task.isComplete)
+            ABOUT_YOUR_STORE -> OnboardingTaskUi(task.type, AboutYourStoreTaskRes, isCompleted = task.isComplete)
+            LAUNCH_YOUR_STORE -> OnboardingTaskUi(task.type, LaunchStoreTaskRes, isCompleted = task.isComplete)
+            CUSTOMIZE_DOMAIN -> OnboardingTaskUi(task.type, CustomizeDomainTaskRes, isCompleted = task.isComplete)
             WC_PAYMENTS,
-            PAYMENTS -> OnboardingTaskUi(SetupPaymentsTaskRes, isCompleted = task.isComplete)
+            PAYMENTS -> OnboardingTaskUi(task.type, SetupPaymentsTaskRes, isCompleted = task.isComplete)
 
             ADD_FIRST_PRODUCT -> OnboardingTaskUi(
-                AddProductTaskRes,
+                type = task.type,
+                taskUiResources = AddProductTaskRes,
                 isCompleted = task.isComplete,
                 isLabelVisible = isAIProductDescriptionEnabled()
             )
 
             LOCAL_NAME_STORE -> OnboardingTaskUi(
-                NameYourStoreTaskRes,
+                type = task.type,
+                taskUiResources = NameYourStoreTaskRes,
                 isCompleted = task.isComplete
             )
 
@@ -133,7 +136,7 @@ class StoreOnboardingViewModel @Inject constructor(
             CustomizeDomainTaskRes -> triggerEvent(NavigateToDomains)
             LaunchStoreTaskRes -> triggerEvent(NavigateToLaunchStore)
             NameYourStoreTaskRes -> triggerEvent(ShowNameYourStoreDialog)
-            SetupPaymentsTaskRes -> triggerEvent(NavigateToSetupPayments)
+            SetupPaymentsTaskRes -> triggerEvent(NavigateToSetupPayments(task.type))
         }
         analyticsTrackerWrapper.track(
             stat = AnalyticsEvent.STORE_ONBOARDING_TASK_TAPPED,
@@ -172,6 +175,7 @@ class StoreOnboardingViewModel @Inject constructor(
     )
 
     data class OnboardingTaskUi(
+        val type: OnboardingTaskType,
         val taskUiResources: OnboardingTaskUiResources,
         val isCompleted: Boolean,
         val isLabelVisible: Boolean = false,
@@ -227,7 +231,10 @@ class StoreOnboardingViewModel @Inject constructor(
     object NavigateToSurvey : MultiLiveEvent.Event()
     object NavigateToLaunchStore : MultiLiveEvent.Event()
     object NavigateToDomains : MultiLiveEvent.Event()
-    object NavigateToSetupPayments : MultiLiveEvent.Event()
+    data class NavigateToSetupPayments(
+        val taskType: OnboardingTaskType
+    ) : MultiLiveEvent.Event()
+
     object NavigateToAboutYourStore : MultiLiveEvent.Event()
     object NavigateToAddProduct : MultiLiveEvent.Event()
     object ShowNameYourStoreDialog : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -15,10 +15,10 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_LOCAL_
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PAYMENTS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUCTS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STORE_DETAILS
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_WOO_PAYMENTS
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.login.storecreation.onboarding.ShouldShowOnboarding.Source.ONBOARDING_LIST
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTask
-import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.ABOUT_YOUR_STORE
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.ADD_FIRST_PRODUCT
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.CUSTOMIZE_DOMAIN
@@ -75,21 +75,19 @@ class StoreOnboardingViewModel @Inject constructor(
 
     private fun mapToOnboardingTaskState(task: OnboardingTask) =
         when (task.type) {
-            ABOUT_YOUR_STORE -> OnboardingTaskUi(task.type, AboutYourStoreTaskRes, isCompleted = task.isComplete)
-            LAUNCH_YOUR_STORE -> OnboardingTaskUi(task.type, LaunchStoreTaskRes, isCompleted = task.isComplete)
-            CUSTOMIZE_DOMAIN -> OnboardingTaskUi(task.type, CustomizeDomainTaskRes, isCompleted = task.isComplete)
-            WC_PAYMENTS,
-            PAYMENTS -> OnboardingTaskUi(task.type, SetupPaymentsTaskRes, isCompleted = task.isComplete)
+            ABOUT_YOUR_STORE -> OnboardingTaskUi(AboutYourStoreTaskRes, isCompleted = task.isComplete)
+            LAUNCH_YOUR_STORE -> OnboardingTaskUi(LaunchStoreTaskRes, isCompleted = task.isComplete)
+            CUSTOMIZE_DOMAIN -> OnboardingTaskUi(CustomizeDomainTaskRes, isCompleted = task.isComplete)
+            WC_PAYMENTS -> OnboardingTaskUi(SetupWooPaymentsTaskRes, isCompleted = task.isComplete)
+            PAYMENTS -> OnboardingTaskUi(SetupPaymentsTaskRes, isCompleted = task.isComplete)
 
             ADD_FIRST_PRODUCT -> OnboardingTaskUi(
-                type = task.type,
                 taskUiResources = AddProductTaskRes,
                 isCompleted = task.isComplete,
                 isLabelVisible = isAIProductDescriptionEnabled()
             )
 
             LOCAL_NAME_STORE -> OnboardingTaskUi(
-                type = task.type,
                 taskUiResources = NameYourStoreTaskRes,
                 isCompleted = task.isComplete
             )
@@ -136,7 +134,8 @@ class StoreOnboardingViewModel @Inject constructor(
             CustomizeDomainTaskRes -> triggerEvent(NavigateToDomains)
             LaunchStoreTaskRes -> triggerEvent(NavigateToLaunchStore)
             NameYourStoreTaskRes -> triggerEvent(ShowNameYourStoreDialog)
-            SetupPaymentsTaskRes -> triggerEvent(NavigateToSetupPayments(task.type))
+            SetupPaymentsTaskRes -> triggerEvent(NavigateToSetupPayments)
+            SetupWooPaymentsTaskRes -> triggerEvent(NavigateToSetupWooPayments)
         }
         analyticsTrackerWrapper.track(
             stat = AnalyticsEvent.STORE_ONBOARDING_TASK_TAPPED,
@@ -151,6 +150,7 @@ class StoreOnboardingViewModel @Inject constructor(
             CustomizeDomainTaskRes -> VALUE_ADD_DOMAIN
             LaunchStoreTaskRes -> VALUE_LAUNCH_SITE
             SetupPaymentsTaskRes -> VALUE_PAYMENTS
+            SetupWooPaymentsTaskRes -> VALUE_WOO_PAYMENTS
             NameYourStoreTaskRes -> VALUE_LOCAL_NAME_STORE
         }
 
@@ -175,7 +175,6 @@ class StoreOnboardingViewModel @Inject constructor(
     )
 
     data class OnboardingTaskUi(
-        val type: OnboardingTaskType,
         val taskUiResources: OnboardingTaskUiResources,
         val isCompleted: Boolean,
         val isLabelVisible: Boolean = false,
@@ -227,14 +226,22 @@ class StoreOnboardingViewModel @Inject constructor(
         description = R.string.store_onboarding_task_payments_setup_description
     )
 
+    object SetupWooPaymentsTaskRes : OnboardingTaskUiResources(
+        icon = R.drawable.ic_onboarding_payments_setup,
+        title = R.string.store_onboarding_task_payments_setup_title,
+        description = R.string.store_onboarding_task_woopayments_setup_description
+    )
+
     object NavigateToOnboardingFullScreen : MultiLiveEvent.Event()
     object NavigateToSurvey : MultiLiveEvent.Event()
     object NavigateToLaunchStore : MultiLiveEvent.Event()
     object NavigateToDomains : MultiLiveEvent.Event()
-    data class NavigateToSetupPayments(
-        val taskType: OnboardingTaskType
-    ) : MultiLiveEvent.Event()
-
+    object NavigateToSetupPayments : MultiLiveEvent.Event() {
+        val taskId = PAYMENTS.id
+    }
+    object NavigateToSetupWooPayments : MultiLiveEvent.Event() {
+        val taskId = WC_PAYMENTS.id
+    }
     object NavigateToAboutYourStore : MultiLiveEvent.Event()
     object NavigateToAddProduct : MultiLiveEvent.Event()
     object ShowNameYourStoreDialog : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidScreen.kt
@@ -1,24 +1,15 @@
 package com.woocommerce.android.ui.login.storecreation.onboarding.payments
 
-import android.annotation.SuppressLint
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCWebView
-import com.woocommerce.android.ui.login.storecreation.onboarding.payments.GetPaidViewModel.ViewState.LoadingState
-import com.woocommerce.android.ui.login.storecreation.onboarding.payments.GetPaidViewModel.ViewState.WebViewState
 import org.wordpress.android.fluxc.network.UserAgent
 
 @Composable
@@ -27,62 +18,19 @@ fun GetPaidScreen(
     userAgent: UserAgent,
     authenticator: WPComWebViewAuthenticator
 ) {
-    viewModel.viewState.observeAsState(LoadingState).value.let { state ->
+    viewModel.viewState.observeAsState(null).value?.let { state ->
         Scaffold(topBar = {
             Toolbar(
                 title = stringResource(id = string.store_onboarding_task_payments_setup_title),
                 onNavigationButtonClick = viewModel::onBackPressed
             )
         }) { padding ->
-            when (state) {
-                is LoadingState -> {
-                    ProgressIndicator(
-                        modifier = Modifier
-                            .padding(padding)
-                    )
-                }
-                is WebViewState -> {
-                    WpAdmin(
-                        state,
-                        userAgent,
-                        if (state.shouldAuthenticate) authenticator else null,
-                        modifier = Modifier
-                            .background(MaterialTheme.colors.surface)
-                            .fillMaxSize()
-                            .padding(padding)
-                    )
-                }
-            }
+            WCWebView(
+                url = state.url,
+                userAgent = userAgent,
+                wpComAuthenticator = if (state.shouldAuthenticate) authenticator else null,
+                modifier = Modifier.padding(padding)
+            )
         }
     }
-}
-
-@Composable
-private fun ProgressIndicator(modifier: Modifier) {
-    Box(
-        modifier = Modifier
-            .background(MaterialTheme.colors.surface)
-            .fillMaxSize()
-    ) {
-        CircularProgressIndicator(
-            modifier = modifier
-                .align(Alignment.Center)
-        )
-    }
-}
-
-@Composable
-@SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
-private fun WpAdmin(
-    viewState: WebViewState,
-    userAgent: UserAgent,
-    authenticator: WPComWebViewAuthenticator?,
-    modifier: Modifier
-) {
-    WCWebView(
-        url = viewState.url,
-        userAgent = userAgent,
-        wpComAuthenticator = authenticator,
-        modifier = modifier
-    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidViewModel.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.login.storecreation.onboarding.payments
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType
 import com.woocommerce.android.ui.login.storecreation.onboarding.payments.GetPaidViewModel.ViewState.LoadingState
 import com.woocommerce.android.ui.login.storecreation.onboarding.payments.GetPaidViewModel.ViewState.WebViewState
 import com.woocommerce.android.viewmodel.MultiLiveEvent

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidViewModel.kt
@@ -2,47 +2,40 @@ package com.woocommerce.android.ui.login.storecreation.onboarding.payments
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
-import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.common.PluginRepository
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType
 import com.woocommerce.android.ui.login.storecreation.onboarding.payments.GetPaidViewModel.ViewState.LoadingState
 import com.woocommerce.android.ui.login.storecreation.onboarding.payments.GetPaidViewModel.ViewState.WebViewState
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-import org.wordpress.android.fluxc.store.WooCommerceStore.WooPlugin.WOO_PAYMENTS
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import javax.inject.Inject
 
 @HiltViewModel
 class GetPaidViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val selectedSite: SelectedSite,
-    private val pluginRepository: PluginRepository
+    selectedSite: SelectedSite
 ) : ScopedViewModel(savedStateHandle) {
+    private val args: GetPaidFragmentArgs by savedStateHandle.navArgs()
+
     private val wooPaymentsUrl = selectedSite.get().url
         .slashJoin("/wp-admin/admin.php?page=wc-settings&tab=checkout")
     private val allPaymentsUrl = selectedSite.get().url
         .slashJoin("/wp-admin/admin.php?page=wc-admin&task=payments")
+
     private val _viewState = MutableStateFlow<ViewState>(LoadingState)
     val viewState = _viewState.asLiveData()
 
     init {
-        viewModelScope.launch {
-            val webViewUrl = if (hasWCPayPlugin()) wooPaymentsUrl else allPaymentsUrl
-            val shouldAuthenticate = selectedSite.get().isWPComAtomic
-            _viewState.update {
-                WebViewState(webViewUrl, shouldAuthenticate)
-            }
+        val webViewUrl = if (args.taskId == OnboardingTaskType.WC_PAYMENTS.id) wooPaymentsUrl else allPaymentsUrl
+        val shouldAuthenticate = selectedSite.get().isWPComAtomic
+        _viewState.update {
+            WebViewState(webViewUrl, shouldAuthenticate)
         }
-    }
-
-    private suspend fun hasWCPayPlugin(): Boolean {
-        val wooPayPlugin = pluginRepository.fetchPlugin(selectedSite.get(), WOO_PAYMENTS.pluginName)
-        return wooPayPlugin.getOrNull() != null
     }
 
     fun onBackPressed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidViewModel.kt
@@ -22,19 +22,15 @@ class GetPaidViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
     private val args: GetPaidFragmentArgs by savedStateHandle.navArgs()
 
-    private val wooPaymentsUrl = selectedSite.get().url
-        .slashJoin("/wp-admin/admin.php?page=wc-settings&tab=checkout")
-    private val allPaymentsUrl = selectedSite.get().url
-        .slashJoin("/wp-admin/admin.php?page=wc-admin&task=payments")
+    private val setupUrl = selectedSite.get().url.slashJoin("/wp-admin/admin.php?page=wc-admin&task=${args.taskId}")
 
     private val _viewState = MutableStateFlow<ViewState>(LoadingState)
     val viewState = _viewState.asLiveData()
 
     init {
-        val webViewUrl = if (args.taskId == OnboardingTaskType.WC_PAYMENTS.id) wooPaymentsUrl else allPaymentsUrl
         val shouldAuthenticate = selectedSite.get().isWPComAtomic
         _viewState.update {
-            WebViewState(webViewUrl, shouldAuthenticate)
+            WebViewState(setupUrl, shouldAuthenticate)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidViewModel.kt
@@ -3,14 +3,11 @@ package com.woocommerce.android.ui.login.storecreation.onboarding.payments
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.login.storecreation.onboarding.payments.GetPaidViewModel.ViewState.LoadingState
-import com.woocommerce.android.ui.login.storecreation.onboarding.payments.GetPaidViewModel.ViewState.WebViewState
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.flowOf
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import javax.inject.Inject
 
@@ -23,22 +20,19 @@ class GetPaidViewModel @Inject constructor(
 
     private val setupUrl = selectedSite.get().url.slashJoin("/wp-admin/admin.php?page=wc-admin&task=${args.taskId}")
 
-    private val _viewState = MutableStateFlow<ViewState>(LoadingState)
-    val viewState = _viewState.asLiveData()
-
-    init {
-        val shouldAuthenticate = selectedSite.get().isWPComAtomic
-        _viewState.update {
-            WebViewState(setupUrl, shouldAuthenticate)
-        }
-    }
+    val viewState = flowOf(
+        ViewState(
+            url = setupUrl,
+            shouldAuthenticate = selectedSite.get().isWPComAtomic
+        )
+    ).asLiveData()
 
     fun onBackPressed() {
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
-    sealed class ViewState {
-        object LoadingState : ViewState()
-        data class WebViewState(val url: String, val shouldAuthenticate: Boolean) : ViewState()
-    }
+    data class ViewState(
+        val url: String,
+        val shouldAuthenticate: Boolean
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -71,6 +71,7 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import com.woocommerce.android.widgets.WooClickableSpan
@@ -103,13 +104,20 @@ class MyStoreFragment :
     private val storeOnboardingViewModel: StoreOnboardingViewModel by activityViewModels()
     private val blazeViewModel: BlazeBannerViewModel by viewModels()
 
-    @Inject lateinit var selectedSite: SelectedSite
-    @Inject lateinit var currencyFormatter: CurrencyFormatter
-    @Inject lateinit var uiMessageResolver: UIMessageResolver
-    @Inject lateinit var dateUtils: DateUtils
-    @Inject lateinit var usageTracksEventEmitter: MyStoreStatsUsageTracksEventEmitter
-    @Inject lateinit var appPrefsWrapper: AppPrefsWrapper
-    @Inject lateinit var feedbackPrefs: FeedbackPrefs
+    @Inject
+    lateinit var selectedSite: SelectedSite
+    @Inject
+    lateinit var currencyFormatter: CurrencyFormatter
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
+    @Inject
+    lateinit var dateUtils: DateUtils
+    @Inject
+    lateinit var usageTracksEventEmitter: MyStoreStatsUsageTracksEventEmitter
+    @Inject
+    lateinit var appPrefsWrapper: AppPrefsWrapper
+    @Inject
+    lateinit var feedbackPrefs: FeedbackPrefs
 
     private var _binding: FragmentMyStoreBinding? = null
     private val binding get() = _binding!!
@@ -274,44 +282,50 @@ class MyStoreFragment :
         }
 
         storeOnboardingViewModel.event.observe(viewLifecycleOwner) { event ->
-            when (event) {
-                is StoreOnboardingViewModel.NavigateToOnboardingFullScreen -> openOnboardingInFullScreen()
-                is StoreOnboardingViewModel.NavigateToSurvey ->
-                    NavGraphMainDirections.actionGlobalFeedbackSurveyFragment(SurveyType.STORE_ONBOARDING).apply {
-                        findNavController().navigateSafely(this)
-                    }
+            event.handle()
+        }
+    }
 
-                is StoreOnboardingViewModel.NavigateToLaunchStore ->
-                    findNavController().navigateSafely(
-                        directions = MyStoreFragmentDirections.actionMyStoreToLaunchStoreFragment()
-                    )
-
-                is StoreOnboardingViewModel.NavigateToDomains ->
-                    findNavController().navigateSafely(
-                        directions = MyStoreFragmentDirections.actionMyStoreToNavGraphDomainChange()
-                    )
-
-                is StoreOnboardingViewModel.NavigateToAddProduct ->
-                    findNavController().navigateSafely(
-                        directions = MyStoreFragmentDirections.actionMyStoreToProductTypesBottomSheet()
-                    )
-
-                is StoreOnboardingViewModel.NavigateToSetupPayments ->
-                    findNavController().navigateSafely(
-                        directions = MyStoreFragmentDirections.actionMyStoreToGetPaidFragment()
-                    )
-
-                is StoreOnboardingViewModel.NavigateToAboutYourStore ->
-                    findNavController().navigateSafely(
-                        MyStoreFragmentDirections.actionMyStoreToAboutYourStoreFragment()
-                    )
-
-                is StoreOnboardingViewModel.ShowNameYourStoreDialog -> {
-                    NameYourStoreDialogFragment().show(childFragmentManager, NameYourStoreDialogFragment.TAG)
+    private fun Event.handle() {
+        when (this) {
+            is StoreOnboardingViewModel.NavigateToOnboardingFullScreen -> openOnboardingInFullScreen()
+            is StoreOnboardingViewModel.NavigateToSurvey ->
+                NavGraphMainDirections.actionGlobalFeedbackSurveyFragment(SurveyType.STORE_ONBOARDING).apply {
+                    findNavController().navigateSafely(this)
                 }
 
-                is ShowDialog -> event.showDialog()
+            is StoreOnboardingViewModel.NavigateToLaunchStore ->
+                findNavController().navigateSafely(
+                    directions = MyStoreFragmentDirections.actionMyStoreToLaunchStoreFragment()
+                )
+
+            is StoreOnboardingViewModel.NavigateToDomains ->
+                findNavController().navigateSafely(
+                    directions = MyStoreFragmentDirections.actionMyStoreToNavGraphDomainChange()
+                )
+
+            is StoreOnboardingViewModel.NavigateToAddProduct ->
+                findNavController().navigateSafely(
+                    directions = MyStoreFragmentDirections.actionMyStoreToProductTypesBottomSheet()
+                )
+
+            is StoreOnboardingViewModel.NavigateToSetupPayments ->
+                findNavController().navigateSafely(
+                    directions = MyStoreFragmentDirections.actionMyStoreToGetPaidFragment(
+                        taskId = taskType.id
+                    )
+                )
+
+            is StoreOnboardingViewModel.NavigateToAboutYourStore ->
+                findNavController().navigateSafely(
+                    MyStoreFragmentDirections.actionMyStoreToAboutYourStoreFragment()
+                )
+
+            is StoreOnboardingViewModel.ShowNameYourStoreDialog -> {
+                NameYourStoreDialogFragment().show(childFragmentManager, NameYourStoreDialogFragment.TAG)
             }
+
+            is ShowDialog -> showDialog()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -106,16 +106,22 @@ class MyStoreFragment :
 
     @Inject
     lateinit var selectedSite: SelectedSite
+
     @Inject
     lateinit var currencyFormatter: CurrencyFormatter
+
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
+
     @Inject
     lateinit var dateUtils: DateUtils
+
     @Inject
     lateinit var usageTracksEventEmitter: MyStoreStatsUsageTracksEventEmitter
+
     @Inject
     lateinit var appPrefsWrapper: AppPrefsWrapper
+
     @Inject
     lateinit var feedbackPrefs: FeedbackPrefs
 
@@ -312,7 +318,14 @@ class MyStoreFragment :
             is StoreOnboardingViewModel.NavigateToSetupPayments ->
                 findNavController().navigateSafely(
                     directions = MyStoreFragmentDirections.actionMyStoreToGetPaidFragment(
-                        taskId = taskType.id
+                        taskId = taskId
+                    )
+                )
+
+            is StoreOnboardingViewModel.NavigateToSetupWooPayments ->
+                findNavController().navigateSafely(
+                    directions = MyStoreFragmentDirections.actionMyStoreToGetPaidFragment(
+                        taskId = taskId
                     )
                 )
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -551,7 +551,11 @@
     <fragment
         android:id="@+id/getPaidFragment"
         android:name="com.woocommerce.android.ui.login.storecreation.onboarding.payments.GetPaidFragment"
-        android:label="GetPaidFragment" />
+        android:label="GetPaidFragment" >
+        <argument
+            android:name="taskId"
+            app:argType="string" />
+    </fragment>
     <fragment
         android:id="@+id/aboutYourStoreFragment"
         android:name="com.woocommerce.android.ui.login.storecreation.onboarding.aboutyourstore.AboutYourStoreFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3225,6 +3225,7 @@
     <string name="store_onboarding_task_change_domain_description">Have a custom URL to host your store.</string>
     <string name="store_onboarding_task_payments_setup_title">Get paid</string>
     <string name="store_onboarding_task_payments_setup_description">Give your customers an easy and convenient way to pay!</string>
+    <string name="store_onboarding_task_woopayments_setup_description">Manage payments seamlessly with WooPayments, free from setup or monthly fees.</string>
     <string name="store_onboarding_task_name_store_title">Name your store</string>
     <string name="store_onboarding_task_name_store_description">Customizing your store name can also help your store\'s search engine optimization.</string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d completed</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModelTest.kt
@@ -147,7 +147,13 @@ class StoreOnboardingViewModelTest : BaseUnitTest() {
     @Test
     fun `when any task is clicked, track task clicked event`() = testBlocking {
         whenViewModelIsCreated()
-        viewModel.onTaskClicked(OnboardingTaskUi(AboutYourStoreTaskRes, isCompleted = false))
+        viewModel.onTaskClicked(
+            OnboardingTaskUi(
+                type = OnboardingTaskType.ABOUT_YOUR_STORE,
+                taskUiResources = AboutYourStoreTaskRes,
+                isCompleted = false
+            )
+        )
 
         verify(analyticsTrackerWrapper).track(
             stat = STORE_ONBOARDING_TASK_TAPPED,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModelTest.kt
@@ -149,7 +149,6 @@ class StoreOnboardingViewModelTest : BaseUnitTest() {
         whenViewModelIsCreated()
         viewModel.onTaskClicked(
             OnboardingTaskUi(
-                type = OnboardingTaskType.ABOUT_YOUR_STORE,
                 taskUiResources = AboutYourStoreTaskRes,
                 isCompleted = false
             )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9694 Closes: #9689 

### Description
Since the list of changes is small, and the tasks are related, I decided to tackle two tickets in the same PR, this will also make it easier for reviewer (testing the behavior just once).

So this PR makes the following changes:
1. Updates the logic of the setup screen to depend on the task id returned by the backend instead of fetching WCPay.
2. Updates the UI and order of the payment tasks.
3. Updates the setup URL for WooPayments, currently we'll use the same format for both tasks, but we'll just pass the correct ID of the task that we need to handle.

### Testing instructions
1. It's better to start with a fresh self-hosted site, that has WooCommerce.
4. Make sure the WooCommerce wizard is done on the web, and US is selected as the store's country.
5. Open the app, then sign in.
6. **Confirm** that the onboarding task list has one entry with the text: "Give your customers an easy and convenient way to pay", this matches the `payments` task.
7. Click on the task, and confirm it opens the correct payments setup page.
8. Install WCPay.
9. Close and re-open the app.
10. **Confirm** that the onboarding task list has one entry with the text: "Manage payments seamlessly with WooPayments, free from setup or monthly fees.", this matches the `woocommerce-payments` task.
11. Click on the task, and confirm the behavior matches the flow shown in the video below.


### Images/gif
Setup flow for WooPayments:

https://github.com/woocommerce/woocommerce-android/assets/1657201/c2b8b70a-74c8-4600-95f0-5e6c2f9b818b


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
