### PR TITLE
Fix/9654 local notification fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -30,7 +30,7 @@ sealed class LocalNotification(
         title = R.string.local_notification_store_creation_complete_title,
         description = R.string.local_notification_store_creation_complete_description,
         type = LocalNotificationType.STORE_CREATION_FINISHED,
-        delay = 1,
+        delay = 5,
         delayUnit = TimeUnit.MINUTES
     ) {
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import java.util.concurrent.TimeUnit
 
 sealed class LocalNotification(
+    val localNotificationSiteId: Long,
     @StringRes val title: Int,
     @StringRes val description: Int,
     val type: LocalNotificationType,
@@ -21,21 +22,29 @@ sealed class LocalNotification(
         return resourceProvider.getString(title)
     }
 
-    data class StoreCreationFinishedNotification(
+    data class StoreCreationCompletedNotification(
+        val siteId: Long,
         val name: String
     ) : LocalNotification(
+        localNotificationSiteId = siteId,
         title = R.string.local_notification_store_creation_complete_title,
         description = R.string.local_notification_store_creation_complete_description,
         type = LocalNotificationType.STORE_CREATION_FINISHED,
         delay = 5,
         delayUnit = TimeUnit.MINUTES
     ) {
+
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description, name)
         }
     }
 
-    data class StoreCreationIncompleteNotification(val name: String, val storeName: String) : LocalNotification(
+    data class StoreCreationIncompleteNotification(
+        val siteId: Long,
+        val name: String,
+        val storeName: String
+    ) : LocalNotification(
+        localNotificationSiteId = siteId,
         title = R.string.local_notification_without_free_trial_title,
         description = R.string.local_notification_without_free_trial_description,
         type = LocalNotificationType.STORE_CREATION_INCOMPLETE,
@@ -49,71 +58,72 @@ sealed class LocalNotification(
         }
     }
 
-    data class FreeTrialExpiringNotification(val expiryDate: String, val siteId: Long) : LocalNotification(
+    data class FreeTrialExpiringNotification(
+        val expiryDate: String,
+        val siteId: Long
+    ) : LocalNotification(
+        localNotificationSiteId = siteId,
         title = R.string.local_notification_one_day_before_free_trial_expires_title,
         description = R.string.local_notification_one_day_before_free_trial_expires_description,
         type = LocalNotificationType.FREE_TRIAL_EXPIRING,
         delay = 13,
         delayUnit = TimeUnit.DAYS
     ) {
-        override val data: String = siteId.toString()
-
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description, expiryDate)
         }
     }
 
-    data class FreeTrialExpiredNotification(val name: String, val siteId: Long) : LocalNotification(
+    data class FreeTrialExpiredNotification(
+        val name: String,
+        val siteId: Long
+    ) : LocalNotification(
+        localNotificationSiteId = siteId,
         title = R.string.local_notification_one_day_after_free_trial_expires_title,
         description = R.string.local_notification_one_day_after_free_trial_expires_description,
         type = LocalNotificationType.FREE_TRIAL_EXPIRED,
         delay = 15,
         delayUnit = TimeUnit.DAYS
     ) {
-        override val data: String = siteId.toString()
-
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description, name)
         }
     }
 
     data class UpgradeToPaidPlanNotification(val siteId: Long) : LocalNotification(
+        localNotificationSiteId = siteId,
         title = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_title,
         description = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_description,
         type = LocalNotificationType.SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED,
         delay = 6,
         delayUnit = TimeUnit.HOURS
     ) {
-        override val data: String = siteId.toString()
-
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description)
         }
     }
 
     data class FreeTrialSurveyNotification(val siteId: Long) : LocalNotification(
+        localNotificationSiteId = siteId,
         title = R.string.local_notification_survey_after_24_hours_title,
         description = R.string.local_notification_survey_after_24_hours_description,
         type = LocalNotificationType.FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED,
         delay = 24,
         delayUnit = TimeUnit.HOURS
     ) {
-        override val data: String = siteId.toString()
-
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description)
         }
     }
 
     data class StillExploringNotification(val siteId: Long) : LocalNotification(
+        localNotificationSiteId = siteId,
         title = R.string.local_notification_still_exploring_title,
         description = R.string.local_notification_still_exploring_description,
         type = LocalNotificationType.THREE_DAYS_AFTER_STILL_EXPLORING,
         delay = 3,
         delayUnit = TimeUnit.DAYS
     ) {
-        override val data: String = siteId.toString()
-
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -6,7 +6,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import java.util.concurrent.TimeUnit
 
 sealed class LocalNotification(
-    val localNotificationSiteId: Long,
+    open val siteId: Long,
     @StringRes val title: Int,
     @StringRes val description: Int,
     val type: LocalNotificationType,
@@ -23,10 +23,10 @@ sealed class LocalNotification(
     }
 
     data class StoreCreationCompletedNotification(
-        val siteId: Long,
+        override val siteId: Long,
         val name: String
     ) : LocalNotification(
-        localNotificationSiteId = siteId,
+        siteId = siteId,
         title = R.string.local_notification_store_creation_complete_title,
         description = R.string.local_notification_store_creation_complete_description,
         type = LocalNotificationType.STORE_CREATION_FINISHED,
@@ -40,11 +40,11 @@ sealed class LocalNotification(
     }
 
     data class StoreCreationIncompleteNotification(
-        val siteId: Long,
+        override val siteId: Long,
         val name: String,
         val storeName: String
     ) : LocalNotification(
-        localNotificationSiteId = siteId,
+        siteId = siteId,
         title = R.string.local_notification_without_free_trial_title,
         description = R.string.local_notification_without_free_trial_description,
         type = LocalNotificationType.STORE_CREATION_INCOMPLETE,
@@ -60,9 +60,9 @@ sealed class LocalNotification(
 
     data class FreeTrialExpiringNotification(
         val expiryDate: String,
-        val siteId: Long
+        override val siteId: Long
     ) : LocalNotification(
-        localNotificationSiteId = siteId,
+        siteId = siteId,
         title = R.string.local_notification_one_day_before_free_trial_expires_title,
         description = R.string.local_notification_one_day_before_free_trial_expires_description,
         type = LocalNotificationType.FREE_TRIAL_EXPIRING,
@@ -76,9 +76,9 @@ sealed class LocalNotification(
 
     data class FreeTrialExpiredNotification(
         val name: String,
-        val siteId: Long
+        override val siteId: Long
     ) : LocalNotification(
-        localNotificationSiteId = siteId,
+        siteId = siteId,
         title = R.string.local_notification_one_day_after_free_trial_expires_title,
         description = R.string.local_notification_one_day_after_free_trial_expires_description,
         type = LocalNotificationType.FREE_TRIAL_EXPIRED,
@@ -90,21 +90,21 @@ sealed class LocalNotification(
         }
     }
 
-    data class UpgradeToPaidPlanNotification(val siteId: Long) : LocalNotification(
-        localNotificationSiteId = siteId,
+    data class UpgradeToPaidPlanNotification(override val siteId: Long) : LocalNotification(
+        siteId = siteId,
         title = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_title,
         description = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_description,
         type = LocalNotificationType.SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED,
-        delay = 6,
-        delayUnit = TimeUnit.HOURS
+        delay = 2,
+        delayUnit = TimeUnit.MINUTES
     ) {
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description)
         }
     }
 
-    data class FreeTrialSurveyNotification(val siteId: Long) : LocalNotification(
-        localNotificationSiteId = siteId,
+    data class FreeTrialSurveyNotification(override val siteId: Long) : LocalNotification(
+        siteId = siteId,
         title = R.string.local_notification_survey_after_24_hours_title,
         description = R.string.local_notification_survey_after_24_hours_description,
         type = LocalNotificationType.FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED,
@@ -116,8 +116,8 @@ sealed class LocalNotification(
         }
     }
 
-    data class StillExploringNotification(val siteId: Long) : LocalNotification(
-        localNotificationSiteId = siteId,
+    data class StillExploringNotification(override val siteId: Long) : LocalNotification(
+        siteId = siteId,
         title = R.string.local_notification_still_exploring_title,
         description = R.string.local_notification_still_exploring_description,
         type = LocalNotificationType.THREE_DAYS_AFTER_STILL_EXPLORING,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -30,7 +30,7 @@ sealed class LocalNotification(
         title = R.string.local_notification_store_creation_complete_title,
         description = R.string.local_notification_store_creation_complete_description,
         type = LocalNotificationType.STORE_CREATION_FINISHED,
-        delay = 5,
+        delay = 1,
         delayUnit = TimeUnit.MINUTES
     ) {
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
@@ -46,7 +46,7 @@ class LocalNotificationScheduler @Inject constructor(
         val conditionData = workDataOf(
             LOCAL_NOTIFICATION_TYPE to notification.type.value,
             LOCAL_NOTIFICATION_DATA to notification.data,
-            LOCAL_NOTIFICATION_SITE_ID to notification.localNotificationSiteId
+            LOCAL_NOTIFICATION_SITE_ID to notification.siteId
         )
         return OneTimeWorkRequestBuilder<PreconditionCheckWorker>()
             .setInputData(conditionData)
@@ -62,7 +62,7 @@ class LocalNotificationScheduler @Inject constructor(
             LOCAL_NOTIFICATION_TITLE to notification.getTitleString(resourceProvider),
             LOCAL_NOTIFICATION_DESC to notification.getDescriptionString(resourceProvider),
             LOCAL_NOTIFICATION_DATA to notification.data,
-            LOCAL_NOTIFICATION_SITE_ID to notification.localNotificationSiteId
+            LOCAL_NOTIFICATION_SITE_ID to notification.siteId
         )
         return OneTimeWorkRequestBuilder<LocalNotificationWorker>()
             .addTag(notification.type.value)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
@@ -23,6 +23,7 @@ class LocalNotificationScheduler @Inject constructor(
         const val LOCAL_NOTIFICATION_TITLE = "local_notification_title"
         const val LOCAL_NOTIFICATION_DESC = "local_notification_description"
         const val LOCAL_NOTIFICATION_DATA = "local_notification_data"
+        const val LOCAL_NOTIFICATION_SITE_ID = "local_notification_site_id"
     }
 
     private val workManager = WorkManager.getInstance(appContext)
@@ -44,7 +45,8 @@ class LocalNotificationScheduler @Inject constructor(
     private fun buildPreconditionCheckWorkRequest(notification: LocalNotification): OneTimeWorkRequest {
         val conditionData = workDataOf(
             LOCAL_NOTIFICATION_TYPE to notification.type.value,
-            LOCAL_NOTIFICATION_DATA to notification.data
+            LOCAL_NOTIFICATION_DATA to notification.data,
+            LOCAL_NOTIFICATION_SITE_ID to notification.localNotificationSiteId
         )
         return OneTimeWorkRequestBuilder<PreconditionCheckWorker>()
             .setInputData(conditionData)
@@ -59,7 +61,8 @@ class LocalNotificationScheduler @Inject constructor(
             LOCAL_NOTIFICATION_ID to notification.id,
             LOCAL_NOTIFICATION_TITLE to notification.getTitleString(resourceProvider),
             LOCAL_NOTIFICATION_DESC to notification.getDescriptionString(resourceProvider),
-            LOCAL_NOTIFICATION_DATA to notification.data
+            LOCAL_NOTIFICATION_DATA to notification.data,
+            LOCAL_NOTIFICATION_SITE_ID to notification.localNotificationSiteId
         )
         return OneTimeWorkRequestBuilder<LocalNotificationWorker>()
             .addTag(notification.type.value)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.notifications.local
 import android.content.Context
 import android.content.Intent
 import androidx.hilt.work.HiltWorker
-import androidx.work.Worker
+import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.LOCAL_NOTIFICATION_DISPLAYED
@@ -18,7 +18,9 @@ import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Co
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_SITE_ID
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_TITLE
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_TYPE
+import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_FINISHED
 import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.ui.sitepicker.SitePickerRepository
 import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooLogWrapper
 import dagger.assisted.Assisted
@@ -30,15 +32,23 @@ class LocalNotificationWorker @AssistedInject constructor(
     @Assisted private val appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val wooNotificationBuilder: WooNotificationBuilder,
-    private val wooLogWrapper: WooLogWrapper
-) : Worker(appContext, workerParams) {
-    override fun doWork(): Result {
+    private val wooLogWrapper: WooLogWrapper,
+    private val sitePickerRepository: SitePickerRepository,
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
         val type = inputData.getString(LOCAL_NOTIFICATION_TYPE)
         val notificationId = inputData.getInt(LOCAL_NOTIFICATION_ID, -1)
         val title = inputData.getString(LOCAL_NOTIFICATION_TITLE)
         val description = inputData.getString(LOCAL_NOTIFICATION_DESC)
         val data = inputData.getString(LOCAL_NOTIFICATION_DATA)
         val siteId = inputData.getLong(LOCAL_NOTIFICATION_SITE_ID, 0L)
+
+        // This means the new store is ready a we need to refresh the database with it
+        if (type == STORE_CREATION_FINISHED.value) {
+            sitePickerRepository.fetchWooCommerceSites()
+        }
+
         if (siteId != 0L && type != null && notificationId != -1 && title != null && description != null) {
             val notification = buildNotification(notificationId, siteId, type, title, description, data)
             wooNotificationBuilder.buildAndDisplayLocalNotification(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
@@ -67,6 +67,7 @@ class LocalNotificationWorker @AssistedInject constructor(
         }
     }
 
+    @Suppress("LongParameterList")
     private fun buildNotification(
         id: Int,
         siteId: Long,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
@@ -49,10 +49,7 @@ class LocalNotificationWorker @AssistedInject constructor(
 
             AnalyticsTracker.track(
                 LOCAL_NOTIFICATION_DISPLAYED,
-                mapOf(
-                    AnalyticsTracker.KEY_TYPE to type,
-                    AnalyticsTracker.KEY_BLOG_ID to data
-                )
+                mapOf(AnalyticsTracker.KEY_TYPE to type)
             )
         } else {
             wooLogWrapper.e(T.NOTIFICATIONS, "Scheduled local notification data is invalid")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -61,7 +61,7 @@ class PreconditionCheckWorker @AssistedInject constructor(
             val message = "Site id is missing. Cancelling local notification work."
             crashLogging.sendReport(
                 exception = Exception(message),
-                message = "PreconditionCheckWorker: canceling work"
+                message = "PreconditionCheckWorker: cancelling work"
             )
             return cancelWork(message)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -12,13 +12,10 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.extensions.isNotNullOrEmpty
-import com.woocommerce.android.notifications.local.LocalNotification.StoreCreationIncompleteNotification
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.support.help.HelpOrigin.STORE_CREATION
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
-import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
@@ -28,7 +25,6 @@ import com.woocommerce.android.viewmodel.SingleLiveEvent
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.store.AccountStore
 import javax.inject.Inject
@@ -42,7 +38,7 @@ class StoreNamePickerViewModel @Inject constructor(
     private val prefsWrapper: AppPrefsWrapper,
     private val localNotificationScheduler: LocalNotificationScheduler,
     private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
-    private val accountStore: AccountStore
+    private val accountStore: AccountStore,
 ) : ScopedViewModel(savedStateHandle) {
     override val _event = SingleLiveEvent<Event>()
     override val event: LiveData<Event> = _event
@@ -103,21 +99,23 @@ class StoreNamePickerViewModel @Inject constructor(
     }
 
     private fun scheduleDeferredNotification() {
-        launch {
-            if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D)) {
-                val name = if (accountStore.account.firstName.isNotNullOrEmpty())
-                    accountStore.account.firstName
-                else
-                    accountStore.account.userName
+        // TODO: To be removed. With the new store creation flow this notification is no longer needed
+//        launch {
+//            if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D)) {
+//                val name = if (accountStore.account.firstName.isNotNullOrEmpty())
+//                    accountStore.account.firstName
+//                else
+//                    accountStore.account.userName
 
-                localNotificationScheduler.scheduleNotification(
-                    StoreCreationIncompleteNotification(
-                        name,
-                        _viewState.value.storeName
-                    )
-                )
-            }
-        }
+//                localNotificationScheduler.scheduleNotification(
+//                    StoreCreationIncompleteNotification(
+//                        selected
+//                        name,
+//                        _viewState.value.storeName
+//                    )
+//                )
+//            }
+//        }
     }
 
     fun onPermissionRationaleDismissed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -12,8 +12,10 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.support.help.HelpOrigin.STORE_CREATION
 import com.woocommerce.android.ui.login.storecreation.NewStore
+import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
@@ -24,15 +26,20 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.store.AccountStore
 import javax.inject.Inject
 
 @HiltViewModel
+@Suppress("UnusedPrivateMember")
 class StoreNamePickerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     resourceProvider: ResourceProvider,
     private val newStore: NewStore,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val prefsWrapper: AppPrefsWrapper
+    private val prefsWrapper: AppPrefsWrapper,
+    private val localNotificationScheduler: LocalNotificationScheduler,
+    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
+    private val accountStore: AccountStore,
 ) : ScopedViewModel(savedStateHandle) {
     override val _event = SingleLiveEvent<Event>()
     override val event: LiveData<Event> = _event

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -12,10 +12,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.support.help.HelpOrigin.STORE_CREATION
 import com.woocommerce.android.ui.login.storecreation.NewStore
-import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
@@ -26,7 +24,6 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
-import org.wordpress.android.fluxc.store.AccountStore
 import javax.inject.Inject
 
 @HiltViewModel
@@ -35,10 +32,7 @@ class StoreNamePickerViewModel @Inject constructor(
     resourceProvider: ResourceProvider,
     private val newStore: NewStore,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val prefsWrapper: AppPrefsWrapper,
-    private val localNotificationScheduler: LocalNotificationScheduler,
-    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
-    private val accountStore: AccountStore,
+    private val prefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     override val _event = SingleLiveEvent<Event>()
     override val event: LiveData<Event> = _event
@@ -99,7 +93,7 @@ class StoreNamePickerViewModel @Inject constructor(
     }
 
     private fun scheduleDeferredNotification() {
-        // TODO: To be removed. With the new store creation flow this notification is no longer needed
+        // TODO To be removed. With the new store creation flow this notification is no longer needed
 //        launch {
 //            if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D)) {
 //                val name = if (accountStore.account.firstName.isNotNullOrEmpty())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -7,7 +7,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.isNotNullOrEmpty
-import com.woocommerce.android.notifications.local.LocalNotification.StoreCreationFinishedNotification
+import com.woocommerce.android.notifications.local.LocalNotification.StoreCreationCompletedNotification
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_INCOMPLETE
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
@@ -78,7 +78,7 @@ class StoreCreationSummaryViewModel @Inject constructor(
                         )
                         triggerEvent(OnStoreCreationSuccess)
 
-                        manageDeferredNotifications()
+                        manageDeferredNotifications(creationState.siteId)
                     }
 
                     is Failed -> triggerEvent(OnStoreCreationFailure)
@@ -89,14 +89,14 @@ class StoreCreationSummaryViewModel @Inject constructor(
         }
     }
 
-    private fun manageDeferredNotifications() {
+    private fun manageDeferredNotifications(siteId: Long) {
         launch {
             if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_STORE_CREATION_READY)) {
                 val name = if (accountStore.account.firstName.isNotNullOrEmpty())
                     accountStore.account.firstName
                 else
                     accountStore.account.userName
-                localNotificationScheduler.scheduleNotification(StoreCreationFinishedNotification(name))
+                localNotificationScheduler.scheduleNotification(StoreCreationCompletedNotification(siteId, name))
             }
 
             // No need to display a notification to complete store creation anymore

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -39,7 +39,6 @@ import com.woocommerce.android.ui.moremenu.MoreMenuNewFeatureHandler
 import com.woocommerce.android.ui.plans.trial.DetermineTrialStatusBarState
 import com.woocommerce.android.ui.prefs.PrivacySettingsRepository
 import com.woocommerce.android.ui.prefs.RequestedAnalyticsValue
-import com.woocommerce.android.ui.sitepicker.SitePickerRepository
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.CoroutineDispatchers
@@ -69,7 +68,6 @@ class MainActivityViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val resolveAppLink: ResolveAppLink,
     private val privacyRepository: PrivacySettingsRepository,
-    private val sitePickerRepository: SitePickerRepository,
     storeProfilerRepository: StoreProfilerRepository,
     moreMenuNewFeatureHandler: MoreMenuNewFeatureHandler,
     unseenReviewsCountHandler: UnseenReviewsCountHandler,
@@ -185,19 +183,9 @@ class MainActivityViewModel @Inject constructor(
         siteStore.getSiteBySiteId(remoteSiteId)?.let { updatedSite ->
             selectedSite.set(updatedSite)
             triggerEvent(restartEvent)
-        } ?: {
-            launch {
-                // Refresh site db in case the remoteSiteId belongs to a site that has just been created
-                sitePickerRepository.fetchWooCommerceSites()
-                // Try again to match siteId
-                siteStore.getSiteBySiteId(remoteSiteId)?.let { updatedSite ->
-                    selectedSite.set(updatedSite)
-                    triggerEvent(restartEvent)
-                } ?: run {
-                    // If for any reason we can't get the store, show the default screen
-                    triggerEvent(ViewMyStoreStats)
-                }
-            }
+        } ?: run {
+            // If for any reason we can't get the store, show the default screen
+            triggerEvent(ViewMyStoreStats)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -187,7 +187,7 @@ class MainActivityViewModel @Inject constructor(
             triggerEvent(restartEvent)
         } ?: {
             launch {
-                //Refresh site db in case the remoteSiteId belongs to a site that has just been created
+                // Refresh site db in case the remoteSiteId belongs to a site that has just been created
                 sitePickerRepository.fetchWooCommerceSites()
                 // Try again to match siteId
                 siteStore.getSiteBySiteId(remoteSiteId)?.let { updatedSite ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -185,10 +185,11 @@ class MainActivityViewModel @Inject constructor(
         siteStore.getSiteBySiteId(remoteSiteId)?.let { updatedSite ->
             selectedSite.set(updatedSite)
             triggerEvent(restartEvent)
-        } ?: run {
+        } ?: {
             launch {
                 //Refresh site db in case the remoteSiteId belongs to a site that has just been created
                 sitePickerRepository.fetchWooCommerceSites()
+                // Try again to match siteId
                 siteStore.getSiteBySiteId(remoteSiteId)?.let { updatedSite ->
                     selectedSite.set(updatedSite)
                     triggerEvent(restartEvent)
@@ -287,10 +288,9 @@ class MainActivityViewModel @Inject constructor(
     }
 
     fun onLocalNotificationTapped(notification: Notification) {
-        val remoteSiteId = notification.data?.toLongOrNull() ?: 0L
-        if (remoteSiteId != selectedSite.get().siteId) {
+        if (notification.remoteSiteId != selectedSite.get().siteId) {
             changeSiteAndRestart(
-                remoteSiteId,
+                notification.remoteSiteId,
                 RestartActivityForLocalNotification(notification)
             )
         } else {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -30,7 +30,6 @@ import com.woocommerce.android.ui.main.MainActivityViewModel.ViewTapToPay
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewUrlInWebView
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewZendeskTickets
 import com.woocommerce.android.ui.moremenu.MoreMenuNewFeatureHandler
-import com.woocommerce.android.ui.sitepicker.SitePickerRepository
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -116,7 +115,6 @@ class MainActivityViewModelTest : BaseUnitTest() {
         on { observeUnseenCount() } doReturn MutableStateFlow(1)
     }
     private val storeProfilerRepository: StoreProfilerRepository = mock()
-    private val sitePickerRepository: SitePickerRepository = mock()
 
     private val testAnnouncement = FeatureAnnouncement(
         appVersionName = "14.2",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -551,8 +551,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
                 unseenReviewsCountHandler = unseenReviewsCountHandler,
                 determineTrialStatusBarState = mock {
                     onBlocking { invoke(any()) } doReturn emptyFlow()
-                },
-                sitePickerRepository = sitePickerRepository
+                }
             )
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -17,7 +17,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.profiler.StoreProfilerRepository
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.Hidden
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.UnseenReviews
-import com.woocommerce.android.ui.main.MainActivityViewModel.RestartActivityForNotification
+import com.woocommerce.android.ui.main.MainActivityViewModel.RestartActivityForPushNotification
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShortcutOpenOrderCreation
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShortcutOpenPayments
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShowFeatureAnnouncement
@@ -30,6 +30,7 @@ import com.woocommerce.android.ui.main.MainActivityViewModel.ViewTapToPay
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewUrlInWebView
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewZendeskTickets
 import com.woocommerce.android.ui.moremenu.MoreMenuNewFeatureHandler
+import com.woocommerce.android.ui.sitepicker.SitePickerRepository
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -115,6 +116,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         on { observeUnseenCount() } doReturn MutableStateFlow(1)
     }
     private val storeProfilerRepository: StoreProfilerRepository = mock()
+    private val sitePickerRepository: SitePickerRepository = mock()
 
     private val testAnnouncement = FeatureAnnouncement(
         appVersionName = "14.2",
@@ -311,7 +313,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
 
         verify(selectedSite, atLeastOnce()).set(any())
         assertThat(viewModel.event.value)
-            .isEqualTo(RestartActivityForNotification(groupOrderPushId, orderNotification2))
+            .isEqualTo(RestartActivityForPushNotification(groupOrderPushId, orderNotification2))
     }
 
     @Test
@@ -324,7 +326,12 @@ class MainActivityViewModelTest : BaseUnitTest() {
         viewModel.handleIncomingNotification(reviewPushId, reviewNotification2)
 
         verify(selectedSite, atLeastOnce()).set(any())
-        assertThat(viewModel.event.value).isEqualTo(RestartActivityForNotification(reviewPushId, reviewNotification2))
+        assertThat(viewModel.event.value).isEqualTo(
+            RestartActivityForPushNotification(
+                reviewPushId,
+                reviewNotification2
+            )
+        )
     }
 
     @Test
@@ -544,7 +551,8 @@ class MainActivityViewModelTest : BaseUnitTest() {
                 unseenReviewsCountHandler = unseenReviewsCountHandler,
                 determineTrialStatusBarState = mock {
                     onBlocking { invoke(any()) } doReturn emptyFlow()
-                }
+                },
+                sitePickerRepository = sitePickerRepository
             )
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9654
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes several issues related to local notifications: 
- Avoid canceling scheduled local notifications when the user switches to a different store.
- Switch to the correct store upon tapping on a local notification the belongs to another site.
- ~~Notifications missing the `siteId` were being scheduled but never displayed due to the logic in `PreconditionCheckWorker`:~~ 
```kotlin
    private fun proceedIfFreeTrialAndMatchesSite(siteId: Long?): Result {
        val site = selectedSite.get()
        return if (site.isFreeTrial && site.siteId == siteId) {
            Result.success()
        } else {
            cancelWork("Store plan upgraded or a different site. Cancelling work.")
        }
    }
```
~~This PR fixes that and ensures all the scheduled local notifications have the correct `siteId` so we can support site switching.~~
EDIT: As discussed below https://github.com/woocommerce/woocommerce-android/pull/9736#issuecomment-1709798125 not all local notifications are impacted by the previous code. And the ones that were impacted by the previous code had the proper `siteId` set. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The changes in this PR mainly affect `StoreCreationCompletedNotification` so focusing our test around that notification should be enough.  
1. First apply the following change to make the notification trigger sooner after being scheduled: 
``` diff
Subject: [PATCH] Wait only 2 min for notification
---
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt	(revision a451a5453f1e7d721de5c9953805585f548cde03)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt	(date 1694072038449)
@@ -30,7 +30,7 @@
         title = R.string.local_notification_store_creation_complete_title,
         description = R.string.local_notification_store_creation_complete_description,
         type = LocalNotificationType.STORE_CREATION_FINISHED,
-        delay = 5,
+        delay = 2,
         delayUnit = TimeUnit.MINUTES
     ) {
 
```
2. Trigger store creation flow and press "Try for free". Wait for the loading to complete until you are taken to the first profiler step. You should see the following log before moving to the next step: 
```
Tracked: local_notification_scheduled, Properties: {"type":"store_creation_complete","blog_id":223209821,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"ecommerce-trial-bundle-monthly","is_debug":true,"site_url":"url"}
```
3. Kill the app
4. Wait for the notification to show up. We reduced the waiting time to 2 mins, it should be enough for the store to be ready.
5. Tap on the notification and notice how the stores is switched to the new one created one. 
6. Review the following event is only tracked once: 
```
Tracked: local_notification_tapped, Properties: {"type":"store_creation_complete","blog_id":223232803,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"ecommerce-trial-bundle-monthly","is_debug":true,"site_url":"url"}
```