### PR TITLE
Product Creation with AI: Product Name subscreen UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingBottomSheet.kt
@@ -104,7 +104,7 @@ fun ProductShareWithAI(
                     label = stringResource(id = R.string.product_sharing_optional_message_label),
                     isError = isError,
                     helperText = if (isError) viewState.errorMessage else null,
-                    textFieldModifier = Modifier.height(dimensionResource(id = R.dimen.product_sharing_message_height))
+                    textFieldModifier = Modifier.height(dimensionResource(id = R.dimen.multiline_textfield_height))
                 )
 
                 AnimatedVisibility(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products.ai
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -10,23 +11,35 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Icon
+import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCColoredButton
-import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
@@ -76,25 +89,10 @@ fun ProductNameForm(
 
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_250)))
 
-            WCOutlinedTextField(
-                value = enteredName,
-                onValueChange = onProductNameChanged,
-                label = stringResource(id = R.string.ai_product_creation_add_name_keywords_label),
-                placeholderText = stringResource(id = R.string.ai_product_creation_add_name_keywords_placeholder),
-                textFieldModifier = Modifier.height(dimensionResource(id = R.dimen.multiline_textfield_height))
-            )
-
-            WCOutlinedButton(
-                onClick = onSuggestNameClicked,
-                text = stringResource(id = R.string.ai_product_creation_add_name_suggest_name_button),
-                leadingIcon = {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_ai_share_button),
-                        contentDescription = null
-                    )
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
+            ProductKeywordsTextFieldWithEmbeddedButton(
+                textFieldContent = enteredName,
+                onTextFieldContentChanged = onProductNameChanged,
+                onButtonClicked = onSuggestNameClicked
             )
 
             Spacer(modifier = Modifier.weight(1f))
@@ -123,6 +121,59 @@ fun ProductNameForm(
             ) {
                 Text(text = stringResource(id = R.string.continue_button))
             }
