### PR TITLE
[TTPA CA/UK] Highlight text on "create an order" or "collect a payment" line

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/about/TapToPayAboutScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/about/TapToPayAboutScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -83,10 +85,7 @@ fun TapToPayAboutScreen(
                     style = MaterialTheme.typography.h6,
                 )
                 Spacer(Modifier.size(dimensionResource(id = R.dimen.minor_100)))
-                Text(
-                    text = stringResource(id = R.string.card_reader_tap_to_pay_about_how_works_1),
-                    style = MaterialTheme.typography.body1,
-                )
+                TapToPayAboutScreenHowItWorksFirstLine()
                 Spacer(Modifier.size(dimensionResource(id = R.dimen.minor_100)))
                 Text(
                     text = stringResource(id = R.string.card_reader_tap_to_pay_about_how_works_2),
@@ -115,6 +114,41 @@ fun TapToPayAboutScreen(
                 )
             }
         }
+    )
+}
+
+@Composable
+private fun TapToPayAboutScreenHowItWorksFirstLine() {
+    val createOrderPlaceholder = stringResource(id = R.string.card_reader_tap_to_pay_about_how_works_create_order)
+    val collectPaymentPlaceholder = stringResource(id = R.string.card_reader_tap_to_pay_about_how_works_collect_payment)
+
+    val fullText = stringResource(
+        id = R.string.card_reader_tap_to_pay_about_how_works_1,
+        createOrderPlaceholder,
+        collectPaymentPlaceholder
+    )
+
+    val startCollectPayment = fullText.indexOf(collectPaymentPlaceholder)
+    val startCreateOrder = fullText.indexOf(createOrderPlaceholder)
+    val spanStyle = SpanStyle(
+        color = colorResource(id = R.color.color_primary),
+        fontWeight = FontWeight.W600
+    )
+    val spanStyles = listOf(
+        AnnotatedString.Range(
+            spanStyle,
+            start = startCollectPayment,
+            end = startCollectPayment + collectPaymentPlaceholder.length
+        ),
+        AnnotatedString.Range(
+            spanStyle,
+            start = startCreateOrder,
+            end = startCreateOrder + createOrderPlaceholder.length
+        )
+    )
+    Text(
+        text = AnnotatedString(text = fullText, spanStyles = spanStyles),
+        style = MaterialTheme.typography.body1,
     )
 }
 
@@ -162,7 +196,7 @@ fun TapToPayAboutScreenImportantInfo(importantInfo: TapToPayAboutViewModel.UiSta
         Spacer(Modifier.size(dimensionResource(id = R.dimen.minor_100)))
         Text(
             text = stringResource(R.string.card_reader_tap_to_pay_about_important_info_button),
-            fontWeight = FontWeight.Bold,
+            fontWeight = FontWeight.W600,
             color = colorResource(id = R.color.color_primary),
             modifier = Modifier.clickable { importantInfo.onLearnMoreAboutCardReaders() }
         )

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1312,7 +1312,9 @@
     <string name="card_reader_tap_to_pay_about_important_info_description_3">To accept payments above this limit, consider purchasing a card reader that accepts PIN entry.</string>
     <string name="card_reader_tap_to_pay_about_important_info_button">Learn more about card readers</string>
     <string name="card_reader_tap_to_pay_about_how_works_title">How it works</string>
-    <string name="card_reader_tap_to_pay_about_how_works_1">1. Create an order or collect a payment</string>
+    <string name="card_reader_tap_to_pay_about_how_works_1">1. %1$s or %2$s</string>
+    <string name="card_reader_tap_to_pay_about_how_works_create_order">Create an order</string>
+    <string name="card_reader_tap_to_pay_about_how_works_collect_payment">collect a payment</string>
     <string name="card_reader_tap_to_pay_about_how_works_2">2. Tap “Collect Payment” and choose “Tap to Pay”.</string>
     <string name="card_reader_tap_to_pay_about_how_works_3">3. Present your phone to the customer.</string>
     <string name="card_reader_tap_to_pay_about_how_works_4">4. Your customer holds their card horizontally at the top of your phone, over the contactless symbol.</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9898
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Add highlighting of the text of the first line of "how it works"
<img width="173" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/4923871/d493d8ad-1d52-41df-9d5f-9ff1b3158afb">


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* TTP enabled device -> more -> about tap to pay
* Notice highlighted "create an order" or "collect a payment"

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-android/assets/4923871/de823be5-4981-461d-b5c7-736d3ed51749" width = 300>
<img src="https://github.com/woocommerce/woocommerce-android/assets/4923871/71c5d834-a147-4892-a054-b09a7a0752f0" width = 300>



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
