### PR TITLE
Save configuration selection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationFragment.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -48,6 +49,9 @@ class ProductConfigurationFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+                is MultiLiveEvent.Event.ExitWithResult<*> -> {
+                    navigateBackWithResult(PRODUCT_CONFIGURATION_RESULT, event.data)
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
@@ -123,45 +123,57 @@ fun ProductConfigurationScreen(
                 val hasOptionalRule = childMapEntry.value.containsKey(OptionalRule.KEY)
                 val hasQuantityAndOptionalRules = hasQuantityRule && hasOptionalRule
 
-                if (hasQuantityAndOptionalRules) {
-                    OptionalQuantityProductItem(
-                        title = item.title,
-                        imageUrl = item.imageUrl,
-                        info = null,
-                        quantity = childMapEntry.value[QuantityRule.KEY]?.toInt() ?: 0,
-                        onQuantityChanged = { value ->
-                            onUpdateChildrenConfiguration(item.id, QuantityRule.KEY, value.toString())
-                        },
-                        isIncluded = childMapEntry.value[OptionalRule.KEY]?.toBoolean() ?: false,
-                        onSwitchChanged = { value ->
-                            onUpdateChildrenConfiguration(item.id, OptionalRule.KEY, value.toString())
-                        }
-                    )
-                } else {
-                    if (hasQuantityRule) {
-                        QuantityProductItem(
+                    if (hasQuantityAndOptionalRules) {
+                        OptionalQuantityProductItem(
                             title = item.title,
                             imageUrl = item.imageUrl,
                             info = null,
                             quantity = childMapEntry.value[QuantityRule.KEY]?.toInt() ?: 0,
                             onQuantityChanged = { value ->
                                 onUpdateChildrenConfiguration(item.id, QuantityRule.KEY, value.toString())
-                            }
-                        )
-                    }
-                    if (hasOptionalRule) {
-                        OptionalProductItem(
-                            title = item.title,
-                            imageUrl = item.imageUrl,
-                            info = null,
+                            },
                             isIncluded = childMapEntry.value[OptionalRule.KEY]?.toBoolean() ?: false,
                             onSwitchChanged = { value ->
                                 onUpdateChildrenConfiguration(item.id, OptionalRule.KEY, value.toString())
                             }
                         )
+                    } else {
+                        if (hasQuantityRule) {
+                            QuantityProductItem(
+                                title = item.title,
+                                imageUrl = item.imageUrl,
+                                info = null,
+                                quantity = childMapEntry.value[QuantityRule.KEY]?.toInt() ?: 0,
+                                onQuantityChanged = { value ->
+                                    onUpdateChildrenConfiguration(item.id, QuantityRule.KEY, value.toString())
+                                }
+                            )
+                        }
+                        if (hasOptionalRule) {
+                            OptionalProductItem(
+                                title = item.title,
+                                imageUrl = item.imageUrl,
+                                info = null,
+                                isIncluded = childMapEntry.value[OptionalRule.KEY]?.toBoolean() ?: false,
+                                onSwitchChanged = { value ->
+                                    onUpdateChildrenConfiguration(item.id, OptionalRule.KEY, value.toString())
+                                }
+                            )
+                        }
                     }
                 }
             }
+            Divider(
+                color = colorResource(id = R.color.divider_color),
+                thickness = dimensionResource(id = R.dimen.minor_10)
+            )
+            WCColoredButton(
+                onClick = onSaveConfigurationClick,
+                text = stringResource(id = R.string.save_configuration),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(dimensionResource(id = R.dimen.major_100))
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
@@ -108,7 +108,7 @@ fun ProductConfigurationScreen(
     modifier: Modifier = Modifier
 ) {
     Surface {
-        Column (modifier = modifier) {
+        Column(modifier = modifier) {
             LazyColumn(Modifier.weight(1f)) {
                 productRules.isConfigurable()
                 val configurationItems = productConfiguration.childrenConfiguration?.entries?.toList() ?: emptyList()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
@@ -10,13 +10,15 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
@@ -55,6 +57,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 internal const val OUTLINED_BORDER_OPACITY = 0.14f
@@ -87,7 +90,7 @@ fun ProductConfigurationScreen(viewModel: ProductConfigurationViewModel) {
                     productConfiguration = state.productConfiguration,
                     productsInfo = state.productsInfo,
                     onUpdateChildrenConfiguration = viewModel::onUpdateChildrenConfiguration,
-                    onSaveConfigurationClick = {},
+                    onSaveConfigurationClick = viewModel::onSaveConfiguration,
                     modifier = Modifier.padding(padding)
                 )
             }
@@ -105,23 +108,23 @@ fun ProductConfigurationScreen(
     modifier: Modifier = Modifier
 ) {
     Surface {
-        Column(modifier.fillMaxSize()) {
-            productRules.isConfigurable()
-            onSaveConfigurationClick()
-            productConfiguration.childrenConfiguration?.entries?.forEach { childMapEntry ->
-
-                val item = productsInfo.getOrDefault(
-                    childMapEntry.key,
-                    ProductInfo(
+        Column (modifier = modifier) {
+            LazyColumn(Modifier.weight(1f)) {
+                productRules.isConfigurable()
+                val configurationItems = productConfiguration.childrenConfiguration?.entries?.toList() ?: emptyList()
+                items(configurationItems) { childMapEntry ->
+                    val item = productsInfo.getOrDefault(
                         childMapEntry.key,
-                        stringResource(id = R.string.default_product_title, childMapEntry.key),
-                        null
+                        ProductInfo(
+                            childMapEntry.key,
+                            stringResource(id = R.string.default_product_title, childMapEntry.key),
+                            null
+                        )
                     )
-                )
 
-                val hasQuantityRule = childMapEntry.value.containsKey(QuantityRule.KEY)
-                val hasOptionalRule = childMapEntry.value.containsKey(OptionalRule.KEY)
-                val hasQuantityAndOptionalRules = hasQuantityRule && hasOptionalRule
+                    val hasQuantityRule = childMapEntry.value.containsKey(QuantityRule.KEY)
+                    val hasOptionalRule = childMapEntry.value.containsKey(OptionalRule.KEY)
+                    val hasQuantityAndOptionalRules = hasQuantityRule && hasOptionalRule
 
                     if (hasQuantityAndOptionalRules) {
                         OptionalQuantityProductItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.creation.configuration
 
+import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.orders.creation.GetProductRules
@@ -13,6 +14,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
@@ -24,11 +26,13 @@ class ProductConfigurationViewModel @Inject constructor(
 
     private val navArgs: ProductConfigurationFragmentArgs by savedState.navArgs()
 
+    private val productId = navArgs.productId
+
     private val rules = MutableStateFlow<ProductRules?>(null)
 
     private val configuration = MutableStateFlow<ProductConfiguration?>(null)
 
-    private val productsInformation = getChildrenProductInfo(navArgs.productId)
+    private val productsInformation = getChildrenProductInfo(productId)
 
     val viewState = combine(
         flow = rules.drop(1),
@@ -63,6 +67,12 @@ class ProductConfigurationViewModel @Inject constructor(
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
+    fun onSaveConfiguration() {
+        configuration.value?.let {
+            triggerEvent(MultiLiveEvent.Event.ExitWithResult(ProductConfigurationResult(productId, it)))
+        } ?: triggerEvent(MultiLiveEvent.Event.Exit)
+    }
+
     sealed class ViewState {
         object Loading : ViewState()
 
@@ -80,3 +90,9 @@ data class ProductInfo(
     val title: String,
     val imageUrl: String?
 )
+
+@Parcelize
+data class ProductConfigurationResult(
+    val productId: Long,
+    val productConfiguration: ProductConfiguration
+) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
@@ -14,6 +14,8 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.orders.creation.configuration.ProductConfigurationFragment.Companion.PRODUCT_CONFIGURATION_RESULT
+import com.woocommerce.android.ui.orders.creation.configuration.ProductConfigurationResult
 import com.woocommerce.android.ui.products.ProductFilterResult
 import com.woocommerce.android.ui.products.ProductListFragment.Companion.PRODUCT_FILTER_RESULT_KEY
 import com.woocommerce.android.ui.products.ProductNavigationTarget
@@ -88,6 +90,10 @@ class ProductSelectorFragment : BaseFragment() {
                 productCategory = result.productCategory,
                 productCategoryName = result.productCategoryName
             )
+        }
+
+        handleResult<ProductConfigurationResult>(PRODUCT_CONFIGURATION_RESULT) { result ->
+            viewModel.onConfigurationChanged(result.productId, result.productConfiguration)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -330,7 +330,9 @@ class ProductSelectorViewModel @Inject constructor(
                 handleVariationItemTap(item, productSource)
             }
 
-            is ListItem.ConfigurableListItem -> { handleConfigurableItemTap(item) }
+            is ListItem.ConfigurableListItem -> {
+                handleConfigurableItemTap(item)
+            }
         }
     }
 
@@ -354,9 +356,17 @@ class ProductSelectorViewModel @Inject constructor(
     }
 
     private fun handleConfigurableItemTap(item: ListItem.ConfigurableListItem) {
-        triggerEvent(
-            ProductNavigationTarget.NavigateToProductConfiguration(item.id)
-        )
+        if (selectedItems.value.containsItemWith(item.id)) {
+            tracker.trackItemUnselected(productSelectorFlow)
+            selectedItemsSource.remove(item.id)
+            selectedItems.update { items ->
+                items.filter { it.id != item.id }
+            }
+        } else {
+            triggerEvent(
+                ProductNavigationTarget.NavigateToProductConfiguration(item.id)
+            )
+        }
     }
 
     private fun handleNonVariableProductItemTap(
@@ -546,6 +556,14 @@ class ProductSelectorViewModel @Inject constructor(
     fun onSearchTypeChanged(@StringRes searchType: Int) {
         this.searchState.update {
             it.copy(searchType = SearchType.fromLabelResId(searchType)!!)
+        }
+    }
+
+    fun onConfigurationChanged(productId: Long, productConfiguration: ProductConfiguration) {
+        launch {
+            selectedItems.update { items ->
+                items.filter { it.id == productId } + SelectedItem.ConfigurableProduct(productId, productConfiguration)
+            }
         }
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3725,4 +3725,5 @@
     <string name="extension_configure_button">Configure</string>
     <string name="default_product_title">Product %s</string>
     <string name="product_configuration_title">Configuration</string>
+    <string name="save_configuration">Save configuration</string>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9541 

### Why
As part of the support for extensions milestone 2, we are working on support bundle products in the order creation flow.

### Description
This PR adds selection support product bundles in the order creation flow. The changes introduced here focused mainly on the UI changes needed to select a product bundle. More advanced behaviors will be added on  different PRs.

### Testing instructions

#### Prerequisites 

1.  Install the product bundles extension
2. Create a bundle product

#### TC1
1. Go to the orders tab
2. Tap on create new order
3. Tap on Add products
4. Select a bundle
5. Check that the app navigates to the configuration screen
6. Tap on Save configuration
7. Check that the bundle product is selected
8. Tap on the bundle product again
9. Check that the bundle product is unselected

### Images/gif


https://github.com/woocommerce/woocommerce-android/assets/18119390/34411ba8-1340-46d5-8899-12769e678b74


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
