### PR TITLE
Update login library to add latest change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ ext {
     hiltJetpackVersion = '1.0.0'
     wordPressUtilsVersion = '2.6.0'
     mediapickerVersion = '0.2'
-    wordPressLoginVersion = '1.4.0'
+    wordPressLoginVersion = 'trunk-9963d78096edf65f8704b803e5b93c08fc9174cd'
     aboutAutomatticVersion = '0.0.6'
     automatticTracksVersion = '3.2.0'
     workManagerVersion = '2.7.1'


### PR DESCRIPTION
The latest version of the login library removes the call fro fetching user subscription when login in with 2FA. This request is a heavy one and is not needed at all in Woo app.

<!-- Remember about a good descriptive title. -->

Closes: #3911
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Updates WordPress login library. The newer version avoid calling `http://public-api.wordpress.com/rest/v1.2/read/following/mine/` when login in with WP.com email with 2FA enabled. This endpoint is slow and unnecessary for the app to work. Additional discussion on Slack convo: p1698668159519919-slack-C0180B5PRJ4

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Run the app 
2. Login with a WP.com account that has 2FA enabled
3. Check the after entering the 2FA code no request to the endpoint `[public-api.wordpress.com/rest/v1.2/read/following/mine/](http://public-api.wordpress.com/rest/v1.2/read/following/mine/)` is fired. 