### PR TITLE
Create bundle with simple products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.sumByBigDecimal
 import com.woocommerce.android.extensions.sumByFloat
 import com.woocommerce.android.model.Order.OrderStatus
+import com.woocommerce.android.ui.orders.creation.configuration.ProductConfiguration
 import com.woocommerce.android.ui.products.ProductHelper
 import com.woocommerce.android.util.AddressUtils
 import kotlinx.parcelize.IgnoredOnParcel
@@ -104,7 +105,8 @@ data class Order(
         val total: BigDecimal,
         val variationId: Long,
         val attributesList: List<Attribute>,
-        val parent: Long? = null
+        val parent: Long? = null,
+        val configuration: ProductConfiguration? = null
     ) : Parcelable {
         @IgnoredOnParcel
         val uniqueId: Long = ProductHelper.productOrVariationId(productId, variationId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CreateOrderItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CreateOrderItem.kt
@@ -26,10 +26,11 @@ class CreateOrderItem @Inject constructor(
 
             variationId?.let {
                 if (product != null) {
-                    variationDetailRepository.getVariation(remoteProductId, it)?.createItem(product, productConfiguration)
+                    variationDetailRepository.getVariation(remoteProductId, it)
+                        ?.createItem(product, productConfiguration)
                 } else null
             } ?: product?.createItem(productConfiguration)
-            ?: Order.Item.EMPTY.copy(productId = remoteProductId, variationId = variationId ?: 0L)
+                ?: Order.Item.EMPTY.copy(productId = remoteProductId, variationId = variationId ?: 0L)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CreateOrderItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CreateOrderItem.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.creation
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductVariation
+import com.woocommerce.android.ui.orders.creation.configuration.ProductConfiguration
 import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.ui.products.variations.VariationDetailRepository
 import com.woocommerce.android.util.CoroutineDispatchers
@@ -15,20 +16,24 @@ class CreateOrderItem @Inject constructor(
     private val variationDetailRepository: VariationDetailRepository,
     private val productDetailRepository: ProductDetailRepository
 ) {
-    suspend operator fun invoke(remoteProductId: Long, variationId: Long? = null): Order.Item {
+    suspend operator fun invoke(
+        remoteProductId: Long,
+        variationId: Long? = null,
+        productConfiguration: ProductConfiguration? = null
+    ): Order.Item {
         return withContext(coroutineDispatchers.io) {
             val product = productDetailRepository.getProduct(remoteProductId)
 
             variationId?.let {
                 if (product != null) {
-                    variationDetailRepository.getVariation(remoteProductId, it)?.createItem(product)
+                    variationDetailRepository.getVariation(remoteProductId, it)?.createItem(product, productConfiguration)
                 } else null
-            } ?: product?.createItem()
-                ?: Order.Item.EMPTY.copy(productId = remoteProductId, variationId = variationId ?: 0L)
+            } ?: product?.createItem(productConfiguration)
+            ?: Order.Item.EMPTY.copy(productId = remoteProductId, variationId = variationId ?: 0L)
         }
     }
 
-    private fun Product.createItem(): Order.Item = Order.Item(
+    private fun Product.createItem(productConfiguration: ProductConfiguration?): Order.Item = Order.Item(
         itemId = 0L,
         productId = remoteId,
         variationId = 0L,
@@ -40,9 +45,13 @@ class CreateOrderItem @Inject constructor(
         total = price ?: BigDecimal.ZERO,
         sku = sku,
         attributesList = emptyList(),
+        configuration = productConfiguration
     )
 
-    private fun ProductVariation.createItem(parentProduct: Product): Order.Item = Order.Item(
+    private fun ProductVariation.createItem(
+        parentProduct: Product,
+        productConfiguration: ProductConfiguration?
+    ): Order.Item = Order.Item(
         itemId = 0L,
         productId = remoteProductId,
         variationId = remoteVariationId,
@@ -55,6 +64,7 @@ class CreateOrderItem @Inject constructor(
         sku = sku,
         attributesList = attributes
             .filterNot { it.name.isNullOrEmpty() || it.option.isNullOrEmpty() }
-            .map { Order.Item.Attribute(it.name!!, it.option!!) }
+            .map { Order.Item.Attribute(it.name!!, it.option!!) },
+        configuration = productConfiguration
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/GetProductRules.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/GetProductRules.kt
@@ -25,7 +25,9 @@ class GetProductRules @Inject constructor(
     private suspend fun getRules(product: Product): ProductRules? {
         val isBundle = product.productType == ProductType.BUNDLE
         return if (isBundle) {
-            val builder = ProductRules.Builder()
+            val builder = ProductRules.Builder().apply {
+                productType = ProductType.BUNDLE
+            }
             getBundledProducts(product.remoteId).first().forEach { bundledProduct ->
                 builder.setChildQuantityRules(
                     itemId = bundledProduct.id,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/ListItemMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/ListItemMapper.kt
@@ -1,0 +1,60 @@
+package com.woocommerce.android.ui.orders.creation
+
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.creation.configuration.ConfigurationType
+import com.woocommerce.android.ui.orders.creation.configuration.OptionalRule
+import com.woocommerce.android.ui.orders.creation.configuration.ProductConfiguration
+import com.woocommerce.android.ui.orders.creation.configuration.QuantityRule
+import com.woocommerce.android.ui.products.GetBundledProducts
+import kotlinx.coroutines.flow.first
+import org.wordpress.android.fluxc.utils.putIfNotNull
+import javax.inject.Inject
+
+class ListItemMapper @Inject constructor(private val getBundledProducts: GetBundledProducts) {
+    suspend fun toRawListItem(item: Order.Item): Map<String, Any> {
+        return buildMap {
+            item.itemId.takeIf { it != 0L }?.let { put("id", it) }
+            put("name", item.name)
+            put("product_id", item.productId)
+            put("variation_id", item.variationId)
+            put("quantity", item.quantity.toString())
+            put("subtotal", item.subtotal.toString())
+            put("total", item.subtotal.toString())
+            item.configuration?.let {
+                getConfiguration(item.productId,it)?.let { keyConfigurationPair ->
+                    put(keyConfigurationPair.first, keyConfigurationPair.second)
+                }
+            }
+        }
+    }
+
+    private suspend fun getConfiguration(
+        productId: Long,
+        configuration: ProductConfiguration
+    ): Pair<String, MutableList<Map<String, Any>>>? {
+        return when (configuration.configurationType) {
+            ConfigurationType.BUNDLE -> {
+                val result = mutableListOf<Map<String, Any>>()
+                val childrenProducts = getBundledProducts(productId).first().associateBy { it.id }
+                configuration.childrenConfiguration?.let { idConfigurationPair ->
+                    for (childConfiguration in idConfigurationPair) {
+                        val item = childrenProducts[childConfiguration.key] ?: continue
+                        val rawChildConfiguration = buildMap {
+                            put("bundled_item_id", item.id)
+                            put("product_id", item.bundledProductId)
+                            childConfiguration.value.forEach { rule ->
+                                when (rule.key) {
+                                    QuantityRule.KEY -> putIfNotNull("quantity" to rule.value)
+                                    OptionalRule.KEY -> putIfNotNull("optional_selected" to rule.value)
+                                }
+                            }
+                        }
+                        result.add(rawChildConfiguration)
+                    }
+                }
+                Pair("bundle_configuration", result)
+            }
+            ConfigurationType.UNKNOWN -> null
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/ListItemMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/ListItemMapper.kt
@@ -21,7 +21,7 @@ class ListItemMapper @Inject constructor(private val getBundledProducts: GetBund
             put("subtotal", item.subtotal.toString())
             put("total", item.subtotal.toString())
             item.configuration?.let {
-                getConfiguration(item.productId,it)?.let { keyConfigurationPair ->
+                getConfiguration(item.productId, it)?.let { keyConfigurationPair ->
                     put(keyConfigurationPair.first, keyConfigurationPair.second)
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -439,13 +439,23 @@ class OrderCreateEditViewModel @Inject constructor(
                         none { it.productId == selectedItem.id }
                     }
                 }.map {
-                    if (it is SelectedItem.ProductVariation) {
-                        createOrderItem(it.productId, it.variationId)
-                    } else {
-                        createOrderItem(it.id)
+                    when (it) {
+                        is SelectedItem.ProductVariation -> {
+                            createOrderItem(it.productId, it.variationId)
+                        }
+
+                        is SelectedItem.ConfigurableProduct -> {
+                            createOrderItem(
+                                remoteProductId = it.productId,
+                                productConfiguration = it.configuration
+                            )
+                        }
+
+                        else -> {
+                            createOrderItem(it.id)
+                        }
                     }
                 }
-
                 _orderDraft.update { order -> order.updateItems(order.items + itemsToAdd) }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -389,7 +389,7 @@ class OrderCreateEditViewModel @Inject constructor(
             it.removeItem(item)
         }
     }
-
+    @Suppress("LongMethod")
     fun onProductsSelected(
         selectedItems: Collection<SelectedItem>,
         source: ScanningSource? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationViewModel.kt
@@ -59,7 +59,11 @@ class ProductConfigurationViewModel @Inject constructor(
         configuration.value?.let { currentConfiguration ->
             currentConfiguration.updateChildrenConfiguration(itemId, ruleKey, value)
             configuration.value =
-                ProductConfiguration(currentConfiguration.configuration, currentConfiguration.childrenConfiguration)
+                ProductConfiguration(
+                    currentConfiguration.configurationType,
+                    currentConfiguration.configuration,
+                    currentConfiguration.childrenConfiguration
+                )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductRules.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductRules.kt
@@ -114,7 +114,7 @@ class ProductConfiguration(
 enum class ConfigurationType { BUNDLE, UNKNOWN }
 
 fun ProductType.getConfigurationType(): ConfigurationType {
-    return when(this){
+    return when (this) {
         ProductType.BUNDLE -> ConfigurationType.BUNDLE
         else -> ConfigurationType.UNKNOWN
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
@@ -71,7 +71,8 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
             orderMapper = mock(),
             dispatchers = coroutinesTestRule.testDispatchers,
             wooCommerceStore = wooCommerceStore,
-            analyticsTrackerWrapper = trackerWrapper
+            analyticsTrackerWrapper = trackerWrapper,
+            listItemMapper = mock()
         )
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.50.0'
+    fluxCVersion = '2875-8af63519847c53c67232d1cee2668b52a89d5640'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
⚠️ This PR depends on this FluxC PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2875

Part of: #9541 

### Why
As part of the support for extensions milestone 2, we are working on support bundle products in the order creation flow.

### Description
This PR adds the necessary changes to create a bundle product using the app. Editing and configuration validation are handled in the upcoming PRs. I changed the LineItem field of `UpdateOrderRequest` to be a map instead of the LineItem model. The map will allow us to add extra fields when needed, as in the case of product bundles, adding the `bundle_configuration` field.

### Testing instructions
1. Open the Orders tab
2. Tap on create new order (+)
3. Tap on add products
4. Select a bundle product
5. Configure the selected bundle
6. Select the bundle product
7. Tap on create
8. Check that the bundle product is created successfully

⚠️ The validation configuration will be handled in a different PR, please ensure that you use a valid configuration to create the bundle

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/8789e949-fdf0-4b0d-a2db-18f66fd7a459

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
