### PR TITLE
Update FluxC version after adding support for order 'needs_payment' and 'needs_processing' properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-88de533f88cf43c30ba6fa74c8bf9294356edb45'
+    fluxCVersion = 'trunk-8797803a97c6a4153854d7544b819c81fc8e2a4c'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #6992 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we update the FluxC version in Gradle, after adding support for order 'needs_payment' and 'needs_processing' properties https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2861 As we won't use the added properties for now, we only have to update the commit number in `build.gradle `

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
CI should pass

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->