### PR TITLE
Fix/9743 properly schedule notifications

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -95,8 +95,8 @@ sealed class LocalNotification(
         title = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_title,
         description = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_description,
         type = LocalNotificationType.SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED,
-        delay = 2,
-        delayUnit = TimeUnit.MINUTES
+        delay = 6,
+        delayUnit = TimeUnit.HOURS
     ) {
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
@@ -32,7 +32,11 @@ class LocalNotificationScheduler @Inject constructor(
         cancelScheduledNotification(notification.type)
 
         workManager
-            .beginUniqueWork(LOCAL_NOTIFICATION_WORK_NAME, REPLACE, buildPreconditionCheckWorkRequest(notification))
+            .beginUniqueWork(
+                LOCAL_NOTIFICATION_WORK_NAME + notification.type.value,
+                REPLACE,
+                buildPreconditionCheckWorkRequest(notification)
+            )
             .then(buildNotificationWorkRequest(notification))
             .enqueue()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -62,7 +62,7 @@ class PreconditionCheckWorker @AssistedInject constructor(
             return cancelWork(message)
         }
 
-        val notificationLinkedSite = siteStore.getSiteByLocalId(siteId.toInt())
+        val notificationLinkedSite = siteStore.getSiteBySiteId(siteId)
         return if (notificationLinkedSite.isFreeTrial) {
             Result.success()
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -66,7 +66,9 @@ class PreconditionCheckWorker @AssistedInject constructor(
         return if (notificationLinkedSite.isFreeTrial) {
             Result.success()
         } else {
-            cancelWork("Store plan upgraded. Cancelling work.")
+            if (notificationLinkedSite == null) {
+                cancelWork("The site linked to the notifications doesn't exist in the db. Cancelling work.")
+            } else cancelWork("Store plan upgraded. Cancelling work.")
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes: #9743
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
When scheduling local notifications consecutively like we do in [StoreCreationSummaryViewModel](https://github.com/woocommerce/woocommerce-android/blob/9f7cbafa783fdff294c55fc952071758316c4162/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt#L101) we're using: 
```kotlin
        workManager
            .beginUniqueWork(LOCAL_NOTIFICATION_WORK_NAME, REPLACE, buildPreconditionCheckWorkRequest(notification))
            .then(buildNotificationWorkRequest(notification))
            .enqueue()
```
This code has 2 problems: 
- The value used for `uniqueWorkName` is the same for all the notifications
- We are applying a `REPLACE` strategy. 

Because of this, the work requests to schedule the notifications are being replaced, preventing the notifications from properly being scheduled. What is even worse, the actual code will run: 
```kotlin
        AnalyticsTracker.track(
            AnalyticsEvent.LOCAL_NOTIFICATION_SCHEDULED,
            mapOf(
                AnalyticsTracker.KEY_TYPE to notification.type.value,
                AnalyticsTracker.KEY_BLOG_ID to notification.siteId,
            )
        )
```
Making us think that the notifications are scheduled, when they're not.  This is easy to reproduce:
1.  Run the app from `trunk` and set all of the LocalNotifications to be triggered after a few seconds. You can apply the patch below.
2. Run Store Creation flow and check how all notifications are scheduled (in theory): 
```
Tracked: local_notification_scheduled, Properties: {"type":"store_creation_complete","blog_id":223247857,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"ecommerce-trial-bundle-monthly","is_debug":true,"site_url":"https:\/\/woo-honestly-observant-bluebird.wpcomstaging.com"}
Tracked: local_notification_scheduled, Properties: {"type":"one_day_before_free_trial_expires","blog_id":223247857,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"ecommerce-trial-bundle-monthly","is_debug":true,"site_url":"https:\/\/woo-honestly-observant-bluebird.wpcomstaging.com"}
Tracked: local_notification_scheduled, Properties: {"type":"one_day_after_free_trial_expires","blog_id":223247857,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"ecommerce-trial-bundle-monthly","is_debug":true,"site_url":"https:\/\/woo-honestly-observant-bluebird.wpcomstaging.com"}
Tracked: local_notification_scheduled, Properties: {"type":"six_hours_after_free_trial_subscribed","blog_id":223247857,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"ecommerce-trial-bundle-monthly","is_debug":true,"site_url":"https:\/\/woo-honestly-observant-bluebird.wpcomstaging.com"}
Tracked: local_notification_scheduled, Properties: {"type":"free_trial_survey_24h_after_free_trial_subscribed","blog_id":223247857,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"ecommerce-trial-bundle-monthly","is_debug":true,"site_url":"https:\/\/woo-honestly-observant-bluebird.wpcomstaging.com"}
```
3. Kill the app
4. Wait a few minutes and see how none of the notifications are shown except for the last one to be scheduled: `free_trial_survey_24h_after_free_trial_subscribed`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Apply this patch:
```diff
Subject: [PATCH] Add better error handling
---
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt	(revision d84c533f31b295e6b198b24e9799d79ded6b7b09)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt	(date 1694101448007)
@@ -30,7 +30,7 @@
         title = R.string.local_notification_store_creation_complete_title,
         description = R.string.local_notification_store_creation_complete_description,
         type = LocalNotificationType.STORE_CREATION_FINISHED,
-        delay = 5,
+        delay = 2,
         delayUnit = TimeUnit.MINUTES
     ) {
 
@@ -48,8 +48,8 @@
         title = R.string.local_notification_without_free_trial_title,
         description = R.string.local_notification_without_free_trial_description,
         type = LocalNotificationType.STORE_CREATION_INCOMPLETE,
-        delay = 24,
-        delayUnit = TimeUnit.HOURS
+        delay = 3,
+        delayUnit = TimeUnit.MINUTES
     ) {
         override val data: String = storeName
 
@@ -66,8 +66,8 @@
         title = R.string.local_notification_one_day_before_free_trial_expires_title,
         description = R.string.local_notification_one_day_before_free_trial_expires_description,
         type = LocalNotificationType.FREE_TRIAL_EXPIRING,
-        delay = 13,
-        delayUnit = TimeUnit.DAYS
+        delay = 3,
+        delayUnit = TimeUnit.MINUTES
     ) {
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description, expiryDate)
@@ -82,8 +82,8 @@
         title = R.string.local_notification_one_day_after_free_trial_expires_title,
         description = R.string.local_notification_one_day_after_free_trial_expires_description,
         type = LocalNotificationType.FREE_TRIAL_EXPIRED,
-        delay = 15,
-        delayUnit = TimeUnit.DAYS
+        delay = 3,
+        delayUnit = TimeUnit.MINUTES
     ) {
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description, name)
@@ -95,8 +95,8 @@
         title = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_title,
         description = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_description,
         type = LocalNotificationType.SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED,
-        delay = 6,
-        delayUnit = TimeUnit.HOURS
+        delay = 3,
+        delayUnit = TimeUnit.MINUTES
     ) {
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description)
@@ -108,8 +108,8 @@
         title = R.string.local_notification_survey_after_24_hours_title,
         description = R.string.local_notification_survey_after_24_hours_description,
         type = LocalNotificationType.FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED,
-        delay = 24,
-        delayUnit = TimeUnit.HOURS
+        delay = 3,
+        delayUnit = TimeUnit.MINUTES
     ) {
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description)
@@ -122,7 +122,7 @@
         description = R.string.local_notification_still_exploring_description,
         type = LocalNotificationType.THREE_DAYS_AFTER_STILL_EXPLORING,
         delay = 3,
-        delayUnit = TimeUnit.DAYS
+        delayUnit = TimeUnit.MINUTES
     ) {
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description)

```
Repeat the same steps from the previous section and check how all the notifications that were shown as scheduled in the logs: 
```
local_notification_scheduled, Properties: {"type":"store_creation_complete","blog_id":223247857,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"ecommerce-trial-bundle-monthly","is_debug":true,"site_url":"https:\/\/woo-honestly-observant-bluebird.wpcomstaging.com"}
local_notification_scheduled, Properties: {"type":"one_day_before_free_trial_expires","blog_id":223247857,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"ecommerce-trial-bundle-monthly","is_debug":true,"site_url":"https:\/\/woo-honestly-observant-bluebird.wpcomstaging.com"}
local_notification_scheduled, Properties: {"type":"one_day_after_free_trial_expires","blog_id":223247857,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"ecommerce-trial-bundle-monthly","is_debug":true,"site_url":"https:\/\/woo-honestly-observant-bluebird.wpcomstaging.com"}
local_notification_scheduled, Properties: {"type":"six_hours_after_free_trial_subscribed","blog_id":223247857,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"ecommerce-trial-bundle-monthly","is_debug":true,"site_url":"https:\/\/woo-honestly-observant-bluebird.wpcomstaging.com"}
local_notification_scheduled, Properties: {"type":"free_trial_survey_24h_after_free_trial_subscribed","blog_id":223247857,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"ecommerce-trial-bundle-monthly","is_debug":true,"site_url":"https:\/\/woo-honestly-observant-bluebird.wpcomstaging.com"}
```
Wait a couple minutes and as soon as you see the first notification appear, click on it. 
The rest of the notifications will be shown after a couple of minutes. 