### PR TITLE
Feature/9719 navigate to password screen on existing email

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -874,7 +874,7 @@ class LoginActivity :
         showMainActivityAndFinish()
     }
 
-    override fun onLoginWithEmail(email: String?) {
+    override fun onExistingEmail(email: String?) {
         unifiedLoginTracker.setFlow(Flow.WORDPRESS_COM.value)
         appPrefsWrapper.setStoreCreationSource(AnalyticsTracker.VALUE_LOGIN)
         changeFragment(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
@@ -51,6 +51,7 @@ class WooLoginEmailFragment : LoginEmailFragment() {
         if (prefilledEmail.isNotNullOrEmpty()) {
             mEmailInput?.editText?.setText(prefilledEmail)
             next(prefilledEmail)
+            requireArguments().clear()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.login.overrides
 
 import android.content.Context
 import android.os.Bundle
+import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
@@ -38,14 +39,19 @@ class WooLoginEmailFragment : LoginEmailFragment() {
         whatIsWordPressText.setOnClickListener {
             wooLoginEmailListener.onWhatIsWordPressLinkClicked()
         }
-        val prefilledEmail = requireArguments().getString(ARG_PREFILLED_EMAIL)
-        if (prefilledEmail.isNotNullOrEmpty()) {
-            mEmailInput?.editText?.setText(prefilledEmail)
-        }
     }
 
     override fun setupLabel(label: TextView) {
         // NO-OP, For this custom screen, the correct label is set in the layout
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val prefilledEmail = requireArguments().getString(ARG_PREFILLED_EMAIL)
+        if (prefilledEmail.isNotNullOrEmpty()) {
+            mEmailInput?.editText?.setText(prefilledEmail)
+            next(prefilledEmail)
+        }
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/signup/SignUpFragment.kt
@@ -39,7 +39,7 @@ class SignUpFragment : BaseFragment() {
     }
 
     interface Listener {
-        fun onLoginWithEmail(email: String?)
+        fun onExistingEmail(email: String?)
         fun onAccountCreated()
     }
 
@@ -92,7 +92,7 @@ class SignUpFragment : BaseFragment() {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is OnLoginWithEmail -> signUpEmailFragment?.onLoginWithEmail(event.email)
+                is OnLoginWithEmail -> signUpEmailFragment?.onExistingEmail(event.email)
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is OnTermsOfServiceClicked -> openTermsOfServiceUrl()
                 is OnAccountCreated -> signUpEmailFragment?.onAccountCreated()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #9719 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Navigate directly to password screen when the entered email in sign up screen already exists. 
The solution I opted for is triggering the "Continue" button when an email parameter is provided for `WooLoginEmailFragment`. The reasons I opted for this approach are: 
- Very simple and straightforward to implement
- We don't have to manually handle back navigation from password fragment as  `WooLoginEmailFragment` is added to the stack before navigating to password fragment
- We keep triggering the request `https://public-api.wordpress.com/rest/v1.1/users/wpemail@gmail.com/auth-options/?locale=en_US` to fetch auth options for that email before landing on the password screen. Skipping `WooLoginEmailFragment` directly will force us to handle this manually. 
The tradeoff is that the UI is not super smooth as the `WooLoginEmailFragment` is displayed for barely a second before navigating to the password screen. But I think it's a minor thing, considering this flow is pretty corner case for the average user. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Launch the app
2. Click on Create Store
3. Enter an existing WP.com email
4. See how you are taken directly to password screen without extra clicks
5. Navigate back and check you land on login with email screen

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/488ef1eb-8f47-400d-bce0-deda1ca59823

