### PR TITLE
[FIX] Login with given site uses that site for wp.com flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -60,6 +60,8 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
                     mapOf(AnalyticsTracker.KEY_IS_FREE_TRIAL to true)
                 )
 
+                appPrefsWrapper.removeLoginSiteAddress()
+
                 prologueFinishedListener?.onGetStartedClicked()
             }
         }
@@ -80,7 +82,6 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
-        appPrefsWrapper.removeLoginSiteAddress()
         unifiedLoginTracker.setFlowAndStep(Flow.PROLOGUE, Step.PROLOGUE)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginPrologueFragment.kt
@@ -80,6 +80,7 @@ open class LoginPrologueFragment(@LayoutRes layout: Int) : Fragment(layout) {
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
+        appPrefsWrapper.removeLoginSiteAddress()
         unifiedLoginTracker.setFlowAndStep(Flow.PROLOGUE, Step.PROLOGUE)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Possible fixes: #10010

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The issue is described here peaMlT-74-p2

I am not sure that this fixes the crash, but it may be. This, for sure, fixes another bug, though. The issue comes from the fact that the site URL stored in the app prefs is not deleted in some cases, and that's why the entered URL used later on is the "current site" URL, which leads to the different broken states.

To reproduce the bug 
* Open a clean app
* Log in -> Enter a non WP.com site
* Go back to the main screen
* Create a new store -> login
* Enter wp.com email
* Notice that "it looks like <site> is connected to a different wp.com account" error

My not proven theory is that in some cases, if the site entered on step 2 matches the wpcom account, but somehow [not wpcom](https://github.com/woocommerce/woocommerce-android/blob/9de926c0e9f38239937fdb32f50ad35b2c522bad/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt#L175) then JP activation flow started and crash happens, because URL from another site is used that we don't have credentials

@hichamboushaba @JorgeMucientes does this make any sense? Would you be able to think about more cases when we can end up in a bad state knowing about this potential issue? I see that the crash also happens when a user is already logged in, so I think we can keep the wrong site address even after successful login happened and then things go wrong when a user tries to change a site via site picler



### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Follow reproduction steps and notice that login works fine now


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->