### PR TITLE
[Manual Taxes M3] Update TaxRate files to reflect changes in FluxC ( TaxRateModel rename to Dto ) 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRate.kt
@@ -5,7 +5,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class TaxRate(
-    val id: Int,
+    val id: Long,
     val countryCode: String = "",
     val stateCode: String = "",
     val postcode: String = "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateListHandler.kt
@@ -12,8 +12,7 @@ class TaxRateListHandler @Inject constructor(private val repository: TaxRateRepo
 
     val taxRatesFlow: Flow<List<TaxRate>> = repository.observeTaxRates()
 
-    suspend fun fetchTaxRates(
-    ): Result<Unit> = mutex.withLock {
+    suspend fun fetchTaxRates(): Result<Unit> = mutex.withLock {
         // Reset pagination attributes
         page = 1
         canLoadMore = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateRepository.kt
@@ -2,9 +2,10 @@ package com.woocommerce.android.ui.orders.creation.taxes.rates
 
 import com.woocommerce.android.WooException
 import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.taxes.WCTaxRestClient.TaxRateModel
+import kotlinx.coroutines.flow.map
+import org.wordpress.android.fluxc.model.taxes.TaxRateEntity
 import org.wordpress.android.fluxc.store.WCTaxStore
 import javax.inject.Inject
 
@@ -12,9 +13,6 @@ class TaxRateRepository @Inject constructor(
     private val selectedSite: SelectedSite,
     private val taxStore: WCTaxStore,
 ) {
-    private val _taxRates: MutableStateFlow<List<TaxRate>> = MutableStateFlow(emptyList())
-    val taxRates: Flow<List<TaxRate>> = _taxRates
-
     /**
      * Fetches the tax rates for the selected site.
      *
@@ -23,34 +21,42 @@ class TaxRateRepository @Inject constructor(
      *
      * @return A [Boolean] indicating whether more items can be fetched.
      */
-    suspend fun fetchTaxRates(page: Int, pageSize: Int): Result<Boolean> {
-        return taxStore.fetchTaxRateList(selectedSite.get(), page, pageSize).let { result ->
-            if (result.isError) {
-                Result.failure(WooException(result.error))
-            } else {
-                val taxRates = result.model!!.toAppModel()
-                _taxRates.value += taxRates
-                Result.success(taxRates.size == pageSize)
+    suspend fun fetchTaxRates(
+        page: Int,
+        pageSize: Int
+    ): Result<Boolean> {
+        return taxStore.fetchTaxRateList(selectedSite.get(), page, pageSize)
+            .let { result ->
+                if (result.isError) {
+                    Result.failure(WooException(result.error))
+                } else {
+                    Result.success(result.model!!)
+                }
             }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun observeTaxRates(): Flow<List<TaxRate>> = taxStore.observeTaxRates(selectedSite.get()).map {
+        it.map { taxRateEntity ->
+            taxRateEntity.toAppModel()
         }
     }
 
-    private fun Collection<TaxRateModel>.toAppModel() = map {
+    fun TaxRateEntity.toAppModel(): TaxRate =
         TaxRate(
-            id = it.id,
-            name = it.name ?: "",
-            rate = it.rate ?: "",
-            shipping = it.shipping ?: false,
-            compound = it.compound ?: false,
-            order = it.order ?: 0,
-            taxClass = it.taxClass ?: "",
-            postcode = it.postcode ?: "",
-            city = it.city ?: "",
-            priority = it.priority ?: 0,
-            countryCode = it.country ?: "",
-            stateCode = it.state ?: "",
-            postCodes = it.postCodes,
-            cities = it.cities,
+            id = id.value,
+            countryCode = country ?: "",
+            stateCode = state ?: "",
+            postcode = postcode ?: "",
+            city = city ?: "",
+            postCodes = null,
+            cities = null,
+            rate = rate ?: "",
+            name = name ?: "",
+            priority = 0,
+            compound = false,
+            shipping = false,
+            order = 0,
+            taxClass = taxClass ?: "",
         )
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateRepository.kt
@@ -21,10 +21,7 @@ class TaxRateRepository @Inject constructor(
      *
      * @return A [Boolean] indicating whether more items can be fetched.
      */
-    suspend fun fetchTaxRates(
-        page: Int,
-        pageSize: Int
-    ): Result<Boolean> {
+    suspend fun fetchTaxRates(page: Int, pageSize: Int): Result<Boolean> {
         return taxStore.fetchTaxRateList(selectedSite.get(), page, pageSize)
             .let { result ->
                 if (result.isError) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorViewModel.kt
@@ -87,6 +87,7 @@ class TaxRateSelectorViewModel @Inject constructor(
         triggerEvent(EditTaxRatesInAdmin)
         tracker.track(AnalyticsEvent.TAX_RATE_SELECTOR_EDIT_IN_ADMIN_TAPPED)
     }
+
     fun onInfoIconClicked() {
         triggerEvent(ShowTaxesInfoDialog)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-cba33c07f3c8d935fbf56b2c3cfa92d6af0ebf99'
+    fluxCVersion = 'trunk-f8f31bf520a86f145866940e714d187ffd098e44'
     wooCommerceSharedVersion = '0.6.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9767 
<!-- Id number of the GitHub issue this PR addresses. -->

Please review and merge this PR together with its counterpart in FluxC: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2852

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the app to reflect the changes related to FluxC. Moving it to Room

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Log into a site that has a long list of taxes
2. go to orders
3. create new order
4. add a product
5. click on the `set new tax rate` button
6. Make sure the screen loads all the taxes, loading icon works, etc

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

 <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/e5ea47d1-2f57-4d6d-8d35-0415101f6689" width="350"/> 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
