### PR TITLE
App login credentials deep link for Wordpress.com users

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -92,9 +92,9 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data
-                    android:host="jetpack-connected"
-                    android:scheme="woocommerce" />
+                <data android:scheme="woocommerce"/>
+                <data android:host="jetpack-connected"/>
+                <data android:host="app-login" />
             </intent-filter>
         </activity>
         <activity

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -164,6 +164,7 @@ class LoginActivity :
 
             intent?.action == Intent.ACTION_VIEW && intent.data?.authority == APP_LOGIN_AUTHORITY -> {
                 intent.data?.let { uri ->
+                    unifiedLoginTracker.setFlow(Flow.LOGIN_QR.value)
                     val siteUrl = uri.getQueryParameter(SITE_URL_PARAMETER)
                     val wpComEmail = uri.getQueryParameter(WP_COM_EMAIL_PARAMETER)
                     if (wpComEmail != null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -117,6 +117,10 @@ class LoginActivity :
 
         const val LOGIN_WITH_WPCOM_EMAIL_ACTION = "login_with_wpcom_email"
         const val EMAIL_PARAMETER = "email"
+
+        const val SITE_URL_PARAMETER = "siteUrl"
+        const val WP_COM_EMAIL_PARAMETER = "wpcomEmail"
+        const val APP_LOGIN_AUTHORITY = "app-login"
     }
 
     @Inject internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
@@ -156,6 +160,17 @@ class LoginActivity :
             intent?.action == LOGIN_WITH_WPCOM_EMAIL_ACTION -> {
                 val email = intent.extras!!.getString(EMAIL_PARAMETER)
                 gotWpcomEmail(email, verifyEmail = true, null)
+            }
+
+            intent?.action == Intent.ACTION_VIEW && intent.data?.authority == APP_LOGIN_AUTHORITY -> {
+                intent.data?.let { uri ->
+                    val siteUrl = uri.getQueryParameter(SITE_URL_PARAMETER)
+                    val wpComEmail = uri.getQueryParameter(WP_COM_EMAIL_PARAMETER)
+                    if (wpComEmail != null) {
+                        gotWpcomSiteInfo(siteUrl)
+                        showEmailPasswordScreen(email = wpComEmail, verifyEmail = false, password = null)
+                    }
+                }
             }
 
             hasJetpackConnectedIntent() -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
@@ -146,7 +146,8 @@ class UnifiedLoginTracker
         LOGIN_SITE_ADDRESS("login_site_address"),
         SIGNUP("signup"),
         GOOGLE_SIGNUP("google_signup"),
-        EPILOGUE("epilogue")
+        EPILOGUE("epilogue"),
+        LOGIN_QR("login_qr"),
     }
 
     enum class Step(val value: String) {


### PR DESCRIPTION
Closes: #9890
### Why
We are working on improving the app onboarding experience by adding a QR that shares the site URL and the email from the wp-admin. This way, merchants don't need to enter this information when logging into the apps.

### Description
This PR adds the `app-login` authority to the LoginActivity and reads the information shared through the deep link to open the Login screen with the site URL and wordpress.com email filled.

### Testing instructions
1. Log out from the app
2. Open the terminal and run this script using your site URL and wp.com email:

```
adb -s 22091FDF600240 shell am start -W -a android.intent.action.VIEW -d "woocommerce://app-login?siteUrl=[YourSiteUrl]\&wpcomEmail=[YourWPComEmail]"
```
Alternatively, you can change the text in [this](https://jsfiddle.net/atveiga/qbmd0xrn/14/) `jsfiddle`, press run to generate a new QR, and read the QR with your device camera.

3. Check that the app opens on the login screen with your email
4. Enter your credentials
5. Check that you are logged in with the store you used on the site url.

### Images/gif


https://github.com/woocommerce/woocommerce-android/assets/18119390/aeef9d81-cf1b-400a-9c97-ab9bbe67c139


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
