### PR TITLE
[TTPA UK/CA] 30 cents in the UK as test TTP payment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryScreen.kt
@@ -90,7 +90,7 @@ fun TapToPaySummaryScreen(
 
             Column(
                 modifier = Modifier
-                    .padding(horizontal = dimensionResource(id = R.dimen.major_250)),
+                    .padding(horizontal = dimensionResource(id = R.dimen.major_100)),
                 horizontalAlignment = CenterHorizontally,
             ) {
                 Text(
@@ -98,10 +98,16 @@ fun TapToPaySummaryScreen(
                     style = MaterialTheme.typography.subtitle1,
                     textAlign = Center,
                 )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_150)))
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+                Text(
+                    text = stringResource(id = R.string.card_reader_tap_to_pay_explanation_easy),
+                    style = MaterialTheme.typography.subtitle1,
+                    textAlign = Center,
+                )
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
                 Text(
                     text = stringResource(id = R.string.card_reader_tap_to_pay_explanation_try_and_refund),
-                    style = MaterialTheme.typography.subtitle1,
+                    style = MaterialTheme.typography.body1,
                     textAlign = Center,
                 )
             }
@@ -110,7 +116,7 @@ fun TapToPaySummaryScreen(
 
             Column(horizontalAlignment = CenterHorizontally) {
                 Text(
-                    modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_300)),
+                    modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100)),
                     text = stringResource(id = R.string.card_reader_tap_to_pay_explanation_where_to_find),
                     style = MaterialTheme.typography.caption,
                     textAlign = Center,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryScreen.kt
