### PR TITLE
Update product detail loaded

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -160,6 +160,7 @@ class AnalyticsTracker private constructor(
         const val KEY_PRODUCT_ID = "product_id"
         const val KEY_PRODUCT_COUNT = "product_count"
         const val KEY_HAS_LINKED_PRODUCTS = "has_linked_products"
+        const val KEY_HAS_MIN_MAX_QUANTITY_RULES = "has_min_max_quantity_rules"
         const val KEY_IS_LOADING_MORE = "is_loading_more"
         const val KEY_IS_WPCOM_STORE = "is_wpcom_store"
         const val KEY_NAME = "name"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_DETAIL_DUPLICATE
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_BLAZE_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HAS_LINKED_PRODUCTS
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HAS_MIN_MAX_QUANTITY_RULES
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUCTS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUCT_FORM
@@ -1313,9 +1314,15 @@ class ProductDetailViewModel @Inject constructor(
      */
     private fun trackProductDetailLoaded() {
         if (hasTrackedProductDetailLoaded.not()) {
-            storedProduct.value?.let {
-                val properties = mapOf(KEY_HAS_LINKED_PRODUCTS to it.hasLinkedProducts())
-                tracker.track(AnalyticsEvent.PRODUCT_DETAIL_LOADED, properties)
+            storedProduct.value?.let { product ->
+                launch {
+                    val hasQuantityRules = getProductQuantityRules(product.remoteId) != null
+                    val properties = mapOf(
+                        KEY_HAS_LINKED_PRODUCTS to product.hasLinkedProducts(),
+                        KEY_HAS_MIN_MAX_QUANTITY_RULES to hasQuantityRules
+                    )
+                    tracker.track(AnalyticsEvent.PRODUCT_DETAIL_LOADED, properties)
+                }
             } ?: run {
                 tracker.track(AnalyticsEvent.PRODUCT_DETAIL_LOADED)
             }


### PR DESCRIPTION
Closes: #9760

### Why
We are working on the Extensions Support Milestone 2. To better prioritize the extensions we want to support in the app, it'd be great to understand how often they are used in the orders/products viewed by the merchants. We want to know the top priority extensions sorted by active store count in the last 30 days that also use mobile.

### Description
This PR updates the `PRODUCT_DETAIL_LOADED` event to track whether the product contains quantity rules.

`PRODUCT_DETAIL_LOADED` -> Event with the new property:
- `HAS_MIN_MAX_QUANTITY_RULES ` New property indicating whether the product contains quantity rules 

Event registration : https://github.com/Automattic/tracks-events-registration/pull/1830

### Testing instructions
TC1
- Open the Product List
- Tap on a product with quantity rules
- Check that the `PRODUCT_DETAIL_LOADED`  and that `HAS_MIN_MAX_QUANTITY_RULES` is true

TC2
- Open the Product List
- Tap on a product without quantity rules
- Check that the `PRODUCT_DETAIL_LOADED`  and that `HAS_MIN_MAX_QUANTITY_RULES` is false


### Images/gif
```
🔵 Tracked: product_detail_loaded, Properties: {"has_linked_products":false,"has_min_max_quantity_rules":true,"blog_id":214253715,"is_wpcom_store":true,"was_ecommerce_trial":false,"plan_product_slug":"ecommerce-bundle","is_debug":true,"site_url":"https:\/\/superlativecentaur.wpcomstaging.com"}
```

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
