### PR TITLE
Add non wordpress users support

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -121,6 +121,7 @@ class LoginActivity :
         const val SITE_URL_PARAMETER = "siteUrl"
         const val WP_COM_EMAIL_PARAMETER = "wpcomEmail"
         const val APP_LOGIN_AUTHORITY = "app-login"
+        const val USERNAME_PARAMETER = "username"
     }
 
     @Inject internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
@@ -170,6 +171,14 @@ class LoginActivity :
                     if (wpComEmail != null) {
                         gotWpcomSiteInfo(siteUrl)
                         showEmailPasswordScreen(email = wpComEmail, verifyEmail = false, password = null)
+                    } else {
+                        val username = uri.getQueryParameter(USERNAME_PARAMETER)
+                        showUsernamePasswordScreen(
+                            siteAddress = siteUrl,
+                            inputUsername = username,
+                            endpointAddress = null,
+                            inputPassword = null
+                        )
                     }
                 }
             }


### PR DESCRIPTION
Closes: #9890
### Why
We are working on improving the app onboarding experience by adding a QR that shares the site URL and the email from the wp-admin. This way, merchants don't need to enter this information when logging into the apps.

### Description
This PR reads the information shared through the deep link to open the Login screen with the site URL and user name field filled.

### Testing instructions
1. Log out from the app
2. Open the terminal and run this script using your site URL and wp.com email:

```
adb -s 22091FDF600240 shell am start -W -a android.intent.action.VIEW -d "woocommerce://app-login?siteUrl=https://[SiteURL]\&username=[Usermane]"
```
Alternatively, you can change the text in [this](https://jsfiddle.net/atveiga/qbmd0xrn/14/) `jsfiddle`, press run to generate a new QR, and read the QR with your device camera.

3. Check that the app opens on the login screen with your username
4. Enter your credentials
5. Check that you are logged in with the store you used on the site URL.

### Images/gif


https://github.com/woocommerce/woocommerce-android/assets/18119390/312bd2fa-9a8d-4fd7-a339-02f2e9e85538



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
