### PR TITLE
[Mobile Payments] Handle WCPay plugin setup not finished with auth webview

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+15.4
+----
+- [**] [Internal] In-Person Payments: if WcPay setup not finished then we allow a user to finish it from the app [https://github.com/woocommerce/woocommerce-android/pull/9732]
+
 15.3
 -----
 - [**] [Internal] In-Person Payments: if WcPay not install then we allow a user to install that from the app using API [https://github.com/woocommerce/woocommerce-android/pull/9690]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
@@ -96,7 +96,7 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
     companion object {
         private const val WC_PAY_SLUG = "woocommerce-payments"
 
-        private const val WC_PAY_FINISH_SETUP_URL = "/wp-admin/admin.php?page=wc-admin&task=woocommerce-payments"
+        private const val WC_PAY_FINISH_SETUP_URL = "/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.payments.cardreader.onboarding
 
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.adminUrlOrDefault
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.PluginRepository
 import com.woocommerce.android.ui.payments.cardreader.CardReaderTracker
@@ -8,6 +9,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.map
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import javax.inject.Inject
 
 class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
@@ -45,7 +47,9 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
             }
 
             CardReaderOnboardingCTAErrorType.WC_PAY_NOT_SETUP -> {
-                TODO()
+                cardReaderTracker.trackOnboardingCtaTapped(OnboardingCtaTapped.PLUGIN_SETUP_TAPPED)
+
+                Reaction.OpenWebView(selectedSite.get().adminUrlOrDefault.slashJoin(WC_PAY_FINISH_SETUP_URL))
             }
         }
 
@@ -60,7 +64,7 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
                 is PluginRepository.PluginStatus.PluginInstalled ->
                     Reaction.Refresh
 
-                is PluginRepository.PluginStatus.PluginActivationFailed, ->
+                is PluginRepository.PluginStatus.PluginActivationFailed ->
                     buildShowErrorAndRefresh(pluginStatus.errorDescription)
 
                 is PluginRepository.PluginStatus.PluginInstallFailed ->
@@ -80,6 +84,7 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
     sealed class Reaction {
         object Refresh : Reaction()
         data class ShowErrorAndRefresh(val message: String) : Reaction()
+        data class OpenWebView(val url: String) : Reaction()
     }
 
     private val Reaction.errorMessage
@@ -90,12 +95,15 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
 
     companion object {
         private const val WC_PAY_SLUG = "woocommerce-payments"
+
+        private const val WC_PAY_FINISH_SETUP_URL = "admin.php?page=wc-admin&path=%2Fpayments%2Fonboarding"
     }
 }
 
 enum class OnboardingCtaTapped(val value: String) {
     PLUGIN_INSTALL_TAPPED("plugin_install_tapped"),
     PLUGIN_ACTIVATE_TAPPED("plugin_activate_tapped"),
+    PLUGIN_SETUP_TAPPED("plugin_setup_tapped"),
     CASH_ON_DELIVERY_TAPPED("cash_on_delivery_disabled"),
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
@@ -107,7 +107,7 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
     companion object {
         private const val WC_PAY_SLUG = "woocommerce-payments"
 
-        private const val WC_PAY_FINISH_SETUP_URL = "/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
+        private const val WC_PAY_FINISH_SETUP_URL = "/admin.php?page=wc-admin&path=%2Fpayments%2Foverview"
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
@@ -43,6 +43,10 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
                     }
                 }
             }
+
+            CardReaderOnboardingCTAErrorType.WC_PAY_NOT_SETUP -> {
+                TODO()
+            }
         }
 
     private suspend fun installAndActivateWcPayPlugin() =
@@ -98,4 +102,5 @@ enum class OnboardingCtaTapped(val value: String) {
 enum class CardReaderOnboardingCTAErrorType {
     WC_PAY_NOT_INSTALLED,
     WC_PAY_NOT_ACTIVATED,
+    WC_PAY_NOT_SETUP,
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
@@ -49,7 +49,7 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
             CardReaderOnboardingCTAErrorType.WC_PAY_NOT_SETUP -> {
                 cardReaderTracker.trackOnboardingCtaTapped(OnboardingCtaTapped.PLUGIN_SETUP_TAPPED)
 
-                Reaction.OpenWebView(selectedSite.get().adminUrlOrDefault.slashJoin(WC_PAY_FINISH_SETUP_URL))
+                buildReactionToOpenWcPaySetup()
             }
         }
 
@@ -81,10 +81,21 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
             }
         )
 
+    private fun buildReactionToOpenWcPaySetup(): Reaction {
+        val siteModel = selectedSite.get()
+        val url = selectedSite.get().adminUrlOrDefault.slashJoin(WC_PAY_FINISH_SETUP_URL)
+        return if (siteModel.isWPCom || siteModel.isWPComAtomic) {
+            Reaction.OpenWpComWebView(url)
+        } else {
+            Reaction.OpenGenericWebView(url)
+        }
+    }
+
     sealed class Reaction {
         object Refresh : Reaction()
         data class ShowErrorAndRefresh(val message: String) : Reaction()
-        data class OpenWebView(val url: String) : Reaction()
+        data class OpenWpComWebView(val url: String) : Reaction()
+        data class OpenGenericWebView(val url: String) : Reaction()
     }
 
     private val Reaction.errorMessage
