### PR TITLE
Feature/9967 tracking store creation started

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -841,6 +841,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     SITE_CREATION_TIMED_OUT(siteless = true),
     SITE_CREATION_PROPERTIES_OUT_OF_SYNC(siteless = true),
     SITE_CREATION_FREE_TRIAL_CREATED_SUCCESS,
+    SITE_CREATION_FLOW_STARTED,
 
     // Domain change
     CUSTOM_DOMAINS_STEP,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -498,6 +498,7 @@ class AnalyticsTracker private constructor(
         const val KEY_IAP_ELIGIBLE = "is_eligible"
         const val VALUE_LOGIN_EMAIL_ERROR = "login_email_error"
         const val VALUE_SWITCHING_STORE = "switching_store"
+        const val VALUE_STORE_PICKER = "store_picker"
         const val VALUE_PROLOGUE = "prologue"
         const val VALUE_LOGIN = "login"
         const val VALUE_OTHER = "other"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -872,6 +872,7 @@ class LoginActivity :
 
     override fun onLoginWithEmail(email: String?) {
         unifiedLoginTracker.setFlow(Flow.WORDPRESS_COM.value)
+        appPrefsWrapper.setStoreCreationSource(AnalyticsTracker.VALUE_LOGIN)
         changeFragment(
             fragment = WooLoginEmailFragment.newInstance(email) as Fragment,
             shouldAddToBackStack = true,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
-import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -33,24 +33,27 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
     @Inject
     lateinit var unifiedLoginTracker: UnifiedLoginTracker
 
+    @Inject
+    lateinit var appPrefsWrapper: AppPrefsWrapper
+
     private var prologueFinishedListener: PrologueFinishedListener? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         with(FragmentLoginPrologueBinding.bind(view)) {
             buttonLoginStore.setOnClickListener {
                 // Login with site address
-                AppPrefs.setStoreCreationSource(AnalyticsTracker.VALUE_LOGIN)
+                appPrefsWrapper.setStoreCreationSource(AnalyticsTracker.VALUE_LOGIN)
                 prologueFinishedListener?.onPrimaryButtonClicked()
             }
 
             buttonLoginWpcom.setOnClickListener {
                 // Login with WordPress.com account
-                AppPrefs.setStoreCreationSource(AnalyticsTracker.VALUE_LOGIN)
+                appPrefsWrapper.setStoreCreationSource(AnalyticsTracker.VALUE_LOGIN)
                 prologueFinishedListener?.onSecondaryButtonClicked()
             }
 
             buttonGetStarted.setOnClickListener {
-                AppPrefs.setStoreCreationSource(AnalyticsTracker.VALUE_PROLOGUE)
+                appPrefsWrapper.setStoreCreationSource(AnalyticsTracker.VALUE_PROLOGUE)
 
                 AnalyticsTracker.track(
                     AnalyticsEvent.LOGIN_PROLOGUE_CREATE_SITE_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
@@ -39,7 +39,6 @@ class SignUpViewModel @Inject constructor(
     private val appPrefs: AppPrefsWrapper,
     private val signUpCredentialsValidator: SignUpCredentialsValidator,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val prefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     lateinit var nextStep: NextStep
 
@@ -139,7 +138,7 @@ class SignUpViewModel @Inject constructor(
                     }
 
                     AccountCreationSuccess -> {
-                        prefsWrapper.setStoreCreationSource(AnalyticsTracker.VALUE_PROLOGUE)
+                        appPrefs.setStoreCreationSource(AnalyticsTracker.VALUE_PROLOGUE)
                         analyticsTrackerWrapper.track(stat = AnalyticsEvent.SIGNUP_SUCCESS)
                         _viewState.value = _viewState.value?.copy(isLoading = false)
                         if (nextStep == NextStep.STORE_CREATION) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpViewModel.kt
@@ -38,7 +38,8 @@ class SignUpViewModel @Inject constructor(
     private val networkStatus: NetworkStatus,
     private val appPrefs: AppPrefsWrapper,
     private val signUpCredentialsValidator: SignUpCredentialsValidator,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val prefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     lateinit var nextStep: NextStep
 
@@ -138,6 +139,7 @@ class SignUpViewModel @Inject constructor(
                     }
 
                     AccountCreationSuccess -> {
+                        prefsWrapper.setStoreCreationSource(AnalyticsTracker.VALUE_PROLOGUE)
                         analyticsTrackerWrapper.track(stat = AnalyticsEvent.SIGNUP_SUCCESS)
                         _viewState.value = _viewState.value?.copy(isLoading = false)
                         if (nextStep == NextStep.STORE_CREATION) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -188,7 +188,6 @@ class MoreMenuViewModel @Inject constructor(
         AnalyticsTracker.track(
             AnalyticsEvent.HUB_MENU_SWITCH_STORE_TAPPED
         )
-        appPrefsWrapper.setStoreCreationSource(AnalyticsTracker.VALUE_SWITCHING_STORE)
         triggerEvent(MoreMenuEvent.StartSitePickerEvent)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.moremenu
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
-import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_ENTRY_POINT_DISPLAYED
@@ -53,7 +52,6 @@ class MoreMenuViewModel @Inject constructor(
     private val planRepository: SitePlanRepository,
     private val resourceProvider: ResourceProvider,
     private val moreMenuNewFeatureHandler: MoreMenuNewFeatureHandler,
-    private val appPrefsWrapper: AppPrefsWrapper,
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
     private val isBlazeEnabled: IsBlazeEnabled,
 ) : ScopedViewModel(savedState) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/AddStoreBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/AddStoreBottomSheetFragment.kt
@@ -4,15 +4,21 @@ import android.os.Bundle
 import android.view.View
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.DialogSitePickerAddStoreBottomSheetBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class AddStoreBottomSheetFragment : WCBottomSheetDialogFragment(R.layout.dialog_site_picker_add_store_bottom_sheet) {
+    @Inject
+    lateinit var appPrefsWrapper: AppPrefsWrapper
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val binding = DialogSitePickerAddStoreBottomSheetBinding.bind(view)
@@ -20,11 +26,11 @@ class AddStoreBottomSheetFragment : WCBottomSheetDialogFragment(R.layout.dialog_
         binding.createNewStoreButton.setOnClickListener {
             AnalyticsTracker.track(
                 AnalyticsEvent.SITE_PICKER_CREATE_SITE_TAPPED,
-                mapOf(AnalyticsTracker.KEY_SOURCE to AppPrefs.getStoreCreationSource())
+                mapOf(AnalyticsTracker.KEY_SOURCE to appPrefsWrapper.getStoreCreationSource())
             )
             AnalyticsTracker.track(
                 AnalyticsEvent.SITE_CREATION_FLOW_STARTED,
-                mapOf(AnalyticsTracker.KEY_SOURCE to AppPrefs.getStoreCreationSource())
+                mapOf(AnalyticsTracker.KEY_SOURCE to appPrefsWrapper.getStoreCreationSource())
             )
             findNavController().navigateSafely(
                 directions = AddStoreBottomSheetFragmentDirections

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/AddStoreBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/AddStoreBottomSheetFragment.kt
@@ -22,6 +22,10 @@ class AddStoreBottomSheetFragment : WCBottomSheetDialogFragment(R.layout.dialog_
                 AnalyticsEvent.SITE_PICKER_CREATE_SITE_TAPPED,
                 mapOf(AnalyticsTracker.KEY_SOURCE to AppPrefs.getStoreCreationSource())
             )
+            AnalyticsTracker.track(
+                AnalyticsEvent.SITE_CREATION_FLOW_STARTED,
+                mapOf(AnalyticsTracker.KEY_SOURCE to AppPrefs.getStoreCreationSource())
+            )
             findNavController().navigateSafely(
                 directions = AddStoreBottomSheetFragmentDirections
                     .actionAddStoreBottomSheetFragmentToStoreCreationNativeFlow(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -641,6 +641,10 @@ class SitePickerViewModel @Inject constructor(
     }
 
     private fun startStoreCreationFlow() {
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.SITE_CREATION_FLOW_STARTED,
+            mapOf(AnalyticsTracker.KEY_SOURCE to appPrefsWrapper.getStoreCreationSource())
+        )
         appPrefsWrapper.markAsNewSignUp(newSignUp = false)
         triggerEvent(NavigateToStoreCreationEvent)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -441,6 +441,7 @@ class SitePickerViewModel @Inject constructor(
 
     fun onAddStoreClick() {
         analyticsTrackerWrapper.track(AnalyticsEvent.SITE_PICKER_ADD_A_STORE_TAPPED)
+        appPrefsWrapper.setStoreCreationSource(AnalyticsTracker.VALUE_STORE_PICKER)
         triggerEvent(NavigateToAddStoreEvent)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.moremenu
 
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
@@ -68,7 +67,6 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         on { moreMenuPaymentsFeatureWasClicked }.thenReturn(flowOf(true))
     }
 
-    private val appPrefsWrapper: AppPrefsWrapper = mock()
     private val isBlazeEnabled: IsBlazeEnabled = mock {
         onBlocking { invoke() } doReturn false
     }
@@ -88,7 +86,6 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             planRepository = planRepository,
             resourceProvider = resourceProvider,
             tapToPayAvailabilityStatus = tapToPayAvailabilityStatus,
-            appPrefsWrapper = appPrefsWrapper,
             isBlazeEnabled = isBlazeEnabled
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9967 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Please read the full description of the issue to have good context on the tracking we were missing. Further discussion on existing events and namings: p1697534054956069-slack-C03L1NF1EA3

Summarizing, this PR adds a new event with the following properties: 

- Event name: `site_creation_flow_started`
- Properties: `source`: `store_picker` | `prologue` | `login_email_error` | `login`

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Test that `site_creation_flow_started` is tracked with the correct source in the following scenarios: 

1. Create a new account
2. Notice how store creation flow is triggered automatically with `source: prologue` value
3. Navigate back from store creation flow to site picker
4. Click on Add Store button and trigger store creation flow again. This time the event `source: store_picker`
5. Log out
6. Log in again using the account you've just created that has no stores. Store creation should be triggered and event tracked with `source:login`