### PR TITLE
Feature/9945 blaze active campaign view

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
@@ -43,6 +43,7 @@ import com.woocommerce.android.ui.compose.component.WCTextButton
 fun MyStoreBlazeView(
     state: MyStoreBlazeUi,
     onCreateCampaignClicked: () -> Unit,
+    onShowAllClicked: () -> Unit
 ) {
     Card(
         modifier = Modifier
@@ -73,20 +74,43 @@ fun MyStoreBlazeView(
                     }
                 }
             }
-
-            CreateNewBlazeCampaignFooter(onCreateCampaignClicked)
+            when {
+                state.blazeActiveCampaign != null -> CreateCampaignFooter(onCreateCampaignClicked)
+                else -> ShowAllOrCreateCampaignFooter(onShowAllClicked, onCreateCampaignClicked)
+            }
         }
     }
 }
 
 @Composable
-private fun CreateNewBlazeCampaignFooter(onCreateCampaignClicked: () -> Unit) {
+private fun CreateCampaignFooter(onCreateCampaignClicked: () -> Unit) {
     Divider()
     WCTextButton(
         modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_75)),
         onClick = onCreateCampaignClicked
     ) {
         Text(stringResource(id = R.string.blaze_campaign_create_campaign_button))
+    }
+}
+
+@Composable
+private fun ShowAllOrCreateCampaignFooter(
+    onShowAllClicked: () -> Unit,
+    onCreateCampaignClicked: () -> Unit,
+) {
+    Row {
+        WCTextButton(
+            modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_75)),
+            onClick = onShowAllClicked
+        ) {
+            Text(stringResource(id = R.string.blaze_campaign_show_all_button))
+        }
+        WCTextButton(
+            modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_100)),
+            onClick = onCreateCampaignClicked
+        ) {
+            Text(stringResource(id = R.string.blaze_campaign_create_campaign_button))
+        }
     }
 }
 
@@ -255,6 +279,7 @@ fun MyStoreBlazeViewPreview() {
                 budget = 1000
             ),
         ),
-        onCreateCampaignClicked = {}
+        onCreateCampaignClicked = {},
+        onShowAllClicked = {}
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
@@ -33,8 +33,10 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.BlazeCampaignUi
 import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.BlazeProductUi
+import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.CampaignStatusUi
 import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.MyStoreBlazeUi
 import com.woocommerce.android.ui.compose.component.ListItemImage
+import com.woocommerce.android.ui.compose.component.WCTag
 import com.woocommerce.android.ui.compose.component.WCTextButton
 
 @Composable
@@ -172,14 +174,21 @@ fun BlazeCampaignItem(
                     .clip(shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))),
                 placeHolderDrawableId = R.drawable.ic_product,
             )
-            Text(
-                modifier = Modifier
-                    .padding(start = dimensionResource(id = R.dimen.major_100))
-                    .weight(1f),
-                text = campaign.product.name,
-                style = MaterialTheme.typography.subtitle1,
-                fontWeight = FontWeight.Bold
-            )
+            Column {
+                WCTag(
+                    text = stringResource(id = campaign.status.statusDisplayText),
+                    textColor = colorResource(id = campaign.status.textColor),
+                    backgroundColor = colorResource(id = campaign.status.backgroundColor),
+                )
+                Text(
+                    modifier = Modifier
+                        .padding(start = dimensionResource(id = R.dimen.major_100))
+                        .weight(1f),
+                    text = campaign.product.name,
+                    style = MaterialTheme.typography.subtitle1,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
         }
     }
 }
