### PR TITLE
Product Creation with AI: MainViewModel

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Toolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Toolbar.kt
@@ -131,7 +131,7 @@ fun Toolbar(
 @Composable
 fun Toolbar(
     modifier: Modifier = Modifier,
-    title: @Composable () -> Unit = {},
+    title: @Composable () -> Unit,
     onNavigationButtonClick: (() -> Unit)? = null,
     navigationIcon: ImageVector? = null,
     navigationIconContentDescription: String = stringResource(id = string.back),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIBottomSheet.kt
@@ -66,7 +66,9 @@ class AddProductWithAIBottomSheet : WCBottomSheetDialogFragment() {
     }
 
     private fun showAICreationFlow() {
-        // TODO
+        findNavController().navigateSafely(
+            AddProductWithAIBottomSheetDirections.actionAddProductWithAIBottomSheetToAddProductWithAIFragment()
+        )
     }
 
     private fun showManualCreationFlow() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIFragment.kt
@@ -7,9 +7,11 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -27,6 +29,18 @@ class AddProductWithAIFragment : BaseFragment() {
                 WooThemeWithBackground {
                     AddProductWithAIScreen(viewModel)
                 }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        handleEvents()
+    }
+
+    private fun handleEvents() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                Exit -> findNavController().navigateUp()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIFragment.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.products.ai
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class AddProductWithAIFragment : BaseFragment() {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    private val viewModel: AddProductWithAIViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    AddProductWithAIScreen(viewModel)
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
@@ -5,15 +5,21 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCTextButton
 
 @Composable
 fun AddProductWithAIScreen(viewModel: AddProductWithAIViewModel) {
@@ -36,7 +42,20 @@ fun AddProductWithAIScreen(
         topBar = {
             Toolbar(
                 navigationIcon = if (state.isFirstStep) Icons.Filled.Clear else Icons.Filled.ArrowBack,
-                onNavigationButtonClick = onBackButtonClick
+                onNavigationButtonClick = onBackButtonClick,
+                actions = {
+                    when (state.saveButtonState) {
+                        AddProductWithAIViewModel.SaveButtonState.Shown -> WCTextButton(onClick = { /*TODO*/ }) {
+                            Text(text = "Save as draft") // TODO localize this
+                        }
+
+                        AddProductWithAIViewModel.SaveButtonState.Loading -> CircularProgressIndicator(
+                            modifier = Modifier.size(dimensionResource(id = R.dimen.major_150))
+                        )
+
+                        else -> {} // No-op
+                    }
+                }
             )
         }
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products.ai
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Scaffold
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
@@ -15,10 +17,12 @@ import com.woocommerce.android.ui.compose.component.Toolbar
 
 @Composable
 fun AddProductWithAIScreen(viewModel: AddProductWithAIViewModel) {
+    BackHandler(onBack = viewModel::onBackButtonClick)
+
     viewModel.state.observeAsState().value?.let {
         AddProductWithAIScreen(
             state = it,
-            onDismissClick = viewModel::onDismissClick
+            onBackButtonClick = viewModel::onBackButtonClick
         )
     }
 }
@@ -26,13 +30,13 @@ fun AddProductWithAIScreen(viewModel: AddProductWithAIViewModel) {
 @Composable
 fun AddProductWithAIScreen(
     state: AddProductWithAIViewModel.State,
-    onDismissClick: () -> Unit
+    onBackButtonClick: () -> Unit
 ) {
     Scaffold(
         topBar = {
             Toolbar(
-                navigationIcon = Icons.Filled.Clear,
-                onNavigationButtonClick = onDismissClick
+                navigationIcon = if (state.isFirstStep) Icons.Filled.Clear else Icons.Filled.ArrowBack,
+                onNavigationButtonClick = onBackButtonClick
             )
         }
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
@@ -54,8 +54,8 @@ fun AddProductWithAIScreen(
 }
 
 @Composable
-private fun SubScreen(subViewModel: AddProductWithAISubViewModel<*>) {
+private fun SubScreen(subViewModel: AddProductWithAISubViewModel<*>, modifier: Modifier) {
     when (subViewModel) {
-        else -> {}
+        is ProductNameSubViewModel -> ProductNameSubScreen(subViewModel, modifier)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
@@ -1,0 +1,61 @@
+package com.woocommerce.android.ui.products.ai
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.Scaffold
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import com.woocommerce.android.ui.compose.component.Toolbar
+
+@Composable
+fun AddProductWithAIScreen(viewModel: AddProductWithAIViewModel) {
+    viewModel.state.observeAsState().value?.let {
+        AddProductWithAIScreen(
+            state = it,
+            onDismissClick = viewModel::onDismissClick
+        )
+    }
+}
+
+@Composable
+fun AddProductWithAIScreen(
+    state: AddProductWithAIViewModel.State,
+    onDismissClick: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            Toolbar(
+                navigationIcon = Icons.Filled.Clear,
+                onNavigationButtonClick = onDismissClick
+            )
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(it)
+        ) {
+            LinearProgressIndicator(progress = state.progress, modifier = Modifier.fillMaxWidth())
+
+            SubScreen(
+                subViewModel = state.subViewModel,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+private fun SubScreen(subViewModel: AddProductWithAISubViewModel<*>) {
+    when (subViewModel) {
+        else -> {}
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAISubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAISubViewModel.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.products.ai
+
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import java.io.Closeable
+
+sealed interface AddProductWithAISubViewModel<T> : Closeable {
+    val events: Flow<Event>
+        get() = emptyFlow()
+    val onDone: (T) -> Unit
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -22,12 +22,18 @@ class AddProductWithAIViewModel @Inject constructor(
 ) : ScopedViewModel(savedState = savedStateHandle) {
     private val step = savedStateHandle.getStateFlow(viewModelScope, Step.ProductName)
     private val subViewModels = listOf<AddProductWithAISubViewModel<*>>(
-        // TODO add subViewModels
+        ProductNameSubViewModel(
+            savedStateHandle = savedStateHandle,
+            onDone = {
+                // Pass the name to next ViewModel if needed
+                step.value = Step.AboutProduct
+            }
+        ),
     )
 
     val state = step.map {
         State(
-            progress = it.ordinal.toFloat() / Step.values().size,
+            progress = (it.ordinal + 1).toFloat() / Step.values().size,
             subViewModel = subViewModels[it.ordinal]
         )
     }.asLiveData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -32,7 +32,7 @@ class AddProductWithAIViewModel @Inject constructor(
 
     val state = combine(step, saveButtonState) { step, saveButtonState ->
         State(
-            progress = (step.ordinal + 1).toFloat() / Step.values().size,
+            progress = step.order.toFloat() / Step.values().size,
             subViewModel = subViewModels[step.ordinal],
             isFirstStep = step.ordinal == 0,
             saveButtonState = saveButtonState
@@ -44,7 +44,7 @@ class AddProductWithAIViewModel @Inject constructor(
     }
 
     fun onBackButtonClick() {
-        if (step.value.ordinal == 0) {
+        if (step.value.order == 1) {
             triggerEvent(Exit)
         } else {
             goToPreviousStep()
@@ -52,13 +52,13 @@ class AddProductWithAIViewModel @Inject constructor(
     }
 
     private fun goToNextStep() {
-        require(step.value.ordinal < Step.values().size - 1)
-        step.value = Step.values()[step.value.ordinal + 1]
+        require(step.value.order < Step.values().size)
+        step.value = Step.getValueForOrder(step.value.order + 1)
     }
 
     private fun goToPreviousStep() {
-        require(step.value.ordinal > 0)
-        step.value = Step.values()[step.value.ordinal - 1]
+        require(step.value.ordinal > 1)
+        step.value = Step.getValueForOrder(step.value.order - 1)
     }
 
     private fun wireSubViewModels() {
@@ -82,8 +82,13 @@ class AddProductWithAIViewModel @Inject constructor(
     enum class SaveButtonState {
         Hidden, Shown, Loading
     }
-}
 
-private enum class Step {
-    ProductName, AboutProduct, Preview
+    @Suppress("MagicNumber")
+    private enum class Step(val order: Int) {
+        ProductName(1), AboutProduct(2), Preview(3);
+
+        companion object {
+            fun getValueForOrder(order: Int) = values().first { it.order == order }
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -3,17 +3,13 @@ package com.woocommerce.android.ui.products.ai
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import java.io.Closeable
 import javax.inject.Inject
 
 @HiltViewModel
@@ -26,7 +22,7 @@ class AddProductWithAIViewModel @Inject constructor(
             savedStateHandle = savedStateHandle,
             onDone = {
                 // Pass the name to next ViewModel if needed
-                step.value = Step.AboutProduct
+                goToNextStep()
             }
         ),
     )
@@ -34,7 +30,8 @@ class AddProductWithAIViewModel @Inject constructor(
     val state = step.map {
         State(
             progress = (it.ordinal + 1).toFloat() / Step.values().size,
-            subViewModel = subViewModels[it.ordinal]
+            subViewModel = subViewModels[it.ordinal],
+            isFirstStep = it.ordinal == 0
         )
     }.asLiveData()
 
@@ -42,8 +39,22 @@ class AddProductWithAIViewModel @Inject constructor(
         wireSubViewModels()
     }
 
-    fun onDismissClick() {
-        triggerEvent(Exit)
+    fun onBackButtonClick() {
+        if (step.value.ordinal == 0) {
+            triggerEvent(Exit)
+        } else {
+            goToPreviousStep()
+        }
+    }
+
+    private fun goToNextStep() {
+        require(step.value.ordinal < Step.values().size - 1)
+        step.value = Step.values()[step.value.ordinal + 1]
+    }
+
+    private fun goToPreviousStep() {
+        require(step.value.ordinal > 0)
+        step.value = Step.values()[step.value.ordinal - 1]
     }
 
     private fun wireSubViewModels() {
@@ -59,16 +70,11 @@ class AddProductWithAIViewModel @Inject constructor(
 
     data class State(
         val progress: Float,
-        val subViewModel: AddProductWithAISubViewModel<*>
+        val subViewModel: AddProductWithAISubViewModel<*>,
+        val isFirstStep: Boolean
     )
 }
 
 private enum class Step {
     ProductName, AboutProduct, Preview
-}
-
-sealed interface AddProductWithAISubViewModel<T> : Closeable {
-    val events: Flow<MultiLiveEvent.Event>
-        get() = emptyFlow()
-    val onDone: (T) -> Unit
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -1,0 +1,68 @@
+package com.woocommerce.android.ui.products.ai
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import java.io.Closeable
+import javax.inject.Inject
+
+@HiltViewModel
+class AddProductWithAIViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedState = savedStateHandle) {
+    private val step = savedStateHandle.getStateFlow(viewModelScope, Step.ProductName)
+    private val subViewModels = listOf<AddProductWithAISubViewModel<*>>(
+        // TODO add subViewModels
+    )
+
+    val state = step.map {
+        State(
+            progress = it.ordinal.toFloat() / Step.values().size,
+            subViewModel = subViewModels[it.ordinal]
+        )
+    }.asLiveData()
+
+    init {
+        wireSubViewModels()
+    }
+
+    fun onDismissClick() {
+        triggerEvent(Exit)
+    }
+
+    private fun wireSubViewModels() {
+        subViewModels.forEach { subViewModel ->
+            addCloseable(subViewModel)
+
+            subViewModel.events
+                .onEach {
+                    triggerEvent(it)
+                }.launchIn(viewModelScope)
+        }
+    }
+
+    data class State(
+        val progress: Float,
+        val subViewModel: AddProductWithAISubViewModel<*>
+    )
+}
+
+private enum class Step {
+    ProductName, AboutProduct, Preview
+}
+
+sealed interface AddProductWithAISubViewModel<T> : Closeable {
+    val events: Flow<MultiLiveEvent.Event>
+        get() = emptyFlow()
+    val onDone: (T) -> Unit
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.ui.products.ai
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ProductNameSubScreen(viewModel: ProductNameSubViewModel, modifier: Modifier) {
+    Column(modifier = modifier.background(MaterialTheme.colors.surface)) {
+        Text(text = "The product name step")
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Button(onClick = viewModel::onDoneClick) {
+            Text(text = "Continue")
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubViewModel.kt
@@ -1,0 +1,35 @@
+package com.woocommerce.android.ui.products.ai
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import com.woocommerce.android.viewmodel.getStateFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.map
+
+class ProductNameSubViewModel(
+    savedStateHandle: SavedStateHandle,
+    override val onDone: (String) -> Unit
+) : AddProductWithAISubViewModel<String> {
+    private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    private val name = savedStateHandle.getStateFlow(viewModelScope, "")
+
+    val state = name.map {
+        UiState(it)
+    }.asLiveData()
+
+    fun onDoneClick() {
+        onDone(name.value)
+    }
+
+    override fun close() {
+        viewModelScope.cancel()
+    }
+
+    data class UiState(
+        val name: String
+    )
+}

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -675,5 +675,12 @@
         <action
             android:id="@+id/action_addProductWithAIBottomSheet_to_productTypesBottomSheetFragment"
             app:destination="@id/productTypesBottomSheetFragment" />
+        <action
+            android:id="@+id/action_addProductWithAIBottomSheet_to_addProductWithAIFragment"
+            app:destination="@id/addProductWithAIFragment" />
     </dialog>
+    <fragment
+        android:id="@+id/addProductWithAIFragment"
+        android:name="com.woocommerce.android.ui.products.ai.AddProductWithAIFragment"
+        android:label="AddProductWithAIFragment" />
 </navigation>


### PR DESCRIPTION
Closes: #9789 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This is a proposition for the main ViewModel to be used for the main screen, in addition to the SubScreens and their SubViewModels.

Let's discuss it in the comments.

### Testing instructions
1. Use a store eligible for product creation with AI (new WPCom store or selfhosted with Jetpack AI assistant)
2. Open the app, then from the onboarding list click on the task "Create your first product"
3. Select the AI option.
4. Confirm the new screen is shown, with a progress bar at the top (ignore the content of the sub-screen, it'll be implemented separately).

### Images/gif

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
