### PR TITLE
Tracking order products loaded

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -240,6 +240,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     ORDER_VIEW_CUSTOM_FIELDS_TAPPED,
     ORDER_DETAILS_SUBSCRIPTIONS_SHOWN,
     ORDER_DETAILS_GIFT_CARD_SHOWN,
+    ORDER_PRODUCTS_LOADED,
 
     // - Order detail editing
     ORDER_DETAIL_EDIT_FLOW_STARTED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -604,6 +604,9 @@ class AnalyticsTracker private constructor(
         const val KEY_BLAZE_SOURCE = "source"
         const val KEY_BLAZE_STEP = "step"
 
+        const val PRODUCT_TYPES = "product_types"
+        const val HAS_ADDONS = "has_addons"
+
         var sendUsageStats: Boolean = true
             set(value) {
                 if (value != field) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -200,6 +200,13 @@ class OrderDetailRepository @Inject constructor(
         } else 0
     }
 
+    suspend fun getUniqueProductTypes(remoteProductIds: List<Long>): String {
+        return if (remoteProductIds.isNotEmpty()) {
+            val products = productStore.getProductsByRemoteIds(selectedSite.get(), remoteProductIds)
+            products.map { product -> product.type }.toSet().joinToString()
+        } else ""
+    }
+
     fun hasSubscriptionProducts(remoteProductIds: List<Long>): Boolean {
         return if (remoteProductIds.isNotEmpty()) {
             productStore.getProductsByRemoteIds(selectedSite.get(), remoteProductIds)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderProduct.kt
@@ -3,14 +3,14 @@ package com.woocommerce.android.ui.orders.details
 import com.woocommerce.android.model.Order
 import javax.inject.Inject
 
-sealed class OrderProduct {
-    data class ProductItem(val product: Order.Item) : OrderProduct()
+sealed class OrderProduct(open val product: Order.Item) {
+    data class ProductItem(override val product: Order.Item) : OrderProduct(product)
 
     data class GroupedProductItem(
-        val product: Order.Item,
+        override val product: Order.Item,
         val children: List<ProductItem>,
         var isExpanded: Boolean = false
-    ) : OrderProduct()
+    ) : OrderProduct(product)
 }
 
 class OrderProductMapper @Inject constructor() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -158,7 +158,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     private fun createViewModel() {
         viewModel = spy(
             OrderDetailViewModel(
-                coroutinesTestRule.testDispatchers,
                 savedState,
                 appPrefsWrapper,
                 networkStatus,
@@ -1140,7 +1139,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             doReturn(orderStatus).whenever(orderDetailRepository).getOrderStatus(any())
             doReturn(orderStub).whenever(orderDetailRepository).getOrderById(any())
-            doReturn(orderStub).whenever(orderDetailRepository).fetchOrderById(any())
 
             var isMarkOrderCompleteButtonVisible: Boolean? = null
             viewModel.viewStateData.observeForever { _, new ->
@@ -1163,7 +1161,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             doReturn(orderStatus).whenever(orderDetailRepository).getOrderStatus(any())
             doReturn(orderStub).whenever(orderDetailRepository).getOrderById(any())
-            doReturn(orderStub).whenever(orderDetailRepository).fetchOrderById(any())
 
             var isMarkOrderCompleteButtonVisible: Boolean? = null
             viewModel.viewStateData.observeForever { _, new ->
@@ -1186,8 +1183,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             doReturn(orderStatus).whenever(orderDetailRepository).getOrderStatus(any())
             doReturn(orderStub).whenever(orderDetailRepository).getOrderById(any())
-            doReturn(orderStub).whenever(orderDetailRepository).fetchOrderById(any())
-
             var isMarkOrderCompleteButtonVisible: Boolean? = null
             viewModel.viewStateData.observeForever { _, new ->
                 isMarkOrderCompleteButtonVisible = new.isMarkOrderCompleteButtonVisible
@@ -1208,7 +1203,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             val orderStub = order.copy(datePaid = Date(), status = orderStatusStub!!)
 
             doReturn(orderStub).whenever(orderDetailRepository).getOrderById(any())
-            doReturn(orderStub).whenever(orderDetailRepository).fetchOrderById(any())
             doReturn(orderStatus.copy(statusKey = CoreOrderStatus.COMPLETED.value)).whenever(
                 orderDetailRepository
             ).getOrderStatus(any())
@@ -1233,7 +1227,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             doReturn(orderStatus).whenever(orderDetailRepository).getOrderStatus(any())
             doReturn(orderStub).whenever(orderDetailRepository).getOrderById(any())
-            doReturn(orderStub).whenever(orderDetailRepository).fetchOrderById(any())
 
             var isMarkOrderCompleteButtonVisible: Boolean? = null
             viewModel.viewStateData.observeForever { _, new ->
@@ -1256,7 +1249,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             doReturn(orderStatus).whenever(orderDetailRepository).getOrderStatus(any())
             doReturn(orderStub).whenever(orderDetailRepository).getOrderById(any())
-            doReturn(orderStub).whenever(orderDetailRepository).fetchOrderById(any())
 
             var isMarkOrderCompleteButtonVisible: Boolean? = null
             viewModel.viewStateData.observeForever { _, new ->
@@ -1279,7 +1271,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             doReturn(orderStatus).whenever(orderDetailRepository).getOrderStatus(any())
             doReturn(orderStub).whenever(orderDetailRepository).getOrderById(any())
-            doReturn(orderStub).whenever(orderDetailRepository).fetchOrderById(any())
 
             var isMarkOrderCompleteButtonVisible: Boolean? = null
             viewModel.viewStateData.observeForever { _, new ->
@@ -1302,7 +1293,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             doReturn(orderStatus).whenever(orderDetailRepository).getOrderStatus(any())
             doReturn(orderStub).whenever(orderDetailRepository).getOrderById(any())
-            doReturn(orderStub).whenever(orderDetailRepository).fetchOrderById(any())
 
             var isMarkOrderCompleteButtonVisible: Boolean? = null
             viewModel.viewStateData.observeForever { _, new ->
@@ -1338,7 +1328,6 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         testBlocking {
             // Given
             doReturn(order).whenever(orderDetailRepository).getOrderById(any())
-            doReturn(order).whenever(orderDetailRepository).fetchOrderById(any())
             viewModel.start()
 
             // When

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1868,4 +1868,54 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         verify(giftCardRepository, never()).fetchGiftCardSummaryByOrderId(any(), anyOrNull())
     }
+
+    @Test
+    fun `when the order is opened then track order loaded with right types and add-ons`() = testBlocking {
+        val items = OrderTestUtils.generateTestOrderItems(count = 2)
+        val testOrder = order.copy(items = items)
+        val types = "simple, bundle"
+        val hasAddons = true
+        doReturn(testOrder).whenever(orderDetailRepository).getOrderById(any())
+        doReturn(types).whenever(orderDetailRepository).getUniqueProductTypes(any())
+        doReturn(hasAddons).whenever(addonsRepository).containsAddonsFrom(any())
+        doReturn(testOrder).whenever(orderDetailRepository).fetchOrderById(any())
+        doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
+        createViewModel()
+
+        viewModel.start()
+
+        verify(analyticsTraWrapper).track(
+            stat = AnalyticsEvent.ORDER_PRODUCTS_LOADED,
+            properties = mapOf(
+                AnalyticsTracker.KEY_ID to order.id,
+                AnalyticsTracker.PRODUCT_TYPES to types,
+                AnalyticsTracker.HAS_ADDONS to hasAddons
+            )
+        )
+    }
+
+    @Test
+    fun `when the order is opened then track order loaded with right types and add-ons 2`() = testBlocking {
+        val items = OrderTestUtils.generateTestOrderItems(count = 2)
+        val testOrder = order.copy(items = items)
+        val types = "simple, variable"
+        val hasAddons = false
+        doReturn(testOrder).whenever(orderDetailRepository).getOrderById(any())
+        doReturn(types).whenever(orderDetailRepository).getUniqueProductTypes(any())
+        doReturn(hasAddons).whenever(addonsRepository).containsAddonsFrom(any())
+        doReturn(testOrder).whenever(orderDetailRepository).fetchOrderById(any())
+        doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
+        createViewModel()
+
+        viewModel.start()
+
+        verify(analyticsTraWrapper).track(
+            stat = AnalyticsEvent.ORDER_PRODUCTS_LOADED,
+            properties = mapOf(
+                AnalyticsTracker.KEY_ID to order.id,
+                AnalyticsTracker.PRODUCT_TYPES to types,
+                AnalyticsTracker.HAS_ADDONS to hasAddons
+            )
+        )
+    }
 }


### PR DESCRIPTION
Closes: #9755

### Why
We are working on the Extensions Support Milestone 2. To better prioritize the extensions we want to support in the app, it'd be great to understand how often they are used in the orders/products viewed by the merchants. We want to know the top priority extensions sorted by active store count in the last 30 days that also use mobile.

### Description
This PR adds the `ORDER_PRODUCTS_LOADED` event to track the product types included in an order and whether this order has add-ons.

`ORDER_PRODUCTS_LOADED` -> Event with the properties:
- `PRODUCT_TYPES` String containing the product types included in the order separated by `,`
- `HAS_ADDONS` if any of the products contains add-ons 

Event registration : https://github.com/Automattic/tracks-events-registration/pull/1829

### Testing instructions
- Open the Orders List
- Tap on any order
- Check that the `ORDER_PRODUCTS_LOADED` is triggered with the right info (product types and add-ons)

### Images/gif
```
🔵 Tracked: order_products_loaded, Properties: {"id":215,"product_types":"simple","has_addons":true,"blog_id":222408976,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"wooexpress-small-bundle-yearly","is_debug":true,"site_url":"https:\/\/woo-practically-automatic-witch.wpcomstaging.com"}
```


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
