### PR TITLE
Empty products section design

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/IsCustomAmountsFeatureFlagEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/IsCustomAmountsFeatureFlagEnabled.kt
@@ -3,6 +3,6 @@ package com.woocommerce.android.ui.orders.creation
 import com.woocommerce.android.util.FeatureFlag
 import javax.inject.Inject
 
-class CustomAmountsFeatureFlag @Inject constructor() {
+class IsCustomAmountsFeatureFlagEnabled @Inject constructor() {
     operator fun invoke() = FeatureFlag.CUSTOM_AMOUNTS_M1.isEnabled()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -80,7 +80,7 @@ class OrderCreateEditFormFragment :
     lateinit var uiMessageResolver: UIMessageResolver
 
     @Inject
-    lateinit var customAmountsFeatureFlag: CustomAmountsFeatureFlag
+    lateinit var isCustomAmountsFeatureFlagEnabled: IsCustomAmountsFeatureFlagEnabled
 
     private var createOrderMenuItem: MenuItem? = null
     private var progressDialog: CustomProgressDialog? = null
@@ -245,7 +245,7 @@ class OrderCreateEditFormFragment :
     }
 
     private fun FragmentOrderCreateEditFormBinding.initProductsSection() {
-        if (customAmountsFeatureFlag()) {
+        if (isCustomAmountsFeatureFlagEnabled()) {
             productsSection.hideHeader()
             productsSection.setProductSectionButtons(
                 addProductsButton = AddButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -261,7 +261,7 @@ class OrderCreateEditFormFragment :
                 addCustomAmountsButton = AddButton(
                     text = getString(R.string.order_creation_add_custom_amounts),
                     onClickListener = {
-                        // TODO: Implement custom amounts click listener
+                        // Implement custom amounts click listener
                     }
                 )
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -79,6 +79,9 @@ class OrderCreateEditFormFragment :
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
 
+    @Inject
+    lateinit var customAmountsFeatureFlag: CustomAmountsFeatureFlag
+
     private var createOrderMenuItem: MenuItem? = null
     private var progressDialog: CustomProgressDialog? = null
     private var orderUpdateFailureSnackBar: Snackbar? = null
@@ -242,18 +245,40 @@ class OrderCreateEditFormFragment :
     }
 
     private fun FragmentOrderCreateEditFormBinding.initProductsSection() {
-        productsSection.setProductSectionButtons(
-            addProductsButton = AddButton(
-                text = getString(R.string.order_creation_add_products),
-                onClickListener = {
-                    viewModel.onAddProductClicked()
-                }
-            ),
-            addProductsViaScanButton = AddButton(
-                text = getString(R.string.order_creation_add_product_via_barcode_scanning),
-                onClickListener = { viewModel.onScanClicked() }
+        if (customAmountsFeatureFlag()) {
+            productsSection.hideHeader()
+            productsSection.setProductSectionButtons(
+                addProductsButton = AddButton(
+                    text = getString(R.string.order_creation_add_products),
+                    onClickListener = {
+                        viewModel.onAddProductClicked()
+                    }
+                ),
+                addProductsViaScanButton = AddButton(
+                    text = getString(R.string.order_creation_add_product_via_barcode_scanning),
+                    onClickListener = { viewModel.onScanClicked() }
+                ),
+                addCustomAmountsButton = AddButton(
+                    text = getString(R.string.order_creation_add_custom_amounts),
+                    onClickListener = {
+                        // TODO: Implement custom amounts click listener
+                    }
+                )
             )
-        )
+        } else {
+            productsSection.setProductSectionButtons(
+                addProductsButton = AddButton(
+                    text = getString(R.string.order_creation_add_products),
+                    onClickListener = {
+                        viewModel.onAddProductClicked()
+                    }
+                ),
+                addProductsViaScanButton = AddButton(
+                    text = getString(R.string.order_creation_add_product_via_barcode_scanning),
+                    onClickListener = { viewModel.onScanClicked() }
+                ),
+            )
+        }
     }
 
     private fun FragmentOrderCreateEditFormBinding.initPaymentSection() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -246,39 +246,47 @@ class OrderCreateEditFormFragment :
 
     private fun FragmentOrderCreateEditFormBinding.initProductsSection() {
         if (isCustomAmountsFeatureFlagEnabled()) {
-            productsSection.hideHeader()
-            productsSection.setProductSectionButtons(
-                addProductsButton = AddButton(
-                    text = getString(R.string.order_creation_add_products),
-                    onClickListener = {
-                        viewModel.onAddProductClicked()
-                    }
-                ),
-                addProductsViaScanButton = AddButton(
-                    text = getString(R.string.order_creation_add_product_via_barcode_scanning),
-                    onClickListener = { viewModel.onScanClicked() }
-                ),
-                addCustomAmountsButton = AddButton(
-                    text = getString(R.string.order_creation_add_custom_amounts),
-                    onClickListener = {
-                        // Implement custom amounts click listener
-                    }
-                )
-            )
+            initNewProductsSection()
         } else {
-            productsSection.setProductSectionButtons(
-                addProductsButton = AddButton(
-                    text = getString(R.string.order_creation_add_products),
-                    onClickListener = {
-                        viewModel.onAddProductClicked()
-                    }
-                ),
-                addProductsViaScanButton = AddButton(
-                    text = getString(R.string.order_creation_add_product_via_barcode_scanning),
-                    onClickListener = { viewModel.onScanClicked() }
-                ),
-            )
+            initOldProductsSection()
         }
+    }
+
+    private fun FragmentOrderCreateEditFormBinding.initOldProductsSection() {
+        productsSection.setProductSectionButtons(
+            addProductsButton = AddButton(
+                text = getString(R.string.order_creation_add_products),
+                onClickListener = {
+                    viewModel.onAddProductClicked()
+                }
+            ),
+            addProductsViaScanButton = AddButton(
+                text = getString(R.string.order_creation_add_product_via_barcode_scanning),
+                onClickListener = { viewModel.onScanClicked() }
+            ),
+        )
+    }
+
+    private fun FragmentOrderCreateEditFormBinding.initNewProductsSection() {
+        productsSection.hideHeader()
+        productsSection.setProductSectionButtons(
+            addProductsButton = AddButton(
+                text = getString(R.string.order_creation_add_products),
+                onClickListener = {
+                    viewModel.onAddProductClicked()
+                }
+            ),
+            addProductsViaScanButton = AddButton(
+                text = getString(R.string.order_creation_add_product_via_barcode_scanning),
+                onClickListener = { viewModel.onScanClicked() }
+            ),
+            addCustomAmountsButton = AddButton(
+                text = getString(R.string.order_creation_add_custom_amounts),
+                onClickListener = {
+                    // Implement custom amounts click listener
+                }
+            )
+        )
     }
 
     private fun FragmentOrderCreateEditFormBinding.initPaymentSection() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
@@ -17,6 +17,7 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.OrderCreationSectionBinding
+import com.woocommerce.android.extensions.hide
 
 class OrderCreateEditSectionView @JvmOverloads constructor(
     ctx: Context,
@@ -75,6 +76,10 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
         }
     }
 
+    fun hideHeader() {
+        binding.headerLabel.hide()
+    }
+
     fun setAddButtons(buttons: List<AddButton>) {
         binding.addButtonsLayout.removeAllViews()
         buttons.forEach { buttonModel ->
@@ -93,23 +98,43 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
 
     fun setProductSectionButtons(
         addProductsButton: AddButton,
-        addProductsViaScanButton: AddButton? = null,
+        addCustomAmountsButton: AddButton? = null,
+        addProductsViaScanButton: AddButton? = null
     ) {
         binding.addButtonsLayout.removeAllViews()
         val container = RelativeLayout(context)
-        var params = RelativeLayout.LayoutParams(
-            LayoutParams.WRAP_CONTENT,
-            LayoutParams.WRAP_CONTENT
-        )
-        params.addRule(RelativeLayout.ALIGN_PARENT_LEFT)
-        val addingProductsManuallyButton = MaterialButton(context, null, R.attr.secondaryTextButtonStyle)
-        addingProductsManuallyButton.text = addProductsButton.text
-        addingProductsManuallyButton.icon = AppCompatResources.getDrawable(context, R.drawable.ic_add)
-        addingProductsManuallyButton.layoutParams = params
-        addingProductsManuallyButton.setOnClickListener { addProductsButton.onClickListener() }
+        val addingProductsManuallyButtonId = View.generateViewId()
+        addProductsButton(addProductsButton, container, addingProductsManuallyButtonId)
+        addProductsViaScanButton(addProductsViaScanButton, container)
+        addCustomAmountsButton(addCustomAmountsButton, container, addingProductsManuallyButtonId)
+        binding.addButtonsLayout.addView(container)
+    }
 
-        container.addView(addingProductsManuallyButton)
+    private fun addCustomAmountsButton(
+        addCustomAmountsButton: AddButton?,
+        container: RelativeLayout,
+        addingProductsManuallyButtonId: Int
+    ) {
+        addCustomAmountsButton?.let {
+            val addingCustomAmountsButton = MaterialButton(context, null, R.attr.secondaryTextButtonStyle)
+            addingCustomAmountsButton.text = addCustomAmountsButton.text
+            addingCustomAmountsButton.icon = AppCompatResources.getDrawable(context, R.drawable.ic_add)
+            addingCustomAmountsButton.setOnClickListener { addCustomAmountsButton.onClickListener() }
+            val addCustomAmountsButtonParams = RelativeLayout.LayoutParams(
+                LayoutParams.WRAP_CONTENT,
+                LayoutParams.WRAP_CONTENT
+            )
+            addCustomAmountsButtonParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT)
+            addCustomAmountsButtonParams.addRule(RelativeLayout.BELOW, addingProductsManuallyButtonId)
+            addingCustomAmountsButton.layoutParams = addCustomAmountsButtonParams
+            container.addView(addingCustomAmountsButton)
+        }
+    }
 
+    private fun addProductsViaScanButton(
+        addProductsViaScanButton: AddButton?,
+        container: RelativeLayout
+    ) {
         addProductsViaScanButton?.let {
             val addingProductsViaScanningButton = MaterialButton(context, null, R.attr.secondaryTextButtonStyle)
             addingProductsViaScanningButton.icon = AppCompatResources.getDrawable(context, R.drawable.ic_barcode)
@@ -117,16 +142,34 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
             addingProductsViaScanningButton.setPadding(0)
             addingProductsViaScanningButton.iconGravity = MaterialButton.ICON_GRAVITY_TEXT_START
             addingProductsViaScanningButton.setOnClickListener { addProductsViaScanButton.onClickListener() }
-            params = RelativeLayout.LayoutParams(
+            val addProductsViaScanningButtonParams = RelativeLayout.LayoutParams(
                 LayoutParams.WRAP_CONTENT,
                 LayoutParams.WRAP_CONTENT
             )
-            params.addRule(RelativeLayout.ALIGN_PARENT_RIGHT)
-            addingProductsViaScanningButton.layoutParams = params
+            addProductsViaScanningButtonParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT)
+            addingProductsViaScanningButton.layoutParams = addProductsViaScanningButtonParams
             container.addView(addingProductsViaScanningButton)
         }
+    }
 
-        binding.addButtonsLayout.addView(container)
+    private fun addProductsButton(
+        addProductsButton: AddButton,
+        container: RelativeLayout,
+        id: Int,
+    ) {
+        val addProductButtonsParams = RelativeLayout.LayoutParams(
+            LayoutParams.WRAP_CONTENT,
+            LayoutParams.WRAP_CONTENT
+        )
+        addProductButtonsParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT)
+        val addingProductsManuallyButton = MaterialButton(context, null, R.attr.secondaryTextButtonStyle)
+        addingProductsManuallyButton.text = addProductsButton.text
+        addingProductsManuallyButton.icon = AppCompatResources.getDrawable(context, R.drawable.ic_add)
+        addingProductsManuallyButton.id = id
+        addingProductsManuallyButton.layoutParams = addProductButtonsParams
+        addingProductsManuallyButton.setOnClickListener { addProductsButton.onClickListener() }
+
+        container.addView(addingProductsManuallyButton)
     }
 
     private fun updateContent(content: View?) {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -525,6 +525,7 @@
     <string name="order_creation_add_customer_note">Add note</string>
     <string name="order_creation_products">Products</string>
     <string name="order_creation_add_products">Add products</string>
+    <string name="order_creation_add_custom_amounts">Add custom amount</string>
     <string name="order_creation_add_product_via_barcode_scanning">Add products via scanner</string>
     <string name="order_creation_set_tax_rate">Set New Tax Rate</string>
     <string name="order_creation_edit_tax_rate">Edit Tax Rate Setting</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9937 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This pull request introduces a redesign of the empty products section. Key changes include:

1. A new button titled "Add Custom Amounts."
2. The aforementioned changes are currently behind a feature flag.
3. This feature is only available in debug builds for testing and evaluation purposes.

Design: https://www.figma.com/file/ichqhxDjbmZZmvJaJkGhkj/Simple-Payments-%26-Order-Creation?type=design&node-id=165-45952&mode=design&t=ddOsdnzmq3KlU1e8-0

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Navigate to the `orders` tab
2. Click on "+" button to create a new order creation flow
3. Ensure the new products section (before adding any products) is as per design

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-android/assets/1331230/b7f6f6ef-9f8d-42bb-96e8-19d9c43dd390"  alt="new_empty_products_section" width = 400px ></td>



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->