### PR TITLE
[UI Tests] Don't show feature announcement if running a test.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -110,6 +110,7 @@ import com.woocommerce.android.ui.products.ProductListFragmentDirections
 import com.woocommerce.android.ui.reviews.ReviewListFragmentDirections
 import com.woocommerce.android.ui.sitepicker.SitePickerFragmentDirections
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.util.WooAnimUtils.animateBottomBar
 import com.woocommerce.android.util.WooPermissionUtils
@@ -891,8 +892,10 @@ class MainActivity :
     }
 
     private fun navigateToFeatureAnnouncement(event: ShowFeatureAnnouncement) {
-        val action = NavGraphMainDirections.actionOpenWhatsnewFromMain(event.announcement)
-        navController.navigateSafely(action)
+        if (!PackageUtils.isTesting()) {
+            val action = NavGraphMainDirections.actionOpenWhatsnewFromMain(event.announcement)
+            navController.navigateSafely(action)
+        }
     }
 
     private fun navigateToWebView(event: ViewUrlInWebView) {


### PR DESCRIPTION
### Description

This feature announcement dialog might be shown after a login:

<img width="258" alt="Screenshot 2023-09-12 at 13 34 57" src="https://github.com/woocommerce/woocommerce-android/assets/73365754/3973bf82-a445-4cd2-87a3-d256361fee36">

However, it's not shown for _every_ version, and even if _it is_ shown, it's only for the very first test in the run. Because of this, waiting for it at the end of the login flow in order to dismiss it "manually" would be wasteful time-wise.

As suggested at p1694514984711379-slack-C6H8C3G23, this is solved by not showing the dialog at all if the app is running tests. 

### Testing instructions
CI is 🍏