### PR TITLE
WooPayments setup: auto dismiss WebView and celebration screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Settings: Close Account option is moved to a new section Account Settings. [https://github.com/woocommerce/woocommerce-android/pull/9659]
 - [*] Fix some issues with the order's badge counter [https://github.com/woocommerce/woocommerce-android/pull/9671]
+- [*] Improvements to the WooPayments onboarding task [https://github.com/woocommerce/woocommerce-android/pull/9714]
 
 15.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -127,9 +127,9 @@ class StoreOnboardingRepository @Inject constructor(
 
     enum class OnboardingTaskType(val id: String, val order: Int) {
         LOCAL_NAME_STORE(id = "local_name_store", order = 1),
-        WC_PAYMENTS(id = "woocommerce-payments", order = 2),
-        ABOUT_YOUR_STORE(id = "store_details", order = 3),
-        ADD_FIRST_PRODUCT(id = "products", order = 4),
+        ABOUT_YOUR_STORE(id = "store_details", order = 2),
+        ADD_FIRST_PRODUCT(id = "products", order = 3),
+        WC_PAYMENTS(id = "woocommerce-payments", order = 4),
         LAUNCH_YOUR_STORE(id = "launch_site", order = 5),
         CUSTOMIZE_DOMAIN(id = "add_domain", order = 6),
         PAYMENTS(id = "payments", order = 7),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
@@ -11,6 +12,7 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.storecreation.onboarding.payments.GetPaidViewModel.ShowWooPaymentsSetupSuccess
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
@@ -21,8 +23,10 @@ import javax.inject.Inject
 class GetPaidFragment : BaseFragment() {
     private val viewModel: GetPaidViewModel by viewModels()
 
-    @Inject lateinit var userAgent: UserAgent
-    @Inject lateinit var authenticator: WPComWebViewAuthenticator
+    @Inject
+    lateinit var userAgent: UserAgent
+    @Inject
+    lateinit var authenticator: WPComWebViewAuthenticator
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
@@ -46,6 +50,7 @@ class GetPaidFragment : BaseFragment() {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
+                is ShowWooPaymentsSetupSuccess -> TODO()
                 is Exit -> findNavController().popBackStack()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidFragment.kt
@@ -4,11 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -25,6 +25,7 @@ class GetPaidFragment : BaseFragment() {
 
     @Inject
     lateinit var userAgent: UserAgent
+
     @Inject
     lateinit var authenticator: WPComWebViewAuthenticator
 
@@ -50,7 +51,10 @@ class GetPaidFragment : BaseFragment() {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is ShowWooPaymentsSetupSuccess -> TODO()
+                is ShowWooPaymentsSetupSuccess -> findNavController().navigateSafely(
+                    GetPaidFragmentDirections.actionGetPaidFragmentToWooPaymentsSetupCelebrationDialog()
+                )
+
                 is Exit -> findNavController().popBackStack()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidScreen.kt
@@ -29,6 +29,7 @@ fun GetPaidScreen(
                 url = state.url,
                 userAgent = userAgent,
                 wpComAuthenticator = if (state.shouldAuthenticate) authenticator else null,
+                onUrlLoaded = viewModel::onUrlLoaded,
                 modifier = Modifier.padding(padding)
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/GetPaidViewModel.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.login.storecreation.onboarding.payments
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -16,7 +18,14 @@ class GetPaidViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     selectedSite: SelectedSite
 ) : ScopedViewModel(savedStateHandle) {
+    companion object {
+        private const val SUCCESS_FLAG = "wcpay-connection-success"
+        private const val CANCELLATION_FLAG = "wcpay-connection-error"
+    }
+
     private val args: GetPaidFragmentArgs by savedStateHandle.navArgs()
+    private val isWooPaymentsSetup = args.taskId == OnboardingTaskType.WC_PAYMENTS.id
+    private var isDismissed = false
 
     private val setupUrl = selectedSite.get().url.slashJoin("/wp-admin/admin.php?page=wc-admin&task=${args.taskId}")
 
@@ -31,8 +40,28 @@ class GetPaidViewModel @Inject constructor(
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
+    fun onUrlLoaded(url: String) {
+        if (isDismissed || !isWooPaymentsSetup) return
+
+        when {
+            url.contains(SUCCESS_FLAG) -> {
+                WooLog.d(WooLog.T.ONBOARDING, "WooPayments setup completed successfully")
+                triggerEvent(ShowWooPaymentsSetupSuccess)
+                isDismissed = true
+            }
+
+            url.contains(CANCELLATION_FLAG) -> {
+                WooLog.d(WooLog.T.ONBOARDING, "WooPayments setup dismissed")
+                triggerEvent(MultiLiveEvent.Event.Exit)
+                isDismissed = true
+            }
+        }
+    }
+
     data class ViewState(
         val url: String,
         val shouldAuthenticate: Boolean
     )
+
+    object ShowWooPaymentsSetupSuccess : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/WooPaymentsSetupCelebrationDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/WooPaymentsSetupCelebrationDialog.kt
@@ -1,0 +1,149 @@
+package com.woocommerce.android.ui.login.storecreation.onboarding.payments
+
+import android.content.res.Configuration
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.findNavController
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.theme.WooTheme
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
+
+class WooPaymentsSetupCelebrationDialog : WCBottomSheetDialogFragment() {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooTheme {
+                    WooPaymentsSetupCelebrationScreen(
+                        onDoneClick = ::navigateBack
+                    )
+                }
+            }
+        }
+    }
+
+    private fun navigateBack() {
+        findNavController().navigateUp()
+    }
+}
+
+@Composable
+private fun WooPaymentsSetupCelebrationScreen(
+    onDoneClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        shape = RoundedCornerShape(
+            topStart = dimensionResource(id = R.dimen.minor_100),
+            topEnd = dimensionResource(id = R.dimen.minor_100)
+        )
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+        ) {
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_50)))
+            Box(
+                modifier = Modifier
+                    .background(
+                        color = MaterialTheme.colors.onSurface.copy(alpha = 0.4f),
+                        shape = RoundedCornerShape(dimensionResource(id = R.dimen.major_150))
+                    )
+                    .size(
+                        width = dimensionResource(id = R.dimen.major_200),
+                        height = dimensionResource(id = R.dimen.minor_50)
+                    )
+            )
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+            Box(
+                modifier = Modifier
+                    .size(dimensionResource(id = R.dimen.major_400))
+                    .border(
+                        width = dimensionResource(id = R.dimen.minor_100),
+                        color = colorResource(id = R.color.woo_green_50).copy(alpha = 0.5f),
+                        shape = CircleShape
+                    )
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_check_rounded),
+                    tint = colorResource(id = R.color.woo_green_50),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(width = 42.dp, height = 32.dp)
+                )
+            }
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+            Text(
+                text = stringResource(id = R.string.store_onboarding_task_woopayments_celebration_header),
+                style = MaterialTheme.typography.h6,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+            Text(
+                text = stringResource(id = R.string.store_onboarding_task_woopayments_celebration_message),
+                style = MaterialTheme.typography.body2,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+            WCColoredButton(onClick = onDoneClick, modifier = Modifier.fillMaxWidth()) {
+                Text(text = stringResource(id = R.string.done))
+            }
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        }
+    }
+}
+
+@Composable
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "small screen", device = Devices.PIXEL)
+@Preview(name = "mid screen", device = Devices.PIXEL_4)
+@Preview(name = "large screen", device = Devices.NEXUS_10)
+private fun WooPaymentsSetupCelebrationScreenPreview() {
+    WooThemeWithBackground {
+        Box(
+            contentAlignment = Alignment.BottomCenter,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            WooPaymentsSetupCelebrationScreen(onDoneClick = { })
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks
@@ -206,7 +207,7 @@ class MainActivity :
 
     private val fragmentLifecycleObserver: FragmentLifecycleCallbacks = object : FragmentLifecycleCallbacks() {
         override fun onFragmentViewCreated(fm: FragmentManager, f: Fragment, v: View, savedInstanceState: Bundle?) {
-            if (isDialogDestination(navController.currentDestination!!)) return
+            if (f is DialogFragment) return
 
             when (val appBarStatus = (f as? BaseFragment)?.activityAppBarStatus ?: AppBarStatus.Visible()) {
                 is AppBarStatus.Visible -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/AppSettingsActivity.kt
@@ -6,6 +6,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks
@@ -95,6 +96,8 @@ class AppSettingsActivity :
 
     private val fragmentLifecycleObserver: FragmentLifecycleCallbacks = object : FragmentLifecycleCallbacks() {
         override fun onFragmentViewCreated(fm: FragmentManager, f: Fragment, v: View, savedInstanceState: Bundle?) {
+            if (f is DialogFragment) return
+
             when ((f as? BaseFragment)?.activityAppBarStatus ?: AppBarStatus.Visible()) {
                 AppBarStatus.Hidden -> {
                     toolbar?.isVisible = false

--- a/WooCommerce/src/main/res/drawable/ic_check_rounded.xml
+++ b/WooCommerce/src/main/res/drawable/ic_check_rounded.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="35dp"
+    android:viewportWidth="48"
+    android:viewportHeight="35">
+  <path
+      android:pathData="M4.8,17.4L17.6,30.2L43.2,4.6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="8.8"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:strokeLineCap="round"/>
+</vector>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -562,7 +562,16 @@
         <argument
             android:name="taskId"
             app:argType="string" />
+        <action
+            android:id="@+id/action_getPaidFragment_to_wooPaymentsSetupCelebrationDialog"
+            app:destination="@id/wooPaymentsSetupCelebrationDialog"
+            app:popUpTo="@id/getPaidFragment"
+            app:popUpToInclusive="true" />
     </fragment>
+    <dialog
+        android:id="@+id/wooPaymentsSetupCelebrationDialog"
+        android:name="com.woocommerce.android.ui.login.storecreation.onboarding.payments.WooPaymentsSetupCelebrationDialog"
+        android:label="WooPaymentsSetupCelebrationDialog" />
     <fragment
         android:id="@+id/wooPaymentsPreSetupFragment"
         android:name="com.woocommerce.android.ui.login.storecreation.onboarding.payments.WooPaymentsPreSetupFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3234,6 +3234,8 @@
     <string name="store_onboarding_task_payments_setup_title">Get paid</string>
     <string name="store_onboarding_task_payments_setup_description">Give your customers an easy and convenient way to pay!</string>
     <string name="store_onboarding_task_woopayments_setup_description">Manage payments seamlessly with WooPayments, free from setup or monthly fees.</string>
+    <string name="store_onboarding_task_woopayments_celebration_header">You did it!</string>
+    <string name="store_onboarding_task_woopayments_celebration_message">Congratulations! You\'ve successfully navigated through the setup and your payment system is ready to roll.</string>
     <string name="store_onboarding_task_name_store_title">Name your store</string>
     <string name="store_onboarding_task_name_store_description">Customizing your store name can also help your store\'s search engine optimization.</string>
     <string name="store_onboarding_completed_tasks_status">%1$d/%2$d completed</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9692 Closes: #9713

### Description
Same as the previous PR, since the number of changes is not big, I opted to make a single PR to handle two tasks, in order to make testing easier for the reviewer.
This PR handles two tasks:
1. It adds logic for auto-dismissing the WebView when completion or cancellation is detected.
2. It adds a celebration screen when completion is detected.

### Testing instructions
- There is a bug with the current WC Core version: completing the WooPayments task will have it replaced by the Payments task, it will be fixed in the next version, so don't worry about it.
- The WooPayments task is marked as complete after establishing the connection with Stripe, and not when the user is fully onboarded, we still don't know if it's the right behavior or not (p1693411091881309-slack-C03KTTK2YMA), but in all cases, the app reacts to the backend's rules here, just keep this in mind if you accidentally dismissed the setup and noticed it's marked as complete. 

Due to this last issue, you need two sites to properly test the two flows

##### Completion flow
1. Start with a fresh site (both a self-hosted or an upgraded WooExpress one would work).
2. If the site is self-hosted, then install WooPayments.
3. Make sure the country is set to US.
4. Install the WCPay Dev plugin (ping me if you need the URL, but Jurassic Ninja has a toggle to include it automatically)
5. Open the app, the sign in to the site.
6. Click on the "Get Paid" task, and confirms it takes you to Stripe.
7. Finish the onboarding (you can enter test data, check P91TBi-4BH-p2 for more details)
8. Confirm that the WebView is dismissed automatically when entering data if finished and that the celebration bottom sheet is shown.

##### Cancellation flow
1. Repeat 1 to 5 from the above flow, except the part about WCPay Dev
2. Click on the "Get Paid" task
3. Dismiss the onboarding using the "return to WooPayments" button.
4. Confirm the WebView is dismissed.

### Images/gif
Completion flow (please ignore the moment where the app froze, I forgot the debugger attached and a breakpoint was hit)

https://github.com/woocommerce/woocommerce-android/assets/1657201/a194bd54-91de-43ef-8fd5-3b95806b1d50


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->