### PR TITLE
[Blaze] MyStore View when there is a campaign

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
@@ -11,13 +11,13 @@ data class BlazeProductUi(
 
 data class BlazeCampaignUi(
     val product: BlazeProductUi,
-    val status: CampaignStatusUi,
+    val status: CampaignStatusUi?,
     val stats: List<BlazeCampaignStat>,
 )
 
 data class BlazeCampaignStat(
     @StringRes val name: Int,
-    val value: Int
+    val value: Long
 )
 
 enum class CampaignStatusUi(
@@ -44,5 +44,17 @@ enum class CampaignStatusUi(
         statusDisplayText = R.string.blaze_campaign_status_rejected,
         textColor = R.color.blaze_campaign_status_completed_text,
         backgroundColor = R.color.blaze_campaign_status_completed_background
-    ),
+    );
+
+    companion object {
+        fun fromString(status: String): CampaignStatusUi? {
+            return when (status) {
+                "created" -> InModeration
+                "active" -> Active
+                "completed" -> Completed
+                "rejected" -> Rejected
+                else -> null
+            }
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -37,6 +37,11 @@ class IsBlazeEnabled @Inject constructor(
         return BLAZE_CREATION_FLOW_PRODUCT.format(siteUrlWithoutProtocol, productId, source.trackingName)
     }
 
+    fun buildCampaignsListUrl(): String {
+        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
+        return "${BASE_URL}campaigns/$siteUrlWithoutProtocol"
+    }
+
     fun buildCampaignDetailsUrl(campaignId: Int): String {
         val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
         return "${BASE_URL}campaigns/$campaignId/$siteUrlWithoutProtocol"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -37,6 +37,11 @@ class IsBlazeEnabled @Inject constructor(
         return BLAZE_CREATION_FLOW_PRODUCT.format(siteUrlWithoutProtocol, productId, source.trackingName)
     }
 
+    fun buildCampaignDetailsUrl(campaignId: Int): String {
+        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
+        return "${BASE_URL}campaigns/$campaignId/$siteUrlWithoutProtocol"
+    }
+
     enum class BlazeFlowSource(val trackingName: String) {
         PRODUCT_DETAIL_OVERFLOW_MENU("product_more_menu"),
         MORE_MENU_ITEM("menu"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
@@ -60,7 +60,7 @@ fun MyStoreBlazeView(
                 when (state) {
                     is MyStoreBlazeCampaignState.Campaign -> BlazeCampaignItem(
                         campaign = state.campaign,
-                        onCampaignClicked = {},
+                        onCampaignClicked = state.onCampaignClicked,
                         modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100))
                     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
@@ -72,24 +72,23 @@ class MyStoreBlazeViewModel @Inject constructor(
         }
     }
 
-    @Suppress("UNUSED_PARAMETER")
     private fun prepareUiForCampaign(campaign: BlazeCampaignModel): Flow<MyStoreBlazeCampaignState> {
         return flowOf(
             MyStoreBlazeCampaignState.Campaign(
                 campaign = BlazeCampaignUi(
                     product = BlazeProductUi(
-                        name = "Product name",
-                        imgUrl = "https://hips.hearstapps.com/hmg-prod/images/gh-082420-ghi-best-sofas-1598293488.png",
+                        name = campaign.title,
+                        imgUrl = campaign.imageUrl.orEmpty(),
                     ),
-                    status = CampaignStatusUi.Active,
+                    status = CampaignStatusUi.fromString(campaign.uiStatus),
                     stats = listOf(
                         BlazeCampaignStat(
                             name = R.string.blaze_campaign_status_impressions,
-                            value = 100
+                            value = campaign.impressions
                         ),
                         BlazeCampaignStat(
                             name = R.string.blaze_campaign_status_clicks,
-                            value = 10
+                            value = campaign.clicks
                         )
                     )
                 ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
@@ -92,8 +92,16 @@ class MyStoreBlazeViewModel @Inject constructor(
                         )
                     )
                 ),
-                onCampaignClicked = { /* TODO */ },
-                onViewAllCampaignsClicked = { triggerEvent(ShowAllCampaigns) },
+                onCampaignClicked = {
+                    triggerEvent(
+                        ShowCampaignDetails(
+                            url = isBlazeEnabled.buildCampaignDetailsUrl(campaign.campaignId)
+                        )
+                    )
+                },
+                onViewAllCampaignsClicked = {
+                    triggerEvent(ShowAllCampaigns)
+                },
                 onCreateCampaignClicked = {
                     triggerEvent(
                         LaunchBlazeCampaignCreation(isBlazeEnabled.buildUrlForSite(BlazeFlowSource.MY_STORE_BANNER))
@@ -136,4 +144,5 @@ class MyStoreBlazeViewModel @Inject constructor(
 
     data class LaunchBlazeCampaignCreation(val url: String) : MultiLiveEvent.Event()
     object ShowAllCampaigns : MultiLiveEvent.Event()
+    data class ShowCampaignDetails(val url: String) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
@@ -95,7 +95,8 @@ class MyStoreBlazeViewModel @Inject constructor(
                 onCampaignClicked = {
                     triggerEvent(
                         ShowCampaignDetails(
-                            url = isBlazeEnabled.buildCampaignDetailsUrl(campaign.campaignId)
+                            url = isBlazeEnabled.buildCampaignDetailsUrl(campaign.campaignId),
+                            urlToTriggerExit = isBlazeEnabled.buildCampaignsListUrl()
                         )
                     )
                 },
@@ -144,5 +145,8 @@ class MyStoreBlazeViewModel @Inject constructor(
 
     data class LaunchBlazeCampaignCreation(val url: String) : MultiLiveEvent.Event()
     object ShowAllCampaigns : MultiLiveEvent.Event()
-    data class ShowCampaignDetails(val url: String) : MultiLiveEvent.Event()
+    data class ShowCampaignDetails(
+        val url: String,
+        val urlToTriggerExit: String
+    ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
@@ -52,7 +52,7 @@ class MyStoreBlazeViewModel @Inject constructor(
             } else {
                 isBlazeEnabled.buildUrlForSite(BlazeFlowSource.MY_STORE_BANNER)
             }
-            triggerEvent(LaunchBlazeCampaignCreation(url, BlazeFlowSource.MY_STORE_BANNER))
+            triggerEvent(LaunchBlazeCampaignCreation(url))
         }
 
         return getProducts().map { products ->
@@ -94,7 +94,11 @@ class MyStoreBlazeViewModel @Inject constructor(
                 ),
                 onCampaignClicked = { /* TODO */ },
                 onViewAllCampaignsClicked = { triggerEvent(ShowAllCampaigns) },
-                onCreateCampaignClicked = { /* TODO */ }
+                onCreateCampaignClicked = {
+                    triggerEvent(
+                        LaunchBlazeCampaignCreation(isBlazeEnabled.buildUrlForSite(BlazeFlowSource.MY_STORE_BANNER))
+                    )
+                }
             )
         )
     }
@@ -130,6 +134,6 @@ class MyStoreBlazeViewModel @Inject constructor(
         ) : MyStoreBlazeCampaignState
     }
 
-    data class LaunchBlazeCampaignCreation(val url: String, val source: BlazeFlowSource) : MultiLiveEvent.Event()
+    data class LaunchBlazeCampaignCreation(val url: String) : MultiLiveEvent.Event()
     object ShowAllCampaigns : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignItem.kt
@@ -47,14 +47,17 @@ fun BlazeCampaignItem(
                     .padding(start = dimensionResource(id = R.dimen.major_100))
                     .weight(1f),
             ) {
-                WCTag(
-                    text = stringResource(id = campaign.status.statusDisplayText).uppercase(),
-                    textColor = colorResource(id = campaign.status.textColor),
-                    backgroundColor = colorResource(id = campaign.status.backgroundColor),
-                    textStyle = MaterialTheme.typography.caption.copy(
-                        letterSpacing = 1.5.sp
+                campaign.status?.let {
+                    WCTag(
+                        text = stringResource(id = campaign.status.statusDisplayText).uppercase(),
+                        textColor = colorResource(id = campaign.status.textColor),
+                        backgroundColor = colorResource(id = campaign.status.backgroundColor),
+                        textStyle = MaterialTheme.typography.caption.copy(
+                            letterSpacing = 1.5.sp
+                        )
                     )
-                )
+                }
+
                 Text(
                     modifier = Modifier
                         .padding(top = dimensionResource(id = R.dimen.minor_50)),
@@ -78,7 +81,7 @@ fun BlazeCampaignItem(
 @Composable
 private fun CampaignStat(
     statName: String,
-    statValue: Int,
+    statValue: Long,
     modifier: Modifier = Modifier,
 ) {
     Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -47,7 +47,6 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.blaze.BlazeBanner
 import com.woocommerce.android.ui.blaze.BlazeBannerViewModel
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource.MY_STORE_BANNER
 import com.woocommerce.android.ui.blaze.MyStoreBlazeView
 import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel
 import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.MyStoreBlazeCampaignState
@@ -235,7 +234,7 @@ class MyStoreFragment :
     }
 
     private fun setUpBlazeBanner() {
-        blazeBannerViewModel.setBlazeBannerSource(MY_STORE_BANNER)
+        blazeBannerViewModel.setBlazeBannerSource(BlazeFlowSource.MY_STORE_BANNER)
         blazeBannerViewModel.isBlazeBannerVisible.observe(viewLifecycleOwner) { isVisible ->
             if (!isVisible) binding.blazeBannerView.hide()
             else {
@@ -280,7 +279,10 @@ class MyStoreFragment :
         }
         myStoreBlazeViewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is MyStoreBlazeViewModel.LaunchBlazeCampaignCreation -> openBlazeWebView(event.url, event.source)
+                is MyStoreBlazeViewModel.LaunchBlazeCampaignCreation -> openBlazeWebView(
+                    url = event.url,
+                    source = BlazeFlowSource.MY_STORE_BANNER
+                )
                 is MyStoreBlazeViewModel.ShowAllCampaigns -> {
                     findNavController().navigateSafely(
                         MyStoreFragmentDirections.actionMyStoreToBlazeCampaignListFragment()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -292,6 +292,7 @@ class MyStoreFragment :
                     findNavController().navigateSafely(
                         NavGraphMainDirections.actionGlobalWPComWebViewFragment(
                             urlToLoad = event.url,
+                            urlsToTriggerExit = arrayOf(event.urlToTriggerExit),
                             title = getString(R.string.blaze_campaign_details_title)
                         )
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -288,6 +288,14 @@ class MyStoreFragment :
                         MyStoreFragmentDirections.actionMyStoreToBlazeCampaignListFragment()
                     )
                 }
+                is MyStoreBlazeViewModel.ShowCampaignDetails -> {
+                    findNavController().navigateSafely(
+                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+                            urlToLoad = event.url,
+                            title = getString(R.string.blaze_campaign_details_title)
+                        )
+                    )
+                }
             }
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3671,6 +3671,12 @@
     -->
     <string name="blaze_campaign_list_title">Blaze campaigns</string>
 
+
+    <!--
+    Blaze campaign details
+    -->
+    <string name="blaze_campaign_details_title">Campaign details</string>
+
     <!--
     Highlights tooltip
     -->


### PR DESCRIPTION
Closes: #9968 

### Description
This PR adds logic for displaying the campaign's details in the MyStore view, and handling of the navigation events.

### Testing instructions
1. Use a store that has at least one past campaign.
2. Sign in using WordPress.com
3. Notice that in the MyStore fragment, the Blaze view shows the details of the last campaign.
4. Click on the Campain itself, confirm it opens a WebView with the campaign's details.
5. Click on "Go Back" button, confirm it closes the WebView.
6. Click on "Create a campaign", confirm it opens a WebView with the creation flow.

### Images/gif
<img width=320 src="https://github.com/woocommerce/woocommerce-android/assets/1657201/2bde0d00-d0d6-4a50-ac31-5f28446178bd"/>

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
