### PR TITLE
Enable `ORDER_CREATION_TAX_RATE_SELECTOR` feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] [Internal] In-Person Payments: Fixed tracking of the country for the cases when IPP onboarding is not finished [https://github.com/woocommerce/woocommerce-android/pull/9764]
 - [**] [Internal] In-Person Payments: if WcPay setup not finished then we allow a user to finish it from the app [https://github.com/woocommerce/woocommerce-android/pull/9732]
+- [**] Order creation: Merchants can now select a tax rate when creating an order [https://github.com/woocommerce/woocommerce-android/pull/9773]
 
 15.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -42,12 +42,12 @@ enum class FeatureFlag {
             PRIVACY_CHOICES,
             BLAZE,
             ORDER_CREATION_PRODUCT_DISCOUNTS,
-            SHIPPING_ZONES -> true
+            SHIPPING_ZONES,
+            ORDER_CREATION_TAX_RATE_SELECTOR -> true
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
-            BETTER_CUSTOMER_SEARCH_M2,
-            ORDER_CREATION_TAX_RATE_SELECTOR -> PackageUtils.isDebugBuild()
+            BETTER_CUSTOMER_SEARCH_M2 -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Enabling ORDER_CREATION_TAX_RATE_SELECTOR feature flag

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR enables ORDER_CREATION_TAX_RATE_SELECTOR feature flag in order to release the Tax Rate selector in the order creation screen (Manual Taxes Milestone 2).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The scope of the feature has already been reviewed and tested. You can smoke test the tax rate selector functionality:
* Create an order:
1. Verify the "Set new tax rate" button is not visible in case the taxes are based on store address
2. Verify it is visible otherwise
3. Click on the "Set new tax rate" button and select a tax rate
4. Verify the selected tax rate address data are added to the customer billing/shipping address

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
