### PR TITLE
Product Creation with AI: product preview UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIScreen.kt
@@ -80,5 +80,6 @@ fun AddProductWithAIScreen(
 private fun SubScreen(subViewModel: AddProductWithAISubViewModel<*>, modifier: Modifier) {
     when (subViewModel) {
         is ProductNameSubViewModel -> ProductNameSubScreen(subViewModel, modifier)
+        is ProductPreviewSubViewModel -> ProductPreviewSubScreen(viewModel = subViewModel, modifier = modifier)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
@@ -1,0 +1,29 @@
+package com.woocommerce.android.ui.products.ai
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun ProductPreviewSubScreen(viewModel: ProductPreviewSubViewModel, modifier: Modifier) {
+    viewModel.state.observeAsState().value?.let { state ->
+        ProductPreviewSubScreen(state, modifier)
+    }
+}
+
+@Suppress("UNUSED_PARAMETER")
+@Composable
+private fun ProductPreviewSubScreen(state: ProductPreviewSubViewModel.State, modifier: Modifier) {
+
+}
+
+@Composable
+@Preview
+private fun ProductPreviewLoadingPreview() {
+    WooThemeWithBackground {
+        ProductPreviewSubScreen(ProductPreviewSubViewModel.State.Loading, Modifier.fillMaxSize())
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products.ai
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,13 +16,15 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.ClipOp
+import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -80,8 +83,9 @@ private fun ProductPreviewContent(state: ProductPreviewSubViewModel.State.Succes
         verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
         modifier = modifier
     ) {
-        val sectionsBackgroundModifier = Modifier.background(
-            color = colorResource(id = R.color.woo_gray_6),
+        val sectionsBorder = Modifier.border(
+            width = dimensionResource(id = R.dimen.minor_10),
+            color = colorResource(id = R.color.divider_color),
             shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
         )
 
@@ -93,7 +97,7 @@ private fun ProductPreviewContent(state: ProductPreviewSubViewModel.State.Succes
             text = state.title,
             modifier = Modifier
                 .fillMaxWidth()
-                .then(sectionsBackgroundModifier)
+                .then(sectionsBorder)
                 .padding(dimensionResource(id = R.dimen.major_100))
         )
 
@@ -107,7 +111,7 @@ private fun ProductPreviewContent(state: ProductPreviewSubViewModel.State.Succes
             text = state.description,
             modifier = Modifier
                 .fillMaxWidth()
-                .then(sectionsBackgroundModifier)
+                .then(sectionsBorder)
                 .padding(dimensionResource(id = R.dimen.major_100))
         )
 
@@ -130,18 +134,38 @@ private fun ProductProperties(
     properties: List<ProductPreviewSubViewModel.ProductPropertyCard>,
     modifier: Modifier
 ) {
-    val cornerSize = dimensionResource(id = R.dimen.minor_100)
+    val borderRadius = dimensionResource(id = R.dimen.minor_100)
+    val borderWidth = dimensionResource(id = R.dimen.minor_10)
     Column(modifier) {
         properties.forEachIndexed { index, property ->
             Row(
                 Modifier
-                    .background(
-                        color = colorResource(id = R.color.woo_gray_6),
+                    .drawWithContent {
+                        if (index < properties.lastIndex) {
+                            // In order to avoid having duplicate dividers, we clip the last line from all items except
+                            // the last one
+                            val borderWidthInPx = (borderWidth.value * density)
+                            clipRect(
+                                left = borderWidthInPx,
+                                right = size.width - borderWidthInPx,
+                                top = size.height - borderWidthInPx,
+                                bottom = size.height,
+                                clipOp = ClipOp.Difference
+                            ) {
+                                this@drawWithContent.drawContent()
+                            }
+                        } else {
+                            drawContent()
+                        }
+                    }
+                    .border(
+                        width = borderWidth,
+                        color = colorResource(id = R.color.divider_color),
                         shape = RoundedCornerShape(
-                            topStart = if (index == 0) cornerSize else 0.dp,
-                            topEnd = if (index == 0) cornerSize else 0.dp,
-                            bottomStart = if (index == properties.lastIndex) cornerSize else 0.dp,
-                            bottomEnd = if (index == properties.lastIndex) cornerSize else 0.dp
+                            topStart = if (index == 0) borderRadius else 0.dp,
+                            topEnd = if (index == 0) borderRadius else 0.dp,
+                            bottomStart = if (index == properties.lastIndex) borderRadius else 0.dp,
+                            bottomEnd = if (index == properties.lastIndex) borderRadius else 0.dp
                         )
                     )
                     .padding(dimensionResource(id = R.dimen.major_100))
@@ -164,10 +188,6 @@ private fun ProductProperties(
                         color = colorResource(id = R.color.color_on_surface_medium)
                     )
                 }
-            }
-
-            if (index != properties.lastIndex) {
-                Divider()
             }
         }
     }
@@ -207,8 +227,9 @@ private fun ProductPreviewLoading(modifier: Modifier) {
         verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
         modifier = modifier
     ) {
-        val sectionsBackgroundModifier = Modifier.background(
-            color = colorResource(id = R.color.woo_gray_6),
+        val sectionsBorder = Modifier.border(
+            width = dimensionResource(id = R.dimen.minor_10),
+            color = colorResource(id = R.color.divider_color),
             shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
         )
 
@@ -219,7 +240,7 @@ private fun ProductPreviewLoading(modifier: Modifier) {
         LoadingSkeleton(
             modifier = Modifier
                 .fillMaxWidth()
-                .then(sectionsBackgroundModifier)
+                .then(sectionsBorder)
         )
 
         Spacer(Modifier)
@@ -232,7 +253,7 @@ private fun ProductPreviewLoading(modifier: Modifier) {
             lines = 3,
             modifier = Modifier
                 .fillMaxWidth()
-                .then(sectionsBackgroundModifier)
+                .then(sectionsBorder)
         )
 
         Spacer(Modifier)
@@ -244,13 +265,13 @@ private fun ProductPreviewLoading(modifier: Modifier) {
         LoadingSkeleton(
             modifier = Modifier
                 .fillMaxWidth()
-                .then(sectionsBackgroundModifier)
+                .then(sectionsBorder)
         )
         Spacer(Modifier)
         LoadingSkeleton(
             modifier = Modifier
                 .fillMaxWidth()
-                .then(sectionsBackgroundModifier)
+                .then(sectionsBorder)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
@@ -1,10 +1,26 @@
 package com.woocommerce.android.ui.products.ai
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
@@ -14,10 +30,113 @@ fun ProductPreviewSubScreen(viewModel: ProductPreviewSubViewModel, modifier: Mod
     }
 }
 
-@Suppress("UNUSED_PARAMETER")
 @Composable
 private fun ProductPreviewSubScreen(state: ProductPreviewSubViewModel.State, modifier: Modifier) {
+    Column(
+        modifier = modifier
+            .background(MaterialTheme.colors.surface)
+            .padding(dimensionResource(id = R.dimen.major_100))
+    ) {
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        Text(
+            text = stringResource(id = R.string.product_creation_ai_preview_title),
+            style = MaterialTheme.typography.h4,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        Text(
+            text = stringResource(id = R.string.product_creation_ai_preview_subtitle),
+            style = MaterialTheme.typography.body1,
+            color = colorResource(id = R.color.color_on_surface_medium)
+        )
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+        when (state) {
+            ProductPreviewSubViewModel.State.Loading -> ProductPreviewLoading(Modifier.weight(1f))
+            is ProductPreviewSubViewModel.State.Success -> TODO()
+        }
+    }
+}
 
+@Composable
+private fun ProductPreviewLoading(modifier: Modifier) {
+    @Composable
+    fun LoadingSkeleton(lines: Int = 2, modifier: Modifier) {
+        require(lines == 2 || lines == 3)
+        Column(
+            verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+            modifier = modifier
+                .padding(dimensionResource(id = R.dimen.major_100))
+        ) {
+            if (lines == 3) {
+                SkeletonView(
+                    modifier = Modifier
+                        .fillMaxWidth(0.8f)
+                        .height(dimensionResource(id = R.dimen.major_100))
+                )
+            }
+            SkeletonView(
+                modifier = Modifier
+                    .fillMaxWidth(if (lines == 3) 0.5f else 0.6f)
+                    .height(dimensionResource(id = R.dimen.major_100))
+            )
+            SkeletonView(
+                modifier = Modifier
+                    .fillMaxWidth(if (lines == 3) 0.7f else 0.8f)
+                    .height(dimensionResource(id = R.dimen.major_100))
+            )
+        }
+    }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
+        modifier = modifier
+    ) {
+        val sectionsBackgroundModifier = Modifier.background(
+            color = colorResource(id = R.color.woo_gray_6),
+            shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
+        )
+
+        Text(
+            text = stringResource(id = R.string.product_creation_ai_preview_name_section),
+            style = MaterialTheme.typography.subtitle1
+        )
+        LoadingSkeleton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(sectionsBackgroundModifier)
+        )
+
+        Spacer(Modifier)
+
+        Text(
+            text = stringResource(id = R.string.product_creation_ai_preview_description_section),
+            style = MaterialTheme.typography.subtitle1
+        )
+        LoadingSkeleton(
+            lines = 3,
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(sectionsBackgroundModifier)
+        )
+
+        Spacer(Modifier)
+
+        Text(
+            text = stringResource(id = R.string.product_creation_ai_preview_details_section),
+            style = MaterialTheme.typography.subtitle1
+        )
+        LoadingSkeleton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(sectionsBackgroundModifier)
+        )
+        Spacer(Modifier)
+        LoadingSkeleton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(sectionsBackgroundModifier)
+        )
+    }
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
@@ -3,12 +3,20 @@ package com.woocommerce.android.ui.products.ai
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -16,9 +24,11 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -35,6 +45,7 @@ private fun ProductPreviewSubScreen(state: ProductPreviewSubViewModel.State, mod
     Column(
         modifier = modifier
             .background(MaterialTheme.colors.surface)
+            .verticalScroll(rememberScrollState())
             .padding(dimensionResource(id = R.dimen.major_100))
     ) {
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
@@ -51,8 +62,113 @@ private fun ProductPreviewSubScreen(state: ProductPreviewSubViewModel.State, mod
         )
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
         when (state) {
-            ProductPreviewSubViewModel.State.Loading -> ProductPreviewLoading(Modifier.weight(1f))
-            is ProductPreviewSubViewModel.State.Success -> TODO()
+            ProductPreviewSubViewModel.State.Loading -> ProductPreviewLoading(
+                modifier = Modifier.fillMaxHeight()
+            )
+
+            is ProductPreviewSubViewModel.State.Success -> ProductPreviewContent(
+                state = state,
+                modifier = Modifier.fillMaxHeight()
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProductPreviewContent(state: ProductPreviewSubViewModel.State.Success, modifier: Modifier) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
+        modifier = modifier
+    ) {
+        val sectionsBackgroundModifier = Modifier.background(
+            color = colorResource(id = R.color.woo_gray_6),
+            shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
+        )
+
+        Text(
+            text = stringResource(id = R.string.product_creation_ai_preview_name_section),
+            style = MaterialTheme.typography.body2
+        )
+        Text(
+            text = state.title,
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(sectionsBackgroundModifier)
+                .padding(dimensionResource(id = R.dimen.major_100))
+        )
+
+        Spacer(Modifier)
+
+        Text(
+            text = stringResource(id = R.string.product_creation_ai_preview_description_section),
+            style = MaterialTheme.typography.body2
+        )
+        Text(
+            text = state.description,
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(sectionsBackgroundModifier)
+                .padding(dimensionResource(id = R.dimen.major_100))
+        )
+
+        Spacer(Modifier)
+
+        Text(
+            text = stringResource(id = R.string.product_creation_ai_preview_details_section),
+            style = MaterialTheme.typography.body2
+        )
+
+        state.propertyGroups.forEach { properties ->
+            ProductProperties(properties = properties, modifier = Modifier.fillMaxWidth())
+            Spacer(Modifier)
+        }
+    }
+}
+
+@Composable
+private fun ProductProperties(
+    properties: List<ProductPreviewSubViewModel.ProductPropertyCard>,
+    modifier: Modifier
+) {
+    val cornerSize = dimensionResource(id = R.dimen.minor_100)
+    Column(modifier) {
+        properties.forEachIndexed { index, property ->
+            Row(
+                Modifier
+                    .background(
+                        color = colorResource(id = R.color.woo_gray_6),
+                        shape = RoundedCornerShape(
+                            topStart = if (index == 0) cornerSize else 0.dp,
+                            topEnd = if (index == 0) cornerSize else 0.dp,
+                            bottomStart = if (index == properties.lastIndex) cornerSize else 0.dp,
+                            bottomEnd = if (index == properties.lastIndex) cornerSize else 0.dp
+                        )
+                    )
+                    .padding(dimensionResource(id = R.dimen.major_100))
+            ) {
+                Icon(
+                    painter = painterResource(id = property.icon),
+                    contentDescription = null,
+                    modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_50))
+                )
+                Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.major_100)))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        text = property.title,
+                        style = MaterialTheme.typography.subtitle1,
+                        color = colorResource(id = R.color.color_on_surface_high)
+                    )
+                    Text(
+                        text = property.content,
+                        style = MaterialTheme.typography.body2,
+                        color = colorResource(id = R.color.color_on_surface_medium)
+                    )
+                }
+            }
+
+            if (index != properties.lastIndex) {
+                Divider()
+            }
         }
     }
 }
@@ -98,7 +214,7 @@ private fun ProductPreviewLoading(modifier: Modifier) {
 
         Text(
             text = stringResource(id = R.string.product_creation_ai_preview_name_section),
-            style = MaterialTheme.typography.subtitle1
+            style = MaterialTheme.typography.body2
         )
         LoadingSkeleton(
             modifier = Modifier
@@ -110,7 +226,7 @@ private fun ProductPreviewLoading(modifier: Modifier) {
 
         Text(
             text = stringResource(id = R.string.product_creation_ai_preview_description_section),
-            style = MaterialTheme.typography.subtitle1
+            style = MaterialTheme.typography.body2
         )
         LoadingSkeleton(
             lines = 3,
@@ -123,7 +239,7 @@ private fun ProductPreviewLoading(modifier: Modifier) {
 
         Text(
             text = stringResource(id = R.string.product_creation_ai_preview_details_section),
-            style = MaterialTheme.typography.subtitle1
+            style = MaterialTheme.typography.body2
         )
         LoadingSkeleton(
             modifier = Modifier
@@ -144,5 +260,42 @@ private fun ProductPreviewLoading(modifier: Modifier) {
 private fun ProductPreviewLoadingPreview() {
     WooThemeWithBackground {
         ProductPreviewSubScreen(ProductPreviewSubViewModel.State.Loading, Modifier.fillMaxSize())
+    }
+}
+
+@Composable
+@Preview
+private fun ProductPreviewContentPreview() {
+    WooThemeWithBackground {
+        ProductPreviewSubScreen(
+            ProductPreviewSubViewModel.State.Success(
+                title = "Soft Black Tee: Elevate Your Everyday Style",
+                "Introducing our USA-Made Classic Organic Cotton Tee—a staple piece designed for" +
+                    " everyday comfort and sustainability. Crafted with care from organic cotton, this tee is not" +
+                    " just soft on your skin but gentle on the environment.",
+                propertyGroups = listOf(
+                    listOf(
+                        ProductPreviewSubViewModel.ProductPropertyCard(
+                            icon = R.drawable.ic_gridicons_product,
+                            title = "Product Type",
+                            content = "Simple Product"
+                        )
+                    ),
+                    listOf(
+                        ProductPreviewSubViewModel.ProductPropertyCard(
+                            icon = R.drawable.ic_gridicons_money,
+                            title = "Price",
+                            content = "Regular price: $45.00"
+                        ),
+                        ProductPreviewSubViewModel.ProductPropertyCard(
+                            icon = R.drawable.ic_gridicons_list_checkmark,
+                            title = "Inventory",
+                            content = "In stock"
+                        )
+                    )
+                )
+            ),
+            Modifier.fillMaxSize()
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
@@ -16,21 +16,18 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.graphics.ClipOp
-import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -132,40 +129,18 @@ private fun ProductProperties(
     properties: List<ProductPreviewSubViewModel.ProductPropertyCard>,
     modifier: Modifier
 ) {
-    val borderRadius = dimensionResource(id = R.dimen.minor_100)
     val borderWidth = dimensionResource(id = R.dimen.minor_10)
-    Column(modifier) {
+    val borderColor = colorResource(id = R.color.divider_color)
+    Column(
+        modifier.border(
+            width = borderWidth,
+            color = borderColor,
+            shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
+        )
+    ) {
         properties.forEachIndexed { index, property ->
             Row(
                 Modifier
-                    .drawWithContent {
-                        if (index < properties.lastIndex) {
-                            // In order to avoid having duplicate dividers, we clip the last line from all items except
-                            // the last one
-                            val borderWidthInPx = (borderWidth.value * density)
-                            clipRect(
-                                left = borderWidthInPx,
-                                right = size.width - borderWidthInPx,
-                                top = size.height - borderWidthInPx,
-                                bottom = size.height,
-                                clipOp = ClipOp.Difference
-                            ) {
-                                this@drawWithContent.drawContent()
-                            }
-                        } else {
-                            drawContent()
-                        }
-                    }
-                    .border(
-                        width = borderWidth,
-                        color = colorResource(id = R.color.divider_color),
-                        shape = RoundedCornerShape(
-                            topStart = if (index == 0) borderRadius else 0.dp,
-                            topEnd = if (index == 0) borderRadius else 0.dp,
-                            bottomStart = if (index == properties.lastIndex) borderRadius else 0.dp,
-                            bottomEnd = if (index == properties.lastIndex) borderRadius else 0.dp
-                        )
-                    )
                     .padding(dimensionResource(id = R.dimen.major_100))
             ) {
                 Icon(
@@ -186,6 +161,10 @@ private fun ProductProperties(
                         color = colorResource(id = R.color.color_on_surface_medium)
                     )
                 }
+            }
+
+            if (index < properties.lastIndex) {
+                Divider(color = borderColor, thickness = borderWidth)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products.ai
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -27,6 +28,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
@@ -254,7 +256,11 @@ private fun ProductPreviewLoading(modifier: Modifier) {
 }
 
 @Composable
-@Preview
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "small screen", device = Devices.PIXEL)
+@Preview(name = "mid screen", device = Devices.PIXEL_4)
+@Preview(name = "large screen", device = Devices.NEXUS_10)
 private fun ProductPreviewLoadingPreview() {
     WooThemeWithBackground {
         ProductPreviewSubScreen(ProductPreviewSubViewModel.State.Loading, Modifier.fillMaxSize())
@@ -262,7 +268,11 @@ private fun ProductPreviewLoadingPreview() {
 }
 
 @Composable
-@Preview
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "small screen", device = Devices.PIXEL)
+@Preview(name = "mid screen", device = Devices.PIXEL_4)
+@Preview(name = "large screen", device = Devices.NEXUS_10)
 private fun ProductPreviewContentPreview() {
     WooThemeWithBackground {
         ProductPreviewSubScreen(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
@@ -54,13 +53,12 @@ private fun ProductPreviewSubScreen(state: ProductPreviewSubViewModel.State, mod
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         Text(
             text = stringResource(id = R.string.product_creation_ai_preview_title),
-            style = MaterialTheme.typography.h4,
-            fontWeight = FontWeight.Bold
+            style = MaterialTheme.typography.h5
         )
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         Text(
             text = stringResource(id = R.string.product_creation_ai_preview_subtitle),
-            style = MaterialTheme.typography.body1,
+            style = MaterialTheme.typography.subtitle1,
             color = colorResource(id = R.color.color_on_surface_medium)
         )
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
@@ -1,14 +1,16 @@
 package com.woocommerce.android.ui.products.ai
 
+import androidx.annotation.DrawableRes
 import androidx.lifecycle.asLiveData
-import com.woocommerce.android.model.Product
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.flowOf
 
-class ProductPreviewSubViewModel(override val onDone: (Unit) -> Unit) : AddProductWithAISubViewModel<Unit> {
+class ProductPreviewSubViewModel(
+    override val onDone: (Unit) -> Unit
+) : AddProductWithAISubViewModel<Unit> {
     private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     val state = flowOf<State>(State.Loading).asLiveData()
@@ -19,6 +21,16 @@ class ProductPreviewSubViewModel(override val onDone: (Unit) -> Unit) : AddProdu
 
     sealed interface State {
         object Loading : State
-        data class Success(val product: Product) : State
+        data class Success(
+            val title: String,
+            val description: String,
+            val propertyGroups: List<List<ProductPropertyCard>>
+        ) : State
     }
+
+    data class ProductPropertyCard(
+        @DrawableRes val icon: Int,
+        val title: String,
+        val content: String
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
@@ -1,0 +1,24 @@
+package com.woocommerce.android.ui.products.ai
+
+import androidx.lifecycle.asLiveData
+import com.woocommerce.android.model.Product
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.flowOf
+
+class ProductPreviewSubViewModel(override val onDone: (Unit) -> Unit) : AddProductWithAISubViewModel<Unit> {
+    private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    val state = flowOf<State>(State.Loading).asLiveData()
+
+    override fun close() {
+        viewModelScope.cancel()
+    }
+
+    sealed interface State {
+        object Loading : State
+        data class Success(val product: Product) : State
+    }
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1898,6 +1898,11 @@
     <string name="product_creation_ai_entry_sheet_manual_option_title">Add manually</string>
     <string name="product_creation_ai_entry_sheet_manual_option_subtitle">Add a product and the details manually</string>
     <string name="product_creation_ai_entry_sheet_learn_more">Powered by AI. &lt;a href=\'guidelines\'&gt;&lt;u&gt;Learn more&lt;/u&gt;&lt;/a&gt;.</string>
+    <string name="product_creation_ai_preview_title">Preview</string>
+    <string name="product_creation_ai_preview_subtitle">Don’t worry. You can always change those details later.</string>
+    <string name="product_creation_ai_preview_name_section">Product name</string>
+    <string name="product_creation_ai_preview_description_section">Product description</string>
+    <string name="product_creation_ai_preview_details_section">Details</string>
     <!--
         Product Add more details Bottom sheet
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1899,7 +1899,7 @@
     <string name="product_creation_ai_entry_sheet_manual_option_subtitle">Add a product and the details manually</string>
     <string name="product_creation_ai_entry_sheet_learn_more">Powered by AI. &lt;a href=\'guidelines\'&gt;&lt;u&gt;Learn more&lt;/u&gt;&lt;/a&gt;.</string>
     <string name="product_creation_ai_preview_title">Preview</string>
-    <string name="product_creation_ai_preview_subtitle">Don’t worry. You can always change those details later.</string>
+    <string name="product_creation_ai_preview_subtitle">Don’t worry. You can always change below details later.</string>
     <string name="product_creation_ai_preview_name_section">Product name</string>
     <string name="product_creation_ai_preview_description_section">Product description</string>
     <string name="product_creation_ai_preview_details_section">Details</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9810 

### Description
This PR adds the UI part of the product preview.

### Testing instructions
Launch `ProductPreviewLoadingPreview` and `ProductPreviewContentPreview` using Android Studio, and confirm it matches the design.

### Images/gif
| Light | Dark |
| - | - |
| ![Screenshot_20230921_123742](https://github.com/woocommerce/woocommerce-android/assets/1657201/aff9646a-3686-4e01-8e9f-9254c59bb90b) | ![Screenshot_20230921_123750](https://github.com/woocommerce/woocommerce-android/assets/1657201/f1e19f56-1732-4b50-b893-8f450cd9b5a0) |
| ![Screenshot_20230921_123803](https://github.com/woocommerce/woocommerce-android/assets/1657201/46aa2ab2-52f2-4d1e-8fe0-24b28062c19f) |  ![Screenshot_20230921_123812](https://github.com/woocommerce/woocommerce-android/assets/1657201/4eb24b77-5dcf-42b9-aa29-f0a8b54aa1c7) |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
