### PR TITLE
Product Creation With AI: wiring and aligning the sub-screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubScreen.kt
@@ -25,8 +25,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetDefaults
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.ModalBottomSheetValue.HalfExpanded
-import androidx.compose.material.ModalBottomSheetValue.Hidden
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.Check
@@ -77,8 +75,8 @@ fun AboutProductSubScreen(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val modalSheetState = rememberModalBottomSheetState(
-        initialValue = Hidden,
-        confirmStateChange = { it != HalfExpanded },
+        initialValue = ModalBottomSheetValue.Hidden,
+        confirmStateChange = { it != ModalBottomSheetValue.HalfExpanded },
     )
     val configuration = LocalConfiguration.current
 
@@ -107,11 +105,7 @@ fun AboutProductSubScreen(
         Column(
             modifier = modifier
                 .background(MaterialTheme.colors.surface)
-                .padding(
-                    start = dimensionResource(id = R.dimen.major_100),
-                    end = dimensionResource(id = R.dimen.major_100),
-                    top = dimensionResource(id = R.dimen.major_200)
-                )
+                .padding(dimensionResource(id = R.dimen.major_100))
         ) {
             Column(
                 modifier = Modifier
@@ -119,6 +113,7 @@ fun AboutProductSubScreen(
                     .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
             ) {
+                Spacer(modifier = Modifier)
                 Text(
                     text = stringResource(id = R.string.product_creation_ai_about_product_title),
                     style = MaterialTheme.typography.h5
@@ -134,7 +129,7 @@ fun AboutProductSubScreen(
                 ) {
                     Text(
                         text = stringResource(id = R.string.product_creation_ai_about_product_edit_text_header),
-                        style = MaterialTheme.typography.subtitle2,
+                        style = MaterialTheme.typography.body2,
                     )
                     Box {
                         if (state.productFeatures.isEmpty()) {
@@ -188,15 +183,39 @@ fun AboutProductSubScreen(
                         color = colorResource(id = R.color.color_primary)
                     )
                 }
+
+                if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                    // Make button part of the scrollable content on landscape
+                    ContinueButton(
+                        onClick = onCreateProductDetails,
+                        enabled = state.productFeatures.isNotBlank()
+                    )
+                }
             }
-            WCColoredButton(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = onCreateProductDetails,
-                enabled = state.productFeatures.isNotBlank()
-            ) {
-                Text(text = stringResource(id = R.string.product_creation_ai_about_product_continue_button))
+
+            if (configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+                // Stick button to the bottom on portrait mode
+                ContinueButton(
+                    onClick = onCreateProductDetails,
+                    enabled = state.productFeatures.isNotBlank()
+                )
             }
         }
+    }
+}
+
+@Composable
+private fun ContinueButton(
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    WCColoredButton(
+        modifier = modifier.fillMaxWidth(),
+        onClick = onClick,
+        enabled = enabled
+    ) {
+        Text(text = stringResource(id = R.string.product_creation_ai_about_product_continue_button))
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubScreen.kt
@@ -113,10 +113,10 @@ fun AboutProductSubScreen(
                     .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
             ) {
-                Spacer(modifier = Modifier)
                 Text(
                     text = stringResource(id = R.string.product_creation_ai_about_product_title),
-                    style = MaterialTheme.typography.h5
+                    style = MaterialTheme.typography.h5,
+                    modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100))
                 )
                 Text(
                     text = stringResource(id = R.string.product_creation_ai_about_product_subtitle),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubScreen.kt
@@ -128,7 +128,7 @@ fun AboutProductSubScreen(
                     verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100))
                 ) {
                     Text(
-                        text = stringResource(id = R.string.product_creation_ai_about_product_edit_text_header),
+                        text = state.productName,
                         style = MaterialTheme.typography.body2,
                     )
                     Box {
@@ -282,6 +282,7 @@ private fun AiToneBottomSheetContent(
 fun AboutProductSubScreenPreview() {
     AboutProductSubScreen(
         state = UiState(
+            productName = "productName",
             productFeatures = "productFeatures",
             selectedAiTone = Casual
         ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubViewModel.kt
@@ -5,6 +5,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.products.ai.AboutProductSubViewModel.AiTone
 import com.woocommerce.android.viewmodel.getStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -14,8 +15,8 @@ import kotlinx.parcelize.Parcelize
 
 class AboutProductSubViewModel(
     savedStateHandle: SavedStateHandle,
-    override val onDone: (String) -> Unit
-) : AddProductWithAISubViewModel<String> {
+    override val onDone: (Pair<String, AiTone>) -> Unit
+) : AddProductWithAISubViewModel<Pair<String, AiTone>> {
     private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     private val productFeatures = savedStateHandle.getStateFlow(
@@ -29,7 +30,9 @@ class AboutProductSubViewModel(
     val state = productFeatures.asLiveData()
 
     fun onDoneClick() {
-        onDone(productFeatures.value.productFeatures)
+        productFeatures.value.let { (productFeatures, selectedAiTone) ->
+            onDone(Pair(productFeatures, selectedAiTone))
+        }
     }
 
     fun onProductFeaturesUpdated(features: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubViewModel.kt
@@ -22,6 +22,7 @@ class AboutProductSubViewModel(
     private val productFeatures = savedStateHandle.getStateFlow(
         viewModelScope,
         UiState(
+            productName = "",
             productFeatures = "",
             selectedAiTone = AiTone.Casual
         )
@@ -30,7 +31,7 @@ class AboutProductSubViewModel(
     val state = productFeatures.asLiveData()
 
     fun onDoneClick() {
-        productFeatures.value.let { (productFeatures, selectedAiTone) ->
+        productFeatures.value.let { (_, productFeatures, selectedAiTone) ->
             onDone(Pair(productFeatures, selectedAiTone))
         }
     }
@@ -43,12 +44,17 @@ class AboutProductSubViewModel(
         productFeatures.value = productFeatures.value.copy(selectedAiTone = tone)
     }
 
+    fun updateProductName(name: String) {
+        productFeatures.value = productFeatures.value.copy(productName = name)
+    }
+
     override fun close() {
         viewModelScope.cancel()
     }
 
     @Parcelize
     data class UiState(
+        val productName: String,
         val productFeatures: String,
         val selectedAiTone: AiTone
     ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAISubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAISubViewModel.kt
@@ -9,4 +9,7 @@ sealed interface AddProductWithAISubViewModel<T> : Closeable {
     val events: Flow<Event>
         get() = emptyFlow()
     val onDone: (T) -> Unit
+
+    fun onStart() {}
+    fun onStop() {}
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.scan
 import javax.inject.Inject
 
 @HiltViewModel
@@ -54,7 +55,6 @@ class AddProductWithAIViewModel @Inject constructor(
                     previewSubViewModel.updateKeywords(productFeatures)
                     previewSubViewModel.updateTone(selectedAiTone)
                 }
-                previewSubViewModel.startGeneratingProduct()
                 goToNextStep()
             }
         ),
@@ -93,6 +93,13 @@ class AddProductWithAIViewModel @Inject constructor(
     }
 
     private fun wireSubViewModels() {
+        step.scan<Step, Step?>(null) { previousStep, newStep ->
+            previousStep?.let { subViewModels[it.ordinal].onStop() }
+            subViewModels[newStep.ordinal].onStart()
+
+            newStep
+        }.launchIn(viewModelScope)
+
         subViewModels.forEach { subViewModel ->
             addCloseable(subViewModel)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -28,6 +28,24 @@ class AddProductWithAIViewModel @Inject constructor(
     tagsRepository: ProductTagsRepository,
     parameterRepository: ParameterRepository
 ) : ScopedViewModel(savedState = savedStateHandle) {
+    private val nameSubViewModel = ProductNameSubViewModel(
+        savedStateHandle = savedStateHandle,
+        onDone = { name ->
+            aboutSubViewModel.updateProductName(name)
+            previewSubViewModel.updateName(name)
+            goToNextStep()
+        }
+    )
+    private val aboutSubViewModel = AboutProductSubViewModel(
+        savedStateHandle = savedStateHandle,
+        onDone = { result ->
+            result.let { (productFeatures, selectedAiTone) ->
+                previewSubViewModel.updateKeywords(productFeatures)
+                previewSubViewModel.updateTone(selectedAiTone)
+            }
+            goToNextStep()
+        }
+    )
     private val previewSubViewModel = ProductPreviewSubViewModel(
         aiRepository = aiRepository,
         buildProductPreviewProperties = buildProductPreviewProperties,
@@ -42,23 +60,8 @@ class AddProductWithAIViewModel @Inject constructor(
     private val saveButtonState = MutableStateFlow(SaveButtonState.Hidden)
 
     private val subViewModels = listOf<AddProductWithAISubViewModel<*>>(
-        ProductNameSubViewModel(
-            savedStateHandle = savedStateHandle,
-            onDone = { name ->
-                previewSubViewModel.updateName(name)
-                goToNextStep()
-            }
-        ),
-        AboutProductSubViewModel(
-            savedStateHandle = savedStateHandle,
-            onDone = { result ->
-                result.let { (productFeatures, selectedAiTone) ->
-                    previewSubViewModel.updateKeywords(productFeatures)
-                    previewSubViewModel.updateTone(selectedAiTone)
-                }
-                goToNextStep()
-            }
-        ),
+        nameSubViewModel,
+        aboutSubViewModel,
         previewSubViewModel
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -53,6 +53,7 @@ class AddProductWithAIViewModel @Inject constructor(
         tagsRepository = tagsRepository,
         parametersRepository = parameterRepository
     ) {
+        // TODO keep reference to the product for the saving step
         saveButtonState.value = SaveButtonState.Shown
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -42,18 +42,19 @@ class AddProductWithAIViewModel @Inject constructor(
     private val subViewModels = listOf<AddProductWithAISubViewModel<*>>(
         ProductNameSubViewModel(
             savedStateHandle = savedStateHandle,
-            onDone = {
-                // Pass the name to next ViewModel if needed
+            onDone = { name ->
+                previewSubViewModel.updateName(name)
                 goToNextStep()
             }
         ),
         AboutProductSubViewModel(
             savedStateHandle = savedStateHandle,
-            onDone = {
-                previewSubViewModel.startGeneratingProduct(
-                    name = "T-Shirt", // TODO pass data from the name SubViewModel
-                    keywords = it
-                )
+            onDone = { result ->
+                result.let { (productFeatures, selectedAiTone) ->
+                    previewSubViewModel.updateKeywords(productFeatures)
+                    previewSubViewModel.updateTone(selectedAiTone)
+                }
+                previewSubViewModel.startGeneratingProduct()
                 goToNextStep()
             }
         ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.scan
@@ -93,6 +94,7 @@ class AddProductWithAIViewModel @Inject constructor(
     }
 
     private fun wireSubViewModels() {
+        // Notify the sub view models when the user navigates to their screen
         step.scan<Step, Step?>(null) { previousStep, newStep ->
             previousStep?.let { subViewModels[it.ordinal].onStop() }
             subViewModels[newStep.ordinal].onStart()
@@ -100,6 +102,12 @@ class AddProductWithAIViewModel @Inject constructor(
             newStep
         }.launchIn(viewModelScope)
 
+        // Hide the save button when the user leaves the preview screen
+        step.filter { it != Step.Preview }
+            .onEach { saveButtonState.value = SaveButtonState.Hidden }
+            .launchIn(viewModelScope)
+
+        // Handle SubViewModel events
         subViewModels.forEach { subViewModel ->
             addCloseable(subViewModel)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
@@ -69,13 +69,12 @@ fun ProductNameForm(
     val orientation = LocalConfiguration.current.orientation
 
     @Composable
-    fun ContinueButton() {
+    fun ContinueButton(modifier: Modifier = Modifier) {
         WCColoredButton(
             enabled = enteredName.isNotEmpty(),
             onClick = onContinueClicked,
-            modifier = Modifier
+            modifier = modifier
                 .fillMaxWidth()
-                .padding(horizontal = dimensionResource(id = R.dimen.major_100))
         ) {
             Text(text = stringResource(id = R.string.continue_button))
         }
@@ -117,7 +116,7 @@ fun ProductNameForm(
 
             // Button will scroll with the rest of UI on landscape mode, or... (see below)
             if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                ContinueButton()
+                ContinueButton(Modifier.padding(top = dimensionResource(id = R.dimen.major_100)))
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductNameSubScreen.kt
@@ -68,13 +68,30 @@ fun ProductNameForm(
 ) {
     val orientation = LocalConfiguration.current.orientation
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    @Composable
+    fun ContinueButton() {
+        WCColoredButton(
+            enabled = enteredName.isNotEmpty(),
+            onClick = onContinueClicked,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+        ) {
+            Text(text = stringResource(id = R.string.continue_button))
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .padding(dimensionResource(id = R.dimen.major_100))
+            .fillMaxSize()
+    ) {
         Column(
             modifier = Modifier
                 .weight(1f)
                 .verticalScroll(rememberScrollState())
-                .padding(dimensionResource(id = R.dimen.major_100))
         ) {
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
             Text(
                 text = stringResource(id = R.string.ai_product_creation_add_name_title),
                 style = MaterialTheme.typography.h5
@@ -84,7 +101,8 @@ fun ProductNameForm(
 
             Text(
                 text = stringResource(id = R.string.ai_product_creation_add_name_subtitle),
-                style = MaterialTheme.typography.body1
+                style = MaterialTheme.typography.subtitle1,
+                color = colorResource(id = R.color.color_on_surface_medium)
             )
 
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_250)))
@@ -99,35 +117,19 @@ fun ProductNameForm(
 
             // Button will scroll with the rest of UI on landscape mode, or... (see below)
             if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                WCColoredButton(
-                    enabled = enteredName.isNotEmpty(),
-                    onClick = onContinueClicked,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = dimensionResource(id = R.dimen.major_100))
-                ) {
-                    Text(text = stringResource(id = R.string.continue_button))
-                }
+                ContinueButton()
             }
         }
 
         // Button will stick to the bottom on portrait mode
         if (orientation == Configuration.ORIENTATION_PORTRAIT) {
-            WCColoredButton(
-                enabled = enteredName.isNotEmpty(),
-                onClick = onContinueClicked,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
-            ) {
-                Text(text = stringResource(id = R.string.continue_button))
-            }
+            ContinueButton()
         }
     }
 }
 
 @Composable
-fun ProductKeywordsTextFieldWithEmbeddedButton(
+private fun ProductKeywordsTextFieldWithEmbeddedButton(
     textFieldContent: String,
     onTextFieldContentChanged: (String) -> Unit,
     onButtonClicked: () -> Unit
@@ -139,6 +141,7 @@ fun ProductKeywordsTextFieldWithEmbeddedButton(
             style = MaterialTheme.typography.body2,
             modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.minor_100))
         )
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.ui.products.categories.ProductCategoriesRepositor
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -37,8 +38,10 @@ class ProductPreviewSubViewModel(
     private lateinit var productKeywords: String
     private lateinit var tone: AiTone
 
-    fun startGeneratingProduct() {
-        viewModelScope.launch {
+    private var generationJob: Job? = null
+
+    override fun onStart() {
+        generationJob = viewModelScope.launch {
             _state.value = State.Loading
 
             val categories = withContext(Dispatchers.IO) {
@@ -79,6 +82,10 @@ class ProductPreviewSubViewModel(
                 }
             )
         }
+    }
+
+    override fun onStop() {
+        generationJob?.cancel()
     }
 
     fun updateName(name: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.asLiveData
 import com.woocommerce.android.ai.AIRepository
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.ui.products.ai.AboutProductSubViewModel.AiTone
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import kotlinx.coroutines.CoroutineScope
@@ -32,7 +33,11 @@ class ProductPreviewSubViewModel(
     private val _state = MutableStateFlow<State>(State.Loading)
     val state = _state.asLiveData()
 
-    fun startGeneratingProduct(name: String, keywords: String) {
+    private lateinit var productName: String
+    private lateinit var productKeywords: String
+    private lateinit var tone: AiTone
+
+    fun startGeneratingProduct() {
         viewModelScope.launch {
             _state.value = State.Loading
 
@@ -51,9 +56,9 @@ class ProductPreviewSubViewModel(
             }
 
             aiRepository.generateProduct(
-                productName = name,
-                productKeyWords = keywords,
-                tone = "neutral", // TODO,
+                productName = productName,
+                productKeyWords = productKeywords,
+                tone = tone.slug,
                 weightUnit = siteParameters.weightUnit ?: "kg",
                 dimensionUnit = siteParameters.dimensionUnit ?: "cm",
                 currency = siteParameters.currencyCode ?: "USD",
@@ -74,6 +79,18 @@ class ProductPreviewSubViewModel(
                 }
             )
         }
+    }
+
+    fun updateName(name: String) {
+        this.productName = name
+    }
+
+    fun updateKeywords(keywords: String) {
+        this.productKeywords = keywords
+    }
+
+    fun updateTone(tone: AiTone) {
+        this.tone = tone
     }
 
     override fun close() {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1906,7 +1906,6 @@
     <string name="ai_product_creation_add_name_suggest_name_button">Suggest a name</string>
     <string name="product_creation_ai_about_product_title">About your product</string>
     <string name="product_creation_ai_about_product_subtitle">Highlight what makes your product unique, and let AI do the magic.</string>
-    <string name="product_creation_ai_about_product_edit_text_header">My product</string>
     <string name="product_creation_ai_about_product_edit_text_placeholder">For example, Soft fabric, durable stitching, unique design</string>
     <string name="product_creation_ai_about_product_edit_text_caption">Add key features, benefits, or details to help your product get found online.</string>
     <string name="product_creation_ai_about_product_set_tone">Set tone and voice</string>


### PR DESCRIPTION
Closes: #9830
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR has three parts:
1. The first commits are about wiring the subscreens to allow passing data to the generation step, and properly managing the state of the generation logic and the save button.
2. The commit ecbf26431a6130c0eb32517ed59f3d8d15201571 is for improved UI consistency between the steps, let me know if I missed anything.
3. The commit 6734b1c38da7a6336194cdc7b739d0f27161dd25 fixes a bug that I missed during the review: instead of "My Product" as the text field hearer, we are supposed to show the actual product name, and this implements it.

### Testing instructions
1. Use an AI eligible store.
2. Open the app and start the AI product creation.
3. Test the flow and confirm it works as expected (until the product is generated and is shown).
4. Test going back and forth and confirm all works as expected.

### Video
https://github.com/woocommerce/woocommerce-android/assets/1657201/3da307ee-fea7-4315-83e4-de73c194ea2f


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
