### PR TITLE
Use date util string format to fallback to empty string

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -322,7 +322,7 @@ class MyStoreStatsView @JvmOverloads constructor(
     ): String {
         return when (activeGranularity) {
             StatsGranularity.DAYS -> dateUtils.getDayMonthDateString(dateString).orEmpty()
-            StatsGranularity.WEEKS -> dateString.formatToMonthDateOnly()
+            StatsGranularity.WEEKS -> dateUtils.getShortMonthDayString(dateString).orEmpty()
             StatsGranularity.MONTHS -> dateUtils.getMonthString(dateString).orEmpty()
             StatsGranularity.YEARS -> dateUtils.getYearString(dateString).orEmpty()
         }
@@ -608,8 +608,8 @@ class MyStoreStatsView @JvmOverloads constructor(
     private fun getEntryValue(dateString: String): String {
         return when (activeGranularity) {
             StatsGranularity.DAYS -> dateUtils.getShortHourString(dateString).orEmpty()
-            StatsGranularity.WEEKS -> dateString.formatToMonthDateOnly()
-            StatsGranularity.MONTHS -> dateString.formatToMonthDateOnly()
+            StatsGranularity.WEEKS -> dateUtils.getShortMonthDayString(dateString).orEmpty()
+            StatsGranularity.MONTHS -> dateUtils.getShortMonthDayString(dateString).orEmpty()
             StatsGranularity.YEARS -> dateUtils.getShortMonthString(dateString).orEmpty()
         }
     }


### PR DESCRIPTION
### Description
We are facing some `IllegalArgumentException` when displaying some dates that are not in the expected format in the MyStoreScreen. While this PR doesn't solve the issue, it will prevent the app from crashing when the dates trying to represent are not in the expected format.

More context here peaMlT-c8-p2#comment-558

### Testing instructions
#### Prerequisites
1. Apply this patch to force a wrong date format on the new changes

<details>
  <summary>Patch</summary>

```
  Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
  IDEA additional info:
  Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
  <+>UTF-8
  ===================================================================
  diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
  --- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt	(revision ba6089c492dc1bf827964326da0167fe233dd72d)
  +++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt	(date 1699024074248)
  @@ -322,7 +322,7 @@
       ): String {
           return when (activeGranularity) {
               StatsGranularity.DAYS -> dateUtils.getDayMonthDateString(dateString).orEmpty()
  -            StatsGranularity.WEEKS -> dateUtils.getShortMonthDayString(dateString).orEmpty()
  +            StatsGranularity.WEEKS -> dateUtils.getShortMonthDayString("$dateString 00").orEmpty()
               StatsGranularity.MONTHS -> dateUtils.getMonthString(dateString).orEmpty()
               StatsGranularity.YEARS -> dateUtils.getYearString(dateString).orEmpty()
           }
  @@ -608,8 +608,8 @@
       private fun getEntryValue(dateString: String): String {
           return when (activeGranularity) {
               StatsGranularity.DAYS -> dateUtils.getShortHourString(dateString).orEmpty()
  -            StatsGranularity.WEEKS -> dateUtils.getShortMonthDayString(dateString).orEmpty()
  -            StatsGranularity.MONTHS -> dateUtils.getShortMonthDayString(dateString).orEmpty()
  +            StatsGranularity.WEEKS -> dateUtils.getShortMonthDayString("$dateString 00").orEmpty()
  +            StatsGranularity.MONTHS -> dateUtils.getShortMonthDayString("$dateString 00").orEmpty()
               StatsGranularity.YEARS -> dateUtils.getShortMonthString(dateString).orEmpty()
           }
       }

```
</details>

#### Testing
1. Open the MyStore screen
3. Navigate between the tabs and check that the app doesn't crash

### Images/gif


https://github.com/woocommerce/woocommerce-android/assets/18119390/304511b6-3a9c-4232-97b7-551f25e19095




- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->