@@ -96,7 +107,7 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
     companion object {
         private const val WC_PAY_SLUG = "woocommerce-payments"
 
-        private const val WC_PAY_FINISH_SETUP_URL = "/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
+        private const val WC_PAY_FINISH_SETUP_URL = "/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandler.kt
@@ -96,7 +96,7 @@ class CardReaderOnboardingErrorCtaClickHandler @Inject constructor(
     companion object {
         private const val WC_PAY_SLUG = "woocommerce-payments"
 
-        private const val WC_PAY_FINISH_SETUP_URL = "admin.php?page=wc-admin&path=%2Fpayments%2Fonboarding"
+        private const val WC_PAY_FINISH_SETUP_URL = "/wp-admin/admin.php?page=wc-admin&task=woocommerce-payments"
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -58,17 +58,14 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                 is CardReaderOnboardingEvent.NavigateToSupport -> {
                     requireActivity().startHelpActivity(HelpOrigin.CARD_READER_ONBOARDING)
                 }
-
                 is CardReaderOnboardingEvent.NavigateToUrlInWPComWebView -> {
                     findNavController().navigate(
                         NavGraphMainDirections.actionGlobalWPComWebViewFragment(urlToLoad = event.url)
                     )
                 }
-
                 is CardReaderOnboardingEvent.NavigateToUrlInGenericWebView -> {
                     ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 }
-
                 is CardReaderOnboardingEvent.ContinueToHub -> {
                     findNavController().navigate(
                         CardReaderOnboardingFragmentDirections
@@ -77,7 +74,6 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                             )
                     )
                 }
-
                 is CardReaderOnboardingEvent.ContinueToConnection -> {
                     findNavController().navigate(
                         CardReaderOnboardingFragmentDirections
@@ -87,7 +83,6 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                             )
                     )
                 }
-
                 is MultiLiveEvent.Event.ShowUiStringSnackbar -> uiMessageResolver.showSnack(event.message)
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                 else -> event.isHandled = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -125,28 +125,20 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         when (state) {
             is CardReaderOnboardingViewState.GenericErrorState ->
                 showGenericErrorState(layout, state)
-
             is CardReaderOnboardingViewState.NoConnectionErrorState ->
                 showNetworkErrorState(layout, state)
-
             is CardReaderOnboardingViewState.LoadingState ->
                 showLoadingState(layout, state)
-
             is CardReaderOnboardingViewState.UnsupportedErrorState ->
                 showCountryNotSupportedState(layout, state)
-
             is CardReaderOnboardingViewState.WCPayError ->
                 showWCPayErrorState(layout, state)
-
             is CardReaderOnboardingViewState.StripeAcountError ->
                 showStripeAccountError(layout, state)
-
             is CardReaderOnboardingViewState.StripeExtensionError ->
                 showStripeExtensionErrorState(layout, state)
-
             is CardReaderOnboardingViewState.SelectPaymentPluginState ->
                 showPaymentPluginSelectionState(layout, state)
-
             is CardReaderOnboardingViewState.CashOnDeliveryDisabledState ->
                 showCashOnDeliveryDisabledState(layout, state)
         }.exhaustive
@@ -179,7 +171,6 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                         R.string.card_reader_onboarding_cash_on_delivery_enable_failure
                     )
                 }
-
                 null -> {}
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -285,12 +285,19 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingWcpayBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeader, state.headerLabel)
         UiHelpers.setTextOrHide(binding.textLabel, state.hintLabel)
-        UiHelpers.setTextOrHide(binding.refreshButton, state.actionButtonLabelPrimary)
-        UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreLabel)
         UiHelpers.setImageOrHideInLandscape(binding.illustration, state.illustration)
-        binding.refreshButton.setOnClickListener {
-            state.actionButtonActionPrimary.invoke()
+
+        UiHelpers.setTextOrHide(binding.primaryButton, state.actionButtonPrimary.label)
+        binding.primaryButton.setOnClickListener {
+            state.actionButtonPrimary.action.invoke()
         }
+
+        UiHelpers.setTextOrHide(binding.secondaryButton, state.actionButtonSecondary?.label)
+        binding.secondaryButton.setOnClickListener {
+            state.actionButtonSecondary?.action?.invoke()
+        }
+
+        UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreButton.label)
         binding.learnMoreContainer.learnMore.setOnClickListener {
             state.onLearnMoreActionClicked.invoke()
         }
@@ -303,10 +310,10 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingWcpayBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeader, state.headerLabel)
         UiHelpers.setTextOrHide(binding.textLabel, state.hintLabel)
-        UiHelpers.setTextOrHide(binding.refreshButton, state.refreshButtonLabel)
+        UiHelpers.setTextOrHide(binding.secondaryButton, state.refreshButtonLabel)
         UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreLabel)
         UiHelpers.setImageOrHideInLandscape(binding.illustration, state.illustration)
-        binding.refreshButton.setOnClickListener {
+        binding.secondaryButton.setOnClickListener {
             state.refreshButtonAction.invoke()
         }
         binding.learnMoreContainer.learnMore.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -5,10 +5,13 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
+import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.getColor
 import androidx.core.view.get
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.button.MaterialButton
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentCardReaderOnboardingBinding
@@ -55,14 +58,17 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                 is CardReaderOnboardingEvent.NavigateToSupport -> {
                     requireActivity().startHelpActivity(HelpOrigin.CARD_READER_ONBOARDING)
                 }
+
                 is CardReaderOnboardingEvent.NavigateToUrlInWPComWebView -> {
                     findNavController().navigate(
                         NavGraphMainDirections.actionGlobalWPComWebViewFragment(urlToLoad = event.url)
                     )
                 }
+
                 is CardReaderOnboardingEvent.NavigateToUrlInGenericWebView -> {
                     ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 }
+
                 is CardReaderOnboardingEvent.ContinueToHub -> {
                     findNavController().navigate(
                         CardReaderOnboardingFragmentDirections
@@ -71,6 +77,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                             )
                     )
                 }
