### PR TITLE
Discounts using order product model

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -128,7 +128,7 @@ class OrderCreateEditFormFragment :
         handleResult<ProductDetailsEditResult>(KEY_PRODUCT_DETAILS_EDIT_RESULT) {
             viewModel.onProductDetailsEditResult(it)
         }
-        handleResult<Order.Item>(KEY_PRODUCT_DISCOUNT_RESULT) {
+        handleResult<OrderCreationProduct>(KEY_PRODUCT_DISCOUNT_RESULT) {
             viewModel.onProductDiscountEditResult(it)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1125,8 +1125,8 @@ class OrderCreateEditViewModel @Inject constructor(
         }
     }
 
-    fun onProductDiscountEditResult(modifiedItem: Order.Item) {
-        _orderDraft.value = _orderDraft.value.updateItem(modifiedItem)
+    fun onProductDiscountEditResult(modifiedProduct: OrderCreationProduct) {
+        _orderDraft.value = _orderDraft.value.updateItem(modifiedProduct.item)
     }
 
     fun onTaxHelpButtonClicked() = launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProduct.kt
@@ -19,12 +19,22 @@ sealed class OrderCreationProduct(
 ) : Parcelable {
     abstract fun isConfigurable(): Boolean
     abstract fun needsConfiguration(): Boolean
+
+    abstract fun copyProduct(
+        item: Order.Item = this.item,
+        productInfo: ProductInfo = this.productInfo
+    ): OrderCreationProduct
+
     data class ProductItem(
         override val item: Order.Item,
         override val productInfo: ProductInfo
     ) : OrderCreationProduct(item, productInfo) {
         override fun isConfigurable(): Boolean = false
         override fun needsConfiguration() = false
+        override fun copyProduct(
+            item: Order.Item,
+            productInfo: ProductInfo
+        ) = copy(item = item, productInfo = productInfo)
     }
 
     data class GroupedProductItem(
@@ -34,6 +44,10 @@ sealed class OrderCreationProduct(
     ) : OrderCreationProduct(item, productInfo) {
         override fun isConfigurable(): Boolean = false
         override fun needsConfiguration() = false
+        override fun copyProduct(
+            item: Order.Item,
+            productInfo: ProductInfo
+        ) = copy(item = item, productInfo = productInfo)
     }
 
     data class ProductItemWithRules(
@@ -44,6 +58,10 @@ sealed class OrderCreationProduct(
     ) : OrderCreationProduct(item, productInfo) {
         override fun isConfigurable(): Boolean = rules.isConfigurable()
         override fun needsConfiguration() = configuration.needsConfiguration()
+        override fun copyProduct(
+            item: Order.Item,
+            productInfo: ProductInfo
+        ) = copy(item = item, productInfo = productInfo)
     }
 
     data class GroupedProductItemWithRules(
@@ -55,6 +73,10 @@ sealed class OrderCreationProduct(
     ) : OrderCreationProduct(item, productInfo) {
         override fun isConfigurable(): Boolean = rules.isConfigurable()
         override fun needsConfiguration() = configuration.needsConfiguration()
+        override fun copyProduct(
+            item: Order.Item,
+            productInfo: ProductInfo
+        ) = copy(item = item, productInfo = productInfo)
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationFragment.kt
@@ -16,7 +16,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class ProductConfigurationFragment: BaseFragment()  {
+class ProductConfigurationFragment : BaseFragment() {
     companion object {
         const val PRODUCT_CONFIGURATION_RESULT = "product-configuration-result"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 
-
 @Composable
 fun ProductConfigurationScreen(viewModel: ProductConfigurationViewModel) {
     val viewState by viewModel.viewState.collectAsState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
@@ -62,11 +62,11 @@ fun ProductConfigurationScreen(
 ) {
     Column(modifier.fillMaxSize()) {
         Text(
-            text = "Configuration Keys: ${productConfiguration.configuration.keys} Values: ${productConfiguration.configuration.values}",
+            text = productConfiguration.configuration.toString(),
             modifier = modifier
         )
         Text(
-            text = "Configuration Keys: ${productConfiguration.childrenConfiguration?.keys} Values: ${productConfiguration.childrenConfiguration?.values}",
+            text = productConfiguration.childrenConfiguration?.toString() ?: "",
             modifier = modifier
         )
         Button(onClick = onSaveConfigurationClick) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationViewModel.kt
@@ -34,7 +34,7 @@ class ProductConfigurationViewModel @Inject constructor(
         }
     }
 
-    fun onCancel(){
+    fun onCancel() {
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigationTarget.kt
@@ -4,8 +4,8 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.ShippingLine
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel.AutoTaxRateSettingState
-import com.woocommerce.android.ui.orders.creation.taxes.TaxRatesInfoDialogViewState
 import com.woocommerce.android.ui.orders.creation.OrderCreationProduct
+import com.woocommerce.android.ui.orders.creation.taxes.TaxRatesInfoDialogViewState
 import com.woocommerce.android.ui.products.ProductRestriction
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/details/OrderCreateEditProductDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/details/OrderCreateEditProductDetailsViewModel.kt
@@ -98,12 +98,12 @@ class OrderCreateEditProductDetailsViewModel @Inject constructor(
         }
 
     fun onAddDiscountClicked() {
-        triggerEvent(NavigationTarget.DiscountEdit(this.product.value.item, currency))
+        triggerEvent(NavigationTarget.DiscountEdit(this.product.value, currency))
         tracker.track(AnalyticsEvent.ORDER_PRODUCT_DISCOUNT_ADD_BUTTON_TAPPED)
     }
 
     fun onEditDiscountClicked() {
-        triggerEvent(NavigationTarget.DiscountEdit(this.product.value.item, currency))
+        triggerEvent(NavigationTarget.DiscountEdit(this.product.value, currency))
         tracker.track(AnalyticsEvent.ORDER_PRODUCT_DISCOUNT_EDIT_BUTTON_TAPPED)
     }
 
@@ -142,7 +142,7 @@ class OrderCreateEditProductDetailsViewModel @Inject constructor(
     }
 
     sealed class NavigationTarget : MultiLiveEvent.Event() {
-        data class DiscountEdit(val item: Order.Item, val currency: String) : MultiLiveEvent.Event()
+        data class DiscountEdit(val item: OrderCreationProduct, val currency: String) : MultiLiveEvent.Event()
     }
 
     private companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountScreen.kt
@@ -440,7 +440,7 @@ fun OrderCreateEditProductDiscountScreenPreview() =
                     imageUrl = "",
                     isStockManaged = false,
                     stockQuantity = 0.0,
-                    stockStatus =  ProductStockStatus.InStock
+                    stockStatus = ProductStockStatus.InStock
                 )
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountScreen.kt
@@ -56,10 +56,13 @@ import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTypedTextField
 import com.woocommerce.android.ui.compose.component.WCSelectableChip
 import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.orders.creation.OrderCreationProduct
+import com.woocommerce.android.ui.orders.creation.ProductInfo
 import com.woocommerce.android.ui.orders.creation.product.discount.OrderCreateEditProductDiscountViewModel.DiscountAmountValidationState.Invalid
 import com.woocommerce.android.ui.orders.creation.product.discount.OrderCreateEditProductDiscountViewModel.DiscountType.Amount
 import com.woocommerce.android.ui.orders.creation.product.discount.OrderCreateEditProductDiscountViewModel.DiscountType.Percentage
 import com.woocommerce.android.ui.orders.creation.product.discount.OrderCreateEditProductDiscountViewModel.ViewState
+import com.woocommerce.android.ui.products.ProductStockStatus
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import java.math.BigDecimal
@@ -75,7 +78,7 @@ fun OrderCreateEditProductDiscountScreen(
     onPercentageDiscountSelected: () -> Unit,
     onAmountDiscountSelected: () -> Unit,
     discountInputFieldConfig: DiscountInputFieldConfig,
-    productItem: MutableStateFlow<Order.Item>,
+    productItem: MutableStateFlow<OrderCreationProduct>,
 ) {
     val state = viewState.collectAsState()
     Scaffold(topBar = { Toolbar(onCloseClicked, onDoneClicked, state.value.isDoneButtonEnabled) }) { padding ->
@@ -94,10 +97,10 @@ fun OrderCreateEditProductDiscountScreen(
 
                 ProductCard(
                     imageUrl = viewState.value.productDetailsState?.imageUrl,
-                    productName = productItem.value.name,
-                    productPrice = productItem.value.pricePreDiscount,
-                    productQuantity = productItem.value.quantity,
-                    subTotalPerProduct = productItem.value.subtotal,
+                    productName = productItem.value.item.name,
+                    productPrice = productItem.value.item.pricePreDiscount,
+                    productQuantity = productItem.value.item.quantity,
+                    subTotalPerProduct = productItem.value.item.subtotal,
                     state = state.value
                 )
 
@@ -419,18 +422,26 @@ fun OrderCreateEditProductDiscountScreenPreview() =
             numberOfDecimals = 2
         ),
         productItem = MutableStateFlow(
-            Order.Item(
-                name = "Product Name",
-                quantity = 1f,
-                price = BigDecimal.ZERO,
-                total = BigDecimal.ZERO,
-                productId = 1,
-                variationId = 1,
-                subtotal = BigDecimal.ZERO,
-                totalTax = BigDecimal.ZERO,
-                sku = "",
-                itemId = 1L,
-                attributesList = emptyList(),
+            OrderCreationProduct.ProductItem(
+                Order.Item(
+                    name = "Product Name",
+                    quantity = 1f,
+                    price = BigDecimal.ZERO,
+                    total = BigDecimal.ZERO,
+                    productId = 1,
+                    variationId = 1,
+                    subtotal = BigDecimal.ZERO,
+                    totalTax = BigDecimal.ZERO,
+                    sku = "",
+                    itemId = 1L,
+                    attributesList = emptyList(),
+                ),
+                ProductInfo(
+                    imageUrl = "",
+                    isStockManaged = false,
+                    stockQuantity = 0.0,
+                    stockStatus =  ProductStockStatus.InStock
+                )
             )
         )
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountViewModel.kt
@@ -9,9 +9,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ORDER_DI
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_ORDER_DISCOUNT_TYPE_FIXED
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_ORDER_DISCOUNT_TYPE_PERCENTAGE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.model.Order
-import com.woocommerce.android.ui.orders.creation.MapItemToProductUiModel
-import com.woocommerce.android.ui.orders.creation.ProductUIModel
+import com.woocommerce.android.ui.orders.creation.OrderCreationProduct
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -20,8 +18,6 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -39,16 +35,17 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val calculateItemDiscountAmount: CalculateItemDiscountAmount,
     private val tracker: AnalyticsTrackerWrapper,
-    private val mapItemToProductUiModel: MapItemToProductUiModel,
     siteParamsRepo: ParameterRepository,
     currencySymbolFinder: CurrencySymbolFinder,
 ) : ScopedViewModel(savedStateHandle) {
     private val args =
         OrderCreateEditProductDiscountFragmentArgs.fromSavedStateHandle(savedStateHandle)
     private val currency = currencySymbolFinder.findCurrencySymbol(args.currency)
-    val orderItem: MutableStateFlow<Order.Item> =
+    val orderItem: MutableStateFlow<OrderCreationProduct> =
         savedStateHandle.getStateFlow(
-            scope = this, initialValue = args.item.copy(total = args.item.pricePreDiscount), key = "key_item"
+            scope = this,
+            initialValue = args.item.copyProduct(item = args.item.item.copy(total = args.item.item.pricePreDiscount)),
+            key = "key_item"
         )
 
     private val discount = savedStateHandle.getNullableStateFlow(
@@ -71,10 +68,6 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
         numberOfDecimals = numberOfDecimals
     )
 
-    private val itemUiModelFuture: Deferred<ProductUIModel> = async {
-        mapItemToProductUiModel(orderItem.value)
-    }
-
     val viewState: StateFlow<ViewState> =
         combine(discount, discountType) { discount, type ->
             ViewState(
@@ -86,7 +79,7 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
                 priceAfterDiscount = getPriceAfterDiscount(),
                 calculatedPriceAfterDiscount = getCalculatedPriceAfterDiscount(),
                 productDetailsState = ProductDetailsState(
-                    imageUrl = itemUiModelFuture.await().imageUrl
+                    imageUrl = orderItem.value.productInfo.imageUrl
                 )
             )
         }.toStateFlow(ViewState(currency, null))
@@ -95,7 +88,7 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
         this != null && this > BigDecimal.ZERO
     }
 
-    private fun getInitialDiscountAmount(): BigDecimal? = with(calculateItemDiscountAmount(args.item)) {
+    private fun getInitialDiscountAmount(): BigDecimal? = with(calculateItemDiscountAmount(args.item.item)) {
         if (this > BigDecimal.ZERO) this else null
     }
 
@@ -105,7 +98,7 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
 
         val discountAmount: BigDecimal = when (type) {
             DiscountType.Percentage -> {
-                (orderItem.value.pricePreDiscount * discount).divide(
+                (orderItem.value.item.pricePreDiscount * discount).divide(
                     PERCENTAGE_BASE,
                     PERCENTAGE_DIVISION_QUOTIENT_SCALE,
                     RoundingMode.HALF_UP
@@ -116,7 +109,7 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
                 discount
             }
         }
-        if (discountAmount > (orderItem.value.pricePreDiscount * orderItem.value.quantity.toBigDecimal())) {
+        if (discountAmount > (orderItem.value.item.pricePreDiscount * orderItem.value.item.quantity.toBigDecimal())) {
             return DiscountAmountValidationState.Invalid(
                 resourceProvider.getString(R.string.order_creation_discount_too_big_error)
             )
@@ -130,10 +123,10 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
 
     fun onDoneClicked() {
         orderItem.updateAndGet {
-            val subtotal = it.subtotal
+            val subtotal = it.item.subtotal
 
             val total = subtotal - getDiscountAmount()
-            it.copy(total = total)
+            it.copyProduct(item = it.item.copy(total = total))
         }.also {
             triggerEvent(ExitWithResult(data = it))
             tracker.track(
@@ -152,7 +145,7 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
         val discountAmount = discount.value ?: BigDecimal.ZERO
         return when (discountType.value) {
             DiscountType.Percentage -> {
-                orderItem.value.subtotal * discountAmount / PERCENTAGE_BASE
+                orderItem.value.item.subtotal * discountAmount / PERCENTAGE_BASE
             }
             is DiscountType.Amount -> {
                 discountAmount
@@ -175,7 +168,7 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
     }
 
     private fun calculateDiscountPercentage(discountAmount: BigDecimal): BigDecimal {
-        val pricePreDiscount = orderItem.value.pricePreDiscount * orderItem.value.quantity.toBigDecimal()
+        val pricePreDiscount = orderItem.value.item.pricePreDiscount * orderItem.value.item.quantity.toBigDecimal()
         val discountPercentage = if (pricePreDiscount > BigDecimal.ZERO) {
             PERCENTAGE_BASE - (pricePreDiscount - discountAmount).divide(
                 pricePreDiscount,
@@ -189,19 +182,19 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
     }
 
     private fun calculateDiscountAmount(discountPercentage: BigDecimal): BigDecimal {
-        val pricePreDiscount = orderItem.value.pricePreDiscount
+        val pricePreDiscount = orderItem.value.item.pricePreDiscount
         val discountAmount = pricePreDiscount
             .times(discountPercentage)
             .divide(PERCENTAGE_BASE, PERCENTAGE_DIVISION_QUOTIENT_SCALE, RoundingMode.HALF_UP)
 
-        return (discountAmount * orderItem.value.quantity.toBigDecimal())
+        return (discountAmount * orderItem.value.item.quantity.toBigDecimal())
             .setScale(2, RoundingMode.HALF_UP)
             .stripTrailingZeros()
     }
 
     fun onDiscountRemoveClicked() {
         orderItem.updateAndGet {
-            it.copy(total = it.subtotal)
+            it.copyProduct(item = it.item.copy(total = it.item.subtotal))
         }.also {
             triggerEvent(ExitWithResult(data = it))
             tracker.track(ORDER_PRODUCT_DISCOUNT_REMOVE)
@@ -209,7 +202,7 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
     }
 
     private fun getPriceAfterDiscount(): BigDecimal {
-        return if (discount.value == null) BigDecimal.ZERO else orderItem.value.subtotal - getDiscountAmount()
+        return if (discount.value == null) BigDecimal.ZERO else orderItem.value.item.subtotal - getDiscountAmount()
             .setScale(2, RoundingMode.HALF_UP)
     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -223,7 +223,7 @@
         android:label="OrderCreateEditProductDiscountFragment">
         <argument
             android:name="item"
-            app:argType="com.woocommerce.android.model.Order$Item" />
+            app:argType="com.woocommerce.android.ui.orders.creation.OrderCreationProduct" />
         <argument
             android:name="currency"
             app:argType="string" />

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountViewModelTest.kt
@@ -11,8 +11,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_ORDER_
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.ui.orders.creation.MapItemToProductUiModel
-import com.woocommerce.android.ui.orders.creation.ProductUIModel
+import com.woocommerce.android.ui.orders.creation.OrderCreationProduct
+import com.woocommerce.android.ui.orders.creation.ProductInfo
 import com.woocommerce.android.ui.orders.creation.product.discount.OrderCreateEditProductDiscountViewModel.DiscountAmountValidationState.Invalid
 import com.woocommerce.android.ui.orders.creation.product.discount.OrderCreateEditProductDiscountViewModel.DiscountAmountValidationState.Valid
 import com.woocommerce.android.ui.products.ParameterRepository
@@ -45,7 +45,13 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
     }
 
     private val savedState = OrderCreateEditProductDiscountFragmentArgs(
-        item,
+        createProductItem(
+            item = Order.Item.EMPTY.copy(
+                quantity = 2F,
+                subtotal = 100F.toBigDecimal(),
+                total = 80F.toBigDecimal()
+            )
+        ),
         "usd"
     ).initSavedStateHandle()
 
@@ -66,18 +72,6 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
 
     private val tracker: AnalyticsTrackerWrapper = mock()
 
-    private val defaultOrderItem = createOrderItem()
-
-    private val mapItemToProductUIModel: MapItemToProductUiModel = mock {
-        onBlocking { invoke(any()) } doReturn ProductUIModel(
-            item = defaultOrderItem,
-            imageUrl = "",
-            isStockManaged = false,
-            stockQuantity = 0.0,
-            stockStatus = ProductStockStatus.InStock
-        )
-    }
-
     @Test
     fun `given discount bigger than item's total price, when done clicked, then should return Invalid state`() =
         testBlocking {
@@ -86,8 +80,9 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
                 subtotal = 100F.toBigDecimal(),
                 total = 100F.toBigDecimal()
             )
+            val productItem = createProductItem(item)
             val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
-                item,
+                productItem,
                 "usd"
             ).initSavedStateHandle()
 
@@ -110,8 +105,9 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
                 subtotal = 100F.toBigDecimal(),
                 total = 100F.toBigDecimal()
             )
+            val productItem = createProductItem(item)
             val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
-                item,
+                productItem,
                 "usd"
             ).initSavedStateHandle()
 
@@ -132,8 +128,9 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
                 subtotal = 100F.toBigDecimal(),
                 total = 100F.toBigDecimal()
             )
+            val productItem = createProductItem(item)
             val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
-                item,
+                productItem,
                 "usd"
             ).initSavedStateHandle()
 
@@ -152,8 +149,9 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
             quantity = 1F,
             subtotal = 100F.toBigDecimal(),
         )
+        val productItem = createProductItem(item)
         val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
-            item,
+            productItem,
             "usd"
         ).initSavedStateHandle()
 
@@ -167,8 +165,8 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
         with(lastEvent) {
             assertThat(this).isNotNull
             assertThat(this).isInstanceOf(MultiLiveEvent.Event.ExitWithResult::class.java)
-            val result = (this as MultiLiveEvent.Event.ExitWithResult<*>).data as Order.Item
-            assertEquals(99F, result.total.toFloat())
+            val result = (this as MultiLiveEvent.Event.ExitWithResult<*>).data as OrderCreationProduct
+            assertEquals(99F, result.item.total.toFloat())
         }
     }
 
@@ -179,8 +177,9 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
                 quantity = 1F,
                 subtotal = 999.toBigDecimal(),
             )
+            val productItem = createProductItem(item)
             val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
-                item,
+                productItem,
                 "usd"
             ).initSavedStateHandle()
             val sut = createSut(savedStateHandle)
@@ -201,8 +200,9 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
                 quantity = 1F,
                 subtotal = 33.toBigDecimal(),
             )
+            val productItem = createProductItem(item)
             val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
-                item,
+                productItem,
                 "usd"
             ).initSavedStateHandle()
             val sut = createSut(savedStateHandle)
@@ -224,8 +224,9 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
                 quantity = 1F,
                 subtotal = 33.toBigDecimal(),
             )
+            val productItem = createProductItem(item)
             val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
-                item,
+                productItem,
                 "usd"
             ).initSavedStateHandle()
             val sut = createSut(savedStateHandle)
@@ -243,8 +244,9 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
                 quantity = 1F,
                 subtotal = 33.toBigDecimal(),
             )
+            val productItem = createProductItem(item)
             val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
-                item,
+                productItem,
                 "usd"
             ).initSavedStateHandle()
             val sut = createSut(savedStateHandle)
@@ -262,8 +264,9 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
             quantity = 1F,
             subtotal = 33.toBigDecimal(),
         )
+        val productItem = createProductItem(item)
         val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
-            item,
+            productItem,
             "usd"
         ).initSavedStateHandle()
         val sut = createSut(savedStateHandle)
@@ -281,8 +284,9 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
             subtotal = 33.toBigDecimal(),
             total = 30.toBigDecimal(),
         )
+        val productItem = createProductItem(item)
         val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
-            item,
+            productItem,
             "usd"
         ).initSavedStateHandle()
         val sut = createSut(savedStateHandle)
@@ -299,8 +303,9 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
             subtotal = 33.toBigDecimal(),
             total = 33.toBigDecimal(),
         )
+        val productItem = createProductItem(item)
         val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
-            item,
+            productItem,
             "usd"
         ).initSavedStateHandle()
         val sut = createSut(savedStateHandle)
@@ -316,8 +321,9 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
             quantity = 1F,
             subtotal = 33.toBigDecimal(),
         )
+        val productItem = createProductItem(item)
         val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
-            item,
+            productItem,
             "usd"
         ).initSavedStateHandle()
         val sut = createSut(savedStateHandle)
@@ -335,8 +341,9 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
             quantity = 1F,
             subtotal = 33.toBigDecimal(),
         )
+        val productItem = createProductItem(item)
         val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
-            item,
+            productItem,
             "usd"
         ).initSavedStateHandle()
         val sut = createSut(savedStateHandle)
@@ -354,8 +361,9 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
             quantity = 1F,
             subtotal = 33.toBigDecimal(),
         )
