### PR TITLE
[FIX] Click on the local notification after a store creation crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -275,7 +275,7 @@ class MainActivityViewModel @Inject constructor(
     }
 
     fun onLocalNotificationTapped(notification: Notification) {
-        if (notification.remoteSiteId != selectedSite.get().siteId) {
+        if (notification.remoteSiteId != selectedSite.getOrNull()?.siteId) {
             changeSiteAndRestart(
                 notification.remoteSiteId,
                 RestartActivityForLocalNotification(notification)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10000
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The app crashes:
* Start the app in a clean state
* Create store
* Use random email and password
* Follow the flow
* When a store starts it's creation, hide the app and wait a few minutes till a notification is sent
* Click on the notification and notice the crash

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Follow the steps in the description and notice that the created store is opened

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
