### PR TITLE
Fix navigation crashes when using a NavGraph scoped ViewModel

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 15.8
 -----
 - [*] [Internal] Fixed a crash when navigation to Excluded Products from the Coupon Details screen [https://github.com/woocommerce/woocommerce-android/pull/9952]
+- [*] [Internal] Fixed some crashes that occurred when restoring the app after a process-death [https://github.com/woocommerce/woocommerce-android/pull/9956]
 
 15.7
 ----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomerAddFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomerAddFragment.kt
@@ -8,7 +8,6 @@ import android.view.View
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
@@ -36,6 +35,7 @@ import com.woocommerce.android.ui.orders.details.editing.address.LocationCode
 import com.woocommerce.android.ui.searchfilter.SearchFilterItem
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -51,8 +51,8 @@ class OrderCreateEditCustomerAddFragment :
         private const val MENU_ITEM_DELETE_ID = Int.MAX_VALUE
     }
 
-    private val sharedViewModel by hiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
-    private val addressViewModel by hiltNavGraphViewModels<AddressViewModel>(R.id.nav_graph_order_creations)
+    private val sharedViewModel by fixedHiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
+    private val addressViewModel by fixedHiltNavGraphViewModels<AddressViewModel>(R.id.nav_graph_order_creations)
 
     private val editingOfAddedCustomer: OrderCreateEditCustomerAddFragmentArgs by navArgs()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -8,7 +8,6 @@ import android.view.MenuItem
 import android.view.View
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.DefaultItemAnimator
@@ -59,6 +58,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.WCReadMoreTextView
 import dagger.hilt.android.AndroidEntryPoint
@@ -71,7 +71,7 @@ class OrderCreateEditFormFragment :
     BaseFragment(R.layout.fragment_order_create_edit_form),
     BackPressListener,
     MenuProvider {
-    private val viewModel by hiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
+    private val viewModel by fixedHiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
 
     @Inject
     lateinit var currencyFormatter: CurrencyFormatter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -18,13 +17,14 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 import com.woocommerce.android.ui.orders.details.editing.address.AddressViewModel
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class CustomerListFragment : BaseFragment() {
     private val viewModel by viewModels<CustomerListViewModel>()
-    private val addressViewModel by hiltNavGraphViewModels<AddressViewModel>(R.id.nav_graph_order_creations)
-    private val sharedViewModel by hiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
+    private val addressViewModel by fixedHiltNavGraphViewModels<AddressViewModel>(R.id.nav_graph_order_creations)
+    private val sharedViewModel by fixedHiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
 
     override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreateEditFeeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreateEditFeeFragment.kt
@@ -12,7 +12,6 @@ import android.view.View
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderCreateEditFeeBinding
@@ -25,6 +24,7 @@ import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 import com.woocommerce.android.ui.orders.creation.fees.OrderCreateEditFeeViewModel.RemoveFee
 import com.woocommerce.android.ui.orders.creation.fees.OrderCreateEditFeeViewModel.UpdateFee
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import okhttp3.internal.format
 import org.wordpress.android.util.ActivityUtils
@@ -35,7 +35,7 @@ import javax.inject.Inject
 class OrderCreateEditFeeFragment :
     BaseFragment(R.layout.fragment_order_create_edit_fee),
     MenuProvider {
-    private val sharedViewModel by hiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
+    private val sharedViewModel by fixedHiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
     private val editFeeViewModel by viewModels<OrderCreateEditFeeViewModel>()
 
     @Inject lateinit var currencyFormatter: CurrencyFormatter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/notes/OrderCreateEditCustomerNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/notes/OrderCreateEditCustomerNoteFragment.kt
@@ -7,18 +7,18 @@ import android.view.MenuItem
 import android.view.View
 import androidx.core.view.MenuProvider
 import androidx.core.widget.doAfterTextChanged
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderCreateEditCustomerNoteBinding
 import com.woocommerce.android.extensions.showKeyboardWithDelay
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 
 class OrderCreateEditCustomerNoteFragment :
     BaseFragment(R.layout.fragment_order_create_edit_customer_note),
     MenuProvider {
-    private val sharedViewModel by hiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
+    private val sharedViewModel by fixedHiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
 
     private var _binding: FragmentOrderCreateEditCustomerNoteBinding? = null
     val binding

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderCreateEditShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderCreateEditShippingFragment.kt
@@ -8,7 +8,6 @@ import android.view.View
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderCreateEditShippingBinding
@@ -21,6 +20,7 @@ import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 import com.woocommerce.android.ui.orders.creation.shipping.OrderCreateEditShippingViewModel.RemoveShipping
 import com.woocommerce.android.ui.orders.creation.shipping.OrderCreateEditShippingViewModel.UpdateShipping
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -29,7 +29,7 @@ class OrderCreateEditShippingFragment :
     BaseFragment(R.layout.fragment_order_create_edit_shipping),
     MenuProvider {
     private val viewModel: OrderCreateEditShippingViewModel by viewModels()
-    private val sharedViewModel: OrderCreateEditViewModel by hiltNavGraphViewModels(R.id.nav_graph_order_creations)
+    private val sharedViewModel: OrderCreateEditViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_order_creations)
 
     @Inject lateinit var currencyFormatter: CurrencyFormatter
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/setting/AutoTaxRateSettingBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/taxes/rates/setting/AutoTaxRateSettingBottomSheetFragment.kt
@@ -7,16 +7,16 @@ import android.view.ViewGroup
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class AutoTaxRateSettingBottomSheetFragment : WCBottomSheetDialogFragment() {
-    private val sharedViewModel: OrderCreateEditViewModel by hiltNavGraphViewModels(R.id.nav_graph_order_creations)
+    private val sharedViewModel: OrderCreateEditViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_order_creations)
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -11,7 +11,6 @@ import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.transition.TransitionManager
 import com.google.android.material.snackbar.Snackbar
@@ -72,6 +71,7 @@ import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUndoSnackbar
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -86,7 +86,7 @@ class OrderDetailFragment :
     }
 
     private val viewModel: OrderDetailViewModel by viewModels()
-    private val orderEditingViewModel by hiltNavGraphViewModels<OrderEditingViewModel>(R.id.nav_graph_orders)
+    private val orderEditingViewModel by fixedHiltNavGraphViewModels<OrderEditingViewModel>(R.id.nav_graph_orders)
 
     @Inject
     lateinit var navigator: OrderNavigator

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
@@ -10,7 +10,6 @@ import android.view.View
 import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
 import androidx.core.view.MenuProvider
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -19,6 +18,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
@@ -26,7 +26,7 @@ abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener, MenuP
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
 
-    protected val sharedViewModel by hiltNavGraphViewModels<OrderEditingViewModel>(R.id.nav_graph_orders)
+    protected val sharedViewModel by fixedHiltNavGraphViewModels<OrderEditingViewModel>(R.id.nav_graph_orders)
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     protected var doneMenuItem: MenuItem? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -5,7 +5,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updateMargins
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.switchmaterial.SwitchMaterial
 import com.woocommerce.android.R
@@ -24,6 +23,7 @@ import com.woocommerce.android.ui.searchfilter.SearchFilterItem
 import com.woocommerce.android.util.UiHelpers.getPxOfUiDimen
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.combineWith
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
 
@@ -36,7 +36,7 @@ abstract class BaseAddressEditingFragment :
         const val SELECT_STATE_REQUEST = "select_state_request"
     }
 
-    private val addressViewModel by hiltNavGraphViewModels<AddressViewModel>(R.id.nav_graph_orders)
+    private val addressViewModel by fixedHiltNavGraphViewModels<AddressViewModel>(R.id.nav_graph_orders)
 
     abstract val storedAddress: Address
     abstract val addressType: AddressViewModel.AddressType

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundFragment.kt
@@ -10,7 +10,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -23,6 +22,7 @@ import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.IssueRef
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.RefundType
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.RefundType.AMOUNT
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.RefundType.ITEMS
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -30,7 +30,7 @@ import javax.inject.Inject
 class IssueRefundFragment : BaseFragment() {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
-    private val viewModel: IssueRefundViewModel by hiltNavGraphViewModels(R.id.nav_graph_refunds)
+    private val viewModel: IssueRefundViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_refunds)
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Visible(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundAmountDialog.kt
@@ -1,8 +1,8 @@
 package com.woocommerce.android.ui.payments.refunds
 
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.CurrencyAmountDialog
 import dagger.hilt.android.AndroidEntryPoint
 import java.math.BigDecimal
@@ -12,7 +12,7 @@ import javax.inject.Inject
 class RefundAmountDialog : CurrencyAmountDialog() {
     @Inject lateinit var currencyFormatter: CurrencyFormatter
 
-    private val viewModel: IssueRefundViewModel by hiltNavGraphViewModels(R.id.nav_graph_refunds)
+    private val viewModel: IssueRefundViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_refunds)
 
     override fun returnResult(enteredAmount: BigDecimal) {
         viewModel.onProductsRefundAmountChanged(enteredAmount)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundByAmountFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundByAmountFragment.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.payments.refunds
 
 import android.os.Bundle
 import android.view.View
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentRefundByAmountBinding
@@ -12,6 +11,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.IssueRefundEvent.HideValidationError
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.IssueRefundEvent.ShowValidationError
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -22,7 +22,7 @@ class RefundByAmountFragment : BaseFragment(R.layout.fragment_refund_by_amount) 
     private var _binding: FragmentRefundByAmountBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: IssueRefundViewModel by hiltNavGraphViewModels(R.id.nav_graph_refunds)
+    private val viewModel: IssueRefundViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_refunds)
 
     override fun onResume() {
         super.onResume()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundByItemsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundByItemsFragment.kt
@@ -7,7 +7,6 @@ import android.text.method.LinkMovementMethod
 import android.view.View
 import android.widget.TextView
 import androidx.core.view.isVisible
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
@@ -29,6 +28,7 @@ import com.woocommerce.android.ui.payments.refunds.RefundFeeListAdapter.OnFeeLin
 import com.woocommerce.android.ui.payments.refunds.RefundShippingListAdapter.OnCheckedChangeListener
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.WooClickableSpan
 import dagger.hilt.android.AndroidEntryPoint
 import java.math.BigDecimal
@@ -54,7 +54,7 @@ class RefundByItemsFragment :
     private var _feeLinesBinding: RefundByItemsFeesBinding? = null
     private val feeLinesBinding get() = _feeLinesBinding!!
 
-    private val viewModel: IssueRefundViewModel by hiltNavGraphViewModels(R.id.nav_graph_refunds)
+    private val viewModel: IssueRefundViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_refunds)
 
     override fun onResume() {
         super.onResume()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundConfirmationDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundConfirmationDialog.kt
@@ -1,17 +1,17 @@
 package com.woocommerce.android.ui.payments.refunds
 
 import android.os.Bundle
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.ConfirmationDialog
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class RefundConfirmationDialog : ConfirmationDialog() {
-    private val viewModel: IssueRefundViewModel by hiltNavGraphViewModels(R.id.nav_graph_refunds)
+    private val viewModel: IssueRefundViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_refunds)
 
     override fun returnResult(result: Boolean) {
         viewModel.onRefundConfirmed(result)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundItemsPickerDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundItemsPickerDialog.kt
@@ -1,14 +1,14 @@
 package com.woocommerce.android.ui.payments.refunds
 
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.NumberPickerDialog
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class RefundItemsPickerDialog : NumberPickerDialog() {
-    private val viewModel: IssueRefundViewModel by hiltNavGraphViewModels(R.id.nav_graph_refunds)
+    private val viewModel: IssueRefundViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_refunds)
 
     private val navArgs: RefundItemsPickerDialogArgs by navArgs()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import android.widget.Toast
 import androidx.core.widget.doOnTextChanged
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -21,6 +20,7 @@ import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.IssueRefundEvent.ShowRefundConfirmation
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -33,7 +33,7 @@ class RefundSummaryFragment : BaseFragment(R.layout.fragment_refund_summary), Ba
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
-    private val viewModel: IssueRefundViewModel by hiltNavGraphViewModels(R.id.nav_graph_refunds)
+    private val viewModel: IssueRefundViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_refunds)
 
     private var _binding: FragmentRefundSummaryBinding? = null
     private val binding get() = _binding!!

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsFragment.kt
@@ -6,7 +6,6 @@ import androidx.core.view.isVisible
 import androidx.core.widget.TextViewCompat
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.viewModels
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -25,6 +24,7 @@ import com.woocommerce.android.ui.orders.taxes.OrderTaxesAdapter
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -32,7 +32,7 @@ import javax.inject.Inject
 class SimplePaymentsFragment : BaseFragment(R.layout.fragment_simple_payments), BackPressListener {
     private val args: SimplePaymentsFragmentArgs by navArgs()
     private val viewModel: SimplePaymentsViewModel by viewModels()
-    private val sharedViewModel by hiltNavGraphViewModels<SimplePaymentsSharedViewModel>(R.id.nav_graph_main)
+    private val sharedViewModel by fixedHiltNavGraphViewModels<SimplePaymentsSharedViewModel>(R.id.nav_graph_main)
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
@@ -13,6 +12,7 @@ import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
@@ -27,7 +27,7 @@ abstract class BaseProductFragment : BaseFragment, BackPressListener {
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
 
-    protected val viewModel: ProductDetailViewModel by hiltNavGraphViewModels(R.id.nav_graph_products)
+    protected val viewModel: ProductDetailViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_products)
 
     @CallSuper
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetFragment.kt
@@ -4,19 +4,19 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.DialogProductDetailBottomSheetListBinding
 import com.woocommerce.android.ui.products.ProductDetailBottomSheetBuilder.ProductDetailBottomSheetUiItem
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class ProductDetailBottomSheetFragment : WCBottomSheetDialogFragment() {
-    val viewModel: ProductDetailViewModel by hiltNavGraphViewModels(R.id.nav_graph_products)
+    val viewModel: ProductDetailViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_products)
 
     private lateinit var productDetailBottomSheetAdapter: ProductDetailBottomSheetAdapter
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt
@@ -6,7 +6,6 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.core.view.MenuProvider
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -25,6 +24,7 @@ import com.woocommerce.android.ui.products.ProductFilterListViewModel.FilterList
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -37,7 +37,7 @@ class ProductFilterListFragment :
         const val TAG = "ProductFilterListFragment"
     }
 
-    private val viewModel: ProductFilterListViewModel by hiltNavGraphViewModels(R.id.nav_graph_product_filters)
+    private val viewModel: ProductFilterListViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_product_filters)
 
     private lateinit var productFilterListAdapter: ProductFilterListAdapter
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterOptionListFragment.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.products
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -20,6 +19,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.products.ProductFilterListViewModel.FilterListOptionItemUiModel
 import com.woocommerce.android.ui.products.ProductFilterOptionListAdapter.OnProductFilterOptionClickListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.hilt.android.AndroidEntryPoint
@@ -29,7 +29,7 @@ class ProductFilterOptionListFragment :
     BaseFragment(R.layout.fragment_product_filter_option_list),
     OnLoadMoreListener,
     OnProductFilterOptionClickListener {
-    private val viewModel: ProductFilterListViewModel by hiltNavGraphViewModels(R.id.nav_graph_product_filters)
+    private val viewModel: ProductFilterListViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_product_filters)
 
     private val arguments: ProductFilterOptionListFragmentArgs by navArgs()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageViewerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImageViewerFragment.kt
@@ -13,7 +13,6 @@ import androidx.annotation.AnimRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -31,6 +30,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.ImageViewerFragment.Companion.ImageViewerListener
 import com.woocommerce.android.util.WooAnimUtils
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -49,7 +49,7 @@ class ProductImageViewerFragment :
     }
 
     private val navArgs: ProductImageViewerFragmentArgs by navArgs()
-    private val viewModel: ProductImagesViewModel by hiltNavGraphViewModels(R.id.nav_graph_image_gallery)
+    private val viewModel: ProductImagesViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_image_gallery)
 
     private var isConfirmationShowing = false
     private var confirmationDialog: AlertDialog? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -14,7 +14,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.text.HtmlCompat
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -45,6 +44,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowActionSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageInteractionListener
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.mediapicker.MediaPickerUtils
@@ -60,7 +60,7 @@ import javax.inject.Inject
 class ProductImagesFragment :
     BaseProductEditorFragment(R.layout.fragment_product_images), OnGalleryImageInteractionListener, MenuProvider {
     private val navArgs: ProductImagesFragmentArgs by navArgs()
-    private val viewModel: ProductImagesViewModel by hiltNavGraphViewModels(R.id.nav_graph_image_gallery)
+    private val viewModel: ProductImagesViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_image_gallery)
 
     @Inject
     lateinit var navigator: ProductNavigator

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
@@ -45,7 +45,9 @@ class AddProductCategoryFragment :
     private var _binding: FragmentAddProductCategoryBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: AddProductCategoryViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_add_product_category)
+    private val viewModel: AddProductCategoryViewModel by fixedHiltNavGraphViewModels(
+        navGraphId = R.id.nav_graph_add_product_category
+    )
 
     override fun getFragmentTitle() = getString(R.string.product_add_category)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
@@ -6,7 +6,6 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.core.view.MenuProvider
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -22,6 +21,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
@@ -45,7 +45,7 @@ class AddProductCategoryFragment :
     private var _binding: FragmentAddProductCategoryBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: AddProductCategoryViewModel by hiltNavGraphViewModels(R.id.nav_graph_add_product_category)
+    private val viewModel: AddProductCategoryViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_add_product_category)
 
     override fun getFragmentTitle() = getString(R.string.product_add_category)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ParentCategoryListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ParentCategoryListFragment.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.products.categories
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -16,6 +15,7 @@ import com.woocommerce.android.ui.products.OnLoadMoreListener
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.hilt.android.AndroidEntryPoint
@@ -28,7 +28,7 @@ class ParentCategoryListFragment :
     OnProductCategoryClickListener {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
-    private val viewModel: AddProductCategoryViewModel by hiltNavGraphViewModels(R.id.nav_graph_add_product_category)
+    private val viewModel: AddProductCategoryViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_add_product_category)
 
     private lateinit var parentCategoryListAdapter: ParentCategoryListAdapter
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ParentCategoryListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ParentCategoryListFragment.kt
@@ -28,7 +28,9 @@ class ParentCategoryListFragment :
     OnProductCategoryClickListener {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
-    private val viewModel: AddProductCategoryViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_add_product_category)
+    private val viewModel: AddProductCategoryViewModel by fixedHiltNavGraphViewModels(
+        navGraphId = R.id.nav_graph_add_product_category
+    )
 
     private lateinit var parentCategoryListAdapter: ParentCategoryListAdapter
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/AddProductDownloadBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/AddProductDownloadBottomSheetFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.viewModels
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.DialogProductAddDownloadableFileBinding
@@ -22,6 +21,7 @@ import com.woocommerce.android.ui.products.downloads.AddProductDownloadViewModel
 import com.woocommerce.android.ui.products.downloads.AddProductDownloadViewModel.PickDocumentFromDevice
 import com.woocommerce.android.ui.products.downloads.AddProductDownloadViewModel.PickFileFromMedialLibrary
 import com.woocommerce.android.ui.products.downloads.AddProductDownloadViewModel.PickMediaFileFromDevice
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.mediapicker.api.MediaPickerSetup
@@ -39,7 +39,7 @@ class AddProductDownloadBottomSheetFragment : WCBottomSheetDialogFragment() {
     lateinit var mediaPickerSetupFactory: MediaPickerSetup.Factory
 
     private val viewModel: AddProductDownloadViewModel by viewModels()
-    private val parentViewModel: ProductDetailViewModel by hiltNavGraphViewModels(R.id.nav_graph_products)
+    private val parentViewModel: ProductDetailViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_products)
 
     private var _binding: DialogProductAddDownloadableFileBinding? = null
     private val binding get() = _binding!!

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsFragment.kt
@@ -7,7 +7,6 @@ import android.view.MenuItem
 import android.view.View
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
-import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
@@ -27,6 +26,7 @@ import com.woocommerce.android.ui.products.downloads.ProductDownloadDetailsViewM
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
@@ -37,7 +37,7 @@ class ProductDownloadDetailsFragment :
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     private val viewModel: ProductDownloadDetailsViewModel by viewModels()
-    private val parentViewModel: ProductDetailViewModel by hiltNavGraphViewModels(R.id.nav_graph_products)
+    private val parentViewModel: ProductDetailViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_products)
     private val navArgs by navArgs<ProductDownloadDetailsFragmentArgs>()
     private lateinit var doneOrUpdateMenuItem: MenuItem
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/FixedHiltNavGraphViewModelLazy.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/FixedHiltNavGraphViewModelLazy.kt
@@ -31,7 +31,7 @@ import androidx.navigation.fragment.findNavController
  * -annotated [ViewModel] scoped to a navigation graph present on the [NavController] back stack:
  * ```
  * class MyFragment : Fragment() {
- *     val viewmodel: MainViewModel by com.woocommerce.android.viewmodel.hiltNavGraphViewModels(R.navigation.main)
+ *     val viewmodel: MainViewModel by com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels(R.navigation.main)
  * }
  * ```
  *

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/FixedHiltNavGraphViewModelLazy.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/FixedHiltNavGraphViewModelLazy.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.woocommerce.android.viewmodel
+
+import androidx.annotation.IdRes
+import androidx.annotation.MainThread
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.createViewModelLazy
+import androidx.hilt.navigation.HiltViewModelFactory
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import androidx.navigation.fragment.findNavController
+
+/**
+ * Returns a property delegate to access a
+ * [HiltViewModel](https://dagger.dev/api/latest/dagger/hilt/android/lifecycle/HiltViewModel)
+ * -annotated [ViewModel] scoped to a navigation graph present on the [NavController] back stack:
+ * ```
+ * class MyFragment : Fragment() {
+ *     val viewmodel: MainViewModel by com.woocommerce.android.viewmodel.hiltNavGraphViewModels(R.navigation.main)
+ * }
+ * ```
+ *
+ * This property can be accessed only after this NavGraph is on the NavController back stack,
+ * and an attempt access prior to that will result in an IllegalArgumentException.
+ *
+ * ** WooCommerce edit **
+ * The default implementation from the androidx library doesn't supply the `extrasProducer` argument
+ * to the `createViewModelLazy` function, this breaks the state restoration when the scoped ViewModel
+ * is recreated after a process death from a child Fragment, as its SavedState will be linked to the Fragment
+ * itself and not the NavBackStackEntry.
+ * The fix below is to supply the `extrasProducer` argument to the `createViewModelLazy` function.
+ *
+ * @param navGraphId ID of a NavGraph that exists on the [NavController] back stack
+ */
+@MainThread
+@Suppress("MissingNullability") // Due to https://youtrack.jetbrains.com/issue/KT-39209
+public inline fun <reified VM : ViewModel> Fragment.fixedHiltNavGraphViewModels(
+    @IdRes navGraphId: Int
+): Lazy<VM> {
+    val backStackEntry by lazy {
+        findNavController().getBackStackEntry(navGraphId)
+    }
+    val storeProducer: () -> ViewModelStore = {
+        backStackEntry.viewModelStore
+    }
+    return createViewModelLazy(
+        viewModelClass = VM::class,
+        storeProducer = storeProducer,
+        extrasProducer = {
+            backStackEntry.defaultViewModelCreationExtras
+        },
+        factoryProducer = {
+            HiltViewModelFactory(requireActivity(), backStackEntry)
+        }
+    )
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9954 Closes: #9955 

### Description
This PR fixes the above two crashes, and potentially more.
After an investigation to understand the cause of the above crashes, we identified a bug in the function `hiltNavGraphViewModels‎`, the function causes a state loss when a NavGraph scoped ViewModel is re-created after a process death from one of the child fragments, this state loss can cause a crash when it involves navigation arguments, as it's our case here.

The cause: when [calling](https://github.com/androidx/androidx/blob/bd03ca26be241823d7eef2cd4b0ceb94f812f82b/hilt/hilt-navigation-fragment/src/main/java/androidx/hilt/navigation/fragment/HiltNavGraphViewModelLazy.kt#L54C22-L54C22) `createViewModelLazy`, `hiltNavGraphViewModels‎` doesn’t pass a value for the `extrasProducer`, which causes using the default value, this default value causes the ViewModel to have its saved state attached to the Fragment [itself](https://github.com/androidx/androidx/blob/bd03ca26be241823d7eef2cd4b0ceb94f812f82b/fragment/fragment/src/main/java/androidx/fragment/app/FragmentViewLifecycleOwner.java#L158-L159) and not the BackStackEntry of the NavGraph.

Our temporary fix: use what the regular navGraphViewModels [uses](https://github.com/androidx/androidx/blob/bd03ca26be241823d7eef2cd4b0ceb94f812f82b/navigation/navigation-fragment/src/main/java/androidx/navigation/NavGraphViewModelLazy.kt#L118), which is assigning an `extrasProducer` that’s linked to the `BackStackEntry` itself.

We'll then follow up with a bug report to the AndroidX team.

### Testing instructions
For both the cases below, please enable "Don't Keep Activities" from the developer options.

##### Product Filters
1. Open product list screen.
2. Click on the Filters button.
3. Click on Stock Status.
4. Minimize the app.
5. Go back to the app, and confirm it doesn't crash.

**Note**: there is an additional bug in this screen, when going back, we get an empty list of filters, I think this is because we [perform](https://github.com/woocommerce/woocommerce-android/blob/ed503353506d142797c1c4ce13b193c3a9e3d868/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListFragment.kt#L123) data loading in the `onViewCreated` of the fragment, the Fragment's View is not restored at this stage, as it's in the BackStack.
Making a call to `loadFilters` in the ViewMode's `init` block fixed the issue, but I'm not sure about any other side effects, so I left it for now, and we should investigate it separately.

##### Order Creation
1. Open Order Creation screen.
2. Click on Fees.
3. Type something.
4. Minimize the app.
5. Re-open the app.
6. Tap on Done.
7. Confirm the app doesn't crash.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
