### PR TITLE
[Blaze] Extract Blaze URL related functions to a separate class

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeBannerViewModel.kt
@@ -10,8 +10,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_ENTRY_POINT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource.MY_STORE_BANNER
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.products.ProductListRepository
 import com.woocommerce.android.ui.products.ProductStatus.PUBLISH
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -26,6 +25,7 @@ import javax.inject.Inject
 class BlazeBannerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val isBlazeEnabled: IsBlazeEnabled,
+    private val blazeUrlsHelper: BlazeUrlsHelper,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val productRepository: ProductListRepository,
     private val appPrefsWrapper: AppPrefsWrapper,
@@ -36,7 +36,7 @@ class BlazeBannerViewModel @Inject constructor(
     private val _isBlazeBannerVisible = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = false)
     val isBlazeBannerVisible = _isBlazeBannerVisible.asLiveData()
 
-    private var blazeBannerSource: BlazeFlowSource = MY_STORE_BANNER
+    private var blazeBannerSource: BlazeFlowSource = BlazeFlowSource.MY_STORE_BANNER
 
     fun updateBlazeBannerStatus() {
         launch {
@@ -78,7 +78,7 @@ class BlazeBannerViewModel @Inject constructor(
         )
         triggerEvent(
             OpenBlazeEvent(
-                url = isBlazeEnabled.buildUrlForSite(MY_STORE_BANNER),
+                url = blazeUrlsHelper.buildUrlForSite(BlazeFlowSource.MY_STORE_BANNER),
                 source = blazeBannerSource
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUrlsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUrlsHelper.kt
@@ -24,9 +24,9 @@ class BlazeUrlsHelper @Inject constructor(
         return BLAZE_CREATION_FLOW_PRODUCT.format(getSiteUrl(), productId, source.trackingName)
     }
 
-    fun buildCampaignsListUrl(): String = "${BASE_URL}/campaigns/${getSiteUrl()}"
+    fun buildCampaignsListUrl(): String = "$BASE_URL/campaigns/${getSiteUrl()}"
 
-    fun buildCampaignDetailsUrl(campaignId: Int): String = "${BASE_URL}/campaigns/$campaignId/${getSiteUrl()}"
+    fun buildCampaignDetailsUrl(campaignId: Int): String = "$BASE_URL/campaigns/$campaignId/${getSiteUrl()}"
 
     private fun getSiteUrl() = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUrlsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUrlsHelper.kt
@@ -8,33 +8,27 @@ class BlazeUrlsHelper @Inject constructor(
 ) {
     companion object {
         private const val HTTP_PATTERN = "(https?://)"
-        private const val BASE_URL = "https://wordpress.com/advertising/"
-        private const val BLAZE_CREATION_FLOW_PRODUCT = "$BASE_URL%s?blazepress-widget=post-%d&_source=%s"
-        private const val BLAZE_CREATION_FLOW_SITE = "$BASE_URL%s?_source=%s"
+        private const val BASE_URL = "https://wordpress.com/advertising"
+        private const val BLAZE_CREATION_FLOW_PRODUCT = "$BASE_URL/%s?blazepress-widget=post-%d&_source=%s"
+        private const val BLAZE_CREATION_FLOW_SITE = "$BASE_URL/%s?_source=%s"
 
         // Analytics
         const val BLAZEPRESS_WIDGET = "blazepress-widget"
     }
 
     fun buildUrlForSite(source: BlazeFlowSource): String {
-        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
-        return BLAZE_CREATION_FLOW_SITE.format(siteUrlWithoutProtocol, source.trackingName)
+        return BLAZE_CREATION_FLOW_SITE.format(getSiteUrl(), source.trackingName)
     }
 
     fun buildUrlForProduct(productId: Long, source: BlazeFlowSource): String {
-        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
-        return BLAZE_CREATION_FLOW_PRODUCT.format(siteUrlWithoutProtocol, productId, source.trackingName)
+        return BLAZE_CREATION_FLOW_PRODUCT.format(getSiteUrl(), productId, source.trackingName)
     }
 
-    fun buildCampaignsListUrl(): String {
-        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
-        return "${BASE_URL}campaigns/$siteUrlWithoutProtocol"
-    }
+    fun buildCampaignsListUrl(): String = "${BASE_URL}/campaigns/${getSiteUrl()}"
 
-    fun buildCampaignDetailsUrl(campaignId: Int): String {
-        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
-        return "${BASE_URL}campaigns/$campaignId/$siteUrlWithoutProtocol"
-    }
+    fun buildCampaignDetailsUrl(campaignId: Int): String = "${BASE_URL}/campaigns/$campaignId/${getSiteUrl()}"
+
+    private fun getSiteUrl() = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
 
     enum class BlazeFlowSource(val trackingName: String) {
         PRODUCT_DETAIL_OVERFLOW_MENU("product_more_menu"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUrlsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUrlsHelper.kt
@@ -1,0 +1,45 @@
+package com.woocommerce.android.ui.blaze
+
+import com.woocommerce.android.tools.SelectedSite
+import javax.inject.Inject
+
+class BlazeUrlsHelper @Inject constructor(
+    private val selectedSite: SelectedSite
+) {
+    companion object {
+        private const val HTTP_PATTERN = "(https?://)"
+        private const val BASE_URL = "https://wordpress.com/advertising/"
+        private const val BLAZE_CREATION_FLOW_PRODUCT = "$BASE_URL%s?blazepress-widget=post-%d&_source=%s"
+        private const val BLAZE_CREATION_FLOW_SITE = "$BASE_URL%s?_source=%s"
+
+        // Analytics
+        const val BLAZEPRESS_WIDGET = "blazepress-widget"
+    }
+
+    fun buildUrlForSite(source: BlazeFlowSource): String {
+        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
+        return BLAZE_CREATION_FLOW_SITE.format(siteUrlWithoutProtocol, source.trackingName)
+    }
+
+    fun buildUrlForProduct(productId: Long, source: BlazeFlowSource): String {
+        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
+        return BLAZE_CREATION_FLOW_PRODUCT.format(siteUrlWithoutProtocol, productId, source.trackingName)
+    }
+
+    fun buildCampaignsListUrl(): String {
+        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
+        return "${BASE_URL}campaigns/$siteUrlWithoutProtocol"
+    }
+
+    fun buildCampaignDetailsUrl(campaignId: Int): String {
+        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
+        return "${BASE_URL}campaigns/$campaignId/$siteUrlWithoutProtocol"
+    }
+
+    enum class BlazeFlowSource(val trackingName: String) {
+        PRODUCT_DETAIL_OVERFLOW_MENU("product_more_menu"),
+        MORE_MENU_ITEM("menu"),
+        MY_STORE_BANNER("my_store_banner"),
+        PRODUCT_LIST_BANNER("product_list_banner"),
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeWebViewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeWebViewViewModel.kt
@@ -9,8 +9,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_FLOW_STARTED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.Companion.BLAZEPRESS_WIDGET
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -79,7 +78,7 @@ class BlazeWebViewViewModel @Inject constructor(
         val uri = Uri.parse(url)
         return when {
             uri.fragment != null -> BlazeFlowStep.fromString(uri.fragment!!)
-            uri.getQueryParameter(BLAZEPRESS_WIDGET) != null -> BlazeFlowStep.STEP_1
+            uri.getQueryParameter(BlazeUrlsHelper.BLAZEPRESS_WIDGET) != null -> BlazeFlowStep.STEP_1
             isAdvertisingCampaign(uri.toString()) -> BlazeFlowStep.CAMPAIGNS_LIST
             matchAdvertisingPath(uri.path) -> BlazeFlowStep.PRODUCTS_LIST
             else -> BlazeFlowStep.UNSPECIFIED

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -11,46 +11,9 @@ class IsBlazeEnabled @Inject constructor(
     private val selectedSite: SelectedSite,
     private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
 ) {
-    companion object {
-        const val HTTP_PATTERN = "(https?://)"
-        private const val BASE_URL = "https://wordpress.com/advertising/"
-        const val BLAZE_CREATION_FLOW_PRODUCT = "$BASE_URL%s?blazepress-widget=post-%d&_source=%s"
-        const val BLAZE_CREATION_FLOW_SITE = "$BASE_URL%s?_source=%s"
-
-        // Analytics
-        const val BLAZEPRESS_WIDGET = "blazepress-widget"
-    }
-
     suspend operator fun invoke(): Boolean = FeatureFlag.BLAZE.isEnabled() &&
         selectedSite.getIfExists()?.isAdmin ?: false &&
         selectedSite.getIfExists()?.canBlaze ?: false &&
         selectedSite.getIfExists()?.isSitePublic ?: false &&
         isRemoteFeatureFlagEnabled(WOO_BLAZE)
-
-    fun buildUrlForSite(source: BlazeFlowSource): String {
-        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
-        return BLAZE_CREATION_FLOW_SITE.format(siteUrlWithoutProtocol, source.trackingName)
-    }
-
-    fun buildUrlForProduct(productId: Long, source: BlazeFlowSource): String {
-        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
-        return BLAZE_CREATION_FLOW_PRODUCT.format(siteUrlWithoutProtocol, productId, source.trackingName)
-    }
-
-    fun buildCampaignsListUrl(): String {
-        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
-        return "${BASE_URL}campaigns/$siteUrlWithoutProtocol"
-    }
-
-    fun buildCampaignDetailsUrl(campaignId: Int): String {
-        val siteUrlWithoutProtocol = selectedSite.get().url.replace(Regex(HTTP_PATTERN), "")
-        return "${BASE_URL}campaigns/$campaignId/$siteUrlWithoutProtocol"
-    }
-
-    enum class BlazeFlowSource(val trackingName: String) {
-        PRODUCT_DETAIL_OVERFLOW_MENU("product_more_menu"),
-        MORE_MENU_ITEM("menu"),
-        MY_STORE_BANNER("my_store_banner"),
-        PRODUCT_LIST_BANNER("product_list_banner"),
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.products.ProductListRepository
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.util.FeatureFlag
@@ -28,7 +28,7 @@ class MyStoreBlazeViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     observeMostRecentBlazeCampaign: ObserveMostRecentBlazeCampaign,
     private val productListRepository: ProductListRepository,
-    private val isBlazeEnabled: IsBlazeEnabled
+    private val blazeUrlsHelper: BlazeUrlsHelper
 ) : ScopedViewModel(savedStateHandle) {
     @OptIn(ExperimentalCoroutinesApi::class)
     val blazeCampaignState = flow {
@@ -48,9 +48,9 @@ class MyStoreBlazeViewModel @Inject constructor(
     private fun prepareUiForNoCampaign(): Flow<MyStoreBlazeCampaignState> {
         fun launchCampaignCreation(productId: Long?) {
             val url = if (productId != null) {
-                isBlazeEnabled.buildUrlForProduct(productId, BlazeFlowSource.MY_STORE_BANNER)
+                blazeUrlsHelper.buildUrlForProduct(productId, BlazeFlowSource.MY_STORE_BANNER)
             } else {
-                isBlazeEnabled.buildUrlForSite(BlazeFlowSource.MY_STORE_BANNER)
+                blazeUrlsHelper.buildUrlForSite(BlazeFlowSource.MY_STORE_BANNER)
             }
             triggerEvent(LaunchBlazeCampaignCreation(url))
         }
@@ -95,8 +95,8 @@ class MyStoreBlazeViewModel @Inject constructor(
                 onCampaignClicked = {
                     triggerEvent(
                         ShowCampaignDetails(
-                            url = isBlazeEnabled.buildCampaignDetailsUrl(campaign.campaignId),
-                            urlToTriggerExit = isBlazeEnabled.buildCampaignsListUrl()
+                            url = blazeUrlsHelper.buildCampaignDetailsUrl(campaign.campaignId),
+                            urlToTriggerExit = blazeUrlsHelper.buildCampaignsListUrl()
                         )
                     )
                 },
@@ -105,7 +105,7 @@ class MyStoreBlazeViewModel @Inject constructor(
                 },
                 onCreateCampaignClicked = {
                     triggerEvent(
-                        LaunchBlazeCampaignCreation(isBlazeEnabled.buildUrlForSite(BlazeFlowSource.MY_STORE_BANNER))
+                        LaunchBlazeCampaignCreation(blazeUrlsHelper.buildUrlForSite(BlazeFlowSource.MY_STORE_BANNER))
                     )
                 }
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
@@ -28,11 +28,12 @@ class MyStoreBlazeViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     observeMostRecentBlazeCampaign: ObserveMostRecentBlazeCampaign,
     private val productListRepository: ProductListRepository,
+    private val isBlazeEnabled: IsBlazeEnabled,
     private val blazeUrlsHelper: BlazeUrlsHelper
 ) : ScopedViewModel(savedStateHandle) {
     @OptIn(ExperimentalCoroutinesApi::class)
     val blazeCampaignState = flow {
-        if (!FeatureFlag.BLAZE_ITERATION_2.isEnabled()) emit(MyStoreBlazeCampaignState.Hidden)
+        if (!FeatureFlag.BLAZE_ITERATION_2.isEnabled() || !isBlazeEnabled()) emit(MyStoreBlazeCampaignState.Hidden)
         else {
             emitAll(
                 observeMostRecentBlazeCampaign().flatMapLatest {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -22,9 +22,9 @@ import com.woocommerce.android.notifications.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.tools.connectionType
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource.MORE_MENU_ITEM
 import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
 import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.payments.taptopay.isAvailable
@@ -56,6 +56,7 @@ class MoreMenuViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
     private val isBlazeEnabled: IsBlazeEnabled,
+    private val blazeUrlsHelper: BlazeUrlsHelper,
 ) : ScopedViewModel(savedState) {
     val moreMenuViewState =
         combine(
@@ -138,7 +139,7 @@ class MoreMenuViewModel @Inject constructor(
     private suspend fun trackBlazeDisplayed() {
         if (isBlazeEnabled()) AnalyticsTracker.track(
             stat = BLAZE_ENTRY_POINT_DISPLAYED,
-            properties = mapOf(AnalyticsTracker.KEY_BLAZE_SOURCE to MORE_MENU_ITEM.trackingName)
+            properties = mapOf(AnalyticsTracker.KEY_BLAZE_SOURCE to BlazeFlowSource.MORE_MENU_ITEM.trackingName)
         )
     }
 
@@ -211,12 +212,12 @@ class MoreMenuViewModel @Inject constructor(
     private fun onPromoteProductsWithBlaze() {
         AnalyticsTracker.track(
             stat = BLAZE_ENTRY_POINT_TAPPED,
-            properties = mapOf(AnalyticsTracker.KEY_BLAZE_SOURCE to MORE_MENU_ITEM.trackingName)
+            properties = mapOf(AnalyticsTracker.KEY_BLAZE_SOURCE to BlazeFlowSource.MORE_MENU_ITEM.trackingName)
         )
         triggerEvent(
             MoreMenuEvent.OpenBlazeEvent(
-                url = isBlazeEnabled.buildUrlForSite(MORE_MENU_ITEM),
-                source = MORE_MENU_ITEM
+                url = blazeUrlsHelper.buildUrlForSite(BlazeFlowSource.MORE_MENU_ITEM),
+                source = BlazeFlowSource.MORE_MENU_ITEM
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -46,7 +46,7 @@ import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.blaze.BlazeBanner
 import com.woocommerce.android.ui.blaze.BlazeBannerViewModel
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.MyStoreBlazeView
 import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel
 import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.MyStoreBlazeCampaignState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -55,9 +55,9 @@ import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource.PRODUCT_DETAIL_OVERFLOW_MENU
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.media.getMediaUploadErrorMessage
 import com.woocommerce.android.ui.products.AddProductSource.STORE_ONBOARDING
@@ -146,7 +146,8 @@ class ProductDetailViewModel @Inject constructor(
     private val getBundledProductsCount: GetBundledProductsCount,
     private val getComponentProducts: GetComponentProducts,
     private val productListRepository: ProductListRepository,
-    private val isBlazeEnabled: IsBlazeEnabled
+    private val isBlazeEnabled: IsBlazeEnabled,
+    private val blazeUrlsHelper: BlazeUrlsHelper
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_PARAMETERS = "key_product_parameters"
@@ -267,7 +268,7 @@ class ProductDetailViewModel @Inject constructor(
         }.map { (productDraft, hasChanges) ->
             val canBeSavedAsDraft = isAddFlowEntryPoint &&
                 !isProductStoredAtSite &&
-                productDraft.status != ProductStatus.DRAFT
+                productDraft.status != DRAFT
             val isNotPublishedUnderCreation = isProductUnderCreation &&
                 productDraft.status != ProductStatus.PUBLISH &&
                 productDraft.status != ProductStatus.PRIVATE
@@ -405,7 +406,7 @@ class ProductDetailViewModel @Inject constructor(
             tracker.track(
                 AnalyticsEvent.PRODUCT_DETAIL_SHARE_BUTTON_TAPPED,
                 mapOf(
-                    AnalyticsTracker.KEY_SOURCE to source
+                    KEY_SOURCE to source
                 )
             )
 
@@ -452,16 +453,16 @@ class ProductDetailViewModel @Inject constructor(
     fun onBlazeClicked() {
         tracker.track(
             stat = BLAZE_ENTRY_POINT_TAPPED,
-            properties = mapOf(KEY_BLAZE_SOURCE to PRODUCT_DETAIL_OVERFLOW_MENU.trackingName)
+            properties = mapOf(KEY_BLAZE_SOURCE to BlazeFlowSource.PRODUCT_DETAIL_OVERFLOW_MENU.trackingName)
         )
         viewState.productDraft?.let {
             triggerEvent(
                 NavigateToBlazeWebView(
-                    url = isBlazeEnabled.buildUrlForProduct(
+                    url = blazeUrlsHelper.buildUrlForProduct(
                         productId = it.remoteId,
-                        source = PRODUCT_DETAIL_OVERFLOW_MENU
+                        source = BlazeFlowSource.PRODUCT_DETAIL_OVERFLOW_MENU
                     ),
-                    source = PRODUCT_DETAIL_OVERFLOW_MENU
+                    source = BlazeFlowSource.PRODUCT_DETAIL_OVERFLOW_MENU
                 )
             )
         }
@@ -837,7 +838,7 @@ class ProductDetailViewModel @Inject constructor(
             val (neutralAction, neutralBtnId) = if (isProductUnderCreation) {
                 Pair(
                     DialogInterface.OnClickListener { _, _ ->
-                        startPublishProduct(productStatus = ProductStatus.DRAFT, exitWhenDone = true)
+                        startPublishProduct(productStatus = DRAFT, exitWhenDone = true)
                     },
                     R.string.product_detail_save_as_draft
                 )
@@ -894,7 +895,7 @@ class ProductDetailViewModel @Inject constructor(
      * Called when the "Save as draft" button is clicked in Product detail screen
      */
     fun onSaveAsDraftButtonClicked() {
-        startPublishProduct(productStatus = ProductStatus.DRAFT)
+        startPublishProduct(productStatus = DRAFT)
     }
 
     /**
@@ -915,7 +916,7 @@ class ProductDetailViewModel @Inject constructor(
             ?.takeIf {
                 isProductStoredAtSite.not() and
                     (it.type == ProductType.VARIABLE.value) and
-                    (it.status == ProductStatus.DRAFT)
+                    (it.status == DRAFT)
             }
             ?.takeIf { addProduct(it).first }
             ?.let {
@@ -1007,7 +1008,7 @@ class ProductDetailViewModel @Inject constructor(
         productWasAdded: Boolean,
         requestedProductStatus: ProductStatus
     ): Int {
-        val isDraftStatus = requestedProductStatus == ProductStatus.DRAFT
+        val isDraftStatus = requestedProductStatus == DRAFT
         val isPublishStatus = requestedProductStatus == ProductStatus.PUBLISH
         val failedAddingProduct = !productWasAdded
         return when {
@@ -1022,7 +1023,7 @@ class ProductDetailViewModel @Inject constructor(
 
     private fun trackPublishing(it: Product) {
         val properties = mapOf("product_type" to it.productType.value.lowercase(Locale.ROOT))
-        val statId = if (it.status == ProductStatus.DRAFT) {
+        val statId = if (it.status == DRAFT) {
             AnalyticsEvent.ADD_PRODUCT_SAVE_AS_DRAFT_TAPPED
         } else {
             AnalyticsEvent.ADD_PRODUCT_PUBLISH_TAPPED
@@ -2342,7 +2343,7 @@ class ProductDetailViewModel @Inject constructor(
         return getBundledProductsCount(remoteId)
     }
 
-    suspend fun getComponents(remoteId: Long): List<Component>? {
+    suspend fun getComponents(remoteId: Long): List<Component> {
         return getComponentProducts(remoteId)
     }
 
@@ -2356,7 +2357,7 @@ class ProductDetailViewModel @Inject constructor(
         if (menuButtonsState.value?.showPromoteWithBlaze == true)
             tracker.track(
                 stat = BLAZE_ENTRY_POINT_DISPLAYED,
-                properties = mapOf(KEY_BLAZE_SOURCE to PRODUCT_DETAIL_OVERFLOW_MENU.trackingName)
+                properties = mapOf(KEY_BLAZE_SOURCE to BlazeFlowSource.PRODUCT_DETAIL_OVERFLOW_MENU.trackingName)
             )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -47,7 +47,7 @@ import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.blaze.BlazeBanner
 import com.woocommerce.android.ui.blaze.BlazeBannerViewModel
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource.PRODUCT_LIST_BANNER
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.main.MainActivity
@@ -176,7 +176,7 @@ class ProductListFragment :
     }
 
     private fun setUpBlazeBanner() {
-        blazeViewModel.setBlazeBannerSource(PRODUCT_LIST_BANNER)
+        blazeViewModel.setBlazeBannerSource(BlazeFlowSource.PRODUCT_LIST_BANNER)
         blazeViewModel.isBlazeBannerVisible.observe(viewLifecycleOwner) { isVisible ->
             if (!isVisible) binding.blazeBannerView.hide()
             else {

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -635,7 +635,7 @@
             app:argType="string" />
         <argument
             android:name="source"
-            app:argType="com.woocommerce.android.ui.blaze.IsBlazeEnabled$BlazeFlowSource"
+            app:argType="com.woocommerce.android.ui.blaze.BlazeUrlsHelper$BlazeFlowSource"
             app:nullable="false" />
     </fragment>
     <fragment

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
 import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
 import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
@@ -89,7 +90,8 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             resourceProvider = resourceProvider,
             tapToPayAvailabilityStatus = tapToPayAvailabilityStatus,
             appPrefsWrapper = appPrefsWrapper,
-            isBlazeEnabled = isBlazeEnabled
+            isBlazeEnabled = isBlazeEnabled,
+            blazeUrlsHelper = BlazeUrlsHelper(selectedSite)
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelGenerateVariationFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelGenerateVariationFlowTest.kt
@@ -113,6 +113,7 @@ class ProductDetailViewModelGenerateVariationFlowTest : BaseUnitTest() {
                 getComponentProducts = mock(),
                 productListRepository = mock(),
                 isBlazeEnabled = mock(),
+                blazeUrlsHelper = mock(),
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.media.ProductImagesServiceWrapper
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.media.MediaFileUploadHandler.ProductImageUploadData
@@ -263,7 +264,8 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                 getBundledProductsCount = mock(),
                 getComponentProducts = mock(),
                 productListRepository = mock(),
-                isBlazeEnabled = isBlazeEnabled
+                isBlazeEnabled = isBlazeEnabled,
+                blazeUrlsHelper = BlazeUrlsHelper(selectedSite),
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.media.ProductImagesServiceWrapper
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.products.ProductDetailViewModel.MenuButtonsState
@@ -185,7 +186,8 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 getBundledProductsCount = mock(),
                 getComponentProducts = mock(),
                 productListRepository = mock(),
-                isBlazeEnabled = isBlazeEnabled
+                isBlazeEnabled = isBlazeEnabled,
+                blazeUrlsHelper = BlazeUrlsHelper(selectedSite)
             )
         )
 


### PR DESCRIPTION
### Description
As discussed, this PR simply extracts all of the URL related functions to a separate class, instead of hijacking the `IsBlazeEnabled` one.

It also adds one missing bit in the commit 94f22c1ce9bc09e9b0e1a29e25bfed160276b89e to force hiding the MyStore view if the feature is not supported.

### Testing instructions
I think green CI should be enough, but a small smoke testing of Blaze features would be great too.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
