### PR TITLE
Move versions from `build.gradle` to `version.properties`

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -74,15 +74,13 @@ android {
 
     compileSdkVersion gradle.ext.compileSdkVersion
 
+    def versionProperties = loadPropertiesFromFile(file("${rootDir}/version.properties"))
+
     defaultConfig {
         applicationId "com.woocommerce.android"
-        // Allow versionName to be overridden with property. e.g. -PversionName=1234
-        if (project.hasProperty("versionName")) {
-            versionName project.property("versionName")
-        } else {
-            versionName "15.5-rc-1"
-        }
-        versionCode 458
+
+        versionName versionProperties.getProperty("versionName")
+        versionCode versionProperties.getProperty("versionCode").toInteger()
 
         minSdkVersion gradle.ext.minSdkVersion
         // Update targetSdkVersion only after reviewing all the OS changes (developer.android.com/about/versions/[ENTER_ANDROID_VERSION]/migration)

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -74,8 +74,6 @@ android {
 
     compileSdkVersion gradle.ext.compileSdkVersion
 
-    def versionProperties = loadPropertiesFromFile(file("${rootDir}/version.properties"))
-
     defaultConfig {
         applicationId "com.woocommerce.android"
 
@@ -514,6 +512,8 @@ def checkGradlePropertiesFile() {
     }
     return inputFile
 }
+
+def versionProperties = loadPropertiesFromFile(file("${rootDir}/version.properties"))
 
 static def loadPropertiesFromFile(inputFile) {
     def properties = new Properties()

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -69,6 +69,8 @@ repositories {
     }
 }
 
+def versionProperties = loadPropertiesFromFile(file("${rootDir}/version.properties"))
+
 android {
     namespace "com.woocommerce.android"
 
@@ -512,8 +514,6 @@ def checkGradlePropertiesFile() {
     }
     return inputFile
 }
-
-def versionProperties = loadPropertiesFromFile(file("${rootDir}/version.properties"))
 
 static def loadPropertiesFromFile(inputFile) {
     def properties = new Properties()

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,2 @@
+versionName=15.5-rc-1
+versionCode=458


### PR DESCRIPTION
This PR moves the `versionName` and `versionCode` from `build.gradle` into `version.properties`. This change is required before the Version model updates can be merged: https://github.com/woocommerce/woocommerce-android/pull/9865 (which is why this is getting merged into that branch instead of `trunk`)

