### PR TITLE
Log user out when a INVALID_TOKEN error is received

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -649,7 +649,7 @@ class MainActivity :
     /**
      * Called when the user switches sites - restarts the activity so all fragments and child fragments are reset
      */
-    private fun restart() {
+    override fun restart() {
         val intent = intent
         intent.addFlags(
             Intent.FLAG_ACTIVITY_CLEAR_TOP or

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainContract.kt
@@ -31,5 +31,6 @@ interface MainContract {
         fun showProgressDialog(@StringRes stringId: Int)
         fun showUserEligibilityErrorScreen()
         fun updateStatsWidgets()
+        fun restart()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainPresenterTest.kt
@@ -24,6 +24,8 @@ import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticationError
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType.INVALID_TOKEN
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -146,5 +148,18 @@ class MainPresenterTest : BaseUnitTest() {
         mainPresenter.takeView(mainContractView)
 
         verify(mainContractView).hideOrderBadge()
+    }
+
+    @Test
+    fun `Handles invalid token error correctly`() = testBlocking {
+        mainPresenter.takeView(mainContractView)
+
+        // Check that the resulting OnAuthenticationChanged ends up logging user out and restarting the View
+        val event = OnAuthenticationChanged()
+        event.error = AuthenticationError(INVALID_TOKEN, "Invalid token")
+        mainPresenter.onAuthenticationChanged(event)
+
+        verify(accountRepository).logout()
+        verify(mainContractView).restart()
     }
 }


### PR DESCRIPTION
Fixes #2840.

**To test:**
1. Install and login into the app using WPCOM account
2. Pick a store and navigate into the app
3. Open https://wordpress.com/me/security/connected-applications in a web browser
4. Disconnect "WooCommerce for Android"
5. Open the mobile app and reload any screen
6. You should be logged out of the app