+
                 is CardReaderOnboardingEvent.ContinueToConnection -> {
                     findNavController().navigate(
                         CardReaderOnboardingFragmentDirections
@@ -80,6 +87,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                             )
                     )
                 }
+
                 is MultiLiveEvent.Event.ShowUiStringSnackbar -> uiMessageResolver.showSnack(event.message)
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                 else -> event.isHandled = false
@@ -117,20 +125,28 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         when (state) {
             is CardReaderOnboardingViewState.GenericErrorState ->
                 showGenericErrorState(layout, state)
+
             is CardReaderOnboardingViewState.NoConnectionErrorState ->
                 showNetworkErrorState(layout, state)
+
             is CardReaderOnboardingViewState.LoadingState ->
                 showLoadingState(layout, state)
+
             is CardReaderOnboardingViewState.UnsupportedErrorState ->
                 showCountryNotSupportedState(layout, state)
+
             is CardReaderOnboardingViewState.WCPayError ->
                 showWCPayErrorState(layout, state)
+
             is CardReaderOnboardingViewState.StripeAcountError ->
                 showStripeAccountError(layout, state)
+
             is CardReaderOnboardingViewState.StripeExtensionError ->
                 showStripeExtensionErrorState(layout, state)
+
             is CardReaderOnboardingViewState.SelectPaymentPluginState ->
                 showPaymentPluginSelectionState(layout, state)
+
             is CardReaderOnboardingViewState.CashOnDeliveryDisabledState ->
                 showCashOnDeliveryDisabledState(layout, state)
         }.exhaustive
@@ -163,6 +179,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                         R.string.card_reader_onboarding_cash_on_delivery_enable_failure
                     )
                 }
+
                 null -> {}
             }
         }
@@ -288,11 +305,13 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         UiHelpers.setImageOrHideInLandscape(binding.illustration, state.illustration)
 
         UiHelpers.setTextOrHide(binding.primaryButton, state.actionButtonPrimary.label)
+        binding.primaryButton.setWhiteIcon(state.actionButtonPrimary.icon)
         binding.primaryButton.setOnClickListener {
             state.actionButtonPrimary.action.invoke()
         }
 
         UiHelpers.setTextOrHide(binding.secondaryButton, state.actionButtonSecondary?.label)
+        binding.secondaryButton.setWhiteIcon(state.actionButtonSecondary?.icon)
         binding.secondaryButton.setOnClickListener {
             state.actionButtonSecondary?.action?.invoke()
         }
@@ -340,6 +359,15 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
     }
 
     override fun getFragmentTitle() = resources.getString(R.string.card_reader_onboarding_title)
+
+    private fun MaterialButton.setWhiteIcon(@DrawableRes icon: Int?) {
+        icon?.let {
+            setIconResource(it)
+            iconTint = ColorStateList.valueOf(getColor(context, R.color.woo_white))
+            iconGravity = MaterialButton.ICON_GRAVITY_TEXT_END
+            iconSize = resources.getDimensionPixelSize(R.dimen.major_125)
+        }
+    }
 }
 
 sealed class CardReaderOnboardingParams : Parcelable {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -285,11 +285,11 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingWcpayBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeader, state.headerLabel)
         UiHelpers.setTextOrHide(binding.textLabel, state.hintLabel)
