### PR TITLE
Shorten 15.4 CHANGELOG from 519 characters to 393 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
 ## 15.4
-In this update of the WooCommerce app, we've prioritized enhancing your user experience. Merchants can now select a tax rate when creating an order and add downloadable files from all supported file types during product editing. We've improved In-Person Payments; if WcPay setup isn't finished, users can now complete it from the app. Minor updates include a fix for tracking the country when IPP onboarding isn't finished and an explanation screen before opening the Payments task. Enjoy your enhanced WooCommerce app.
+Merchants can now select a tax rate when creating an order and add downloadable files from all supported file types during product editing. We've improved In-Person Payments; if WcPay setup isn't finished, users can now complete it from the app. Minor updates include a fix for tracking the country when IPP onboarding isn't finished and an explanation screen before opening the Payments task.
 
 ## 15.3
 We're excited to roll out the latest update for our Android App. This release brings general improvements for a smoother, faster, and more user-friendly experience. Enjoy enhanced performance, a streamlined interface, and bug fixes. Happy selling!


### PR DESCRIPTION
I realized that the changelog was over the 500 character Play Store limit after I approved https://github.com/woocommerce/woocommerce-android/pull/9786. Since the first and last sentences are somewhat of a filler, I thought we could remove them both to leave some room for translations for more verbose languages.