### PR TITLE
Product Creation with AI: networking support for bulk creating categories

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/FreeDomainRegistrationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/FreeDomainRegistrationViewModel.kt
@@ -34,7 +34,7 @@ import org.wordpress.android.fluxc.store.SiteStore.OnDomainSupportedStatesFetche
 import org.wordpress.android.fluxc.store.SiteStore.OnPrimaryDomainDesignated
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.TransactionsStore
-import org.wordpress.android.fluxc.store.TransactionsStore.CreateShoppingCartPayload
+import org.wordpress.android.fluxc.store.TransactionsStore.CreateShoppingCartWithDomainAndPlanPayload
 import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
 import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartRedeemed
 import org.wordpress.android.fluxc.store.TransactionsStore.OnSupportedCountriesFetched
@@ -127,8 +127,8 @@ class FreeDomainRegistrationViewModel @Inject constructor(
         )
 
         dispatcher.dispatch(
-            TransactionActionBuilder.newCreateShoppingCartAction(
-                CreateShoppingCartPayload(
+            TransactionActionBuilder.newCreateShoppingCartWithDomainAndPlanAction(
+                CreateShoppingCartWithDomainAndPlanPayload(
                     selectedSite.get(),
                     navArgs.domainProductDetails.productId,
                     navArgs.domainProductDetails.domainName,

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-88de533f88cf43c30ba6fa74c8bf9294356edb45'
+    fluxCVersion = '2862-d71411967982d5df686d78b4a639317b70970bdb'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2862-d71411967982d5df686d78b4a639317b70970bdb'
+    fluxCVersion = 'trunk-17371313376023d52f6e0aa1bc8f96ddd4ec1d65'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9882 

⚠️ Please don't merge until https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2862 is merged and the commit hash updated

### Description
This PR uses the work added in above FluxC PR to add a Repository function that allows bulk-creating categories.

### Testing instructions
No testing is needed, just code review, the feature should have been tested as part of the FluxC PR and will be tested further when the UI work is done.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
