### PR TITLE
Add missing store profiler tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -518,6 +518,7 @@ class AnalyticsTracker private constructor(
         const val KEY_NEW_SITE_ID = "new_site_id"
         const val KEY_INITIAL_DOMAIN = "initial_domain"
         const val KEY_CHALLENGE = "challenges"
+        const val KEY_FEATURES = "features"
         const val VALUE_CHALLENGE_SETTING_UP_ONLINE_STORE = "setting_up_online_store"
         const val VALUE_CHALLENGE_FINDING_CUSTOMERS = "finding_customers"
         const val VALUE_CHALLENGE_MANAGING_INVENTORY = "managing_inventory"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/BaseStoreProfilerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/BaseStoreProfilerViewModel.kt
@@ -16,6 +16,7 @@ abstract class BaseStoreProfilerViewModel(
     private val storeProfilerRepository: StoreProfilerRepository,
 ) : ScopedViewModel(savedStateHandle) {
     abstract val hasSearchableContent: Boolean
+    open val isMultiChoice: Boolean = false
     protected val profilerOptions = MutableStateFlow(emptyList<StoreProfilerOptionUi>())
 
     val isLoading = MutableStateFlow(false)
@@ -77,8 +78,13 @@ abstract class BaseStoreProfilerViewModel(
     open fun onOptionSelected(option: StoreProfilerOptionUi) {
         profilerOptions.update { currentOptions ->
             currentOptions.map {
-                if (option.name == it.name) it.copy(isSelected = true)
-                else it.copy(isSelected = false)
+                if (isMultiChoice) {
+                    if (option.name == it.name) it.copy(isSelected = !it.isSelected)
+                    else it
+                } else {
+                    if (option.name == it.name) it.copy(isSelected = true)
+                    else it.copy(isSelected = false)
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerChallengesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerChallengesViewModel.kt
@@ -26,9 +26,9 @@ class StoreProfilerChallengesViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     storeProfilerRepository: StoreProfilerRepository
 ) : BaseStoreProfilerViewModel(savedStateHandle, newStore, storeProfilerRepository) {
-
     override val hasSearchableContent: Boolean
         get() = false
+    override val isMultiChoice: Boolean = true
 
     init {
         analyticsTracker.track(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerEcommercePlatformsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerEcommercePlatformsViewModel.kt
@@ -22,6 +22,7 @@ class StoreProfilerEcommercePlatformsViewModel @Inject constructor(
 ) : BaseStoreProfilerViewModel(savedStateHandle, newStore, storeProfilerRepository) {
     override val hasSearchableContent: Boolean
         get() = false
+    override val isMultiChoice: Boolean = true
 
     init {
         analyticsTracker.track(
@@ -56,15 +57,6 @@ class StoreProfilerEcommercePlatformsViewModel @Inject constructor(
 
     override fun getProfilerStepTitle(): String =
         resourceProvider.getString(R.string.store_creation_store_profiler_platforms_title)
-
-    override fun onOptionSelected(option: StoreProfilerOptionUi) {
-        profilerOptions.update { currentOptions ->
-            currentOptions.map {
-                if (option.name == it.name) it.copy(isSelected = !it.isSelected)
-                else it
-            }
-        }
-    }
 
     override fun saveStepAnswer() {
         newStore.update(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerFeaturesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerFeaturesViewModel.kt
@@ -23,6 +23,7 @@ class StoreProfilerFeaturesViewModel @Inject constructor(
 ) : BaseStoreProfilerViewModel(savedStateHandle, newStore, storeProfilerRepository) {
     override val hasSearchableContent: Boolean
         get() = false
+    override val isMultiChoice: Boolean = true
 
     init {
         analyticsTracker.track(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerRepository.kt
@@ -83,6 +83,8 @@ class StoreProfilerRepository @Inject constructor(
                             AnalyticsTracker.KEY_ECOMMERCE_PLATFORMS to
                                 storedAnswers.answers?.eCommercePlatformKeys?.joinToString(),
                             AnalyticsTracker.KEY_COUNTRY_CODE to storedAnswers.countryCode,
+                            AnalyticsTracker.KEY_CHALLENGE to storedAnswers.answers?.challengeKey,
+                            AnalyticsTracker.KEY_FEATURES to storedAnswers.answers?.featuresKey,
                         )
                     )
                     appPrefs.storeCreationProfilerAnswers = null


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9960 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Add missing tracking for store creation profiler steps. Additionally, make challenges and features profiler steps multi-choice (this behavior was defined for iOS designs in Figma: 8sNT07kW3VEdnor4baI6ft-fi-393%3A52234 and I missed it 😞).

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Trigger store creation flow
2. Select at least 1 option on each of the profiler steps
3. Verify that `eCommerce_platforms` step, `challenges` step and, `features` step are multi-choice
4. Verify the following event is tracked with the selected values: 
```
Tracked: site_creation_profiler_data, Properties: {"industry_slug":"food_and_drink","user_commerce_journey":"im_already_selling_online","ecommerce_platforms":"big-cartel, ecwid, etsy","country_code":"US","challenges":"setting_up_online_store","features":"sales_and_analytics","is_debug":true,"site_url":"https:\/\/woo-valiantly-chocolate-blaze.wpcomstaging.com"}
```

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/0e15b20a-4190-473a-b2b7-9cc10953bdfd

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->