### PR TITLE
[Jetpack Connection] Handle edge case of custom admin URLs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 16.1
 - [*] [Internal] Fixed a crash during store creation flow [https://github.com/woocommerce/woocommerce-android/pull/10039]
+- [*] [Internal] Improve error handling during Jetpack Connection when using a custom admin URL [https://github.com/woocommerce/woocommerce-android/pull/10077]
 
 16.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/WebView.kt
@@ -4,6 +4,9 @@ import android.annotation.SuppressLint
 import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.WebChromeClient
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebStorage
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -45,6 +48,7 @@ fun WCWebView(
     modifier: Modifier = Modifier,
     onUrlLoaded: (String) -> Unit = {},
     onPageFinished: (String) -> Unit = {},
+    onUrlFailed: (String, Int?) -> Unit = { _, _ -> },
     captureBackPresses: Boolean = true,
     wpComAuthenticator: WPComWebViewAuthenticator? = null,
     webViewNavigator: WebViewNavigator = rememberWebViewNavigator(),
@@ -105,9 +109,28 @@ fun WCWebView(
                         }
 
                         override fun onPageFinished(view: WebView?, url: String?) {
-                            super.onPageFinished(view, url)
                             url?.let { onPageFinished(it) }
                             canGoBack = view?.canGoBack() ?: false
+                        }
+
+                        override fun onReceivedError(
+                            view: WebView?,
+                            request: WebResourceRequest?,
+                            error: WebResourceError?
+                        ) {
+                            request?.url?.let { url ->
+                                onUrlFailed(url.toString(), error?.errorCode)
+                            }
+                        }
+
+                        override fun onReceivedHttpError(
+                            view: WebView?,
+                            request: WebResourceRequest?,
+                            errorResponse: WebResourceResponse?
+                        ) {
+                            request?.url?.let { url ->
+                                onUrlFailed(url.toString(), errorResponse?.statusCode)
+                            }
                         }
                     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
@@ -50,10 +50,10 @@ class JetpackActivationWebViewFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-               is JetpackActivationWebViewViewModel.ConnectionResult -> navigateBackWithResult(
-                   key = JETPACK_CONNECTION_RESULT,
-                   result = event
-               )
+                is JetpackActivationWebViewViewModel.ConnectionResult -> navigateBackWithResult(
+                    key = JETPACK_CONNECTION_RESULT,
+                    result = event
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
@@ -41,6 +41,7 @@ class JetpackActivationWebViewFragment : BaseFragment() {
                     wpComAuthenticator = wpComAuthenticator,
                     userAgent = userAgent,
                     onUrlLoaded = viewModel::onUrlLoaded,
+                    onUrlFailed = viewModel::onUrlFailed,
                     onDismiss = viewModel::onDismiss
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.fluxc.network.UserAgent
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -18,15 +19,24 @@ class JetpackActivationWebViewFragment : BaseFragment() {
         get() = AppBarStatus.Hidden
 
     private val viewModel: JetpackActivationWebViewViewModel by viewModels()
+
     @Inject
-    lateinit var wpComWebViewAuthenticator: WPComWebViewAuthenticator
+    lateinit var wpComAuthenticator: WPComWebViewAuthenticator
+    @Inject
+    lateinit var userAgent: UserAgent
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
         ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
             setContent {
-                JetpackActivationWebViewScreen(viewModel, wpComWebViewAuthenticator)
+                JetpackActivationWebViewScreen(
+                    viewModel = viewModel,
+                    wpComAuthenticator = wpComAuthenticator,
+                    userAgent = userAgent,
+                    onUrlLoaded = viewModel::onUrlLoaded,
+                    onDismiss = viewModel::onDismiss
+                )
             }
         }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android.ui.login.jetpack.connection
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class JetpackActivationWebViewFragment : BaseFragment() {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    private val viewModel: JetpackActivationWebViewViewModel by viewModels()
+    @Inject
+    lateinit var wpComWebViewAuthenticator: WPComWebViewAuthenticator
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
+        ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                JetpackActivationWebViewScreen(viewModel, wpComWebViewAuthenticator)
+            }
+        }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewFragment.kt
@@ -2,10 +2,12 @@ package com.woocommerce.android.ui.login.jetpack.connection
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -15,6 +17,9 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class JetpackActivationWebViewFragment : BaseFragment() {
+    companion object {
+        const val JETPACK_CONNECTION_RESULT = "jetpack-connection-result"
+    }
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
@@ -22,6 +27,7 @@ class JetpackActivationWebViewFragment : BaseFragment() {
 
     @Inject
     lateinit var wpComAuthenticator: WPComWebViewAuthenticator
+
     @Inject
     lateinit var userAgent: UserAgent
 
@@ -39,4 +45,15 @@ class JetpackActivationWebViewFragment : BaseFragment() {
                 )
             }
         }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+               is JetpackActivationWebViewViewModel.ConnectionResult -> navigateBackWithResult(
+                   key = JETPACK_CONNECTION_RESULT,
+                   result = event
+               )
+            }
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewScreen.kt
@@ -19,7 +19,8 @@ fun JetpackActivationWebViewScreen(
     wpComAuthenticator: WPComWebViewAuthenticator,
     userAgent: UserAgent,
     onUrlLoaded: (String) -> Unit,
-    onDismiss: () -> Unit
+    onUrlFailed: (String, Int?) -> Unit,
+    onDismiss: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -35,6 +36,7 @@ fun JetpackActivationWebViewScreen(
             userAgent = userAgent,
             wpComAuthenticator = wpComAuthenticator,
             onUrlLoaded = onUrlLoaded,
+            onUrlFailed = onUrlFailed,
             clearCache = true,
             modifier = Modifier.padding(paddingValues)
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewScreen.kt
@@ -1,12 +1,42 @@
 package com.woocommerce.android.ui.login.jetpack.connection
 
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Scaffold
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCWebView
+import org.wordpress.android.fluxc.network.UserAgent
 
 @Composable
 fun JetpackActivationWebViewScreen(
     viewModel: JetpackActivationWebViewViewModel,
-    wpComWebViewAuthenticator: WPComWebViewAuthenticator
+    wpComAuthenticator: WPComWebViewAuthenticator,
+    userAgent: UserAgent,
+    onUrlLoaded: (String) -> Unit,
+    onDismiss: () -> Unit
 ) {
-
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = stringResource(id = R.string.login_jetpack_installation_approve_connection),
+                onNavigationButtonClick = onDismiss,
+                navigationIcon = Icons.Filled.Clear
+            )
+        }
+    ) { paddingValues ->
+        WCWebView(
+            url = viewModel.urlToLoad,
+            userAgent = userAgent,
+            wpComAuthenticator = wpComAuthenticator,
+            onUrlLoaded = onUrlLoaded,
+            clearCache = true,
+            modifier = Modifier.padding(paddingValues)
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewScreen.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.login.jetpack.connection
+
+import androidx.compose.runtime.Composable
+import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+
+@Composable
+fun JetpackActivationWebViewScreen(
+    viewModel: JetpackActivationWebViewViewModel,
+    wpComWebViewAuthenticator: WPComWebViewAuthenticator
+) {
+
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewViewModel.kt
@@ -23,19 +23,22 @@ class JetpackActivationWebViewViewModel @Inject constructor(
     }
 
     private val navArgs: JetpackActivationWebViewFragmentArgs by savedStateHandle.navArgs()
+    private var isExiting = false
 
     val urlToLoad = navArgs.urlToLoad
 
     fun onUrlLoaded(url: String) {
-        if (url.startsWith(JETPACK_PLANS_URL) || url.startsWith(MOBILE_REDIRECT)) {
+        if (!isExiting && url.startsWith(JETPACK_PLANS_URL) || url.startsWith(MOBILE_REDIRECT)) {
             triggerEvent(ConnectionResult.Success)
+            isExiting = true
         }
     }
 
     fun onUrlFailed(url: String, errorCode: Int?) {
-        if (url.contains("wp-admin") && errorCode != null) {
+        if (!isExiting && url.contains("wp-admin") && errorCode != null) {
             // This will happen when the site uses a custom admin URL, in addition to other eventual errors
             triggerEvent(ConnectionResult.Failure(errorCode))
+            isExiting = true
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewViewModel.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.login.jetpack.connection
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -9,4 +11,15 @@ import javax.inject.Inject
 class JetpackActivationWebViewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
+    private val navArgs: JetpackActivationWebViewFragmentArgs by savedStateHandle.navArgs()
+
+    val urlToLoad = navArgs.urlToLoad
+
+    fun onUrlLoaded(url: String) {
+        TODO()
+    }
+
+    fun onDismiss() {
+        triggerEvent(Exit)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewViewModel.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.login.jetpack.connection
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class JetpackActivationWebViewViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedStateHandle) {
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewViewModel.kt
@@ -1,25 +1,49 @@
 package com.woocommerce.android.ui.login.jetpack.connection
 
+import android.os.Parcelable
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
 class JetpackActivationWebViewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
+    companion object {
+        @VisibleForTesting
+        const val JETPACK_PLANS_URL = "https://wordpress.com/jetpack/connect/plans"
+
+        @VisibleForTesting
+        const val MOBILE_REDIRECT = "woocommerce://jetpack-connected"
+    }
+
     private val navArgs: JetpackActivationWebViewFragmentArgs by savedStateHandle.navArgs()
 
     val urlToLoad = navArgs.urlToLoad
 
     fun onUrlLoaded(url: String) {
-        TODO()
+        if (url.startsWith(JETPACK_PLANS_URL) || url.startsWith(MOBILE_REDIRECT)) {
+            triggerEvent(ConnectionResult.Success)
+        }
     }
 
     fun onDismiss() {
-        triggerEvent(Exit)
+        triggerEvent(ConnectionResult.Cancel)
+    }
+
+    sealed class ConnectionResult : Event(), Parcelable {
+        @Parcelize
+        object Success : ConnectionResult()
+
+        @Parcelize
+        object Cancel : ConnectionResult()
+
+        @Parcelize
+        data class Failure(val errorCode: Int) : ConnectionResult()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewViewModel.kt
@@ -20,7 +20,6 @@ class JetpackActivationWebViewViewModel @Inject constructor(
 
         @VisibleForTesting
         const val MOBILE_REDIRECT = "woocommerce://jetpack-connected"
-        private const val NOT_FOUND = 404
     }
 
     private val navArgs: JetpackActivationWebViewFragmentArgs by savedStateHandle.navArgs()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/connection/JetpackActivationWebViewViewModel.kt
@@ -20,6 +20,7 @@ class JetpackActivationWebViewViewModel @Inject constructor(
 
         @VisibleForTesting
         const val MOBILE_REDIRECT = "woocommerce://jetpack-connected"
+        private const val NOT_FOUND = 404
     }
 
     private val navArgs: JetpackActivationWebViewFragmentArgs by savedStateHandle.navArgs()
@@ -29,6 +30,13 @@ class JetpackActivationWebViewViewModel @Inject constructor(
     fun onUrlLoaded(url: String) {
         if (url.startsWith(JETPACK_PLANS_URL) || url.startsWith(MOBILE_REDIRECT)) {
             triggerEvent(ConnectionResult.Success)
+        }
+    }
+
+    fun onUrlFailed(url: String, errorCode: Int?) {
+        if (url.contains("wp-admin") && errorCode != null) {
+            // This will happen when the site uses a custom admin URL, in addition to other eventual errors
+            triggerEvent(ConnectionResult.Failure(errorCode))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainFragment.kt
@@ -11,7 +11,6 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.AppPrefs
-import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.navigateBackWithNotice
@@ -20,7 +19,6 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.navigateToHelpScreen
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel.DisplayMode
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.jetpack.GoToStore
@@ -122,14 +120,10 @@ class JetpackActivationMainFragment : BaseFragment() {
 
     private fun showConnectionWebView(event: ShowJetpackConnectionWebView) {
         findNavController().navigateSafely(
-            directions = NavGraphMainDirections.actionGlobalWPComWebViewFragment(
-                urlToLoad = event.url,
-                urlsToTriggerExit = event.connectionValidationUrls.toTypedArray(),
-                title = getString(R.string.login_jetpack_installation_approve_connection),
-                displayMode = DisplayMode.MODAL,
-                urlComparisonMode = event.urlComparisonMode,
-                clearCache = event.clearCache
-            ),
+            directions = JetpackActivationMainFragmentDirections
+                .actionJetpackActivationMainFragmentToJetpackActivationWebViewFragment(
+                    urlToLoad = event.url
+                ),
             navOptions = NavOptions.Builder()
                 .setEnterAnim(R.anim.slide_up)
                 .setExitAnim(R.anim.no_anime)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainFragment.kt
@@ -12,18 +12,20 @@ import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.handleNotice
+import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.navigateToHelpScreen
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.login.jetpack.GoToStore
+import com.woocommerce.android.ui.login.jetpack.connection.JetpackActivationWebViewFragment
+import com.woocommerce.android.ui.login.jetpack.connection.JetpackActivationWebViewViewModel
 import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.GoToPasswordScreen
 import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.ShowJetpackConnectionWebView
+import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.ShowWebViewDismissedError
 import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.ShowWooNotInstalledScreen
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
@@ -69,17 +71,17 @@ class JetpackActivationMainFragment : BaseFragment() {
                 is ShowWooNotInstalledScreen -> showWooNotInstalledScreen(event.siteUrl)
                 is NavigateToHelpScreen -> navigateToHelpScreen(event.origin)
                 is GoToPasswordScreen -> openPasswordScreen(event.email)
+                is ShowWebViewDismissedError -> navigateBackWithNotice(CONNECTION_DISMISSED_RESULT)
                 is Exit -> findNavController().navigateUp()
             }
         }
     }
 
     private fun setupResultHandlers() {
-        handleNotice(WPComWebViewFragment.WEBVIEW_RESULT) {
-            viewModel.onJetpackConnected()
-        }
-        handleNotice(WPComWebViewFragment.WEBVIEW_DISMISSED) {
-            navigateBackWithNotice(CONNECTION_DISMISSED_RESULT)
+        handleResult<JetpackActivationWebViewViewModel.ConnectionResult>(
+            key = JetpackActivationWebViewFragment.JETPACK_CONNECTION_RESULT
+        ) {
+            viewModel.onJetpackConnectionResult(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -225,12 +225,18 @@ private fun AnimatedVisibilityScope.ErrorState(
             )
         }
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+
         val subtitle = when {
             viewState.errorCode == FORBIDDEN_ERROR_CODE &&
                 viewState.stepType == JetpackActivationMainViewModel.StepType.Connection ->
                 R.string.login_jetpack_installation_error_connection_permission_message
+
             viewState.errorCode == FORBIDDEN_ERROR_CODE ->
                 R.string.login_jetpack_installation_error_plugin_permission_message
+
+            viewState.stepType == JetpackActivationMainViewModel.StepType.Connection ->
+                R.string.login_jetpack_installation_error_connection_message
+
             else -> R.string.login_jetpack_installation_error_generic_message
         }
         Text(
@@ -238,10 +244,15 @@ private fun AnimatedVisibilityScope.ErrorState(
             style = MaterialTheme.typography.body1
         )
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
-        val suggestion = if (viewState.errorCode == FORBIDDEN_ERROR_CODE) {
-            R.string.login_jetpack_installation_error_forbidden_suggestion
-        } else {
-            R.string.login_jetpack_installation_retry_or_contact_support
+
+        val suggestion = when {
+            viewState.errorCode == FORBIDDEN_ERROR_CODE ->
+                R.string.login_jetpack_installation_error_forbidden_suggestion
+
+            viewState.stepType == JetpackActivationMainViewModel.StepType.Connection ->
+                R.string.login_jetpack_installation_error_connection_suggestion
+
+            else -> R.string.login_jetpack_installation_error_generic_suggestion
         }
         Text(
             text = stringResource(id = suggestion),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -22,7 +22,6 @@ import com.woocommerce.android.ui.common.PluginRepository.PluginStatus.PluginAct
 import com.woocommerce.android.ui.common.PluginRepository.PluginStatus.PluginActivationFailed
 import com.woocommerce.android.ui.common.PluginRepository.PluginStatus.PluginInstallFailed
 import com.woocommerce.android.ui.common.PluginRepository.PluginStatus.PluginInstalled
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel.UrlComparisonMode
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.jetpack.GoToStore
 import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
@@ -436,41 +435,23 @@ class JetpackActivationMainViewModel @Inject constructor(
                     //  &mobile_redirect=woocommerce://jetpack-connected&from=mobile
                     // See: pe5sF9-1le-p2#comment-1942
 
-                    val chosenUrl =
-                        if (connectionUrl.startsWith(JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX)) {
-                            connectionUrl
-                        } else {
-                            "https://wordpress.com/jetpack/connect?url=" + navArgs.siteUrl +
-                                "&mobile_redirect=" + MOBILE_REDIRECT +
-                                "&from=mobile"
-                        }
-
-                    // We use STARTS_WITH for the special URL case, to make sure MOBILE_REDIRECT is only used
-                    // as validation if it's at the start of the URL, not as a parameter in the special URL.
-                    val comparisonMode =
-                        if (connectionUrl.startsWith(JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX)) {
-                            UrlComparisonMode.PARTIAL
-                        } else {
-                            UrlComparisonMode.STARTS_WITH
-                        }
-
-                    // Occasionally, while connecting Jetpack, the webview may redirect to the Jetpack plans page
-                    // instead of MOBILE_REDIRECT. We are uncertain about the cause. However, since this redirect
-                    // occurs after the site connects, let's use the plans page as a validation URL too.
+                    val chosenUrl = if (connectionUrl.startsWith(JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX)) {
+                        connectionUrl
+                    } else {
+                        "https://wordpress.com/jetpack/connect?url=" + navArgs.siteUrl +
+                            "&mobile_redirect=" + MOBILE_REDIRECT +
+                            "&from=mobile"
+                    }
 
                     triggerEvent(
                         ShowJetpackConnectionWebView(
-                            url = chosenUrl,
-                            connectionValidationUrls = listOf(MOBILE_REDIRECT, JETPACK_PLANS_URL),
-                            urlComparisonMode = comparisonMode,
-                            clearCache = true
+                            url = chosenUrl
                         )
                     )
                 } else {
                     triggerEvent(
                         ShowJetpackConnectionWebView(
-                            url = connectionUrl,
-                            connectionValidationUrls = listOf(JETPACK_PLANS_URL, navArgs.siteUrl)
+                            url = connectionUrl
                         )
                     )
                 }
@@ -631,10 +612,7 @@ class JetpackActivationMainViewModel @Inject constructor(
     }
 
     data class ShowJetpackConnectionWebView(
-        val url: String,
-        val connectionValidationUrls: List<String>,
-        val urlComparisonMode: UrlComparisonMode = UrlComparisonMode.PARTIAL,
-        val clearCache: Boolean = false
+        val url: String
     ) : MultiLiveEvent.Event()
 
     data class GoToPasswordScreen(val email: String) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -72,15 +72,15 @@ class JetpackActivationMainViewModel @Inject constructor(
     companion object {
         private const val JETPACK_SLUG = "jetpack"
         private const val JETPACK_NAME = "jetpack/jetpack"
+        private const val DELAY_AFTER_CONNECTION_MS = 500L
+        private const val DELAY_BEFORE_SHOWING_ERROR_STATE_MS = 1000L
+        private const val CONNECTED_EMAIL_KEY = "connected-email"
 
         @VisibleForTesting
         const val JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX = "https://jetpack.wordpress.com/jetpack.authorize"
 
         @VisibleForTesting
         const val MOBILE_REDIRECT = "woocommerce://jetpack-connected"
-        private const val DELAY_AFTER_CONNECTION_MS = 500L
-        private const val DELAY_BEFORE_SHOWING_ERROR_STATE_MS = 1000L
-        private const val CONNECTED_EMAIL_KEY = "connected-email"
     }
 
     private val navArgs: JetpackActivationMainFragmentArgs by savedStateHandle.navArgs()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -72,8 +72,10 @@ class JetpackActivationMainViewModel @Inject constructor(
     companion object {
         private const val JETPACK_SLUG = "jetpack"
         private const val JETPACK_NAME = "jetpack/jetpack"
+
         @VisibleForTesting
         const val JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX = "https://jetpack.wordpress.com/jetpack.authorize"
+
         @VisibleForTesting
         const val MOBILE_REDIRECT = "woocommerce://jetpack-connected"
         private const val DELAY_AFTER_CONNECTION_MS = 500L
@@ -209,7 +211,11 @@ class JetpackActivationMainViewModel @Inject constructor(
         when (result) {
             Success -> connectionStep.value = ConnectionStep.Validation
             Cancel -> triggerEvent(ShowWebViewDismissedError)
-            is Failure -> TODO()
+            is Failure -> currentStep.update {
+                it.copy(
+                    state = StepState.Error(result.errorCode)
+                )
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModel.kt
@@ -25,6 +25,10 @@ import com.woocommerce.android.ui.common.PluginRepository.PluginStatus.PluginIns
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.jetpack.GoToStore
 import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
+import com.woocommerce.android.ui.login.jetpack.connection.JetpackActivationWebViewViewModel
+import com.woocommerce.android.ui.login.jetpack.connection.JetpackActivationWebViewViewModel.ConnectionResult.Cancel
+import com.woocommerce.android.ui.login.jetpack.connection.JetpackActivationWebViewViewModel.ConnectionResult.Failure
+import com.woocommerce.android.ui.login.jetpack.connection.JetpackActivationWebViewViewModel.ConnectionResult.Success
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -70,8 +74,6 @@ class JetpackActivationMainViewModel @Inject constructor(
         private const val JETPACK_NAME = "jetpack/jetpack"
         @VisibleForTesting
         const val JETPACK_SITE_CONNECTED_AUTH_URL_PREFIX = "https://jetpack.wordpress.com/jetpack.authorize"
-        @VisibleForTesting
-        const val JETPACK_PLANS_URL = "https://wordpress.com/jetpack/connect/plans"
         @VisibleForTesting
         const val MOBILE_REDIRECT = "woocommerce://jetpack-connected"
         private const val DELAY_AFTER_CONNECTION_MS = 500L
@@ -203,8 +205,12 @@ class JetpackActivationMainViewModel @Inject constructor(
         }
     }
 
-    fun onJetpackConnected() {
-        connectionStep.value = ConnectionStep.Validation
+    fun onJetpackConnectionResult(result: JetpackActivationWebViewViewModel.ConnectionResult) {
+        when (result) {
+            Success -> connectionStep.value = ConnectionStep.Validation
+            Cancel -> triggerEvent(ShowWebViewDismissedError)
+            is Failure -> TODO()
+        }
     }
 
     fun onRetryClick() {
@@ -617,4 +623,5 @@ class JetpackActivationMainViewModel @Inject constructor(
 
     data class GoToPasswordScreen(val email: String) : MultiLiveEvent.Event()
     data class ShowWooNotInstalledScreen(val siteUrl: String) : MultiLiveEvent.Event()
+    object ShowWebViewDismissedError : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
@@ -78,6 +78,9 @@
         <argument
             android:name="isJetpackInstalled"
             app:argType="boolean" />
+        <action
+            android:id="@+id/action_jetpackActivationMainFragment_to_jetpackActivationWebViewFragment"
+            app:destination="@id/jetpackActivationWebViewFragment" />
     </fragment>
     <fragment
         android:id="@+id/jetpackActivationWPComEmailFragment"
@@ -156,5 +159,13 @@
             app:destination="@id/jetpackActivationMainFragment"
             app:popUpTo="@id/jetpackActivationDispatcherFragment"
             app:popUpToInclusive="true" />
+    </fragment>
+    <fragment
+        android:id="@+id/jetpackActivationWebViewFragment"
+        android:name="com.woocommerce.android.ui.login.jetpack.connection.JetpackActivationWebViewFragment"
+        android:label="JetpackActivationWebViewFragment">
+        <argument
+            android:name="urlToLoad"
+            app:argType="string" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -815,7 +815,7 @@ Language: ar
     <string name="login_jetpack_installation_retry_activating">محاولة التفعيل مجددًا</string>
     <string name="login_jetpack_installation_retry_installing">محاولة التثبيت مجددًا</string>
     <string name="login_jetpack_installation_get_support">الحصول على الدعم</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">ترجى المحاولة مجددًا والاتصال بالدعم إذا استمر هذا الخطأ.</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">ترجى المحاولة مجددًا والاتصال بالدعم إذا استمر هذا الخطأ.</string>
     <string name="login_jetpack_installation_error_generic_message">حدث خطأ في أثناء الاتصال بموقعك.</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">ليس لديك الإذن اللازم لإدارة الإضافات على هذا المتجر</string>
     <string name="login_jetpack_installation_error_authorizing">حدث خطأ في أثناء تخويل الاتصال بـ Jetpack</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -815,7 +815,7 @@ Language: de
     <string name="login_jetpack_installation_retry_activating">Aktivierung erneut versuchen</string>
     <string name="login_jetpack_installation_retry_installing">Installation erneut versuchen</string>
     <string name="login_jetpack_installation_get_support">Unterstützung erhalten</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">Versuche es erneut und wende dich an den Support, falls dieser Fehler weiterhin auftritt.</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">Versuche es erneut und wende dich an den Support, falls dieser Fehler weiterhin auftritt.</string>
     <string name="login_jetpack_installation_error_generic_message">Bei der Kommunikation mit deiner Website ist ein Fehler aufgetreten.</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">Du bist nicht berechtigt, Plugins in diesem Shop zu verwalten</string>
     <string name="login_jetpack_installation_error_authorizing">Fehler beim Autorisieren der Verbindung mit Jetpack</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -815,7 +815,7 @@ Language: es
     <string name="login_jetpack_installation_retry_activating">Prueba a activarlo de nuevo</string>
     <string name="login_jetpack_installation_retry_installing">Prueba a instalarlo de nuevo</string>
     <string name="login_jetpack_installation_get_support">Obtener soporte</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">Inténtalo de nuevo o ponte en contacto con el soporte si el error continúa.</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">Inténtalo de nuevo o ponte en contacto con el soporte si el error continúa.</string>
     <string name="login_jetpack_installation_error_generic_message">Se ha producido un error al comunicarse con el sitio.</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">No tienes permiso para gestionar plugins en esta tienda.</string>
     <string name="login_jetpack_installation_error_authorizing">Error al autorizar la conexión con Jetpack</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -815,7 +815,7 @@ Language: fr
     <string name="login_jetpack_installation_retry_activating">Réessayer d’activer</string>
     <string name="login_jetpack_installation_retry_installing">Réessayer d’installer</string>
     <string name="login_jetpack_installation_get_support">Obtenir de l’aide</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">Veuillez réessayer. Si le problème persiste, contactez l’assistance.</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">Veuillez réessayer. Si le problème persiste, contactez l’assistance.</string>
     <string name="login_jetpack_installation_error_generic_message">Une erreur est survenue lors de la communication avec votre site.</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">Vous n’êtes pas autorisé à gérer les extensions sur cette boutique.</string>
     <string name="login_jetpack_installation_error_authorizing">Erreur lors de l’autorisation de la connexion à Jetpack</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -815,7 +815,7 @@ Language: he_IL
     <string name="login_jetpack_installation_retry_activating">יש לנסות להפעיל שוב</string>
     <string name="login_jetpack_installation_retry_installing">יש לנסות להתקין שוב</string>
     <string name="login_jetpack_installation_get_support">לקבלת תמיכה</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">יש לנסות שוב ולפנות לתמיכה אם השגיאה ממשיכה להופיע.</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">יש לנסות שוב ולפנות לתמיכה אם השגיאה ממשיכה להופיע.</string>
     <string name="login_jetpack_installation_error_generic_message">אירעה שגיאה בתקשורת עם האתר שלך.</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">אין לך הרשאה לניהול התוספים בחנות הזאת</string>
     <string name="login_jetpack_installation_error_authorizing">אירעה שגיאה באישור החיבור אל Jetpack</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -815,7 +815,7 @@ Language: id
     <string name="login_jetpack_installation_retry_activating">Coba aktifkan ulang</string>
     <string name="login_jetpack_installation_retry_installing">Coba instal ulang</string>
     <string name="login_jetpack_installation_get_support">Dapatkan dukungan</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">Harap coba lagi dan hubungi dukungan jika error ini berlanjut.</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">Harap coba lagi dan hubungi dukungan jika error ini berlanjut.</string>
     <string name="login_jetpack_installation_error_generic_message">Terjadi error saat berkomunikasi dengan situs Anda.</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">Anda tidak memiliki izin untuk mengelola plugin di toko ini</string>
     <string name="login_jetpack_installation_error_authorizing">Terjadi error saat memberi izin penyambungan ke Jetpack</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -815,7 +815,7 @@ Language: it
     <string name="login_jetpack_installation_retry_activating">Prova di nuovo l\'attivazione</string>
     <string name="login_jetpack_installation_retry_installing">Prova di nuovo l\'installazione</string>
     <string name="login_jetpack_installation_get_support">Ottieni assistenza</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">Riprova e contatta il supporto se l\'errore persiste.</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">Riprova e contatta il supporto se l\'errore persiste.</string>
     <string name="login_jetpack_installation_error_generic_message">Si è verificato un errore durante la comunicazione con il sito.</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">Non disponi dell\'autorizzazione per gestire i plugin in questo negozio</string>
     <string name="login_jetpack_installation_error_authorizing">Errore di autorizzazione della connessione a Jetpack</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -815,7 +815,7 @@ Language: ja_JP
     <string name="login_jetpack_installation_retry_activating">有効化を再試行</string>
     <string name="login_jetpack_installation_retry_installing">インストールを再試行</string>
     <string name="login_jetpack_installation_get_support">サポートを受ける</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">もう一度やり直してみてください。エラーが続く場合は、サポートにお問い合わせください。</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">もう一度やり直してみてください。エラーが続く場合は、サポートにお問い合わせください。</string>
     <string name="login_jetpack_installation_error_generic_message">サイトとの通信でエラーが発生しました。</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">このストアのプラグインを管理する権限がありません</string>
     <string name="login_jetpack_installation_error_authorizing">Jetpack との連携を認証する際にエラーが発生しました</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -815,7 +815,7 @@ Language: ko_KR
     <string name="login_jetpack_installation_retry_activating">다시 활성화 시도</string>
     <string name="login_jetpack_installation_retry_installing">다시 설치 시도</string>
     <string name="login_jetpack_installation_get_support">지원받기</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">다시 시도하고 이 오류가 계속 발생하면 지원팀에 문의하세요.</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">다시 시도하고 이 오류가 계속 발생하면 지원팀에 문의하세요.</string>
     <string name="login_jetpack_installation_error_generic_message">사이트와 통신 중 오류가 발생했습니다.</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">이 스토어의 플러그인을 관리할 권한이 없습니다.</string>
     <string name="login_jetpack_installation_error_authorizing">젯팩에 연결하는 권한 부여 중 오류 발생</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -815,7 +815,7 @@ Language: nl
     <string name="login_jetpack_installation_retry_activating">Probeer opnieuw te activeren</string>
     <string name="login_jetpack_installation_retry_installing">Probeer opnieuw te installeren</string>
     <string name="login_jetpack_installation_get_support">Vraag ondersteuning</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">Probeer het opnieuw en neem contact op met ondersteuning als het probleem aanhoudt.</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">Probeer het opnieuw en neem contact op met ondersteuning als het probleem aanhoudt.</string>
     <string name="login_jetpack_installation_error_generic_message">Er is een fout opgetreden tijdens het communiceren met je site.</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">Je hebt geen toestemming om plugins te beheren op deze winkel.</string>
     <string name="login_jetpack_installation_error_authorizing">Fout bij het autoriseren van de verbinding met Jetpack</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -815,7 +815,7 @@ Language: pt_BR
     <string name="login_jetpack_installation_retry_activating">Tentar ativar novamente</string>
     <string name="login_jetpack_installation_retry_installing">Tentar instalar novamente</string>
     <string name="login_jetpack_installation_get_support">Obter suporte</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">Tente novamente e entre em contato com o suporte se o erro persistir.</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">Tente novamente e entre em contato com o suporte se o erro persistir.</string>
     <string name="login_jetpack_installation_error_generic_message">Ocorreu um erro durante a comunicação com seu site.</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">Você não tem permissão para gerenciar plugins nesta loja</string>
     <string name="login_jetpack_installation_error_authorizing">Erro ao autorizar a conexão ao Jetpack</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -815,7 +815,7 @@ Language: ru
     <string name="login_jetpack_installation_retry_activating">Повторить активацию</string>
     <string name="login_jetpack_installation_retry_installing">Повторить установку</string>
     <string name="login_jetpack_installation_get_support">Получить поддержку</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">Повторите попытку и обратитесь в службу поддержки, если эта ошибка произойдёт снова.</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">Повторите попытку и обратитесь в службу поддержки, если эта ошибка произойдёт снова.</string>
     <string name="login_jetpack_installation_error_generic_message">Во время обмена данными с вашим веб-сайтом произошла ошибка.</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">У вас нет разрешения на управление плагинами в этом магазине</string>
     <string name="login_jetpack_installation_error_authorizing">Ошибка при авторизации подключения к Jetpack</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -815,7 +815,7 @@ Language: sv_SE
     <string name="login_jetpack_installation_retry_activating">Försök att aktivera igen</string>
     <string name="login_jetpack_installation_retry_installing">Försök installera igen</string>
     <string name="login_jetpack_installation_get_support">Skaffa support</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">Försök igen och kontakta supporten om detta fel fortsätter.</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">Försök igen och kontakta supporten om detta fel fortsätter.</string>
     <string name="login_jetpack_installation_error_generic_message">Ett fel uppstod vid kommunikationen med din webbplats.</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">Du har inte behörighet att hantera tillägg på denna butik</string>
     <string name="login_jetpack_installation_error_authorizing">Det gick inte att auktorisera anslutningen till Jetpack</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -815,7 +815,7 @@ Language: tr
     <string name="login_jetpack_installation_retry_activating">Tekrar etkinleştirmeyi deneyin</string>
     <string name="login_jetpack_installation_retry_installing">Tekrar kurmayı deneyin</string>
     <string name="login_jetpack_installation_get_support">Destek alın</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">Lütfen tekrar deneyin ve bu hata devam ederse destekle iletişime geçin.</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">Lütfen tekrar deneyin ve bu hata devam ederse destekle iletişime geçin.</string>
     <string name="login_jetpack_installation_error_generic_message">Sitenizle iletişim kurmada bir hata yaşandı:</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">Bu mağazada eklentileri yönetme izniniz yok.</string>
     <string name="login_jetpack_installation_error_authorizing">Jetpack\'e bağlantı yetkisi verilirken hata oluştu</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -815,7 +815,7 @@ Language: zh_CN
     <string name="login_jetpack_installation_retry_activating">再次尝试启用</string>
     <string name="login_jetpack_installation_retry_installing">再次尝试安装</string>
     <string name="login_jetpack_installation_get_support">获取支持</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">如果此错误仍然存在，请重试并联系支持人员。</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">如果此错误仍然存在，请重试并联系支持人员。</string>
     <string name="login_jetpack_installation_error_generic_message">与您的站点通信时发生错误。</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">您没有在此商店中管理插件的权限</string>
     <string name="login_jetpack_installation_error_authorizing">授权连接 Jetpack 时发生错误</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -815,7 +815,7 @@ Language: zh_TW
     <string name="login_jetpack_installation_retry_activating">嘗試重新啟用</string>
     <string name="login_jetpack_installation_retry_installing">嘗試重新安裝</string>
     <string name="login_jetpack_installation_get_support">取得支援</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">請再試一次；如果持續發生此錯誤，請聯絡支援團隊。</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">請再試一次；如果持續發生此錯誤，請聯絡支援團隊。</string>
     <string name="login_jetpack_installation_error_generic_message">與你的網站通訊時發生錯誤。</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">你無權管理此商店的外掛程式</string>
     <string name="login_jetpack_installation_error_authorizing">授權連結到 Jetpack 時發生錯誤</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -322,8 +322,10 @@
     <string name="login_jetpack_installation_error_activating">Error activating Jetpack</string>
     <string name="login_jetpack_installation_error_authorizing">Error authorising connection to Jetpack</string>
     <string name="login_jetpack_installation_error_plugin_permission_message">You don’t have permission to manage plugins on this store</string>
+    <string name="login_jetpack_installation_error_connection_message">There was an error communicating with your site.</string>
+    <string name="login_jetpack_installation_error_connection_suggestion">Please connect Jetpack through your admin page on a browser or contact support.</string>
     <string name="login_jetpack_installation_error_generic_message">There was an error communicating with your site.</string>
-    <string name="login_jetpack_installation_retry_or_contact_support">Please try again and contact support if this error continues.</string>
+    <string name="login_jetpack_installation_error_generic_suggestion">Please try again and contact support if this error continues.</string>
     <string name="login_jetpack_installation_get_support">Get support</string>
     <string name="login_jetpack_installation_retry_installing">Try installing again</string>
     <string name="login_jetpack_installation_retry_activating">Try activating again</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModelTest.kt
@@ -5,9 +5,9 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.common.PluginRepository
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewViewModel.UrlComparisonMode
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
+import com.woocommerce.android.ui.login.jetpack.connection.JetpackActivationWebViewViewModel
 import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.ConnectionStep
 import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.ShowJetpackConnectionWebView
 import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainViewModel.StepState
@@ -87,12 +87,7 @@ class JetpackActivationMainViewModelTest : BaseUnitTest() {
             assertThat(event).isEqualTo(
                 ShowJetpackConnectionWebView(
                     url = "https://wordpress.com/jetpack/connect?url=example.com" +
-                        "&mobile_redirect=${JetpackActivationMainViewModel.MOBILE_REDIRECT}&from=mobile",
-                    connectionValidationUrls = listOf(
-                        JetpackActivationMainViewModel.MOBILE_REDIRECT, JetpackActivationMainViewModel.JETPACK_PLANS_URL
-                    ),
-                    urlComparisonMode = UrlComparisonMode.STARTS_WITH,
-                    clearCache = true
+                        "&mobile_redirect=${JetpackActivationMainViewModel.MOBILE_REDIRECT}&from=mobile"
                 )
             )
         }
@@ -115,12 +110,7 @@ class JetpackActivationMainViewModelTest : BaseUnitTest() {
 
             assertThat(event).isEqualTo(
                 ShowJetpackConnectionWebView(
-                    url = connectionUrl,
-                    connectionValidationUrls = listOf(
-                        JetpackActivationMainViewModel.MOBILE_REDIRECT, JetpackActivationMainViewModel.JETPACK_PLANS_URL
-                    ),
-                    urlComparisonMode = UrlComparisonMode.PARTIAL,
-                    clearCache = true
+                    url = connectionUrl
                 )
             )
         }
@@ -143,9 +133,7 @@ class JetpackActivationMainViewModelTest : BaseUnitTest() {
 
             assertThat(event).isEqualTo(
                 ShowJetpackConnectionWebView(
-                    url = connectionUrl,
-                    connectionValidationUrls = listOf(JetpackActivationMainViewModel.JETPACK_PLANS_URL, siteUrl),
-                    urlComparisonMode = UrlComparisonMode.PARTIAL
+                    url = connectionUrl
                 )
             )
         }
@@ -167,7 +155,7 @@ class JetpackActivationMainViewModelTest : BaseUnitTest() {
         }
 
         val state = viewModel.viewState.runAndCaptureValues {
-            viewModel.onJetpackConnected()
+            viewModel.onJetpackConnectionResult(JetpackActivationWebViewViewModel.ConnectionResult.Success)
         }.last()
 
         assertThat((state as ProgressViewState).connectionStep).isEqualTo(ConnectionStep.Validation)
@@ -186,7 +174,7 @@ class JetpackActivationMainViewModelTest : BaseUnitTest() {
         }
 
         val state = viewModel.viewState.runAndCaptureValues {
-            viewModel.onJetpackConnected()
+            viewModel.onJetpackConnectionResult(JetpackActivationWebViewViewModel.ConnectionResult.Success)
             advanceUntilIdle()
             runCurrent()
         }.last()
@@ -209,7 +197,7 @@ class JetpackActivationMainViewModelTest : BaseUnitTest() {
             }
 
             val state = viewModel.viewState.runAndCaptureValues {
-                viewModel.onJetpackConnected()
+                viewModel.onJetpackConnectionResult(JetpackActivationWebViewViewModel.ConnectionResult.Success)
                 viewModel.onRetryClick()
             }.last()
 


### PR DESCRIPTION
Closes: #8731 

### Description
This PR adds logic to handle an edge case during the Jetpack Connection from the Application Passwords login state, more details can be found in the ticket and the linked P2.

The PR got big because I needed a new screen that handles the connection, instead of relying on the reusable `WPComWebViewFragment`, which was needed to allow detecting errors in the WebView.

### Testing instructions
**Copied from https://github.com/woocommerce/woocommerce-ios/pull/9354**
- Make sure that WCPay is deactivated on your test store.
- Install and activate [WP Hide](https://wordpress.org/plugins/wp-hide-security-enhancer/) plugin on your store.
- On wp-admin left side bar navigate to WP Hide > Hide Admin. Update a custom URL and enable "Block default Admin Url"
<img width="1087" alt="Screenshot 2023-04-04 at 09 35 33" src="https://user-images.githubusercontent.com/5533851/229679826-54444b80-d040-4eef-a4cd-7d8fbf9dfe97.png">

- On the app, navigate to the Jetpack setup flow by tapping the Jetpack benefit banner on the dashboard screen or go to Menu > Settings > Install Jetpack.
- During the connection step of the setup flow, notice that the connection web view is dismissed and the setup screen should show an error about the connection.

### Images/gif
https://github.com/woocommerce/woocommerce-android/assets/1657201/3817e828-233f-4920-a2f3-4dbfdbeb1162


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
