### PR TITLE
Campaign screen list logic

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
@@ -30,6 +30,11 @@ enum class CampaignStatusUi(
         textColor = R.color.blaze_campaign_status_in_moderation_text,
         backgroundColor = R.color.blaze_campaign_status_in_moderation_background
     ),
+    Scheduled(
+        statusDisplayText = R.string.blaze_campaign_status_scheduled,
+        textColor = R.color.blaze_campaign_status_completed_text,
+        backgroundColor = R.color.blaze_campaign_status_completed_background
+    ),
     Active(
         statusDisplayText = R.string.blaze_campaign_status_active,
         textColor = R.color.blaze_campaign_status_active_text,
@@ -44,15 +49,22 @@ enum class CampaignStatusUi(
         statusDisplayText = R.string.blaze_campaign_status_rejected,
         textColor = R.color.blaze_campaign_status_rejected_text,
         backgroundColor = R.color.blaze_campaign_status_rejected_background
+    ),
+    Canceled(
+        statusDisplayText = R.string.blaze_campaign_status_canceled,
+        textColor = R.color.blaze_campaign_status_rejected_text,
+        backgroundColor = R.color.blaze_campaign_status_rejected_background
     );
 
     companion object {
         fun fromString(status: String): CampaignStatusUi? {
             return when (status) {
                 "created" -> InModeration
+                "scheduled" -> Scheduled
                 "active" -> Active
-                "completed" -> Completed
+                "finished" -> Completed
                 "rejected" -> Rejected
+                "canceled" -> Canceled
                 else -> null
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
@@ -37,13 +37,13 @@ enum class CampaignStatusUi(
     ),
     Completed(
         statusDisplayText = R.string.blaze_campaign_status_completed,
-        textColor = R.color.blaze_campaign_status_rejected_text,
-        backgroundColor = R.color.blaze_campaign_status_rejected_background
+        textColor = R.color.blaze_campaign_status_completed_text,
+        backgroundColor = R.color.blaze_campaign_status_completed_background
     ),
     Rejected(
         statusDisplayText = R.string.blaze_campaign_status_rejected,
-        textColor = R.color.blaze_campaign_status_completed_text,
-        backgroundColor = R.color.blaze_campaign_status_completed_background
+        textColor = R.color.blaze_campaign_status_rejected_text,
+        backgroundColor = R.color.blaze_campaign_status_rejected_background
     );
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUrlsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUrlsHelper.kt
@@ -35,5 +35,6 @@ class BlazeUrlsHelper @Inject constructor(
         MORE_MENU_ITEM("menu"),
         MY_STORE_BANNER("my_store_banner"),
         PRODUCT_LIST_BANNER("product_list_banner"),
+        CAMPAIGN_LIST("campaign_list"),
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -52,5 +52,6 @@ class IsBlazeEnabled @Inject constructor(
         MORE_MENU_ITEM("menu"),
         MY_STORE_BANNER("my_store_banner"),
         PRODUCT_LIST_BANNER("product_list_banner"),
+        CAMPAIGN_LIST("campaign_list"),
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListFragment.kt
@@ -46,6 +46,10 @@ class BlazeCampaignListFragment : BaseFragment() {
             when (event) {
                 is Exit -> findNavController().popBackStack()
                 is BlazeCampaignListViewModel.LaunchBlazeCampaignCreation -> openBlazeWebView(event.url, event.source)
+                is BlazeCampaignListViewModel.ShowCampaignDetails -> openCampaignDetails(
+                    event.url,
+                    event.urlToTriggerExit
+                )
             }
         }
     }
@@ -55,6 +59,16 @@ class BlazeCampaignListFragment : BaseFragment() {
             NavGraphMainDirections.actionGlobalBlazeWebViewFragment(
                 urlToLoad = url,
                 source = source
+            )
+        )
+    }
+
+    private fun openCampaignDetails(url: String, urlToTriggerExit: String) {
+        findNavController().navigateSafely(
+            NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+                urlToLoad = url,
+                urlsToTriggerExit = arrayOf(urlToTriggerExit),
+                title = getString(R.string.blaze_campaign_details_title)
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListFragment.kt
@@ -12,7 +12,7 @@ import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListFragment.kt
@@ -8,8 +8,11 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -42,7 +45,17 @@ class BlazeCampaignListFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is Exit -> findNavController().popBackStack()
+                is BlazeCampaignListViewModel.LaunchBlazeCampaignCreation -> openBlazeWebView(event.url, event.source)
             }
         }
+    }
+
+    private fun openBlazeWebView(url: String, source: BlazeFlowSource) {
+        findNavController().navigateSafely(
+            NavGraphMainDirections.actionGlobalBlazeWebViewFragment(
+                urlToLoad = url,
+                source = source
+            )
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListScreen.kt
@@ -101,7 +101,7 @@ fun BlazeCampaignListScreenPreview() {
                     BlazeCampaignUi(
                         product = BlazeProductUi(
                             name = "Product name",
-                            imgUrl = "https://hips.hearstapps.com/hmg-prod/images/gh-082420-ghi-best-sofas-1598293488.png",
+                            imgUrl = "https://picsum.photos/200/300",
                         ),
                         status = Active,
                         stats = listOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListScreen.kt
@@ -30,14 +30,13 @@ import com.woocommerce.android.ui.blaze.BlazeCampaignUi
 import com.woocommerce.android.ui.blaze.BlazeProductUi
 import com.woocommerce.android.ui.blaze.CampaignStatusUi.Active
 import com.woocommerce.android.ui.blaze.campaigs.BlazeCampaignListViewModel.BlazeCampaignListState
+import com.woocommerce.android.ui.blaze.campaigs.BlazeCampaignListViewModel.CampaignState
 
 @Composable
 fun BlazeCampaignListScreen(viewModel: BlazeCampaignListViewModel) {
     viewModel.state.observeAsState().value?.let { state ->
         BlazeCampaignListScreen(
             state = state,
-            onCampaignClicked = viewModel::onCampaignClicked,
-            onAddNewCampaignClicked = viewModel::onAddNewCampaignClicked,
             modifier = Modifier.background(color = MaterialTheme.colors.surface)
         )
     }
@@ -46,8 +45,6 @@ fun BlazeCampaignListScreen(viewModel: BlazeCampaignListViewModel) {
 @Composable
 private fun BlazeCampaignListScreen(
     state: BlazeCampaignListState,
-    onCampaignClicked: () -> Unit,
-    onAddNewCampaignClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     when {
@@ -65,14 +62,14 @@ private fun BlazeCampaignListScreen(
                 LazyColumn {
                     items(state.campaigns) { campaign ->
                         BlazeCampaignItem(
-                            campaign = campaign,
-                            onCampaignClicked = onCampaignClicked,
+                            campaign = campaign.campaignUi,
+                            onCampaignClicked = campaign.onCampaignClicked,
                         )
                         Spacer(modifier = Modifier.size(dimensionResource(id = R.dimen.major_100)))
                     }
                 }
                 FloatingActionButton(
-                    onClick = onAddNewCampaignClicked,
+                    onClick = state.onAddNewCampaignClicked,
                     shape = CircleShape,
                     backgroundColor = MaterialTheme.colors.primary,
                     modifier = Modifier
@@ -100,31 +97,33 @@ fun BlazeCampaignListScreenPreview() {
     BlazeCampaignListScreen(
         state = BlazeCampaignListState(
             campaigns = listOf(
-                BlazeCampaignUi(
-                    product = BlazeProductUi(
-                        name = "Product name",
-                        imgUrl = "https://hips.hearstapps.com/hmg-prod/images/gh-082420-ghi-best-sofas-1598293488.png",
+                CampaignState(
+                    BlazeCampaignUi(
+                        product = BlazeProductUi(
+                            name = "Product name",
+                            imgUrl = "https://hips.hearstapps.com/hmg-prod/images/gh-082420-ghi-best-sofas-1598293488.png",
+                        ),
+                        status = Active,
+                        stats = listOf(
+                            BlazeCampaignStat(
+                                name = string.blaze_campaign_status_impressions,
+                                value = 100
+                            ),
+                            BlazeCampaignStat(
+                                name = string.blaze_campaign_status_clicks,
+                                value = 10
+                            ),
+                            BlazeCampaignStat(
+                                name = string.blaze_campaign_status_budget,
+                                value = 1000
+                            ),
+                        ),
                     ),
-                    status = Active,
-                    stats = listOf(
-                        BlazeCampaignStat(
-                            name = string.blaze_campaign_status_impressions,
-                            value = 100
-                        ),
-                        BlazeCampaignStat(
-                            name = string.blaze_campaign_status_clicks,
-                            value = 10
-                        ),
-                        BlazeCampaignStat(
-                            name = string.blaze_campaign_status_budget,
-                            value = 1000
-                        ),
-                    ),
+                    onCampaignClicked = {}
                 )
             ),
+            onAddNewCampaignClicked = {},
             isLoading = false
-        ),
-        onCampaignClicked = { },
-        onAddNewCampaignClicked = { }
+        )
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListScreen.kt
@@ -36,7 +36,7 @@ fun BlazeCampaignListScreen(viewModel: BlazeCampaignListViewModel) {
     viewModel.state.observeAsState().value?.let { state ->
         BlazeCampaignListScreen(
             state = state,
-            onCampaignClicked = viewModel::onCampaignSelected,
+            onCampaignClicked = viewModel::onCampaignClicked,
             onAddNewCampaignClicked = viewModel::onAddNewCampaignClicked,
             modifier = Modifier.background(color = MaterialTheme.colors.surface)
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.ui.blaze.BlazeProductUi
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.CampaignStatusUi
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -25,7 +24,6 @@ class BlazeCampaignListViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val blazeCampaignsStore: BlazeCampaignsStore,
     private val selectedSite: SelectedSite,
-    private val isBlazeEnabled: IsBlazeEnabled,
     private val blazeUrlsHelper: BlazeUrlsHelper
 ) : ScopedViewModel(savedStateHandle) {
     val state = blazeCampaignsStore.observeBlazeCampaigns(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
@@ -3,71 +3,64 @@ package com.woocommerce.android.ui.blaze.campaigs
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R.string
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.BlazeCampaignStat
 import com.woocommerce.android.ui.blaze.BlazeCampaignUi
 import com.woocommerce.android.ui.blaze.BlazeProductUi
-import com.woocommerce.android.ui.blaze.CampaignStatusUi.Active
-import com.woocommerce.android.ui.blaze.CampaignStatusUi.InModeration
+import com.woocommerce.android.ui.blaze.CampaignStatusUi
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.store.blaze.BlazeCampaignsStore
 import javax.inject.Inject
 
 @HiltViewModel
 
 class BlazeCampaignListViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val blazeCampaignsStore: BlazeCampaignsStore,
+    private val selectedSite: SelectedSite
 ) : ScopedViewModel(savedStateHandle) {
-    private val _state = MutableStateFlow(
-        BlazeCampaignListState(
-            campaigns = listOf(
-                BlazeCampaignUi(
-                    product = BlazeProductUi(
-                        name = "Product name",
-                        imgUrl = "https://hips.hearstapps.com/hmg-prod/images/gh-082420-ghi-best-sofas-1598293488.png",
-                    ),
-                    status = Active,
-                    stats = listOf(
-                        BlazeCampaignStat(
-                            name = string.blaze_campaign_status_impressions,
-                            value = 100
-                        ),
-                        BlazeCampaignStat(
-                            name = string.blaze_campaign_status_clicks,
-                            value = 10
-                        ),
-                        BlazeCampaignStat(
-                            name = string.blaze_campaign_status_budget,
-                            value = 1000
-                        ),
-                    ),
-                ),
-                BlazeCampaignUi(
-                    product = BlazeProductUi(
-                        name = "Product name",
-                        imgUrl = "",
-                    ),
-                    status = InModeration,
-                    stats = listOf(
-                        BlazeCampaignStat(
-                            name = string.blaze_campaign_status_impressions,
-                            value = 100
-                        ),
-                        BlazeCampaignStat(
-                            name = string.blaze_campaign_status_clicks,
-                            value = 10
-                        ),
-                        BlazeCampaignStat(
-                            name = string.blaze_campaign_status_budget,
-                            value = 1000
-                        ),
-                    ),
-                )
-            ),
-            isLoading = false
-        )
+    val state = blazeCampaignsStore.observeBlazeCampaigns(
+        selectedSite.get()
     )
-    val state = _state.asLiveData()
+        .map { campaigns ->
+            BlazeCampaignListState(
+                campaigns = campaigns
+                    .map {
+                        BlazeCampaignUi(
+                            product = BlazeProductUi(
+                                name = it.title,
+                                imgUrl = it.imageUrl.orEmpty(),
+                            ),
+                            status = CampaignStatusUi.fromString(it.uiStatus),
+                            stats = listOf(
+                                BlazeCampaignStat(
+                                    name = string.blaze_campaign_status_impressions,
+                                    value = it.impressions
+                                ),
+                                BlazeCampaignStat(
+                                    name = string.blaze_campaign_status_clicks,
+                                    value = it.clicks
+                                ),
+                                BlazeCampaignStat(
+                                    name = string.blaze_campaign_status_clicks,
+                                    value = it.budgetCents
+                                )
+                            )
+                        )
+                    },
+                isLoading = false
+            )
+        }
+        .asLiveData()
+
+    init {
+        launch {
+            blazeCampaignsStore.fetchBlazeCampaigns(selectedSite.get())
+        }
+    }
 
     fun onCampaignSelected() {
         // TODO

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
@@ -33,28 +33,32 @@ class BlazeCampaignListViewModel @Inject constructor(
             BlazeCampaignListState(
                 campaigns = campaigns
                     .map {
-                        BlazeCampaignUi(
-                            product = BlazeProductUi(
-                                name = it.title,
-                                imgUrl = it.imageUrl.orEmpty(),
-                            ),
-                            status = CampaignStatusUi.fromString(it.uiStatus),
-                            stats = listOf(
-                                BlazeCampaignStat(
-                                    name = string.blaze_campaign_status_impressions,
-                                    value = it.impressions
+                        CampaignState(
+                            campaignUi = BlazeCampaignUi(
+                                product = BlazeProductUi(
+                                    name = it.title,
+                                    imgUrl = it.imageUrl.orEmpty(),
                                 ),
-                                BlazeCampaignStat(
-                                    name = string.blaze_campaign_status_clicks,
-                                    value = it.clicks
-                                ),
-                                BlazeCampaignStat(
-                                    name = string.blaze_campaign_status_clicks,
-                                    value = it.budgetCents
+                                status = CampaignStatusUi.fromString(it.uiStatus),
+                                stats = listOf(
+                                    BlazeCampaignStat(
+                                        name = string.blaze_campaign_status_impressions,
+                                        value = it.impressions
+                                    ),
+                                    BlazeCampaignStat(
+                                        name = string.blaze_campaign_status_clicks,
+                                        value = it.clicks
+                                    ),
+                                    BlazeCampaignStat(
+                                        name = string.blaze_campaign_status_clicks,
+                                        value = it.budgetCents
+                                    )
                                 )
-                            )
+                            ),
+                            onCampaignClicked = { onCampaignClicked(it.campaignId) }
                         )
                     },
+                onAddNewCampaignClicked = { onAddNewCampaignClicked() },
                 isLoading = false
             )
         }
@@ -66,19 +70,35 @@ class BlazeCampaignListViewModel @Inject constructor(
         }
     }
 
-    fun onCampaignClicked() {
-        // TODO
+    private fun onCampaignClicked(campaignId: Int) {
+        val url = isBlazeEnabled.buildCampaignDetailsUrl(campaignId)
+        triggerEvent(
+            ShowCampaignDetails(
+                url = url,
+                urlToTriggerExit = isBlazeEnabled.buildCampaignsListUrl()
+            )
+        )
     }
 
-    fun onAddNewCampaignClicked() {
+    private fun onAddNewCampaignClicked() {
         val url = isBlazeEnabled.buildUrlForSite(BlazeFlowSource.MY_STORE_BANNER)
         triggerEvent(LaunchBlazeCampaignCreation(url, BlazeFlowSource.CAMPAIGN_LIST))
     }
 
     data class BlazeCampaignListState(
-        val campaigns: List<BlazeCampaignUi>,
+        val campaigns: List<CampaignState>,
+        val onAddNewCampaignClicked: () -> Unit,
         val isLoading: Boolean,
     )
 
+    data class CampaignState(
+        val campaignUi: BlazeCampaignUi,
+        val onCampaignClicked: () -> Unit,
+    )
+
     data class LaunchBlazeCampaignCreation(val url: String, val source: BlazeFlowSource) : MultiLiveEvent.Event()
+    data class ShowCampaignDetails(
+        val url: String,
+        val urlToTriggerExit: String
+    ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
@@ -8,6 +8,9 @@ import com.woocommerce.android.ui.blaze.BlazeCampaignStat
 import com.woocommerce.android.ui.blaze.BlazeCampaignUi
 import com.woocommerce.android.ui.blaze.BlazeProductUi
 import com.woocommerce.android.ui.blaze.CampaignStatusUi
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.map
@@ -20,7 +23,8 @@ import javax.inject.Inject
 class BlazeCampaignListViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val blazeCampaignsStore: BlazeCampaignsStore,
-    private val selectedSite: SelectedSite
+    private val selectedSite: SelectedSite,
+    private val isBlazeEnabled: IsBlazeEnabled
 ) : ScopedViewModel(savedStateHandle) {
     val state = blazeCampaignsStore.observeBlazeCampaigns(
         selectedSite.get()
@@ -62,16 +66,19 @@ class BlazeCampaignListViewModel @Inject constructor(
         }
     }
 
-    fun onCampaignSelected() {
+    fun onCampaignClicked() {
         // TODO
     }
 
     fun onAddNewCampaignClicked() {
-        // TODO
+        val url = isBlazeEnabled.buildUrlForSite(BlazeFlowSource.MY_STORE_BANNER)
+        triggerEvent(LaunchBlazeCampaignCreation(url, BlazeFlowSource.CAMPAIGN_LIST))
     }
 
     data class BlazeCampaignListState(
         val campaigns: List<BlazeCampaignUi>,
         val isLoading: Boolean,
     )
+
+    data class LaunchBlazeCampaignCreation(val url: String, val source: BlazeFlowSource) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
@@ -7,9 +7,10 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.BlazeCampaignStat
 import com.woocommerce.android.ui.blaze.BlazeCampaignUi
 import com.woocommerce.android.ui.blaze.BlazeProductUi
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.CampaignStatusUi
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
-import com.woocommerce.android.ui.blaze.IsBlazeEnabled.BlazeFlowSource
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -24,7 +25,8 @@ class BlazeCampaignListViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val blazeCampaignsStore: BlazeCampaignsStore,
     private val selectedSite: SelectedSite,
-    private val isBlazeEnabled: IsBlazeEnabled
+    private val isBlazeEnabled: IsBlazeEnabled,
+    private val blazeUrlsHelper: BlazeUrlsHelper
 ) : ScopedViewModel(savedStateHandle) {
     val state = blazeCampaignsStore.observeBlazeCampaigns(
         selectedSite.get()
@@ -71,17 +73,17 @@ class BlazeCampaignListViewModel @Inject constructor(
     }
 
     private fun onCampaignClicked(campaignId: Int) {
-        val url = isBlazeEnabled.buildCampaignDetailsUrl(campaignId)
+        val url = blazeUrlsHelper.buildCampaignDetailsUrl(campaignId)
         triggerEvent(
             ShowCampaignDetails(
                 url = url,
-                urlToTriggerExit = isBlazeEnabled.buildCampaignsListUrl()
+                urlToTriggerExit = blazeUrlsHelper.buildCampaignsListUrl()
             )
         )
     }
 
     private fun onAddNewCampaignClicked() {
-        val url = isBlazeEnabled.buildUrlForSite(BlazeFlowSource.MY_STORE_BANNER)
+        val url = blazeUrlsHelper.buildUrlForSite(BlazeFlowSource.MY_STORE_BANNER)
         triggerEvent(LaunchBlazeCampaignCreation(url, BlazeFlowSource.CAMPAIGN_LIST))
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3664,7 +3664,9 @@
     <string name="blaze_campaign_status_in_moderation">In moderation</string>
     <string name="blaze_campaign_status_active">Active</string>
     <string name="blaze_campaign_status_completed">Completed</string>
+    <string name="blaze_campaign_status_scheduled">Scheduled</string>
     <string name="blaze_campaign_status_rejected">Rejected</string>
+    <string name="blaze_campaign_status_canceled">Canceled</string>
     <string name="blaze_campaign_status_impressions">Impressions</string>
     <string name="blaze_campaign_status_clicks">Clicks</string>
     <string name="blaze_campaign_status_budget">Budget</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #9963 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the logic for: 
- Fetching and observing campaigns 
- Handling clicks on campaign items 
- Handling clicks on FAB button to create new campaigns
- Bonus it adds a couple more unhandled campaign states replicating what Jetpack app code has. 

This doesn't add pagination to the list. I'm working on that in a different PR

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

If you have Blaze campaigns already created in some of you sites, skip to step 4: 

1. Log into a site that is Blaze eligible (Wp.com site or Jetpack connected)
2. Have at least one product published
3. Click on "create campaign"  from Blaze view in My Store tab and create a Blaze campaign
4. Click on "Show All" from My Store tab Blaze view
5. Notice how your campaigns are displayed. 
6. Click on any of the campaign and check that the details are loaded correctly
7. Click on `+` FAB button and check the Blaze campaign creation flow for existing products is triggered. 

