### PR TITLE
[Mobile Payments] Simple payments tax calculation total bug fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+15.7
+----
+- [*] [Internal] In-Person Payments: Fixed wrong total payment amount display on the payment method selections screen when simple payments without tax used [https://github.com/woocommerce/woocommerce-android/pull/9826]
 
 15.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsFragment.kt
@@ -31,7 +31,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments), BackPressListener {
     private val args: SimplePaymentsFragmentArgs by navArgs()
-    private val viewModel: SimplePaymentsFragmentViewModel by viewModels()
+    private val viewModel: SimplePaymentsViewModel by viewModels()
     private val sharedViewModel by hiltNavGraphViewModels<SimplePaymentsSharedViewModel>(R.id.nav_graph_main)
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
@@ -99,13 +99,13 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments), 
                 is MultiLiveEvent.Event.ShowSnackbar -> {
                     uiMessageResolver.showSnack(event.message)
                 }
-                is SimplePaymentsFragmentViewModel.ShowCustomerNoteEditor -> {
+                is SimplePaymentsViewModel.ShowCustomerNoteEditor -> {
                     showCustomerNoteEditor()
                 }
-                is SimplePaymentsFragmentViewModel.ShowTakePaymentScreen -> {
+                is SimplePaymentsViewModel.ShowTakePaymentScreen -> {
                     showTakePaymentScreen()
                 }
-                is SimplePaymentsFragmentViewModel.CancelSimplePayment -> {
+                is SimplePaymentsViewModel.CancelSimplePayment -> {
                     viewModel.deleteDraftOrder(viewModel.orderDraft)
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsFragment.kt
@@ -145,6 +145,10 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments), 
                     binding.editEmail.error = getString(R.string.email_invalid)
                 }
             }
+            new.isLoading.takeIfNotEqualTo(old?.isLoading) { isLoading ->
+                binding.progressBar.isVisible = isLoading
+                binding.buttonDone.isEnabled = !isLoading
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsFragment.kt
@@ -102,7 +102,7 @@ class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments), 
                 is SimplePaymentsViewModel.ShowCustomerNoteEditor -> {
                     showCustomerNoteEditor()
                 }
-                is SimplePaymentsViewModel.ShowTakePaymentScreen -> {
+                is SimplePaymentsViewModel.ShowPaymentMethodSelectionScreen -> {
                     showTakePaymentScreen()
                 }
                 is SimplePaymentsViewModel.CancelSimplePayment -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsViewModel.kt
@@ -139,9 +139,15 @@ class SimplePaymentsViewModel @Inject constructor(
         collect { result ->
             if (result.event.isError) {
                 recordUpdateSimplePaymentError(result)
-            } else if (result is UpdateOrderResult.RemoteUpdateResult) {
+            }
+
+            if (result is UpdateOrderResult.RemoteUpdateResult) {
                 viewState = viewState.copy(isLoading = false)
-                triggerEvent(ShowTakePaymentScreen)
+                if (result.event.isError) {
+                    triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.simple_payments_update_error))
+                } else {
+                    triggerEvent(ShowPaymentMethodSelectionScreen)
+                }
             }
         }
     }
@@ -186,6 +192,6 @@ class SimplePaymentsViewModel @Inject constructor(
     ) : Parcelable
 
     object ShowCustomerNoteEditor : MultiLiveEvent.Event()
-    object ShowTakePaymentScreen : MultiLiveEvent.Event()
+    object ShowPaymentMethodSelectionScreen : MultiLiveEvent.Event()
     object CancelSimplePayment : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsViewModel.kt
@@ -29,7 +29,7 @@ import java.math.BigDecimal
 import javax.inject.Inject
 
 @HiltViewModel
