### PR TITLE
Product Creation with AI: Error handling

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
@@ -68,7 +68,7 @@ private fun ProductPreviewSubScreen(state: ProductPreviewSubViewModel.State, mod
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
         when (state) {
             ProductPreviewSubViewModel.State.Loading,
-            ProductPreviewSubViewModel.State.Error -> ProductPreviewLoading(
+            is ProductPreviewSubViewModel.State.Error -> ProductPreviewLoading(
                 modifier = Modifier.fillMaxHeight()
             )
 
@@ -80,8 +80,8 @@ private fun ProductPreviewSubScreen(state: ProductPreviewSubViewModel.State, mod
 
         if (state is ProductPreviewSubViewModel.State.Error) {
             ErrorDialog(
-                onRetryClick = {},
-                onDismissClick = {}
+                onRetryClick = state.onRetryClick,
+                onDismissClick = state.onDismissClick
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.AlertDialog
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -30,8 +31,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.window.DialogProperties
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.products.ProductHelper
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
@@ -64,13 +67,21 @@ private fun ProductPreviewSubScreen(state: ProductPreviewSubViewModel.State, mod
         )
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
         when (state) {
-            ProductPreviewSubViewModel.State.Loading -> ProductPreviewLoading(
+            ProductPreviewSubViewModel.State.Loading,
+            ProductPreviewSubViewModel.State.Error -> ProductPreviewLoading(
                 modifier = Modifier.fillMaxHeight()
             )
 
             is ProductPreviewSubViewModel.State.Success -> ProductPreviewContent(
                 state = state,
                 modifier = Modifier.fillMaxHeight()
+            )
+        }
+
+        if (state is ProductPreviewSubViewModel.State.Error) {
+            ErrorDialog(
+                onRetryClick = {},
+                onDismissClick = {}
             )
         }
     }
@@ -255,6 +266,30 @@ private fun ProductPreviewLoading(modifier: Modifier) {
                 .then(sectionsBorder)
         )
     }
+}
+
+@Composable
+private fun ErrorDialog(
+    onRetryClick: () -> Unit,
+    onDismissClick: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = {},
+        properties = DialogProperties(dismissOnClickOutside = false, dismissOnBackPress = false),
+        text = {
+            Text(text = stringResource(id = R.string.product_creation_ai_generation_failure_message))
+        },
+        confirmButton = {
+            WCTextButton(onClick = onRetryClick) {
+                Text(stringResource(id = R.string.retry))
+            }
+        },
+        dismissButton = {
+            WCTextButton(onClick = onDismissClick) {
+                Text(stringResource(id = R.string.dismiss))
+            }
+        }
+    )
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
@@ -15,12 +15,17 @@ import com.woocommerce.android.ui.products.categories.ProductCategoriesRepositor
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -37,6 +42,9 @@ class ProductPreviewSubViewModel(
     private val _state = MutableStateFlow<State>(State.Loading)
     val state = _state.asLiveData()
 
+    private val _events = MutableSharedFlow<MultiLiveEvent.Event>(extraBufferCapacity = 1)
+    override val events: Flow<MultiLiveEvent.Event> = _events.asSharedFlow()
+
     private lateinit var isoLanguageCode: String
     private lateinit var productName: String
     private lateinit var productKeywords: String
@@ -45,13 +53,42 @@ class ProductPreviewSubViewModel(
     private var generationJob: Job? = null
 
     override fun onStart() {
+        startProductGeneration()
+    }
+
+    override fun onStop() {
+        generationJob?.cancel()
+    }
+
+    fun updateName(name: String) {
+        this.productName = name
+    }
+
+    fun updateKeywords(keywords: String) {
+        this.productKeywords = keywords
+    }
+
+    fun updateTone(tone: AiTone) {
+        this.tone = tone
+    }
+
+    override fun close() {
+        viewModelScope.cancel()
+    }
+
+    private fun startProductGeneration() {
+        fun createErrorState() = State.Error(
+            onRetryClick = ::startProductGeneration,
+            onDismissClick = { _events.tryEmit(Exit) }
+        )
+
         generationJob = viewModelScope.launch {
             _state.value = State.Loading
 
             if (!::isoLanguageCode.isInitialized) {
                 isoLanguageCode = identifyLanguage() ?: run {
                     WooLog.e(WooLog.T.AI, "Identifying language for the AI prompt failed")
-                    _state.value = State.Error
+                    _state.value = createErrorState()
                     return@launch
                 }
             }
@@ -61,7 +98,7 @@ class ProductPreviewSubViewModel(
             val siteParameters = getSiteParameters() ?: run {
                 // We can't create a product without site parameters, so show an error and abort
                 WooLog.e(WooLog.T.AI, "Getting site parameters failed")
-                _state.value = State.Error
+                _state.value = createErrorState()
                 return@launch
             }
 
@@ -85,30 +122,10 @@ class ProductPreviewSubViewModel(
                 },
                 onFailure = {
                     WooLog.e(WooLog.T.AI, "Failed to generate product with AI", it)
-                    _state.value = State.Error
+                    _state.value = createErrorState()
                 }
             )
         }
-    }
-
-    override fun onStop() {
-        generationJob?.cancel()
-    }
-
-    fun updateName(name: String) {
-        this.productName = name
-    }
-
-    fun updateKeywords(keywords: String) {
-        this.productKeywords = keywords
-    }
-
-    fun updateTone(tone: AiTone) {
-        this.tone = tone
-    }
-
-    override fun close() {
-        viewModelScope.cancel()
     }
 
     private suspend fun identifyLanguage(): String? {
@@ -182,7 +199,10 @@ class ProductPreviewSubViewModel(
             val description: String
                 get() = product.description
         }
-        object Error : State
+        data class Error(
+            val onRetryClick: () -> Unit,
+            val onDismissClick: () -> Unit
+        ) : State
     }
 
     data class ProductPropertyCard(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
@@ -50,7 +50,8 @@ class ProductPreviewSubViewModel(
 
             if (!::isoLanguageCode.isInitialized) {
                 isoLanguageCode = identifyLanguage() ?: run {
-                    // TODO show error alert
+                    WooLog.e(WooLog.T.AI, "Identifying language for the AI prompt failed")
+                    _state.value = State.Error
                     return@launch
                 }
             }
@@ -59,7 +60,8 @@ class ProductPreviewSubViewModel(
             val tags = getTags()
             val siteParameters = getSiteParameters() ?: run {
                 // We can't create a product without site parameters, so show an error and abort
-                // TODO show error alert
+                WooLog.e(WooLog.T.AI, "Getting site parameters failed")
+                _state.value = State.Error
                 return@launch
             }
 
@@ -82,8 +84,8 @@ class ProductPreviewSubViewModel(
                     onDone(product)
                 },
                 onFailure = {
-                    // TODO
-                    it.printStackTrace()
+                    WooLog.e(WooLog.T.AI, "Failed to generate product with AI", it)
+                    _state.value = State.Error
                 }
             )
         }
@@ -180,6 +182,7 @@ class ProductPreviewSubViewModel(
             val description: String
                 get() = product.description
         }
+        object Error : State
     }
 
     data class ProductPropertyCard(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1922,6 +1922,7 @@
     <string name="product_creation_ai_tone_flowery">Flowery</string>
     <string name="product_creation_ai_tone_convincing">Convincing</string>
     <string name="product_creation_ai_tone_selected_content_desc">Tone selected</string>
+    <string name="product_creation_ai_generation_failure_message">Product generation failed. Please try again</string>
 
     <!--
         Product Add more details Bottom sheet


### PR DESCRIPTION
Closes: #9842 

### Description
This PR adds a basic handling for errors during the AI generation step, for now it's simply an alert with a retry button and a dismiss button to exit from the whole flow.

### Testing instructions
1. Open the app, then sign in to a Jetpack-AI eligible site.
2. Start product creation, and choose AI flow
3. Finish the two early steps.
4. Disable internet, then start product generation.
5. Confirm the display of the alert.
6. Test its two buttons and confirm they work as expected.

### Images/gif
<img width=360 src="https://github.com/woocommerce/woocommerce-android/assets/1657201/59693eb9-3b41-4072-af81-b1c050c79e50"/>


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
