### PR TITLE
Enable Gradle Build Scans locally

### DIFF
--- a/config/gradle/gradle_build_scan.gradle
+++ b/config/gradle/gradle_build_scan.gradle
@@ -1,11 +1,14 @@
+Boolean userEnabledTracking = (findProperty('tracksEnabled') ?: false).toBoolean()
+Boolean isBuildOnCI = (System.getenv('CI') ?: false).toBoolean()
 
-// Only run build scan on CI builds.
-if (System.getenv('CI')) {
+if (isBuildOnCI || userEnabledTracking) {
     buildScan {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'
         termsOfServiceAgree = 'yes'
-        tag 'CI'
+        if (isBuildOnCI) {
+            tag 'CI'
+        }
         publishAlways()
-        uploadInBackground = false
+        uploadInBackground = !isBuildOnCI
     }
 }

--- a/config/gradle/gradle_build_scan.gradle
+++ b/config/gradle/gradle_build_scan.gradle
@@ -5,10 +5,16 @@ if (isBuildOnCI || userEnabledTracking) {
     buildScan {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'
         termsOfServiceAgree = 'yes'
+        publishAlways()
         if (isBuildOnCI) {
             tag 'CI'
+            uploadInBackground = false
+        } else {
+            obfuscation {
+                username { username -> username.digest('SHA-1') }
+                hostname { _ -> "" }
+                ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0" } }
+            }
         }
-        publishAlways()
-        uploadInBackground = !isBuildOnCI
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -42,7 +42,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gradle.enterprise' version '3.9'
+    id 'com.gradle.enterprise' version '3.15.1'
 }
 
 rootProject.name = 'WCAndroid'


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR addresses internal request: pdnsEh-1kB-p2

It adds the feature of generating Gradle Build Scans for developers locally. It's an opt-in feature, enabled by default for A12s (`tracksEnabled` flag in `gradle.properties`)

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Run any Gradle task locally, see if the scan was generated. See that the personal data is obfuscated (bottom of "Switches" in scan)
2. Remove and/or update value to `false` of `trackeEnabled` property, run any Gradle task and see that build scan was not generated
3. Assert that scans are generated on CI

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->