### PR TITLE
Schedule local notifications sooner in the store creation flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -87,7 +87,7 @@ class AnalyticsTracker private constructor(
         val selectedSiteModel = selectedSite.getOrNull()
         if (!isSiteless) {
             selectedSiteModel?.let {
-                finalProperties[KEY_BLOG_ID] = it.siteId
+                if (!finalProperties.containsKey(KEY_BLOG_ID)) finalProperties[KEY_BLOG_ID] = it.siteId
                 finalProperties[KEY_IS_WPCOM_STORE] = it.isWpComStore
                 finalProperties[KEY_WAS_ECOMMERCE_TRIAL] = it.wasEcommerceTrial
                 finalProperties[KEY_PLAN_PRODUCT_SLUG] = it.planProductSlug

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
@@ -38,7 +38,10 @@ class LocalNotificationScheduler @Inject constructor(
 
         AnalyticsTracker.track(
             AnalyticsEvent.LOCAL_NOTIFICATION_SCHEDULED,
-            mapOf(AnalyticsTracker.KEY_TYPE to notification.type.value)
+            mapOf(
+                AnalyticsTracker.KEY_TYPE to notification.type.value,
+                AnalyticsTracker.KEY_BLOG_ID to notification.siteId,
+            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
@@ -59,7 +59,10 @@ class LocalNotificationWorker @AssistedInject constructor(
 
             AnalyticsTracker.track(
                 LOCAL_NOTIFICATION_DISPLAYED,
-                mapOf(AnalyticsTracker.KEY_TYPE to type)
+                mapOf(
+                    AnalyticsTracker.KEY_TYPE to type,
+                    AnalyticsTracker.KEY_BLOG_ID to siteId,
+                )
             )
         } else {
             wooLogWrapper.e(T.NOTIFICATIONS, "Scheduled local notification data is invalid")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -33,10 +33,6 @@ class PreconditionCheckWorker @AssistedInject constructor(
     private val siteStore: SiteStore,
     private val crashLogging: CrashLogging,
 ) : Worker(appContext, workerParams) {
-    private companion object {
-        const val LOCAL_NOTIFICATION_SCHEDULED_ERROR = "local_notification_scheduled_error"
-    }
-
     override fun doWork(): Result {
         if (!canDisplayNotifications) cancelWork("Notifications permission not granted. Cancelling work.")
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
@@ -11,12 +11,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.extensions.isNotNullOrEmpty
-import com.woocommerce.android.notifications.local.LocalNotification.FreeTrialExpiredNotification
-import com.woocommerce.android.notifications.local.LocalNotification.FreeTrialExpiringNotification
-import com.woocommerce.android.notifications.local.LocalNotification.FreeTrialSurveyNotification
-import com.woocommerce.android.notifications.local.LocalNotification.UpgradeToPaidPlanNotification
-import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType
@@ -25,9 +19,6 @@ import com.woocommerce.android.ui.login.storecreation.installation.ObserveSiteIn
 import com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationViewModel.ViewState.ErrorState
 import com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationViewModel.ViewState.StoreCreationLoadingState
 import com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationViewModel.ViewState.SuccessState
-import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
-import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES
-import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -40,10 +31,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 @HiltViewModel
@@ -56,10 +44,7 @@ class StoreInstallationViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     private val storeInstallationLoadingTimer: StoreInstallationLoadingTimer,
     private val installationTransactionLauncher: InstallationTransactionLauncher,
-    private val observeSiteInstallation: ObserveSiteInstallation,
-    private val localNotificationScheduler: LocalNotificationScheduler,
-    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
-    private val accountStore: AccountStore
+    private val observeSiteInstallation: ObserveSiteInstallation
 ) : ScopedViewModel(savedStateHandle) {
 
     companion object {
@@ -117,8 +102,6 @@ class StoreInstallationViewModel @Inject constructor(
                 installationTransactionLauncher.onStoreInstalled(properties)
 
                 _viewState.update { SuccessState(newStoreWpAdminUrl) }
-
-                scheduleDeferredNotifications()
             }
 
             is InstallationState.Failure -> {
@@ -147,36 +130,6 @@ class StoreInstallationViewModel @Inject constructor(
             }
 
             InstallationState.InProgress -> Unit
-        }
-    }
-
-    private fun scheduleDeferredNotifications() {
-        launch {
-            if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES)) {
-                val in14days = LocalDateTime.now()
-                    .plusDays(TRIAL_LENGTH_IN_DAYS)
-                    .format(DateTimeFormatter.ofPattern("EEEE, MMMM d"))
-                localNotificationScheduler.scheduleNotification(
-                    FreeTrialExpiringNotification(in14days, selectedSite.get().siteId)
-                )
-            }
-
-            if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES)) {
-                val name = if (accountStore.account.firstName.isNotNullOrEmpty())
-                    accountStore.account.firstName
-                else
-                    accountStore.account.userName
-
-                localNotificationScheduler.scheduleNotification(
-                    FreeTrialExpiredNotification(name, selectedSite.get().siteId)
-                )
-            }
-            localNotificationScheduler.scheduleNotification(
-                UpgradeToPaidPlanNotification(selectedSite.get().siteId)
-            )
-            localNotificationScheduler.scheduleNotification(
-                FreeTrialSurveyNotification(selectedSite.get().siteId)
-            )
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/StoreInstallationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/StoreInstallationViewModelTest.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.STORE_LOADING_FAILED
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.STORE_NOT_READY
@@ -18,7 +17,6 @@ import com.woocommerce.android.ui.login.storecreation.installation.StoreInstalla
 import com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationViewModel.ViewState.ErrorState
 import com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationViewModel.ViewState.StoreCreationLoadingState
 import com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationViewModel.ViewState.SuccessState
-import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -32,7 +30,6 @@ import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import kotlin.test.assertEquals
 
@@ -46,9 +43,6 @@ class StoreInstallationViewModelTest : BaseUnitTest() {
     private val storeInstallationLoadingTimer: StoreInstallationLoadingTimer = mock()
     private val installationTransactionLauncher: InstallationTransactionLauncher = mock()
     private val observeSiteInstallation: ObserveSiteInstallation = mock()
-    private val localNotificationScheduler: LocalNotificationScheduler = mock()
-    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled = mock()
-    private val accountStore: AccountStore = mock()
 
     private lateinit var viewModel: StoreInstallationViewModel
 
@@ -72,10 +66,7 @@ class StoreInstallationViewModelTest : BaseUnitTest() {
             selectedSite,
             storeInstallationLoadingTimer,
             installationTransactionLauncher,
-            observeSiteInstallation,
-            localNotificationScheduler,
-            isRemoteFeatureFlagEnabled,
-            accountStore
+            observeSiteInstallation
         )
         viewModel.viewState.observeForever {}
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
**NOTE:** It is possible that this fix alongside this other one: https://github.com/woocommerce/woocommerce-android/pull/9736 might need to be merged to `release/15.2` too. I'll share this changes in P2 and open the discussion to see if these are critical enough to merge them as release fixes. I'll then cherry pick if needed, from `trunk`. 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The new store creation flow has now a single step before the new site is created. After that the user will have to navigate several profiler steps (up to 7 screens) before they land on `StoreInstallationScreen`. We currently are scheduling most of the store free trial local notification in this screen `StoreInstallationScreen`. There's a high chance with the new UX that the user will never land on `StoreInstallationScreen`. So to avoid the risk of the notification not being scheduled this PR moves that logic from `StoreInstallationViewModel` to `StoreCreationSummaryViewModel`.

Additionally this PR, fixes a tracking issue where the `blog_id` we were sending when tracking local notification events was incorrect. I've added a small change that now enables us to manually override the default `blog_id` valu added to `!isSiteless` `Tracks` events.  

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Trigger store creation flow and verify the following logs are displayed as soon as the new store is created after clicking on "Try for free" button: 
```
Tracked: site_creation_free_trial_created_success, Properties: {"new_site_id":223240239,"initial_domain":"woo-honestly-magnificent-kitty.wordpress.com","blog_id":222726089,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"free_plan","is_debug":true,"site_url":"https:\/\/woo-mysteriously-virtual-harmony.wpcomstaging.com"}
Tracked: local_notification_scheduled, Properties: {"type":"store_creation_complete","blog_id":223240239,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"free_plan","is_debug":true,"site_url":"https:\/\/woo-mysteriously-virtual-harmony.wpcomstaging.com"}
Tracked: local_notification_scheduled, Properties: {"type":"one_day_before_free_trial_expires","blog_id":223240239,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"free_plan","is_debug":true,"site_url":"https:\/\/woo-mysteriously-virtual-harmony.wpcomstaging.com"}
Tracked: local_notification_scheduled, Properties: {"type":"one_day_after_free_trial_expires","blog_id":223240239,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"free_plan","is_debug":true,"site_url":"https:\/\/woo-mysteriously-virtual-harmony.wpcomstaging.com"}
Tracked: local_notification_scheduled, Properties: {"type":"six_hours_after_free_trial_subscribed","blog_id":223240239,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"free_plan","is_debug":true,"site_url":"https:\/\/woo-mysteriously-virtual-harmony.wpcomstaging.com"}
Tracked: local_notification_scheduled, Properties: {"type":"free_trial_survey_24h_after_free_trial_subscribed","blog_id":223240239,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"free_plan","is_debug":true,"site_url":"https:\/\/woo-mysteriously-virtual-harmony.wpcomstaging.com"}
```
