### PR TITLE
Extract Tracking From OrderDetailViewModel

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailTracker.kt
@@ -1,0 +1,131 @@
+package com.woocommerce.android.ui.orders.details
+
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.Order
+import org.wordpress.android.fluxc.store.WCOrderStore
+import javax.inject.Inject
+
+class OrderDetailTracker @Inject constructor(
+    private val trackerWrapper: AnalyticsTrackerWrapper
+) {
+    fun trackCustomFieldsTapped() {
+        trackerWrapper.track(AnalyticsEvent.ORDER_VIEW_CUSTOM_FIELDS_TAPPED)
+    }
+
+    fun trackEditButtonTapped(feeLinesCount: Int, shippingLinesCount: Int) {
+        trackerWrapper.track(
+            AnalyticsEvent.ORDER_EDIT_BUTTON_TAPPED,
+            mapOf(
+                AnalyticsTracker.KEY_HAS_MULTIPLE_FEE_LINES to (feeLinesCount > 1),
+                AnalyticsTracker.KEY_HAS_MULTIPLE_SHIPPING_LINES to (shippingLinesCount > 1)
+            )
+        )
+    }
+
+    fun trackReceiptViewTapped(orderId: Long, orderStatus: Order.Status) {
+        trackerWrapper.track(
+            AnalyticsEvent.RECEIPT_VIEW_TAPPED,
+            mapOf(
+                AnalyticsTracker.KEY_ORDER_ID to orderId,
+                AnalyticsTracker.KEY_STATUS to orderStatus
+            )
+        )
+    }
+
+    fun trackAddOrderTrackingTapped(orderId: Long, orderStatus: Order.Status, trackingProvider: String) {
+        trackerWrapper.track(
+            AnalyticsEvent.ORDER_TRACKING_ADD,
+            mapOf(
+                AnalyticsTracker.KEY_ID to orderId,
+                AnalyticsTracker.KEY_STATUS to orderStatus,
+                AnalyticsTracker.KEY_CARRIER to trackingProvider
+            )
+        )
+    }
+
+    fun trackOrderStatusChanged(orderId: Long, oldStatus: String, newStatus: String) {
+        trackerWrapper.track(
+            AnalyticsEvent.ORDER_STATUS_CHANGE,
+            mapOf(
+                AnalyticsTracker.KEY_ID to orderId,
+                AnalyticsTracker.KEY_FROM to oldStatus,
+                AnalyticsTracker.KEY_TO to newStatus,
+                AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_FLOW_EDITING
+            )
+        )
+    }
+
+    fun trackOrderTrackingDeleteSucceeded() {
+        trackerWrapper.track(AnalyticsEvent.ORDER_TRACKING_DELETE_SUCCESS)
+    }
+
+    fun trackOrderTrackingDeleteFailed(error: WCOrderStore.OrderError) {
+        trackerWrapper.track(
+            AnalyticsEvent.ORDER_TRACKING_DELETE_FAILED,
+            prepareErrorEventDetails(error)
+        )
+    }
+
+    fun trackOrderStatusChangeSucceeded() {
+        trackerWrapper.track(AnalyticsEvent.ORDER_STATUS_CHANGE_SUCCESS)
+    }
+
+    fun trackOrderStatusChangeFailed(error: WCOrderStore.OrderError) {
+        trackerWrapper.track(
+            AnalyticsEvent.ORDER_STATUS_CHANGE_FAILED,
+            prepareErrorEventDetails(error)
+        )
+    }
+
+    fun trackOrderDetailPulledToRefresh() {
+        trackerWrapper.track(AnalyticsEvent.ORDER_DETAIL_PULLED_TO_REFRESH)
+    }
+
+    fun trackShippinhLabelTapped() {
+        trackerWrapper.track(AnalyticsEvent.ORDER_DETAIL_CREATE_SHIPPING_LABEL_BUTTON_TAPPED)
+    }
+
+    fun trackMarkOrderAsCompleteTapped() {
+        trackerWrapper.track(AnalyticsEvent.ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED)
+    }
+
+    fun trackViewAddonsTapped() {
+        trackerWrapper.track(AnalyticsEvent.PRODUCT_ADDONS_ORDER_DETAIL_VIEW_PRODUCT_ADDONS_TAPPED)
+    }
+
+    fun trackProductsLoaded(orderId: Long, productTypes: String, hasAddons: Boolean) {
+        trackerWrapper.track(
+            stat = AnalyticsEvent.ORDER_PRODUCTS_LOADED,
+            properties = mapOf(
+                AnalyticsTracker.KEY_ID to orderId,
+                AnalyticsTracker.PRODUCT_TYPES to productTypes,
+                AnalyticsTracker.HAS_ADDONS to hasAddons
+            )
+        )
+    }
+
+    fun trackOrderDetailsSubscriptionsShown() {
+        trackerWrapper.track(AnalyticsEvent.ORDER_DETAILS_SUBSCRIPTIONS_SHOWN)
+    }
+
+    fun trackOrderDetailsGiftCardShown() {
+        trackerWrapper.track(AnalyticsEvent.ORDER_DETAILS_GIFT_CARD_SHOWN)
+    }
+
+    fun trackOrderEligibleForShippingLabelCreation(orderStatus: String) {
+        trackerWrapper.track(
+            stat = AnalyticsEvent.SHIPPING_LABEL_ORDER_IS_ELIGIBLE,
+            properties = mapOf(
+                "order_status" to orderStatus
+            )
+        )
+    }
+
+    private fun prepareErrorEventDetails(error: WCOrderStore.OrderError) = mapOf(
+        AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
+        AnalyticsTracker.KEY_ERROR_TYPE to error.type.toString(),
+        AnalyticsTracker.KEY_ERROR_DESC to error.message
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -11,23 +11,6 @@ import androidx.lifecycle.distinctUntilChanged
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
-import com.woocommerce.android.analytics.AnalyticsEvent
-import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_DETAIL_CREATE_SHIPPING_LABEL_BUTTON_TAPPED
-import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED
-import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_DETAIL_PULLED_TO_REFRESH
-import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_EDIT_BUTTON_TAPPED
-import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_STATUS_CHANGE
-import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_STATUS_CHANGE_FAILED
-import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_STATUS_CHANGE_SUCCESS
-import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_TRACKING_ADD
-import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_TRACKING_DELETE_FAILED
-import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_TRACKING_DELETE_SUCCESS
-import com.woocommerce.android.analytics.AnalyticsEvent.PRODUCT_ADDONS_ORDER_DETAIL_VIEW_PRODUCT_ADDONS_TAPPED
-import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_VIEW_TAPPED
-import com.woocommerce.android.analytics.AnalyticsEvent.SHIPPING_LABEL_ORDER_IS_ELIGIBLE
-import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FLOW_EDITING
-import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.whenNotNullNorEmpty
 import com.woocommerce.android.model.GiftCardSummary
 import com.woocommerce.android.model.Order
@@ -81,7 +64,6 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.wordpress.android.fluxc.persistence.entity.OrderMetaDataEntity
-import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.OptimisticUpdateResult
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -99,7 +81,7 @@ class OrderDetailViewModel @Inject constructor(
     private val productImageMap: ProductImageMap,
     private val paymentCollectibilityChecker: CardReaderPaymentCollectibilityChecker,
     private val cardReaderTracker: CardReaderTracker,
-    private val trackerWrapper: AnalyticsTrackerWrapper,
+    private val tracker: OrderDetailTracker,
     private val shippingLabelOnboardingRepository: ShippingLabelOnboardingRepository,
     private val orderDetailsTransactionLauncher: OrderDetailsTransactionLauncher,
     private val getOrderSubscriptions: GetOrderSubscriptions,
@@ -245,7 +227,7 @@ class OrderDetailViewModel @Inject constructor(
      * User clicked the button to view custom fields
      */
     fun onCustomFieldsButtonClicked() {
-        AnalyticsTracker.track(AnalyticsEvent.ORDER_VIEW_CUSTOM_FIELDS_TAPPED)
+        tracker.trackCustomFieldsTapped()
         triggerEvent(OrderNavigationTarget.ViewCustomFields(navArgs.orderId))
     }
 
@@ -261,7 +243,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onRefreshRequested() {
-        trackerWrapper.track(ORDER_DETAIL_PULLED_TO_REFRESH)
+        tracker.trackOrderDetailPulledToRefresh()
         viewState = viewState.copy(isRefreshing = true)
         launch { fetchOrder(false) }
     }
@@ -289,13 +271,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onEditClicked() {
-        trackerWrapper.track(
-            ORDER_EDIT_BUTTON_TAPPED,
-            mapOf(
-                AnalyticsTracker.KEY_HAS_MULTIPLE_FEE_LINES to (order.feesLines.size > 1),
-                AnalyticsTracker.KEY_HAS_MULTIPLE_SHIPPING_LINES to (order.shippingLines.size > 1)
-            )
-        )
+        tracker.trackEditButtonTapped(order.feesLines.size, order.shippingLines.size)
         triggerEvent(OrderNavigationTarget.EditOrder(order.id))
     }
 
@@ -337,13 +313,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onSeeReceiptClicked() {
-        trackerWrapper.track(
-            RECEIPT_VIEW_TAPPED,
-            mapOf(
-                AnalyticsTracker.KEY_ORDER_ID to order.id,
-                AnalyticsTracker.KEY_STATUS to order.status
-            )
-        )
+        tracker.trackReceiptViewTapped(order.id, order.status)
         loadReceiptUrl()?.let {
             triggerEvent(PreviewReceipt(order.billingAddress.email, it, order.id))
         } ?: WooLog.e(T.ORDERS, "ReceiptUrl is null, but SeeReceipt button is visible")
@@ -411,14 +381,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onNewShipmentTrackingAdded(shipmentTracking: OrderShipmentTracking) {
-        trackerWrapper.track(
-            ORDER_TRACKING_ADD,
-            mapOf(
-                AnalyticsTracker.KEY_ID to order.id,
-                AnalyticsTracker.KEY_STATUS to order.status,
-                AnalyticsTracker.KEY_CARRIER to shipmentTracking.trackingProvider
-            )
-        )
+        tracker.trackAddOrderTrackingTapped(order.id, order.status, shipmentTracking.trackingProvider)
         refreshShipmentTracking()
     }
 
@@ -449,15 +412,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onOrderStatusChanged(updateSource: OrderStatusUpdateSource) {
-        trackerWrapper.track(
-            ORDER_STATUS_CHANGE,
-            mapOf(
-                AnalyticsTracker.KEY_ID to order.id,
-                AnalyticsTracker.KEY_FROM to order.status.value,
-                AnalyticsTracker.KEY_TO to updateSource.newStatus,
-                AnalyticsTracker.KEY_FLOW to VALUE_FLOW_EDITING
-            )
-        )
+        tracker.trackOrderStatusChanged(order.id, order.status.value, updateSource.newStatus)
 
         val snackbarMessage = when (updateSource) {
             is OrderStatusUpdateSource.FullFillScreen -> string.order_fulfill_completed
@@ -527,13 +482,10 @@ class OrderDetailViewModel @Inject constructor(
                 navArgs.orderId, shipmentTracking.toDataModel()
             )
             if (!onOrderChanged.isError) {
-                trackerWrapper.track(ORDER_TRACKING_DELETE_SUCCESS)
+                tracker.trackOrderTrackingDeleteSucceeded()
                 triggerEvent(ShowSnackbar(string.order_shipment_tracking_delete_success))
             } else {
-                trackerWrapper.track(
-                    ORDER_TRACKING_DELETE_FAILED,
-                    prepareTracksEventsDetails(onOrderChanged)
-                )
+                tracker.trackOrderTrackingDeleteFailed(onOrderChanged.error)
                 onDeleteShipmentTrackingReverted(shipmentTracking)
                 triggerEvent(ShowSnackbar(string.order_shipment_tracking_delete_error))
             }
@@ -553,12 +505,9 @@ class OrderDetailViewModel @Inject constructor(
                             is RemoteUpdateResult -> {
                                 if (result.event.isError) {
                                     triggerEvent(ShowSnackbar(string.order_error_update_general))
-                                    trackerWrapper.track(
-                                        ORDER_STATUS_CHANGE_FAILED,
-                                        prepareTracksEventsDetails(result.event)
-                                    )
+                                    tracker.trackOrderStatusChangeFailed(result.event.error)
                                 } else {
-                                    trackerWrapper.track(ORDER_STATUS_CHANGE_SUCCESS)
+                                    tracker.trackOrderStatusChangeSucceeded()
                                 }
                             }
                         }
@@ -574,17 +523,17 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onCreateShippingLabelButtonTapped() {
-        trackerWrapper.track(ORDER_DETAIL_CREATE_SHIPPING_LABEL_BUTTON_TAPPED)
+        tracker.trackShippinhLabelTapped()
         triggerEvent(StartShippingLabelCreationFlow(order.id))
     }
 
     fun onMarkOrderCompleteButtonTapped() {
-        trackerWrapper.track(ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED)
+        tracker.trackMarkOrderAsCompleteTapped()
         triggerEvent(ViewOrderFulfillInfo(order.id))
     }
 
     fun onViewOrderedAddonButtonTapped(orderItem: Order.Item) {
-        trackerWrapper.track(PRODUCT_ADDONS_ORDER_DETAIL_VIEW_PRODUCT_ADDONS_TAPPED)
+        tracker.trackViewAddonsTapped()
         triggerEvent(
             ViewOrderedAddons(
                 navArgs.orderId,
@@ -654,14 +603,7 @@ class OrderDetailViewModel @Inject constructor(
         val ids = orderProducts.map { orderProduct -> orderProduct.product.productId }
         val productTypes = orderDetailRepository.getUniqueProductTypes(ids)
         val hasAddons = orderProducts.any { orderProduct -> orderProduct.product.containsAddons }
-        trackerWrapper.track(
-            stat = AnalyticsEvent.ORDER_PRODUCTS_LOADED,
-            properties = mapOf(
-                AnalyticsTracker.KEY_ID to order.id,
-                AnalyticsTracker.PRODUCT_TYPES to productTypes,
-                AnalyticsTracker.HAS_ADDONS to hasAddons
-            )
-        )
+        tracker.trackProductsLoaded(order.id, productTypes, hasAddons)
     }
 
     private suspend fun checkAddonAvailability(products: List<Order.Item>) {
@@ -724,7 +666,7 @@ class OrderDetailViewModel @Inject constructor(
             getOrderSubscriptions(navArgs.orderId).getOrNull()?.let { subscription ->
                 _subscriptions.value = subscription
                 if (subscription.isNotEmpty()) {
-                    trackerWrapper.track(AnalyticsEvent.ORDER_DETAILS_SUBSCRIPTIONS_SHOWN)
+                    tracker.trackOrderDetailsSubscriptionsShown()
                 }
             }
         }
@@ -740,7 +682,7 @@ class OrderDetailViewModel @Inject constructor(
                     val giftCardSummaries = result.model ?: return@let
                     _giftCards.value = giftCardSummaries
                     if (giftCardSummaries.isNotEmpty()) {
-                        trackerWrapper.track(AnalyticsEvent.ORDER_DETAILS_GIFT_CARD_SHOWN)
+                        tracker.trackOrderDetailsGiftCardShown()
                     }
                 }
         }
@@ -790,12 +732,7 @@ class OrderDetailViewModel @Inject constructor(
         ) {
             // we check against the viewstate to avoid sending the event multiple times
             // if the eligibility was cached, and we had the same value after re-fetching it
-            trackerWrapper.track(
-                stat = SHIPPING_LABEL_ORDER_IS_ELIGIBLE,
-                properties = mapOf(
-                    "order_status" to order.status.value
-                )
-            )
+            tracker.trackOrderEligibleForShippingLabelCreation(order.status.value)
         }
 
         viewState = viewState.copy(
@@ -814,12 +751,6 @@ class OrderDetailViewModel @Inject constructor(
     override fun onProductFetched(remoteProductId: Long) {
         viewState = viewState.copy(refreshedProductId = remoteProductId)
     }
-
-    private fun prepareTracksEventsDetails(event: OnOrderChanged) = mapOf(
-        AnalyticsTracker.KEY_ERROR_CONTEXT to this::class.java.simpleName,
-        AnalyticsTracker.KEY_ERROR_TYPE to event.error.type.toString(),
-        AnalyticsTracker.KEY_ERROR_DESC to event.error.message
-    )
 
     fun onCardReaderPaymentCompleted() {
         reloadOrderDetails()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewState.kt
@@ -34,5 +34,4 @@ data class OrderDetailViewState(
         val isPaymentCollectableWithCardReader: Boolean = false,
         val isReceiptButtonsVisible: Boolean = false
     ) : Parcelable
-
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -5,9 +5,6 @@ import android.content.SharedPreferences
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
-import com.woocommerce.android.analytics.AnalyticsEvent
-import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.GiftCardSummary
@@ -30,9 +27,10 @@ import com.woocommerce.android.ui.orders.OrderNavigationTarget.PreviewReceipt
 import com.woocommerce.android.ui.orders.details.GetOrderSubscriptions
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentArgs
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.ui.orders.details.OrderDetailTracker
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
-import com.woocommerce.android.ui.orders.details.OrderDetailViewState.OrderInfo
 import com.woocommerce.android.ui.orders.details.OrderDetailViewState
+import com.woocommerce.android.ui.orders.details.OrderDetailViewState.OrderInfo
 import com.woocommerce.android.ui.orders.details.OrderDetailsTransactionLauncher
 import com.woocommerce.android.ui.orders.details.OrderProduct
 import com.woocommerce.android.ui.orders.details.OrderProductMapper
@@ -100,7 +98,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     }
     private val addonsRepository: AddonRepository = mock()
     private val cardReaderTracker: CardReaderTracker = mock()
-    private val analyticsTraWrapper: AnalyticsTrackerWrapper = mock()
+    private val orderDetailTracker: OrderDetailTracker = mock()
     private val resources: ResourceProvider = mock {
         on { getString(any()) } doAnswer { invocationOnMock -> invocationOnMock.arguments[0].toString() }
         on { getString(any(), any()) } doAnswer { invocationOnMock -> invocationOnMock.arguments[0].toString() }
@@ -172,7 +170,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 productImageMap,
                 paymentCollectibilityChecker,
                 cardReaderTracker,
-                analyticsTraWrapper,
+                orderDetailTracker,
                 shippingLabelOnboardingRepository,
                 orderDetailsTransactionLauncher,
                 getOrderSubscriptions,
@@ -195,7 +193,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 productImageMap,
                 paymentCollectibilityChecker,
                 cardReaderTracker,
-                analyticsTraWrapper,
+                orderDetailTracker,
                 shippingLabelOnboardingRepository,
                 orderDetailsTransactionLauncher,
                 getOrderSubscriptions,
@@ -1148,13 +1146,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             viewModel.onSeeReceiptClicked()
 
-            verify(analyticsTraWrapper).track(
-                AnalyticsEvent.RECEIPT_VIEW_TAPPED,
-                mapOf(
-                    AnalyticsTracker.KEY_ORDER_ID to order.id,
-                    AnalyticsTracker.KEY_STATUS to order.status
-                )
-            )
+            verify(orderDetailTracker).trackReceiptViewTapped(order.id, order.status)
         }
 
     @Test
@@ -1376,7 +1368,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             viewModel.onRefreshRequested()
 
             // Then
-            verify(analyticsTraWrapper).track(AnalyticsEvent.ORDER_DETAIL_PULLED_TO_REFRESH)
+            verify(orderDetailTracker).trackOrderDetailPulledToRefresh()
         }
 
     @Test
@@ -1393,13 +1385,10 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             viewModel.onNewShipmentTrackingAdded(testOrderShipmentTrackings[0])
 
             // Then
-            verify(analyticsTraWrapper).track(
-                AnalyticsEvent.ORDER_TRACKING_ADD,
-                mapOf(
-                    AnalyticsTracker.KEY_ID to order.id,
-                    AnalyticsTracker.KEY_STATUS to order.status,
-                    AnalyticsTracker.KEY_CARRIER to testOrderShipmentTrackings[0].trackingProvider
-                )
+            verify(orderDetailTracker).trackAddOrderTrackingTapped(
+                order.id,
+                order.status,
+                testOrderShipmentTrackings[0].trackingProvider
             )
         }
 
@@ -1421,14 +1410,10 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             viewModel.onOrderStatusChanged(updateSource)
 
             // Then
-            verify(analyticsTraWrapper).track(
-                AnalyticsEvent.ORDER_STATUS_CHANGE,
-                mapOf(
-                    AnalyticsTracker.KEY_ID to order.id,
-                    AnalyticsTracker.KEY_FROM to order.status.value,
-                    AnalyticsTracker.KEY_TO to updateSource.newStatus,
-                    AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_FLOW_EDITING
-                )
+            verify(orderDetailTracker).trackOrderStatusChanged(
+                order.id,
+                order.status.value,
+                updateSource.newStatus
             )
         }
 
@@ -1446,7 +1431,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             viewModel.onCreateShippingLabelButtonTapped()
 
             // Then
-            verify(analyticsTraWrapper).track(AnalyticsEvent.ORDER_DETAIL_CREATE_SHIPPING_LABEL_BUTTON_TAPPED)
+            verify(orderDetailTracker).trackShippinhLabelTapped()
         }
 
     @Test
@@ -1463,7 +1448,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             viewModel.onMarkOrderCompleteButtonTapped()
 
             // Then
-            verify(analyticsTraWrapper).track(AnalyticsEvent.ORDER_DETAIL_FULFILL_ORDER_BUTTON_TAPPED)
+            verify(orderDetailTracker).trackMarkOrderAsCompleteTapped()
         }
 
     @Test
@@ -1480,7 +1465,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             viewModel.onViewOrderedAddonButtonTapped(order.items[0])
 
             // Then
-            verify(analyticsTraWrapper).track(AnalyticsEvent.PRODUCT_ADDONS_ORDER_DETAIL_VIEW_PRODUCT_ADDONS_TAPPED)
+            verify(orderDetailTracker).trackViewAddonsTapped()
         }
 
     @Test
@@ -1497,12 +1482,9 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             viewModel.onEditClicked()
 
             // Then
-            verify(analyticsTraWrapper).track(
-                AnalyticsEvent.ORDER_EDIT_BUTTON_TAPPED,
-                mapOf(
-                    AnalyticsTracker.KEY_HAS_MULTIPLE_FEE_LINES to (order.feesLines.size > 1),
-                    AnalyticsTracker.KEY_HAS_MULTIPLE_SHIPPING_LINES to (order.shippingLines.size > 1)
-                )
+            verify(orderDetailTracker).trackEditButtonTapped(
+                order.feesLines.size,
+                order.shippingLines.size
             )
         }
 
@@ -1722,7 +1704,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        verify(analyticsTraWrapper).track(AnalyticsEvent.ORDER_DETAILS_SUBSCRIPTIONS_SHOWN)
+        verify(orderDetailTracker).trackOrderDetailsSubscriptionsShown()
     }
 
     @Test
@@ -1743,7 +1725,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        verify(analyticsTraWrapper, never()).track(AnalyticsEvent.ORDER_DETAILS_SUBSCRIPTIONS_SHOWN)
+        verify(orderDetailTracker, never()).trackOrderDetailsSubscriptionsShown()
     }
 
     @Test
@@ -1764,7 +1746,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        verify(analyticsTraWrapper, never()).track(AnalyticsEvent.ORDER_DETAILS_SUBSCRIPTIONS_SHOWN)
+        verify(orderDetailTracker, never()).trackOrderDetailsSubscriptionsShown()
     }
 
     @Test
@@ -1822,7 +1804,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        verify(analyticsTraWrapper).track(AnalyticsEvent.ORDER_DETAILS_GIFT_CARD_SHOWN)
+        verify(orderDetailTracker).trackOrderDetailsGiftCardShown()
     }
 
     @Test
@@ -1843,7 +1825,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        verify(analyticsTraWrapper, never()).track(AnalyticsEvent.ORDER_DETAILS_GIFT_CARD_SHOWN)
+        verify(orderDetailTracker, never()).trackOrderDetailsGiftCardShown()
     }
 
     @Test
@@ -1864,7 +1846,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        verify(analyticsTraWrapper, never()).track(AnalyticsEvent.ORDER_DETAILS_GIFT_CARD_SHOWN)
+        verify(orderDetailTracker, never()).trackOrderDetailsGiftCardShown()
     }
 
     @Test
@@ -1900,13 +1882,10 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        verify(analyticsTraWrapper).track(
-            stat = AnalyticsEvent.ORDER_PRODUCTS_LOADED,
-            properties = mapOf(
-                AnalyticsTracker.KEY_ID to order.id,
-                AnalyticsTracker.PRODUCT_TYPES to types,
-                AnalyticsTracker.HAS_ADDONS to hasAddons
-            )
+        verify(orderDetailTracker).trackProductsLoaded(
+            order.id,
+            types,
+            hasAddons
         )
     }
 
@@ -1925,30 +1904,28 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start()
 
-        verify(analyticsTraWrapper).track(
-            stat = AnalyticsEvent.ORDER_PRODUCTS_LOADED,
-            properties = mapOf(
-                AnalyticsTracker.KEY_ID to order.id,
-                AnalyticsTracker.PRODUCT_TYPES to types,
-                AnalyticsTracker.HAS_ADDONS to hasAddons
-            )
+        verify(orderDetailTracker).trackProductsLoaded(
+            order.id,
+            types,
+            hasAddons
         )
     }
 
     @Test
-    fun `given order ids passed, when ViewModel starts, then previous order navigations is not enabled`() = testBlocking {
-        val newSavedState = OrderDetailFragmentArgs(
-            orderId = ORDER_ID,
-            allOrderIds = arrayOf(ORDER_ID, 2).toLongArray()
-        ).initSavedStateHandle()
+    fun `given order ids passed, when ViewModel starts, then previous order navigations is not enabled`() =
+        testBlocking {
+            val newSavedState = OrderDetailFragmentArgs(
+                orderId = ORDER_ID,
+                allOrderIds = arrayOf(ORDER_ID, 2).toLongArray()
+            ).initSavedStateHandle()
 
-        createViewModel(newSavedState)
+            createViewModel(newSavedState)
 
-        viewModel.start()
+            viewModel.start()
 
-        // Then
-        assertThat(viewModel.previousOrderNavigationIsEnabled()).isFalse
-    }
+            // Then
+            assertThat(viewModel.previousOrderNavigationIsEnabled()).isFalse
+        }
 
     @Test
     fun `when the order is the last one then it disables navigation to next order`() = testBlocking {


### PR DESCRIPTION
This PR extracts tracking from OrderDetailViewModel into a separate class. The main push for this change was a detected `ClassToLarge` error in[ Cesar's PR](https://github.com/woocommerce/woocommerce-android/pull/9904) which is preventing him from merging it. I should have created this PR based on trunk instead of his branch, but I realized it too late.

Proposal for the next steps:
1. Review this PR (Do not merge it).
2. Wrap up review of Cesar's PR (Do not merge it).
3. When both PRs are reviewed, merge one after the other (I'd consider force-merging Cesar's PR first even though it has the failing detekt issue to retain the history of PRs on GitHub, but it's not necessary).

To Test:
1. I think green unit tests are enough.

cc @toupper 