### PR TITLE
[Manual Taxes M3] Bottom bar with auto-rate switch

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorFragment.kt
@@ -40,7 +40,8 @@ class TaxRateSelectorFragment : BaseFragment() {
                     viewModel::onTaxRateSelected,
                     viewModel::onDismissed,
                     viewModel::onLoadMore,
-                    viewModel::onEditTaxRatesInAdminClicked
+                    viewModel::onEditTaxRatesInAdminClicked,
+                    viewModel::onAutoRateSwitchStateChanged,
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorFragment.kt
@@ -57,7 +57,6 @@ class TaxRateSelectorFragment : BaseFragment() {
                 is TaxRateSelectorViewModel.EditTaxRatesInAdmin -> {
                     args.dialogState.taxRatesSettingsUrl.let {
                         ChromeCustomTabUtils.launchUrl(requireContext(), it)
-                        findNavController().navigateUp()
                     }
                 }
                 is TaxRateSelectorViewModel.ShowTaxesInfoDialog -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.creation.taxes.rates
 
 import android.os.Parcelable
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -107,11 +108,16 @@ class TaxRateSelectorViewModel @Inject constructor(
         }
     }
 
+    fun onAutoRateSwitchStateChanged(selected: Boolean) {
+        Log.d("TaxRateSelectorViewModel", "onAutoRateToggleStateChanged: $selected")
+    }
+
     @Parcelize
     data class ViewState(
         val taxRates: List<TaxRateUiModel> = emptyList(),
         val isLoading: Boolean = false,
         val isEmpty: Boolean = taxRates.isEmpty() && !isLoading,
+        val isAutoRateEnabled: Boolean = false
     ) : Parcelable
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -23,7 +23,8 @@ enum class FeatureFlag {
     ORDER_CREATION_PRODUCT_DISCOUNTS,
     SHIPPING_ZONES,
     BETTER_CUSTOMER_SEARCH_M2,
-    ORDER_CREATION_TAX_RATE_SELECTOR;
+    ORDER_CREATION_TAX_RATE_SELECTOR,
+    ORDER_CREATION_AUTO_TAX_RATE;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -47,7 +48,8 @@ enum class FeatureFlag {
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
-            ORDER_CREATION_TAX_RATE_SELECTOR -> PackageUtils.isDebugBuild()
+            ORDER_CREATION_TAX_RATE_SELECTOR,
+            ORDER_CREATION_AUTO_TAX_RATE -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3618,5 +3618,7 @@
     <string name="tax_rate_selector_empty_list_message">Add tax rates in admin. Only tax rates with location information will be shown here.</string>
     <string name="tax_rate_selector_empty_list_button">Edit Tax Rates in Admin</string>
     <string name="tax_rate_selector_empty_list_button_alt">Edit Tax Rates</string>
+    <string name="tax_rate_selector_auto_rate_label">Add this rate to all created orders</string>
+    <string name="tax_rate_selector_auto_rate_subtitle">This will not affect online orders</string>
 
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the footer with an auto-rate setting switch. It's just a pure UI code in this PR.
The footer is hidden under the feature flag `ORDER_CREATION_AUTO_TAX_RATE`.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Verify the footer matches the designs: ue2M9WUgbPdPk8Up5Sxzby-fi-52%3A8554.


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Dark|Light|
|---|---|
|<img width=300 src=https://github.com/woocommerce/woocommerce-android/assets/4527432/1adc23cc-0cc8-479d-8f65-1194ebc6978b/>|<img width=300 src=https://github.com/woocommerce/woocommerce-android/assets/4527432/4d98a1df-c8b2-41a3-a75e-68fb16216565/>|

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->