### PR TITLE
Disable ShippingZones feature

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -245,7 +245,8 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         binding.storeSettingsContainer.isVisible = binding.optionInstallJetpack.isVisible ||
             binding.optionDomain.isVisible ||
             binding.optionStoreOnboardingListVisibility.isVisible ||
-            binding.shippingClasses.isVisible
+            binding.shippingClasses.isVisible ||
+            binding.optionStoreName.isVisible
 
         binding.optionStoreName.setOnClickListener {
             findNavController()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -43,7 +43,6 @@ enum class FeatureFlag {
             PRIVACY_CHOICES,
             BLAZE,
             ORDER_CREATION_PRODUCT_DISCOUNTS,
-            SHIPPING_ZONES,
             ORDER_CREATION_TAX_RATE_SELECTOR -> true
 
             MORE_MENU_INBOX,
@@ -51,6 +50,7 @@ enum class FeatureFlag {
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE -> PackageUtils.isDebugBuild()
 
+            SHIPPING_ZONES,
             IAP_FOR_STORE_CREATION -> false
         }
     }


### PR DESCRIPTION
# Why

As per the latest React Native announcement pe5pgL-3H5-p2, this PR disables the "Shipping Classes" feature built React Native. 

@wzieba will be removing all the RN code and infrastructure when he comes back from his AFK time.

# How

- Set the `SHIPPING_ZONES` feature flag to false.
- Make sure the `Store Name Setting` keeps being visible. It wasn't considered when defining the store setting section visibility.

# Screenshots

Before | After
--- | ---
<img width="293" alt="remove-shipping" src="https://github.com/woocommerce/woocommerce-android/assets/562080/7c0bb04a-22c5-4214-af95-1ca7ef26582c"> | <img width="286" alt="add-shipping" src="https://github.com/woocommerce/woocommerce-android/assets/562080/c24a4ab7-d58b-413a-9f3f-de70678903fe">

# Testing Instructions
- Navigate to settings
- Make sure the "Shipping Zones" row under the "Store Settings" section is not visible


<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
