### PR TITLE
Product Creation with AI: AI prompt and networking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIPrompts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIPrompts.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MaximumLineLength")
+
 package com.woocommerce.android.ai
 
 object AIPrompts {
@@ -37,7 +39,7 @@ object AIPrompts {
         return String.format(PRODUCT_SHARING_PROMPT, name, descriptionPart, url, languageISOCode)
     }
 
-    @Suppress("MaxLineLength", "LongParameterList")
+    @Suppress("LongParameterList")
     fun generateProductCreationPrompt(
         name: String,
         keywords: String,
@@ -49,6 +51,20 @@ object AIPrompts {
         existingTags: List<String>,
         languageISOCode: String
     ): String {
+        fun getTagsLine(): String {
+            return if (existingTags.isNotEmpty()) {
+                """tags":"Given the list of available tags "${existingTags.joinToString()}", suggest an array of the best matching tags for this product, if no matches are found return an empty array, don’t suggest any value other than the available ones",
+                    """"
+            } else ""
+        }
+
+        fun getCategoriesLine(): String {
+            return if (existingCategories.isNotEmpty()) {
+                """"categories":"Given the list of available categories "${existingCategories.joinToString()}", suggest an array of the best matching categories for this product, if no matches are found return an empty array, don’t suggest any value other than the available ones"
+                    """"
+            } else ""
+        }
+
         return """
             You are a WooCommerce SEO and marketing expert, perform in-depth research about the product using the provided name, keywords and tone, and give your response in the below JSON format
 
@@ -69,16 +85,8 @@ object AIPrompts {
                   "height":"Guess and provide only the number in $dimensionUnit"
                },
                "price":"Guess the price in $currency, return the price unformatted",
-            ${
-                @Suppress("MaxLineLength")
-                if (existingTags.isNotEmpty()) """"tags":"Given the list of available tags "${existingTags.joinToString()}", suggest an array of the best matching tags for this product, if no matches are found return an empty array, don’t suggest any value other than the available ones","""
-                else ""
-            }
-            ${
-                @Suppress("MaxLineLength")
-                if (existingCategories.isNotEmpty()) """"categories":"Given the list of available categories "${existingCategories.joinToString()}", suggest an array of the best matching categories for this product, if no matches are found return an empty array, don’t suggest any value other than the available ones""""
-                else ""
-            }
+               ${getTagsLine()}
+               ${getCategoriesLine()}
             }"
         """.trimIndent()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIPrompts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIPrompts.kt
@@ -37,6 +37,52 @@ object AIPrompts {
         return String.format(PRODUCT_SHARING_PROMPT, name, descriptionPart, url, languageISOCode)
     }
 
+    @Suppress("MaxLineLength", "LongParameterList")
+    fun generateProductCreationPrompt(
+        name: String,
+        keywords: String,
+        tone: String,
+        weightUnit: String,
+        dimensionUnit: String,
+        currency: String,
+        existingCategories: List<String>,
+        existingTags: List<String>,
+        languageISOCode: String
+    ): String {
+        return """
+            You are a WooCommerce SEO and marketing expert, perform in-depth research about the product using the provided name, keywords and tone, and give your response in the below JSON format
+
+            name: "$name"
+            keywords: "$keywords"
+            tone: "$tone"
+
+            Expected json response format:
+            "{
+               "name":"The name of the product, in the ISO language code "$languageISOCode"",
+               "description":"Product description of around 100 words long in a "$tone" tone, in the ISO language code "$languageISOCode"",
+               "short_description":"Product's short description, in the ISO language code "$languageISOCode"",
+               "virtual":"A boolean value that shows whether the product is virtual or physical",
+               "shipping":{
+                  "length":"Guess and provide only the number in $dimensionUnit",
+                  "weight":"Guess and provide only the number in $weightUnit",
+                  "width":"Guess and provide only the number in $dimensionUnit",
+                  "height":"Guess and provide only the number in $dimensionUnit"
+               },
+               "price":"Guess the price in $currency, return the price unformatted",
+            ${
+                @Suppress("MaxLineLength")
+                if (existingTags.isNotEmpty()) """"tags":"Given the list of available tags "${existingTags.joinToString()}", suggest an array of the best matching tags for this product, if no matches are found return an empty array, don’t suggest any value other than the available ones","""
+                else ""
+            }
+            ${
+                @Suppress("MaxLineLength")
+                if (existingCategories.isNotEmpty()) """"categories":"Given the list of available categories "${existingCategories.joinToString()}", suggest an array of the best matching categories for this product, if no matches are found return an empty array, don’t suggest any value other than the available ones""""
+                else ""
+            }
+            }"
+        """.trimIndent()
+    }
+
     private const val LANGUAGE_IDENTIFICATION_PROMPT = "What is the ISO language code of the language used in the " +
         "below text? Do not include any explanations and only provide the ISO language code in your response. \n" +
         "Text: ```(%1\$s)```"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
@@ -101,8 +101,8 @@ class AIRepository @Inject constructor(
                 languageISOCode = languageISOCode
             ),
             PRODUCT_CREATION_FEATURE
-        ).mapCatching {
-            val parsedResponse = Gson().fromJson(it, JsonResponse::class.java)
+        ).mapCatching { json ->
+            val parsedResponse = Gson().fromJson(json, JsonResponse::class.java)
             ProductHelper.getDefaultNewProduct(
                 SIMPLE,
                 parsedResponse.isVirtual
@@ -111,8 +111,12 @@ class AIRepository @Inject constructor(
                 description = parsedResponse.description,
                 shortDescription = parsedResponse.shortDescription,
                 regularPrice = parsedResponse.price,
-                categories = parsedResponse.categories?.map { ProductCategory(name = it) }.orEmpty(),
-                tags = parsedResponse.tags?.map { ProductTag(name = it) }.orEmpty(),
+                categories = parsedResponse.categories.orEmpty()
+                    .filter { existingCategories.contains(it) }
+                    .map { ProductCategory(name = it) },
+                tags = parsedResponse.tags.orEmpty()
+                    .filter { existingTags.contains(it) }
+                    .map { ProductTag(name = it) },
                 weight = parsedResponse.shipping.weight,
                 height = parsedResponse.shipping.height,
                 length = parsedResponse.shipping.length,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
@@ -65,8 +65,8 @@ class AIRepository @Inject constructor(
         weightUnit: String,
         dimensionUnit: String,
         currency: String,
-        existingCategories: List<String>,
-        existingTags: List<String>,
+        existingCategories: List<ProductCategory>,
+        existingTags: List<ProductTag>,
         languageISOCode: String = "en"
     ): Result<Product> {
         data class Shipping(
@@ -96,8 +96,8 @@ class AIRepository @Inject constructor(
                 weightUnit = weightUnit,
                 dimensionUnit = dimensionUnit,
                 currency = currency,
-                existingCategories = existingCategories,
-                existingTags = existingTags,
+                existingCategories = existingCategories.map { it.name },
+                existingTags = existingTags.map { it.name },
                 languageISOCode = languageISOCode
             ),
             PRODUCT_CREATION_FEATURE
@@ -111,12 +111,8 @@ class AIRepository @Inject constructor(
                 description = parsedResponse.description,
                 shortDescription = parsedResponse.shortDescription,
                 regularPrice = parsedResponse.price,
-                categories = parsedResponse.categories.orEmpty()
-                    .filter { existingCategories.contains(it) }
-                    .map { ProductCategory(name = it) },
-                tags = parsedResponse.tags.orEmpty()
-                    .filter { existingTags.contains(it) }
-                    .map { ProductTag(name = it) },
+                categories = existingCategories.filter { parsedResponse.categories.orEmpty().contains(it.name) },
+                tags = existingTags.filter { parsedResponse.tags.orEmpty().contains(it.name) },
                 weight = parsedResponse.shipping.weight,
                 height = parsedResponse.shipping.height,
                 length = parsedResponse.shipping.length,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/AIProductDescriptionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/AIProductDescriptionViewModel.kt
@@ -59,7 +59,6 @@ class AIProductDescriptionViewModel @Inject constructor(
 
     private suspend fun identifyLanguage(): Result<String> {
         return aiRepository.identifyISOLanguageCode(
-            site = selectedSite.get(),
             text = "${navArgs.productTitle} ${_viewState.value.features}",
             feature = PRODUCT_DESCRIPTION_FEATURE
         ).fold(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingViewModel.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.ai.AIRepository.JetpackAICompletionsException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.LaunchUrlInChromeTab
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -27,7 +26,6 @@ class ProductSharingViewModel @Inject constructor(
     private val aiRepository: AIRepository,
     private val tracker: AnalyticsTrackerWrapper,
     resourceProvider: ResourceProvider,
-    private val selectedSite: SelectedSite,
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: ProductSharingDialogArgs by savedStateHandle.navArgs()
@@ -77,7 +75,6 @@ class ProductSharingViewModel @Inject constructor(
 
     private suspend fun identifyLanguage(): Result<String> {
         return aiRepository.identifyISOLanguageCode(
-            site = selectedSite.get(),
             text = "${navArgs.productName} ${navArgs.productDescription.orEmpty()}",
             feature = PRODUCT_SHARING_FEATURE
         ).fold(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ai.AIRepository
+import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
+import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -18,9 +21,18 @@ import javax.inject.Inject
 class AddProductWithAIViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     aiRepository: AIRepository,
-    buildProductPreviewProperties: BuildProductPreviewProperties
+    buildProductPreviewProperties: BuildProductPreviewProperties,
+    categoriesRepository: ProductCategoriesRepository,
+    tagsRepository: ProductTagsRepository,
+    parameterRepository: ParameterRepository
 ) : ScopedViewModel(savedState = savedStateHandle) {
-    private val previewSubViewModel = ProductPreviewSubViewModel(aiRepository, buildProductPreviewProperties) {
+    private val previewSubViewModel = ProductPreviewSubViewModel(
+        aiRepository = aiRepository,
+        buildProductPreviewProperties = buildProductPreviewProperties,
+        categoriesRepository = categoriesRepository,
+        tagsRepository = tagsRepository,
+        parametersRepository = parameterRepository
+    ) {
         saveButtonState.value = SaveButtonState.Shown
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
@@ -37,7 +37,7 @@ class ProductPreviewSubViewModel(
             aiRepository.generateProduct(
                 productName = name,
                 productKeyWords = keywords,
-                tone = "neutral",  // TODO,
+                tone = "neutral", // TODO,
                 weightUnit = siteParameters.weightUnit ?: "kg",
                 dimensionUnit = siteParameters.dimensionUnit ?: "cm",
                 currency = siteParameters.currencyCode ?: "USD",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
@@ -5,27 +5,46 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.ai.AIRepository
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
+import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import java.util.Locale
 
 class ProductPreviewSubViewModel(
     private val aiRepository: AIRepository,
     private val buildProductPreviewProperties: BuildProductPreviewProperties,
+    private val categoriesRepository: ProductCategoriesRepository,
+    private val tagsRepository: ProductTagsRepository,
+    private val parametersRepository: ParameterRepository,
     override val onDone: (Product) -> Unit,
 ) : AddProductWithAISubViewModel<Product> {
     private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    private val siteParameters by lazy { parametersRepository.getParameters() }
 
     private val _state = MutableStateFlow<State>(State.Loading)
     val state = _state.asLiveData()
 
     fun startGeneratingProduct(name: String, keywords: String) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             _state.value = State.Loading
-            aiRepository.generateProduct(name, keywords).fold(
+            aiRepository.generateProduct(
+                productName = name,
+                productKeyWords = keywords,
+                tone = "neutral",  // TODO,
+                weightUnit = siteParameters.weightUnit ?: "kg",
+                dimensionUnit = siteParameters.dimensionUnit ?: "cm",
+                currency = siteParameters.currencyCode ?: "USD",
+                existingCategories = categoriesRepository.getProductCategoriesList().map { it.name },
+                existingTags = tagsRepository.getProductTags().map { it.name },
+                languageISOCode = Locale.getDefault().language
+            ).fold(
                 onSuccess = { product ->
                     _state.value = State.Success(
                         product = product,
@@ -34,7 +53,8 @@ class ProductPreviewSubViewModel(
                     onDone(product)
                 },
                 onFailure = {
-                    TODO()
+                    // TODO
+                    it.printStackTrace()
                 }
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
@@ -57,8 +57,8 @@ class ProductPreviewSubViewModel(
                 weightUnit = siteParameters.weightUnit ?: "kg",
                 dimensionUnit = siteParameters.dimensionUnit ?: "cm",
                 currency = siteParameters.currencyCode ?: "USD",
-                existingCategories = categories.map { it.name },
-                existingTags = tags.map { it.name },
+                existingCategories = categories,
+                existingTags = tags,
                 languageISOCode = Locale.getDefault().language
             ).fold(
                 onSuccess = { product ->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9817 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds the handling of the product generation by AI, it adds the prompt according to the agreed version, and parsing the result and creating a `Product` instance that we can pass to the ViewModel.

### Testing instructions
1. Apply the patch from below
2. Open the app, then sign to an AI-eligible site.
3. Start product creation and choose the AI flow.
4. Click on Continue on the first screen.
5. Confirm the AI generation is completed successfully and the product details are shown.

### Images/gif
https://github.com/woocommerce/woocommerce-android/assets/1657201/cd2eb269-0d9b-4843-8507-70610677db09

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
