### PR TITLE
Issue/10043 attempt jetpack connection fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
@@ -169,5 +169,5 @@ class JetpackActivationRepository @Inject constructor(
         return Result.failure(lastError!!)
     }
 
-    object JetpackMissingConnectionEmailException: Exception("Email missing from response")
+    object JetpackMissingConnectionEmailException : RuntimeException("Email missing from response")
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
@@ -75,7 +75,7 @@ class JetpackActivationRepository @Inject constructor(
                     stat = AnalyticsEvent.LOGIN_JETPACK_SETUP_CANNOT_FIND_WPCOM_USER
                 )
                 WooLog.w(WooLog.T.LOGIN, "Cannot find Jetpack Email in response")
-                Result.failure(Exception("Email missing from response"))
+                Result.failure(JetpackMissingConnectionEmailException)
             }
 
             else -> {
@@ -168,4 +168,6 @@ class JetpackActivationRepository @Inject constructor(
         }
         return Result.failure(lastError!!)
     }
+
+    object JetpackMissingConnectionEmailException: Exception("Email missing from response")
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.login.jetpack.main
 
 import android.os.Parcelable
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
@@ -68,9 +69,12 @@ class JetpackActivationMainViewModel @Inject constructor(
     companion object {
         private const val JETPACK_SLUG = "jetpack"
         private const val JETPACK_NAME = "jetpack/jetpack"
-        private const val JETPACK_PLANS_URL = "https://wordpress.com/jetpack/connect/plans"
-        private const val JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX = "https://jetpack.wordpress.com/jetpack.authorize"
-        private const val MOBILE_REDIRECT = "woocommerce://jetpack-connected"
+        @VisibleForTesting
+        const val JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX = "https://jetpack.wordpress.com/jetpack.authorize"
+        @VisibleForTesting
+        const val JETPACK_PLANS_URL = "https://wordpress.com/jetpack/connect/plans"
+        @VisibleForTesting
+        const val MOBILE_REDIRECT = "woocommerce://jetpack-connected"
         private const val DELAY_AFTER_CONNECTION_MS = 500L
         private const val DELAY_BEFORE_SHOWING_ERROR_STATE_MS = 1000L
         private const val CONNECTED_EMAIL_KEY = "connected-email"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -14,8 +14,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.support.help.HelpOrigin.JETPACK_INSTALLATION
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
-import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.common.PluginRepository
 import com.woocommerce.android.ui.common.PluginRepository.PluginStatus.PluginActivated
 import com.woocommerce.android.ui.common.PluginRepository.PluginStatus.PluginActivationFailed
@@ -62,7 +62,8 @@ class JetpackActivationMainViewModel @Inject constructor(
     private val pluginRepository: PluginRepository,
     private val accountRepository: AccountRepository,
     private val appPrefsWrapper: AppPrefsWrapper,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val selectedSite: SelectedSite
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         private const val JETPACK_SLUG = "jetpack"
@@ -405,7 +406,7 @@ class JetpackActivationMainViewModel @Inject constructor(
     private suspend fun startJetpackConnection() {
         WooLog.d(WooLog.T.LOGIN, "Jetpack Activation: start Jetpack Connection")
         val currentSite = site.await()
-        val useApplicationPasswords = currentSite.connectionType == SiteConnectionType.ApplicationPasswords
+        val useApplicationPasswords = selectedSite.connectionType == SiteConnectionType.ApplicationPasswords
         jetpackActivationRepository.fetchJetpackConnectionUrl(currentSite, useApplicationPasswords).fold(
             onSuccess = { connectionUrl ->
                 if (!isFromBanner) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModelTest.kt
@@ -1,0 +1,219 @@
+package com.woocommerce.android.ui.login.jetpack.main
+
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.ui.common.PluginRepository
+import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel.UrlComparisonMode
+import com.woocommerce.android.ui.login.AccountRepository
+import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
+import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.ConnectionStep
+import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.ShowJetpackConnectionWebView
+import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.StepState
+import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.StepType
+import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.ViewState.ProgressViewState
+import com.woocommerce.android.util.captureValues
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+
+/**
+ * This is still missing tests for some scenarios, for now it covers only the connection step and its flows.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class JetpackActivationMainViewModelTest : BaseUnitTest() {
+    private lateinit var viewModel: JetpackActivationMainViewModel
+
+    private val jetpackActivationRepository: JetpackActivationRepository = mock()
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+    private val pluginRepository: PluginRepository = mock()
+    private val accountRepository: AccountRepository = mock()
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
+    private val selectedSite: SelectedSite = mock()
+
+    private val siteUrl = "example.com"
+    private val site = SiteModel().apply {
+        url = siteUrl
+        username = "username"
+        password = "password"
+    }
+
+    suspend fun setup(
+        isJetpackInstalled: Boolean = false,
+        prepareMocks: suspend () -> Unit = { }
+    ) {
+        prepareMocks()
+
+        whenever(jetpackActivationRepository.getSiteByUrl(siteUrl)).thenReturn(site)
+
+        viewModel = JetpackActivationMainViewModel(
+            savedStateHandle = JetpackActivationMainFragmentArgs(
+                isJetpackInstalled = isJetpackInstalled, siteUrl = siteUrl
+            ).toSavedStateHandle(),
+            jetpackActivationRepository = jetpackActivationRepository,
+            pluginRepository = pluginRepository,
+            accountRepository = accountRepository,
+            appPrefsWrapper = appPrefsWrapper,
+            analyticsTrackerWrapper = analyticsTrackerWrapper,
+            selectedSite = selectedSite
+        )
+    }
+
+    @Test
+    fun `given site using application passwords and fully disconnected, when starting Jetpack connection, then use alternative URL`() =
+        testBlocking {
+            setup(isJetpackInstalled = true) {
+                whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
+                whenever(
+                    jetpackActivationRepository.fetchJetpackConnectionUrl(
+                        site = site, useApplicationPasswords = true
+                    )
+                ).thenReturn(Result.success("https://example.com"))
+            }
+
+            val event = viewModel.event.captureValues().last()
+
+            assertThat(event).isEqualTo(
+                ShowJetpackConnectionWebView(
+                    url = "https://wordpress.com/jetpack/connect?url=example.com" +
+                        "&mobile_redirect=${JetpackActivationMainViewModel.MOBILE_REDIRECT}&from=mobile",
+                    connectionValidationUrls = listOf(
+                        JetpackActivationMainViewModel.MOBILE_REDIRECT, JetpackActivationMainViewModel.JETPACK_PLANS_URL
+                    ),
+                    urlComparisonMode = UrlComparisonMode.STARTS_WITH,
+                    clearCache = true
+                )
+            )
+        }
+
+    @Test
+    fun `given site using application passwords and with site-level connection, when starting Jetpack connection, then use default URL`() =
+        testBlocking {
+            val connectionUrl = JetpackActivationMainViewModel.JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX
+            setup(isJetpackInstalled = true) {
+                whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
+                whenever(
+                    jetpackActivationRepository.fetchJetpackConnectionUrl(
+                        site = site,
+                        useApplicationPasswords = true
+                    )
+                ).thenReturn(Result.success(connectionUrl))
+            }
+
+            val event = viewModel.event.captureValues().last()
+
+            assertThat(event).isEqualTo(
+                ShowJetpackConnectionWebView(
+                    url = connectionUrl,
+                    connectionValidationUrls = listOf(
+                        JetpackActivationMainViewModel.MOBILE_REDIRECT, JetpackActivationMainViewModel.JETPACK_PLANS_URL
+                    ),
+                    urlComparisonMode = UrlComparisonMode.PARTIAL,
+                    clearCache = true
+                )
+            )
+        }
+
+    @Test
+    fun `given site not using application passwords, when starting Jetpack connection, then use default URL`() =
+        testBlocking {
+            val connectionUrl = JetpackActivationMainViewModel.JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX
+            setup(isJetpackInstalled = true) {
+                whenever(selectedSite.connectionType).thenReturn(null)
+                whenever(
+                    jetpackActivationRepository.fetchJetpackConnectionUrl(
+                        site = site,
+                        useApplicationPasswords = false
+                    )
+                ).thenReturn(Result.success(connectionUrl))
+            }
+
+            val event = viewModel.event.captureValues().last()
+
+            assertThat(event).isEqualTo(
+                ShowJetpackConnectionWebView(
+                    url = connectionUrl,
+                    connectionValidationUrls = listOf(JetpackActivationMainViewModel.JETPACK_PLANS_URL, siteUrl),
+                    urlComparisonMode = UrlComparisonMode.PARTIAL
+                )
+            )
+        }
+
+    @Test
+    fun `when connection step succeeds, then start connection validation`() = testBlocking {
+        setup(isJetpackInstalled = true) {
+            whenever(
+                jetpackActivationRepository.fetchJetpackConnectionUrl(site = site)
+            ).thenReturn(Result.success("https://example.com/connect"))
+
+            whenever(
+                jetpackActivationRepository.fetchJetpackConnectedEmail(site = site)
+            ).doSuspendableAnswer {
+                // The duration value is not important, it's just to make sure we suspend at this step
+                delay(100)
+                Result.success("")
+            }
+        }
+
+        val state = viewModel.viewState.runAndCaptureValues {
+            viewModel.onJetpackConnected()
+        }.last()
+
+        assertThat((state as ProgressViewState).connectionStep).isEqualTo(ConnectionStep.Validation)
+    }
+
+    @Test
+    fun `when validation step succeeds, then mark steps as done`() = testBlocking {
+        setup(isJetpackInstalled = true) {
+            whenever(
+                jetpackActivationRepository.fetchJetpackConnectionUrl(site = site)
+            ).thenReturn(Result.success("https://example.com/connect"))
+
+            whenever(
+                jetpackActivationRepository.fetchJetpackConnectedEmail(site = site)
+            ).doReturn(Result.success("email"))
+        }
+
+        val state = viewModel.viewState.runAndCaptureValues {
+            viewModel.onJetpackConnected()
+            advanceUntilIdle()
+            runCurrent()
+        }.last()
+
+        assertThat((state as ProgressViewState).steps).allSatisfy { step ->
+            assertThat(step.state).isEqualTo(StepState.Success)
+        }
+    }
+
+    @Test
+    fun `when validation step fails due to missing email, then retrying should restart the connection`() =
+        testBlocking {
+            setup(isJetpackInstalled = true) {
+                whenever(
+                    jetpackActivationRepository.fetchJetpackConnectionUrl(site = site)
+                ).thenReturn(Result.success("https://example.com/connect"))
+                whenever(
+                    jetpackActivationRepository.fetchJetpackConnectedEmail(site = site)
+                ).thenThrow(JetpackActivationRepository.JetpackMissingConnectionEmailException)
+            }
+
+            val state = viewModel.viewState.runAndCaptureValues {
+                viewModel.onJetpackConnected()
+                viewModel.onRetryClick()
+            }.last()
+
+            assertThat((state as ProgressViewState).steps.single { it.state == StepState.Ongoing }.type)
+                .isEqualTo(StepType.Connection)
+        }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10043 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
While I couldn't reproduce 10043 consistently like what happened to me on Friday, I found some edge cases where it happens, and my theory is that they are caused by the instability of the `https://wordpress.com/jetpack/connect` that we use for Application Passwords flow. This PR attempts a way for the user to recover from the error, instead of offering a retry that doesn't help.
The retry logic we have in this screen, allows retrying just the last step, while when this issue occurs, we need to retry the `connection` step itself, and not just the `validation`, and this PR does this exactly.

The PR also adds a second fix, I'll explain in the comments below.

### Testing instructions
The test is not straightforward, either do it, or trust me that I did it 😅 
1. Create a site that has Jetpack but not connected.
2. Sign in to the site using the app.
3. Click on the Jetpack benefits banner.
4. Debug the app, and put a breakpoint at this [line](https://github.com/woocommerce/woocommerce-android/blob/4f61b6b2e176c679ee61d50dd7c9c5c9d9d33871/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt#L461).
5. Start the WordPress.com authentication, and proceed until the breakpoint is hit.
6. Go to the site, and start Jetpack connection, but don't click on Approve in the account screen (this establishes a site-only connection).
7. Go back to the app, and resume execution.
8. Notice that the WebView is dismissed automatically without connection, and an error is shown.
9. Click on Retry.
10. Confirm it allows you to retry the connection step, and you can connect successfully now.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
