### PR TITLE
[M6 Orders With Coupons] Expandable product cards in order creation - part 3

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -501,7 +501,7 @@ class OrderCreateEditFormFragment :
                         ExpandableProductCard(
                             item,
                             onRemoveProductClicked = { viewModel.onRemoveProduct(item.item) },
-                            onDiscountButtonClicked = {},
+                            onDiscountButtonClicked = { viewModel.onDiscountButtonClicked(item.item) },
                         )
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -499,9 +499,12 @@ class OrderCreateEditFormFragment :
                 Column(modifier = Modifier) {
                     state.value.forEach { item ->
                         ExpandableProductCard(
+                            viewModel.viewStateData.liveData.observeAsState(),
                             item,
                             onRemoveProductClicked = { viewModel.onRemoveProduct(item.item) },
                             onDiscountButtonClicked = { viewModel.onDiscountButtonClicked(item.item) },
+                            onIncreaseItemAmountClicked = { viewModel.onIncreaseProductsQuantity(item.item.itemId) },
+                            onDecreaseItemAmountClicked = { viewModel.onDecreaseProductsQuantity(item.item.itemId) },
                         )
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1190,6 +1190,16 @@ class OrderCreateEditViewModel @Inject constructor(
         tracker.track(AnalyticsEvent.TAX_RATE_AUTO_TAX_RATE_CLEAR_ADDRESS_TAPPED)
     }
 
+    fun onDiscountButtonClicked(item: Order.Item) {
+        triggerEvent(OrderCreateEditNavigationTarget.EditDiscount(item, _orderDraft.value.currency))
+        val analyticsEvent = if (item.discount > BigDecimal.ZERO) {
+            AnalyticsEvent.ORDER_PRODUCT_DISCOUNT_EDIT_BUTTON_TAPPED
+        } else {
+            AnalyticsEvent.ORDER_PRODUCT_DISCOUNT_ADD_BUTTON_TAPPED
+        }
+        tracker.track(analyticsEvent)
+    }
+
     @Parcelize
     data class ViewState(
         val isProgressDialogShown: Boolean = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigationTarget.kt
@@ -26,7 +26,9 @@ sealed class OrderCreateEditNavigationTarget : Event() {
     ) : OrderCreateEditNavigationTarget()
 
     data class ShowCreatedOrder(val orderId: Long) : OrderCreateEditNavigationTarget()
-    data class EditShipping(val currentShippingLine: ShippingLine?) : OrderCreateEditNavigationTarget()
+    data class EditShipping(val currentShippingLine: ShippingLine?) :
+        OrderCreateEditNavigationTarget()
+
     data class EditFee(
         val orderSubTotal: BigDecimal,
         val currentFeeValue: BigDecimal? = null
@@ -44,7 +46,17 @@ sealed class OrderCreateEditNavigationTarget : Event() {
         val couponLines: Collection<Order.CouponLine>
     ) : OrderCreateEditNavigationTarget()
 
-    data class TaxRatesInfoDialog(val state: TaxRatesInfoDialogViewState) : OrderCreateEditNavigationTarget()
-    data class TaxRateSelector(val state: TaxRatesInfoDialogViewState) : OrderCreateEditNavigationTarget()
-    data class AutoTaxRateSettingDetails(val state: AutoTaxRateSettingState) : OrderCreateEditNavigationTarget()
+    data class TaxRatesInfoDialog(val state: TaxRatesInfoDialogViewState) :
+        OrderCreateEditNavigationTarget()
+
+    data class TaxRateSelector(val state: TaxRatesInfoDialogViewState) :
+        OrderCreateEditNavigationTarget()
+
+    data class AutoTaxRateSettingDetails(val state: AutoTaxRateSettingState) :
+        OrderCreateEditNavigationTarget()
+
+    data class EditDiscount(
+        val item: Order.Item,
+        val currency: String,
+    ) : OrderCreateEditNavigationTarget()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt
@@ -79,6 +79,12 @@ object OrderCreateEditNavigator {
                     target.state
                 )
             }
+            is OrderCreateEditNavigationTarget.EditDiscount -> {
+                OrderCreateEditFormFragmentDirections.actionOrderCreationToOrderCreationProductDiscountFragment(
+                    target.item,
+                    target.currency
+                )
+            }
         }
         navController.navigate(action)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -90,7 +90,7 @@ fun ExpandableProductCard(
                     shape = RoundedCornerShape(8.dp)
                 )
         ) {
-            val (img, name, stock, sku, quantity, chevron, expandedPart) = createRefs()
+            val (img, name, stock, sku, quantity, price, chevron, expandedPart) = createRefs()
             val collapsedStateBottomBarrier = createBottomBarrier(sku, quantity)
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current).data(item.imageUrl)
@@ -132,7 +132,7 @@ fun ExpandableProductCard(
                 style = MaterialTheme.typography.body2,
                 color = colorResource(id = R.color.color_on_surface_disabled)
             )
-            if (!isExpanded) {
+            if (isExpanded) {
                 Text(
                     text = stringResource(
                         id = R.string.orderdetail_product_lineitem_sku_value,
@@ -164,8 +164,16 @@ fun ExpandableProductCard(
                             bottom = dimensionResource(id = R.dimen.major_100),
                         ),
                     style = MaterialTheme.typography.body2,
-                    text = "${item.item.quantity.toInt()} x ${item.item.pricePreDiscount}",
+                    text = getQuantityWithTotalText(item),
                     color = colorResource(id = R.color.color_on_surface_disabled)
+                )
+                Text(
+                    modifier = Modifier.constrainAs(price) {
+                        end.linkTo(chevron.start)
+                        top.linkTo(quantity.top)
+                    },
+                    style = MaterialTheme.typography.body2,
+                    text = item.priceSubtotal
                 )
             }
             IconButton(
@@ -238,7 +246,7 @@ fun ExtendedProductCardContent(
             Text(
                 modifier = Modifier.padding(end = dimensionResource(id = R.dimen.major_100)),
                 color = colorResource(id = R.color.color_on_surface_disabled),
-                text = "${item.item.quantity.toInt()} x ${item.item.pricePreDiscount}"
+                text = getQuantityWithTotalText(item)
             )
             val totalAmountStyle = if (item.hasDiscount) {
                 MaterialTheme.typography.body1.copy(
@@ -331,6 +339,10 @@ fun ExtendedProductCardContent(
         }
     }
 }
+
+@Composable
+private fun getQuantityWithTotalText(item: ProductUIModel) =
+    "${item.item.quantity.toInt()} x ${item.item.pricePreDiscount}"
 
 @Preview
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -88,7 +88,7 @@ fun ExpandableProductCard(
     val chevronRotation by transition.animateFloat(
         transitionSpec = { tween(durationMillis = ANIM_DURATION_MILLIS) }, label = "chevronRotation"
     ) {
-        if (isExpanded) 0f else 180f
+        if (isExpanded) 180f else 0f
     }
     ConstraintLayout(
         modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -100,7 +100,7 @@ fun ExpandableProductCard(
             .border(
                 1.dp,
                 colorResource(id = R.color.divider_color),
-                shape = RoundedCornerShape(8.dp)
+                shape = RoundedCornerShape(dimensionResource(id = R.dimen.corner_radius_large))
             )
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -9,7 +9,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -42,7 +41,6 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -107,7 +105,8 @@ fun ExpandableProductCard(
                     }
                     .size(dimensionResource(R.dimen.major_375))
                     .padding(dimensionResource(id = R.dimen.major_100))
-                    .clip(RoundedCornerShape(dimensionResource(id = R.dimen.corner_radius_image))))
+                    .clip(RoundedCornerShape(dimensionResource(id = R.dimen.corner_radius_image)))
+            )
             Text(
                 text = item.item.name,
                 modifier = Modifier
@@ -228,11 +227,13 @@ fun ExtendedProductCardContent(
             priceAfterDiscountValue,
             removeButton
         ) = createRefs()
-        Divider(modifier = Modifier.constrainAs(topDivider) {
-            top.linkTo(parent.top)
-            start.linkTo(parent.start)
-            end.linkTo(parent.end)
-        })
+        Divider(
+            modifier = Modifier.constrainAs(topDivider) {
+                top.linkTo(parent.top)
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+            }
+        )
         Row(
             modifier = Modifier
                 .constrainAs(price) {
@@ -262,7 +263,8 @@ fun ExtendedProductCardContent(
             WCTextButton(
                 modifier = Modifier.constrainAs(discountButton) {
                     top.linkTo(price.bottom)
-                }, onClick = onDiscountButtonClicked
+                },
+                onClick = onDiscountButtonClicked
             ) {
                 Text(
                     text = stringResource(id = R.string.discount),
@@ -306,7 +308,8 @@ fun ExtendedProductCardContent(
                 modifier = Modifier.constrainAs(discountButton) {
                     top.linkTo(price.bottom)
                     bottom.linkTo(bottomDivider.top)
-                }, onClick = onDiscountButtonClicked
+                },
+                onClick = onDiscountButtonClicked
             ) {
                 Icon(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_add),
@@ -318,17 +321,20 @@ fun ExtendedProductCardContent(
                 )
             }
         }
-        Divider(modifier = Modifier.constrainAs(bottomDivider) {
-            bottom.linkTo(removeButton.top)
-            start.linkTo(parent.start)
-            end.linkTo(parent.end)
-        })
+        Divider(
+            modifier = Modifier.constrainAs(bottomDivider) {
+                bottom.linkTo(removeButton.top)
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+            }
+        )
         WCTextButton(
             modifier = Modifier.constrainAs(removeButton) {
                 bottom.linkTo(parent.bottom)
                 start.linkTo(parent.start)
                 end.linkTo(parent.end)
-            }, onClick = onRemoveProductClicked
+            },
+            onClick = onRemoveProductClicked
         ) {
             Text(
                 text = stringResource(id = R.string.order_creation_remove_product),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -428,7 +428,8 @@ private fun AmountPicker(
         ) {
             Icon(
                 imageVector = Icons.Filled.Remove,
-                contentDescription = stringResource(id = R.string.order_creation_decrease_item_amount_content_description),
+                contentDescription =
+                stringResource(id = R.string.order_creation_decrease_item_amount_content_description),
                 tint = buttonTint
             )
         }
@@ -439,7 +440,8 @@ private fun AmountPicker(
         ) {
             Icon(
                 imageVector = Icons.Filled.Add,
-                contentDescription = stringResource(id = R.string.order_creation_increase_item_amount_content_description),
+                contentDescription =
+                stringResource(id = R.string.order_creation_increase_item_amount_content_description),
                 tint = buttonTint
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -243,7 +243,7 @@ fun ExtendedProductCardContent(
             priceAfterDiscountValue,
             removeButton
         ) = createRefs()
-        val editableControlsEnabled = state.value?.isUpdatingOrderDraft?.not() ?: true
+        val editableControlsEnabled = state.value?.isIdle == true
         Divider(
             modifier = Modifier.constrainAs(topDivider) {
                 top.linkTo(parent.top)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -256,7 +256,7 @@ fun ExtendedProductCardContent(
             } else {
                 MaterialTheme.typography.body1
             }
-            Text(text = "${item.item.subtotal}", style = totalAmountStyle)
+            Text(text = item.priceSubtotal, style = totalAmountStyle)
         }
         if (item.hasDiscount) {
             WCTextButton(
@@ -342,7 +342,7 @@ fun ExtendedProductCardContent(
 
 @Composable
 private fun getQuantityWithTotalText(item: ProductUIModel) =
-    "${item.item.quantity.toInt()} x ${item.item.pricePreDiscount}"
+    "${item.item.quantity.toInt()} x ${item.pricePreDiscount}"
 
 @Preview
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -144,6 +144,10 @@
         <action
             android:id="@+id/action_order_creationFragment_to_taxRateSelectorFragment"
             app:destination="@id/taxRateSelectorFragment" />
+        <action
+            android:id="@+id/action_orderCreation_to_orderCreationProductDiscountFragment"
+            app:destination="@id/orderCreationProductDiscountFragment"
+            />
     </fragment>
     <fragment
         android:id="@+id/barcodeScanningFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -535,6 +535,8 @@
     <string name="order_creation_coupon_discount_value">-%1$s</string>
     <string name="order_creation_coupon_codes">Coupon (%1$s)</string>
     <string name="order_creation_coupons_title">Coupons applied</string>
+    <string name="order_creation_increase_item_amount_content_description">Increase product quantity</string>
+    <string name="order_creation_decrease_item_amount_content_description">Decrease product quantity</string>
     <string name="coupon_selector_empty_list_button">Go to Coupons</string>
     <string name="coupon_selector_empty_list_message">You haven\'t created any coupons yet. Create a coupon to apply it to this order.</string>
     <string name="coupon_selector_empty_list_title">Everyone loves a deal</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
## Expandable product cards in order creation - part 3
This is part 3 of the following PRs:
* Part 1: https://github.com/woocommerce/woocommerce-android/pull/9851 
* Part 2: https://github.com/woocommerce/woocommerce-android/pull/9852
* **Part 3: https://github.com/woocommerce/woocommerce-android/pull/10018**

#### ⚠️ Do not merge

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the remaining updates to the expandable product cards, as per design specs: FTOWxedKUyDbBdOrxRfMyI-fi-14%3A9617 
* Item amount picker
* Disabling buttons during order update
* Redirecting to discount edit screen
* Showing total prices with currency symbol

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Create a new order and add some items. 
2. Verify expandable product cards match the designs.
3. Verify the amount picker updates the order as expected.
4. Verify "+ Add discount" and "Edit discount" buttons work as expected
5. Verify "Remove product" button works as expected
6. Verify that after applying a discount the totals are displayed correctly on the product card.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4527432/0577f84e-4b80-4d60-8035-1607514b62af

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->