### PR TITLE
Fix the reference of wrong id and some UI changes when the amount name is long

### DIFF
--- a/WooCommerce/src/main/res/layout/custom_amount_item_view.xml
+++ b/WooCommerce/src/main/res/layout/custom_amount_item_view.xml
@@ -45,8 +45,9 @@
         android:layout_margin="@dimen/major_100"
         android:orientation="vertical"
         app:layout_constrainedWidth="true"
+        android:layout_marginEnd="@dimen/major_75"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/product_btnDelete"
+        app:layout_constraintEnd_toStartOf="@id/customAmountEdit"
         app:layout_constraintStart_toEndOf="@+id/customAmountImageFrame"
         app:layout_constraintTop_toBottomOf="@id/divider"
         app:layout_constraintVertical_bias="0.50">
@@ -59,21 +60,14 @@
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/customAmountName"
                 style="@style/Woo.ListItem.Title"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_weight="1"
                 android:layout_margin="@dimen/minor_00"
                 android:ellipsize="end"
                 android:includeFontPadding="false"
-                android:maxLines="2"
+                android:maxLines="1"
                 tools:text="Services rendered" />
-
-            <androidx.appcompat.widget.AppCompatImageView
-                android:id="@+id/customAmountEdit"
-                android:layout_width="@dimen/major_150"
-                android:layout_height="@dimen/major_150"
-                android:padding="@dimen/minor_25"
-                android:layout_marginStart="@dimen/major_75"
-                android:src="@drawable/ic_edit_pencil"/>
         </LinearLayout>
 
         <com.google.android.material.textview.MaterialTextView
@@ -84,6 +78,19 @@
             android:layout_margin="@dimen/minor_00"
             tools:text="$20.00" />
     </LinearLayout>
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/customAmountEdit"
+        android:layout_width="@dimen/major_150"
+        android:layout_height="@dimen/major_150"
+        android:padding="@dimen/minor_25"
+        android:layout_marginStart="@dimen/major_75"
+        android:layout_marginEnd="@dimen/major_75"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/customAmountInfoContainer"
+        app:layout_constraintEnd_toStartOf="@id/customAmountDeleteBtn"
+        app:layout_constraintTop_toTopOf="parent"
+        android:src="@drawable/ic_edit_pencil"/>
 
     <ImageButton
         android:id="@+id/customAmountDeleteBtn"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10104 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This pull request corrects an incorrect ID reference within the custom_amount_item_view layout file and implements minor adjustments to properly handle lengthy amount names. 

Visual comparisons of the UI are provided below for review.

**Before**
<img width="325" alt="Screenshot 2023-11-07 at 8 57 57 AM" src="https://github.com/woocommerce/woocommerce-android/assets/1331230/d27d5e19-d57a-4e53-a86b-e8d29617edc6">

**After**
<img width="397" alt="Screenshot 2023-11-07 at 9 06 51 AM" src="https://github.com/woocommerce/woocommerce-android/assets/1331230/633d8158-6bff-48c7-ae71-c452d3de400e">



### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Run the release build and ensure the app compiles fine.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
