### PR TITLE
Fix crash in Coupons screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 15.8
 -----
-
+- [*] [Internal] Fixed a crash when navigation to Excluded Products from the Coupon Details screen [https://github.com/woocommerce/woocommerce-android/pull/9952]
 
 15.7
 ----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
@@ -12,7 +12,7 @@ import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditIn
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.EditIncludedProducts
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenCouponRestrictions
 import com.woocommerce.android.ui.coupons.edit.EditCouponNavigationTarget.OpenDescriptionEditor
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
 
 object EditCouponNavigator {
     fun navigate(fragment: Fragment, target: EditCouponNavigationTarget) {
@@ -32,7 +32,7 @@ object EditCouponNavigator {
                 navController.navigateSafely(
                     EditCouponFragmentDirections.actionEditCouponFragmentToProductSelectorFragment(
                         target.selectedItems.toTypedArray(),
-                        ProductSelectorFlow.CouponEdition
+                        ProductSelectorViewModel.ProductSelectorFlow.CouponEdition
                     )
                 )
             }
@@ -55,7 +55,8 @@ object EditCouponNavigator {
             is EditExcludedProducts -> {
                 navController.navigateSafely(
                     CouponRestrictionsFragmentDirections.actionCouponRestrictionsFragmentToProductSelectorFragment(
-                        selectedItems = target.excludedItems.toTypedArray()
+                        selectedItems = target.excludedItems.toTypedArray(),
+                        productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.CouponEdition
                     )
                 )
             }

--- a/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_coupons.xml
@@ -82,6 +82,9 @@
             <argument
                 android:name="selectedItems"
                 app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectedItem[]" />
+            <argument
+                android:name="productSelectorFlow"
+                app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$ProductSelectorFlow" />
         </action>
     </fragment>
     <fragment


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9951 

### Description
This PR adds a missing argument that was causing a crash when navigation to the "Excluded products" in the Coupon Details screen.

### Testing instructions
1. Open coupon details screen (either creation or edit)
2. Click on “Usage restrictions”
3. Click on “Exclude products”
4. Confirm the app doesn't crash and the feature works as expected.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
