### PR TITLE
App login deep link track events

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -92,9 +92,9 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data
-                    android:host="jetpack-connected"
-                    android:scheme="woocommerce" />
+                <data android:scheme="woocommerce"/>
+                <data android:host="jetpack-connected"/>
+                <data android:host="app-login" />
             </intent-filter>
         </activity>
         <activity

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -104,6 +104,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     LOGIN_WITH_QR_CODE_SCANNED(siteless = true),
     LOGIN_PROLOGUE_CREATE_SITE_TAPPED(siteless = true),
     LOGIN_MALFORMED_APP_LOGIN_LINK(siteless = true),
+    LOGIN_APP_LOGIN_LINK_SUCCESS(siteless = true),
     SIGNUP_LOGIN_BUTTON_TAPPED(siteless = true),
     SIGNUP_SUBMITTED(siteless = true),
     SIGNUP_SUCCESS(siteless = true),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -103,6 +103,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     LOGIN_WITH_QR_CODE_BUTTON_TAPPED(siteless = true),
     LOGIN_WITH_QR_CODE_SCANNED(siteless = true),
     LOGIN_PROLOGUE_CREATE_SITE_TAPPED(siteless = true),
+    LOGIN_MALFORMED_APP_LOGIN_LINK(siteless = true),
     SIGNUP_LOGIN_BUTTON_TAPPED(siteless = true),
     SIGNUP_SUBMITTED(siteless = true),
     SIGNUP_SUCCESS(siteless = true),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -243,6 +243,8 @@ class AnalyticsTracker private constructor(
         const val VALUE_SUBMIT = "submit"
         const val VALUE_DISMISS = "dismiss"
         const val VALUE_SUPPORT = "support"
+        const val VALUE_WP_COM = "wp_com"
+        const val VALUE_NO_WP_COM = "no_wp_com"
 
         const val KEY_FLOW = "flow"
         const val KEY_HAS_DIFFERENT_SHIPPING_DETAILS = "has_different_shipping_details"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -939,6 +939,7 @@ class LoginActivity :
                     stat = AnalyticsEvent.LOGIN_MALFORMED_APP_LOGIN_LINK,
                     properties = mapOf(KEY_URL to uri.toString())
                 )
+                ToastUtils.showToast(this, R.string.login_app_login_malformed_link)
                 showPrologue()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -121,6 +121,7 @@ class LoginActivity :
         const val SITE_URL_PARAMETER = "siteUrl"
         const val WP_COM_EMAIL_PARAMETER = "wpcomEmail"
         const val APP_LOGIN_AUTHORITY = "app-login"
+        const val USERNAME_PARAMETER = "username"
     }
 
     @Inject internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
