### PR TITLE
Format Blaze budget to support decimals

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
@@ -17,7 +17,7 @@ data class BlazeCampaignUi(
 
 data class BlazeCampaignStat(
     @StringRes val name: Int,
-    val value: Long
+    val value: String
 )
 
 enum class CampaignStatusUi(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeView.kt
@@ -215,15 +215,15 @@ fun MyStoreBlazeViewCampaignPreview() {
                 stats = listOf(
                     BlazeCampaignStat(
                         name = R.string.blaze_campaign_status_impressions,
-                        value = 100
+                        value = 100.toString()
                     ),
                     BlazeCampaignStat(
                         name = R.string.blaze_campaign_status_clicks,
-                        value = 10
+                        value = 10.toString()
                     ),
                     BlazeCampaignStat(
                         name = R.string.blaze_campaign_status_budget,
-                        value = 1000
+                        value = 1000.toString()
                     ),
                 ),
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/MyStoreBlazeViewModel.kt
@@ -99,11 +99,11 @@ class MyStoreBlazeViewModel @Inject constructor(
                     stats = listOf(
                         BlazeCampaignStat(
                             name = R.string.blaze_campaign_status_impressions,
-                            value = campaign.impressions
+                            value = campaign.impressions.toString()
                         ),
                         BlazeCampaignStat(
                             name = R.string.blaze_campaign_status_clicks,
-                            value = campaign.clicks
+                            value = campaign.clicks.toString()
                         )
                     )
                 ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignItem.kt
@@ -81,7 +81,7 @@ fun BlazeCampaignItem(
 @Composable
 private fun CampaignStat(
     statName: String,
-    statValue: Long,
+    statValue: String,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -95,7 +95,7 @@ private fun CampaignStat(
         Text(
             modifier = Modifier
                 .padding(top = dimensionResource(id = R.dimen.minor_50)),
-            text = statValue.toString(),
+            text = statValue,
             style = MaterialTheme.typography.h6,
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListScreen.kt
@@ -235,15 +235,15 @@ fun BlazeCampaignListScreenPreview() {
                         stats = listOf(
                             BlazeCampaignStat(
                                 name = R.string.blaze_campaign_status_impressions,
-                                value = 100
+                                value = 100.toString()
                             ),
                             BlazeCampaignStat(
                                 name = R.string.blaze_campaign_status_clicks,
-                                value = 10
+                                value = 10.toString()
                             ),
                             BlazeCampaignStat(
                                 name = R.string.blaze_campaign_status_budget,
-                                value = 1000
+                                value = 1000.toString()
                             ),
                         ),
                     ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.blaze.campaigs
 
-import android.icu.text.NumberFormat
+import android.icu.text.DecimalFormat
+import android.icu.text.DecimalFormatSymbols
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppPrefsWrapper
@@ -43,7 +44,7 @@ class BlazeCampaignListViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         private const val LOADING_TRANSITION_DELAY = 200L
-        private const val CENTS_TO_UNITS = 100
+        private const val CENTS_TO_UNITS = 100f
     }
 
     private val navArgs: BlazeCampaignListFragmentArgs by savedStateHandle.navArgs()
@@ -136,9 +137,8 @@ class BlazeCampaignListViewModel @Inject constructor(
                     ),
                     BlazeCampaignStat(
                         name = R.string.blaze_campaign_status_budget,
-                        value = NumberFormat.getInstance(Locale.getDefault())
+                        value = DecimalFormat("#.##", DecimalFormatSymbols(Locale.getDefault()))
                             .format(campaignEntity.budgetCents / CENTS_TO_UNITS)
-                            .toString()
                     )
                 )
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.blaze.campaigs
 
+import android.icu.text.NumberFormat
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppPrefsWrapper
@@ -27,6 +28,7 @@ import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.persistence.blaze.BlazeCampaignsDao.BlazeCampaignEntity
 import org.wordpress.android.fluxc.store.blaze.BlazeCampaignsStore
+import java.util.Locale
 import javax.inject.Inject
 
 @OptIn(FlowPreview::class)
@@ -126,15 +128,17 @@ class BlazeCampaignListViewModel @Inject constructor(
                 stats = listOf(
                     BlazeCampaignStat(
                         name = R.string.blaze_campaign_status_impressions,
-                        value = campaignEntity.impressions
+                        value = campaignEntity.impressions.toString()
                     ),
                     BlazeCampaignStat(
                         name = R.string.blaze_campaign_status_clicks,
-                        value = campaignEntity.clicks
+                        value = campaignEntity.clicks.toString()
                     ),
                     BlazeCampaignStat(
                         name = R.string.blaze_campaign_status_budget,
-                        value = campaignEntity.budgetCents / CENTS_TO_UNITS
+                        value = NumberFormat.getInstance(Locale.getDefault())
+                            .format(campaignEntity.budgetCents / CENTS_TO_UNITS)
+                            .toString()
                     )
                 )
             ),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Coming from this discussion https://github.com/woocommerce/woocommerce-android/pull/10093#discussion_r1381782482, add support to display Blaze campaign stats with decimals if needed.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open Blaze campaign list and check that all stats are displayed correctly
2.  Currently,it is not possible to set a budget with decimals, so the only way to test the decimal formatting is hard-coding a decimal `budget` value and run the app. Note that we can't use compose `@Preview` for this because, with the usage of Coil for displaying the image of the product, the preview doesn't work. Apply this patch if you want to test a decimal value. 

```diff
Subject: [PATCH] Divide by float constant value to avoid missing decimal values
---
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt	(revision b6a99ea2dbf649dbbb3c2b9f2c599061cbad4d6a)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt	(date 1699287796653)
@@ -138,7 +138,7 @@
                     BlazeCampaignStat(
                         name = R.string.blaze_campaign_status_budget,
                         value = DecimalFormat("#.##", DecimalFormatSymbols(Locale.getDefault()))
-                            .format(campaignEntity.budgetCents / CENTS_TO_UNITS)
+                            .format(74353 / CENTS_TO_UNITS)
                     )
                 )
             ),

```

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->