### PR TITLE
Default configuration

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -85,7 +85,8 @@ data class Product(
     override val weight: Float,
     val subscription: SubscriptionDetails?,
     val isSampleProduct: Boolean,
-    val specialStockStatus: ProductStockStatus? = null
+    val specialStockStatus: ProductStockStatus? = null,
+    val isConfigurable: Boolean = false
 ) : Parcelable, IProduct {
     companion object {
         const val TAX_CLASS_DEFAULT = "standard"
@@ -571,7 +572,8 @@ fun WCProductModel.toAppModel(): Product {
             ProductStockStatus.fromString(this.specialStockStatus)
         } else {
             null
-        }
+        },
+        isConfigurable = isConfigurable
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CreateOrderItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CreateOrderItem.kt
@@ -38,7 +38,7 @@ class CreateOrderItem @Inject constructor(
                         ?.createItem(product, configuration)
                 } else null
             } ?: product?.createItem(configuration)
-            ?: Order.Item.EMPTY.copy(productId = remoteProductId, variationId = variationId ?: 0L)
+                ?: Order.Item.EMPTY.copy(productId = remoteProductId, variationId = variationId ?: 0L)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CreateOrderItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/CreateOrderItem.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.ui.orders.creation.configuration.ProductConfiguration
 import com.woocommerce.android.ui.products.ProductDetailRepository
