### PR TITLE
Remove StoreCreationIncompleteNotification from codebase

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -39,25 +39,6 @@ sealed class LocalNotification(
         }
     }
 
-    data class StoreCreationIncompleteNotification(
-        override val siteId: Long,
-        val name: String,
-        val storeName: String
-    ) : LocalNotification(
-        siteId = siteId,
-        title = R.string.local_notification_without_free_trial_title,
-        description = R.string.local_notification_without_free_trial_description,
-        type = LocalNotificationType.STORE_CREATION_INCOMPLETE,
-        delay = 24,
-        delayUnit = TimeUnit.HOURS
-    ) {
-        override val data: String = storeName
-
-        override fun getDescriptionString(resourceProvider: ResourceProvider): String {
-            return resourceProvider.getString(description, name, storeName)
-        }
-    }
-
     data class FreeTrialExpiringNotification(
         val expiryDate: String,
         override val siteId: Long

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationType.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.notifications.local
 
 enum class LocalNotificationType(val value: String) {
     STORE_CREATION_FINISHED("store_creation_complete"),
-    STORE_CREATION_INCOMPLETE("one_day_after_store_creation_name_without_free_trial"),
     FREE_TRIAL_EXPIRING("one_day_before_free_trial_expires"),
     FREE_TRIAL_EXPIRED("one_day_after_free_trial_expires"),
     SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED("six_hours_after_free_trial_subscribed"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TR
 import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED
 import com.woocommerce.android.notifications.local.LocalNotificationType.SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED
 import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_FINISHED
-import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_INCOMPLETE
 import com.woocommerce.android.notifications.local.LocalNotificationType.THREE_DAYS_AFTER_STILL_EXPLORING
 import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
 import com.woocommerce.android.util.WooLogWrapper
@@ -39,8 +38,7 @@ class PreconditionCheckWorker @AssistedInject constructor(
         val type = LocalNotificationType.fromString(inputData.getString(LOCAL_NOTIFICATION_TYPE))
         val siteId = inputData.getLong(LOCAL_NOTIFICATION_SITE_ID, 0L)
         return when (type) {
-            STORE_CREATION_FINISHED,
-            STORE_CREATION_INCOMPLETE -> Result.success()
+            STORE_CREATION_FINISHED -> Result.success()
 
             FREE_TRIAL_EXPIRING,
             FREE_TRIAL_EXPIRED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModel.kt
@@ -12,10 +12,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.support.help.HelpOrigin.STORE_CREATION
 import com.woocommerce.android.ui.login.storecreation.NewStore
-import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
@@ -26,7 +24,6 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
-import org.wordpress.android.fluxc.store.AccountStore
 import javax.inject.Inject
 
 @HiltViewModel
@@ -36,10 +33,7 @@ class StoreNamePickerViewModel @Inject constructor(
     resourceProvider: ResourceProvider,
     private val newStore: NewStore,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val prefsWrapper: AppPrefsWrapper,
-    private val localNotificationScheduler: LocalNotificationScheduler,
-    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
-    private val accountStore: AccountStore,
+    private val prefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     override val _event = SingleLiveEvent<Event>()
     override val event: LiveData<Event> = _event
@@ -94,29 +88,7 @@ class StoreNamePickerViewModel @Inject constructor(
 
     fun onContinueClicked() {
         newStore.update(name = _viewState.value.storeName)
-
-        scheduleDeferredNotification()
         triggerEvent(NavigateToStoreProfiler)
-    }
-
-    private fun scheduleDeferredNotification() {
-        // TODO To be removed. With the new store creation flow this notification is no longer needed
-//        launch {
-//            if (isRemoteFeatureFlagEnabled(LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D)) {
-//                val name = if (accountStore.account.firstName.isNotNullOrEmpty())
-//                    accountStore.account.firstName
-//                else
-//                    accountStore.account.userName
-
-//                localNotificationScheduler.scheduleNotification(
-//                    StoreCreationIncompleteNotification(
-//                        selected
-//                        name,
-//                        _viewState.value.storeName
-//                    )
-//                )
-//            }
-//        }
     }
 
     fun onPermissionRationaleDismissed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.notifications.local.LocalNotification.FreeTrialSu
 import com.woocommerce.android.notifications.local.LocalNotification.StoreCreationCompletedNotification
 import com.woocommerce.android.notifications.local.LocalNotification.UpgradeToPaidPlanNotification
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler
-import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_INCOMPLETE
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Failed
 import com.woocommerce.android.ui.login.storecreation.CreateFreeTrialStore.StoreCreationState.Finished
@@ -132,9 +131,6 @@ class StoreCreationSummaryViewModel @Inject constructor(
             localNotificationScheduler.scheduleNotification(
                 FreeTrialSurveyNotification(siteId)
             )
-
-            // No need to display a notification to complete store creation anymore
-            localNotificationScheduler.cancelScheduledNotification(STORE_CREATION_INCOMPLETE)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -37,7 +37,6 @@ import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.navOptions
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.google.android.material.appbar.AppBarLayout
 import com.woocommerce.android.AppPrefs
@@ -83,7 +82,6 @@ import com.woocommerce.android.ui.main.MainActivityViewModel.RestartActivityForL
 import com.woocommerce.android.ui.main.MainActivityViewModel.RestartActivityForPushNotification
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShortcutOpenOrderCreation
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShortcutOpenPayments
-import com.woocommerce.android.ui.main.MainActivityViewModel.ShortcutOpenStoreCreation
 import com.woocommerce.android.ui.main.MainActivityViewModel.ShowFeatureAnnouncement
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewMyStoreStats
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewOrderDetail
@@ -768,7 +766,6 @@ class MainActivity :
                 is ShowFeatureAnnouncement -> navigateToFeatureAnnouncement(event)
                 is ViewUrlInWebView -> navigateToWebView(event)
                 is RequestNotificationsPermission -> requestNotificationsPermission()
-                is ShortcutOpenStoreCreation -> shortcutOpenStoreCreation(event.storeName)
                 is ViewStorePlanUpgrade -> startUpgradeFlowFactory.create(navController).invoke(event.source)
                 ViewPayments -> showPayments()
                 ViewTapToPay -> showTapToPaySummary()
@@ -805,22 +802,6 @@ class MainActivity :
         navController.navigateSafely(
             NavGraphMainDirections.actionGlobalFreeTrialSurveyFragment()
         )
-    }
-
-    private fun shortcutOpenStoreCreation(storeName: String?) {
-        navController.apply {
-            navigate(
-                NavGraphMainDirections.actionGlobalLoginToSitePickerFragment(
-                    openedFromLogin = AppPrefs.getStoreCreationSource() != AnalyticsTracker.VALUE_SWITCHING_STORE
-                )
-            )
-            navigate(
-                SitePickerFragmentDirections.actionSitePickerFragmentToStoreCreationNativeFlow(storeName),
-                navOptions {
-                    popUpTo(R.id.sitePickerFragment) { inclusive = true }
-                }
-            )
-        }
     }
 
     private fun observeNotificationsPermissionBarVisibility() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -106,7 +106,6 @@ import com.woocommerce.android.ui.prefs.RequestedAnalyticsValue
 import com.woocommerce.android.ui.products.ProductDetailFragment
 import com.woocommerce.android.ui.products.ProductListFragmentDirections
 import com.woocommerce.android.ui.reviews.ReviewListFragmentDirections
-import com.woocommerce.android.ui.sitepicker.SitePickerFragmentDirections
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -22,7 +22,6 @@ import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TR
 import com.woocommerce.android.notifications.local.LocalNotificationType.FREE_TRIAL_SURVEY_24H_AFTER_FREE_TRIAL_SUBSCRIBED
 import com.woocommerce.android.notifications.local.LocalNotificationType.SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED
 import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_FINISHED
-import com.woocommerce.android.notifications.local.LocalNotificationType.STORE_CREATION_INCOMPLETE
 import com.woocommerce.android.notifications.local.LocalNotificationType.THREE_DAYS_AFTER_STILL_EXPLORING
 import com.woocommerce.android.notifications.push.NotificationMessageHandler
 import com.woocommerce.android.tools.SelectedSite
@@ -288,7 +287,6 @@ class MainActivityViewModel @Inject constructor(
             )
             LocalNotificationType.fromString(notification.tag)?.let {
                 when (it) {
-                    STORE_CREATION_INCOMPLETE -> triggerEvent(ShortcutOpenStoreCreation(storeName = notification.data))
                     FREE_TRIAL_EXPIRED,
                     FREE_TRIAL_EXPIRING,
                     SIX_HOURS_AFTER_FREE_TRIAL_SUBSCRIBED -> triggerEvent(ViewStorePlanUpgrade(NOTIFICATION))
@@ -338,7 +336,6 @@ class MainActivityViewModel @Inject constructor(
     data class ViewUrlInWebView(val url: String) : Event()
     object ShortcutOpenPayments : Event()
     object ShortcutOpenOrderCreation : Event()
-    data class ShortcutOpenStoreCreation(val storeName: String?) : Event()
     data class ViewStorePlanUpgrade(val source: PlanUpgradeStartSource) : Event()
 
     sealed class RestartActivityEvent : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.util
 import com.woocommerce.android.config.WPComRemoteFeatureFlagRepository
 import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES
 import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES
-import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D
 import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_STORE_CREATION_READY
 import com.woocommerce.android.util.RemoteFeatureFlag.WOO_BLAZE
 import javax.inject.Inject
@@ -14,7 +13,6 @@ class IsRemoteFeatureFlagEnabled @Inject constructor(
     suspend operator fun invoke(featureFlag: RemoteFeatureFlag): Boolean {
         return when (featureFlag) {
             LOCAL_NOTIFICATION_STORE_CREATION_READY,
-            LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D,
             LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES,
             LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES,
             WOO_BLAZE ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/RemoteFeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/RemoteFeatureFlag.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.util
 
 enum class RemoteFeatureFlag(val remoteKey: String) {
     LOCAL_NOTIFICATION_STORE_CREATION_READY("woo_notification_store_creation_ready"),
-    LOCAL_NOTIFICATION_NUDGE_FREE_TRIAL_AFTER_1D("woo_notification_nudge_free_trial_after_1d"),
     LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES("woo_notification_1d_before_free_trial_expires"),
     LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES("woo_notification_1d_after_free_trial_expires"),
     WOO_BLAZE("woo_blaze")

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3505,8 +3505,6 @@
     -->
     <string name="local_notification_store_creation_complete_title">🎉 Your store is ready!</string>
     <string name="local_notification_store_creation_complete_description">Hi %1$s! Welcome to your 14-day free trial of Woo Express – everything you need to start and grow a successful online business, all in one place. Ready to explore?</string>
-    <string name="local_notification_without_free_trial_title">🛍️ Your store is waiting!</string>
-    <string name="local_notification_without_free_trial_description">Hi %1$s, %2$s is ready for you! Start your 14-day free trial of Woo Express right in just one click to start your online business.  </string>
     <string name="local_notification_one_day_before_free_trial_expires_title">⏰ Time’s running out on your free trial!</string>
     <string name="local_notification_one_day_before_free_trial_expires_description">Your free trial of Woo Express ends tomorrow (%1$s). Now’s the time to own your future – pick a plan and get ready to grow.</string>
     <string name="local_notification_one_day_after_free_trial_expires_title">🌟 Keep your business going with our plan!</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/name/StoreNamePickerViewModelTest.kt
@@ -5,10 +5,8 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.login.storecreation.name.StoreNamePickerViewModel.NavigateToStoreProfiler
-import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -21,7 +19,6 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.wordpress.android.fluxc.store.AccountStore
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class StoreNamePickerViewModelTest : BaseUnitTest() {
@@ -29,9 +26,6 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
     private lateinit var analyticsTracker: AnalyticsTrackerWrapper
     private lateinit var prefsWrapper: AppPrefsWrapper
     private val savedState = SavedStateHandle()
-    private val localNotificationScheduler: LocalNotificationScheduler = mock()
-    private val accountStore: AccountStore = mock()
-    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled = mock()
     private val resourceProvider: ResourceProvider = mock {
         on { getString(any()) } doAnswer { it.arguments[0].toString() }
     }
@@ -45,10 +39,7 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
             resourceProvider = resourceProvider,
             newStore = mock(),
             analyticsTrackerWrapper = analyticsTracker,
-            prefsWrapper = prefsWrapper,
-            localNotificationScheduler,
-            isRemoteFeatureFlagEnabled,
-            accountStore
+            prefsWrapper = prefsWrapper
         )
     }
 
@@ -80,10 +71,7 @@ internal class StoreNamePickerViewModelTest : BaseUnitTest() {
             resourceProvider = resourceProvider,
             newStore = mock(),
             analyticsTrackerWrapper = analyticsTracker,
-            prefsWrapper = prefsWrapper,
-            localNotificationScheduler,
-            isRemoteFeatureFlagEnabled,
-            accountStore
+            prefsWrapper = prefsWrapper
         )
 
         var latestEvent: MultiLiveEvent.Event? = null


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9739 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Removes `StoreCreationIncompleteNotification` from codebase. With the current store creation flow were we have a single step before creating the free trial store, this notification was not being scheduled anymore. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
There's really nothing to test here as this notification was not being scheduled anymore. Checking that the app compiles and all the checks pass is enough. 
