### PR TITLE
[Mobile Payments] Add height for the payments welcome dialog in landscape.

### DIFF
--- a/WooCommerce/src/main/res/values-land/dimens_payments.xml
+++ b/WooCommerce/src/main/res/values-land/dimens_payments.xml
@@ -2,4 +2,5 @@
 <resources>
     <dimen name="payments_dialog_width">280dp</dimen>
     <dimen name="payments_dialog_height">244dp</dimen>
+    <dimen name="payments_welcome_dialog_height">244dp</dimen>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9402 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fixed the Card Reader Welcome Dialog layout on landscape. 

It was not showing correctly because there was no fixed height in landscape mode. Because of this, it rendered the dialog with portrait height. Given that the dialog's height was larger than the device landscape's height, the dialog couldn't show its entire area, showing only the upper part.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

On the first time you capture a payment through the app (or hardcoding the `actionCardReaderStatusCheckerDialogFragmentToCardReaderWelcomeDialogFragment` in CardReaderStatusCheckerDialogFragment)

1. Go to Menu
2. Go to Payments
3. Tap on Collect Payment and follow the flow
4. When reaching the payments methods screen, tap on Card Reader. You should see the Card Reader Welcome Dialog
5. Turn to landscape. Ensure that the layout looks good: there is no big gap in the image area and the button shows.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

#### Before

<img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/fbef39b4-b458-42a7-858b-0d3a5459635c" width="500"/>

#### After

<img src="https://github.com/woocommerce/woocommerce-android/assets/1864060/36237ecd-7085-44fa-b251-ce3529c74189" width="500"/>


- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
