### PR TITLE
[Order Creation] Check if customer empty before setting content

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -248,7 +248,18 @@ data class Order(
         val email: String? = null,
         val billingAddress: Address,
         val shippingAddress: Address,
-    ) : Parcelable
+    ) : Parcelable {
+        companion object {
+            val EMPTY = Customer(
+                customerId = null,
+                firstName = null,
+                lastName = null,
+                email = null,
+                billingAddress = Address.EMPTY,
+                shippingAddress = Address.EMPTY,
+            )
+        }
+    }
 
     fun getBillingName(defaultValue: String): String {
         return when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -511,7 +511,7 @@ class OrderCreateEditFormFragment :
         customerAddressSection.setContentHorizontalPadding(R.dimen.minor_00)
 
         val customer = order.customer
-        if (customer == null) {
+        if (customer == null || customer == Order.Customer.EMPTY) {
             customerAddressSection.content = null
             return
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9923
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I noticed a bug - we show the "edit customer" button after a product was added, even if there is not customer. That happened because an empty customer object was created as part of the order after update from the backend

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Start order creation 
* Add a product
* Notice that there is still an "add customer details" button, instead of an edit

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/9771ee33-b16c-49a1-ae9e-16cd146573a9



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
