### PR TITLE
Add missing log out tracking for application passwords

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -82,7 +82,7 @@ class AccountRepository @Inject constructor(
                     WooLog.i(LOGIN, "Application password deleted")
                 }
             }
-
+            AnalyticsTracker.track(AnalyticsEvent.ACCOUNT_LOGOUT)
             cleanup()
             true
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fix missing log out tracking

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After the Close Account feature was added, I introduced a bug where we stopped tracking the event: 
```
Tracked: account_logout, Properties: {"is_debug":true,"site_url":"$siteUrlValue"}
```
@kidinov reported the issue in this https://github.com/woocommerce/woocommerce-android/pull/9703#discussion_r1312667409. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in using application passwords flow
- Log out and check the following event is tracked: 
```
Tracked: account_logout, Properties: {"is_debug":true,"site_url":"$siteUrlValue"}
```