### PR TITLE
Feature/10058 check if product already blazed

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsProductCurrentlyPromoted.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsProductCurrentlyPromoted.kt
@@ -1,0 +1,24 @@
+package com.woocommerce.android.ui.blaze
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.blaze.CampaignStatusUi.Active
+import com.woocommerce.android.ui.blaze.CampaignStatusUi.InModeration
+import com.woocommerce.android.ui.blaze.CampaignStatusUi.Scheduled
+import org.wordpress.android.fluxc.store.blaze.BlazeCampaignsStore
+import javax.inject.Inject
+
+class IsProductCurrentlyPromoted @Inject constructor(
+    private val blazeStore: BlazeCampaignsStore,
+    private val selectedSite: SelectedSite
+) {
+    suspend operator fun invoke(productId: String): Boolean {
+        return blazeStore.getBlazeCampaigns(selectedSite.get())
+            .campaigns
+            .filter {
+                CampaignStatusUi.fromString(it.uiStatus) == InModeration ||
+                    CampaignStatusUi.fromString(it.uiStatus) == Scheduled ||
+                    CampaignStatusUi.fromString(it.uiStatus) == Active
+            }
+            .any { it.targetUrn.split(":").last() == productId }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsProductCurrentlyPromoted.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsProductCurrentlyPromoted.kt
@@ -19,6 +19,6 @@ class IsProductCurrentlyPromoted @Inject constructor(
                     CampaignStatusUi.fromString(it.uiStatus) == Scheduled ||
                     CampaignStatusUi.fromString(it.uiStatus) == Active
             }
-            .any { it.targetUrn.split(":").last() == productId }
+            .any { it.targetUrn?.split(":")?.last() == productId }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -142,6 +142,7 @@ class ProductDetailCardBuilder(
         val isProductPublic = product.status == ProductStatus.PUBLISH &&
             viewModel.getProductVisibility() == ProductVisibility.PUBLIC
 
+        @Suppress("ComplexCondition")
         if (!isBlazeEnabled() ||
             !isProductPublic ||
             viewModel.isProductUnderCreation ||

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
+import com.woocommerce.android.ui.blaze.IsProductCurrentlyPromoted
 import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewGroupedProducts
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewLinkedProducts
@@ -84,6 +85,7 @@ class ProductDetailCardBuilder(
     private val variationRepository: VariationRepository,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val isBlazeEnabled: IsBlazeEnabled,
+    private val isProductCurrentlyPromoted: IsProductCurrentlyPromoted,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) {
     private var blazeCtaShownTracked = false
@@ -142,7 +144,8 @@ class ProductDetailCardBuilder(
 
         if (!isBlazeEnabled() ||
             !isProductPublic ||
-            viewModel.isProductUnderCreation
+            viewModel.isProductUnderCreation ||
+            isProductCurrentlyPromoted(product.remoteId.toString())
         ) return null
 
         if (!blazeCtaShownTracked) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -55,6 +55,7 @@ import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
+import com.woocommerce.android.ui.blaze.IsProductCurrentlyPromoted
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.media.getMediaUploadErrorMessage
 import com.woocommerce.android.ui.products.AddProductSource.STORE_ONBOARDING
@@ -144,7 +145,8 @@ class ProductDetailViewModel @Inject constructor(
     private val getComponentProducts: GetComponentProducts,
     private val productListRepository: ProductListRepository,
     private val isBlazeEnabled: IsBlazeEnabled,
-    private val blazeUrlsHelper: BlazeUrlsHelper
+    private val blazeUrlsHelper: BlazeUrlsHelper,
+    private val isProductCurrentlyPromoted: IsProductCurrentlyPromoted
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_PARAMETERS = "key_product_parameters"
@@ -229,7 +231,8 @@ class ProductDetailViewModel @Inject constructor(
             variationRepository = variationRepository,
             appPrefsWrapper = appPrefsWrapper,
             isBlazeEnabled = isBlazeEnabled,
-            analyticsTrackerWrapper = tracker
+            isProductCurrentlyPromoted = isProductCurrentlyPromoted,
+            analyticsTrackerWrapper = tracker,
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilderTest.kt
@@ -53,6 +53,7 @@ class ProductDetailCardBuilderTest : BaseUnitTest() {
             variationRepository = mock(),
             appPrefsWrapper = mock(),
             isBlazeEnabled = isBlazeEnabled,
+            isProductCurrentlyPromoted = mock(),
             analyticsTrackerWrapper = mock()
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelGenerateVariationFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelGenerateVariationFlowTest.kt
@@ -114,6 +114,7 @@ class ProductDetailViewModelGenerateVariationFlowTest : BaseUnitTest() {
                 productListRepository = mock(),
                 isBlazeEnabled = mock(),
                 blazeUrlsHelper = mock(),
+                isProductCurrentlyPromoted = mock(),
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -266,6 +266,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                 productListRepository = mock(),
                 isBlazeEnabled = isBlazeEnabled,
                 blazeUrlsHelper = BlazeUrlsHelper(selectedSite),
+                isProductCurrentlyPromoted = mock(),
             )
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -189,7 +189,8 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
                 getComponentProducts = mock(),
                 productListRepository = mock(),
                 isBlazeEnabled = isBlazeEnabled,
-                blazeUrlsHelper = BlazeUrlsHelper(selectedSite)
+                blazeUrlsHelper = BlazeUrlsHelper(selectedSite),
+                isProductCurrentlyPromoted = mock(),
             )
         )
 

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.52.0'
+    fluxCVersion = '2888-350ba902d0f7e1ea74b79275f430aa1ab35d3b22'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2888-350ba902d0f7e1ea74b79275f430aa1ab35d3b22'
+    fluxCVersion = '2888-3d0e98d64a91c70ab2208433ec0406f256251131'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2888-3d0e98d64a91c70ab2208433ec0406f256251131'
+    fluxCVersion = 'trunk-bf74da433541f7ce29faeeb281dd55ad6e806bd1'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10058 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Hides Blaze product CTA on product detail screen if the current product has an active ongoing campaign. Note that for this use case we consider a campaign to be active if it's in one of the following states:
- InModeration
- Scheduled
- Active

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Log into a WP.com site with at last one product published
2. Navigate to product detail and click on "Promote with Blaze" 
3. Create a campaign
4. Navigate again to the same product detail and notice how the CTA is gone

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/d18caad2-34e2-4bb4-98b7-cdcf44c3985b