### PR TITLE
Product Creation with AI: entry bottom sheet

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/BottomSheetHandle.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/BottomSheetHandle.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.ui.compose.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import com.woocommerce.android.R.dimen
+
+@Composable
+fun BottomSheetHandle(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .background(
+                color = MaterialTheme.colors.onSurface.copy(alpha = 0.4f),
+                shape = RoundedCornerShape(dimensionResource(id = dimen.major_150))
+            )
+            .size(
+                width = dimensionResource(id = dimen.major_200),
+                height = dimensionResource(id = dimen.minor_50)
+            )
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Toolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Toolbar.kt
@@ -131,7 +131,7 @@ fun Toolbar(
 @Composable
 fun Toolbar(
     modifier: Modifier = Modifier,
-    title: @Composable () -> Unit = {},
+    title: @Composable () -> Unit,
     onNavigationButtonClick: (() -> Unit)? = null,
     navigationIcon: ImageVector? = null,
     navigationIconContentDescription: String = stringResource(id = string.back),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingFragment.kt
@@ -103,9 +103,8 @@ class StoreOnboardingFragment : BaseFragment() {
                 is StoreOnboardingViewModel.NavigateToAddProduct ->
                     with(addProductNavigator) {
                         findNavController().navigateToAddProducts(
-                            // TODO replace with correct NavDirections when implemented
                             aiBottomSheetAction = StoreOnboardingFragmentDirections
-                                .actionStoreOnboardingFragmentToProductTypesBottomSheet(),
+                                .actionStoreOnboardingFragmentToAddProductWithAIBottomSheet(),
                             typesBottomSheetAction = StoreOnboardingFragmentDirections
                                 .actionStoreOnboardingFragmentToProductTypesBottomSheet()
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/WooPaymentsSetupCelebrationDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/payments/WooPaymentsSetupCelebrationDialog.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,9 +33,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.navigation.findNavController
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.BottomSheetHandle
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -80,17 +79,7 @@ private fun WooPaymentsSetupCelebrationScreen(
                 .padding(horizontal = dimensionResource(id = R.dimen.major_100))
         ) {
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_50)))
-            Box(
-                modifier = Modifier
-                    .background(
-                        color = MaterialTheme.colors.onSurface.copy(alpha = 0.4f),
-                        shape = RoundedCornerShape(dimensionResource(id = R.dimen.major_150))
-                    )
-                    .size(
-                        width = dimensionResource(id = R.dimen.major_200),
-                        height = dimensionResource(id = R.dimen.minor_50)
-                    )
-            )
+            BottomSheetHandle()
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
             Box(
                 modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -318,8 +318,7 @@ class MyStoreFragment :
             is StoreOnboardingViewModel.NavigateToAddProduct ->
                 with(addProductNavigator) {
                     findNavController().navigateToAddProducts(
-                        // TODO replace with correct NavDirections when implemented
-                        aiBottomSheetAction = MyStoreFragmentDirections.actionMyStoreToProductTypesBottomSheet(),
+                        aiBottomSheetAction = MyStoreFragmentDirections.actionDashboardToAddProductWithAIBottomSheet(),
                         typesBottomSheetAction = MyStoreFragmentDirections.actionMyStoreToProductTypesBottomSheet()
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/AddProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/AddProductNavigator.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.products
 
-import android.widget.Toast
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import com.woocommerce.android.extensions.isEligibleForAI
@@ -21,8 +20,6 @@ class AddProductNavigator @Inject constructor(
             selectedSite.get().isEligibleForAI &&
             !hasNonSampleProducts()
         ) {
-            // TODO remove this when the bottom sheet is implemented
-            Toast.makeText(context, "Will show product creation with AI bottom sheet", Toast.LENGTH_SHORT).show()
             navigateSafely(aiBottomSheetAction)
         } else {
             navigateSafely(typesBottomSheetAction)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -721,10 +721,7 @@ class ProductListFragment :
     private fun showAddProductBottomSheet() {
         with(addProductNavigator) {
             findNavController().navigateToAddProducts(
-                // TODO replace with correct NavDirections when implemented
-                aiBottomSheetAction = ProductListFragmentDirections.actionProductListFragmentToProductTypesBottomSheet(
-                    isAddProduct = true
-                ),
+                aiBottomSheetAction = ProductListFragmentDirections.actionProductsToAddProductWithAIBottomSheet(),
                 typesBottomSheetAction = ProductListFragmentDirections
                     .actionProductListFragmentToProductTypesBottomSheet(
                         isAddProduct = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIBottomSheet.kt
@@ -66,7 +66,9 @@ class AddProductWithAIBottomSheet : WCBottomSheetDialogFragment() {
     }
 
     private fun showAICreationFlow() {
-        // TODO
+        findNavController().navigateSafely(
+            AddProductWithAIBottomSheetDirections.actionAddProductWithAIBottomSheetToAddProductWithAIFragment()
+        )
     }
 
     private fun showManualCreationFlow() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIBottomSheet.kt
@@ -4,9 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -34,10 +32,15 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.compose.URL_ANNOTATION_TAG
 import com.woocommerce.android.ui.compose.annotatedStringRes
+import com.woocommerce.android.ui.compose.component.BottomSheetHandle
 import com.woocommerce.android.ui.compose.theme.WooTheme
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 
 class AddProductWithAIBottomSheet : WCBottomSheetDialogFragment() {
@@ -76,18 +79,7 @@ private fun AddProductWithAIContent(
                 .fillMaxWidth()
         ) {
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
-            Box(
-                modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .background(
-                        color = MaterialTheme.colors.onSurface.copy(alpha = 0.4f),
-                        shape = RoundedCornerShape(dimensionResource(id = R.dimen.major_150))
-                    )
-                    .size(
-                        width = dimensionResource(id = R.dimen.major_200),
-                        height = dimensionResource(id = R.dimen.minor_50)
-                    )
-            )
+            BottomSheetHandle(Modifier.align(Alignment.CenterHorizontally))
             Text(
                 text = stringResource(id = R.string.product_creation_ai_entry_sheet_header),
                 color = colorResource(id = R.color.color_on_surface_medium),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIBottomSheet.kt
@@ -56,15 +56,34 @@ class AddProductWithAIBottomSheet : WCBottomSheetDialogFragment() {
             setContent {
                 WooTheme {
                     AddProductWithAIContent(
-                        onAIClick = { /*TODO*/ },
-                        onManualClick = { /*TODO*/ },
-                        onLearnMoreClick = { /*TODO*/ }
+                        onAIClick = { showAICreationFlow() },
+                        onManualClick = { showManualCreationFlow() },
+                        onLearnMoreClick = { openAIGuidelinesPage() }
                     )
                 }
             }
         }
     }
 
+    private fun showAICreationFlow() {
+        // TODO
+    }
+
+    private fun showManualCreationFlow() {
+        findNavController().navigateSafely(
+            AddProductWithAIBottomSheetDirections
+                .actionAddProductWithAIBottomSheetToProductTypesBottomSheetFragment(
+                    isAddProduct = true
+                )
+        )
+    }
+
+    private fun openAIGuidelinesPage() {
+        ChromeCustomTabUtils.launchUrl(
+            requireContext(),
+            AppUrls.AUTOMATTIC_AI_GUIDELINES
+        )
+    }
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIBottomSheet.kt
@@ -1,13 +1,16 @@
 package com.woocommerce.android.ui.products.ai
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -31,6 +34,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.AppUrls
@@ -40,6 +44,7 @@ import com.woocommerce.android.ui.compose.URL_ANNOTATION_TAG
 import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.BottomSheetHandle
 import com.woocommerce.android.ui.compose.theme.WooTheme
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 
@@ -165,13 +170,22 @@ private fun BottomSheetButton(
 }
 
 @Composable
-@Preview
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "small screen", device = Devices.PIXEL)
+@Preview(name = "mid screen", device = Devices.PIXEL_4)
+@Preview(name = "large screen", device = Devices.NEXUS_10)
 private fun AddProductWithAIContentPreview() {
-    WooTheme {
-        AddProductWithAIContent(
-            onAIClick = {},
-            onManualClick = {},
-            onLearnMoreClick = {},
-        )
+    WooThemeWithBackground {
+        Box(
+            contentAlignment = Alignment.BottomCenter,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            AddProductWithAIContent(
+                onAIClick = {},
+                onManualClick = {},
+                onLearnMoreClick = {},
+            )
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIBottomSheet.kt
@@ -1,0 +1,185 @@
+package com.woocommerce.android.ui.products.ai
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.URL_ANNOTATION_TAG
+import com.woocommerce.android.ui.compose.annotatedStringRes
+import com.woocommerce.android.ui.compose.theme.WooTheme
+import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
+
+class AddProductWithAIBottomSheet : WCBottomSheetDialogFragment() {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooTheme {
+                    AddProductWithAIContent(
+                        onAIClick = { /*TODO*/ },
+                        onManualClick = { /*TODO*/ },
+                        onLearnMoreClick = { /*TODO*/ }
+                    )
+                }
+            }
+        }
+    }
+
+}
+
+@Composable
+private fun AddProductWithAIContent(
+    onAIClick: () -> Unit,
+    onManualClick: () -> Unit,
+    onLearnMoreClick: () -> Unit
+) {
+    Surface(
+        shape = RoundedCornerShape(
+            topStart = dimensionResource(id = R.dimen.minor_100),
+            topEnd = dimensionResource(id = R.dimen.minor_100)
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+        ) {
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .background(
+                        color = MaterialTheme.colors.onSurface.copy(alpha = 0.4f),
+                        shape = RoundedCornerShape(dimensionResource(id = R.dimen.major_150))
+                    )
+                    .size(
+                        width = dimensionResource(id = R.dimen.major_200),
+                        height = dimensionResource(id = R.dimen.minor_50)
+                    )
+            )
+            Text(
+                text = stringResource(id = R.string.product_creation_ai_entry_sheet_header),
+                color = colorResource(id = R.color.color_on_surface_medium),
+                modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))
+            )
+
+            BottomSheetButton(
+                title = stringResource(id = R.string.product_creation_ai_entry_sheet_ai_option_title),
+                subtitle = stringResource(id = R.string.product_creation_ai_entry_sheet_ai_option_subtitle),
+                icon = painterResource(id = R.drawable.ic_ai),
+                onClick = onAIClick,
+                iconTint = MaterialTheme.colors.primary
+            )
+
+            Spacer(Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+
+            val learnMoreText = annotatedStringRes(stringResId = R.string.product_creation_ai_entry_sheet_learn_more)
+            ClickableText(
+                text = learnMoreText,
+                style = MaterialTheme.typography.caption.copy(
+                    color = colorResource(id = R.color.color_on_surface_medium)
+                ),
+                modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_325))
+            ) {
+                learnMoreText.getStringAnnotations(tag = URL_ANNOTATION_TAG, start = it, end = it)
+                    .firstOrNull()
+                    ?.let { onLearnMoreClick() }
+            }
+
+            Divider(Modifier.padding(dimensionResource(id = R.dimen.major_100)))
+
+            BottomSheetButton(
+                title = stringResource(id = R.string.product_creation_ai_entry_sheet_manual_option_title),
+                subtitle = stringResource(id = R.string.product_creation_ai_entry_sheet_manual_option_subtitle),
+                icon = painterResource(id = R.drawable.ic_gridicon_circle_plus),
+                onClick = onManualClick
+            )
+
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        }
+    }
+}
+
+@Composable
+private fun BottomSheetButton(
+    title: String,
+    subtitle: String,
+    icon: Painter,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    iconTint: Color = Color.Unspecified
+) {
+    Row(
+        modifier
+            .clickable(onClick = onClick)
+            .padding(
+                vertical = dimensionResource(id = R.dimen.minor_100),
+                horizontal = dimensionResource(id = R.dimen.major_100)
+            )
+    ) {
+        Icon(
+            painter = icon,
+            contentDescription = null,
+            tint = iconTint,
+            modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_50))
+        )
+
+        Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.major_100)))
+
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.subtitle1,
+                color = colorResource(id = R.color.color_on_surface_high)
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.body2,
+                color = colorResource(id = R.color.color_on_surface_medium)
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun AddProductWithAIContentPreview() {
+    WooTheme {
+        AddProductWithAIContent(
+            onAIClick = {},
+            onManualClick = {},
+            onLearnMoreClick = {},
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIFragment.kt
@@ -7,9 +7,11 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -27,6 +29,18 @@ class AddProductWithAIFragment : BaseFragment() {
                 WooThemeWithBackground {
                     AddProductWithAIScreen(viewModel)
                 }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        handleEvents()
+    }
+
+    private fun handleEvents() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                Exit -> findNavController().navigateUp()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIFragment.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.products.ai
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class AddProductWithAIFragment : BaseFragment() {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    private val viewModel: AddProductWithAIViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    AddProductWithAIScreen(viewModel)
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
@@ -5,15 +5,21 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCTextButton
 
 @Composable
 fun AddProductWithAIScreen(viewModel: AddProductWithAIViewModel) {
@@ -36,7 +42,20 @@ fun AddProductWithAIScreen(
         topBar = {
             Toolbar(
                 navigationIcon = if (state.isFirstStep) Icons.Filled.Clear else Icons.Filled.ArrowBack,
-                onNavigationButtonClick = onBackButtonClick
+                onNavigationButtonClick = onBackButtonClick,
+                actions = {
+                    when (state.saveButtonState) {
+                        AddProductWithAIViewModel.SaveButtonState.Shown -> WCTextButton(onClick = { /*TODO*/ }) {
+                            Text(text = "Save as draft") // TODO localize this
+                        }
+
+                        AddProductWithAIViewModel.SaveButtonState.Loading -> CircularProgressIndicator(
+                            modifier = Modifier.size(dimensionResource(id = R.dimen.major_150))
+                        )
+
+                        else -> {} // No-op
+                    }
+                }
             )
         }
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products.ai
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Scaffold
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
@@ -15,10 +17,12 @@ import com.woocommerce.android.ui.compose.component.Toolbar
 
 @Composable
 fun AddProductWithAIScreen(viewModel: AddProductWithAIViewModel) {
+    BackHandler(onBack = viewModel::onBackButtonClick)
+
     viewModel.state.observeAsState().value?.let {
         AddProductWithAIScreen(
             state = it,
-            onDismissClick = viewModel::onDismissClick
+            onBackButtonClick = viewModel::onBackButtonClick
         )
     }
 }
@@ -26,13 +30,13 @@ fun AddProductWithAIScreen(viewModel: AddProductWithAIViewModel) {
 @Composable
 fun AddProductWithAIScreen(
     state: AddProductWithAIViewModel.State,
-    onDismissClick: () -> Unit
+    onBackButtonClick: () -> Unit
 ) {
     Scaffold(
         topBar = {
             Toolbar(
-                navigationIcon = Icons.Filled.Clear,
-                onNavigationButtonClick = onDismissClick
+                navigationIcon = if (state.isFirstStep) Icons.Filled.Clear else Icons.Filled.ArrowBack,
+                onNavigationButtonClick = onBackButtonClick
             )
         }
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
@@ -54,8 +54,8 @@ fun AddProductWithAIScreen(
 }
 
 @Composable
-private fun SubScreen(subViewModel: AddProductWithAISubViewModel<*>) {
+private fun SubScreen(subViewModel: AddProductWithAISubViewModel<*>, modifier: Modifier) {
     when (subViewModel) {
-        else -> {}
+        is ProductNameSubViewModel -> ProductNameSubScreen(subViewModel, modifier)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
@@ -1,0 +1,61 @@
+package com.woocommerce.android.ui.products.ai
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.Scaffold
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import com.woocommerce.android.ui.compose.component.Toolbar
+
+@Composable
+fun AddProductWithAIScreen(viewModel: AddProductWithAIViewModel) {
+    viewModel.state.observeAsState().value?.let {
+        AddProductWithAIScreen(
+            state = it,
+            onDismissClick = viewModel::onDismissClick
+        )
+    }
+}
+
+@Composable
+fun AddProductWithAIScreen(
+    state: AddProductWithAIViewModel.State,
+    onDismissClick: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            Toolbar(
+                navigationIcon = Icons.Filled.Clear,
+                onNavigationButtonClick = onDismissClick
+            )
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(it)
+        ) {
+            LinearProgressIndicator(progress = state.progress, modifier = Modifier.fillMaxWidth())
+
+            SubScreen(
+                subViewModel = state.subViewModel,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+private fun SubScreen(subViewModel: AddProductWithAISubViewModel<*>) {
+    when (subViewModel) {
+        else -> {}
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAISubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAISubViewModel.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.products.ai
+
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import java.io.Closeable
+
+sealed interface AddProductWithAISubViewModel<T> : Closeable {
+    val events: Flow<Event>
+        get() = emptyFlow()
+    val onDone: (T) -> Unit
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -22,12 +22,18 @@ class AddProductWithAIViewModel @Inject constructor(
 ) : ScopedViewModel(savedState = savedStateHandle) {
     private val step = savedStateHandle.getStateFlow(viewModelScope, Step.ProductName)
     private val subViewModels = listOf<AddProductWithAISubViewModel<*>>(
-        // TODO add subViewModels
+        ProductNameSubViewModel(
+            savedStateHandle = savedStateHandle,
+            onDone = {
+                // Pass the name to next ViewModel if needed
+                step.value = Step.AboutProduct
+            }
+        ),
     )
 
     val state = step.map {
         State(
-            progress = it.ordinal.toFloat() / Step.values().size,
+            progress = (it.ordinal + 1).toFloat() / Step.values().size,
             subViewModel = subViewModels[it.ordinal]
         )
     }.asLiveData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -32,7 +32,7 @@ class AddProductWithAIViewModel @Inject constructor(
 
     val state = combine(step, saveButtonState) { step, saveButtonState ->
         State(
-            progress = (step.ordinal + 1).toFloat() / Step.values().size,
+            progress = step.order.toFloat() / Step.values().size,
             subViewModel = subViewModels[step.ordinal],
             isFirstStep = step.ordinal == 0,
             saveButtonState = saveButtonState
@@ -44,7 +44,7 @@ class AddProductWithAIViewModel @Inject constructor(
     }
 
     fun onBackButtonClick() {
-        if (step.value.ordinal == 0) {
+        if (step.value.order == 1) {
             triggerEvent(Exit)
         } else {
             goToPreviousStep()
@@ -52,13 +52,13 @@ class AddProductWithAIViewModel @Inject constructor(
     }
 
     private fun goToNextStep() {
-        require(step.value.ordinal < Step.values().size - 1)
-        step.value = Step.values()[step.value.ordinal + 1]
+        require(step.value.order < Step.values().size)
+        step.value = Step.getValueForOrder(step.value.order + 1)
     }
 
     private fun goToPreviousStep() {
-        require(step.value.ordinal > 0)
-        step.value = Step.values()[step.value.ordinal - 1]
+        require(step.value.ordinal > 1)
+        step.value = Step.getValueForOrder(step.value.order - 1)
     }
 
     private fun wireSubViewModels() {
@@ -82,8 +82,13 @@ class AddProductWithAIViewModel @Inject constructor(
     enum class SaveButtonState {
         Hidden, Shown, Loading
     }
-}
 
-private enum class Step {
-    ProductName, AboutProduct, Preview
+    @Suppress("MagicNumber")
+    private enum class Step(val order: Int) {
+        ProductName(1), AboutProduct(2), Preview(3);
+
+        companion object {
+            fun getValueForOrder(order: Int) = values().first { it.order == order }
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -3,17 +3,13 @@ package com.woocommerce.android.ui.products.ai
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import java.io.Closeable
 import javax.inject.Inject
 
 @HiltViewModel
@@ -26,7 +22,7 @@ class AddProductWithAIViewModel @Inject constructor(
             savedStateHandle = savedStateHandle,
             onDone = {
                 // Pass the name to next ViewModel if needed
-                step.value = Step.AboutProduct
+                goToNextStep()
             }
         ),
     )
@@ -34,7 +30,8 @@ class AddProductWithAIViewModel @Inject constructor(
     val state = step.map {
         State(
             progress = (it.ordinal + 1).toFloat() / Step.values().size,
-            subViewModel = subViewModels[it.ordinal]
+            subViewModel = subViewModels[it.ordinal],
+            isFirstStep = it.ordinal == 0
         )
     }.asLiveData()
 
@@ -42,8 +39,22 @@ class AddProductWithAIViewModel @Inject constructor(
         wireSubViewModels()
     }
 
-    fun onDismissClick() {
-        triggerEvent(Exit)
+    fun onBackButtonClick() {
+        if (step.value.ordinal == 0) {
+            triggerEvent(Exit)
+        } else {
+            goToPreviousStep()
+        }
+    }
+
+    private fun goToNextStep() {
+        require(step.value.ordinal < Step.values().size - 1)
+        step.value = Step.values()[step.value.ordinal + 1]
+    }
+
+    private fun goToPreviousStep() {
+        require(step.value.ordinal > 0)
+        step.value = Step.values()[step.value.ordinal - 1]
     }
 
     private fun wireSubViewModels() {
@@ -59,16 +70,11 @@ class AddProductWithAIViewModel @Inject constructor(
 
     data class State(
         val progress: Float,
-        val subViewModel: AddProductWithAISubViewModel<*>
+        val subViewModel: AddProductWithAISubViewModel<*>,
+        val isFirstStep: Boolean
     )
 }
 
 private enum class Step {
     ProductName, AboutProduct, Preview
-}
-
-sealed interface AddProductWithAISubViewModel<T> : Closeable {
-    val events: Flow<MultiLiveEvent.Event>
-        get() = emptyFlow()
-    val onDone: (T) -> Unit
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -1,0 +1,68 @@
+package com.woocommerce.android.ui.products.ai
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import java.io.Closeable
+import javax.inject.Inject
+
+@HiltViewModel
+class AddProductWithAIViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedState = savedStateHandle) {
+    private val step = savedStateHandle.getStateFlow(viewModelScope, Step.ProductName)
+    private val subViewModels = listOf<AddProductWithAISubViewModel<*>>(
+        // TODO add subViewModels
+    )
+
+    val state = step.map {
+        State(
+            progress = it.ordinal.toFloat() / Step.values().size,
+            subViewModel = subViewModels[it.ordinal]
+        )
+    }.asLiveData()
+
+    init {
+        wireSubViewModels()
+    }
+
+    fun onDismissClick() {
+        triggerEvent(Exit)
+    }
+
+    private fun wireSubViewModels() {
+        subViewModels.forEach { subViewModel ->
+            addCloseable(subViewModel)
+
+            subViewModel.events
+                .onEach {
+                    triggerEvent(it)
+                }.launchIn(viewModelScope)
+        }
+    }
+
+    data class State(
+        val progress: Float,
+        val subViewModel: AddProductWithAISubViewModel<*>
+    )
+}
+
+private enum class Step {
+    ProductName, AboutProduct, Preview
+}
+
+sealed interface AddProductWithAISubViewModel<T> : Closeable {
+    val events: Flow<MultiLiveEvent.Event>
+        get() = emptyFlow()
+    val onDone: (T) -> Unit
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.ui.products.ai
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ProductNameSubScreen(viewModel: ProductNameSubViewModel, modifier: Modifier) {
+    Column(modifier = modifier.background(MaterialTheme.colors.surface)) {
+        Text(text = "The product name step")
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Button(onClick = viewModel::onDoneClick) {
+            Text(text = "Continue")
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubViewModel.kt
@@ -1,0 +1,35 @@
+package com.woocommerce.android.ui.products.ai
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import com.woocommerce.android.viewmodel.getStateFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.map
+
+class ProductNameSubViewModel(
+    savedStateHandle: SavedStateHandle,
+    override val onDone: (String) -> Unit
+) : AddProductWithAISubViewModel<String> {
+    private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    private val name = savedStateHandle.getStateFlow(viewModelScope, "")
+
+    val state = name.map {
+        UiState(it)
+    }.asLiveData()
+
+    fun onDoneClick() {
+        onDone(name.value)
+    }
+
+    override fun close() {
+        viewModelScope.cancel()
+    }
+
+    data class UiState(
+        val name: String
+    )
+}

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -674,7 +674,9 @@
         android:label="AddProductWithAIBottomSheet" >
         <action
             android:id="@+id/action_addProductWithAIBottomSheet_to_productTypesBottomSheetFragment"
-            app:destination="@id/productTypesBottomSheetFragment" />
+            app:destination="@id/productTypesBottomSheetFragment"
+            app:popUpTo="@id/addProductWithAIBottomSheet"
+            app:popUpToInclusive="true" />
         <action
             android:id="@+id/action_addProductWithAIBottomSheet_to_addProductWithAIFragment"
             app:destination="@id/addProductWithAIFragment" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -675,5 +675,12 @@
         <action
             android:id="@+id/action_addProductWithAIBottomSheet_to_productTypesBottomSheetFragment"
             app:destination="@id/productTypesBottomSheetFragment" />
+        <action
+            android:id="@+id/action_addProductWithAIBottomSheet_to_addProductWithAIFragment"
+            app:destination="@id/addProductWithAIFragment" />
     </dialog>
+    <fragment
+        android:id="@+id/addProductWithAIFragment"
+        android:name="com.woocommerce.android.ui.products.ai.AddProductWithAIFragment"
+        android:label="AddProductWithAIFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -80,6 +80,9 @@
         <action
             android:id="@+id/action_myStore_to_nameYourStoreDialogFragment"
             app:destination="@id/nameYourStoreDialogFragment" />
+        <action
+            android:id="@+id/action_dashboard_to_addProductWithAIBottomSheet"
+            app:destination="@id/addProductWithAIBottomSheet" />
     </fragment>
     <fragment
         android:id="@+id/orders"
@@ -553,6 +556,9 @@
             android:id="@+id/action_storeOnboardingFragment_to_wooPaymentsSetupInstructionsFragment"
             app:destination="@id/wooPaymentsSetupInstructionsFragment"
             app:popUpTo="@id/dashboard" />
+        <action
+            android:id="@+id/action_storeOnboardingFragment_to_addProductWithAIBottomSheet"
+            app:destination="@id/addProductWithAIBottomSheet" />
     </fragment>
     <dialog
         android:id="@+id/privacyBannerFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -180,6 +180,9 @@
                 android:defaultValue="false"
                 app:argType="boolean" />
         </action>
+        <action
+            android:id="@+id/action_products_to_addProductWithAIBottomSheet"
+            app:destination="@id/addProductWithAIBottomSheet" />
     </fragment>
     <fragment
         android:id="@+id/reviews"
@@ -658,5 +661,13 @@
             android:name="fromOnboarding"
             app:argType="boolean"
             android:defaultValue="false" />
+    </dialog>
+    <dialog
+        android:id="@+id/addProductWithAIBottomSheet"
+        android:name="com.woocommerce.android.ui.products.ai.AddProductWithAIBottomSheet"
+        android:label="AddProductWithAIBottomSheet" >
+        <action
+            android:id="@+id/action_addProductWithAIBottomSheet_to_productTypesBottomSheetFragment"
+            app:destination="@id/productTypesBottomSheetFragment" />
     </dialog>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1890,6 +1890,12 @@
     <string name="product_category_selector_search_failed">Searching product categories failed</string>
     <string name="product_list_multiselect">Select multiple</string>
     <string name="product_detail_menu_item_promote_with_blaze">Promote with Blaze</string>
+    <string name="product_creation_ai_entry_sheet_header">Add a product</string>
+    <string name="product_creation_ai_entry_sheet_ai_option_title">Create a product with AI</string>
+    <string name="product_creation_ai_entry_sheet_ai_option_subtitle">Quickly generate details for you</string>
+    <string name="product_creation_ai_entry_sheet_manual_option_title">Add manually</string>
+    <string name="product_creation_ai_entry_sheet_manual_option_subtitle">Add a product and the details manually</string>
+    <string name="product_creation_ai_entry_sheet_learn_more">Powered by AI. &lt;a href=\'guidelines\'&gt;&lt;u&gt;Learn more&lt;/u&gt;&lt;/a&gt;.</string>
     <!--
         Product Add more details Bottom sheet
     -->
@@ -3621,5 +3627,4 @@
     <string name="tax_rate_selector_empty_list_button_alt">Edit Tax Rates</string>
     <string name="tax_rate_selector_auto_rate_label">Add this rate to all created orders</string>
     <string name="tax_rate_selector_auto_rate_subtitle">This will not affect online orders</string>
-
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9790 

⚠️ Please don't merge yet

### Description
This PR adds the entry bottom sheet for the Product Creation with AI, it's based on the work of the previous PR #9798.

### Testing instructions
##### Eligible site
1. Use an eligible site (a WPCom site or a Jetpack site that supports Jetpack Assistant AI)
2. Open the app.
3. From the onboarding screen, click on "Add your first product"
4. Confirm it shows the new Bottom sheet.
5. Click on "Learn more", confirm it opens the correct guidelines page.
6. Click on "Add manually", confirm it opens the regular product creation bottom sheet.
7. Go back, then go to products list.
8. Click on "Add" button.
9. Repeat 4 to 6.

##### Non-eligible site
1. Using a non-eligible site (either a self-hosted site that doesn't have Jetpack Assistant AI, or a site that already contains products) 
2. Open the app.
3. From both the onboarding and the products list screens, start the product creation flow.
4. Confirm it uses the regular flow.

### Images/gif
<img width=360 src="https://github.com/woocommerce/woocommerce-android/assets/1657201/53e72126-5bcb-4027-aecf-59f9ff4e1ebc" />

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