-        UiHelpers.setTextOrHide(binding.refreshButton, state.actionButtonLabel)
+        UiHelpers.setTextOrHide(binding.refreshButton, state.actionButtonLabelPrimary)
         UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreLabel)
         UiHelpers.setImageOrHideInLandscape(binding.illustration, state.illustration)
         binding.refreshButton.setOnClickListener {
-            state.actionButtonAction.invoke()
+            state.actionButtonActionPrimary.invoke()
         }
         binding.learnMoreContainer.learnMore.setOnClickListener {
             state.onLearnMoreActionClicked.invoke()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -121,8 +121,13 @@ class CardReaderOnboardingViewModel @Inject constructor(
                     triggerEvent(Event.ShowUiStringSnackbar(UiString.UiStringText(reaction.message)))
                     refreshState()
                 }
-                is CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWebView -> {
+                is CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWpComWebView -> {
                     triggerEvent(NavigateToUrlInWPComWebView(reaction.url))
+                    viewState.value = prevState!!
+                }
+
+                is CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenGenericWebView -> {
+                    triggerEvent(NavigateToUrlInGenericWebView(reaction.url))
                     viewState.value = prevState!!
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -113,6 +113,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
 
     private fun handleErrorCtaClick(errorType: CardReaderOnboardingCTAErrorType) {
         launch {
+            val prevState = viewState.value
             viewState.value = CardReaderOnboardingViewState.LoadingState
             when (val reaction = errorClickHandler(errorType)) {
                 CardReaderOnboardingErrorCtaClickHandler.Reaction.Refresh -> refreshState()
@@ -122,6 +123,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 }
                 is CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWebView -> {
                     triggerEvent(NavigateToUrlInWPComWebView(reaction.url))
+                    viewState.value = prevState!!
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -193,7 +193,13 @@ class CardReaderOnboardingViewModel @Inject constructor(
             is SetupNotCompleted ->
                 viewState.value = when (state.preferredPlugin) {
                     WOOCOMMERCE_PAYMENTS ->
-                        WCPayNotSetupState(::refreshState, ::onLearnMoreClicked)
+                        WCPayNotSetupState(
+                            actionButtonActionPrimary = {
+                                handleErrorCtaClick(CardReaderOnboardingCTAErrorType.WC_PAY_NOT_SETUP)
+                            },
+                            actionButtonActionSecondary = ::refreshState,
+                            onLearnMoreActionClicked = ::onLearnMoreClicked
+                        )
                     STRIPE_EXTENSION_GATEWAY ->
                         StripeExtensionNotSetupState(
                             ::refreshState, ::onLearnMoreClicked

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.payments.cardreader.LearnMoreUrlProvider
 import com.woocommerce.android.ui.payments.cardreader.LearnMoreUrlProvider.LearnMoreUrlType.IN_PERSON_PAYMENTS
 import com.woocommerce.android.ui.payments.cardreader.hub.CardReaderHubViewModel.CashOnDeliverySource.ONBOARDING
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingEvent.NavigateToUrlInGenericWebView
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingEvent.NavigateToUrlInWPComWebView
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingParams.Check
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingParams.Failed
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState.ChoosePaymentGatewayProvider
@@ -118,6 +119,9 @@ class CardReaderOnboardingViewModel @Inject constructor(
                 is CardReaderOnboardingErrorCtaClickHandler.Reaction.ShowErrorAndRefresh -> {
                     triggerEvent(Event.ShowUiStringSnackbar(UiString.UiStringText(reaction.message)))
                     refreshState()
+                }
+                is CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWebView -> {
+                    triggerEvent(NavigateToUrlInWPComWebView(reaction.url))
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewState.kt
@@ -268,6 +268,7 @@ sealed class CardReaderOnboardingViewState(@LayoutRes val layoutRes: Int) {
             ),
             actionButtonPrimary = ActionButton(
                 UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_go_to_wpadmin_button),
+                icon = R.drawable.ic_external,
                 action = actionButtonActionPrimary
             ),
             actionButtonSecondary = ActionButton(
@@ -338,7 +339,7 @@ sealed class CardReaderOnboardingViewState(@LayoutRes val layoutRes: Int) {
 
     data class ActionButton(
         val label: UiString,
-        val icon: Int? = null,
+        @DrawableRes val icon: Int? = null,
         val action: () -> Unit
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewState.kt
@@ -213,9 +213,9 @@ sealed class CardReaderOnboardingViewState(@LayoutRes val layoutRes: Int) {
     sealed class WCPayError(
         val headerLabel: UiString,
         val hintLabel: UiString,
-        val learnMoreLabel: ActionButton,
-        val actionButtonLabelPrimary: ActionButton,
-        val actionButtonLabelSecondary: ActionButton? = null
+        val learnMoreButton: ActionButton,
+        val actionButtonPrimary: ActionButton,
+        val actionButtonSecondary: ActionButton? = null
     ) : CardReaderOnboardingViewState(R.layout.fragment_card_reader_onboarding_wcpay) {
         abstract val actionButtonActionPrimary: () -> Unit
         abstract val onLearnMoreActionClicked: (() -> Unit)
@@ -229,11 +229,11 @@ sealed class CardReaderOnboardingViewState(@LayoutRes val layoutRes: Int) {
         ) : WCPayError(
             headerLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_installed_header),
             hintLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_installed_hint),
-            learnMoreLabel = ActionButton(
+            learnMoreButton = ActionButton(
                 label = UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true),
                 action = onLearnMoreActionClicked
             ),
-            actionButtonLabelPrimary = ActionButton(
+            actionButtonPrimary = ActionButton(
                 label = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_installed_install_button),
                 action = actionButtonActionPrimary
             )
@@ -245,11 +245,11 @@ sealed class CardReaderOnboardingViewState(@LayoutRes val layoutRes: Int) {
         ) : WCPayError(
             headerLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_activated_header),
             hintLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_activated_hint),
-            learnMoreLabel = ActionButton(
+            learnMoreButton = ActionButton(
                 label = UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true),
                 action = onLearnMoreActionClicked
             ),
-            actionButtonLabelPrimary = ActionButton(
+            actionButtonPrimary = ActionButton(
                 label = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_activated_activate_button),
                 action = actionButtonActionPrimary
             )
@@ -262,15 +262,15 @@ sealed class CardReaderOnboardingViewState(@LayoutRes val layoutRes: Int) {
         ) : WCPayError(
             headerLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_header),
             hintLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_hint),
-            learnMoreLabel = ActionButton(
+            learnMoreButton = ActionButton(
                 label = UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true),
                 action = onLearnMoreActionClicked
             ),
-            actionButtonLabelPrimary = ActionButton(
+            actionButtonPrimary = ActionButton(
                 UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_go_to_wpadmin_button),
                 action = actionButtonActionPrimary
             ),
-            actionButtonLabelSecondary = ActionButton(
+            actionButtonSecondary = ActionButton(
                 label = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_refresh_button),
                 action = actionButtonActionSecondary
             )
@@ -282,11 +282,11 @@ sealed class CardReaderOnboardingViewState(@LayoutRes val layoutRes: Int) {
         ) : WCPayError(
             headerLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_unsupported_version_header),
             hintLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_unsupported_version_hint),
-            learnMoreLabel = ActionButton(
+            learnMoreButton = ActionButton(
                 label = UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true),
                 action = onLearnMoreActionClicked
             ),
-            actionButtonLabelPrimary = ActionButton(
+            actionButtonPrimary = ActionButton(
                 label = UiString.UiStringRes(
                     R.string.card_reader_onboarding_wcpay_unsupported_version_refresh_button
                 ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewState.kt
@@ -213,56 +213,84 @@ sealed class CardReaderOnboardingViewState(@LayoutRes val layoutRes: Int) {
     sealed class WCPayError(
         val headerLabel: UiString,
         val hintLabel: UiString,
-        val learnMoreLabel: UiString,
-        val actionButtonLabel: UiString
+        val learnMoreLabel: ActionButton,
+        val actionButtonLabelPrimary: ActionButton,
+        val actionButtonLabelSecondary: ActionButton? = null
     ) : CardReaderOnboardingViewState(R.layout.fragment_card_reader_onboarding_wcpay) {
-        abstract val actionButtonAction: () -> Unit
+        abstract val actionButtonActionPrimary: () -> Unit
         abstract val onLearnMoreActionClicked: (() -> Unit)
 
         @DrawableRes
         val illustration = R.drawable.img_woo_payments
 
         data class WCPayNotInstalledState(
-            override val actionButtonAction: () -> Unit,
+            override val actionButtonActionPrimary: () -> Unit,
             override val onLearnMoreActionClicked: (() -> Unit)
         ) : WCPayError(
             headerLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_installed_header),
             hintLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_installed_hint),
-            learnMoreLabel = UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true),
-            actionButtonLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_installed_install_button)
+            learnMoreLabel = ActionButton(
+                label = UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true),
+                action = onLearnMoreActionClicked
+            ),
+            actionButtonLabelPrimary = ActionButton(
+                label = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_installed_install_button),
+                action = actionButtonActionPrimary
+            )
         )
 
         data class WCPayNotActivatedState(
-            override val actionButtonAction: () -> Unit,
+            override val actionButtonActionPrimary: () -> Unit,
             override val onLearnMoreActionClicked: (() -> Unit)
         ) : WCPayError(
             headerLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_activated_header),
             hintLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_activated_hint),
-            learnMoreLabel = UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true),
-            actionButtonLabel = UiString.UiStringRes(
-                R.string.card_reader_onboarding_wcpay_not_activated_activate_button
+            learnMoreLabel = ActionButton(
+                label = UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true),
+                action = onLearnMoreActionClicked
+            ),
+            actionButtonLabelPrimary = ActionButton(
+                label = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_activated_activate_button),
+                action = actionButtonActionPrimary
             )
         )
 
         data class WCPayNotSetupState(
-            override val actionButtonAction: () -> Unit,
+            override val actionButtonActionPrimary: () -> Unit,
+            val actionButtonActionSecondary: () -> Unit,
             override val onLearnMoreActionClicked: (() -> Unit)
         ) : WCPayError(
             headerLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_header),
             hintLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_hint),
-            learnMoreLabel = UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true),
-            actionButtonLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_refresh_button)
+            learnMoreLabel = ActionButton(
+                label = UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true),
+                action = onLearnMoreActionClicked
+            ),
+            actionButtonLabelPrimary = ActionButton(
+                UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_go_to_wpadmin_button),
+                action = actionButtonActionPrimary
+            ),
+            actionButtonLabelSecondary = ActionButton(
+                label = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_not_setup_refresh_button),
+                action = actionButtonActionSecondary
+            )
         )
 
         data class WCPayUnsupportedVersionState(
-            override val actionButtonAction: () -> Unit,
+            override val actionButtonActionPrimary: () -> Unit,
             override val onLearnMoreActionClicked: (() -> Unit)
         ) : WCPayError(
             headerLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_unsupported_version_header),
             hintLabel = UiString.UiStringRes(R.string.card_reader_onboarding_wcpay_unsupported_version_hint),
