### PR TITLE
Fix duplicated clicks string and replace it with "Budget"

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
@@ -41,6 +41,7 @@ class BlazeCampaignListViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         private const val LOADING_TRANSITION_DELAY = 200L
+        private const val CENTS_TO_UNITS = 100
     }
 
     private val navArgs: BlazeCampaignListFragmentArgs by savedStateHandle.navArgs()
@@ -133,7 +134,7 @@ class BlazeCampaignListViewModel @Inject constructor(
                     ),
                     BlazeCampaignStat(
                         name = R.string.blaze_campaign_status_budget,
-                        value = campaignEntity.budgetCents
+                        value = campaignEntity.budgetCents / CENTS_TO_UNITS
                     )
                 )
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
@@ -132,7 +132,7 @@ class BlazeCampaignListViewModel @Inject constructor(
                         value = campaignEntity.clicks
                     ),
                     BlazeCampaignStat(
-                        name = R.string.blaze_campaign_status_clicks,
+                        name = R.string.blaze_campaign_status_budget,
                         value = campaignEntity.budgetCents
                     )
                 )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes 2 UI glitches: 
- Converting the `budget` value from cents to units. 
- Fix duplicated "click" string used in Blaze campaign item:
<img width="300"  src="https://github.com/woocommerce/woocommerce-android/assets/2663464/9edd96a7-364e-4df9-8c4d-39347678b19e"> 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Log into a store with some Blaze campaigns
2. Check the Campaign item inside Blaze list screen displays 3 different stats: "Impression", "Clicks" and "Budget"
