### PR TITLE
Beta fix: fix product creation with AI on release builds

### DIFF
--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -37,6 +37,10 @@
 }
 ###### Event Bus 2 - end
 
+##### WooCommerce (this is needed for Json deserializers, but generally, we should keep our own classes) - begin
+-keep class com.woocommerce.** { *; }
+##### WooCommerce - end
+
 ###### FluxC (was needed for Json deserializers) - begin
 -keep class org.wordpress.android.fluxc** { *; }
 ###### FluxC - end


### PR DESCRIPTION
### Description
This PR fixes a bug identified by @selanthiraiyan during the beta test of the last beta release: the product creation with AI always fails.
After investigating, we found out that R8 removes a class (or its fields) that's used in the Json deserializing of the AI response, this PR fixes this by adding the following line to the proguard file:
```
-keep class com.woocommerce.** { *; }
```

Instead of keeping only the impacted class, we opted to add the line for all of our classes, which would avoid similar issues in the future.

### Testing instructions
1. Launch the release version of the app.
2. Test product creation with AI.
3. Confirm it succeeds.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