+        }
+    }
+}
+
+@Composable
+fun ProductKeywordsTextFieldWithEmbeddedButton(
+    textFieldContent: String,
+    onTextFieldContentChanged: (String) -> Unit,
+    onButtonClicked: () -> Unit
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    Column {
+        Text(
+            text = stringResource(id = R.string.ai_product_creation_add_name_keywords_label),
+            style = MaterialTheme.typography.body2,
+            modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.minor_100))
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .border(
+                    width = 1.dp,
+                    color = if (isFocused) colorResource(id = R.color.color_primary)
+                    else colorResource(id = R.color.divider_color),
+                    shape = RoundedCornerShape(10.dp)
+                )
+                .clip(RoundedCornerShape(10.dp))
+        ) {
+            WCOutlinedTextField(
+                value = textFieldContent,
+                onValueChange = onTextFieldContentChanged,
+                label = "", // Can't use label here as it breaks the visual design.
+                placeholderText = stringResource(id = R.string.ai_product_creation_add_name_keywords_placeholder),
+                textFieldModifier = Modifier.height(dimensionResource(id = R.dimen.multiline_textfield_height)),
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = Color.Transparent, // Remove outline and use Column's border instead.
+                    unfocusedBorderColor = Color.Transparent
+                ),
+                modifier = Modifier
+                    .onFocusChanged { focusState -> isFocused = focusState.isFocused }
+            )
+
+            Divider()
+
+            WCTextButton(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = dimensionResource(id = R.dimen.minor_50)),
+                onClick = onButtonClicked,
+                icon = ImageVector.vectorResource(id = R.drawable.ic_ai_share_button),
+                allCaps = false,
+                text = stringResource(id = R.string.ai_product_creation_add_name_suggest_name_button),
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
@@ -69,11 +68,12 @@ fun ProductNameForm(
 ) {
     val orientation = LocalConfiguration.current.orientation
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
-                .padding(dimensionResource(id = R.dimen.major_100))
+                .weight(1f)
                 .verticalScroll(rememberScrollState())
+                .padding(dimensionResource(id = R.dimen.major_100))
         ) {
             Text(
                 text = stringResource(id = R.string.ai_product_creation_add_name_title),
@@ -103,7 +103,7 @@ fun ProductNameForm(
                     onClick = onContinueClicked,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(dimensionResource(id = R.dimen.major_100))
+                        .padding(horizontal = dimensionResource(id = R.dimen.major_100))
                 ) {
                     Text(text = stringResource(id = R.string.continue_button))
                 }
@@ -115,9 +115,8 @@ fun ProductNameForm(
             WCColoredButton(
                 onClick = onContinueClicked,
                 modifier = Modifier
-                    .align(Alignment.BottomCenter)
                     .fillMaxWidth()
-                    .padding(dimensionResource(id = R.dimen.major_100))
+                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
             ) {
                 Text(text = stringResource(id = R.string.continue_button))
             }
@@ -150,7 +149,7 @@ fun ProductKeywordsTextFieldWithEmbeddedButton(
                 .clip(RoundedCornerShape(10.dp))
         ) {
             Box {
-                if(textFieldContent.isEmpty()) {
+                if (textFieldContent.isEmpty()) {
                     Text(
                         text = stringResource(id = R.string.ai_product_creation_add_name_keywords_placeholder),
                         style = MaterialTheme.typography.body1,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
@@ -149,19 +149,33 @@ fun ProductKeywordsTextFieldWithEmbeddedButton(
                 )
                 .clip(RoundedCornerShape(10.dp))
         ) {
-            WCOutlinedTextField(
-                value = textFieldContent,
-                onValueChange = onTextFieldContentChanged,
-                label = "", // Can't use label here as it breaks the visual design.
-                placeholderText = stringResource(id = R.string.ai_product_creation_add_name_keywords_placeholder),
-                textFieldModifier = Modifier.height(dimensionResource(id = R.dimen.multiline_textfield_height)),
-                colors = TextFieldDefaults.outlinedTextFieldColors(
-                    focusedBorderColor = Color.Transparent, // Remove outline and use Column's border instead.
-                    unfocusedBorderColor = Color.Transparent
-                ),
-                modifier = Modifier
-                    .onFocusChanged { focusState -> isFocused = focusState.isFocused }
-            )
+            Box {
+                if(textFieldContent.isEmpty()) {
+                    Text(
+                        text = stringResource(id = R.string.ai_product_creation_add_name_keywords_placeholder),
+                        style = MaterialTheme.typography.body1,
+                        color = Color.Gray,
+                        modifier = Modifier.padding(
+                            horizontal = dimensionResource(id = R.dimen.major_100),
+                            vertical = dimensionResource(id = R.dimen.major_150)
+                        )
+                    )
+                }
+
+                WCOutlinedTextField(
+                    value = textFieldContent,
+                    onValueChange = onTextFieldContentChanged,
+                    label = "", // Can't use label here as it breaks the visual design.
+                    placeholderText = "", // Uses Text() above instead.
+                    textFieldModifier = Modifier.height(dimensionResource(id = R.dimen.multiline_textfield_height)),
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = Color.Transparent, // Remove outline and use Column's border instead.
+                        unfocusedBorderColor = Color.Transparent
+                    ),
+                    modifier = Modifier
+                        .onFocusChanged { focusState -> isFocused = focusState.isFocused }
+                )
+            }
 
             Divider()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
@@ -1,23 +1,141 @@
 package com.woocommerce.android.ui.products.ai
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.material.Button
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 fun ProductNameSubScreen(viewModel: ProductNameSubViewModel, modifier: Modifier) {
-    Column(modifier = modifier.background(MaterialTheme.colors.surface)) {
-        Text(text = "The product name step")
-
-        Spacer(modifier = Modifier.weight(1f))
-
-        Button(onClick = viewModel::onDoneClick) {
-            Text(text = "Continue")
+    viewModel.state.observeAsState().value?.let { state ->
+        Column(
+            modifier = modifier
+                .background(MaterialTheme.colors.surface)
+                .fillMaxWidth()
+        ) {
+            ProductNameForm(
+                enteredName = state.name,
+                onProductNameChanged = {},
+                onSuggestNameClicked = {},
+                onContinueClicked = {}
+            )
         }
+    }
+}
+
+@Composable
+fun ProductNameForm(
+    enteredName: String,
+    onProductNameChanged: (String) -> Unit,
+    onSuggestNameClicked: () -> Unit,
+    onContinueClicked: () -> Unit
+) {
+    val orientation = LocalConfiguration.current.orientation
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .padding(dimensionResource(id = R.dimen.major_100))
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                text = stringResource(id = R.string.ai_product_creation_add_name_title),
+                style = MaterialTheme.typography.h5
+            )
+
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+
+            Text(
+                text = stringResource(id = R.string.ai_product_creation_add_name_subtitle),
+                style = MaterialTheme.typography.body1
+            )
+
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_250)))
+
+            WCOutlinedTextField(
+                value = enteredName,
+                onValueChange = onProductNameChanged,
+                label = stringResource(id = R.string.ai_product_creation_add_name_keywords_label),
+                placeholderText = stringResource(id = R.string.ai_product_creation_add_name_keywords_placeholder),
+                textFieldModifier = Modifier.height(dimensionResource(id = R.dimen.multiline_textfield_height))
+            )
+
+            WCOutlinedButton(
+                onClick = onSuggestNameClicked,
+                text = stringResource(id = R.string.ai_product_creation_add_name_suggest_name_button),
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_ai_share_button),
+                        contentDescription = null
+                    )
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Button will scroll with the rest of UI on landscape mode, or... (see below)
+            if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                WCColoredButton(
+                    onClick = onContinueClicked,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(dimensionResource(id = R.dimen.major_100))
+                ) {
+                    Text(text = stringResource(id = R.string.continue_button))
+                }
+            }
+        }
+
+        // Button will stick to the bottom on portrait mode
+        if (orientation == Configuration.ORIENTATION_PORTRAIT) {
+            WCColoredButton(
+                onClick = onContinueClicked,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .padding(dimensionResource(id = R.dimen.major_100))
+            ) {
+                Text(text = stringResource(id = R.string.continue_button))
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ProductNamePreview() {
+    WooThemeWithBackground {
+        ProductNameForm(
+            enteredName = "Everyday Elegance with Our Soft Black Tee",
+            onProductNameChanged = {},
+            onSuggestNameClicked = {},
+            onContinueClicked = {}
+        )
     }
 }

--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -138,7 +138,7 @@ so that's the baseline as defined in `major_100`.
     <dimen name="prologue_logo_height">36dp</dimen>
     <dimen name="prologue_button_wide">300dp</dimen>
     <dimen name="support_request_message_height">400dp</dimen>
-    <dimen name="product_sharing_message_height">155dp</dimen>
+    <dimen name="multiline_textfield_height">155dp</dimen>
 
     <!-- More Menu dimens -->
     <dimen name="more_menu_button_height">190dp</dimen>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3570,6 +3570,16 @@
     <string name="ai_product_description_tooltip_message">Use our AI-powered tool to quickly generate product descriptions. Just input keywords and we\'ll do the rest!</string>
     <string name="ai_product_description_tooltip_dismiss">Got it</string>
 
+
+    <!--
+    AI Product creation
+    -->
+    <string name="ai_product_creation_add_name_title">Add your product name</string>
+    <string name="ai_product_creation_add_name_subtitle">Or, expand your choices by typing for more name suggestions.</string>
+    <string name="ai_product_creation_add_name_keywords_label">Product name</string>
+    <string name="ai_product_creation_add_name_keywords_placeholder">For example: Soft fabric, durable stitching, unique design.</string>
+    <string name="ai_product_creation_add_name_suggest_name_button">Suggest a name</string>
+
     <!--
     Blaze banner
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3575,7 +3575,7 @@
     AI Product creation
     -->
     <string name="ai_product_creation_add_name_title">Add your product name</string>
-    <string name="ai_product_creation_add_name_subtitle">Or, expand your choices by typing for more name suggestions.</string>
+    <string name="ai_product_creation_add_name_subtitle">Or, expand your choices by tapping for more name suggestions.</string>
     <string name="ai_product_creation_add_name_keywords_label">Product name</string>
     <string name="ai_product_creation_add_name_keywords_placeholder">For example: Soft fabric, durable stitching, unique design.</string>
     <string name="ai_product_creation_add_name_suggest_name_button">Suggest a name</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9800 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds the UI for the following screen:

#### Design:
<img src="https://github.com/woocommerce/woocommerce-android/assets/266376/3af325c1-fd27-4b2a-9c5f-95fad40dfcbd" width="42%" />

#### Android:

| Unfocused text field | Focused text field |
|-|-|
| <img src="https://github.com/woocommerce/woocommerce-android/assets/266376/561fbad6-52ce-478a-b070-fa53af132682" /> | <img src="https://github.com/woocommerce/woocommerce-android/assets/266376/3a7ab4b3-c95d-47c6-8963-e2207dddc72d" /> |

#### Known issues/differences:
1. Android doesn't have "Use package photo" button.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Go to products list, tap "+" button,
2. Choose "Create a product with AI",
3. Ensure the screen is shown properly. Test in portrait and landscape mode.