### PR TITLE
Attempt to fix the "Site not selected" issue

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -55,6 +55,7 @@ import dagger.android.DispatchingAndroidInjector
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -138,6 +139,8 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
                         if (it.model?.hasWooCommerce == false && it.model?.connectionType == ApplicationPasswords) {
                             // The previously selected site doesn't have Woo anymore, take the user to the login screen
                             WooLog.w(T.LOGIN, "Selected site no longer has WooCommerce")
+
+                            delay(1000) // delay the site reset and allow for the requests to fail gracefully
                             selectedSite.reset()
                             restartMainActivity()
                         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -84,6 +84,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         private const val SECONDS_BETWEEN_SITE_UPDATE = 60 * 60 // 1 hour
         private const val UNAUTHORIZED_STATUS_CODE = 401
         private const val CARD_READER_USAGE_THIRTY_DAYS = 30
+        private const val RESET_DELAY = 1000L
     }
 
     @Inject lateinit var crashLogging: CrashLogging
@@ -140,7 +141,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
                             // The previously selected site doesn't have Woo anymore, take the user to the login screen
                             WooLog.w(T.LOGIN, "Selected site no longer has WooCommerce")
 
-                            delay(1000) // delay the site reset and allow for the requests to fail gracefully
+                            delay(RESET_DELAY) // delay the site reset and allow for the requests to fail gracefully
                             selectedSite.reset()
                             restartMainActivity()
                         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.LOGIN
 import com.woocommerce.android.util.dispatchAndAwait
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
@@ -108,7 +109,7 @@ class AccountRepository @Inject constructor(
         }
     }
 
-    private fun cleanup() {
+    private suspend fun cleanup() {
         // Reset analytics
         AnalyticsTracker.flush()
         AnalyticsTracker.clearAllData()
@@ -116,6 +117,8 @@ class AccountRepository @Inject constructor(
 
         // Wipe user-specific preferences
         prefs.resetUserPreferences()
+
+        delay(1000) // delay the site reset and allow for the requests to fail gracefully
         selectedSite.reset()
 
         // Delete sites

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -35,6 +35,9 @@ class AccountRepository @Inject constructor(
     private val prefs: AppPrefs,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) {
+    companion object {
+        private const val RESET_DELAY = 1000L
+    }
 
     fun getUserAccount(): AccountModel? = accountStore.account.takeIf { it.userId != 0L }
 
@@ -118,7 +121,7 @@ class AccountRepository @Inject constructor(
         // Wipe user-specific preferences
         prefs.resetUserPreferences()
 
-        delay(1000) // delay the site reset and allow for the requests to fail gracefully
+        delay(RESET_DELAY) // delay the site reset and allow for the requests to fail gracefully
         selectedSite.reset()
 
         // Delete sites


### PR DESCRIPTION
This PR adds a delay before calling the `SelectedSite.reset()` so that the app can complete the `SelectedSite.get()` calls and fail gracefully, instead of crashing. More information here: peaMlT-6L#comment-543

**To test:**

1. Set up a self-hosted Jurassic ninja site with without activating Jetpack
2. Install WooCommerce plugin and activate it
3. Install Disable application passwords plugin (don't activate it yet)
4. Log into the app using username/password 
5. Go to More menu screen
6. While keeping the app open, disable application passwords by activating the plugin
7. Tap on Inbox, for example
8. Notice the request fails, showing an error
9. The app is logged out
10. There is no unhandled exception in the log