### PR TITLE
Use plugin fetching to check Jetpack installation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
@@ -4,9 +4,6 @@ import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.extensions.orNullIfEmpty
 import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.jetpack.benefits.FetchJetpackStatus.JetpackStatusFetchResponse.FORBIDDEN
-import com.woocommerce.android.ui.jetpack.benefits.FetchJetpackStatus.JetpackStatusFetchResponse.NOT_FOUND
-import com.woocommerce.android.ui.jetpack.benefits.FetchJetpackStatus.JetpackStatusFetchResponse.SUCCESS
 import org.wordpress.android.fluxc.store.JetpackStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
@@ -33,15 +30,17 @@ class FetchJetpackStatus @Inject constructor(
 ) {
     companion object {
         private const val FORBIDDEN_CODE = 403
+        private const val NOT_FOUND_CODE = 404
         private const val JETPACK_SLUG = "jetpack"
     }
 
-    enum class JetpackStatusFetchResponse {
-        SUCCESS, NOT_FOUND, FORBIDDEN
+    sealed interface JetpackStatusFetchResponse {
+        data class Success(val status: JetpackStatus) : JetpackStatusFetchResponse
+        object ConnectionForbidden : JetpackStatusFetchResponse
     }
 
     @Suppress("ReturnCount")
-    suspend operator fun invoke(): Result<Pair<JetpackStatus, JetpackStatusFetchResponse>> {
+    suspend operator fun invoke(): Result<JetpackStatusFetchResponse> {
         val isJetpackInstalled = wooCommerceStore.fetchSitePlugins(selectedSite.get()).let { result ->
             when {
                 result.isError -> {
@@ -56,14 +55,17 @@ class FetchJetpackStatus @Inject constructor(
         return jetpackStore.fetchJetpackUser(selectedSite.get(), useApplicationPasswords = true).let { result ->
             when {
                 result.error?.errorCode == FORBIDDEN_CODE -> {
+                    Result.success(JetpackStatusFetchResponse.ConnectionForbidden)
+                }
+
+                result.error?.errorCode == NOT_FOUND_CODE -> {
                     Result.success(
-                        Pair(
+                        JetpackStatusFetchResponse.Success(
                             JetpackStatus(
-                                isJetpackInstalled = isJetpackInstalled,
+                                isJetpackInstalled = false,
                                 isJetpackConnected = false,
                                 wpComEmail = null
-                            ),
-                            if (isJetpackInstalled) FORBIDDEN else NOT_FOUND
+                            )
                         )
                     )
                 }
@@ -74,13 +76,12 @@ class FetchJetpackStatus @Inject constructor(
 
                 else -> {
                     Result.success(
-                        Pair(
+                        JetpackStatusFetchResponse.Success(
                             JetpackStatus(
                                 isJetpackInstalled = isJetpackInstalled,
                                 isJetpackConnected = result.user!!.isConnected,
                                 wpComEmail = result.user!!.wpcomEmail.orNullIfEmpty()
-                            ),
-                            if (isJetpackInstalled) SUCCESS else NOT_FOUND
+                            )
                         )
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
@@ -9,13 +9,10 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
 /**
- * First, a list of plugins is fetched from the site. If Jetpack is not installed, then the
- * [JetpackStatus] is returned with `isJetpackInstalled` set to `false`. We cannot use the 404 NOT FOUND response
- * because a site may have Jetpack Connection Package installed, but not Jetpack itself.
- *
- * Meaning for Jetpack's `/connection/data` endpoint responses, as outlined from the Jetpack codebase:
+ * Jetpack's `/connection/data` endpoint responses, as outlined from the Jetpack codebase:
  * `projects/packages/connection/tests/php/test-rest-endpoints.php`
  *
+ * - 404: Jetpack is not activated.
  * - 403: Jetpack is activated but current user has no permission to get connection data.
  * - 200: Jetpack is activated, connection data is given.
  *

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/FetchJetpackStatus.kt
@@ -39,19 +39,8 @@ class FetchJetpackStatus @Inject constructor(
         object ConnectionForbidden : JetpackStatusFetchResponse
     }
 
-    @Suppress("ReturnCount")
+    @Suppress("ReturnCount", "NestedBlockDepth")
     suspend operator fun invoke(): Result<JetpackStatusFetchResponse> {
-        val isJetpackInstalled = wooCommerceStore.fetchSitePlugins(selectedSite.get()).let { result ->
-            when {
-                result.isError -> {
-                    return Result.failure(OnChangedException(result.error))
-                }
-                else -> {
-                    result.model!!.any { it.slug == JETPACK_SLUG && it.isActive }
-                }
-            }
-        }
-
         return jetpackStore.fetchJetpackUser(selectedSite.get(), useApplicationPasswords = true).let { result ->
             when {
                 result.error?.errorCode == FORBIDDEN_CODE -> {
@@ -75,6 +64,17 @@ class FetchJetpackStatus @Inject constructor(
                 }
 
                 else -> {
+                    val isJetpackInstalled = wooCommerceStore.fetchSitePlugins(selectedSite.get()).let { result ->
+                        when {
+                            result.isError -> {
+                                return Result.failure(OnChangedException(result.error))
+                            }
+                            else -> {
+                                result.model!!.any { it.slug == JETPACK_SLUG && it.isActive }
+                            }
+                        }
+                    }
+
                     Result.success(
                         JetpackStatusFetchResponse.Success(
                             JetpackStatus(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackActivationEligibilityErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackActivationEligibilityErrorViewModel.kt
@@ -62,7 +62,7 @@ class JetpackActivationEligibilityErrorViewModel @Inject constructor(
     }
 
     private fun handleJetpackStatusResult(
-        result: Result<Pair<JetpackStatus, JetpackStatusFetchResponse>>
+        result: Result<JetpackStatusFetchResponse>
     ) {
         fun handleSuccess(jetpackStatus: JetpackStatus) {
             triggerEvent(
@@ -89,11 +89,15 @@ class JetpackActivationEligibilityErrorViewModel @Inject constructor(
         }
 
         result.fold(
-            onSuccess = { (jetpackStatus, fetchResponse) ->
-                when (fetchResponse) {
-                    JetpackStatusFetchResponse.SUCCESS -> handleSuccess(jetpackStatus)
-                    JetpackStatusFetchResponse.NOT_FOUND -> checkUserEligibility(jetpackStatus)
-                    else -> { /* Still not eligible, keep showing error screen */ }
+            onSuccess = { fetchResponse ->
+                if (fetchResponse is JetpackStatusFetchResponse.Success) {
+                    if (fetchResponse.status.isJetpackInstalled) {
+                        handleSuccess(fetchResponse.status)
+                    } else {
+                        checkUserEligibility(fetchResponse.status)
+                    }
+                } else {
+                    /* Still not eligible, keep showing error screen */
                 }
             },
             onFailure = { /* Still not eligible, keep showing error screen */ }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModelTest.kt
@@ -79,8 +79,7 @@ class JetpackBenefitsViewModelTest : BaseUnitTest() {
         )
         givenConnectionType(SiteConnectionType.ApplicationPasswords)
         givenJetpackFetchResult(
-            jetpackStatus,
-            FetchJetpackStatus.JetpackStatusFetchResponse.SUCCESS
+            FetchJetpackStatus.JetpackStatusFetchResponse.Success(jetpackStatus)
         )
 
         // When
@@ -98,13 +97,8 @@ class JetpackBenefitsViewModelTest : BaseUnitTest() {
     @Test
     fun `given REST API login and user role is not eligible, when user starts installation, then OpenJetpackEligibilityError event is triggered`() = testBlocking {
         // Given
-        val jetpackStatus = JetpackStatus(
-            isJetpackInstalled = true,
-            isJetpackConnected = false,
-            wpComEmail = null
-        )
         givenConnectionType(SiteConnectionType.ApplicationPasswords)
-        givenJetpackFetchResult(jetpackStatus, FetchJetpackStatus.JetpackStatusFetchResponse.FORBIDDEN)
+        givenJetpackFetchResult(FetchJetpackStatus.JetpackStatusFetchResponse.ConnectionForbidden)
         givenUserEligibility(user, UserRole.Editor)
 
         // When
@@ -128,7 +122,7 @@ class JetpackBenefitsViewModelTest : BaseUnitTest() {
             wpComEmail = null
         )
         givenConnectionType(SiteConnectionType.ApplicationPasswords)
-        givenJetpackFetchResult(jetpackStatus, FetchJetpackStatus.JetpackStatusFetchResponse.NOT_FOUND)
+        givenJetpackFetchResult(FetchJetpackStatus.JetpackStatusFetchResponse.Success(jetpackStatus))
         givenUserEligibility(user, UserRole.Administrator)
 
         // When
@@ -152,7 +146,7 @@ class JetpackBenefitsViewModelTest : BaseUnitTest() {
             wpComEmail = null
         )
         givenConnectionType(SiteConnectionType.ApplicationPasswords)
-        givenJetpackFetchResult(jetpackStatus, FetchJetpackStatus.JetpackStatusFetchResponse.NOT_FOUND)
+        givenJetpackFetchResult(FetchJetpackStatus.JetpackStatusFetchResponse.Success(jetpackStatus))
         givenUserEligibility(user, UserRole.Editor)
 
         // When
@@ -181,10 +175,9 @@ class JetpackBenefitsViewModelTest : BaseUnitTest() {
     }
 
     private fun givenJetpackFetchResult(
-        jetpackStatus: JetpackStatus,
         jetpackStatusFetchResponse: FetchJetpackStatus.JetpackStatusFetchResponse
     ) = testBlocking {
-        val result = Result.success(jetpackStatus to jetpackStatusFetchResponse)
+        val result = Result.success(jetpackStatusFetchResponse)
         whenever(fetchJetpackStatus.invoke()).thenReturn(result)
     }
 


### PR DESCRIPTION
Fixes #9397. The PR updates the Jetpack installation & activation check by using a separate endpoint to fetch plugins. The JP connection and email address endpoint stayed the same.

**To test:**
1. Prepare a self-hosted site with WooCommerce but without Jetpack
2. Log in
3. Tap on the Jetpack promotion banner
4. Notice the next screen prompts you to install Jetpack
5. Go back to to main screen
6. Install & activate Jetpack on the site, but don't connect
7. Tap on the Jetpack banner
8. Notice the next screen either prompts you to connect an email address to Jetpack