### PR TITLE
Cherrypicked local notification fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -87,7 +87,7 @@ class AnalyticsTracker private constructor(
         val selectedSiteModel = selectedSite.getOrNull()
         if (!isSiteless) {
             selectedSiteModel?.let {
-                finalProperties[KEY_BLOG_ID] = it.siteId
+                if (!finalProperties.containsKey(KEY_BLOG_ID)) finalProperties[KEY_BLOG_ID] = it.siteId
                 finalProperties[KEY_IS_WPCOM_STORE] = it.isWpComStore
                 finalProperties[KEY_WAS_ECOMMERCE_TRIAL] = it.wasEcommerceTrial
                 finalProperties[KEY_PLAN_PRODUCT_SLUG] = it.planProductSlug

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -95,8 +95,8 @@ sealed class LocalNotification(
         title = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_title,
         description = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_description,
         type = LocalNotificationType.SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED,
-        delay = 2,
-        delayUnit = TimeUnit.MINUTES
+        delay = 6,
+        delayUnit = TimeUnit.HOURS
     ) {
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import java.util.concurrent.TimeUnit
 
 sealed class LocalNotification(
+    open val siteId: Long,
     @StringRes val title: Int,
     @StringRes val description: Int,
     val type: LocalNotificationType,
@@ -21,21 +22,29 @@ sealed class LocalNotification(
         return resourceProvider.getString(title)
     }
 
-    data class StoreCreationFinishedNotification(
+    data class StoreCreationCompletedNotification(
+        override val siteId: Long,
         val name: String
     ) : LocalNotification(
+        siteId = siteId,
         title = R.string.local_notification_store_creation_complete_title,
         description = R.string.local_notification_store_creation_complete_description,
         type = LocalNotificationType.STORE_CREATION_FINISHED,
         delay = 5,
         delayUnit = TimeUnit.MINUTES
     ) {
+
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description, name)
         }
     }
 
-    data class StoreCreationIncompleteNotification(val name: String, val storeName: String) : LocalNotification(
+    data class StoreCreationIncompleteNotification(
+        override val siteId: Long,
+        val name: String,
+        val storeName: String
+    ) : LocalNotification(
+        siteId = siteId,
         title = R.string.local_notification_without_free_trial_title,
         description = R.string.local_notification_without_free_trial_description,
         type = LocalNotificationType.STORE_CREATION_INCOMPLETE,
@@ -49,71 +58,72 @@ sealed class LocalNotification(
         }
     }
 
-    data class FreeTrialExpiringNotification(val expiryDate: String, val siteId: Long) : LocalNotification(
+    data class FreeTrialExpiringNotification(
+        val expiryDate: String,
+        override val siteId: Long
+    ) : LocalNotification(
+        siteId = siteId,
         title = R.string.local_notification_one_day_before_free_trial_expires_title,
         description = R.string.local_notification_one_day_before_free_trial_expires_description,
         type = LocalNotificationType.FREE_TRIAL_EXPIRING,
         delay = 13,
         delayUnit = TimeUnit.DAYS
     ) {
-        override val data: String = siteId.toString()
-
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description, expiryDate)
         }
     }
 
-    data class FreeTrialExpiredNotification(val name: String, val siteId: Long) : LocalNotification(
+    data class FreeTrialExpiredNotification(
+        val name: String,
+        override val siteId: Long
+    ) : LocalNotification(
+        siteId = siteId,
         title = R.string.local_notification_one_day_after_free_trial_expires_title,
         description = R.string.local_notification_one_day_after_free_trial_expires_description,
         type = LocalNotificationType.FREE_TRIAL_EXPIRED,
         delay = 15,
         delayUnit = TimeUnit.DAYS
     ) {
-        override val data: String = siteId.toString()
-
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description, name)
         }
     }
 
-    data class UpgradeToPaidPlanNotification(val siteId: Long) : LocalNotification(
+    data class UpgradeToPaidPlanNotification(override val siteId: Long) : LocalNotification(
+        siteId = siteId,
         title = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_title,
         description = R.string.local_notification_upgrade_to_paid_plan_after_6_hours_description,
         type = LocalNotificationType.SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED,
-        delay = 6,
-        delayUnit = TimeUnit.HOURS
+        delay = 2,
+        delayUnit = TimeUnit.MINUTES
     ) {
-        override val data: String = siteId.toString()
-
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description)
         }
     }
 
-    data class FreeTrialSurveyNotification(val siteId: Long) : LocalNotification(
+    data class FreeTrialSurveyNotification(override val siteId: Long) : LocalNotification(
+        siteId = siteId,
         title = R.string.local_notification_survey_after_24_hours_title,
         description = R.string.local_notification_survey_after_24_hours_description,
         type = LocalNotificationType.FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED,
         delay = 24,
         delayUnit = TimeUnit.HOURS
     ) {
-        override val data: String = siteId.toString()
-
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description)
         }
     }
 
-    data class StillExploringNotification(val siteId: Long) : LocalNotification(
+    data class StillExploringNotification(override val siteId: Long) : LocalNotification(
+        siteId = siteId,
         title = R.string.local_notification_still_exploring_title,
         description = R.string.local_notification_still_exploring_description,
         type = LocalNotificationType.THREE_DAYS_AFTER_STILL_EXPLORING,
         delay = 3,
         delayUnit = TimeUnit.DAYS
     ) {
-        override val data: String = siteId.toString()
-
         override fun getDescriptionString(resourceProvider: ResourceProvider): String {
             return resourceProvider.getString(description)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
@@ -32,7 +32,11 @@ class LocalNotificationScheduler @Inject constructor(
         cancelScheduledNotification(notification.type)
 
         workManager
-            .beginUniqueWork(LOCAL_NOTIFICATION_WORK_NAME, REPLACE, buildPreconditionCheckWorkRequest(notification))
+            .beginUniqueWork(
+                LOCAL_NOTIFICATION_WORK_NAME + notification.type.value,
+                REPLACE,
+                buildPreconditionCheckWorkRequest(notification)
+            )
             .then(buildNotificationWorkRequest(notification))
             .enqueue()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
@@ -23,6 +23,7 @@ class LocalNotificationScheduler @Inject constructor(
         const val LOCAL_NOTIFICATION_TITLE = "local_notification_title"
         const val LOCAL_NOTIFICATION_DESC = "local_notification_description"
         const val LOCAL_NOTIFICATION_DATA = "local_notification_data"
+        const val LOCAL_NOTIFICATION_SITE_ID = "local_notification_site_id"
     }
 
     private val workManager = WorkManager.getInstance(appContext)
@@ -44,7 +45,8 @@ class LocalNotificationScheduler @Inject constructor(
     private fun buildPreconditionCheckWorkRequest(notification: LocalNotification): OneTimeWorkRequest {
         val conditionData = workDataOf(
             LOCAL_NOTIFICATION_TYPE to notification.type.value,
-            LOCAL_NOTIFICATION_DATA to notification.data
+            LOCAL_NOTIFICATION_DATA to notification.data,
+            LOCAL_NOTIFICATION_SITE_ID to notification.siteId
         )
         return OneTimeWorkRequestBuilder<PreconditionCheckWorker>()
             .setInputData(conditionData)
@@ -59,7 +61,8 @@ class LocalNotificationScheduler @Inject constructor(
             LOCAL_NOTIFICATION_ID to notification.id,
             LOCAL_NOTIFICATION_TITLE to notification.getTitleString(resourceProvider),
             LOCAL_NOTIFICATION_DESC to notification.getDescriptionString(resourceProvider),
-            LOCAL_NOTIFICATION_DATA to notification.data
+            LOCAL_NOTIFICATION_DATA to notification.data,
+            LOCAL_NOTIFICATION_SITE_ID to notification.siteId
         )
         return OneTimeWorkRequestBuilder<LocalNotificationWorker>()
             .addTag(notification.type.value)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
@@ -38,7 +38,10 @@ class LocalNotificationScheduler @Inject constructor(
 
         AnalyticsTracker.track(
             AnalyticsEvent.LOCAL_NOTIFICATION_SCHEDULED,
-            mapOf(AnalyticsTracker.KEY_TYPE to notification.type.value)
+            mapOf(
+                AnalyticsTracker.KEY_TYPE to notification.type.value,
+                AnalyticsTracker.KEY_BLOG_ID to notification.siteId,
+            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
@@ -59,7 +59,10 @@ class LocalNotificationWorker @AssistedInject constructor(
 
             AnalyticsTracker.track(
                 LOCAL_NOTIFICATION_DISPLAYED,
-                mapOf(AnalyticsTracker.KEY_TYPE to type)
+                mapOf(
+                    AnalyticsTracker.KEY_TYPE to type,
+                    AnalyticsTracker.KEY_BLOG_ID to siteId,
+                )
             )
         } else {
             wooLogWrapper.e(T.NOTIFICATIONS, "Scheduled local notification data is invalid")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.notifications.local
 import android.content.Context
 import android.content.Intent
 import androidx.hilt.work.HiltWorker
-import androidx.work.Worker
+import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.LOCAL_NOTIFICATION_DISPLAYED
@@ -15,9 +15,12 @@ import com.woocommerce.android.notifications.WooNotificationType.LOCAL_REMINDER
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_DATA
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_DESC
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_ID
+import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_SITE_ID
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_TITLE
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_TYPE
+import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_FINISHED
 import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.ui.sitepicker.SitePickerRepository
 import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.util.WooLogWrapper
 import dagger.assisted.Assisted
@@ -29,17 +32,25 @@ class LocalNotificationWorker @AssistedInject constructor(
     @Assisted private val appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val wooNotificationBuilder: WooNotificationBuilder,
-    private val wooLogWrapper: WooLogWrapper
-) : Worker(appContext, workerParams) {
-    override fun doWork(): Result {
+    private val wooLogWrapper: WooLogWrapper,
+    private val sitePickerRepository: SitePickerRepository,
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
         val type = inputData.getString(LOCAL_NOTIFICATION_TYPE)
-        val id = inputData.getInt(LOCAL_NOTIFICATION_ID, -1)
+        val notificationId = inputData.getInt(LOCAL_NOTIFICATION_ID, -1)
         val title = inputData.getString(LOCAL_NOTIFICATION_TITLE)
         val description = inputData.getString(LOCAL_NOTIFICATION_DESC)
         val data = inputData.getString(LOCAL_NOTIFICATION_DATA)
+        val siteId = inputData.getLong(LOCAL_NOTIFICATION_SITE_ID, 0L)
 
-        if (type != null && id != -1 && title != null && description != null) {
-            val notification = buildNotification(id, type, title, description, data)
+        // This means the new store is ready a we need to refresh the database with it
+        if (type == STORE_CREATION_FINISHED.value) {
+            sitePickerRepository.fetchWooCommerceSites()
+        }
+
+        if (siteId != 0L && type != null && notificationId != -1 && title != null && description != null) {
+            val notification = buildNotification(notificationId, siteId, type, title, description, data)
             wooNotificationBuilder.buildAndDisplayLocalNotification(
                 appContext.getString(R.string.notification_channel_general_id),
                 notification,
@@ -63,8 +74,10 @@ class LocalNotificationWorker @AssistedInject constructor(
         }
     }
 
+    @Suppress("LongParameterList")
     private fun buildNotification(
         id: Int,
+        siteId: Long,
         type: String,
         title: String,
         description: String,
@@ -74,7 +87,7 @@ class LocalNotificationWorker @AssistedInject constructor(
         tag = type,
         uniqueId = 0,
         remoteNoteId = 0,
-        remoteSiteId = 0,
+        remoteSiteId = siteId,
         icon = null,
         noteTitle = title,
         noteMessage = description,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -33,10 +33,6 @@ class PreconditionCheckWorker @AssistedInject constructor(
     private val siteStore: SiteStore,
     private val crashLogging: CrashLogging,
 ) : Worker(appContext, workerParams) {
-    private companion object {
-        const val LOCAL_NOTIFICATION_SCHEDULED_ERROR = "local_notification_scheduled_error"
-    }
-
     override fun doWork(): Result {
         if (!canDisplayNotifications) cancelWork("Notifications permission not granted. Cancelling work.")
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -62,11 +62,13 @@ class PreconditionCheckWorker @AssistedInject constructor(
             return cancelWork(message)
         }
 
-        val notificationLinkedSite = siteStore.getSiteByLocalId(siteId.toInt())
+        val notificationLinkedSite = siteStore.getSiteBySiteId(siteId)
         return if (notificationLinkedSite.isFreeTrial) {
             Result.success()
         } else {
-            cancelWork("Store plan upgraded. Cancelling work.")
+            if (notificationLinkedSite == null) {
+                cancelWork("The site linked to the notifications doesn't exist in the db. Cancelling work.")
+            } else cancelWork("Store plan upgraded. Cancelling work.")
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -7,8 +7,9 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.extensions.isFreeTrial
-import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_DATA
+import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_SITE_ID
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_TYPE
 import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TRIAL_EXPIRED
 import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TRIAL_EXPIRING
@@ -17,25 +18,30 @@ import com.woocommerce.android.notifications.local.LocalNotificationType.SIX_HOU
 import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_FINISHED
 import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_INCOMPLETE
 import com.woocommerce.android.notifications.local.LocalNotificationType.THREE_DAYS_AFTER_STILL_EXPLORING
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
 import com.woocommerce.android.util.WooLogWrapper
 import com.woocommerce.android.util.WooPermissionUtils
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import org.wordpress.android.fluxc.store.SiteStore
 
 @HiltWorker
 class PreconditionCheckWorker @AssistedInject constructor(
     @Assisted private val appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val wooLogWrapper: WooLogWrapper,
-    private val selectedSite: SelectedSite
+    private val siteStore: SiteStore,
+    private val crashLogging: CrashLogging,
 ) : Worker(appContext, workerParams) {
+    private companion object {
+        const val LOCAL_NOTIFICATION_SCHEDULED_ERROR = "local_notification_scheduled_error"
+    }
+
     override fun doWork(): Result {
         if (!canDisplayNotifications) cancelWork("Notifications permission not granted. Cancelling work.")
 
         val type = LocalNotificationType.fromString(inputData.getString(LOCAL_NOTIFICATION_TYPE))
-        val data = inputData.getString(LOCAL_NOTIFICATION_DATA)
+        val siteId = inputData.getLong(LOCAL_NOTIFICATION_SITE_ID, 0L)
         return when (type) {
             STORE_CREATION_FINISHED,
             STORE_CREATION_INCOMPLETE -> Result.success()
@@ -44,18 +50,27 @@ class PreconditionCheckWorker @AssistedInject constructor(
             FREE_TRIAL_EXPIRED,
             SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED,
             FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED,
-            THREE_DAYS_AFTER_STILL_EXPLORING -> proceedIfFreeTrialAndMatchesSite(data?.toLongOrNull())
+            THREE_DAYS_AFTER_STILL_EXPLORING -> proceedIfFreeTrialAndMatchesSite(siteId)
 
             null -> cancelWork("Notification type is null. Cancelling work.")
         }
     }
 
-    private fun proceedIfFreeTrialAndMatchesSite(siteId: Long?): Result {
-        val site = selectedSite.get()
-        return if (site.isFreeTrial && site.siteId == siteId) {
+    private fun proceedIfFreeTrialAndMatchesSite(siteId: Long): Result {
+        if (siteId == 0L) {
+            val message = "Site id is missing. Cancelling local notification work."
+            crashLogging.sendReport(
+                exception = Exception(message),
+                message = "PreconditionCheckWorker: cancelling work"
+            )
+            return cancelWork(message)
+        }
+
+        val notificationLinkedSite = siteStore.getSiteByLocalId(siteId.toInt())
+        return if (notificationLinkedSite.isFreeTrial) {
             Result.success()
         } else {
-            cancelWork("Store plan upgraded or a different site. Cancelling work.")
+            cancelWork("Store plan upgraded. Cancelling work.")
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
@@ -11,12 +11,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.extensions.isNotNullOrEmpty
-import com.woocommerce.android.notifications.local.LocalNotification.FreeTrialExpiredNotification
-import com.woocommerce.android.notifications.local.LocalNotification.FreeTrialExpiringNotification
-import com.woocommerce.android.notifications.local.LocalNotification.FreeTrialSurveyNotification
-import com.woocommerce.android.notifications.local.LocalNotification.UpgradeToPaidPlanNotification
-import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType
@@ -25,9 +19,6 @@ import com.woocommerce.android.ui.login.storecreation.installation.ObserveSiteIn
 import com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationViewModel.ViewState.ErrorState
 import com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationViewModel.ViewState.StoreCreationLoadingState
 import com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationViewModel.ViewState.SuccessState
-import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
-import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES
-import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -40,10 +31,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 @HiltViewModel
@@ -56,10 +44,7 @@ class StoreInstallationViewModel @Inject constructor(
     private val selectedSite: SelectedSite,
     private val storeInstallationLoadingTimer: StoreInstallationLoadingTimer,
     private val installationTransactionLauncher: InstallationTransactionLauncher,
-    private val observeSiteInstallation: ObserveSiteInstallation,
-    private val localNotificationScheduler: LocalNotificationScheduler,
-    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
-    private val accountStore: AccountStore
+    private val observeSiteInstallation: ObserveSiteInstallation
 ) : ScopedViewModel(savedStateHandle) {
 
     companion object {
@@ -117,8 +102,6 @@ class StoreInstallationViewModel @Inject constructor(
                 installationTransactionLauncher.onStoreInstalled(properties)
 
                 _viewState.update { SuccessState(newStoreWpAdminUrl) }
-
-                scheduleDeferredNotifications()
             }
 
             is InstallationState.Failure -> {
@@ -147,36 +130,6 @@ class StoreInstallationViewModel @Inject constructor(
             }
 
             InstallationState.InProgress -> Unit
-        }
-    }
-
-    private fun scheduleDeferredNotifications() {
-        launch {
-            if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES)) {
-                val in14days = LocalDateTime.now()
-                    .plusDays(TRIAL_LENGTH_IN_DAYS)
-                    .format(DateTimeFormatter.ofPattern("EEEE, MMMM d"))
-                localNotificationScheduler.scheduleNotification(
-                    FreeTrialExpiringNotification(in14days, selectedSite.get().siteId)
-                )
-            }
-
-            if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES)) {
-                val name = if (accountStore.account.firstName.isNotNullOrEmpty())
-                    accountStore.account.firstName
-                else
-                    accountStore.account.userName
-
-                localNotificationScheduler.scheduleNotification(
-                    FreeTrialExpiredNotification(name, selectedSite.get().siteId)
-                )
-            }
-            localNotificationScheduler.scheduleNotification(
-                UpgradeToPaidPlanNotification(selectedSite.get().siteId)
-            )
-            localNotificationScheduler.scheduleNotification(
-                FreeTrialSurveyNotification(selectedSite.get().siteId)
-            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -12,13 +12,10 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.extensions.isNotNullOrEmpty
-import com.woocommerce.android.notifications.local.LocalNotification.StoreCreationIncompleteNotification
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.support.help.HelpOrigin.STORE_CREATION
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
-import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
@@ -28,12 +25,12 @@ import com.woocommerce.android.viewmodel.SingleLiveEvent
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.store.AccountStore
 import javax.inject.Inject
 
 @HiltViewModel
+@Suppress("UnusedPrivateMember")
 class StoreNamePickerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     resourceProvider: ResourceProvider,
@@ -42,7 +39,7 @@ class StoreNamePickerViewModel @Inject constructor(
     private val prefsWrapper: AppPrefsWrapper,
     private val localNotificationScheduler: LocalNotificationScheduler,
     private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
-    private val accountStore: AccountStore
+    private val accountStore: AccountStore,
 ) : ScopedViewModel(savedStateHandle) {
     override val _event = SingleLiveEvent<Event>()
     override val event: LiveData<Event> = _event
@@ -103,21 +100,23 @@ class StoreNamePickerViewModel @Inject constructor(
     }
 
     private fun scheduleDeferredNotification() {
-        launch {
-            if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D)) {
-                val name = if (accountStore.account.firstName.isNotNullOrEmpty())
-                    accountStore.account.firstName
-                else
-                    accountStore.account.userName
+        // TODO To be removed. With the new store creation flow this notification is no longer needed
+//        launch {
+//            if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D)) {
+//                val name = if (accountStore.account.firstName.isNotNullOrEmpty())
+//                    accountStore.account.firstName
+//                else
+//                    accountStore.account.userName
 
-                localNotificationScheduler.scheduleNotification(
-                    StoreCreationIncompleteNotification(
-                        name,
-                        _viewState.value.storeName
-                    )
-                )
-            }
-        }
+//                localNotificationScheduler.scheduleNotification(
+//                    StoreCreationIncompleteNotification(
+//                        selected
+//                        name,
+//                        _viewState.value.storeName
+//                    )
+//                )
+//            }
+//        }
     }
 
     fun onPermissionRationaleDismissed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -7,7 +7,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.isNotNullOrEmpty
-import com.woocommerce.android.notifications.local.LocalNotification.StoreCreationFinishedNotification
+import com.woocommerce.android.notifications.local.LocalNotification.StoreCreationCompletedNotification
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_INCOMPLETE
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
@@ -78,7 +78,7 @@ class StoreCreationSummaryViewModel @Inject constructor(
                         )
                         triggerEvent(OnStoreCreationSuccess)
 
-                        manageDeferredNotifications()
+                        manageDeferredNotifications(creationState.siteId)
                     }
 
                     is Failed -> triggerEvent(OnStoreCreationFailure)
@@ -89,14 +89,14 @@ class StoreCreationSummaryViewModel @Inject constructor(
         }
     }
 
-    private fun manageDeferredNotifications() {
+    private fun manageDeferredNotifications(siteId: Long) {
         launch {
             if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_STORE_CREATION_READY)) {
                 val name = if (accountStore.account.firstName.isNotNullOrEmpty())
                     accountStore.account.firstName
                 else
                     accountStore.account.userName
-                localNotificationScheduler.scheduleNotification(StoreCreationFinishedNotification(name))
+                localNotificationScheduler.scheduleNotification(StoreCreationCompletedNotification(siteId, name))
             }
 
             // No need to display a notification to complete store creation anymore

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -55,6 +55,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Inject
 
 @HiltViewModel
+@Suppress("LongParameterList")
 class MainActivityViewModel @Inject constructor(
     savedState: SavedStateHandle,
     dispatchers: CoroutineDispatchers,
@@ -132,7 +133,7 @@ class MainActivityViewModel @Inject constructor(
             val currentSite = selectedSite.get()
             val isSiteSpecificNotification = it.remoteSiteId != 0L
             if (isSiteSpecificNotification && it.remoteSiteId != currentSite.siteId) {
-                changeSiteAndRestart(it.remoteSiteId, RestartActivityForNotification(localPushId, notification))
+                changeSiteAndRestart(it.remoteSiteId, RestartActivityForPushNotification(localPushId, notification))
             } else {
                 when (localPushId) {
                     it.getGroupPushId() -> onGroupMessageOpened(it.channelType, it.remoteSiteId)
@@ -177,11 +178,10 @@ class MainActivityViewModel @Inject constructor(
         }.exhaustive
     }
 
-    private fun changeSiteAndRestart(remoteSiteId: Long, restartEvent: Event) {
+    private fun changeSiteAndRestart(remoteSiteId: Long, restartEvent: RestartActivityEvent) {
         // Update selected store
         siteStore.getSiteBySiteId(remoteSiteId)?.let { updatedSite ->
             selectedSite.set(updatedSite)
-            // Recreate activity before showing notification
             triggerEvent(restartEvent)
         } ?: run {
             // If for any reason we can't get the store, show the default screen
@@ -276,21 +276,28 @@ class MainActivityViewModel @Inject constructor(
     }
 
     fun onLocalNotificationTapped(notification: Notification) {
-        AnalyticsTracker.track(
-            AnalyticsEvent.LOCAL_NOTIFICATION_TAPPED,
-            mapOf(AnalyticsTracker.KEY_TYPE to notification.tag)
-        )
-        LocalNotificationType.fromString(notification.tag)?.let {
-            when (it) {
-                STORE_CREATION_INCOMPLETE -> triggerEvent(ShortcutOpenStoreCreation(storeName = notification.data))
-                FREE_TRIAL_EXPIRED,
-                FREE_TRIAL_EXPIRING,
-                SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED -> triggerEvent(ViewStorePlanUpgrade(NOTIFICATION))
+        if (notification.remoteSiteId != selectedSite.get().siteId) {
+            changeSiteAndRestart(
+                notification.remoteSiteId,
+                RestartActivityForLocalNotification(notification)
+            )
+        } else {
+            AnalyticsTracker.track(
+                AnalyticsEvent.LOCAL_NOTIFICATION_TAPPED,
+                mapOf(AnalyticsTracker.KEY_TYPE to notification.tag)
+            )
+            LocalNotificationType.fromString(notification.tag)?.let {
+                when (it) {
+                    STORE_CREATION_INCOMPLETE -> triggerEvent(ShortcutOpenStoreCreation(storeName = notification.data))
+                    FREE_TRIAL_EXPIRED,
+                    FREE_TRIAL_EXPIRING,
+                    SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED -> triggerEvent(ViewStorePlanUpgrade(NOTIFICATION))
 
-                FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED -> triggerEvent(OpenFreeTrialSurvey)
+                    FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED -> triggerEvent(OpenFreeTrialSurvey)
 
-                STORE_CREATION_FINISHED,
-                THREE_DAYS_AFTER_STILL_EXPLORING -> {
+                    STORE_CREATION_FINISHED,
+                    THREE_DAYS_AFTER_STILL_EXPLORING -> {
+                    }
                 }
             }
         }
@@ -333,8 +340,14 @@ class MainActivityViewModel @Inject constructor(
     object ShortcutOpenOrderCreation : Event()
     data class ShortcutOpenStoreCreation(val storeName: String?) : Event()
     data class ViewStorePlanUpgrade(val source: PlanUpgradeStartSource) : Event()
-    data class RestartActivityForNotification(val pushId: Int, val notification: Notification) : Event()
-    data class RestartActivityForAppLink(val data: Uri) : Event()
+
+    sealed class RestartActivityEvent : Event()
+    data class RestartActivityForLocalNotification(val notification: Notification) : RestartActivityEvent()
+    data class RestartActivityForPushNotification(val pushId: Int, val notification: Notification) :
+        RestartActivityEvent()
+
+    data class RestartActivityForAppLink(val data: Uri) : RestartActivityEvent()
+
     data class ShowFeatureAnnouncement(val announcement: FeatureAnnouncement) : Event()
     data class ViewReviewDetail(val uniqueId: Long) : Event()
     data class ViewOrderDetail(val uniqueId: Long, val remoteNoteId: Long) : Event()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/StoreInstallationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/StoreInstallationViewModelTest.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.STORE_LOADING_FAILED
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.STORE_NOT_READY
@@ -18,7 +17,6 @@ import com.woocommerce.android.ui.login.storecreation.installation.StoreInstalla
 import com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationViewModel.ViewState.ErrorState
 import com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationViewModel.ViewState.StoreCreationLoadingState
 import com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationViewModel.ViewState.SuccessState
-import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -32,7 +30,6 @@ import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import kotlin.test.assertEquals
 
@@ -46,9 +43,6 @@ class StoreInstallationViewModelTest : BaseUnitTest() {
     private val storeInstallationLoadingTimer: StoreInstallationLoadingTimer = mock()
     private val installationTransactionLauncher: InstallationTransactionLauncher = mock()
     private val observeSiteInstallation: ObserveSiteInstallation = mock()
-    private val localNotificationScheduler: LocalNotificationScheduler = mock()
-    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled = mock()
-    private val accountStore: AccountStore = mock()
 
     private lateinit var viewModel: StoreInstallationViewModel
 
@@ -72,10 +66,7 @@ class StoreInstallationViewModelTest : BaseUnitTest() {
             selectedSite,
             storeInstallationLoadingTimer,
             installationTransactionLauncher,
-            observeSiteInstallation,
-            localNotificationScheduler,
-            isRemoteFeatureFlagEnabled,
-            accountStore
+            observeSiteInstallation
         )
         viewModel.viewState.observeForever {}
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -17,7 +17,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.profiler.StoreProfilerRepository
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.Hidden
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.UnseenReviews
-import com.woocommerce.android.ui.main.MainActivityViewModel.RestartActivityForNotification
+import com.woocommerce.android.ui.main.MainActivityViewModel.RestartActivityForPushNotification
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShortcutOpenOrderCreation
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShortcutOpenPayments
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShowFeatureAnnouncement
@@ -311,7 +311,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
 
         verify(selectedSite, atLeastOnce()).set(any())
         assertThat(viewModel.event.value)
-            .isEqualTo(RestartActivityForNotification(groupOrderPushId, orderNotification2))
+            .isEqualTo(RestartActivityForPushNotification(groupOrderPushId, orderNotification2))
     }
 
     @Test
@@ -324,7 +324,12 @@ class MainActivityViewModelTest : BaseUnitTest() {
         viewModel.handleIncomingNotification(reviewPushId, reviewNotification2)
 
         verify(selectedSite, atLeastOnce()).set(any())
-        assertThat(viewModel.event.value).isEqualTo(RestartActivityForNotification(reviewPushId, reviewNotification2))
+        assertThat(viewModel.event.value).isEqualTo(
+            RestartActivityForPushNotification(
+                reviewPushId,
+                reviewNotification2
+            )
+        )
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

This PR cherry-picks several fixes related to Store Creation Local notifications. This fixes have already been reviewed and tested in the following PRs, so this is just a new PR to bring those fixes into `release/15.2`. No need to review or test anything.
- Local notification support site switch: https://github.com/woocommerce/woocommerce-android/pull/9736
- Schedule local notifications sooner in the store creation flow: https://github.com/woocommerce/woocommerce-android/pull/9742
- Fix consecutive notification scheduling using `WorkManager`: https://github.com/woocommerce/woocommerce-android/pull/9744
