### PR TITLE
[Tooling] Modernize Prototype Build comment

### DIFF
--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -7,4 +7,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_installable_build
+bundle exec fastlane build_and_upload_prototype_build

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,8 +60,8 @@ steps:
       ./gradlew assembleJalapenoDebugAndroidTest
     plugins: [*ci_toolkit]
 
-  - label: "🛠 Installable Build"
-    command: ".buildkite/commands/installable-build.sh"
+  - label: "🛠 Prototype Build"
+    command: ".buildkite/commands/prototype-build.sh"
     if: build.pull_request.id != null
     plugins: [*ci_toolkit]
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,7 +15,7 @@ end
 ########################################################################
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 BUILD_PRODUCTS_PATH = File.join(PROJECT_ROOT_FOLDER, 'artifacts')
-INSTALLABLE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
+PROTOTYPE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
 ORIGINALS_METADATA_DIR_PATH = File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'metadata')
 RELEASE_NOTES_PATH = File.join(ORIGINALS_METADATA_DIR_PATH, 'release_notes.txt')
 MAIN_STRINGS_PATH = File.join('WooCommerce', 'src', 'main', 'res', 'values', 'strings.xml')
@@ -848,31 +848,39 @@ platform :android do
   # bundle exec fastlane build_apk
   #####################################################################################
   desc "Builds an APK"
-  lane :build_and_upload_installable_build do | options |
-
+  lane :build_and_upload_prototype_build do |options|
     UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
+
+    prototype_flavor = 'Jalapeno'
+    prototype_build_type = 'Debug'
 
     gradle(
       task: "assemble",
-      flavor: "Jalapeno",
-      build_type: "Debug"
+      flavor: prototype_flavor,
+      build_type: prototype_build_type
     )
 
     upload_path = upload_to_s3(
       bucket: 'a8c-apps-public-artifacts',
-      key: "woocommerce-installable-build-#{generate_installable_build_number}.apk",
+      key: "woocommerce-prototype-build-#{generate_prototype_build_number}.apk",
       file: lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH],
       skip_if_exists: true
     )
 
-    install_url = "#{INSTALLABLE_BUILD_DOMAIN}/#{upload_path}"
-    qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{URI::encode( install_url )}&choe=UTF-8"
-    comment_body = "You can test the changes on this Pull Request by <a href='#{install_url}'>downloading an installable build</a>, or scanning this QR code:<br><a href='#{install_url}'><img src='#{qr_code_url}' width='250' height='250' /></a>"
-
+    install_url = "#{PROTOTYPE_BUILD_DOMAIN}/#{upload_path}"
+    comment_body = prototype_build_details_comment(
+      app_display_name: 'WooCommerce Android',
+      download_url: install_url,
+      metadata: {
+        Flavor: prototype_flavor,
+        'Build Type': prototype_build_type,
+      }
+    )
+  
     comment_on_pr(
       project: 'woocommerce/woocommerce-android',
       pr_number: Integer(ENV['BUILDKITE_PULL_REQUEST']),
-      reuse_identifier: 'installable-build-link',
+      reuse_identifier: 'prototype-build-link',
       body: comment_body
     ) unless ENV['BUILDKITE_PULL_REQUEST'].nil?
   end
@@ -957,7 +965,7 @@ platform :android do
    end
 
   # This function is Buildkite-specific
-  def generate_installable_build_number
+  def generate_prototype_build_number
 
     if ENV['BUILDKITE']
       commit = ENV['BUILDKITE_COMMIT'][0,7]


### PR DESCRIPTION
### Description

Recently while I was browsing PRs in this repo, I noticed that the "Installable Builds" PR comment were quite old-looking and not using our more modern and rich comment (which was announced internally in paaHJt-4ET-p2 and paaHJt-4ue-p2).

This PR thus:
 - Uses our `prototype_build_details_comment` action from `release-toolkit` to generate a richer PR comment body
   - Which will make that PR comment look more standardized, and with **more information** about the build
   - And with a **direct link to install the right build**
 - Rename that feature from "Installable Build" to "Prototype Build", since this is the vocabulary that we've started to adopt for a while in other apps (also because all builds are "installable" in some way, so the term "Installable Builds" wasn't super specific)

### Testing instructions

 - Check that the comment left about the Prototype Build looks nicer and have all the new information
 - Follow the link to the Prototype Build(either by clicking the link or using the QR code) and validate that it points to a direct URL to the `.apk` associated with that PR.

### Images/gif

<table><tr>
  <th>Before</th>
  <td><img width="916" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/216089/b991364e-ca72-48da-a6d3-643e3f38d461"></td>
</tr><tr>
  <th>After</th>
  <td><img width="930" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/216089/b0c73744-b6f8-4728-ad61-f9a2bf32a554"></td>
</tr></table>

- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~
