### PR TITLE
REST API: fix login issue when WordPress is installed in a custom subdirectory

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 15.6
 -----
-
+- [*] Fix an issue that prevents login when the site uses a custom directory for the WordPress installation [https://github.com/woocommerce/woocommerce-android/pull/9846]
 
 15.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
@@ -233,19 +233,14 @@ private fun WebAuthorizationScreen(
         viewState.errorDialogMessage != null -> {
             AlertDialog(
                 text = {
-                    Column {
-                        Text(text = viewState.errorDialogMessage.getText())
-                    }
+                    Text(text = viewState.errorDialogMessage.getText())
                 },
                 onDismissRequest = onErrorDialogDismissed,
-                buttons = {
-                    Column(modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))) {
-                        WCTextButton(
-                            onClick = onErrorDialogDismissed
-                        ) {
-                            Text(text = stringResource(id = android.R.string.ok))
-                        }
-                        Spacer(modifier = Modifier.weight(1f))
+                confirmButton = {
+                    WCTextButton(
+                        onClick = onErrorDialogDismissed
+                    ) {
+                        Text(text = stringResource(id = android.R.string.ok))
                     }
                 }
             )

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2860-75d3cdfb7942be7555d57901e106af438830a7c1'
+    fluxCVersion = 'trunk-b300dead6b98db05d8d5416c196ef065764c3f86'
     wooCommerceSharedVersion = '0.6.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.47.0'
+    fluxCVersion = '2860-75d3cdfb7942be7555d57901e106af438830a7c1'
     wooCommerceSharedVersion = '0.6.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'


### PR DESCRIPTION
Closes: #9829 

⚠️ Don't merge until the FluxC commit is updated

### Description
This PR fixes a login issue that occurs when WordPress is installed in a custom subdirectory, and not in the server's root, users might make this change for security reasons to try to hide the login and admin URLs.
It has two changes:
1. First it fixes the UI of the error dialog.
2. It updates FluxC to bring the change https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2860 that fixes the log in issue.

### Testing instructions
1. Prepare a site according to these instructions https://wordpress.org/documentation/article/giving-wordpress-its-own-directory/#method-ii-with-url-change
2. Make sure the site doesn't have a Jetpack connection
3. Open the app, then attempt a login, the native login will fail.
4. Proceed with the wp-admin login
5. Enter site credentials and approve the Application Password creation.
6. Confirm the rest of the flow works as expected.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
