### PR TITLE
Product Creation with AI: support creating new categories/tags

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,13 +5,8 @@
 - [*] In-Person Payments: Proactively notify users about optional card reader updates [https://github.com/woocommerce/woocommerce-android/pull/9847]
 - [*] Order creation: Customers list first page uses cached data [https://github.com/woocommerce/woocommerce-android/pull/9835]
 - [*] Order creation: Customers selected from the list that don't have address information now properly displayed on the order details screen [https://github.com/woocommerce/woocommerce-android/pull/9863]
-
-15.7
------
 - [*] Order creation: If a customer not found with given email, then there is a shortcut to create that manually [https://github.com/woocommerce/woocommerce-android/pull/9841]
-
-15.6
------
+- [*] Product Creation using AI: Added support for suggesting new categories and tags [https://github.com/woocommerce/woocommerce-android/pull/9919]
 
 15.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIPrompts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIPrompts.kt
@@ -68,16 +68,26 @@ object AIPrompts {
     ): String {
         fun getTagsLine(): String {
             return if (existingTags.isNotEmpty()) {
-                """tags":"Given the list of available tags "${existingTags.joinToString()}", suggest an array of the best matching tags for this product, if no matches are found return an empty array, don’t suggest any value other than the available ones",
-                    """"
-            } else ""
+                """
+                    "tags":"Given the list of available tags "${existingTags.joinToString()}", suggest an array of the best matching tags for this product. You can suggest new tags as well."
+                    """.trimIndent()
+            } else {
+                """
+                    "tags":"suggest an array of the best matching tags for this product."
+                    """.trimIndent()
+            }
         }
 
         fun getCategoriesLine(): String {
             return if (existingCategories.isNotEmpty()) {
-                """"categories":"Given the list of available categories "${existingCategories.joinToString()}", suggest an array of the best matching categories for this product, if no matches are found return an empty array, don’t suggest any value other than the available ones"
-                    """"
-            } else ""
+                """
+                    "categories":"Given the list of available categories "${existingCategories.joinToString()}", suggest an array of the best matching categories for this product. You can suggest new categories as well."
+                """.trimIndent()
+            } else {
+                """
+                    "categories":"suggest an array of the best matching categories for this product."
+                    """.trimIndent()
+            }
         }
 
         return """
@@ -100,7 +110,7 @@ object AIPrompts {
                   "height":"Guess and provide only the number in $dimensionUnit"
                },
                "price":"Guess the price in $currency, do not include the currency symbol, only provide the price as a number",
-               ${getTagsLine()}
+               ${getTagsLine()},
                ${getCategoriesLine()}
             }"
         """.trimIndent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIPrompts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIPrompts.kt
@@ -70,11 +70,11 @@ object AIPrompts {
             return if (existingTags.isNotEmpty()) {
                 """
                     "tags":"Given the list of available tags "${existingTags.joinToString()}", suggest an array of the best matching tags for this product. You can suggest new tags as well."
-                    """.trimIndent()
+                """.trimIndent()
             } else {
                 """
                     "tags":"suggest an array of the best matching tags for this product."
-                    """.trimIndent()
+                """.trimIndent()
             }
         }
 
@@ -86,7 +86,7 @@ object AIPrompts {
             } else {
                 """
                     "categories":"suggest an array of the best matching categories for this product."
-                    """.trimIndent()
+                """.trimIndent()
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
@@ -1,20 +1,13 @@
 package com.woocommerce.android.ai
 
-import com.google.gson.Gson
-import com.google.gson.annotations.SerializedName
-import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.products.ProductHelper
-import com.woocommerce.android.ui.products.ProductStatus.DRAFT
-import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAICompletionsResponse
 import org.wordpress.android.fluxc.store.jetpackai.JetpackAIStore
-import java.math.BigDecimal
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -81,25 +74,7 @@ class AIRepository @Inject constructor(
         existingCategories: List<ProductCategory>,
         existingTags: List<ProductTag>,
         languageISOCode: String
-    ): Result<Product> {
-        data class Shipping(
-            val weight: Float,
-            val height: Float,
-            val length: Float,
-            val width: Float
-        )
-
-        data class JsonResponse(
-            val name: String,
-            val description: String,
-            @SerializedName("short_description") val shortDescription: String,
-            @SerializedName("virtual") val isVirtual: Boolean,
-            val price: BigDecimal,
-            val shipping: Shipping,
-            val categories: List<String>? = null,
-            val tags: List<String>? = null
-        )
-
+    ): Result<String> {
         return fetchJetpackAICompletionsForSite(
             prompt = AIPrompts.generateProductCreationPrompt(
                 name = productName,
@@ -113,25 +88,7 @@ class AIRepository @Inject constructor(
                 languageISOCode = languageISOCode
             ),
             feature = PRODUCT_CREATION_FEATURE
-        ).mapCatching { json ->
-            val parsedResponse = Gson().fromJson(json, JsonResponse::class.java)
-            ProductHelper.getDefaultNewProduct(
-                SIMPLE,
-                parsedResponse.isVirtual
-            ).copy(
-                name = parsedResponse.name,
-                description = parsedResponse.description,
-                shortDescription = parsedResponse.shortDescription,
-                regularPrice = parsedResponse.price,
-                categories = existingCategories.filter { parsedResponse.categories.orEmpty().contains(it.name) },
-                tags = existingTags.filter { parsedResponse.tags.orEmpty().contains(it.name) },
-                weight = parsedResponse.shipping.weight,
-                height = parsedResponse.shipping.height,
-                length = parsedResponse.shipping.length,
-                width = parsedResponse.shipping.width,
-                status = DRAFT
-            )
-        }
+        )
     }
 
     suspend fun identifyISOLanguageCode(text: String, feature: String): Result<String> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1233,7 +1233,6 @@ class ProductDetailViewModel @Inject constructor(
         super.onCleared()
         productRepository.onCleanup()
         productCategoriesRepository.onCleanup()
-        productTagsRepository.onCleanup()
         if (isProductUnderCreation) {
             // cancel uploads for the default ID, since we can't assign the uploads to it
             mediaFileUploadHandler.cancelUpload(DEFAULT_ADD_NEW_PRODUCT_ID)
@@ -2112,7 +2111,9 @@ class ProductDetailViewModel @Inject constructor(
         if (tags.isNotEmpty()) {
             productTagsViewState = productTagsViewState.copy(isProgressDialogShown = true)
             launch {
-                val addedTags = productTagsRepository.addProductTags(tags.map { it.name })
+                val addedTags = productTagsRepository.addProductTags(tags.map { it.name }).getOrElse {
+                    emptyList()
+                }
                 // if there are some tags that could not be added, display an error message
                 if (addedTags.size < tags.size) {
                     triggerEvent(ShowSnackbar(R.string.product_add_tag_error))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -2051,6 +2051,10 @@ class ProductDetailViewModel @Inject constructor(
     private suspend fun fetchProductCategories(loadMore: Boolean = false) {
         if (networkStatus.isConnected()) {
             _productCategories.value = productCategoriesRepository.fetchProductCategories(loadMore = loadMore)
+                .getOrElse {
+                    triggerEvent(ShowSnackbar(R.string.error_generic))
+                    productCategoriesRepository.getProductCategoriesList()
+                }
 
             productCategoriesViewState = productCategoriesViewState.copy(
                 isLoading = true,
@@ -2304,7 +2308,10 @@ class ProductDetailViewModel @Inject constructor(
             val products = productTagsRepository.fetchProductTags(
                 loadMore = loadMore,
                 searchQuery = searchQuery
-            )
+            ).getOrElse {
+                triggerEvent(ShowSnackbar(R.string.error_generic))
+                productTagsRepository.getProductTags()
+            }
             filterProductTagList(products)
 
             productTagsViewState = productTagsViewState.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.annotation.DimenRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.sortCategories
@@ -16,6 +17,7 @@ import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -97,6 +99,7 @@ class ProductFilterListViewModel @Inject constructor(
         if (productCategories.isEmpty() || isProductCategoriesPartiallyFilled()) {
             productCategories = if (networkStatus.isConnected()) {
                 productCategoriesRepository.fetchProductCategories()
+                    .getOrDefault(productCategoriesRepository.getProductCategoriesList())
             } else {
                 productCategoriesRepository.getProductCategoriesList()
             }
@@ -354,6 +357,10 @@ class ProductFilterListViewModel @Inject constructor(
                 launch {
                     productFilterOptionListViewState = productFilterOptionListViewState.copy(isLoadingMore = true)
                     productCategories = productCategoriesRepository.fetchProductCategories(loadMore = true)
+                        .getOrElse {
+                            triggerEvent(ShowSnackbar(R.string.error_generic))
+                            return@launch
+                        }
                     val categoryOptions = productCategoriesToOptionListItems()
                     _filterOptionListItems.value = categoryOptions
                     updateCategoryFilterListItem(categoryOptions)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -117,6 +117,7 @@ class AddProductWithAIViewModel @Inject constructor(
         }
     }
 
+    @Suppress("ReturnCount")
     private suspend fun saveProduct(): Pair<Boolean, Long> {
         // Create missing categories
         val missingCategories = product.categories.filter { it.remoteCategoryId == 0L }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -9,10 +9,7 @@ import com.woocommerce.android.ai.AIRepository
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductDetailRepository
-import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
-import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -34,9 +31,7 @@ class AddProductWithAIViewModel @Inject constructor(
     aiRepository: AIRepository,
     private val productDetailRepository: ProductDetailRepository,
     buildProductPreviewProperties: BuildProductPreviewProperties,
-    categoriesRepository: ProductCategoriesRepository,
-    tagsRepository: ProductTagsRepository,
-    parameterRepository: ParameterRepository,
+    generateProductWithAI: GenerateProductWithAI,
     private val appsPrefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedState = savedStateHandle) {
     private val nameSubViewModel = ProductNameSubViewModel(
@@ -61,9 +56,7 @@ class AddProductWithAIViewModel @Inject constructor(
     private val previewSubViewModel = ProductPreviewSubViewModel(
         aiRepository = aiRepository,
         buildProductPreviewProperties = buildProductPreviewProperties,
-        categoriesRepository = categoriesRepository,
-        tagsRepository = tagsRepository,
-        parametersRepository = parameterRepository
+        generateProductWithAI = generateProductWithAI,
     ) {
         product = it
         saveButtonState.value = SaveButtonState.Shown

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/GenerateProductWithAI.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/GenerateProductWithAI.kt
@@ -5,6 +5,8 @@ import com.google.gson.annotations.SerializedName
 import com.woocommerce.android.ai.AIRepository
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.model.ProductCategory
+import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductHelper
 import com.woocommerce.android.ui.products.ProductStatus.DRAFT
@@ -66,8 +68,8 @@ class GenerateProductWithAI @Inject constructor(
                 description = parsedResponse.description,
                 shortDescription = parsedResponse.shortDescription,
                 regularPrice = parsedResponse.price,
-                categories = existingCategories.filter { parsedResponse.categories.orEmpty().contains(it.name) },
-                tags = existingTags.filter { parsedResponse.tags.orEmpty().contains(it.name) },
+                categories = parsedResponse.getCategories(existingCategories),
+                tags = parsedResponse.getTags(existingTags),
                 weight = parsedResponse.shipping.weight,
                 height = parsedResponse.shipping.height,
                 length = parsedResponse.shipping.length,
@@ -89,6 +91,22 @@ class GenerateProductWithAI @Inject constructor(
                 require(predicate(it)) { "Site parameters missing information after a successful fetch" }
                 it
             }
+    }
+
+    private fun AIProductJsonResponse.getCategories(
+        existingCategories: List<ProductCategory>
+    ): List<ProductCategory> = categories.orEmpty().map { name ->
+        existingCategories.find { category ->
+            category.name == name
+        } ?: ProductCategory(name = name)
+    }
+
+    private fun AIProductJsonResponse.getTags(
+        existingTags: List<ProductTag>
+    ): List<ProductTag> = tags.orEmpty().map { name ->
+        existingTags.find { tag ->
+            tag.name == name
+        } ?: ProductTag(name = name)
     }
 
     private data class AIProductJsonResponse(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/GenerateProductWithAI.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/GenerateProductWithAI.kt
@@ -1,0 +1,79 @@
+package com.woocommerce.android.ui.products.ai
+
+import com.woocommerce.android.ai.AIRepository
+import com.woocommerce.android.extensions.isNotNullOrEmpty
+import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.ui.products.ai.AboutProductSubViewModel.AiTone
+import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
+import com.woocommerce.android.ui.products.models.SiteParameters
+import com.woocommerce.android.ui.products.tags.ProductTagsRepository
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T.AI
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class GenerateProductWithAI @Inject constructor(
+    private val aiRepository: AIRepository,
+    private val categoriesRepository: ProductCategoriesRepository,
+    private val tagsRepository: ProductTagsRepository,
+    private val parametersRepository: ParameterRepository
+) {
+    suspend operator fun invoke(
+        productName: String,
+        productKeyWords: String,
+        tone: AiTone,
+        languageISOCode: String
+    ): Result<Product> {
+        val categories = getCategories()
+        val tags = getTags()
+        val siteParameters = getSiteParameters().fold(
+            onSuccess = { it },
+            onFailure = {
+                WooLog.e(AI, "Failed to get site parameters", it)
+                return Result.failure(it)
+            }
+        )
+
+        return aiRepository.generateProduct(
+            productName = productName,
+            productKeyWords = productKeyWords,
+            tone = tone.slug,
+            weightUnit = siteParameters.weightUnit!!,
+            dimensionUnit = siteParameters.dimensionUnit!!,
+            currency = siteParameters.currencyCode!!,
+            existingCategories = categories,
+            existingTags = tags,
+            languageISOCode = languageISOCode
+        )
+    }
+
+    private suspend fun getSiteParameters(): Result<SiteParameters> = withContext(Dispatchers.IO) {
+        fun predicate(parameters: SiteParameters): Boolean {
+            return parameters.weightUnit.isNotNullOrEmpty() &&
+                parameters.dimensionUnit.isNotNullOrEmpty() &&
+                parameters.currencyCode.isNotNullOrEmpty()
+        }
+
+        return@withContext parametersRepository.getParameters().takeIf(::predicate)?.let { Result.success(it) }
+            ?: parametersRepository.fetchParameters().mapCatching {
+                require(predicate(it)) { "Site parameters missing information after a successful fetch" }
+                it
+            }
+    }
+
+    private suspend fun getTags() = withContext(Dispatchers.IO) {
+        tagsRepository.getProductTags().ifEmpty {
+            tagsRepository.fetchProductTags()
+            tagsRepository.getProductTags()
+        }
+    }
+
+    private suspend fun getCategories() = withContext(Dispatchers.IO) {
+        categoriesRepository.getProductCategoriesList().ifEmpty {
+            categoriesRepository.fetchProductCategories()
+            categoriesRepository.getProductCategoriesList()
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/GenerateProductWithAI.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/GenerateProductWithAI.kt
@@ -57,7 +57,7 @@ class GenerateProductWithAI @Inject constructor(
             existingTags = existingTags,
             languageISOCode = languageISOCode
         ).mapCatching { json ->
-            val parsedResponse = Gson().fromJson(json, JsonResponse::class.java)
+            val parsedResponse = Gson().fromJson(json, AIProductJsonResponse::class.java)
             ProductHelper.getDefaultNewProduct(
                 SIMPLE,
                 parsedResponse.isVirtual
@@ -91,14 +91,7 @@ class GenerateProductWithAI @Inject constructor(
             }
     }
 
-    private data class Shipping(
-        val weight: Float,
-        val height: Float,
-        val length: Float,
-        val width: Float
-    )
-
-    private data class JsonResponse(
+    private data class AIProductJsonResponse(
         val name: String,
         val description: String,
         @SerializedName("short_description") val shortDescription: String,
@@ -107,5 +100,12 @@ class GenerateProductWithAI @Inject constructor(
         val shipping: Shipping,
         val categories: List<String>? = null,
         val tags: List<String>? = null
+    )
+
+    private data class Shipping(
+        val weight: Float,
+        val height: Float,
+        val length: Float,
+        val width: Float
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
@@ -103,7 +103,7 @@ class ProductPreviewSubViewModel(
                     onDone(product)
                 },
                 onFailure = {
-                    val errorType = when(it) {
+                    val errorType = when (it) {
                         is JetpackAICompletionsException -> it.errorType
                         is OnChangedException -> (it.error as? ProductError)?.type?.name
                         is WooException -> it.error.type.name

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
@@ -6,6 +6,7 @@ import android.text.TextUtils
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.model.RequestResult
 import com.woocommerce.android.model.sortCategories
@@ -200,6 +201,10 @@ class AddProductCategoryViewModel @Inject constructor(
         if (networkStatus.isConnected()) {
             _parentCategories.value = productCategoriesRepository
                 .fetchProductCategories(loadMore = loadMore)
+                .getOrElse {
+                    triggerEvent(ShowSnackbar(R.string.error_generic))
+                    productCategoriesRepository.getProductCategoriesList()
+                }
                 .sortCategories(resourceProvider)
 
             parentCategoryListViewState = parentCategoryListViewState.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsRepository.kt
@@ -1,19 +1,13 @@
 package com.woocommerce.android.ui.products.tags
 
-import com.woocommerce.android.AppConstants
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.model.toProductTag
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.ContinuationWrapper
-import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.dispatchAndAwait
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.WCProductAction.ADDED_PRODUCT_TAGS
 import org.wordpress.android.fluxc.generated.WCProductActionBuilder
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchProductTagsPayload
@@ -29,18 +23,9 @@ class ProductTagsRepository @Inject constructor(
         private const val PRODUCT_TAGS_PAGE_SIZE = WCProductStore.DEFAULT_PRODUCT_TAGS_PAGE_SIZE
     }
 
-    private var addProductTagsContinuation = ContinuationWrapper<Boolean>(WooLog.T.PRODUCTS)
     private var offset = 0
 
     var canLoadMoreProductTags = true
-
-    init {
-        dispatcher.register(this)
-    }
-
-    fun onCleanup() {
-        dispatcher.unregister(this)
-    }
 
     /**
      * Submits a fetch request to get a list of products tags for the current site
@@ -84,12 +69,15 @@ class ProductTagsRepository @Inject constructor(
      *
      * @return the result of the action as a [Boolean]
      */
-    suspend fun addProductTags(tagNames: List<String>): List<ProductTag> {
-        addProductTagsContinuation.callAndWaitUntilTimeout(AppConstants.REQUEST_TIMEOUT) {
-            val payload = WCProductStore.AddProductTagsPayload(selectedSite.get(), tagNames)
-            dispatcher.dispatch(WCProductActionBuilder.newAddProductTagsAction(payload))
+    suspend fun addProductTags(tagNames: List<String>): Result<List<ProductTag>> {
+        val payload = WCProductStore.AddProductTagsPayload(selectedSite.get(), tagNames)
+        val action = WCProductActionBuilder.newAddProductTagsAction(payload)
+        val result: OnProductTagChanged = dispatcher.dispatchAndAwait(action)
+
+        return when {
+            result.isError -> Result.failure(OnChangedException(result.error, result.error.message))
+            else -> Result.success(getProductTagsByNames(tagNames))
         }
-        return getProductTagsByNames(tagNames)
     }
 
     fun getProductTagsByNames(names: List<String>) =
@@ -97,18 +85,4 @@ class ProductTagsRepository @Inject constructor(
 
     fun getProductTagByName(name: String) =
         productStore.getProductTagByName(selectedSite.get(), name)?.toProductTag()
-
-    @SuppressWarnings("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onProductTagsChanged(event: OnProductTagChanged) {
-        when (event.causeOfChange) {
-            ADDED_PRODUCT_TAGS -> {
-                // No need to handle errors because errors are currently handled by `OrderListViewModel`.
-                addProductTagsContinuation.continueWith(false)
-            }
-
-            else -> {
-            }
-        }
-    }
 }


### PR DESCRIPTION
Closes: #9918 

⚠️ Please don't merge until we finish the internal discussion around the AI prompt

### Description
This PR adds support for creating new categories/tags when generating a product, and as a preparation, I needed some other changes:
- 0a9bda19ed07b2a9d2edd8163b6f801177978769 to allow showing an error when fetching categories and tags fails.
- 22d9b6b3d27cb6c0d477e17f5c48ca5b8b0d5023 to allow showing an error when creating tags fails.

Reviewing these two commit separately will make reviewing the rest of the PR easier.

### Testing instructions
##### TC1: no existing categories/tags
1. Use an AI-eligible website that doesn't have any categories/tags
2. Create a product using AI.
3. Confirm the created product has categories and tags that match the description.

##### TC2: store with existing categories/tags
1. Use an AI-eligible website that has some categories/tags
2. Create a product using AI.
3. Confirm the created product has categories and tags that match the description, the AI will pick from the existing ones when they match, and might add new ones.

### Images/gif
[Screen_recording_20231005_183224.webm](https://github.com/woocommerce/woocommerce-android/assets/1657201/82bd6ec4-5a37-4eda-8519-9c79cd03e864)

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
