### PR TITLE
[Blaze] Update More Menu CTA handling

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.NavigateToSettingsEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.NavigateToSubscriptionsEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.OpenBlazeCampaignCreationEvent
+import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.OpenBlazeCampaignListEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.StartSitePickerEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewAdminEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewCouponsEvent
@@ -91,8 +92,14 @@ class MoreMenuFragment : TopLevelFragment() {
                 is ViewCouponsEvent -> navigateToCoupons()
                 is ViewPayments -> navigateToPayments()
                 is OpenBlazeCampaignCreationEvent -> openBlazeWebView(event)
+                is OpenBlazeCampaignListEvent -> openBlazeCampaignList()
             }
         }
+    }
+    private fun openBlazeCampaignList() {
+        findNavController().navigateSafely(
+            MoreMenuFragmentDirections.actionMoreMenuToBlazeCampaignListFragment()
+        )
     }
 
     private fun openBlazeWebView(event: OpenBlazeCampaignCreationEvent) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -19,7 +19,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.NavigateToSettingsEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.NavigateToSubscriptionsEvent
-import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.OpenBlazeEvent
+import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.OpenBlazeCampaignCreationEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.StartSitePickerEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewAdminEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewCouponsEvent
@@ -90,12 +90,12 @@ class MoreMenuFragment : TopLevelFragment() {
                 is ViewInboxEvent -> navigateToInbox()
                 is ViewCouponsEvent -> navigateToCoupons()
                 is ViewPayments -> navigateToPayments()
-                is OpenBlazeEvent -> openBlazeWebView(event)
+                is OpenBlazeCampaignCreationEvent -> openBlazeWebView(event)
             }
         }
     }
 
-    private fun openBlazeWebView(event: OpenBlazeEvent) {
+    private fun openBlazeWebView(event: OpenBlazeCampaignCreationEvent) {
         findNavController().navigateSafely(
             NavGraphMainDirections.actionGlobalBlazeCampaignCreationFragment(
                 urlToLoad = event.url,

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -273,6 +273,9 @@
         <action
             android:id="@+id/action_moreMenu_to_subscriptions"
             app:destination="@id/subscriptions" />
+        <action
+            android:id="@+id/action_moreMenu_to_blazeCampaignListFragment"
+            app:destination="@id/nav_graph_blaze" />
     </fragment>
     <fragment
         android:id="@+id/feedbackSurveyFragment"


### PR DESCRIPTION
Closes: #10005 

### Description
This PR updates the logic of the More Menu CTA to do the following:
- Opens the Blaze campaigns list if there are existing campaigns.
- Opens the Blaze campaign creation screen when there are no existing campaigns yet.

### Testing instructions
TC 1: Site with no campaigns
1. Make sure you are signed in using WordPress.com to a site that doesn't have any campaigns yet.
2. Open the More Menu screen.
3. Click on the Blaze button.
4. Confirm it opens the campaign creation screen.

TC 2: Site with existing campaigns
1. Make sure you are signed in using WordPress.com to a site that has some campaigns.
2. Open the More Menu screen.
3. Click on the Blaze button.
4. Confirm it opens the blaze campaigns list.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