@@ -192,14 +201,21 @@ fun BlazeCampaignItem(
 @Preview(name = "large screen", device = Devices.NEXUS_10)
 @Composable
 fun MyStoreBlazeViewPreview() {
+    val product = BlazeProductUi(
+        name = "Product name",
+        imgUrl = "",
+    )
     MyStoreBlazeView(
         state = MyStoreBlazeUi(
             isVisible = true,
-            product = BlazeProductUi(
-                name = "Product name",
-                imgUrl = "",
+            product = product,
+            blazeActiveCampaign = BlazeCampaignUi(
+                product = product,
+                status = CampaignStatusUi.Active,
+                impressions = 100,
+                clicks = 10,
+                budget = 1000
             ),
-            blazeActiveCampaign = null,
         ),
         onCreateCampaignClicked = {}
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
@@ -55,7 +55,12 @@ fun MyStoreBlazeView(
             Column(modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))) {
                 BlazeCampaignHeader()
                 when {
-                    state.blazeActiveCampaign != null -> BlazeCampaignItem(state.blazeActiveCampaign, {})
+                    state.blazeActiveCampaign != null -> BlazeCampaignItem(
+                        campaign = state.blazeActiveCampaign,
+                        onCampaignClicked = {},
+                        modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100))
+                    )
+
                     else -> {
                         Text(
                             modifier = Modifier.padding(
@@ -63,8 +68,7 @@ fun MyStoreBlazeView(
                                 end = dimensionResource(id = R.dimen.major_300)
                             ),
                             text = stringResource(id = R.string.blaze_campaign_subtitle),
-                            style = MaterialTheme.typography.subtitle1,
-                            color = colorResource(id = R.color.color_on_surface_medium_selector)
+                            style = MaterialTheme.typography.body1,
                         )
                         BlazeProductItem(
                             product = state.product,
@@ -190,7 +194,7 @@ fun BlazeCampaignItem(
             .clickable { onCampaignClicked() }
             .padding(dimensionResource(id = R.dimen.major_100))
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(verticalAlignment = Alignment.Top) {
             ListItemImage(
                 imageUrl = campaign.product.imgUrl,
                 modifier = Modifier
@@ -215,7 +219,7 @@ fun BlazeCampaignItem(
                     style = MaterialTheme.typography.subtitle1,
                     fontWeight = FontWeight.Bold,
                 )
-                Row {
+                Row(modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100))) {
                     CampaignStat(
                         statName = stringResource(id = R.string.blaze_campaign_status_impressions),
                         statValue = campaign.impressions
@@ -235,22 +239,25 @@ fun BlazeCampaignItem(
 }
 
 @Composable
-private fun CampaignStat(statName: String, statValue: Int) {
+private fun CampaignStat(
+    statName: String,
+    statValue: Int,
+    modifier: Modifier = Modifier,
+) {
     Column(
-        modifier = Modifier
-            .padding(end = dimensionResource(id = R.dimen.major_100))
+        modifier = modifier.padding(end = dimensionResource(id = R.dimen.major_100))
     ) {
         Text(
-            text = statValue.toString(),
-            style = MaterialTheme.typography.h6,
-            fontWeight = FontWeight.Bold,
+            text = statName,
+            style = MaterialTheme.typography.body2,
         )
         Text(
             modifier = Modifier
                 .padding(top = dimensionResource(id = R.dimen.minor_50)),
-            text = statName,
-            style = MaterialTheme.typography.caption,
-            color = colorResource(id = R.color.color_on_surface_medium_selector)
+            text = statValue.toString(),
+            style = MaterialTheme.typography.h6,
+            color = colorResource(id = R.color.color_on_surface_medium_selector),
+            fontWeight = FontWeight.Bold
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
@@ -31,15 +31,15 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
-import com.woocommerce.android.R.dimen
 import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.BlazeCampaignUi
-import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.BlazeProduct
+import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.BlazeProductUi
+import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.MyStoreBlazeUi
 import com.woocommerce.android.ui.compose.component.ListItemImage
 import com.woocommerce.android.ui.compose.component.WCTextButton
 
 @Composable
 fun MyStoreBlazeView(
-    state: BlazeCampaignUi,
+    state: MyStoreBlazeUi,
     onCreateCampaignClicked: () -> Unit,
 ) {
     Card(
@@ -50,52 +50,65 @@ fun MyStoreBlazeView(
     ) {
         Column {
             Column(modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Image(
-                        painter = painterResource(id = R.drawable.ic_more_menu_blaze),
-                        contentDescription = "", // Blaze icon, no relevant content desc
-                        modifier = Modifier
-                            .padding(end = dimensionResource(id = dimen.minor_100))
-                            .size(dimensionResource(id = dimen.major_125))
-                    )
-                    Text(
-                        text = stringResource(id = R.string.blaze_campaign_title),
-                        style = MaterialTheme.typography.h6,
-                        fontWeight = FontWeight.Bold
-                    )
-                }
-                Text(
-                    modifier = Modifier.padding(
-                        top = dimensionResource(id = R.dimen.major_100),
-                        end = dimensionResource(id = R.dimen.major_300)
-                    ),
-                    text = stringResource(id = R.string.blaze_campaign_subtitle),
-                    style = MaterialTheme.typography.subtitle1,
-                    color = colorResource(id = R.color.color_on_surface_medium_selector)
-                )
-                if (!state.hasActiveCampaigns) {
-                    BlazeProductItem(
-                        product = state.product,
-                        onProductSelected = {},
-                        modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100))
-                    )
+                BlazeCampaignHeader()
+                when {
+                    state.blazeActiveCampaign != null -> BlazeCampaignItem(state.blazeActiveCampaign, {})
+                    else -> {
+                        Text(
+                            modifier = Modifier.padding(
+                                top = dimensionResource(id = R.dimen.major_100),
+                                end = dimensionResource(id = R.dimen.major_300)
+                            ),
+                            text = stringResource(id = R.string.blaze_campaign_subtitle),
+                            style = MaterialTheme.typography.subtitle1,
+                            color = colorResource(id = R.color.color_on_surface_medium_selector)
+                        )
+                        BlazeProductItem(
+                            product = state.product,
+                            onProductSelected = {},
+                            modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100))
+                        )
+                    }
                 }
             }
 
-            Divider()
-            WCTextButton(
-                modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_75)),
-                onClick = onCreateCampaignClicked
-            ) {
-                Text(stringResource(id = R.string.blaze_campaign_create_campaign_button))
-            }
+            CreateNewBlazeCampaignFooter(onCreateCampaignClicked)
         }
     }
 }
 
 @Composable
+private fun CreateNewBlazeCampaignFooter(onCreateCampaignClicked: () -> Unit) {
+    Divider()
+    WCTextButton(
+        modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_75)),
+        onClick = onCreateCampaignClicked
+    ) {
+        Text(stringResource(id = R.string.blaze_campaign_create_campaign_button))
+    }
+}
+
+@Composable
+private fun BlazeCampaignHeader() {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Image(
+            painter = painterResource(id = R.drawable.ic_more_menu_blaze),
+            contentDescription = "", // Blaze icon, no relevant content desc
+            modifier = Modifier
+                .padding(end = dimensionResource(id = R.dimen.minor_100))
+                .size(dimensionResource(id = R.dimen.major_125))
+        )
+        Text(
+            text = stringResource(id = R.string.blaze_campaign_title),
+            style = MaterialTheme.typography.h6,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+@Composable
 fun BlazeProductItem(
-    product: BlazeProduct,
+    product: BlazeProductUi,
     onProductSelected: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -134,6 +147,43 @@ fun BlazeProductItem(
     }
 }
 
+@Composable
+fun BlazeCampaignItem(
+    campaign: BlazeCampaignUi,
+    onCampaignClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .border(
+                width = dimensionResource(id = R.dimen.minor_10),
+                color = colorResource(R.color.divider_color),
+                shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
+            )
+            .clip(shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100)))
+            .clickable { onCampaignClicked() }
+            .padding(dimensionResource(id = R.dimen.major_100))
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            ListItemImage(
+                imageUrl = campaign.product.imgUrl,
+                modifier = Modifier
+                    .size(dimensionResource(id = R.dimen.major_275))
+                    .clip(shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))),
+                placeHolderDrawableId = R.drawable.ic_product,
+            )
+            Text(
+                modifier = Modifier
+                    .padding(start = dimensionResource(id = R.dimen.major_100))
+                    .weight(1f),
+                text = campaign.product.name,
+                style = MaterialTheme.typography.subtitle1,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}
+
 @ExperimentalFoundationApi
 @Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO)
@@ -143,13 +193,13 @@ fun BlazeProductItem(
 @Composable
 fun MyStoreBlazeViewPreview() {
     MyStoreBlazeView(
-        state = BlazeCampaignUi(
+        state = MyStoreBlazeUi(
             isVisible = true,
-            hasActiveCampaigns = false,
-            product = BlazeProduct(
+            product = BlazeProductUi(
                 name = "Product name",
                 imgUrl = "",
-            )
+            ),
+            blazeActiveCampaign = null,
         ),
         onCreateCampaignClicked = {}
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.BlazeCampaignUi
 import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.BlazeProductUi
@@ -52,7 +53,13 @@ fun MyStoreBlazeView(
         shape = RoundedCornerShape(0.dp)
     ) {
         Column {
-            Column(modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))) {
+            Column(
+                modifier = Modifier.padding(
+                    top = dimensionResource(id = R.dimen.major_100),
+                    start = dimensionResource(id = R.dimen.major_100),
+                    end = dimensionResource(id = R.dimen.major_100),
+                )
+            ) {
                 BlazeCampaignHeader()
                 when {
                     state.blazeActiveCampaign != null -> BlazeCampaignItem(
@@ -79,8 +86,12 @@ fun MyStoreBlazeView(
                 }
             }
             when {
-                state.blazeActiveCampaign != null -> CreateCampaignFooter(onCreateCampaignClicked)
-                else -> ShowAllOrCreateCampaignFooter(onShowAllClicked, onCreateCampaignClicked)
+                state.blazeActiveCampaign != null -> ShowAllOrCreateCampaignFooter(
+                    onShowAllClicked,
+                    onCreateCampaignClicked
+                )
+
+                else -> CreateCampaignFooter(onCreateCampaignClicked)
             }
         }
     }
@@ -157,7 +168,7 @@ fun BlazeProductItem(
             ListItemImage(
                 imageUrl = product.imgUrl,
                 modifier = Modifier
-                    .size(dimensionResource(id = R.dimen.major_275))
+                    .size(dimensionResource(id = R.dimen.major_300))
                     .clip(shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))),
                 placeHolderDrawableId = R.drawable.ic_product,
             )
@@ -208,9 +219,12 @@ fun BlazeCampaignItem(
                     .weight(1f),
             ) {
                 WCTag(
-                    text = stringResource(id = campaign.status.statusDisplayText),
+                    text = stringResource(id = campaign.status.statusDisplayText).uppercase(),
                     textColor = colorResource(id = campaign.status.textColor),
                     backgroundColor = colorResource(id = campaign.status.backgroundColor),
+                    textStyle = MaterialTheme.typography.caption.copy(
+                        letterSpacing = 1.5.sp
+                    )
                 )
                 Text(
                     modifier = Modifier
@@ -227,10 +241,6 @@ fun BlazeCampaignItem(
                     CampaignStat(
                         statName = stringResource(id = R.string.blaze_campaign_status_clicks),
                         statValue = campaign.clicks
-                    )
-                    CampaignStat(
-                        statName = stringResource(id = R.string.blaze_campaign_status_budget),
-                        statValue = campaign.budget
                     )
                 }
             }
@@ -250,14 +260,13 @@ private fun CampaignStat(
         Text(
             text = statName,
             style = MaterialTheme.typography.body2,
+            color = colorResource(id = R.color.color_on_surface_medium_selector),
         )
         Text(
             modifier = Modifier
                 .padding(top = dimensionResource(id = R.dimen.minor_50)),
             text = statValue.toString(),
             style = MaterialTheme.typography.h6,
-            color = colorResource(id = R.color.color_on_surface_medium_selector),
-            fontWeight = FontWeight.Bold
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
@@ -174,7 +174,11 @@ fun BlazeCampaignItem(
                     .clip(shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))),
                 placeHolderDrawableId = R.drawable.ic_product,
             )
-            Column {
+            Column(
+                modifier = Modifier
+                    .padding(start = dimensionResource(id = R.dimen.major_100))
+                    .weight(1f),
+            ) {
                 WCTag(
                     text = stringResource(id = campaign.status.statusDisplayText),
                     textColor = colorResource(id = campaign.status.textColor),
@@ -182,14 +186,48 @@ fun BlazeCampaignItem(
                 )
                 Text(
                     modifier = Modifier
-                        .padding(start = dimensionResource(id = R.dimen.major_100))
-                        .weight(1f),
+                        .padding(top = dimensionResource(id = R.dimen.minor_50)),
                     text = campaign.product.name,
                     style = MaterialTheme.typography.subtitle1,
                     fontWeight = FontWeight.Bold,
                 )
+                Row {
+                    CampaignStat(
+                        statName = stringResource(id = R.string.blaze_campaign_status_impressions),
+                        statValue = campaign.impressions
+                    )
+                    CampaignStat(
+                        statName = stringResource(id = R.string.blaze_campaign_status_clicks),
+                        statValue = campaign.clicks
+                    )
+                    CampaignStat(
+                        statName = stringResource(id = R.string.blaze_campaign_status_budget),
+                        statValue = campaign.budget
+                    )
+                }
             }
         }
+    }
+}
+
+@Composable
+private fun CampaignStat(statName: String, statValue: Int) {
+    Column(
+        modifier = Modifier
+            .padding(end = dimensionResource(id = R.dimen.major_100))
+    ) {
+        Text(
+            text = statValue.toString(),
+            style = MaterialTheme.typography.h6,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            modifier = Modifier
+                .padding(top = dimensionResource(id = R.dimen.minor_50)),
+            text = statName,
+            style = MaterialTheme.typography.caption,
+            color = colorResource(id = R.color.color_on_surface_medium_selector)
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
@@ -18,27 +18,35 @@ class MyStoreBlazeViewModel @Inject constructor(
     private val _blazeCampaignState =
         savedStateHandle.getStateFlow(
             scope = viewModelScope,
-            initialValue = BlazeCampaignUi(
+            initialValue = MyStoreBlazeUi(
                 isVisible = FeatureFlag.BLAZE_ITERATION_2.isEnabled(),
-                hasActiveCampaigns = false,
-                product = BlazeProduct(
+                product = BlazeProductUi(
                     name = "Product name",
                     imgUrl = "https://hips.hearstapps.com/hmg-prod/images/gh-082420-ghi-best-sofas-1598293488.png",
-                )
+                ),
+                blazeActiveCampaign = null
             )
         )
     val blazeCampaignState = _blazeCampaignState.asLiveData()
 
     @Parcelize
-    data class BlazeCampaignUi(
+    data class MyStoreBlazeUi(
         val isVisible: Boolean,
-        val hasActiveCampaigns: Boolean = false,
-        val product: BlazeProduct
+        val product: BlazeProductUi,
+        val blazeActiveCampaign: BlazeCampaignUi?
     ) : Parcelable
 
     @Parcelize
-    data class BlazeProduct(
+    data class BlazeProductUi(
         val name: String,
         val imgUrl: String
+    ) : Parcelable
+
+    @Parcelize
+    data class BlazeCampaignUi(
+        val product: BlazeProductUi,
+        val impressions: Int,
+        val clicks: Int,
+        val budget: Int
     ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
@@ -27,7 +27,16 @@ class MyStoreBlazeViewModel @Inject constructor(
                     name = "Product name",
                     imgUrl = "https://hips.hearstapps.com/hmg-prod/images/gh-082420-ghi-best-sofas-1598293488.png",
                 ),
-                blazeActiveCampaign = null
+                blazeActiveCampaign = BlazeCampaignUi(
+                    product = BlazeProductUi(
+                        name = "Product name",
+                        imgUrl = "https://hips.hearstapps.com/hmg-prod/images/gh-082420-ghi-best-sofas-1598293488.png",
+                    ),
+                    status = CampaignStatusUi.Active,
+                    impressions = 100,
+                    clicks = 10,
+                    budget = 1000
+                )
             )
         )
     val blazeCampaignState = _blazeCampaignState.asLiveData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
@@ -1,9 +1,12 @@
 package com.woocommerce.android.ui.blaze
 
 import android.os.Parcelable
+import androidx.annotation.ColorRes
+import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -45,8 +48,36 @@ class MyStoreBlazeViewModel @Inject constructor(
     @Parcelize
     data class BlazeCampaignUi(
         val product: BlazeProductUi,
+        val status: CampaignStatusUi,
         val impressions: Int,
         val clicks: Int,
         val budget: Int
     ) : Parcelable
+
+    enum class CampaignStatusUi(
+        @StringRes val statusDisplayText: Int,
+        @ColorRes val textColor: Int,
+        @ColorRes val backgroundColor: Int,
+    ) {
+        InModeration(
+            statusDisplayText = R.string.blaze_campaign_status_in_moderation,
+            textColor = R.color.blaze_campaign_status_in_moderation_text,
+            backgroundColor = R.color.blaze_campaign_status_in_moderation_background
+        ),
+        Active(
+            statusDisplayText = R.string.blaze_campaign_status_active,
+            textColor = R.color.blaze_campaign_status_active_text,
+            backgroundColor = R.color.blaze_campaign_status_active_background
+        ),
+        Completed(
+            statusDisplayText = R.string.blaze_campaign_status_completed,
+            textColor = R.color.blaze_campaign_status_rejected_text,
+            backgroundColor = R.color.blaze_campaign_status_rejected_background
+        ),
+        Rejected(
+            statusDisplayText = R.string.blaze_campaign_status_rejected,
+            textColor = R.color.blaze_campaign_status_completed_text,
+            backgroundColor = R.color.blaze_campaign_status_completed_background
+        ),
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Tag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Tag.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
@@ -23,20 +24,24 @@ fun WCTag(
     modifier: Modifier = Modifier,
     textColor: Color = colorResource(id = R.color.tag_text_main),
     backgroundColor: Color = colorResource(R.color.tag_bg_main),
-    textAllCaps: Boolean = false,
+    textStyle: TextStyle = MaterialTheme.typography.caption
 ) {
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(percent = 35))
             .background(backgroundColor)
+            .padding(
+                start = dimensionResource(id = R.dimen.minor_50),
+                end = dimensionResource(id = R.dimen.minor_50),
+            )
     ) {
         Text(
             modifier = Modifier.padding(
                 horizontal = dimensionResource(id = R.dimen.minor_75),
                 vertical = dimensionResource(id = R.dimen.minor_25)
             ),
-            text = if (textAllCaps) text.uppercase() else text,
-            style = MaterialTheme.typography.caption,
+            text = text,
+            style = textStyle,
             color = textColor,
             fontWeight = FontWeight.Bold
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Tag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Tag.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.compose.component
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
@@ -9,30 +10,43 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 
 @Composable
-fun WcTag(
+fun WCTag(
     text: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    textColor: Color = colorResource(id = R.color.tag_text_main),
+    backgroundColor: Color = colorResource(R.color.tag_bg_main),
+    textAllCaps: Boolean = false,
 ) {
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(percent = 35))
-            .background(colorResource(id = R.color.tag_bg_main))
+            .background(backgroundColor)
     ) {
         Text(
             modifier = Modifier.padding(
                 horizontal = dimensionResource(id = R.dimen.minor_75),
                 vertical = dimensionResource(id = R.dimen.minor_25)
             ),
-            text = text,
+            text = if (textAllCaps) text.uppercase() else text,
             style = MaterialTheme.typography.caption,
-            color = colorResource(id = R.color.tag_text_main),
+            color = textColor,
             fontWeight = FontWeight.Bold
         )
     }
+}
+
+@Preview
+@Preview(name = "Light mode")
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun WcTagPreview() {
+    WCTag(text = "This is a tag")
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -55,8 +55,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCTag
 import com.woocommerce.android.ui.compose.component.WCTextButton
-import com.woocommerce.android.ui.compose.component.WcTag
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.AboutYourStoreTaskRes
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.Companion.NUMBER_ITEMS_IN_COLLAPSED_MODE
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.LaunchStoreTaskRes
@@ -263,7 +263,7 @@ private fun TaskItem(
                     fontWeight = FontWeight.Bold
                 )
                 if (!task.isCompleted && task.taskUiResources is LaunchStoreTaskRes) {
-                    WcTag(
+                    WCTag(
                         text = stringResource(id = string.store_onboarding_launch_store_task_private_tag).uppercase(),
                         modifier = Modifier.padding(start = dimensionResource(id = dimen.minor_100))
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -269,7 +269,8 @@ class MyStoreFragment :
                         WooThemeWithBackground {
                             MyStoreBlazeView(
                                 state = blazeCampaignState,
-                                onCreateCampaignClicked = { }
+                                onCreateCampaignClicked = { },
+                                onShowAllClicked = { },
                             )
                         }
                     }

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -277,4 +277,15 @@
     -->
     <color name="tap_to_pay_about_important_info_background">@color/woo_purple_0</color>
 
+    <!--
+    Blaze
+    -->
+    <color name="blaze_campaign_status_in_moderation_background">@color/blaze_yellow_5</color>
+    <color name="blaze_campaign_status_in_moderation_text">@color/blaze_yellow_70</color>
+    <color name="blaze_campaign_status_active_background">@color/blaze_green_5</color>
+    <color name="blaze_campaign_status_active_text">@color/blaze_green_60</color>
+    <color name="blaze_campaign_status_completed_background">@color/blaze_blue_5</color>
+    <color name="blaze_campaign_status_completed_text">@color/blaze_blue_60</color>
+    <color name="blaze_campaign_status_rejected_background">@color/blaze_red_5</color>
+    <color name="blaze_campaign_status_rejected_text">@color/blaze_red_6</color>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3656,6 +3656,10 @@
     <string name="blaze_campaign_title">Blaze campaign</string>
     <string name="blaze_campaign_subtitle">Increase visibility and get your products sold quickly.</string>
     <string name="blaze_campaign_create_campaign_button">Create campaign</string>
+    <string name="blaze_campaign_status_in_moderation">In moderation</string>
+    <string name="blaze_campaign_status_active">Active</string>
+    <string name="blaze_campaign_status_completed">Completed</string>
+    <string name="blaze_campaign_status_rejected">Rejected</string>
 
     <!--
     Highlights tooltip

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3656,6 +3656,7 @@
     <string name="blaze_campaign_title">Blaze campaign</string>
     <string name="blaze_campaign_subtitle">Increase visibility and get your products sold quickly.</string>
     <string name="blaze_campaign_create_campaign_button">Create campaign</string>
+    <string name="blaze_campaign_show_all_button">Show all</string>
     <string name="blaze_campaign_status_in_moderation">In moderation</string>
     <string name="blaze_campaign_status_active">Active</string>
     <string name="blaze_campaign_status_completed">Completed</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3660,6 +3660,9 @@
     <string name="blaze_campaign_status_active">Active</string>
     <string name="blaze_campaign_status_completed">Completed</string>
     <string name="blaze_campaign_status_rejected">Rejected</string>
+    <string name="blaze_campaign_status_impressions">Impressions</string>
+    <string name="blaze_campaign_status_clicks">Clicks</string>
+    <string name="blaze_campaign_status_budget">Budget</string>
 
     <!--
     Highlights tooltip

--- a/WooCommerce/src/main/res/values/wc_colors_base.xml
+++ b/WooCommerce/src/main/res/values/wc_colors_base.xml
@@ -78,4 +78,13 @@
     <color name="jetpack_black">#0B2621</color>
 
     <color name="wp_blue">#399CE3</color>
+
+    <color name="blaze_yellow_5">#F5E6B3</color>
+    <color name="blaze_yellow_70">#674600</color>
+    <color name="blaze_green_5">#B8E6BF</color>
+    <color name="blaze_green_60">#007017</color>
+    <color name="blaze_blue_5">#BBE0FA</color>
+    <color name="blaze_blue_60">#055D9C</color>
+    <color name="blaze_red_5">#FACFD2</color>
+    <color name="blaze_red_6">#B32D2E</color>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9945
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds new UI to display active Blaze campaign details in My Store tab. This PR only add UI logic, the displayed data is hardcoded for testing purposes.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Just run the app
Open My store tab and check the displayed Blaze campaign view matches the Figma designs: mBhyoV7OPhFnOugxLy6SMS-fi-691%3A49332

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
![Screenshot 2023-10-13 at 10 38 27](https://github.com/woocommerce/woocommerce-android/assets/2663464/e1607c4a-e7e6-4fa4-89be-eb5517250b96)