### PR TITLE
Product Creation with AI: product preview logic

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
@@ -1,17 +1,26 @@
 package com.woocommerce.android.ai
 
+import com.woocommerce.android.model.Product
+import com.woocommerce.android.model.ProductCategory
+import com.woocommerce.android.model.ProductTag
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.products.ProductHelper
+import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAICompletionsResponse
 import org.wordpress.android.fluxc.store.jetpackai.JetpackAIStore
-import java.lang.Exception
+import java.math.BigDecimal
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
 
 @Singleton
 class AIRepository @Inject constructor(
+    private val selectedSite: SelectedSite,
     private val jetpackAIStore: JetpackAIStore
 ) {
     companion object {
@@ -49,6 +58,34 @@ class AIRepository @Inject constructor(
         return fetchJetpackAICompletionsForSite(site, prompt, PRODUCT_DESCRIPTION_FEATURE)
     }
 
+    @Suppress("UNUSED_PARAMETER")
+    suspend fun generateProduct(
+        productName: String,
+        productKeyWords: String,
+        languageISOCode: String = "en"
+    ): Result<Product> {
+        // TODO implement the AI prompt and parsing
+        delay(5.seconds)
+        return Result.success(
+            ProductHelper.getDefaultNewProduct(
+                SIMPLE,
+                false
+            ).copy(
+                name = "Soft Black Tee: Elevate Your Everyday Style",
+                description = "Introducing our USA-Made Classic Organic Cotton Tee—a staple piece designed for " +
+                    "everyday comfort and sustainability. Crafted with care from organic cotton, this tee is not" +
+                    " just soft on your skin but gentle on the environment.",
+                regularPrice = BigDecimal.TEN,
+                categories = listOf(ProductCategory(name = "Category 1"), ProductCategory(name = "Category 2")),
+                tags = listOf(ProductTag(name = "tag 1")),
+                weight = 10f,
+                height = 10f,
+                length = 10f,
+                width = 10f
+            )
+        )
+    }
+
     suspend fun identifyISOLanguageCode(site: SiteModel, text: String, feature: String): Result<String> {
         val prompt = AIPrompts.generateLanguageIdentificationPrompt(text)
         return fetchJetpackAICompletionsForSite(site, prompt, feature)
@@ -65,6 +102,7 @@ class AIRepository @Inject constructor(
                     WooLog.d(WooLog.T.AI, "Fetching Jetpack AI completions succeeded")
                     Result.success(completion)
                 }
+
                 is JetpackAICompletionsResponse.Error -> {
                     WooLog.w(WooLog.T.AI, "Fetching Jetpack AI completions failed: $message")
                     Result.failure(this.mapToException())
@@ -72,6 +110,7 @@ class AIRepository @Inject constructor(
             }
         }
     }
+
     data class JetpackAICompletionsException(
         val errorMessage: String,
         val errorType: String

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
@@ -29,7 +29,6 @@ class AIRepository @Inject constructor(
     }
 
     suspend fun generateProductSharingText(
-        site: SiteModel,
         productName: String,
         permalink: String,
         productDescription: String?,
@@ -41,11 +40,10 @@ class AIRepository @Inject constructor(
             productDescription.orEmpty(),
             languageISOCode
         )
-        return fetchJetpackAICompletionsForSite(site, prompt, PRODUCT_SHARING_FEATURE)
+        return fetchJetpackAICompletionsForSite(selectedSite.get(), prompt, PRODUCT_SHARING_FEATURE)
     }
 
     suspend fun generateProductDescription(
-        site: SiteModel,
         productName: String,
         features: String,
         languageISOCode: String = "en"
@@ -55,7 +53,7 @@ class AIRepository @Inject constructor(
             features,
             languageISOCode
         )
-        return fetchJetpackAICompletionsForSite(site, prompt, PRODUCT_DESCRIPTION_FEATURE)
+        return fetchJetpackAICompletionsForSite(selectedSite.get(), prompt, PRODUCT_DESCRIPTION_FEATURE)
     }
 
     @Suppress("UNUSED_PARAMETER")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
@@ -87,3 +87,7 @@ fun String.toCamelCase(delimiter: String = " "): String {
         word.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
     }
 }
+
+fun String.capitalize(locale: Locale = Locale.getDefault()) = replaceFirstChar {
+    if (it.isLowerCase()) it.titlecase(locale) else it.toString()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/AIProductDescriptionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/AIProductDescriptionViewModel.kt
@@ -105,7 +105,6 @@ class AIProductDescriptionViewModel @Inject constructor(
 
     private suspend fun generateProductDescriptionText(languageISOCode: String) {
         val result = aiRepository.generateProductDescription(
-            site = selectedSite.get(),
             productName = navArgs.productTitle,
             features = _viewState.value.features,
             languageISOCode = languageISOCode

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingViewModel.kt
@@ -94,7 +94,6 @@ class ProductSharingViewModel @Inject constructor(
 
     private suspend fun generateProductSharingText(languageISOCode: String) {
         val result = aiRepository.generateProductSharingText(
-            site = selectedSite.get(),
             navArgs.productName,
             navArgs.permalink,
             navArgs.productDescription.orEmpty(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/BuildProductPreviewProperties.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/BuildProductPreviewProperties.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.ui.products.ai
+
+import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.ai.ProductPreviewSubViewModel.ProductPropertyCard
+import javax.inject.Inject
+
+class BuildProductPreviewProperties @Inject constructor() {
+    operator fun invoke(product: Product): List<List<ProductPropertyCard>> = buildList {
+        TODO()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/BuildProductPreviewProperties.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/BuildProductPreviewProperties.kt
@@ -110,7 +110,8 @@ class BuildProductPreviewProperties @Inject constructor(
             content = """
                 ${resourceProvider.getString(R.string.product_weight)}: $weightFormatted
                 ${resourceProvider.getString(R.string.product_dimensions)}: $dimensionsFormatted
-                """.trimIndent()
+                """
+                .trimIndent()
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/BuildProductPreviewProperties.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/BuildProductPreviewProperties.kt
@@ -1,11 +1,116 @@
 package com.woocommerce.android.ui.products.ai
 
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.capitalize
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.ai.ProductPreviewSubViewModel.ProductPropertyCard
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.PriceUtils
+import com.woocommerce.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
-class BuildProductPreviewProperties @Inject constructor() {
+class BuildProductPreviewProperties @Inject constructor(
+    private val resourceProvider: ResourceProvider,
+    private val currencyFormatter: CurrencyFormatter,
+    private val parameterRepository: ParameterRepository,
+) {
+    private val siteParameters by lazy { parameterRepository.getParameters() }
+
     operator fun invoke(product: Product): List<List<ProductPropertyCard>> = buildList {
-        TODO()
+        add(
+            listOf(product.productType())
+        )
+
+        add(
+            buildList {
+                add(product.price())
+
+                add(product.inventory())
+
+                if (product.categories.isNotEmpty()) {
+                    add(product.categories())
+                }
+
+                if (product.tags.isNotEmpty()) {
+                    add(product.tags())
+                }
+
+                add(product.shipping())
+            }
+        )
+    }
+
+    private fun Product.productType(): ProductPropertyCard {
+        fun Product.productTypeDisplayName(): String {
+            return when (productType) {
+                ProductType.SIMPLE -> {
+                    when {
+                        this.isVirtual -> resourceProvider.getString(R.string.product_type_virtual)
+                        this.isDownloadable -> resourceProvider.getString(R.string.product_type_downloadable)
+                        else -> resourceProvider.getString(R.string.product_type_physical)
+                    }
+                }
+
+                ProductType.VARIABLE -> resourceProvider.getString(R.string.product_type_variable)
+                ProductType.GROUPED -> resourceProvider.getString(R.string.product_type_grouped)
+                ProductType.EXTERNAL -> resourceProvider.getString(R.string.product_type_external)
+                ProductType.SUBSCRIPTION -> resourceProvider.getString(R.string.product_type_subscription)
+                else -> this.type.capitalize() // show the actual product type R.string for unsupported products
+            }
+        }
+
+        return ProductPropertyCard(
+            icon = R.drawable.ic_gridicons_product,
+            title = R.string.product_type,
+            content = resourceProvider.getString(
+                R.string.product_detail_product_type_hint,
+                productTypeDisplayName()
+            )
+        )
+    }
+
+    private fun Product.price() = ProductPropertyCard(
+        icon = R.drawable.ic_gridicons_money,
+        title = R.string.product_price,
+        content = PriceUtils.formatCurrency(
+            regularPrice,
+            siteParameters.currencyCode,
+            currencyFormatter
+        )
+    )
+
+    @Suppress("UnusedReceiverParameter")
+    private fun Product.inventory() = ProductPropertyCard(
+        icon = R.drawable.ic_gridicons_list_checkmark,
+        title = R.string.product_inventory,
+        content = resourceProvider.getString(R.string.product_stock_status_instock)
+    )
+
+    private fun Product.categories() = ProductPropertyCard(
+        icon = R.drawable.ic_gridicons_folder,
+        title = R.string.product_categories,
+        content = categories.joinToString(transform = { it.name })
+    )
+
+    private fun Product.tags() = ProductPropertyCard(
+        icon = R.drawable.ic_gridicons_tag,
+        title = R.string.product_tags,
+        content = tags.joinToString(transform = { it.name })
+    )
+
+    private fun Product.shipping(): ProductPropertyCard {
+        val weightFormatted = getWeightWithUnits(siteParameters.weightUnit)
+        val dimensionsFormatted = getSizeWithUnits(siteParameters.dimensionUnit)
+
+        return ProductPropertyCard(
+            icon = R.drawable.ic_gridicons_shipping,
+            title = R.string.product_shipping,
+            content = """
+                ${resourceProvider.getString(R.string.product_weight)}: $weightFormatted
+                ${resourceProvider.getString(R.string.product_dimensions)}: $dimensionsFormatted
+                """.trimIndent()
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/BuildProductPreviewProperties.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/BuildProductPreviewProperties.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.capitalize
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.ui.products.ProductDetailCardBuilder
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.ai.ProductPreviewSubViewModel.ProductPropertyCard
 import com.woocommerce.android.util.CurrencyFormatter
@@ -11,6 +12,11 @@ import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
+/**
+ * This is a simplified version of [ProductDetailCardBuilder], we decided to create it instead of reusing the other
+ * class because our usage for now is quite simple, and [ProductDetailCardBuilder] is tightly coupled with the Product
+ * Detail ViewModel.
+ */
 class BuildProductPreviewProperties @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val currencyFormatter: CurrencyFormatter,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.products.ProductHelper
+import com.woocommerce.android.ui.products.ProductType.SIMPLE
 
 @Composable
 fun ProductPreviewSubScreen(viewModel: ProductPreviewSubViewModel, modifier: Modifier) {
@@ -153,7 +155,7 @@ private fun ProductProperties(
                 Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.major_100)))
                 Column(Modifier.weight(1f)) {
                     Text(
-                        text = property.title,
+                        text = stringResource(id = property.title),
                         style = MaterialTheme.typography.subtitle1,
                         color = colorResource(id = R.color.color_on_surface_high)
                     )
@@ -277,27 +279,29 @@ private fun ProductPreviewContentPreview() {
     WooThemeWithBackground {
         ProductPreviewSubScreen(
             ProductPreviewSubViewModel.State.Success(
-                title = "Soft Black Tee: Elevate Your Everyday Style",
-                "Introducing our USA-Made Classic Organic Cotton Tee—a staple piece designed for" +
-                    " everyday comfort and sustainability. Crafted with care from organic cotton, this tee is not" +
-                    " just soft on your skin but gentle on the environment.",
+                product = ProductHelper.getDefaultNewProduct(SIMPLE, false).copy(
+                    name = "Soft Black Tee: Elevate Your Everyday Style",
+                    description = "Introducing our USA-Made Classic Organic Cotton Tee—a staple piece designed for" +
+                        " everyday comfort and sustainability. Crafted with care from organic cotton, this tee is not" +
+                        " just soft on your skin but gentle on the environment."
+                ),
                 propertyGroups = listOf(
                     listOf(
                         ProductPreviewSubViewModel.ProductPropertyCard(
                             icon = R.drawable.ic_gridicons_product,
-                            title = "Product Type",
+                            title = R.string.product_type,
                             content = "Simple Product"
                         )
                     ),
                     listOf(
                         ProductPreviewSubViewModel.ProductPropertyCard(
                             icon = R.drawable.ic_gridicons_money,
-                            title = "Price",
+                            title = R.string.product_price,
                             content = "Regular price: $45.00"
                         ),
                         ProductPreviewSubViewModel.ProductPropertyCard(
                             icon = R.drawable.ic_gridicons_list_checkmark,
-                            title = "Inventory",
+                            title = R.string.product_inventory,
                             content = "In stock"
                         )
                     )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9810 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds the logic of the preview:
1. Calls the AIRepository to start generating the product (the AI prompt is not implemented now, it'll be implemented separately)
2. Builds the property cards from the received product and updates the state.

The error handling will be done separately as well.

### Testing instructions
1. Apply the patch from below.
2. Use an eligible site for AI.
3. Open the app, then start product creation.
4. Select the AI path.
5. Click on Continue on first two screens.
6. Notice the loading, then the UI should be updated after 5 seconds with a **demo** product.

```patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt	(revision 813172782bed5382a21f8c93d23039398d77faf9)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt	(date 1695402763823)
@@ -53,7 +53,7 @@
                 enteredName = state.name,
                 onProductNameChanged = {},
                 onSuggestNameClicked = {},
-                onContinueClicked = {}
+                onContinueClicked = viewModel::onDoneClick
             )
         }
     }
```

### Images/gif
https://github.com/woocommerce/woocommerce-android/assets/1657201/252d00ba-ac6b-497a-958c-3062579d21b0


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