-            learnMoreLabel = UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true),
-            actionButtonLabel = UiString.UiStringRes(
-                R.string.card_reader_onboarding_wcpay_unsupported_version_refresh_button
+            learnMoreLabel = ActionButton(
+                label = UiString.UiStringRes(R.string.card_reader_onboarding_learn_more, containsHtml = true),
+                action = onLearnMoreActionClicked
+            ),
+            actionButtonLabelPrimary = ActionButton(
+                label = UiString.UiStringRes(
+                    R.string.card_reader_onboarding_wcpay_unsupported_version_refresh_button
+                ),
+                action = actionButtonActionPrimary
             )
         )
     }
@@ -307,4 +335,10 @@ sealed class CardReaderOnboardingViewState(@LayoutRes val layoutRes: Int) {
             )
         )
     }
+
+    data class ActionButton(
+        val label: UiString,
+        val icon: Int? = null,
+        val action: () -> Unit
+    )
 }

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding_wcpay.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding_wcpay.xml
@@ -40,15 +40,25 @@
         android:gravity="center"
         android:paddingHorizontal="@dimen/major_200"
         android:textColor="@color/color_on_surface_high"
-        app:layout_constraintBottom_toTopOf="@id/refreshButton"
+        app:layout_constraintBottom_toTopOf="@id/primary_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/illustration"
         tools:text="@string/card_reader_onboarding_wcpay_not_installed_hint" />
 
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/refreshButton"
+        android:id="@+id/primary_button"
         style="@style/Woo.Button.Colored"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/major_100"
