### PR TITLE
Address "Site not selected" crash when app receives invalid token error

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -55,7 +55,6 @@ import dagger.android.DispatchingAndroidInjector
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -84,7 +83,6 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         private const val SECONDS_BETWEEN_SITE_UPDATE = 60 * 60 // 1 hour
         private const val UNAUTHORIZED_STATUS_CODE = 401
         private const val CARD_READER_USAGE_THIRTY_DAYS = 30
-        private const val RESET_DELAY = 1000L
     }
 
     @Inject lateinit var crashLogging: CrashLogging
@@ -141,7 +139,6 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
                             // The previously selected site doesn't have Woo anymore, take the user to the login screen
                             WooLog.w(T.LOGIN, "Selected site no longer has WooCommerce")
 
-                            delay(RESET_DELAY) // delay the site reset and allow for the requests to fail gracefully
                             selectedSite.reset()
                             restartMainActivity()
                         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/SelectedSiteModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/SelectedSiteModule.kt
@@ -6,6 +6,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Singleton
 
@@ -14,5 +15,9 @@ import javax.inject.Singleton
 class SelectedSiteModule {
     @Provides
     @Singleton
-    fun provideSelectedSite(context: Context, siteStore: SiteStore) = SelectedSite(context, siteStore)
+    fun provideSelectedSite(
+        context: Context,
+        siteStore: SiteStore,
+        @AppCoroutineScope scope: CoroutineScope
+    ) = SelectedSite(context, siteStore, scope)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -3,8 +3,11 @@ package com.woocommerce.android.tools
 import android.content.Context
 import androidx.preference.PreferenceManager
 import com.woocommerce.android.util.PreferenceUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.EventBus
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
@@ -18,9 +21,11 @@ import javax.inject.Singleton
 class SelectedSite(
     private val context: Context,
     private val siteStore: SiteStore,
+    private val scope: CoroutineScope
 ) {
     companion object {
         const val SELECTED_SITE_LOCAL_ID = "SELECTED_SITE_LOCAL_ID"
+        private const val RESET_DELAY = 1000L
 
         fun getEventBus(): EventBus = EventBus.getDefault()
     }
@@ -81,8 +86,11 @@ class SelectedSite(
     fun getSelectedSiteId() = PreferenceUtils.getInt(getPreferences(), SELECTED_SITE_LOCAL_ID, -1)
 
     fun reset() {
-        state.value = null
-        getPreferences().edit().remove(SELECTED_SITE_LOCAL_ID).apply()
+        scope.launch {
+            delay(RESET_DELAY) // delay the site reset and allow for the requests to fail gracefully
+            state.value = null
+            getPreferences().edit().remove(SELECTED_SITE_LOCAL_ID).apply()
+        }
     }
 
     private fun getPreferences() = PreferenceManager.getDefaultSharedPreferences(context)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.LOGIN
 import com.woocommerce.android.util.dispatchAndAwait
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
@@ -35,10 +34,6 @@ class AccountRepository @Inject constructor(
     private val prefs: AppPrefs,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) {
-    companion object {
-        private const val RESET_DELAY = 1000L
-    }
-
     fun getUserAccount(): AccountModel? = accountStore.account.takeIf { it.userId != 0L }
 
     suspend fun fetchUserAccount(): Result<Unit> {
@@ -112,7 +107,7 @@ class AccountRepository @Inject constructor(
         }
     }
 
-    private suspend fun cleanup() {
+    private fun cleanup() {
         // Reset analytics
         AnalyticsTracker.flush()
         AnalyticsTracker.clearAllData()
@@ -121,7 +116,6 @@ class AccountRepository @Inject constructor(
         // Wipe user-specific preferences
         prefs.resetUserPreferences()
 
-        delay(RESET_DELAY) // delay the site reset and allow for the requests to fail gracefully
         selectedSite.reset()
 
         // Delete sites


### PR DESCRIPTION
This is an addition to #2840 and is also related to #10056. Because the invalid token error now causes the app to reset, this behaviour can result in the same `Site not selected` error as with application passwords. 

This PR moves the delay directly into SelectedSite.reset() function, so that any call to `reset` will will wait for parallel requests to complete.

**To test:**
1. Install and login into the app using WPCOM account
2. Pick a store and navigate into the app
3. Open https://wordpress.com/me/security/connected-applications in a web browser
4. Disconnect "WooCommerce for Android"
5. Open the mobile app and reload any screen
6. Notice the app is logged out
7. Notice there is no `IllegalStateException` related to site not selected in the logs