### PR TITLE
[Order creation] Product cards UI improvements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -8,7 +8,6 @@ import android.view.MenuItem
 import android.view.View
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
@@ -320,9 +319,7 @@ class OrderCreateEditFormFragment :
             binding.orderStatusView.updateStatus(it)
         }
 
-        viewModel.products.observe(viewLifecycleOwner) {
-            bindProductsSection(binding.productsSection, viewModel.products)
-        }
+        bindProductsSection(binding.productsSection, viewModel.products)
 
         if (isCustomAmountsFeatureFlagEnabled()) {
             viewModel.customAmounts.observe(viewLifecycleOwner) {
@@ -712,7 +709,7 @@ class OrderCreateEditFormFragment :
         setContent {
             val state = items.observeAsState(emptyList())
             WooTheme {
-                Column(modifier = Modifier) {
+                Column {
                     state.value.forEach { item ->
                         ExpandableProductCard(
                             viewModel.viewStateData.liveData.observeAsState(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.runtime.Composable
@@ -65,6 +66,7 @@ import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.util.getStockText
 
 private const val ANIM_DURATION_MILLIS = 128
+private const val MULTIPLICATION_CHAR = "×"
 
 @SuppressLint("UnusedTransitionTargetStateParameter")
 @Composable
@@ -158,6 +160,7 @@ fun ExpandableProductCard(
                         start.linkTo(stock.end)
                     },
                 text = "-${item.discountAmount}",
+                style = MaterialTheme.typography.body2,
                 color = colorResource(id = R.color.woo_green_50)
             )
         }
@@ -270,11 +273,13 @@ fun ExtendedProductCardContent(
         ) = createRefs()
         val editableControlsEnabled = state.value?.isIdle == true
         Divider(
-            modifier = Modifier.constrainAs(topDivider) {
-                top.linkTo(parent.top)
-                start.linkTo(parent.start)
-                end.linkTo(parent.end)
-            }
+            modifier = Modifier
+                .constrainAs(topDivider) {
+                    top.linkTo(parent.top)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                }
+                .padding(horizontal = dimensionResource(id = R.dimen.minor_100))
         )
         Row(
             modifier = Modifier
@@ -310,7 +315,12 @@ fun ExtendedProductCardContent(
                     end.linkTo(parent.end)
                     top.linkTo(orderCount.bottom)
                 }
-                .padding(dimensionResource(id = R.dimen.minor_100)),
+                .padding(
+                    start = dimensionResource(id = R.dimen.minor_100),
+                    end = dimensionResource(id = R.dimen.minor_100),
+                    top = dimensionResource(id = R.dimen.major_100),
+                    bottom = dimensionResource(id = R.dimen.minor_100)
+                ),
         ) {
             Text(
                 text = stringResource(id = R.string.product_price),
@@ -344,10 +354,10 @@ fun ExtendedProductCardContent(
                     text = stringResource(id = R.string.discount),
                     style = MaterialTheme.typography.body1,
                 )
-                Spacer(Modifier.width(dimensionResource(id = R.dimen.minor_50)))
+                Spacer(Modifier.width(dimensionResource(id = R.dimen.minor_100)))
                 Icon(
                     modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_40)),
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_edit),
+                    imageVector = Icons.Filled.Edit,
                     contentDescription = null
                 )
             }
@@ -404,11 +414,13 @@ fun ExtendedProductCardContent(
             }
         }
         Divider(
-            modifier = Modifier.constrainAs(bottomDivider) {
-                bottom.linkTo(removeButton.top)
-                start.linkTo(parent.start)
-                end.linkTo(parent.end)
-            }
+            modifier = Modifier
+                .constrainAs(bottomDivider) {
+                    bottom.linkTo(removeButton.top)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                }
+                .padding(horizontal = dimensionResource(id = R.dimen.minor_100))
         )
         WCTextButton(
             modifier = Modifier.constrainAs(removeButton) {
@@ -482,7 +494,7 @@ private fun AmountPicker(
 
 @Composable
 private fun getQuantityWithTotalText(item: ProductUIModel) =
-    "${item.item.quantity.toInt()} x ${item.pricePreDiscount}"
+    "${item.item.quantity.toInt()} $MULTIPLICATION_CHAR ${item.pricePreDiscount}"
 
 @Preview
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -302,7 +302,6 @@ fun ExtendedProductCardContent(
                 color = MaterialTheme.colors.onSurface
             )
             AmountPicker(
-                isEnabled = editableControlsEnabled,
                 onIncreaseClicked = onIncreaseItemAmountClicked,
                 onDecreaseClicked = onDecreaseItemAmountClicked,
                 item = item,
@@ -449,7 +448,6 @@ private fun AmountPicker(
     onIncreaseClicked: () -> Unit,
     onDecreaseClicked: () -> Unit,
     item: ProductUIModel,
-    isEnabled: Boolean
 ) {
     Row(
         modifier = modifier
@@ -461,15 +459,8 @@ private fun AmountPicker(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100))
     ) {
-        val buttonTint = if (isEnabled) {
-            MaterialTheme.colors.primary
-        } else {
-            colorResource(id = R.color.color_on_surface_disabled)
-        }
-        IconButton(
-            onClick = onDecreaseClicked,
-            enabled = isEnabled
-        ) {
+        val buttonTint = MaterialTheme.colors.primary
+        IconButton(onClick = onDecreaseClicked) {
             Icon(
                 imageVector = Icons.Filled.Remove,
                 contentDescription =
@@ -478,10 +469,7 @@ private fun AmountPicker(
             )
         }
         Text(text = item.item.quantity.toInt().toString(), color = MaterialTheme.colors.onSurface)
-        IconButton(
-            onClick = onIncreaseClicked,
-            enabled = isEnabled
-        ) {
+        IconButton(onClick = onIncreaseClicked) {
             Icon(
                 imageVector = Icons.Filled.Add,
                 contentDescription =
@@ -514,7 +502,7 @@ fun AmountPickerPreview() {
         priceAfterDiscount = "$25"
     )
     WooThemeWithBackground {
-        AmountPicker(Modifier, {}, {}, product, true)
+        AmountPicker(Modifier, {}, {}, product)
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -97,7 +97,7 @@ fun ExpandableProductCard(
             )
             .border(
                 1.dp,
-                colorResource(id = R.color.divider_color),
+                colorResource(id = if (isExpanded) R.color.color_on_surface else R.color.divider_color),
                 shape = RoundedCornerShape(dimensionResource(id = R.dimen.corner_radius_large))
             )
             .clickable(
@@ -456,7 +456,7 @@ private fun AmountPicker(
             .border(
                 1.dp,
                 colorResource(id = R.color.divider_color),
-                shape = RoundedCornerShape(8.dp)
+                shape = RoundedCornerShape(dimensionResource(id = R.dimen.corner_radius_large))
             ),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100))


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds various UI improvements to Order creation's expandable product cards:
1. Font size adjustments
2. Padding values adjustments
3. Multiplication char replacement
4. Setting different border color in the expanded state
5. List rendering optimization
6. Enabling continuous item amount adjusting during ongoing order update

Closes: #10061

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Before | After|
|---|---|
|<img width=300 src=https://github.com/woocommerce/woocommerce-android/assets/4527432/ca884231-46a9-4e28-944e-fc1353b3576f/>|<img width=300 src=https://github.com/woocommerce/woocommerce-android/assets/4527432/e41d8706-458d-42dc-8b87-44bd6ad50ec1/>|

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