+        app:layout_constraintBottom_toTopOf="@+id/secondary_button"
+        app:layout_goneMarginBottom="@dimen/major_300"
+        tools:text="@string/card_reader_onboarding_wcpay_not_setup_go_to_wpadmin_button" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/secondary_button"
+        style="@style/Woo.Button.Outlined"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/major_100"

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding_wcpay.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding_wcpay.xml
@@ -1,78 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fillViewport="true">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/textHeader"
-        style="@style/TextAppearance.Woo.Headline6"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_large"
-        android:gravity="center"
-        android:paddingHorizontal="@dimen/major_200"
-        app:layout_constraintBottom_toTopOf="@id/illustration"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_chainStyle="packed"
-        tools:text="@string/card_reader_onboarding_wcpay_not_installed_header" />
-
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/illustration"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/major_275"
-        app:layout_constraintBottom_toTopOf="@id/textLabel"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textHeader"
-        tools:src="@drawable/img_woo_payments" />
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/textLabel"
-        style="@style/TextAppearance.Woo.Body1"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/major_275"
-        android:gravity="center"
-        android:paddingHorizontal="@dimen/major_200"
-        android:textColor="@color/color_on_surface_high"
-        app:layout_constraintBottom_toTopOf="@id/primary_button"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/illustration"
-        tools:text="@string/card_reader_onboarding_wcpay_not_installed_hint" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/primary_button"
-        style="@style/Woo.Button.Colored"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/major_100"
-        app:layout_constraintBottom_toTopOf="@+id/secondary_button"
-        app:layout_goneMarginBottom="@dimen/major_300"
-        tools:text="@string/card_reader_onboarding_wcpay_not_setup_go_to_wpadmin_button" />
+        android:layout_height="wrap_content">
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/secondary_button"
-        style="@style/Woo.Button.Outlined"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/major_100"
-        app:layout_constraintBottom_toTopOf="@+id/learn_more_container"
-        tools:text="@string/refresh_button" />
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textHeader"
+            style="@style/TextAppearance.Woo.Headline6"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:gravity="center"
+            android:paddingHorizontal="@dimen/major_200"
+            app:layout_constraintBottom_toTopOf="@id/illustration"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed"
+            tools:text="@string/card_reader_onboarding_wcpay_not_installed_header" />
 
-    <include
-        android:id="@+id/learn_more_container"
-        layout="@layout/card_reader_learn_more_section"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/major_350"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="1" />
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/illustration"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_275"
+            app:layout_constraintBottom_toTopOf="@id/textLabel"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textHeader"
+            tools:src="@drawable/img_woo_payments" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textLabel"
+            style="@style/TextAppearance.Woo.Body1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/major_275"
+            android:gravity="center"
+            android:paddingHorizontal="@dimen/major_200"
+            android:textColor="@color/color_on_surface_high"
+            app:layout_constraintBottom_toTopOf="@id/primary_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/illustration"
+            tools:text="@string/card_reader_onboarding_wcpay_not_installed_hint" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/primary_button"
+            style="@style/Woo.Button.Colored"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
+            app:layout_constraintBottom_toTopOf="@+id/secondary_button"
+            tools:text="@string/card_reader_onboarding_wcpay_not_setup_go_to_wpadmin_button" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/secondary_button"
+            style="@style/Woo.Button.Outlined"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/major_100"
+            app:layout_constraintBottom_toTopOf="@+id/learn_more_container"
+            tools:text="@string/refresh_button" />
+
+        <include
+            android:id="@+id/learn_more_container"
+            layout="@layout/card_reader_learn_more_section"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1521,6 +1521,7 @@
     <string name="card_reader_onboarding_wcpay_not_setup_header">Finish setup WooCommerce Payments in your store admin</string>
     <string name="card_reader_onboarding_wcpay_not_setup_hint">You’re almost there! Please finish setting up WooCommerce Payments to start accepting In-Person Payments.</string>
     <string name="card_reader_onboarding_wcpay_not_setup_refresh_button">Refresh</string>
+    <string name="card_reader_onboarding_wcpay_not_setup_go_to_wpadmin_button">Finish setup</string>
 
     <string name="card_reader_onboarding_wcpay_unsupported_version_header">Update WooCommerce Payments</string>
     <string name="card_reader_onboarding_wcpay_unsupported_version_hint">Outdated version of the WooCommerce Payments extension is installed on your store. Please update it to accept In-Person Payments.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandlerTest.kt
@@ -372,7 +372,7 @@ class CardReaderOnboardingErrorCtaClickHandlerTest : BaseUnitTest() {
             // THEN
             assertThat(result).isEqualTo(
                 CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWpComWebView(
-                    url = "$adminUrl/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
+                    url = "$adminUrl/admin.php?page=wc-admin&path=%2Fpayments%2Foverview"
                 )
             )
         }
@@ -391,7 +391,7 @@ class CardReaderOnboardingErrorCtaClickHandlerTest : BaseUnitTest() {
             // THEN
             assertThat(result).isEqualTo(
                 CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWpComWebView(
-                    url = "$adminUrl/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
+                    url = "$adminUrl/admin.php?page=wc-admin&path=%2Fpayments%2Foverview"
                 )
             )
         }
