### PR TITLE
Avoid sending duplicated event when Blaze campaign is created

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeCampaignCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeCampaignCreationViewModel.kt
@@ -93,7 +93,7 @@ class BlazeCampaignCreationViewModel @Inject constructor(
             )
         }
         currentBlazeStep = extractCurrentStep(url)
-        if (currentBlazeStep == BlazeFlowStep.STEP_5) {
+        if (currentBlazeStep == BlazeFlowStep.STEP_5 && !isCompleted) {
             isCompleted = true
             analyticsTracker.track(
                 stat = BLAZE_FLOW_COMPLETED,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10099
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Something has changed in the way Blaze webview redirects to the last step of the campaign creation flow. This has lead to Android app tracking the event `BLAZE_FLOW_COMPLETED` twice or more times when creating a Blaze campaign successfully. Not sure if this started after the work we did in Blaze iteration 2 or if something changed on the webview flow. In any case, the fix is straightforward. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Log into a site eligible for Blaze
2. Create a Blaze campaign and check the following event is tracked only once:
```
Tracked: blaze_flow_completed, Properties: {"source":"product_detail_promote_button","step":"step-5","blog_id":212909500,"is_wpcom_store":true,"was_ecommerce_trial":false,"plan_product_slug":"ecommerce-bundle","is_debug":true,"site_url":"https:\/\/proxied.site"}
```