### PR TITLE
Product information configuration screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/GetChildrenProductInfo.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/GetChildrenProductInfo.kt
@@ -1,0 +1,34 @@
+package com.woocommerce.android.ui.orders.creation.configuration
+
+import com.woocommerce.android.ui.products.GetBundledProducts
+import com.woocommerce.android.ui.products.ProductDetailRepository
+import com.woocommerce.android.ui.products.ProductType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class GetChildrenProductInfo @Inject constructor(
+    private val productDetailRepository: ProductDetailRepository,
+    private val getBundledProducts: GetBundledProducts
+) {
+    operator fun invoke(productId: Long): Flow<Map<Long, ProductInfo>> {
+        val product = productDetailRepository.getProduct(productId) ?: return flowOf(emptyMap())
+        return when (product.productType) {
+            ProductType.BUNDLE -> {
+                getBundledProducts(productId).map { list ->
+                    val result = mutableMapOf<Long, ProductInfo>()
+                    list.onEach { bundledProduct ->
+                        result[bundledProduct.id] = ProductInfo(
+                            id = bundledProduct.id,
+                            title = bundledProduct.title,
+                            imageUrl = bundledProduct.imageUrl
+                        )
+                    }
+                    result
+                }
+            }
+            else -> flowOf(emptyMap())
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
@@ -85,6 +85,7 @@ fun ProductConfigurationScreen(viewModel: ProductConfigurationViewModel) {
                 ProductConfigurationScreen(
                     productRules = state.productRules,
                     productConfiguration = state.productConfiguration,
+                    productsInfo = state.productsInfo,
                     onUpdateChildrenConfiguration = viewModel::onUpdateChildrenConfiguration,
                     onSaveConfigurationClick = {},
                     modifier = Modifier.padding(padding)
@@ -98,6 +99,7 @@ fun ProductConfigurationScreen(viewModel: ProductConfigurationViewModel) {
 fun ProductConfigurationScreen(
     productRules: ProductRules,
     productConfiguration: ProductConfiguration,
+    productsInfo: Map<Long, ProductInfo>,
     onUpdateChildrenConfiguration: (Long, String, String) -> Unit,
     onSaveConfigurationClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -108,7 +110,14 @@ fun ProductConfigurationScreen(
             onSaveConfigurationClick()
             productConfiguration.childrenConfiguration?.entries?.forEach { childMapEntry ->
 
-                val item = childMapEntry.key
+                val item = productsInfo.getOrDefault(
+                    childMapEntry.key,
+                    ProductInfo(
+                        childMapEntry.key,
+                        stringResource(id = R.string.default_product_title, childMapEntry.key),
+                        null
+                    )
+                )
 
                 val hasQuantityRule = childMapEntry.value.containsKey(QuantityRule.KEY)
                 val hasOptionalRule = childMapEntry.value.containsKey(OptionalRule.KEY)
@@ -116,38 +125,38 @@ fun ProductConfigurationScreen(
 
                 if (hasQuantityAndOptionalRules) {
                     OptionalQuantityProductItem(
-                        "item: $item",
-                        imageUrl = null,
+                        title = item.title,
+                        imageUrl = item.imageUrl,
                         info = null,
                         quantity = childMapEntry.value[QuantityRule.KEY]?.toInt() ?: 0,
                         onQuantityChanged = { value ->
-                            onUpdateChildrenConfiguration(item, QuantityRule.KEY, value.toString())
+                            onUpdateChildrenConfiguration(item.id, QuantityRule.KEY, value.toString())
                         },
                         isIncluded = childMapEntry.value[OptionalRule.KEY]?.toBoolean() ?: false,
                         onSwitchChanged = { value ->
-                            onUpdateChildrenConfiguration(item, OptionalRule.KEY, value.toString())
+                            onUpdateChildrenConfiguration(item.id, OptionalRule.KEY, value.toString())
                         }
                     )
                 } else {
                     if (hasQuantityRule) {
                         QuantityProductItem(
-                            "item: $item",
-                            imageUrl = null,
+                            title = item.title,
+                            imageUrl = item.imageUrl,
                             info = null,
                             quantity = childMapEntry.value[QuantityRule.KEY]?.toInt() ?: 0,
                             onQuantityChanged = { value ->
-                                onUpdateChildrenConfiguration(item, QuantityRule.KEY, value.toString())
+                                onUpdateChildrenConfiguration(item.id, QuantityRule.KEY, value.toString())
                             }
                         )
                     }
                     if (hasOptionalRule) {
                         OptionalProductItem(
-                            title = "item: $item",
-                            imageUrl = null,
+                            title = item.title,
+                            imageUrl = item.imageUrl,
                             info = null,
                             isIncluded = childMapEntry.value[OptionalRule.KEY]?.toBoolean() ?: false,
                             onSwitchChanged = { value ->
-                                onUpdateChildrenConfiguration(item, OptionalRule.KEY, value.toString())
+                                onUpdateChildrenConfiguration(item.id, OptionalRule.KEY, value.toString())
                             }
                         )
                     }
@@ -205,7 +214,7 @@ fun QuantityProductItem(
         title = title,
         imageUrl = imageUrl,
         info = info,
-        modifier = modifier.padding(vertical = 16.dp, horizontal = 8.dp)
+        modifier = modifier.padding(top = 16.dp, bottom = 16.dp, start = 16.dp, end = 8.dp)
     ) {
         Stepper(
             value = quantity,
@@ -377,11 +386,11 @@ fun OrderProductItem(
             modifier = Modifier
                 .size(dimensionResource(R.dimen.major_300))
                 .clip(RoundedCornerShape(3.dp))
-                .padding(end = 8.dp)
         )
 
         Column(
             modifier = Modifier
+                .padding(start = 8.dp)
                 .wrapContentHeight()
                 .weight(1f)
         ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationViewModel.kt
@@ -18,7 +18,8 @@ import javax.inject.Inject
 @HiltViewModel
 class ProductConfigurationViewModel @Inject constructor(
     savedState: SavedStateHandle,
-    private val getProductRules: GetProductRules
+    private val getProductRules: GetProductRules,
+    getChildrenProductInfo: GetChildrenProductInfo
 ) : ScopedViewModel(savedState) {
 
     private val navArgs: ProductConfigurationFragmentArgs by savedState.navArgs()
@@ -27,14 +28,17 @@ class ProductConfigurationViewModel @Inject constructor(
 
     private val configuration = MutableStateFlow<ProductConfiguration?>(null)
 
+    private val productsInformation = getChildrenProductInfo(navArgs.productId)
+
     val viewState = combine(
         flow = rules.drop(1),
-        flow2 = configuration.drop(1)
-    ) { rules, configuration ->
+        flow2 = configuration.drop(1),
+        flow3 = productsInformation
+    ) { rules, configuration, productsInfo ->
         if (rules == null || configuration == null) {
             ViewState.Error("rules not found")
         } else {
-            ViewState.DisplayConfiguration(rules, configuration)
+            ViewState.DisplayConfiguration(rules, configuration, productsInfo)
         }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, ViewState.Loading)
 
@@ -66,6 +70,13 @@ class ProductConfigurationViewModel @Inject constructor(
         data class DisplayConfiguration(
             val productRules: ProductRules,
             val productConfiguration: ProductConfiguration,
+            val productsInfo: Map<Long, ProductInfo>
         ) : ViewState()
     }
 }
+
+data class ProductInfo(
+    val id: Long,
+    val title: String,
+    val imageUrl: String?
+)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3677,4 +3677,6 @@
     <string name="tax_rate_selector_auto_rate_details_set_a_new_rate_button_label">Set a new tax rate for this order</string>
     <string name="tax_rate_selector_auto_rate_details_clear_button_label">Clear address and stop using this rate</string>
 
+    <string name="default_product_title">Product %s</string>
+
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/configuration/GetChildrenProductInfoTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/configuration/GetChildrenProductInfoTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class GetChildrenProductInfoTest: BaseUnitTest() {
+class GetChildrenProductInfoTest : BaseUnitTest() {
 
     // Mock dependencies
     private val productDetailRepository: ProductDetailRepository = mock()
@@ -69,13 +69,13 @@ class GetChildrenProductInfoTest: BaseUnitTest() {
         // Assert
         resultFlow.collect { productInfoMap ->
             assert(productInfoMap.size == 2)
-            with(productInfoMap[childProduct1.id]){
+            with(productInfoMap[childProduct1.id]) {
                 assertNotNull(this)
                 assertEquals(this.id, childProduct1.id)
                 assertEquals(this.title, childProduct1.title)
                 assertEquals(this.imageUrl, childProduct1.imageUrl)
             }
-            with(productInfoMap[childProduct2.id]){
+            with(productInfoMap[childProduct2.id]) {
                 assertNotNull(this)
                 assertEquals(this.id, childProduct2.id)
                 assertEquals(this.title, childProduct2.title)
@@ -84,8 +84,8 @@ class GetChildrenProductInfoTest: BaseUnitTest() {
         }
 
         // Verify
-        verify (productDetailRepository).getProduct(productBundle.remoteId)
-        verify (getBundledProducts).invoke(productBundle.remoteId)
+        verify(productDetailRepository).getProduct(productBundle.remoteId)
+        verify(getBundledProducts).invoke(productBundle.remoteId)
     }
 
     @Test
@@ -105,7 +105,7 @@ class GetChildrenProductInfoTest: BaseUnitTest() {
         resultFlow.collect { productInfoMap -> assert(productInfoMap.isEmpty()) }
 
         // Verify
-        verify (productDetailRepository).getProduct(product.remoteId)
+        verify(productDetailRepository).getProduct(product.remoteId)
         verify(getBundledProducts, never()).invoke(product.remoteId)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/configuration/GetChildrenProductInfoTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/configuration/GetChildrenProductInfoTest.kt
@@ -1,0 +1,111 @@
+package com.woocommerce.android.ui.orders.creation.configuration
+
+import com.woocommerce.android.model.BundleProductRules
+import com.woocommerce.android.model.BundledProduct
+import com.woocommerce.android.ui.products.GetBundledProducts
+import com.woocommerce.android.ui.products.ProductDetailRepository
+import com.woocommerce.android.ui.products.ProductStockStatus
+import com.woocommerce.android.ui.products.ProductTestUtils
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetChildrenProductInfoTest: BaseUnitTest() {
+
+    // Mock dependencies
+    private val productDetailRepository: ProductDetailRepository = mock()
+    private val getBundledProducts: GetBundledProducts = mock()
+
+    private lateinit var getChildrenProductInfo: GetChildrenProductInfo
+
+    @Before
+    fun setUp() {
+        getChildrenProductInfo = GetChildrenProductInfo(productDetailRepository, getBundledProducts)
+    }
+
+    @Test
+    fun `invoke with bundle product type should return a flow of product info map`() = testBlocking {
+        // Given
+        val productBundle = ProductTestUtils.generateProduct(
+            productId = 1L,
+            productName = "Product 1",
+            imageUrl = "image1.jpg",
+            productType = "bundle"
+        )
+        val childProduct1 = BundledProduct(
+            id = 2L,
+            parentProductId = 1L,
+            bundledProductId = 2L,
+            title = "Child product 1",
+            stockStatus = ProductStockStatus.InStock,
+            rules = BundleProductRules(),
+            imageUrl = "image2.jpg"
+        )
+        val childProduct2 = BundledProduct(
+            id = 3L,
+            parentProductId = 1L,
+            bundledProductId = 3L,
+            title = "Child product 2",
+            stockStatus = ProductStockStatus.InStock,
+            rules = BundleProductRules()
+        )
+        val bundledProducts = listOf(childProduct1, childProduct2)
+
+        whenever(productDetailRepository.getProduct(productBundle.remoteId)).thenReturn(productBundle)
+        whenever(getBundledProducts.invoke(productBundle.remoteId)).thenReturn(flowOf(bundledProducts))
+
+        // When
+        val resultFlow = getChildrenProductInfo(productBundle.remoteId)
+
+        // Assert
+        resultFlow.collect { productInfoMap ->
+            assert(productInfoMap.size == 2)
+            with(productInfoMap[childProduct1.id]){
+                assertNotNull(this)
+                assertEquals(this.id, childProduct1.id)
+                assertEquals(this.title, childProduct1.title)
+                assertEquals(this.imageUrl, childProduct1.imageUrl)
+            }
+            with(productInfoMap[childProduct2.id]){
+                assertNotNull(this)
+                assertEquals(this.id, childProduct2.id)
+                assertEquals(this.title, childProduct2.title)
+                assertEquals(this.imageUrl, childProduct2.imageUrl)
+            }
+        }
+
+        // Verify
+        verify (productDetailRepository).getProduct(productBundle.remoteId)
+        verify (getBundledProducts).invoke(productBundle.remoteId)
+    }
+
+    @Test
+    fun `invoke with non-children product type should return an empty flow`() = testBlocking {
+        // Given
+        val product = ProductTestUtils.generateProduct(
+            productId = 1L,
+            productName = "Product 1",
+            imageUrl = "image1.jpg"
+        )
+        whenever(productDetailRepository.getProduct(product.remoteId)).thenReturn(product)
+
+        // When
+        val resultFlow = getChildrenProductInfo(product.remoteId)
+
+        // Assert
+        resultFlow.collect { productInfoMap -> assert(productInfoMap.isEmpty()) }
+
+        // Verify
+        verify (productDetailRepository).getProduct(product.remoteId)
+        verify(getBundledProducts, never()).invoke(product.remoteId)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -23,6 +23,8 @@ object ProductTestUtils {
         variationIds: String = if (isVariable) "[123]" else "[]",
         productType: String? = null,
         amount: String = "20.00",
+        productName: String = "product $productId",
+        imageUrl: String? = null
     ): Product {
         return WCProductModel(2).apply {
             dateCreated = "2018-01-05T05:14:30Z"
@@ -36,9 +38,9 @@ object ProductTestUtils {
             salePrice = "10.00"
             regularPrice = "30.00"
             averageRating = "3.0"
-            name = "product 1"
+            name = productName
             description = "product 1 description"
-            images = "[]"
+            images = if (imageUrl != null) """[{"src":"$imageUrl"}]""" else "[]"
             downloadable = true
             downloads = """[
                                 {


### PR DESCRIPTION
Part of: #9541

### Why
As part of the support for extensions milestone 2, we are working on support bundle products in the order creation flow. 

### Description
This PR adds support for product images and names in the configuration screen

### Testing instructions

#### Prerequisites 

1.  Install the product bundles extension
2. Create several bundle products requiring a configuration (simple products with quantity rules and or optional)

#### Testing

1. Open the orders list
2. Tap on create a new order
3. Tap on add product
4. Select one of the product bundles
5. Check that the app navigates to the configuration screen
6. Check that quantity and optional controls are displayed on the configuration screen (depending on the children's product rules) and that product names and images are displayed

### Images/gif

<img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/7b5317c2-4133-4c9d-ae1b-4b0df33352ff" />

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