-class SimplePaymentsFragmentViewModel @Inject constructor(
+class SimplePaymentsViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val simplePaymentsRepository: SimplePaymentsRepository,
     private val networkStatus: NetworkStatus,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsViewModelTests.kt
@@ -1,24 +1,29 @@
 package com.woocommerce.android.ui.payments.simplepayments
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType
+import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.store.WCOrderStore
 
 @ExperimentalCoroutinesApi
 class SimplePaymentsViewModelTests : BaseUnitTest() {
-    companion object {
-        private const val ORDER_ID = 1L
-        private const val REMOTE_ORDER_NUMBER = "100"
-        private const val TAX_LINE_ID = 1L
-        private const val TAX_LINE_TAX_RATE = 0.15f
-        private const val TAX_LINE_TAX_RATE_CODE = "US CA 92679"
+    private val simplePaymentsRepository: SimplePaymentsRepository = mock()
+    private val networkStatus: NetworkStatus = mock {
+        on { isConnected() }.thenReturn(true)
     }
 
     private val testOrder: Order
@@ -50,7 +55,7 @@ class SimplePaymentsViewModelTests : BaseUnitTest() {
         ).initSavedStateHandle()
 
     private fun initViewModel() {
-        viewModel = SimplePaymentsViewModel(savedState, mock(), mock(), mock())
+        viewModel = SimplePaymentsViewModel(savedState, simplePaymentsRepository, networkStatus, mock())
     }
 
     @Test
@@ -68,4 +73,84 @@ class SimplePaymentsViewModelTests : BaseUnitTest() {
             viewModel.onChargeTaxesChanged(chargeTaxes = false)
             assertThat(viewModel.orderDraft.total).isEqualTo(viewModel.orderDraft.feesTotal)
         }
+
+    @Test
+    fun `given error result from update simple payments, when onDoneButtonClicked, then show error message`() =
+        testBlocking {
+            // GIVEN
+            whenever(
+                simplePaymentsRepository.updateSimplePayment(
+                    orderId = any(),
+                    amount = any(),
+                    customerNote = any(),
+                    billingEmail = any(),
+                    isTaxable = any(),
+                )
+            ).thenReturn(
+                flowOf(
+                    WCOrderStore.UpdateOrderResult.RemoteUpdateResult(
+                        WCOrderStore.OnOrderChanged(
+                            orderError = mock()
+                        )
+                    )
+                )
+            )
+            initViewModel()
+
+            val states = viewModel.viewStateLiveData.liveData.captureValues()
+
+            // WHEN
+            viewModel.onDoneButtonClicked()
+
+            // THEN
+            assertThat(states[1].isLoading).isFalse
+            assertThat(states[2].isLoading).isTrue()
+            assertThat(states[3].isLoading).isFalse
+
+            assertThat(viewModel.event.value).isEqualTo(
+                MultiLiveEvent.Event.ShowSnackbar(R.string.simple_payments_update_error)
+            )
+        }
+
+    @Test
+    fun `given successful result from update simple payments, when onDoneButtonClicked, then ShowPaymentMethodSelectionScreen`() =
+        testBlocking {
+            // GIVEN
+            whenever(
+                simplePaymentsRepository.updateSimplePayment(
+                    orderId = any(),
+                    amount = any(),
+                    customerNote = any(),
+                    billingEmail = any(),
+                    isTaxable = any(),
+                )
+            ).thenReturn(
+                flowOf(
+                    WCOrderStore.UpdateOrderResult.RemoteUpdateResult(
+                        WCOrderStore.OnOrderChanged()
+                    )
+                )
+            )
+            initViewModel()
+
+            val states = viewModel.viewStateLiveData.liveData.captureValues()
+
+            // WHEN
+            viewModel.onDoneButtonClicked()
+
+            // THEN
+            assertThat(states[1].isLoading).isFalse
+            assertThat(states[2].isLoading).isTrue()
+            assertThat(states[3].isLoading).isFalse
+
+            assertThat(viewModel.event.value).isEqualTo(SimplePaymentsViewModel.ShowPaymentMethodSelectionScreen)
+        }
+
+    companion object {
+        private const val ORDER_ID = 1L
+        private const val REMOTE_ORDER_NUMBER = "100"
+        private const val TAX_LINE_ID = 1L
+        private const val TAX_LINE_TAX_RATE = 0.15f
+        private const val TAX_LINE_TAX_RATE_CODE = "US CA 92679"
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsViewModelTests.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 
 @ExperimentalCoroutinesApi
-class SimplePaymentsFragmentViewModelTests : BaseUnitTest() {
+class SimplePaymentsViewModelTests : BaseUnitTest() {
     companion object {
         private const val ORDER_ID = 1L
         private const val REMOTE_ORDER_NUMBER = "100"
@@ -41,7 +41,7 @@ class SimplePaymentsFragmentViewModelTests : BaseUnitTest() {
             )
         }
 
-    private lateinit var viewModel: SimplePaymentsFragmentViewModel
+    private lateinit var viewModel: SimplePaymentsViewModel
 
     private val savedState: SavedStateHandle =
         SimplePaymentsFragmentArgs(
@@ -50,7 +50,7 @@ class SimplePaymentsFragmentViewModelTests : BaseUnitTest() {
         ).initSavedStateHandle()
 
     private fun initViewModel() {
-        viewModel = SimplePaymentsFragmentViewModel(savedState, mock(), mock(), mock())
+        viewModel = SimplePaymentsViewModel(savedState, mock(), mock(), mock())
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9825
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Simple payments with tax calculations enabled on the backend were showing the wrong amount to be collected on the payment method selection screen. The reason was that we were navigating to the payment method selection screen right after order was updated locally. Locally updated order doesn't update "order total". The PR brings a change that we navigate to the next screen only after order successful updated on the backed and orders total updated locally after that

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Follow the flow:
* Tax rates are defined in wp-admin
* Create simple payment, with the “Charge taxes” toggle disabled
* Click “Take payment” and notice the amount includes taxes
* Notice that on the payments method selection screen title matches the order's total

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/5083bc5c-769b-4874-a145-221b1fe6cc40



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
