### PR TITLE
[Manual Taxes M2] Fix for initial page fetching

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateRepository.kt
@@ -7,9 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.taxes.WCTaxRestClient.TaxRateModel
 import org.wordpress.android.fluxc.store.WCTaxStore
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class TaxRateRepository @Inject constructor(
     private val selectedSite: SelectedSite,
     private val taxStore: WCTaxStore,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateRepository.kt
@@ -26,6 +26,7 @@ class TaxRateRepository @Inject constructor(
      * @return A [Boolean] indicating whether more items can be fetched.
      */
     suspend fun fetchTaxRates(page: Int, pageSize: Int): Result<Boolean> {
+        if (page == 1) _taxRates.value = emptyList()
         return taxStore.fetchTaxRateList(selectedSite.get(), page, pageSize).let { result ->
             if (result.isError) {
                 Result.failure(WooException(result.error))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateRepository.kt
@@ -24,7 +24,6 @@ class TaxRateRepository @Inject constructor(
      * @return A [Boolean] indicating whether more items can be fetched.
      */
     suspend fun fetchTaxRates(page: Int, pageSize: Int): Result<Boolean> {
-        if (page == 1) _taxRates.value = emptyList()
         return taxStore.fetchTaxRateList(selectedSite.get(), page, pageSize).let { result ->
             if (result.isError) {
                 Result.failure(WooException(result.error))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
## [Manual Taxes M2] Fix for initial page fetching

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
There is a bug related fetching initial page of tax rates - the results were being duplicated when entering tax rate selector and exiting multiple times due to the fact the `TaxRateRepository` is a Singleton. 
This PR fixes this behavior by resetting the list of rates (cached in memory) in case we are requesting the initial page.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Test if rates are loading properly while entering and exiting the rates selector multiple times.

### Visual changes
| Before | After |
|---|---|
|<video src=https://github.com/woocommerce/woocommerce-android/assets/4527432/e87f44e7-0aff-4fdc-ab97-cc218762d483/>|<video src=https://github.com/woocommerce/woocommerce-android/assets/4527432/21bf2e14-ab8e-4e99-a7a0-269d28a51983/>|

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
