### PR TITLE
[FIX] Store new store data in bundle to survive process death

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+16.1
+-----
+- [*] [Internal] Fixed a crash during store creation flow [https://github.com/woocommerce/woocommerce-android/pull/10039]
+
 16.0
 -----
 - [**] Revamped UI of order's item list in order creation flow [https://github.com/woocommerce/woocommerce-android/pull/9851]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/NewStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/NewStore.kt
@@ -34,6 +34,7 @@ class NewStore @Inject constructor() {
         data = NewStoreData()
     }
 
+    @Parcelize
     data class NewStoreData(
         val name: String? = null,
         val domain: String? = null,
@@ -42,12 +43,13 @@ class NewStore @Inject constructor() {
         val siteId: Long? = null,
         val planProductId: Int? = null,
         val planPathSlug: String? = null
-    )
+    ) : Parcelable
 
+    @Parcelize
     data class Country(
         val name: String,
         val code: String,
-    )
+    ) : Parcelable
 
     @Parcelize
     data class ProfilerData(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9036
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Reproduction steps:
* Developer settings -> Background process limit -> no background process
* Open a clean app
* Start store creation flow with random email/password
* On the screen with the progress switch to another app and switch back
* Notice crash

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Follow the reproduction steps and notice that the app recovers correctly

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/4923871/4350c344-3ed2-4912-8ead-c242954a4ab4

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
