### PR TITLE
Attempt to fix crash during Jetpack connection

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 16.0
 -----
-
+- [*] [Internal] Fixed a rare crash that occurs in the Jetpack Connection flow [https://github.com/woocommerce/woocommerce-android/pull/10012]
 
 15.9
 ----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -170,6 +170,13 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
                 )
 
                 when {
+                    sitePickRepository.getSiteBySiteUrl(siteAddress) != null -> {
+                        // If the site is already connected to the account, go back to site picker
+                        // We need this additional handling here to handle any non-standard suffixes that the users
+                        // might have added to the site address, and that weren't handled by [UrlUtils.sanitiseUrl],
+                        // as the `urlAfterRedirects` coming from the API will clear those.
+                        navigateBackToSitePicker()
+                    }
                     !it.exists -> inlineErrorFlow.value = R.string.invalid_site_url_message
                     !it.isWordPress -> stepFlow.value = Step.NotWordpress
                     !it.isWPCom -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -161,6 +161,8 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
                 analyticsTracker.track(
                     stat = AnalyticsEvent.SITE_PICKER_SITE_DISCOVERY,
                     properties = mapOf(
+                        "user_entered_address" to siteAddressFlow.value,
+                        "fetched_address" to siteAddress,
                         "has_wordpress" to it.isWordPress,
                         "is_wpcom" to it.isWPCom,
                         "is_jetpack_installed" to it.hasJetpack,


### PR DESCRIPTION
Closes: #8049 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR is a second attempt to fix the above crash, our theory is that the cause is that the users enter the address of sites that are already connected to their account, but they add some random suffixes that prevents the below check from working:
https://github.com/woocommerce/woocommerce-android/blob/4b888fb4fda73f8bd22b0be2addd8bcce28256e6/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt#L148

The PR adds a second check for the site's existence, but this time it uses the URL we receive from the API, as it comes without those suffixes.

### Testing instructions
1. Make sure you are logged in using [WordPress.com](http://wordpress.com/)
2. Open site picker, and click on “Add a store”, then choose “Connect an existing store”
3. Enter the address of one of your stores, with any random path (just make sure it’s different than wp-admin and wp-login.php)
4. Notice the app takes you to the site picker, then switches automatically to the new site.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
