### PR TITLE
Onboarding: Country selector refactor

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerFragment.kt
@@ -8,12 +8,12 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.NewStore
-import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryListPickerViewModel.NavigateToSummaryStep
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -22,6 +22,10 @@ import javax.inject.Inject
 class CountryListPickerFragment : BaseFragment() {
     private val viewModel: CountryListPickerViewModel by viewModels()
     @Inject lateinit var newStore: NewStore
+
+    companion object {
+        const val KEY_COUNTRY_LIST_PICKER_RESULT = "key_country_list_picker_result"
+    }
 
     override
     val activityAppBarStatus: AppBarStatus
@@ -48,14 +52,13 @@ class CountryListPickerFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is Exit -> findNavController().popBackStack()
-                is NavigateToSummaryStep -> navigateToStoreChallengesStep()
+                is MultiLiveEvent.Event.ExitWithResult<*> -> {
+                    navigateBackWithResult(
+                        KEY_COUNTRY_LIST_PICKER_RESULT,
+                        event.data as StoreCreationCountry
+                    )
+                }
             }
         }
-    }
-
-    private fun navigateToStoreChallengesStep() {
-        findNavController().navigateSafely(
-            CountryListPickerFragmentDirections.actionCountryListPickerFragmentToChallengesFragment()
-        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.Toolbar
-import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
@@ -48,7 +47,6 @@ fun CountryListPickerScreen(viewModel: CountryListPickerViewModel) {
             CountryListPickerForm(
                 countries = viewState.countries,
                 onCountrySelected = viewModel::onCountrySelected,
-                onContinueClicked = viewModel::onContinueClicked,
                 modifier = Modifier
                     .background(MaterialTheme.colors.surface)
                     .padding(padding)
@@ -61,7 +59,6 @@ fun CountryListPickerScreen(viewModel: CountryListPickerViewModel) {
 fun CountryListPickerForm(
     countries: List<StoreCreationCountry>,
     onCountrySelected: (StoreCreationCountry) -> Unit,
-    onContinueClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
@@ -95,14 +92,6 @@ fun CountryListPickerForm(
             color = colorResource(id = R.color.divider_color),
             thickness = dimensionResource(id = R.dimen.minor_10)
         )
-        WCColoredButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(dimensionResource(id = R.dimen.major_100)),
-            onClick = onContinueClicked,
-        ) {
-            Text(text = stringResource(id = R.string.continue_button))
-        }
     }
 }
 
@@ -263,7 +252,6 @@ fun CountryListPickerPreview() {
                 )
             ),
             onCountrySelected = {},
-            onContinueClicked = {},
             modifier = Modifier
                 .background(MaterialTheme.colors.surface)
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerViewModel.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.login.storecreation.countrypicker
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
-import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.util.EmojiUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -19,7 +18,6 @@ import javax.inject.Inject
 class CountryListPickerViewModel @Inject constructor(
     private val localCountriesRepository: LocalCountriesRepository,
     private val emojiUtils: EmojiUtils,
-    private val newStore: NewStore,
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
     private val availableCountries = MutableStateFlow(emptyList<StoreCreationCountry>())
@@ -51,14 +49,8 @@ class CountryListPickerViewModel @Inject constructor(
     }
 
     fun onCountrySelected(selectedCountry: StoreCreationCountry) {
-        availableCountries.update {
-            it.map { country ->
-                country.copy(isSelected = country.code == selectedCountry.code)
-            }
-        }
+        triggerEvent(MultiLiveEvent.Event.ExitWithResult(selectedCountry))
     }
-
-    object NavigateToSummaryStep : MultiLiveEvent.Event()
 
     data class CountryListPickerState(
         val countries: List<StoreCreationCountry>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryListPickerViewModel.kt
@@ -58,17 +58,6 @@ class CountryListPickerViewModel @Inject constructor(
         }
     }
 
-    fun onContinueClicked() {
-        val selectedCountry = availableCountries.value.first { it.isSelected }
-        newStore.update(
-            country = selectedCountry.toNewStoreCountry()
-        )
-
-        launch {
-            triggerEvent(NavigateToSummaryStep)
-        }
-    }
-
     object NavigateToSummaryStep : MultiLiveEvent.Event()
 
     data class CountryListPickerState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerFragment.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.navigateToHelpScreen
 import com.woocommerce.android.ui.base.BaseFragment
@@ -42,6 +43,7 @@ class CountryPickerFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers()
+        handleCountrySelectionResult()
     }
 
     private fun setupObservers() {
@@ -52,6 +54,12 @@ class CountryPickerFragment : BaseFragment() {
                 is NavigateToSummaryStep -> navigateToStoreChallengesStep()
                 is NavigateToDomainListPicker -> navigateToDomainListPicker(event.locationCode)
             }
+        }
+    }
+
+    private fun handleCountrySelectionResult() {
+        handleResult<StoreCreationCountry>(CountryListPickerFragment.KEY_COUNTRY_LIST_PICKER_RESULT) {
+            viewModel.onCountrySelected(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
@@ -97,6 +97,10 @@ class CountryPickerViewModel @Inject constructor(
         )
     }
 
+    fun onCountrySelected(country: StoreCreationCountry) {
+        detectedCountry.update { country }
+    }
+
     data class NavigateToDomainListPicker(val locationCode: String) : MultiLiveEvent.Event()
     object NavigateToSummaryStep : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/StoreCreationCountry.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/StoreCreationCountry.kt
@@ -1,13 +1,16 @@
 package com.woocommerce.android.ui.login.storecreation.countrypicker
 
+import android.os.Parcelable
 import com.woocommerce.android.ui.login.storecreation.NewStore
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class StoreCreationCountry(
     val name: String,
     val code: String,
     val emojiFlag: String,
     val isSelected: Boolean = false
-) {
+) : Parcelable {
     fun toNewStoreCountry() =
         NewStore.Country(
             name = name,

--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
@@ -139,9 +139,6 @@
         android:id="@+id/countryListPickerFragment"
         android:name="com.woocommerce.android.ui.login.storecreation.countrypicker.CountryListPickerFragment"
         android:label="CountryListPickerFragment">
-        <action
-            android:id="@+id/action_countryListPickerFragment_to_challengesFragment"
-            app:destination="@id/storeProfilerChallengesFragment" />
         <argument
             android:name="currentLocationCode"
             app:argType="string" />


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: https://github.com/woocommerce/woocommerce-android/issues/9702
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the Country List Picker behavior. Now, when a country is selected, the merchant is automatically brought back to the previous Country Picker screen, with the selected country now being the highlighted value. The merchant can then proceed with onboarding using the "Next" button on Country Picker screen.

This PR also removes the "Continue" button on the Country List Picker screen.

This matches the behavior in iOS better.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Create a new store, then go to the "Where is your business located?" (Country Picker) screen,
2. Tap the highlighted country, the "Select a country" (Country List Picker) screen is shown,
3. Select a different country, you should be brought back to the Country Picker screen,
4. Ensure that the selected country is now on the highlighted country,
5. tap "Next" and ensure the onboarding continues normally.

[Screen_recording_20230901_193451.webm](https://github.com/woocommerce/woocommerce-android/assets/266376/61071b75-1b26-461a-8b0e-6693623f6faf)

