### PR TITLE
Filter out wildcards from TaxRate list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorViewModel.kt
@@ -35,12 +35,7 @@ class TaxRateSelectorViewModel @Inject constructor(
     ) { rates, isLoading, autoRateSwitchState ->
         rates
             .filter { taxRate ->
-                taxRate.city.isNotEmpty() ||
-                    taxRate.stateCode.isNotEmpty() ||
-                    taxRate.countryCode.isNotEmpty() ||
-                    taxRate.postcode.isNotEmpty() ||
-                    taxRate.postCodes != null ||
-                    taxRate.cities != null
+                hasAddress(taxRate)
             } // Filter out tax rates with wildcard address
             .map { taxRate ->
                 TaxRateUiModel(
@@ -121,8 +116,12 @@ class TaxRateSelectorViewModel @Inject constructor(
     object EditTaxRatesInAdmin : MultiLiveEvent.Event()
     object ShowTaxesInfoDialog : MultiLiveEvent.Event()
 
-    fun TaxRate.hasAddress(taxRate: TaxRate): Boolean {
-        return taxRate.city.isNotEmpty() || taxRate.stateCode.isNotEmpty() ||
-            taxRate.postcode.isNotEmpty() || taxRate.countryCode.isNotEmpty()
+    private fun hasAddress(taxRate: TaxRate): Boolean {
+        return taxRate.city.isNotEmpty() ||
+            taxRate.stateCode.isNotEmpty() ||
+            taxRate.countryCode.isNotEmpty() ||
+            taxRate.postcode.isNotEmpty() ||
+            taxRate.postCodes != null ||
+            taxRate.cities != null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorViewModel.kt
@@ -38,7 +38,9 @@ class TaxRateSelectorViewModel @Inject constructor(
                 taxRate.city.isNotEmpty() ||
                     taxRate.stateCode.isNotEmpty() ||
                     taxRate.countryCode.isNotEmpty() ||
-                    taxRate.postcode.isNotEmpty()
+                    taxRate.postcode.isNotEmpty() ||
+                    taxRate.postCodes != null ||
+                    taxRate.cities != null
             } // Filter out tax rates with wildcard address
             .map { taxRate ->
                 TaxRateUiModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorViewModel.kt
@@ -116,7 +116,7 @@ class TaxRateSelectorViewModel @Inject constructor(
     object EditTaxRatesInAdmin : MultiLiveEvent.Event()
     object ShowTaxesInfoDialog : MultiLiveEvent.Event()
 
-    private fun hasAddress(taxRate: TaxRate): Boolean {
+    fun hasAddress(taxRate: TaxRate): Boolean {
         return taxRate.city.isNotEmpty() ||
             taxRate.stateCode.isNotEmpty() ||
             taxRate.countryCode.isNotEmpty() ||

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/TaxRateSelectorViewModel.kt
@@ -33,15 +33,23 @@ class TaxRateSelectorViewModel @Inject constructor(
         isLoading,
         autoRateSwitchState
     ) { rates, isLoading, autoRateSwitchState ->
-        rates.map { taxRate ->
-            TaxRateUiModel(
-                label = getTaxRateLabel(taxRate),
-                rate = getTaxRatePercentageValueText(taxRate),
-                taxRate = taxRate,
-            )
-        }.let {
-            ViewState(taxRates = it, isLoading = isLoading, isAutoRateEnabled = autoRateSwitchState)
-        }
+        rates
+            .filter { taxRate ->
+                taxRate.city.isNotEmpty() ||
+                    taxRate.stateCode.isNotEmpty() ||
+                    taxRate.countryCode.isNotEmpty() ||
+                    taxRate.postcode.isNotEmpty()
+            } // Filter out tax rates with wildcard address
+            .map { taxRate ->
+                TaxRateUiModel(
+                    label = getTaxRateLabel(taxRate),
+                    rate = getTaxRatePercentageValueText(taxRate),
+                    taxRate = taxRate
+                )
+            }
+            .let {
+                ViewState(taxRates = it, isLoading = isLoading, isAutoRateEnabled = autoRateSwitchState)
+            }
     }.toStateFlow(ViewState())
 
     init {
@@ -104,10 +112,15 @@ class TaxRateSelectorViewModel @Inject constructor(
     data class TaxRateUiModel(
         val label: String,
         val rate: String,
-        val taxRate: TaxRate,
+        val taxRate: TaxRate
     ) : Parcelable
 
     data class TaxRateSelected(val taxRate: TaxRate) : MultiLiveEvent.Event()
     object EditTaxRatesInAdmin : MultiLiveEvent.Event()
     object ShowTaxesInfoDialog : MultiLiveEvent.Event()
+
+    fun TaxRate.hasAddress(taxRate: TaxRate): Boolean {
+        return taxRate.city.isNotEmpty() || taxRate.stateCode.isNotEmpty() ||
+            taxRate.postcode.isNotEmpty() || taxRate.countryCode.isNotEmpty()
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/taxes/TaxRateSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/taxes/TaxRateSelectorViewModelTest.kt
@@ -104,4 +104,19 @@ internal class TaxRateSelectorViewModelTest : BaseUnitTest() {
         // THEN
         assert(!filteredTaxRate)
     }
+
+    @Test
+    fun `given tax rate added with address, then should not filter it out`() {
+        // Create a TaxRateUiModel for testing with an empty address
+        val taxRate = TaxRate(1, "US", "NY", "12345", "New York")
+        val taxRateUiModel = TaxRateSelectorViewModel.TaxRateUiModel(
+            "Test Rate · US NY 12345 New York", "10%", taxRate
+        )
+
+        // GIVEN
+        val filteredTaxRate = viewModel.hasAddress(taxRateUiModel.taxRate)
+
+        // THEN
+        assert(filteredTaxRate)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/taxes/TaxRateSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/taxes/TaxRateSelectorViewModelTest.kt
@@ -89,4 +89,19 @@ internal class TaxRateSelectorViewModelTest : BaseUnitTest() {
         // THEN
         verify(tracker).track(AnalyticsEvent.TAX_RATE_SELECTOR_EDIT_IN_ADMIN_TAPPED)
     }
+
+    @Test
+    fun `given tax rate added without address, then should filter it out`() {
+        // Create a TaxRateUiModel for testing with an empty address
+        val taxRate = TaxRate(1, "", "", "", "")
+        val taxRateUiModel = TaxRateSelectorViewModel.TaxRateUiModel(
+            "Test Rate · US", "10%", taxRate
+        )
+
+        // GIVEN
+        val filteredTaxRate = viewModel.hasAddress(taxRateUiModel.taxRate)
+
+        // THEN
+        assert(!filteredTaxRate)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9855 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR aims to reach platform parity with iOS and filter out tax rates from the tax rate selector (in order creation) that don't have at least one of the address fields filled out (country, city(ies), PC(s), state)

context: pdfdoF-3GW-p2#comment-5078

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. In WP Admin, insert new tax rows that have no address added (it will populate the fields with the wildcard *)
2. In the app, go to orders
3. add  new order
4. click on set new tax rate
5. make sure the tax rates without at least one address field
 are filtered out

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Before | After |
| ---- | ---- |
| <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/957401d9-3553-44ef-a214-155eeff173f8" width="350"/> | <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/4b6db134-db63-4432-b48b-6d91d42abfe2" width="350"/> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->