### PR TITLE
[TTPA CA/UK] Configuration including amount for pin

### DIFF
--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfig.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfig.kt
@@ -16,6 +16,7 @@ sealed class CardReaderConfigForSupportedCountry(
     val paymentMethodTypes: List<PaymentMethodType>,
     val supportedExtensions: List<SupportedExtension>,
     val minimumAllowedChargeAmount: BigDecimal,
+    val maximumTTPAllowedChargeAmountWithoutPin: BigDecimal?,
 ) : CardReaderConfig()
 
 fun CardReaderConfigForSupportedCountry.isExtensionSupported(type: SupportedExtensionType) =

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForCanada.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForCanada.kt
@@ -9,7 +9,10 @@ import java.math.BigDecimal
 object CardReaderConfigForCanada : CardReaderConfigForSupportedCountry(
     currency = "CAD",
     countryCode = "CA",
-    supportedReaders = listOf(ReaderType.ExternalReader.WisePade3),
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+        ReaderType.BuildInReader.CotsDevice,
+    ),
     paymentMethodTypes = listOf(
         PaymentMethodType.CARD_PRESENT,
         PaymentMethodType.INTERAC_PRESENT
@@ -20,5 +23,6 @@ object CardReaderConfigForCanada : CardReaderConfigForSupportedCountry(
             supportedSince = "4.0.0"
         ),
     ),
-    minimumAllowedChargeAmount = BigDecimal("0.50")
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = BigDecimal("250.00"),
 )

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForGB.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForGB.kt
@@ -9,7 +9,10 @@ import java.math.BigDecimal
 object CardReaderConfigForGB : CardReaderConfigForSupportedCountry(
     currency = "GBP",
     countryCode = "GB",
-    supportedReaders = listOf(ReaderType.ExternalReader.WisePade3),
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+        ReaderType.BuildInReader.CotsDevice,
+    ),
     paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
     supportedExtensions = listOf(
         SupportedExtension(
@@ -17,5 +20,6 @@ object CardReaderConfigForGB : CardReaderConfigForSupportedCountry(
             supportedSince = "4.4.0"
         ),
     ),
-    minimumAllowedChargeAmount = BigDecimal("0.30")
+    minimumAllowedChargeAmount = BigDecimal("0.30"),
+    maximumTTPAllowedChargeAmountWithoutPin = BigDecimal("100.00"),
 )

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForUSA.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForUSA.kt
@@ -25,5 +25,6 @@ object CardReaderConfigForUSA : CardReaderConfigForSupportedCountry(
             supportedSince = "3.2.1"
         ),
     ),
-    minimumAllowedChargeAmount = BigDecimal("0.50")
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
 )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9875
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds configuration that allows us to collect payments in the UK and CA

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Make sure that you can collect TTPA payments in the UK and CA

Reminder: We can collect TTP payments with a test card only on the release builds (remember to turn the feature flag ON). On the debug build we have to use a real device (with NFC) but you can use simulated payments - then the screen with collection will have "tap here to simulate" payment

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
