### PR TITLE
Product Creation with AI: miscellaneous fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIPrompts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIPrompts.kt
@@ -84,7 +84,7 @@ object AIPrompts {
                   "width":"Guess and provide only the number in $dimensionUnit",
                   "height":"Guess and provide only the number in $dimensionUnit"
                },
-               "price":"Guess the price in $currency, return the price unformatted",
+               "price":"Guess the price in $currency, do not include the currency symbol, only provide the price as a number",
                ${getTagsLine()}
                ${getCategoriesLine()}
             }"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
@@ -66,7 +66,7 @@ class AIRepository @Inject constructor(
         currency: String,
         existingCategories: List<ProductCategory>,
         existingTags: List<ProductTag>,
-        languageISOCode: String = "en"
+        languageISOCode: String
     ): Result<Product> {
         data class Shipping(
             val weight: Float,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ParameterRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ParameterRepository.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.WooException
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.models.CurrencyFormattingParameters
 import com.woocommerce.android.ui.products.models.SiteParameters
@@ -18,6 +19,16 @@ class ParameterRepository @Inject constructor(
     }
 
     fun getParameters(): SiteParameters = loadParameters()
+
+    suspend fun fetchParameters(): Result<SiteParameters> {
+        return wooCommerceStore.fetchSiteGeneralSettings(selectedSite.get())
+            .let {
+                when {
+                    it.isError -> Result.failure(WooException(it.error))
+                    else -> Result.success(loadParameters())
+                }
+            }
+    }
 
     private fun loadParameters(): SiteParameters {
         val siteSettings = wooCommerceStore.getSiteSettings(selectedSite.get())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ParameterRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ParameterRepository.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.WooException
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.models.CurrencyFormattingParameters
 import com.woocommerce.android.ui.products.models.SiteParameters
+import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -39,9 +40,15 @@ class ParameterRepository @Inject constructor(
         awaitAll(siteSettingsTask, productSettingsTask)
 
         if (siteSettingsTask.getCompleted().isError) {
+            siteSettingsTask.getCompleted().error.let {
+                WooLog.e(WooLog.T.UTILS, "Error fetching site settings,  ${it.type} ${it.message}")
+            }
             return@coroutineScope Result.failure(WooException(siteSettingsTask.getCompleted().error))
         }
         if (productSettingsTask.getCompleted().isError) {
+            productSettingsTask.getCompleted().error.let {
+                WooLog.e(WooLog.T.UTILS, "Error fetching product settings,  ${it.type} ${it.message}")
+            }
             return@coroutineScope Result.failure(WooException(productSettingsTask.getCompleted().error))
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.products.ai.AboutProductSubViewModel.AiTone
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
+import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -140,7 +141,16 @@ class ProductPreviewSubViewModel(
         return@withContext parametersRepository.getParameters().takeIf(::predicate)
             ?: parametersRepository.fetchParameters()
                 .fold(
-                    onSuccess = { it.takeIf(::predicate) },
+                    onSuccess = { siteParameters ->
+                        siteParameters.takeIf(::predicate).also {
+                            if (it == null) {
+                                WooLog.w(
+                                    tag = WooLog.T.AI,
+                                    message = "Site parameters missing information after a successful fetch"
+                                )
+                            }
+                        }
+                    },
                     onFailure = { null }
                 )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
@@ -44,21 +44,12 @@ class ProductPreviewSubViewModel(
         generationJob = viewModelScope.launch {
             _state.value = State.Loading
 
-            val categories = withContext(Dispatchers.IO) {
-                categoriesRepository.getProductCategoriesList().ifEmpty {
-                    categoriesRepository.fetchProductCategories()
-                    categoriesRepository.getProductCategoriesList()
-                }
-            }
+            val categories = getCategories()
 
-            val tags = withContext(Dispatchers.IO) {
-                tagsRepository.getProductTags().ifEmpty {
-                    tagsRepository.fetchProductTags()
-                    tagsRepository.getProductTags()
-                }
-            }
+            val tags = getTags()
 
             val siteParameters = getSiteParameters() ?: run {
+                // We can't create a product without site parameters, so show an error and abort
                 // TOOD show error alert
                 return@launch
             }
@@ -122,6 +113,20 @@ class ProductPreviewSubViewModel(
                     onSuccess = { it.takeIf(::predicate) },
                     onFailure = { null }
                 )
+    }
+
+    private suspend fun getTags() = withContext(Dispatchers.IO) {
+        tagsRepository.getProductTags().ifEmpty {
+            tagsRepository.fetchProductTags()
+            tagsRepository.getProductTags()
+        }
+    }
+
+    private suspend fun getCategories() = withContext(Dispatchers.IO) {
+        categoriesRepository.getProductCategoriesList().ifEmpty {
+            categoriesRepository.fetchProductCategories()
+            categoriesRepository.getProductCategoriesList()
+        }
     }
 
     sealed interface State {


### PR DESCRIPTION
Closes: #9838 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR has three fixes:
1. The first one is about the main ticket, it adds logic for fetching dimension, weight and currency units if they are missing, and if we can't get them, it'll abort the generation.
2. Identify the language using the user's entered text instead of using the app's language.
3. Update the AI prompt to be clearer about asking the AI to exclude the currency symbol from the price, in my experience, the previous version worked most of the time, but sometimes the AI might still put the symbol in it.
If we still experience this, we might need to handle removing the symbol manually before parsing the price, but I prefer not doing it if we don't have to.

### Testing instructions
##### Change 1
1. Either clear the `WCSettingsModel` table using AS inspection tool before starting the creation
**or** apply the patch from below, then clear the app's data then sign in
2. Start AI product creation.
3. Confirm it works as expected, and the correct symbols are used in the price and shipping sections.

##### Change 2
1. Start AI product creation.
2. Enter title and keywords in non-English words
3. Confirm the generated product respects the language of the text.

##### Change 3
Just confirm the generation works successfully during multiple tests.

##### Patch for change 1
```patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt	(revision f2283168921fea517c3b95412afd5b549932e509)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt	(date 1695768332023)
@@ -142,7 +142,7 @@
                             restartMainActivity()
                         }
                     }
-                    wooCommerceStore.fetchSiteGeneralSettings(it)
+                    // wooCommerceStore.fetchSiteGeneralSettings(it)
                     wooCommerceStore.fetchSiteProductSettings(it)
                 }
             }
Index: build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/build.gradle b/build.gradle
--- a/build.gradle	(revision f2283168921fea517c3b95412afd5b549932e509)
+++ b/build.gradle	(date 1695768414492)
@@ -27,7 +27,7 @@
     tasks.withType(KotlinCompile).all {
         kotlinOptions {
             jvmTarget = JavaVersion.VERSION_1_8
-            allWarningsAsErrors = true
+//            allWarningsAsErrors = true
             freeCompilerArgs += [
                     "-opt-in=kotlin.RequiresOptIn",
                     "-Xjvm-default=all-compatibility",
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt	(revision f2283168921fea517c3b95412afd5b549932e509)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt	(date 1695768332019)
@@ -71,21 +71,22 @@
     }
 
     private suspend fun getCurrencyCode(site: SiteModel): String {
-        val localSettings = wcStore.getSiteSettings(site)
-        if (localSettings != null) return localSettings.currencyCode
-
-        var currentDelay = BACKOFF_DELAY
-        var currencyCode = ""
-        for (i in 0 until BACKOFF_INTENTS) {
-            val settings = wcStore.fetchSiteGeneralSettings(site).model
-            if (settings != null) {
-                currencyCode = settings.currencyCode
-                break
-            }
-            delay(currentDelay)
-            currentDelay = (currentDelay * i)
-        }
-        return currencyCode
+//        val localSettings = wcStore.getSiteSettings(site)
+//        if (localSettings != null) return localSettings.currencyCode
+//
+//        var currentDelay = BACKOFF_DELAY
+//        var currencyCode = ""
+//        for (i in 0 until BACKOFF_INTENTS) {
+//            val settings = wcStore.fetchSiteGeneralSettings(site).model
+//            if (settings != null) {
+//                currencyCode = settings.currencyCode
+//                break
+//            }
+//            delay(currentDelay)
+//            currentDelay = (currentDelay * i)
+//        }
+//        return currencyCode
+        return ""
     }
 
     /**
```

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
