### PR TITLE
Specify android agent in Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,9 @@ common_params:
       files: "WooCommerce/build/buildkite-test-analytics/*.xml"
       format: "junit"
 
+agents:
+  queue: "android"
+
 steps:
   - label: "Gradle Wrapper Validation"
     command: |
@@ -45,7 +48,7 @@ steps:
 
   - label: "Unit tests"
     command: .buildkite/commands/run-unit-tests.sh
-    plugins: 
+    plugins:
       - *ci_toolkit
       - *test_collector :
           <<: *test_collector_common_params
@@ -67,7 +70,7 @@ steps:
 
   - label: "Instrumented tests"
     command: .buildkite/commands/run-instrumented-tests.sh
-    plugins: 
+    plugins:
       - *ci_toolkit
       - *test_collector :
           <<: *test_collector_common_params


### PR DESCRIPTION
We are already using `android` agent for this pipeline, but having it specified in the `.buildkite/pipeline.yml` file will make it easier to programmatically change it.

I am working on a small bash script that will make it easier to test `android-staging` changes such as [this one](https://github.com/wordpress-mobile/WordPress-Android/pull/18773) and this change will help keep that script simple.