+        val productItem = createProductItem(item)
         val savedStateHandle: SavedStateHandle = OrderCreateEditProductDiscountFragmentArgs(
-            item,
+            productItem,
             "usd"
         ).initSavedStateHandle()
         val sut = createSut(savedStateHandle)
@@ -371,7 +379,6 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
             resourceProvider,
             CalculateItemDiscountAmount(),
             tracker,
-            mapItemToProductUIModel,
             parameterRepository,
             currencySymbolFinder,
         )
@@ -393,11 +400,17 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
             )
         }
 
-    private companion object {
-        val item = Order.Item.EMPTY.copy(
-            quantity = 2F,
-            subtotal = 100F.toBigDecimal(),
-            total = 80F.toBigDecimal()
+    private fun createProductItem(item: Order.Item? = null): OrderCreationProduct {
+        val orderItem = item ?: createOrderItem()
+        val productInfo = ProductInfo(
+            imageUrl = "",
+            isStockManaged = false,
+            stockQuantity = 0.0,
+            stockStatus = ProductStockStatus.InStock
+        )
+        return OrderCreationProduct.ProductItem(
+            item = orderItem,
+            productInfo = productInfo
         )
     }
 }


### PR DESCRIPTION
### Why
As part of the support for extensions milestone 2, we are working on support bundle products in the order creation flow. 
I introduced the new `OrderCreationProduct` to support bundle products and in general, grouped products, in the order creation flow. This new concept will group children products inside their parents, and it will make it easy to work with those grouped products (like bundles). I removed the `ProductUIModel` to favor the new `OrderCreationProduct` in the order creation flow.

Part of: #9541

### Description
The `ProductUIModel` was used on the new discount flows. I removed the `ProductUIModel` when introducing the new `OrderCreationProduct` so we rely on a single concept when working with order creation. This PR solves the conflicts generated by this change by using the `OrderCreationProduct` in the new discount flows.

### Testing instructions
**Discounts should be working as expected**

TC1
* Open the products tab
* Select an order including a product with a discount
* Tap on EDIT
* Check that the discount info appears in the product description
* Tap on the product with the discount and navigate to the order product details
* Check that the discount info is shown
* Tap on edit discount and navigate to the discount screen
* Update the product discount and tap on done
* Check that the discount is updated successfully

TC2
* Open the products tab
* Select an order with a product
* Tap on EDIT
* Tap on a product and navigate to the order product details
* Tap on add discount and navigate to the discount screen
* Set a discount and tap on done
* Check that the discount is created successfully

TC3
* Open the products tab
* Select an order including a product with a discount
* Tap on EDIT
* Check that the discount info appears in the product description
* Tap on the product with the discount and navigate to the order product details
* Check that the discount info is shown
* Tap on edit discount and navigate to the discount screen
* Tap on Remove discount
* Check that the discount is removed successfully

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/839b40e8-4a2c-4b25-a871-016a64db277c



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