@@ -106,7 +106,7 @@ fun TapToPaySummaryScreen(
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
                 Text(
-                    text = stringResource(id = R.string.card_reader_tap_to_pay_explanation_try_and_refund),
+                    text = uiState.messageWithAmount,
                     style = MaterialTheme.typography.body1,
                     textAlign = Center,
                 )
@@ -170,7 +170,10 @@ fun LearnMoreAboutTTP(onLearnMoreClicked: () -> Unit) {
 fun TapToPaySummaryScreenPreview() {
     WooThemeWithBackground {
         TapToPaySummaryScreen(
-            uiState = UiState(isProgressVisible = false),
+            uiState = UiState(
+                isProgressVisible = false,
+                messageWithAmount = "Try a $0.50 payment with your debit or credit card."
+            ),
             onTryPaymentClicked = {},
             onBackClick = {},
             onLearnMoreClicked = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
@@ -10,9 +10,11 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
+import com.woocommerce.android.ui.payments.cardreader.CardReaderCountryConfigProvider
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -21,6 +23,7 @@ import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.WCRefundStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import javax.inject.Inject
 
@@ -31,9 +34,15 @@ class TapToPaySummaryViewModel @Inject constructor(
     private val refundStore: WCRefundStore,
     private val resourceProvider: ResourceProvider,
     private val selectedSite: SelectedSite,
+    wooStore: WooCommerceStore,
+    cardReaderCountryConfigProvider: CardReaderCountryConfigProvider,
     savedStateHandle: SavedStateHandle,
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: TapToPaySummaryFragmentArgs by savedState.navArgs()
+
+    private val countryConfig = cardReaderCountryConfigProvider.provideCountryConfigFor(
+        wooStore.getStoreCountryCode(selectedSite.get())
+    ) as CardReaderConfigForSupportedCountry
 
     private val _viewState = MutableLiveData(UiState())
     val viewState: LiveData<UiState> = _viewState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
@@ -156,7 +156,7 @@ class TapToPaySummaryViewModel @Inject constructor(
             currencyCode = currency,
         )
         return resourceProvider.getString(
-            R.string.card_reader_tap_to_pay_explanation_try_and_refund,
+            R.string.card_reader_tap_to_pay_explanation_try_and_refund_with_amount,
             amount,
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
@@ -24,7 +24,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.WCRefundStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
-import java.math.BigDecimal
 import javax.inject.Inject
 
 @HiltViewModel
@@ -76,7 +75,7 @@ class TapToPaySummaryViewModel @Inject constructor(
         launch {
             _viewState.value = UiState(isProgressVisible = true)
             val result = orderCreateEditRepository.createSimplePaymentOrder(
-                TEST_ORDER_AMOUNT,
+                countryConfig.minimumAllowedChargeAmount,
                 customerNote = resourceProvider.getString(R.string.card_reader_tap_to_pay_test_payment_note)
             )
             result.fold(
@@ -162,8 +161,4 @@ class TapToPaySummaryViewModel @Inject constructor(
     ) : Event()
 
     data class NavigateToUrlInGenericWebView(val url: String) : Event()
-
-    companion object {
-        private val TEST_ORDER_AMOUNT = BigDecimal.valueOf(0.5)
-    }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1290,7 +1290,7 @@
     <string name="card_reader_tap_to_pay_explanation_title">Collect card payments\nwith your phone</string>
     <string name="card_reader_tap_to_pay_explanation_ready">Accept all types of in-person payments, right\non your phone. No extra hardware needed.</string>
     <string name="card_reader_tap_to_pay_explanation_easy">It’s easy, secure, and private.</string>
-    <string name="card_reader_tap_to_pay_explanation_try_and_refund">Try a %s payment with your debit or credit card.\nThe payment will be refunded when you’re done.</string>
+    <string name="card_reader_tap_to_pay_explanation_try_and_refund_with_amount">Try a %s payment with your debit or credit card.\nThe payment will be refunded when you’re done.</string>
     <string name="card_reader_tap_to_pay_explanation_where_to_find">Choose the Tap to Pay from the Collect Payment options in\nOrder Details or Menu > Payments.</string>
     <string name="card_reader_tap_to_pay_explanation_try_payment">Try a payment</string>
     <string name="card_reader_tap_to_pay_explanation_test_payment_error">Something went wrong. Please try again later.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1288,9 +1288,10 @@
         -->
     <string name="card_reader_tap_to_pay_explanation_screen_title">Tap To Pay</string>
     <string name="card_reader_tap_to_pay_explanation_title">Collect card payments\nwith your phone</string>
-    <string name="card_reader_tap_to_pay_explanation_ready">Your phone is ready for Tap to Pay.\nYour customer can tap their card\non your phone to pay.</string>
-    <string name="card_reader_tap_to_pay_explanation_try_and_refund">Try a payment using your card and\nit will be refunded when you’re done.</string>
-    <string name="card_reader_tap_to_pay_explanation_where_to_find"> You can find Tap to Pay on Android in\nMenu &gt; Payments, or Collect Payment and\nchoose Tap to Pay.</string>
+    <string name="card_reader_tap_to_pay_explanation_ready">Accept all types of in-person payments, right\non your phone. No extra hardware needed.</string>
+    <string name="card_reader_tap_to_pay_explanation_easy">It’s easy, secure, and private.</string>
+    <string name="card_reader_tap_to_pay_explanation_try_and_refund">Try a %s payment with your debit or credit card.\nThe payment will be refunded when you’re done.</string>
+    <string name="card_reader_tap_to_pay_explanation_where_to_find">Choose the Tap to Pay from the Collect Payment options in\nOrder Details or Menu > Payments.</string>
     <string name="card_reader_tap_to_pay_explanation_try_payment">Try a payment</string>
     <string name="card_reader_tap_to_pay_explanation_test_payment_error">Something went wrong. Please try again later.</string>
     <string name="card_reader_tap_to_pay_explanation_refunding_payment">Refunding test payment…</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
@@ -4,10 +4,12 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
+import com.woocommerce.android.ui.payments.cardreader.CardReaderCountryConfigProvider
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -28,6 +30,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCRefundStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -47,6 +50,15 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
     }
     private val selectedSite: SelectedSite = mock {
         on { get() }.thenReturn(site)
+    }
+    private val wooStore: WooCommerceStore = mock {
+        on { getStoreCountryCode(site) }.thenReturn("US")
+    }
+    private val cardReaderConfig = mock<CardReaderConfigForSupportedCountry> {
+        on { minimumAllowedChargeAmount }.thenReturn(BigDecimal("0.5"))
+    }
+    private val cardReaderCountryConfigProvider: CardReaderCountryConfigProvider = mock {
+        on { provideCountryConfigFor(any()) }.thenReturn(cardReaderConfig)
     }
 
     @Test
@@ -454,6 +466,8 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
             refundStore,
             resourceProvider,
             selectedSite,
+            wooStore,
+            cardReaderCountryConfigProvider,
             TapToPaySummaryFragmentArgs(flow).initSavedStateHandle()
         )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
@@ -178,6 +178,23 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given 30 cents min allowed charged config, when onTryPaymentClicked, then order created with 30 cents value`() =
+        testBlocking {
+            // GIVEN
+            whenever(cardReaderConfig.minimumAllowedChargeAmount).thenReturn(BigDecimal.valueOf(0.3))
+            val viewModel = initViewModel()
+
+            // WHEN
+            viewModel.onTryPaymentClicked()
+
+            // THEN
+            verify(orderCreateEditRepository).createSimplePaymentOrder(
+                BigDecimal.valueOf(0.3),
+                customerNote = "Test payment"
+            )
+        }
+
+    @Test
     fun `when onBackClicked, then exit emitted`() {
         // GIVEN
         val viewModel = initViewModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
@@ -48,7 +48,7 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
     private val resourceProvider: ResourceProvider = mock {
         on { getString(R.string.tap_to_pay_refund_reason) }.thenReturn("Test Tap To Pay payment auto refund")
         on { getString(R.string.card_reader_tap_to_pay_test_payment_note) }.thenReturn("Test payment")
-        on { getString(R.string.card_reader_tap_to_pay_explanation_try_and_refund, "$0.50") }.thenReturn(
+        on { getString(R.string.card_reader_tap_to_pay_explanation_try_and_refund_with_amount, "$0.50") }.thenReturn(
             "Try a $0.50 payment with your debit or credit card."
         )
     }
@@ -77,7 +77,7 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
         whenever(currencyFormatter.formatCurrency("0.5", "USD")).thenReturn("$0.50")
         whenever(
             resourceProvider.getString(
-                R.string.card_reader_tap_to_pay_explanation_try_and_refund, "$0.50"
+                R.string.card_reader_tap_to_pay_explanation_try_and_refund_with_amount, "$0.50"
             )
         ).thenReturn("Try a $0.50 payment with your debit or credit card.")
         val viewModel = initViewModel()
@@ -213,7 +213,7 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
             whenever(currencyFormatter.formatCurrency("0.3", "GDP")).thenReturn("£0.30")
             whenever(
                 resourceProvider.getString(
-                    R.string.card_reader_tap_to_pay_explanation_try_and_refund, "£0.30"
+                    R.string.card_reader_tap_to_pay_explanation_try_and_refund_with_amount, "£0.30"
                 )
             ).thenReturn("Try a £0.30 payment with your debit or credit card.")
             val viewModel = initViewModel()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9961
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In the UK, the minimum charge amount is £0.30. We use the minimum charge of $0.50 for Try a Payment in the US/CA. Previously, this carried over as a £0.50 trial payment when that flow is followed in the UK, but it's better for our merchants if we use the minimum amount in the UK as well. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Using a UK WooPayments store
* Navigate to Menu > Payments > Try Out Tap to Pay
* Tap Try a Payment
* Notice new copies and the one that contains £0.30 value
* Observe that the try a payment flow uses £0.30 for its payment

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->



https://github.com/woocommerce/woocommerce-android/assets/4923871/45394c49-ef2d-45dc-916d-c349519f72c6




- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