@@ -411,7 +411,7 @@ class CardReaderOnboardingErrorCtaClickHandlerTest : BaseUnitTest() {
             // THEN
             assertThat(result).isEqualTo(
                 CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenGenericWebView(
-                    url = "$adminUrl/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
+                    url = "$adminUrl/admin.php?page=wc-admin&path=%2Fpayments%2Foverview"
                 )
             )
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandlerTest.kt
@@ -357,4 +357,38 @@ class CardReaderOnboardingErrorCtaClickHandlerTest : BaseUnitTest() {
                 CardReaderOnboardingErrorCtaClickHandler.Reaction.Refresh
             )
         }
+
+    @Test
+    fun `when invoked with WC_PAY_NOT_SETUP, then OpenWebView returned`() =
+        testBlocking {
+            // GIVEN
+            val adminUrl = "mywebsite.com"
+            whenever(siteModel.adminUrl).thenReturn(adminUrl)
+
+            // WHEN
+            val result = handler(CardReaderOnboardingCTAErrorType.WC_PAY_NOT_SETUP)
+
+            // THEN
+            assertThat(result).isEqualTo(
+                CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWebView(
+                    url = "$adminUrl/wp-admin/admin.php?page=wc-admin&task=woocommerce-payments"
+                )
+            )
+        }
+
+    @Test
+    fun `when invoked with WC_PAY_NOT_SETUP, then event tracked with reason`() =
+        testBlocking {
+            // GIVEN
+            val adminUrl = "mywebsite.com"
+            whenever(siteModel.adminUrl).thenReturn(adminUrl)
+
+            // WHEN
+            handler(CardReaderOnboardingCTAErrorType.WC_PAY_NOT_SETUP)
+
+            // THEN
+            verify(cardReaderTracker).trackOnboardingCtaTapped(
+                OnboardingCtaTapped.PLUGIN_SETUP_TAPPED
+            )
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandlerTest.kt
@@ -371,7 +371,7 @@ class CardReaderOnboardingErrorCtaClickHandlerTest : BaseUnitTest() {
             // THEN
             assertThat(result).isEqualTo(
                 CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWebView(
-                    url = "$adminUrl/wp-admin/admin.php?page=wc-admin&task=woocommerce-payments"
+                    url = "$adminUrl/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
                 )
             )
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandlerTest.kt
@@ -370,7 +370,7 @@ class CardReaderOnboardingErrorCtaClickHandlerTest : BaseUnitTest() {
 
             // THEN
             assertThat(result).isEqualTo(
-                CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWebView(
+                CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWpComWebView(
                     url = "$adminUrl/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
                 )
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingErrorCtaClickHandlerTest.kt
@@ -359,9 +359,10 @@ class CardReaderOnboardingErrorCtaClickHandlerTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when invoked with WC_PAY_NOT_SETUP, then OpenWebView returned`() =
+    fun `given wpcom site, when invoked with WC_PAY_NOT_SETUP, then OpenWpComWebView returned`() =
         testBlocking {
             // GIVEN
+            whenever(siteModel.isWPCom).thenReturn(true)
             val adminUrl = "mywebsite.com"
             whenever(siteModel.adminUrl).thenReturn(adminUrl)
 
@@ -371,7 +372,46 @@ class CardReaderOnboardingErrorCtaClickHandlerTest : BaseUnitTest() {
             // THEN
             assertThat(result).isEqualTo(
                 CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWpComWebView(
-                    url = "$adminUrl/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
+                    url = "$adminUrl/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
+                )
+            )
+        }
+
+    @Test
+    fun `given wpcomatomic site, when invoked with WC_PAY_NOT_SETUP, then OpenWpComWebView returned`() =
+        testBlocking {
+            // GIVEN
+            whenever(siteModel.isWPComAtomic).thenReturn(true)
+            val adminUrl = "mywebsite.com"
+            whenever(siteModel.adminUrl).thenReturn(adminUrl)
+
+            // WHEN
+            val result = handler(CardReaderOnboardingCTAErrorType.WC_PAY_NOT_SETUP)
+
+            // THEN
+            assertThat(result).isEqualTo(
+                CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWpComWebView(
+                    url = "$adminUrl/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
+                )
+            )
+        }
+
+    @Test
+    fun `given non wpcom site, when invoked with WC_PAY_NOT_SETUP, then OpenGenericWebView returned`() =
+        testBlocking {
+            // GIVEN
+            whenever(siteModel.isWPCom).thenReturn(false)
+            whenever(siteModel.isWPComAtomic).thenReturn(false)
+            val adminUrl = "mywebsite.com"
+            whenever(siteModel.adminUrl).thenReturn(adminUrl)
+
+            // WHEN
+            val result = handler(CardReaderOnboardingCTAErrorType.WC_PAY_NOT_SETUP)
+
+            // THEN
+            assertThat(result).isEqualTo(
+                CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenGenericWebView(
+                    url = "$adminUrl/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect"
                 )
             )
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -665,7 +665,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given handler returned OpenWebView, when clicked on wcpay not setup, then open webview`() =
+    fun `given handler returned OpenWpComWebView, when clicked on wcpay not setup, then open wp webview`() =
         testBlocking {
             val url = "url"
             whenever(errorClickHandler.invoke(CardReaderOnboardingCTAErrorType.WC_PAY_NOT_SETUP))
@@ -686,6 +686,31 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
 
             assertThat(viewModel.event.value).isEqualTo(
                 CardReaderOnboardingEvent.NavigateToUrlInWPComWebView(url)
+            )
+        }
+
+    @Test
+    fun `given handler returned OpenGenericWebView, when clicked on wcpay not setup, then open generic webview`() =
+        testBlocking {
+            val url = "url"
+            whenever(errorClickHandler.invoke(CardReaderOnboardingCTAErrorType.WC_PAY_NOT_SETUP))
+                .thenReturn(CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenGenericWebView(url))
+
+            val viewModel = createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = CardReaderFlowParam.PaymentOrRefund.Payment(1L, ORDER),
+                        onboardingState = SetupNotCompleted(WOOCOMMERCE_PAYMENTS),
+                    ),
+                    cardReaderType = CardReaderType.EXTERNAL
+                ).initSavedStateHandle()
+            )
+
+            (viewModel.viewStateData.value as WCPayError.WCPayNotSetupState)
+                .actionButtonActionPrimary.invoke()
+
+            assertThat(viewModel.event.value).isEqualTo(
+                CardReaderOnboardingEvent.NavigateToUrlInGenericWebView(url)
             )
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -665,7 +665,32 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given returned refresh, when clicked on wcpay not installed CTA, then error shown`() =
+    fun `given handler returned OpenWebView, when clicked on wcpay not setup, then open webview`() =
+        testBlocking {
+            val url = "url"
+            whenever(errorClickHandler.invoke(CardReaderOnboardingCTAErrorType.WC_PAY_NOT_SETUP))
+                .thenReturn(CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWebView(url))
+
+            val viewModel = createVM(
+                CardReaderOnboardingFragmentArgs(
+                    CardReaderOnboardingParams.Failed(
+                        cardReaderFlowParam = CardReaderFlowParam.PaymentOrRefund.Payment(1L, ORDER),
+                        onboardingState = SetupNotCompleted(WOOCOMMERCE_PAYMENTS),
+                    ),
+                    cardReaderType = CardReaderType.EXTERNAL
+                ).initSavedStateHandle()
+            )
+
+            (viewModel.viewStateData.value as WCPayError.WCPayNotSetupState)
+                .actionButtonActionPrimary.invoke()
+
+            assertThat(viewModel.event.value).isEqualTo(
+                CardReaderOnboardingEvent.NavigateToUrlInWPComWebView(url)
+            )
+        }
+
+    @Test
+    fun `given handler returned refresh, when clicked on wcpay not installed CTA, then get onboarding state`() =
         testBlocking {
             whenever(errorClickHandler.invoke(CardReaderOnboardingCTAErrorType.WC_PAY_NOT_INSTALLED))
                 .thenReturn(CardReaderOnboardingErrorCtaClickHandler.Reaction.Refresh)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -655,7 +655,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 )
 
             (viewModel.viewStateData.value as WCPayNotInstalledState)
-                .actionButtonAction.invoke()
+                .actionButtonActionPrimary.invoke()
 
             assertThat(viewModel.event.value).isEqualTo(
                 MultiLiveEvent.Event.ShowUiStringSnackbar(UiString.UiStringText(errorText))
@@ -689,7 +689,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 )
 
             (viewModel.viewStateData.value as WCPayNotInstalledState)
-                .actionButtonAction.invoke()
+                .actionButtonActionPrimary.invoke()
 
             verify(onboardingChecker).getOnboardingState()
         }
@@ -720,7 +720,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 )
 
             (viewModel.viewStateData.value as WCPayError.WCPayNotActivatedState)
-                .actionButtonAction.invoke()
+                .actionButtonActionPrimary.invoke()
 
             assertThat(viewModel.event.value).isEqualTo(
                 MultiLiveEvent.Event.ShowUiStringSnackbar(UiString.UiStringText(errorText))
@@ -754,7 +754,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
                 )
 
             (viewModel.viewStateData.value as WCPayError.WCPayNotActivatedState)
-                .actionButtonAction.invoke()
+                .actionButtonActionPrimary.invoke()
 
             verify(onboardingChecker).getOnboardingState()
         }
@@ -1973,7 +1973,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             }
 
             (viewModel.viewStateData.value as WCPayError.WCPayNotActivatedState)
-                .actionButtonAction.invoke()
+                .actionButtonActionPrimary.invoke()
 
             assertThat(receivedViewStates[1]).isEqualTo(LoadingState)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -669,7 +669,7 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
         testBlocking {
             val url = "url"
             whenever(errorClickHandler.invoke(CardReaderOnboardingCTAErrorType.WC_PAY_NOT_SETUP))
-                .thenReturn(CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWebView(url))
+                .thenReturn(CardReaderOnboardingErrorCtaClickHandler.Reaction.OpenWpComWebView(url))
 
             val viewModel = createVM(
                 CardReaderOnboardingFragmentArgs(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9685
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds CTA on the "WCPay setup not finished" onboarding error screen. The CTA opens webview where a user can finish the setup

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The only way I found our how to simulate this error in the test environment is to deactivate WCPay Dev plugin
* Open More -> Payments -> Click on the error
* Notice new CTA
* Click on it and notice that WCPay onboarding opens in the webview of wp-admin (you should be logged in automatically)

Also, noticed the event being tracked:

```
Tracked: card_present_onboarding_cta_tapped, Properties: {"reason":"plugin_setup_tapped","plugin_slug":"woocommerce-payments","country":"US","card_reader_model":"STRIPE_M2","blog_id":198219640,"is_wpcom_store":true,"was_ecommerce_trial":false,"plan_product_slug":"business-bundle","is_debug":true,"site_url":"https:\/\/anotherpaymentssite.wpcomstaging.com"}
```

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
https://github.com/woocommerce/woocommerce-android/assets/4923871/a6416a85-a100-4e34-9fdc-edb533601db5


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