+import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.variations.VariationDetailRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.withContext
@@ -14,23 +15,30 @@ import javax.inject.Inject
 class CreateOrderItem @Inject constructor(
     private val coroutineDispatchers: CoroutineDispatchers,
     private val variationDetailRepository: VariationDetailRepository,
-    private val productDetailRepository: ProductDetailRepository
+    private val productDetailRepository: ProductDetailRepository,
+    private val getProductRules: GetProductRules
 ) {
     suspend operator fun invoke(
         remoteProductId: Long,
         variationId: Long? = null,
-        productConfiguration: ProductConfiguration? = null
+        productConfiguration: ProductConfiguration? = null,
     ): Order.Item {
         return withContext(coroutineDispatchers.io) {
             val product = productDetailRepository.getProduct(remoteProductId)
+            // Try to get the default configuration for not configurable bundles
+            val configuration = if (product?.productType == ProductType.BUNDLE && productConfiguration == null) {
+                getProductRules.getRules(remoteProductId)?.let { ProductConfiguration.getConfiguration(it) }
+            } else {
+                productConfiguration
+            }
 
             variationId?.let {
                 if (product != null) {
                     variationDetailRepository.getVariation(remoteProductId, it)
-                        ?.createItem(product, productConfiguration)
+                        ?.createItem(product, configuration)
                 } else null
-            } ?: product?.createItem(productConfiguration)
-                ?: Order.Item.EMPTY.copy(productId = remoteProductId, variationId = variationId ?: 0L)
+            } ?: product?.createItem(configuration)
+            ?: Order.Item.EMPTY.copy(productId = remoteProductId, variationId = variationId ?: 0L)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProduct.kt
@@ -19,7 +19,6 @@ sealed class OrderCreationProduct(
     open val productInfo: ProductInfo
 ) : Parcelable {
     abstract fun isConfigurable(): Boolean
-    abstract fun needsConfiguration(): Boolean
 
     abstract fun copyProduct(
         item: Order.Item = this.item,
@@ -31,7 +30,6 @@ sealed class OrderCreationProduct(
         override val productInfo: ProductInfo
     ) : OrderCreationProduct(item, productInfo) {
         override fun isConfigurable(): Boolean = false
-        override fun needsConfiguration() = false
         override fun copyProduct(
             item: Order.Item,
             productInfo: ProductInfo
@@ -44,7 +42,6 @@ sealed class OrderCreationProduct(
         val children: List<ProductItem>
     ) : OrderCreationProduct(item, productInfo) {
         override fun isConfigurable(): Boolean = false
-        override fun needsConfiguration() = false
         override fun copyProduct(
             item: Order.Item,
             productInfo: ProductInfo
@@ -57,8 +54,7 @@ sealed class OrderCreationProduct(
         val rules: ProductRules,
         var configuration: ProductConfiguration = ProductConfiguration.getConfiguration(rules)
     ) : OrderCreationProduct(item, productInfo) {
-        override fun isConfigurable(): Boolean = rules.isConfigurable()
-        override fun needsConfiguration() = configuration.needsConfiguration()
+        override fun isConfigurable(): Boolean = productInfo.isConfigurable
         override fun copyProduct(
             item: Order.Item,
             productInfo: ProductInfo
@@ -72,8 +68,7 @@ sealed class OrderCreationProduct(
         val rules: ProductRules,
         var configuration: ProductConfiguration = ProductConfiguration.getConfiguration(rules, children)
     ) : OrderCreationProduct(item, productInfo) {
-        override fun isConfigurable(): Boolean = rules.isConfigurable()
-        override fun needsConfiguration() = configuration.needsConfiguration()
+        override fun isConfigurable(): Boolean = productInfo.isConfigurable
         override fun copyProduct(
             item: Order.Item,
             productInfo: ProductInfo
@@ -88,6 +83,7 @@ data class ProductInfo(
     val stockQuantity: Double,
     val stockStatus: ProductStockStatus,
     val productType: ProductType,
+    val isConfigurable: Boolean
 ) : Parcelable
 
 class OrderCreationProductMapper @Inject constructor(
@@ -165,7 +161,8 @@ class OrderCreationProductMapper @Inject constructor(
                     variation?.isStockManaged ?: false,
                     variation?.stockQuantity ?: 0.0,
                     variation?.stockStatus ?: ProductStockStatus.InStock,
-                    ProductType.VARIATION
+                    ProductType.VARIATION,
+                    false
                 )
             } else {
                 val product = productDetailRepository.getProduct(item.productId)
@@ -174,7 +171,8 @@ class OrderCreationProductMapper @Inject constructor(
                     product?.isStockManaged ?: false,
                     product?.stockQuantity ?: 0.0,
                     product?.specialStockStatus ?: product?.stockStatus ?: ProductStockStatus.InStock,
-                    product?.productType ?: ProductType.OTHER
+                    product?.productType ?: ProductType.OTHER,
+                    product?.isConfigurable ?: false
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
@@ -110,7 +110,7 @@ fun ProductConfigurationScreen(
     Surface {
         Column(modifier = modifier) {
             LazyColumn(Modifier.weight(1f)) {
-                productRules.isConfigurable()
+                productRules.productType
                 val configurationItems = productConfiguration.childrenConfiguration?.entries?.toList() ?: emptyList()
                 items(configurationItems) { childMapEntry ->
                     val item = productsInfo.getOrDefault(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductRules.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductRules.kt
@@ -12,14 +12,6 @@ class ProductRules private constructor(
     val itemRules: Map<String, ItemRules>,
     val childrenRules: Map<Long, Map<String, ItemRules>>? = null
 ) : Parcelable {
-    fun isConfigurable(): Boolean {
-        return itemRules.any { it.value.isConfigurable() } || childrenRules?.any {
-            it.value.any { childrenRules ->
-                childrenRules.value.isConfigurable()
-            }
-        } ?: false
-    }
-
     class Builder {
         var productType: ProductType = ProductType.OTHER
         private val rules = mutableMapOf<String, ItemRules>()
@@ -52,7 +44,6 @@ class ProductRules private constructor(
 
 interface ItemRules : Parcelable {
     fun getInitialValue(): String?
-    fun isConfigurable(): Boolean
 }
 
 @Parcelize
@@ -63,7 +54,6 @@ class QuantityRule(val quantityMin: Long?, val quantityMax: Long?, val quantityD
     }
 
     override fun getInitialValue(): String? = quantityDefault?.toString()
-    override fun isConfigurable(): Boolean = quantityMin != quantityMax
 }
 
 @Parcelize
@@ -73,7 +63,6 @@ class OptionalRule : ItemRules {
     }
 
     override fun getInitialValue(): String? = null
-    override fun isConfigurable(): Boolean = true
 }
 
 @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountScreen.kt
@@ -442,7 +442,8 @@ fun OrderCreateEditProductDiscountScreenPreview() =
                     isStockManaged = false,
                     stockQuantity = 0.0,
                     stockStatus = ProductStockStatus.InStock,
-                    productType = ProductType.SIMPLE
+                    productType = ProductType.SIMPLE,
+                    isConfigurable = false
                 )
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -240,7 +240,7 @@ class ProductSelectorViewModel @Inject constructor(
 
         val stockAndPrice = listOfNotNull(stockStatus, price).joinToString(" \u2022 ")
 
-        val isConfigurable = productType == BUNDLE
+        val isConfigurable = isConfigurable
 
         return when {
             isVariation -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.ui.products.ProductNavigationTarget
 import com.woocommerce.android.ui.products.ProductNavigationTarget.NavigateToProductFilter
 import com.woocommerce.android.ui.products.ProductNavigationTarget.NavigateToVariationSelector
 import com.woocommerce.android.ui.products.ProductType
-import com.woocommerce.android.ui.products.ProductType.BUNDLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE_SUBSCRIPTION
 import com.woocommerce.android.ui.products.ProductType.VARIATION

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -1106,7 +1106,8 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
                 false,
                 0.0,
                 ProductStockStatus.NotAvailable,
-                ProductType.SIMPLE
+                ProductType.SIMPLE,
+                false
             )
         )
         sut.onProductClicked(orderItem)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -2224,7 +2224,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             isStockManaged = false,
             stockQuantity = 0.0,
             stockStatus = ProductStockStatus.InStock,
-            productType = ProductType.SIMPLE
+            productType = ProductType.SIMPLE,
+            isConfigurable = false
         )
         return OrderCreationProduct.ProductItem(
             item = orderItem,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/product/details/OrderCreateEditProductDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/product/details/OrderCreateEditProductDetailsViewModelTest.kt
@@ -26,7 +26,8 @@ class OrderCreateEditProductDetailsViewModelTest : BaseUnitTest() {
             isStockManaged = false,
             stockQuantity = 0.0,
             stockStatus = ProductStockStatus.InStock,
-            productType = ProductType.SIMPLE
+            productType = ProductType.SIMPLE,
+            isConfigurable = false
         )
     )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountViewModelTest.kt
@@ -408,7 +408,8 @@ class OrderCreateEditProductDiscountViewModelTest : BaseUnitTest() {
             isStockManaged = false,
             stockQuantity = 0.0,
             stockStatus = ProductStockStatus.InStock,
-            productType = ProductType.SIMPLE
+            productType = ProductType.SIMPLE,
+            isConfigurable = false
         )
         return OrderCreationProduct.ProductItem(
             item = orderItem,

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2876-9bda925e36d6a75b4286a3c1c29bc5638198a57f'
+    fluxCVersion = '2880-68df55efd4868c86358b30f8c630c2a3ecc4d527'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
⚠️ This PR depends on this FluxC PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2880

Part of: #9541

### Why
As part of the support for extensions milestone 2, we are working on support bundle products in the order creation flow.

### Description

This PR adds support for bundle items that don't need a configuration. Some bundle products are not configurable, meaning they can only use the default configuration. So, when getting a bundle product that is not configurable without a configuration, we get the default bundle configuration and submit it as part of the bundle. This PR refactors the `isConfigurable` field and moves it to the DB. Now, when getting the products from the database, we can check whether this product is configurable or not. 

### Testing instructions

#### Prerequisites
1. Install the product bundles extension
2. Create a non-configurable bundle. Non-configurable bundles are those where the only valid configuration is the default configuration. For example, a bundle where all inner products have the same min, max, and default values: Min quantity = 1, Max quantity = 1, Default value = 1. If all inner products meet this, the only valid configuration will be the default one.

#### Testing
TC1
1. Open the orders tap 
2. Tap on create new order
3. Check that non-configurable bundles have the same UI as simple products
4. Select a non-configurable bundle product
5. Check that the product is selected and the app doesn't navigate to the configuration screen
6. Tap on select 1 product
7. Check that the non-configurable bundle is added to the product list
8. Tap on CREATE
9. Check that the order containing the non-configurable bundle is created successfully containing all the children items

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/e887bda6-7299-4264-88a8-688ce49e0002

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