@@ -170,6 +171,14 @@ class LoginActivity :
                     if (wpComEmail != null) {
                         gotWpcomSiteInfo(siteUrl)
                         showEmailPasswordScreen(email = wpComEmail, verifyEmail = false, password = null)
+                    } else {
+                        val username = uri.getQueryParameter(USERNAME_PARAMETER)
+                        showUsernamePasswordScreen(
+                            siteAddress = siteUrl,
+                            inputUsername = username,
+                            endpointAddress = null,
+                            inputPassword = null
+                        )
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FLOW
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_URL
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_JETPACK_INSTALLATION_SOURCE_WEB
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_LOGIN_WITH_WORDPRESS_COM
 import com.woocommerce.android.analytics.ExperimentTracker
@@ -168,17 +169,29 @@ class LoginActivity :
                     unifiedLoginTracker.setFlow(Flow.LOGIN_QR.value)
                     val siteUrl = uri.getQueryParameter(SITE_URL_PARAMETER)
                     val wpComEmail = uri.getQueryParameter(WP_COM_EMAIL_PARAMETER)
-                    if (wpComEmail != null) {
-                        gotWpcomSiteInfo(siteUrl)
-                        showEmailPasswordScreen(email = wpComEmail, verifyEmail = false, password = null)
-                    } else {
-                        val username = uri.getQueryParameter(USERNAME_PARAMETER)
-                        showUsernamePasswordScreen(
-                            siteAddress = siteUrl,
-                            inputUsername = username,
-                            endpointAddress = null,
-                            inputPassword = null
-                        )
+                    val username = uri.getQueryParameter(USERNAME_PARAMETER)
+                    when {
+                        siteUrl != null && wpComEmail != null -> {
+                            gotWpcomSiteInfo(siteUrl)
+                            showEmailPasswordScreen(email = wpComEmail, verifyEmail = false, password = null)
+                        }
+
+                        siteUrl != null && username != null -> {
+                            showUsernamePasswordScreen(
+                                siteAddress = siteUrl,
+                                inputUsername = username,
+                                endpointAddress = null,
+                                inputPassword = null
+                            )
+                        }
+
+                        else -> {
+                            AnalyticsTracker.track(
+                                stat = AnalyticsEvent.LOGIN_MALFORMED_APP_LOGIN_LINK,
+                                properties = mapOf(KEY_URL to uri.toString())
+                            )
+                            showPrologue()
+                        }
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -167,43 +167,7 @@ class LoginActivity :
             }
 
             intent?.action == Intent.ACTION_VIEW && intent.data?.authority == APP_LOGIN_AUTHORITY -> {
-                intent.data?.let { uri ->
-                    unifiedLoginTracker.setFlow(Flow.LOGIN_QR.value)
-                    val siteUrl = uri.getQueryParameter(SITE_URL_PARAMETER)
-                    val wpComEmail = uri.getQueryParameter(WP_COM_EMAIL_PARAMETER)
-                    val username = uri.getQueryParameter(USERNAME_PARAMETER)
-                    when {
-                        siteUrl != null && wpComEmail != null -> {
-                            gotWpcomSiteInfo(siteUrl)
-                            AnalyticsTracker.track(
-                                stat = AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
-                                properties = mapOf(KEY_FLOW to VALUE_WP_COM)
-                            )
-                            showEmailPasswordScreen(email = wpComEmail, verifyEmail = false, password = null)
-                        }
-
-                        siteUrl != null && username != null -> {
-                            AnalyticsTracker.track(
-                                stat = AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
-                                properties = mapOf(KEY_FLOW to VALUE_NO_WP_COM)
-                            )
-                            showUsernamePasswordScreen(
-                                siteAddress = siteUrl,
-                                inputUsername = username,
-                                endpointAddress = null,
-                                inputPassword = null
-                            )
-                        }
-
-                        else -> {
-                            AnalyticsTracker.track(
-                                stat = AnalyticsEvent.LOGIN_MALFORMED_APP_LOGIN_LINK,
-                                properties = mapOf(KEY_URL to uri.toString())
-                            )
-                            showPrologue()
-                        }
-                    }
-                }
+                intent.data?.let { uri -> handleAppLoginUri(uri) }
             }
 
             hasJetpackConnectedIntent() -> {
@@ -940,6 +904,44 @@ class LoginActivity :
             )
         )
         openQrCodeScannerFragment()
+    }
+
+    private fun handleAppLoginUri(uri: Uri) {
+        unifiedLoginTracker.setFlow(Flow.LOGIN_QR.value)
+        val siteUrl = uri.getQueryParameter(SITE_URL_PARAMETER)
+        val wpComEmail = uri.getQueryParameter(WP_COM_EMAIL_PARAMETER)
+        val username = uri.getQueryParameter(USERNAME_PARAMETER)
+        when {
+            siteUrl != null && wpComEmail != null -> {
+                gotWpcomSiteInfo(siteUrl)
+                AnalyticsTracker.track(
+                    stat = AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
+                    properties = mapOf(KEY_FLOW to VALUE_WP_COM)
+                )
+                showEmailPasswordScreen(email = wpComEmail, verifyEmail = false, password = null)
+            }
+
+            siteUrl != null && username != null -> {
+                AnalyticsTracker.track(
+                    stat = AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
+                    properties = mapOf(KEY_FLOW to VALUE_NO_WP_COM)
+                )
+                showUsernamePasswordScreen(
+                    siteAddress = siteUrl,
+                    inputUsername = username,
+                    endpointAddress = null,
+                    inputPassword = null
+                )
+            }
+
+            else -> {
+                AnalyticsTracker.track(
+                    stat = AnalyticsEvent.LOGIN_MALFORMED_APP_LOGIN_LINK,
+                    properties = mapOf(KEY_URL to uri.toString())
+                )
+                showPrologue()
+            }
+        }
     }
 
     private fun openQrCodeScannerFragment() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -164,6 +164,7 @@ class LoginActivity :
 
             intent?.action == Intent.ACTION_VIEW && intent.data?.authority == APP_LOGIN_AUTHORITY -> {
                 intent.data?.let { uri ->
+                    unifiedLoginTracker.setFlow(Flow.LOGIN_QR.value)
                     val siteUrl = uri.getQueryParameter(SITE_URL_PARAMETER)
                     val wpComEmail = uri.getQueryParameter(WP_COM_EMAIL_PARAMETER)
                     if (wpComEmail != null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -908,11 +908,11 @@ class LoginActivity :
 
     private fun handleAppLoginUri(uri: Uri) {
         unifiedLoginTracker.setFlow(Flow.LOGIN_QR.value)
-        val siteUrl = uri.getQueryParameter(SITE_URL_PARAMETER)
-        val wpComEmail = uri.getQueryParameter(WP_COM_EMAIL_PARAMETER)
-        val username = uri.getQueryParameter(USERNAME_PARAMETER)
+        val siteUrl = uri.getQueryParameter(SITE_URL_PARAMETER) ?: ""
+        val wpComEmail = uri.getQueryParameter(WP_COM_EMAIL_PARAMETER) ?: ""
+        val username = uri.getQueryParameter(USERNAME_PARAMETER) ?: ""
         when {
-            siteUrl != null && wpComEmail != null -> {
+            siteUrl.isNotEmpty() && wpComEmail.isNotEmpty() -> {
                 gotWpcomSiteInfo(siteUrl)
                 AnalyticsTracker.track(
                     stat = AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
@@ -921,7 +921,7 @@ class LoginActivity :
                 showEmailPasswordScreen(email = wpComEmail, verifyEmail = false, password = null)
             }
 
-            siteUrl != null && username != null -> {
+            siteUrl.isNotEmpty() && username.isNotEmpty() -> {
                 AnalyticsTracker.track(
                     stat = AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
                     properties = mapOf(KEY_FLOW to VALUE_NO_WP_COM)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -25,6 +25,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_URL
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_JETPACK_INSTALLATION_SOURCE_WEB
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_LOGIN_WITH_WORDPRESS_COM
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_NO_WP_COM
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_WP_COM
 import com.woocommerce.android.analytics.ExperimentTracker
 import com.woocommerce.android.databinding.ActivityLoginBinding
 import com.woocommerce.android.extensions.parcelable
@@ -173,10 +175,18 @@ class LoginActivity :
                     when {
                         siteUrl != null && wpComEmail != null -> {
                             gotWpcomSiteInfo(siteUrl)
+                            AnalyticsTracker.track(
+                                stat = AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
+                                properties = mapOf(KEY_FLOW to VALUE_WP_COM)
+                            )
                             showEmailPasswordScreen(email = wpComEmail, verifyEmail = false, password = null)
                         }
 
                         siteUrl != null && username != null -> {
+                            AnalyticsTracker.track(
+                                stat = AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
+                                properties = mapOf(KEY_FLOW to VALUE_NO_WP_COM)
+                            )
                             showUsernamePasswordScreen(
                                 siteAddress = siteUrl,
                                 inputUsername = username,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -117,6 +117,10 @@ class LoginActivity :
 
         const val LOGIN_WITH_WPCOM_EMAIL_ACTION = "login_with_wpcom_email"
         const val EMAIL_PARAMETER = "email"
+
+        const val SITE_URL_PARAMETER = "siteUrl"
+        const val WP_COM_EMAIL_PARAMETER = "wpcomEmail"
+        const val APP_LOGIN_AUTHORITY = "app-login"
     }
 
     @Inject internal lateinit var androidInjector: DispatchingAndroidInjector<Any>
@@ -156,6 +160,17 @@ class LoginActivity :
             intent?.action == LOGIN_WITH_WPCOM_EMAIL_ACTION -> {
                 val email = intent.extras!!.getString(EMAIL_PARAMETER)
                 gotWpcomEmail(email, verifyEmail = true, null)
+            }
+
+            intent?.action == Intent.ACTION_VIEW && intent.data?.authority == APP_LOGIN_AUTHORITY -> {
+                intent.data?.let { uri ->
+                    val siteUrl = uri.getQueryParameter(SITE_URL_PARAMETER)
+                    val wpComEmail = uri.getQueryParameter(WP_COM_EMAIL_PARAMETER)
+                    if (wpComEmail != null) {
+                        gotWpcomSiteInfo(siteUrl)
+                        showEmailPasswordScreen(email = wpComEmail, verifyEmail = false, password = null)
+                    }
+                }
             }
 
             hasJetpackConnectedIntent() -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt
@@ -146,7 +146,8 @@ class UnifiedLoginTracker
         LOGIN_SITE_ADDRESS("login_site_address"),
         SIGNUP("signup"),
         GOOGLE_SIGNUP("google_signup"),
-        EPILOGUE("epilogue")
+        EPILOGUE("epilogue"),
+        LOGIN_QR("login_qr"),
     }
 
     enum class Step(val value: String) {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -350,7 +350,7 @@
     <string name="login_site_credentials_fetching_site_failed">An error occurred while fetching your website</string>
     <string name="login_site_credentials_fetching_site">Fetching site…</string>
     <string name="login_site_credentials_web_authorization_connection_rejected">Unable to login because application password creation is not approved.</string>
-
+    <string name="login_app_login_malformed_link">We couldn\'t process your app login request</string>
     <!--
         My Store View
     -->


### PR DESCRIPTION
Closes: #9890
### Why
We are working on improving the app onboarding experience by adding a QR that shares the site URL and the email from the wp-admin. This way, merchants don't need to enter this information when logging into the apps.

### Description
This PR adds the success and fail events when trying to read the app-login link

### Testing instructions
TC1
1. Log out from the app
2. Open the terminal and run this script using your site URL and wp.com email:

```
adb -s 22091FDF600240 shell am start -W -a android.intent.action.VIEW -d "woocommerce://app-login?siteUrl=https://[SiteURL]\&username=[Usermane]"
```
Alternatively, you can change the text in [this](https://jsfiddle.net/atveiga/qbmd0xrn/14/) `jsfiddle`, press run to generate a new QR, and read the QR with your device camera.

3. Check that the app opens on the login screen with your username
4. Check that the success track event is sent with the flow no-wp

TC2.
1. Repeat the steps above but use this WP Com link

```
adb -s 22091FDF600240 shell am start -W -a android.intent.action.VIEW -d "woocommerce://app-login?siteUrl=https://[SiteURL]\&wpcomEmail=[WPComEmail]"
```
2. Check that the success track event is sent with the flow wp

TC3.
1. Repeat the steps above but use this malformed link

```
adb -s 22091FDF600240 shell am start -W -a android.intent.action.VIEW -d "woocommerce://app-login?siteUrl=https://[SiteURL]\&wpcomEmail=[WPComEmail]"
```
2. Check that the malformed track event is sent with the malformed url parameter

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

#### WP Com flow
```
🔵 Tracked: login_app_login_link_success, Properties: {"flow":"wp_com","is_debug":true}
```
#### No WP Com flow
```
🔵 Tracked: login_app_login_link_success, Properties: {"flow":"no_wp_com","is_debug":true}
```
#### Malformed URL
```
🔵 Tracked: login_malformed_app_login_link, Properties: {"url":"woocommerce:\/\/app-login?siteUrl=tomazlowerwoo.mystagingwebsite.com","is_debug":true}
```

### Event registration
- `login_app_login_link_success` https://github.com/Automattic/tracks-events-registration/pull/1885
-  `login_malformed_app_login_link` https://github.com/Automattic/tracks-events-registration/pull/1886


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
