### PR TITLE
[Deposit Summary] Deposit Summary View to the payments hub

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubAdapter.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.payments.hub
 
 import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.woocommerce.android.ui.payments.hub.PaymentsHubViewState.ListItem.GapBetweenSections
@@ -29,6 +30,9 @@ class PaymentsHubAdapter :
             is LearnMoreListItem -> {
                 VIEW_TYPE_LEARN_MORE
             }
+            is PaymentsHubViewState.ListItem.DepositSummaryListItem -> {
+                VIEW_TYPE_DEPOSIT_SUMMARY
+            }
         }
     }
 
@@ -48,6 +52,9 @@ class PaymentsHubAdapter :
             }
             VIEW_TYPE_LEARN_MORE -> {
                 PaymentsHubViewHolder.LearnMoreViewHolder(parent)
+            }
+            VIEW_TYPE_DEPOSIT_SUMMARY -> {
+                PaymentsHubViewHolder.DepositSummaryViewHolder(ComposeView(parent.context))
             }
             else -> error("Unknown section")
         }
@@ -84,5 +91,6 @@ class PaymentsHubAdapter :
         const val VIEW_TYPE_NON_TOGGELABLE = 2
         const val VIEW_TYPE_GAP_BETWEEN_SECTIONS = 3
         const val VIEW_TYPE_LEARN_MORE = 4
+        const val VIEW_TYPE_DEPOSIT_SUMMARY = 5
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewHolder.kt
@@ -1,10 +1,11 @@
 package com.woocommerce.android.ui.payments.hub
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
-import androidx.annotation.LayoutRes
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.compose.ui.platform.ComposeView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.R
@@ -12,15 +13,17 @@ import com.woocommerce.android.databinding.CardReaderLearnMoreSectionBinding
 import com.woocommerce.android.databinding.PaymentsHubHeaderBinding
 import com.woocommerce.android.databinding.PaymentsHubListItemBinding
 import com.woocommerce.android.databinding.PaymentsHubToggelableItemBinding
+import com.woocommerce.android.ui.payments.hub.depositsummary.PaymentsHubDepositSummaryView
 import com.woocommerce.android.util.UiHelpers
 
 private const val DISABLED_BUTTON_ALPHA = 0.5f
 
-abstract class PaymentsHubViewHolder(val parent: ViewGroup, @LayoutRes layout: Int) :
-    RecyclerView.ViewHolder(LayoutInflater.from(parent.context).inflate(layout, parent, false)) {
+abstract class PaymentsHubViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
     abstract fun onBind(uiState: PaymentsHubViewState.ListItem)
 
-    class RowViewHolder(parent: ViewGroup) : PaymentsHubViewHolder(parent, R.layout.payments_hub_list_item) {
+    class RowViewHolder(parent: ViewGroup) : PaymentsHubViewHolder(
+        LayoutInflater.from(parent.context).inflate(R.layout.payments_hub_list_item, parent, false)
+    ) {
         var binding = PaymentsHubListItemBinding.bind(itemView)
         override fun onBind(uiState: PaymentsHubViewState.ListItem) {
             uiState as PaymentsHubViewState.ListItem.NonToggleableListItem
@@ -29,7 +32,7 @@ abstract class PaymentsHubViewHolder(val parent: ViewGroup, @LayoutRes layout: I
             binding.paymentsHubMenuIcon.setImageResource(uiState.icon)
             UiHelpers.setDrawableOrHide(
                 binding.paymentsHubBadgeIcon,
-                uiState.iconBadge?.let { AppCompatResources.getDrawable(parent.context, it) }
+                uiState.iconBadge?.let { AppCompatResources.getDrawable(view.context, it) }
             )
 
             if (uiState.isEnabled) {
@@ -52,7 +55,9 @@ abstract class PaymentsHubViewHolder(val parent: ViewGroup, @LayoutRes layout: I
     }
 
     class ToggleableViewHolder(parent: ViewGroup) :
-        PaymentsHubViewHolder(parent, R.layout.payments_hub_toggelable_item) {
+        PaymentsHubViewHolder(
+            LayoutInflater.from(parent.context).inflate(R.layout.payments_hub_toggelable_item, parent, false)
+        ) {
         var binding = PaymentsHubToggelableItemBinding.bind(itemView)
         override fun onBind(uiState: PaymentsHubViewState.ListItem) {
             uiState as PaymentsHubViewState.ListItem.ToggleableListItem
@@ -78,7 +83,9 @@ abstract class PaymentsHubViewHolder(val parent: ViewGroup, @LayoutRes layout: I
     }
 
     class HeaderViewHolder(parent: ViewGroup) :
-        PaymentsHubViewHolder(parent, R.layout.payments_hub_header) {
+        PaymentsHubViewHolder(
+            LayoutInflater.from(parent.context).inflate(R.layout.payments_hub_header, parent, false)
+        ) {
         var binding = PaymentsHubHeaderBinding.bind(itemView)
         override fun onBind(uiState: PaymentsHubViewState.ListItem) {
             uiState as PaymentsHubViewState.ListItem.HeaderItem
@@ -87,27 +94,39 @@ abstract class PaymentsHubViewHolder(val parent: ViewGroup, @LayoutRes layout: I
     }
 
     class GapBetweenSectionsViewHolder(parent: ViewGroup) :
-        PaymentsHubViewHolder(parent, R.layout.payments_hub_gap_between_sections) {
+        PaymentsHubViewHolder(
+            LayoutInflater.from(parent.context).inflate(R.layout.payments_hub_gap_between_sections, parent, false)
+        ) {
         override fun onBind(uiState: PaymentsHubViewState.ListItem) {
             // no-op
         }
     }
 
     class LearnMoreViewHolder(parent: ViewGroup) :
-        PaymentsHubViewHolder(parent, R.layout.card_reader_learn_more_section) {
+        PaymentsHubViewHolder(
+            LayoutInflater.from(parent.context).inflate(R.layout.card_reader_learn_more_section, parent, false)
+        ) {
 
         var binding: CardReaderLearnMoreSectionBinding = CardReaderLearnMoreSectionBinding.bind(itemView)
         override fun onBind(uiState: PaymentsHubViewState.ListItem) {
             uiState as PaymentsHubViewState.ListItem.LearnMoreListItem
             UiHelpers.setTextOrHide(binding.learnMore, uiState.label)
             binding.learnMore.setCompoundDrawablesWithIntrinsicBounds(
-                AppCompatResources.getDrawable(parent.context, uiState.icon),
+                AppCompatResources.getDrawable(view.context, uiState.icon),
                 null,
                 null,
                 null
             )
             binding.learnMore.setOnClickListener { uiState.onClick?.invoke() }
             (binding.learnMore.layoutParams as MarginLayoutParams).topMargin = 0
+        }
+    }
+
+    class DepositSummaryViewHolder(private val composeView: ComposeView) : PaymentsHubViewHolder(composeView) {
+        override fun onBind(uiState: PaymentsHubViewState.ListItem) {
+            composeView.setContent {
+                PaymentsHubDepositSummaryView()
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewModel.kt
@@ -41,6 +41,7 @@ import com.woocommerce.android.ui.payments.hub.PaymentsHubViewModel.CashOnDelive
 import com.woocommerce.android.ui.payments.hub.PaymentsHubViewModel.PaymentsHubEvents.ShowToast
 import com.woocommerce.android.ui.payments.hub.PaymentsHubViewModel.PaymentsHubEvents.ShowToastString
 import com.woocommerce.android.ui.payments.hub.PaymentsHubViewState.ListItem
+import com.woocommerce.android.ui.payments.hub.PaymentsHubViewState.ListItem.DepositSummaryListItem
 import com.woocommerce.android.ui.payments.hub.PaymentsHubViewState.ListItem.HeaderItem
 import com.woocommerce.android.ui.payments.hub.PaymentsHubViewState.ListItem.LearnMoreListItem
 import com.woocommerce.android.ui.payments.hub.PaymentsHubViewState.ListItem.NonToggleableListItem
@@ -185,36 +186,39 @@ class PaymentsHubViewModel @Inject constructor(
         isOnboardingComplete: Boolean,
         cashOnDeliveryItem: ToggleableListItem
     ): List<ListItem> = mutableListOf(
+        DepositSummaryListItem(
+            index = 0
+        ),
         HeaderItem(
             label = UiStringRes(R.string.card_reader_hub_actions_category_header),
-            index = 0
+            index = 1
         ),
         NonToggleableListItem(
             icon = R.drawable.ic_gridicons_money_on_surface,
             label = UiStringRes(R.string.card_reader_hub_collect_payment),
-            index = 1,
+            index = 2,
             onClick = ::onCollectPaymentClicked
         ),
         HeaderItem(
             label = UiStringRes(R.string.card_reader_settings_header),
-            index = 2,
+            index = 3,
         ),
         cashOnDeliveryItem,
         HeaderItem(
             label = UiStringRes(R.string.card_reader_card_readers_header),
-            index = 9,
+            index = 10,
         ),
         NonToggleableListItem(
             icon = R.drawable.ic_shopping_cart,
             label = UiStringRes(R.string.card_reader_purchase_card_reader),
-            index = 10,
+            index = 11,
             onClick = ::onPurchaseCardReaderClicked
         ),
         NonToggleableListItem(
             icon = R.drawable.ic_manage_card_reader,
             label = UiStringRes(R.string.card_reader_manage_card_reader),
             isEnabled = isOnboardingComplete,
-            index = 11,
+            index = 12,
             onClick = ::onManageCardReaderClicked
         )
     ).apply {
@@ -228,7 +232,7 @@ class PaymentsHubViewModel @Inject constructor(
             add(
                 HeaderItem(
                     label = UiStringRes(R.string.card_reader_tap_to_pay_header),
-                    index = 5
+                    index = 6
                 )
             )
             add(
@@ -236,7 +240,7 @@ class PaymentsHubViewModel @Inject constructor(
                     icon = R.drawable.ic_baseline_contactless,
                     label = UiStringRes(R.string.card_reader_test_tap_to_pay),
                     description = UiStringRes(R.string.card_reader_tap_to_pay_description),
-                    index = 6,
+                    index = 7,
                     onClick = ::onTapToPayClicked,
                     iconBadge = R.drawable.ic_badge_new,
                 )
@@ -245,7 +249,7 @@ class PaymentsHubViewModel @Inject constructor(
                 NonToggleableListItem(
                     icon = R.drawable.ic_tintable_info_outline_24dp,
                     label = UiStringRes(R.string.card_reader_about_tap_to_pay),
-                    index = 7,
+                    index = 8,
                     onClick = { onAboutTTPClicked(countryConfig as CardReaderConfigForSupportedCountry) },
                 )
             )
@@ -254,7 +258,7 @@ class PaymentsHubViewModel @Inject constructor(
                     NonToggleableListItem(
                         icon = R.drawable.ic_feedback_banner_logo,
                         label = UiStringRes(R.string.card_reader_tap_to_pay_share_feedback),
-                        index = 8,
+                        index = 9,
                         onClick = ::onTapToPayFeedbackClicked
                     )
                 )
@@ -268,7 +272,7 @@ class PaymentsHubViewModel @Inject constructor(
                 NonToggleableListItem(
                     icon = R.drawable.ic_card_reader_manual,
                     label = UiStringRes(R.string.settings_card_reader_manuals),
-                    index = 12,
+                    index = 13,
                     onClick = { onCardReaderManualsClicked(countryConfig) }
                 )
             )
@@ -280,7 +284,7 @@ class PaymentsHubViewModel @Inject constructor(
             LearnMoreListItem(
                 icon = R.drawable.ic_info_outline_20dp,
                 label = UiStringRes(R.string.card_reader_detail_learn_more, containsHtml = true),
-                index = 13,
+                index = 14,
                 onClick = ::onLearnMoreIppClicked
             )
         )
@@ -290,7 +294,7 @@ class PaymentsHubViewModel @Inject constructor(
         NonToggleableListItem(
             icon = R.drawable.ic_payment_provider,
             label = UiStringRes(R.string.card_reader_manage_payment_provider),
-            index = 4,
+            index = 5,
             onClick = ::onCardReaderPaymentProviderClicked
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewModel.kt
@@ -94,7 +94,7 @@ class PaymentsHubViewModel @Inject constructor(
                 R.string.card_reader_enable_pay_in_person_description,
                 containsHtml = true
             ),
-            index = 3,
+            index = 4,
             isChecked = false,
             onToggled = { (::onCashOnDeliveryToggled)(it) },
             onLearnMoreClicked = ::onLearnMoreCodClicked
@@ -186,9 +186,7 @@ class PaymentsHubViewModel @Inject constructor(
         isOnboardingComplete: Boolean,
         cashOnDeliveryItem: ToggleableListItem
     ): List<ListItem> = mutableListOf(
-        DepositSummaryListItem(
-            index = 0
-        ),
+        DepositSummaryListItem(index = 0),
         HeaderItem(
             label = UiStringRes(R.string.card_reader_hub_actions_category_header),
             index = 1

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewState.kt
@@ -15,6 +15,13 @@ data class PaymentsHubViewState(
         abstract val index: Int
         abstract var isEnabled: Boolean
 
+        data class DepositSummaryListItem(override val index: Int = 0) : ListItem() {
+            override val label: UiString? = null
+            override val icon: Int? = null
+            override val onClick: (() -> Unit)? = null
+            override var isEnabled: Boolean = false
+        }
+
         data class NonToggleableListItem(
             @DrawableRes override val icon: Int,
             override val label: UiString,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryRepository.kt
@@ -21,8 +21,10 @@ class PaymentsHubDepositSummaryRepository @Inject constructor(
             val fetchedData = store.fetchDepositsOverview(site)
             val data = fetchedData.result
             if (fetchedData.isError || data == null) {
+                store.deleteDepositsOverview(site)
                 emit(RetrieveDepositOverviewResult.Error(fetchedData.error))
             } else {
+                store.insertDepositsOverview(site, data)
                 emit(RetrieveDepositOverviewResult.Remote(data))
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -20,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.util.StringUtils
 
 @Composable
 fun PaymentsHubDepositSummaryView(
@@ -85,9 +87,11 @@ fun PaymentsHubDepositSummaryView(
                 )
                 Text(
                     style = MaterialTheme.typography.caption,
-                    text = stringResource(
-                        id = R.string.card_reader_hub_deposit_summary_pending_deposits,
-                        overview.infoPerCurrency[overview.defaultCurrency]?.pendingBalanceDepositsCount ?: 0
+                    text = StringUtils.getQuantityString(
+                        context = LocalContext.current,
+                        quantity = overview.infoPerCurrency[overview.defaultCurrency]?.pendingBalanceDepositsCount ?: 0,
+                        default = R.string.card_reader_hub_deposit_summary_pending_deposits_plural,
+                        one = R.string.card_reader_hub_deposit_summary_pending_deposits_one,
                     ),
                     color = colorResource(id = R.color.color_surface_variant)
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.payments.hub.depositsummary
 
 import android.content.res.Configuration
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -42,7 +43,11 @@ fun PaymentsHubDepositSummaryView(
 fun PaymentsHubDepositSummaryView(
     overview: PaymentsHubDepositSummaryState.Overview
 ) {
-    Column {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(colorResource(id = R.color.color_surface))
+    ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
@@ -1,20 +1,15 @@
 package com.woocommerce.android.ui.payments.hub.depositsummary
 
 import android.content.res.Configuration
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Card
+import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
@@ -30,12 +25,14 @@ fun PaymentsHubDepositSummaryView(
     viewModel: PaymentsHubDepositSummaryViewModel = viewModel()
 ) {
     viewModel.viewState.observeAsState().let {
-        when (val value = it.value) {
-            is PaymentsHubDepositSummaryState.Success -> PaymentsHubDepositSummaryView(value.overview)
-            null,
-            PaymentsHubDepositSummaryState.Loading,
-            is PaymentsHubDepositSummaryState.Error -> {
-                // show nothing
+        WooThemeWithBackground {
+            when (val value = it.value) {
+                is PaymentsHubDepositSummaryState.Success -> PaymentsHubDepositSummaryView(value.overview)
+                null,
+                PaymentsHubDepositSummaryState.Loading,
+                is PaymentsHubDepositSummaryState.Error -> {
+                    // show nothing
+                }
             }
         }
     }
@@ -45,15 +42,7 @@ fun PaymentsHubDepositSummaryView(
 fun PaymentsHubDepositSummaryView(
     overview: PaymentsHubDepositSummaryState.Overview
 ) {
-    var isExpanded by rememberSaveable { mutableStateOf(false) }
-    Card(
-        elevation = 4.dp,
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable {
-                isExpanded = !isExpanded
-            }
-    ) {
+    Column {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -68,7 +57,7 @@ fun PaymentsHubDepositSummaryView(
                     color = colorResource(id = R.color.color_on_surface)
                 )
                 Text(
-                    style = MaterialTheme.typography.h2,
+                    style = MaterialTheme.typography.h6,
                     fontWeight = FontWeight(700),
                     text = overview.infoPerCurrency[overview.defaultCurrency]?.availableFunds.toString(),
                     color = colorResource(id = R.color.color_on_surface)
@@ -84,18 +73,25 @@ fun PaymentsHubDepositSummaryView(
                     color = colorResource(id = R.color.color_on_surface)
                 )
                 Text(
-                    style = MaterialTheme.typography.h2,
+                    style = MaterialTheme.typography.h6,
                     fontWeight = FontWeight(700),
                     text = overview.infoPerCurrency[overview.defaultCurrency]?.pendingFunds.toString(),
                     color = colorResource(id = R.color.color_on_surface)
                 )
                 Text(
                     style = MaterialTheme.typography.caption,
-                    text = stringResource(id = R.string.card_reader_hub_deposit_summary_pending_deposits),
-                    color = colorResource(id = R.color.color_on_primary_disabled)
+                    text = stringResource(
+                        id = R.string.card_reader_hub_deposit_summary_pending_deposits,
+                        overview.infoPerCurrency[overview.defaultCurrency]?.pendingBalanceDepositsCount ?: 0
+                    ),
+                    color = colorResource(id = R.color.color_surface_variant)
                 )
             }
         }
+
+        Divider(
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }
 
@@ -109,8 +105,8 @@ fun PaymentsHubDepositSummaryViewPreview() {
                 defaultCurrency = "USD",
                 infoPerCurrency = mapOf(
                     "USD" to PaymentsHubDepositSummaryState.Info(
-                        availableFunds = 100,
-                        pendingFunds = 200,
+                        availableFunds = "100$",
+                        pendingFunds = "200$",
                         pendingBalanceDepositsCount = 1,
                         fundsAvailableInDays = PaymentsHubDepositSummaryState.Info.Interval.Days(1),
                         nextDeposit = PaymentsHubDepositSummaryState.Deposit(
@@ -125,8 +121,8 @@ fun PaymentsHubDepositSummaryViewPreview() {
                         )
                     ),
                     "EUR" to PaymentsHubDepositSummaryState.Info(
-                        availableFunds = 100,
-                        pendingFunds = 200,
+                        availableFunds = "100$",
+                        pendingFunds = "200$",
                         pendingBalanceDepositsCount = 1,
                         fundsAvailableInDays = PaymentsHubDepositSummaryState.Info.Interval.Days(1),
                         nextDeposit = PaymentsHubDepositSummaryState.Deposit(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryState.kt
@@ -13,8 +13,8 @@ sealed class PaymentsHubDepositSummaryState {
     )
 
     data class Info(
-        val availableFunds: Int,
-        val pendingFunds: Int,
+        val availableFunds: String,
+        val pendingFunds: String,
         val pendingBalanceDepositsCount: Int,
         val fundsAvailableInDays: Interval,
         val nextDeposit: Deposit?,
@@ -28,7 +28,7 @@ sealed class PaymentsHubDepositSummaryState {
     }
 
     data class Deposit(
-        val amount: Int,
+        val amount: Long,
         val status: Status,
         val date: Date?,
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryStateMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryStateMapper.kt
@@ -1,10 +1,13 @@
 package com.woocommerce.android.ui.payments.hub.depositsummary
 
+import com.woocommerce.android.util.CurrencyFormatter
 import org.wordpress.android.fluxc.model.payments.woo.WooPaymentsDepositsOverview
 import java.util.Date
 import javax.inject.Inject
 
-class PaymentsHubDepositSummaryStateMapper @Inject constructor() {
+class PaymentsHubDepositSummaryStateMapper @Inject constructor(
+    private val currencyFormatter: CurrencyFormatter,
+) {
 
     @Suppress("ReturnCount")
     fun mapDepositOverviewToViewModelOverviews(
@@ -33,8 +36,14 @@ class PaymentsHubDepositSummaryStateMapper @Inject constructor() {
             defaultCurrency = defaultCurrency,
             infoPerCurrency = currencies.associateWith { currency ->
                 PaymentsHubDepositSummaryState.Info(
-                    availableFunds = availableBalances.firstOrNull { it.currency == currency }?.amount ?: 0,
-                    pendingFunds = pendingBalances.firstOrNull { it.currency == currency }?.amount ?: 0,
+                    availableFunds = formatMoney(
+                        amount = availableBalances.firstOrNull { it.currency == currency }?.amount ?: 0,
+                        currency = currency
+                    ),
+                    pendingFunds = formatMoney(
+                        amount = pendingBalances.firstOrNull { it.currency == currency }?.amount ?: 0,
+                        currency = currency
+                    ),
                     pendingBalanceDepositsCount = pendingBalances.firstOrNull {
                         it.currency == currency
                     }?.depositsCount ?: 0,
@@ -46,11 +55,17 @@ class PaymentsHubDepositSummaryStateMapper @Inject constructor() {
         )
     }
 
-    private fun mapDeposit(it: WooPaymentsDepositsOverview.Deposit.Info) =
+    private fun formatMoney(amount: Long, currency: String) =
+        currencyFormatter.formatCurrencyGivenInTheSmallestCurrencyUnit(
+            amount = amount,
+            currencyCode = currency,
+        )
+
+    private fun mapDeposit(info: WooPaymentsDepositsOverview.Deposit.Info) =
         PaymentsHubDepositSummaryState.Deposit(
-            amount = it.amount ?: 0,
-            status = it.status.toDepositStatus(),
-            date = if (it.date != null) Date(it.date!!) else null
+            amount = info.amount ?: 0L,
+            status = info.status.toDepositStatus(),
+            date = if (info.date != null) Date(info.date!!) else null
         )
 
     // Proper implementation in the following PRs

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHumDepositSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHumDepositSummaryScreen.kt
@@ -1,12 +1,52 @@
 package com.woocommerce.android.ui.payments.hub.depositsummary
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 
+private const val ANIM_DURATION_MILLIS = 128
+
 @Composable
-fun PaymentsHubDepositSummaryScreen(
+fun PaymentsHubDepositSummaryView(
     viewModel: PaymentsHumDepositSummaryViewModel = viewModel()
 ) {
-    viewModel.viewState.observeAsState().let { }
+    viewModel.viewState.observeAsState().let {
+        val value = it.value
+        when (value) {
+            is PaymentsHubDepositSummaryState.Success -> PaymentsHubDepositSummaryView(value.overview)
+            null,
+            PaymentsHubDepositSummaryState.Loading,
+            is PaymentsHubDepositSummaryState.Error -> {
+                // show nothing
+            }
+        }
+    }
+}
+
+@Composable
+fun PaymentsHubDepositSummaryView(
+    overview: PaymentsHubDepositSummaryState.Overview
+) {
+    var isExpanded by rememberSaveable { mutableStateOf(false) }
+    Card(
+        elevation = 8.dp,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+            .clickable {
+                isExpanded = !isExpanded
+            }
+    ) {
+
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHumDepositSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHumDepositSummaryScreen.kt
@@ -1,9 +1,14 @@
 package com.woocommerce.android.ui.payments.hub.depositsummary
 
+import android.content.res.Configuration
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -11,18 +16,21 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-
-private const val ANIM_DURATION_MILLIS = 128
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 fun PaymentsHubDepositSummaryView(
     viewModel: PaymentsHumDepositSummaryViewModel = viewModel()
 ) {
     viewModel.viewState.observeAsState().let {
-        val value = it.value
-        when (value) {
+        when (val value = it.value) {
             is PaymentsHubDepositSummaryState.Success -> PaymentsHubDepositSummaryView(value.overview)
             null,
             PaymentsHubDepositSummaryState.Loading,
@@ -39,14 +47,101 @@ fun PaymentsHubDepositSummaryView(
 ) {
     var isExpanded by rememberSaveable { mutableStateOf(false) }
     Card(
-        elevation = 8.dp,
+        elevation = 4.dp,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(16.dp)
             .clickable {
                 isExpanded = !isExpanded
             }
     ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 16.dp, top = 24.dp, bottom = 16.dp)
+        ) {
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    style = MaterialTheme.typography.body2,
+                    text = stringResource(id = R.string.card_reader_hub_deposit_summary_available_funds),
+                    color = colorResource(id = R.color.color_on_surface)
+                )
+                Text(
+                    style = MaterialTheme.typography.h2,
+                    fontWeight = FontWeight(700),
+                    text = overview.infoPerCurrency[overview.defaultCurrency]?.availableFunds.toString(),
+                    color = colorResource(id = R.color.color_on_surface)
+                )
+            }
 
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    style = MaterialTheme.typography.body2,
+                    text = stringResource(id = R.string.card_reader_hub_deposit_summary_pending_funds),
+                    color = colorResource(id = R.color.color_on_surface)
+                )
+                Text(
+                    style = MaterialTheme.typography.h2,
+                    fontWeight = FontWeight(700),
+                    text = overview.infoPerCurrency[overview.defaultCurrency]?.pendingFunds.toString(),
+                    color = colorResource(id = R.color.color_on_surface)
+                )
+                Text(
+                    style = MaterialTheme.typography.caption,
+                    text = stringResource(id = R.string.card_reader_hub_deposit_summary_pending_deposits),
+                    color = colorResource(id = R.color.color_on_primary_disabled)
+                )
+            }
+        }
+    }
+}
+
+@Preview(name = "Light mode")
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun PaymentsHubDepositSummaryViewPreview() {
+    WooThemeWithBackground {
+        PaymentsHubDepositSummaryView(
+            PaymentsHubDepositSummaryState.Overview(
+                defaultCurrency = "USD",
+                infoPerCurrency = mapOf(
+                    "USD" to PaymentsHubDepositSummaryState.Info(
+                        availableFunds = 100,
+                        pendingFunds = 200,
+                        pendingBalanceDepositsCount = 1,
+                        fundsAvailableInDays = PaymentsHubDepositSummaryState.Info.Interval.Days(1),
+                        nextDeposit = PaymentsHubDepositSummaryState.Deposit(
+                            amount = 100,
+                            status = PaymentsHubDepositSummaryState.Deposit.Status.ESTIMATED,
+                            date = null
+                        ),
+                        lastDeposit = PaymentsHubDepositSummaryState.Deposit(
+                            amount = 100,
+                            status = PaymentsHubDepositSummaryState.Deposit.Status.FAILED,
+                            date = null
+                        )
+                    ),
+                    "EUR" to PaymentsHubDepositSummaryState.Info(
+                        availableFunds = 100,
+                        pendingFunds = 200,
+                        pendingBalanceDepositsCount = 1,
+                        fundsAvailableInDays = PaymentsHubDepositSummaryState.Info.Interval.Days(1),
+                        nextDeposit = PaymentsHubDepositSummaryState.Deposit(
+                            amount = 100,
+                            status = PaymentsHubDepositSummaryState.Deposit.Status.ESTIMATED,
+                            date = null
+                        ),
+                        lastDeposit = PaymentsHubDepositSummaryState.Deposit(
+                            amount = 100,
+                            status = PaymentsHubDepositSummaryState.Deposit.Status.PAID,
+                            date = null
+                        )
+                    )
+                )
+            )
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHumDepositSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHumDepositSummaryViewModel.kt
@@ -5,16 +5,18 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@HiltViewModel
 class PaymentsHumDepositSummaryViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val repository: PaymentsHubDepositSummaryRepository,
     private val mapper: PaymentsHumDepositSummaryStateMapper,
-    private val isFeatureEnabled: IsFeatureEnabled,
+    isFeatureEnabled: IsFeatureEnabled,
 ) : ScopedViewModel(savedState) {
 
     private val _viewState = MutableStateFlow<PaymentsHubDepositSummaryState>(PaymentsHubDepositSummaryState.Loading)
@@ -23,7 +25,6 @@ class PaymentsHumDepositSummaryViewModel @Inject constructor(
     init {
         if (!isFeatureEnabled()) {
             _viewState.value = PaymentsHubDepositSummaryState.Error("Invalid data")
-
         } else {
             launch {
                 repository.retrieveDepositOverview().map {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHumDepositSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHumDepositSummaryViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.payments.hub.depositsummary
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
@@ -13,32 +14,44 @@ class PaymentsHumDepositSummaryViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val repository: PaymentsHubDepositSummaryRepository,
     private val mapper: PaymentsHumDepositSummaryStateMapper,
+    private val isFeatureEnabled: IsFeatureEnabled,
 ) : ScopedViewModel(savedState) {
 
     private val _viewState = MutableStateFlow<PaymentsHubDepositSummaryState>(PaymentsHubDepositSummaryState.Loading)
     val viewState: LiveData<PaymentsHubDepositSummaryState> = _viewState.asLiveData()
 
     init {
-        launch {
-            repository.retrieveDepositOverview().map {
-                when (it) {
-                    is RetrieveDepositOverviewResult.Cache ->
-                        PaymentsHubDepositSummaryState.Success(
-                            mapper.mapDepositOverviewToViewModelOverviews(it.overview)
-                                ?: return@map PaymentsHubDepositSummaryState.Error("Invalid data")
-                        )
-                    is RetrieveDepositOverviewResult.Remote ->
-                        PaymentsHubDepositSummaryState.Success(
-                            mapper.mapDepositOverviewToViewModelOverviews(it.overview)
-                                ?: return@map PaymentsHubDepositSummaryState.Error("Invalid data")
-                        )
-                    is RetrieveDepositOverviewResult.Error -> {
-                        PaymentsHubDepositSummaryState.Error(it.error.message ?: "Unknown error")
+        if (!isFeatureEnabled()) {
+            _viewState.value = PaymentsHubDepositSummaryState.Error("Invalid data")
+
+        } else {
+            launch {
+                repository.retrieveDepositOverview().map {
+                    when (it) {
+                        is RetrieveDepositOverviewResult.Cache ->
+                            PaymentsHubDepositSummaryState.Success(
+                                mapper.mapDepositOverviewToViewModelOverviews(it.overview)
+                                    ?: return@map PaymentsHubDepositSummaryState.Error("Invalid data")
+                            )
+
+                        is RetrieveDepositOverviewResult.Remote ->
+                            PaymentsHubDepositSummaryState.Success(
+                                mapper.mapDepositOverviewToViewModelOverviews(it.overview)
+                                    ?: return@map PaymentsHubDepositSummaryState.Error("Invalid data")
+                            )
+
+                        is RetrieveDepositOverviewResult.Error -> {
+                            PaymentsHubDepositSummaryState.Error(it.error.message ?: "Unknown error")
+                        }
                     }
+                }.collect {
+                    _viewState.value = it
                 }
-            }.collect {
-                _viewState.value = it
             }
         }
     }
+}
+
+class IsFeatureEnabled @Inject constructor() {
+    operator fun invoke() = FeatureFlag.DEPOSIT_SUMMARY.isEnabled()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import java.text.DecimalFormat
+import java.util.Currency
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.absoluteValue
@@ -113,6 +114,17 @@ class CurrencyFormatter @Inject constructor(
         currencyCode: String = defaultCurrencyCode,
         applyDecimalFormatting: Boolean = true
     ) = formatCurrency(amount.toString(), currencyCode, applyDecimalFormatting)
+
+    fun formatCurrencyGivenInTheSmallestCurrencyUnit(
+        amount: Long,
+        currencyCode: String,
+        applyDecimalFormatting: Boolean = true
+    ): String {
+        val currencyObj = Currency.getInstance(currencyCode)
+        val smallestCurrencyUnit = BigDecimal.TEN.pow(currencyObj.defaultFractionDigits)
+        val value = BigDecimal.valueOf(amount).divide(smallestCurrencyUnit)
+        return formatCurrency(value, currencyCode, applyDecimalFormatting)
+    }
 
     /**
      * Formats a raw amount for display based on the WooCommerce site settings, rounding the values to the nearest int.

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1305,7 +1305,8 @@
     <string name="card_reader_tap_to_pay_not_available_error_country">Unfortunately, Tap To Pay on Android is not available in your country yet. Stay tuned!</string>
     <string name="card_reader_hub_deposit_summary_available_funds">Available funds</string>
     <string name="card_reader_hub_deposit_summary_pending_funds">Pending funds</string>
-    <string name="card_reader_hub_deposit_summary_pending_deposits">%d deposits</string>
+    <string name="card_reader_hub_deposit_summary_pending_deposits_plural">%d deposits</string>
+    <string name="card_reader_hub_deposit_summary_pending_deposits_one">%d deposit</string>
     <string name="card_reader_hub_deposit_summary_funds_available_after">Funds become available after pending for 7 days.</string>
     <string name="card_reader_hub_deposit_funds_deposits_title">Deposits</string>
     <string name="card_reader_hub_deposit_summary_next">Next</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1303,7 +1303,15 @@
     <string name="card_reader_tap_to_pay_not_available_error_android_version">To use Tap To Pay on Android, you need Android 10 or newer. To accept in-person payments, please update Android or purchase a Bluetooth card reader.</string>
     <string name="card_reader_tap_to_pay_not_available_error_gms">To use Tap To Pay on Android, your device needs Google Play Services. To accept in-person payments, please install Google Play Services or purchase a Bluetooth card reader.</string>
     <string name="card_reader_tap_to_pay_not_available_error_country">Unfortunately, Tap To Pay on Android is not available in your country yet. Stay tuned!</string>
-
+    <string name="card_reader_hub_deposit_summary_available_funds">Available funds</string>
+    <string name="card_reader_hub_deposit_summary_pending_funds">Pending funds</string>
+    <string name="card_reader_hub_deposit_summary_pending_deposits">%d deposits</string>
+    <string name="card_reader_hub_deposit_summary_funds_available_after">Funds become available after pending for 7 days.</string>
+    <string name="card_reader_hub_deposit_funds_deposits_title">Deposits</string>
+    <string name="card_reader_hub_deposit_summary_next">Next</string>
+    <string name="card_reader_hub_deposit_summary_last">Next</string>
+    <string name="card_reader_hub_deposit_summary_available_deposited_time">Available funds are deposited automatically, every week.</string>
+    <string name="card_reader_hub_deposit_summary_learn_more">Learn more about when you\'ll receive your funds</string>
     <!--
            Card Reader Tap To Pay Explanation
         -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewModelTest.kt
@@ -824,8 +824,17 @@ class PaymentsHubViewModelTest : BaseUnitTest() {
         assertThat((viewModel.viewStateData.getOrAwaitValue()).rows)
             .anyMatch {
                 it is PaymentsHubViewState.ListItem.HeaderItem &&
-                    it.index == 2 &&
+                    it.index == 3 &&
                     it.label == UiStringRes(R.string.card_reader_settings_header)
+            }
+    }
+
+    @Test
+    fun `when screen shown, then DepositSummaryListItem shown`() {
+        assertThat((viewModel.viewStateData.getOrAwaitValue()).rows)
+            .anyMatch {
+                it is PaymentsHubViewState.ListItem.DepositSummaryListItem &&
+                    it.index == 0
             }
     }
 
@@ -1381,7 +1390,7 @@ class PaymentsHubViewModelTest : BaseUnitTest() {
             // THEN
             assertThat((viewModel.viewStateData.getOrAwaitValue()).rows).anyMatch {
                 it is PaymentsHubViewState.ListItem.HeaderItem &&
-                    it.index == 5 &&
+                    it.index == 6 &&
                     it.label == UiStringRes(R.string.card_reader_tap_to_pay_header)
             }
             assertThat((viewModel.viewStateData.getOrAwaitValue()).rows).anyMatch {
@@ -1389,7 +1398,7 @@ class PaymentsHubViewModelTest : BaseUnitTest() {
                     it.icon == R.drawable.ic_baseline_contactless &&
                     it.label == UiStringRes(R.string.card_reader_test_tap_to_pay) &&
                     it.description == UiStringRes(R.string.card_reader_tap_to_pay_description) &&
-                    it.index == 6 &&
+                    it.index == 7 &&
                     it.iconBadge == R.drawable.ic_badge_new
             }
         }
@@ -1414,7 +1423,7 @@ class PaymentsHubViewModelTest : BaseUnitTest() {
                     it.icon == R.drawable.ic_tintable_info_outline_24dp &&
                     it.label == UiStringRes(R.string.card_reader_about_tap_to_pay) &&
                     it.description == null &&
-                    it.index == 7 &&
+                    it.index == 8 &&
                     it.iconBadge == null
             }
         }
@@ -1441,7 +1450,7 @@ class PaymentsHubViewModelTest : BaseUnitTest() {
                     it.icon == R.drawable.ic_feedback_banner_logo &&
                     it.label == UiStringRes(R.string.card_reader_tap_to_pay_share_feedback) &&
                     it.description == null &&
-                    it.index == 8 &&
+                    it.index == 9 &&
                     it.iconBadge == null
             }
         }
@@ -1503,7 +1512,7 @@ class PaymentsHubViewModelTest : BaseUnitTest() {
                     it.icon == R.drawable.ic_feedback_banner_logo &&
                     it.label == UiStringRes(R.string.card_reader_tap_to_pay_share_feedback) &&
                     it.description == null &&
-                    it.index == 8
+                    it.index == 9
             }
         }
 
@@ -1594,7 +1603,7 @@ class PaymentsHubViewModelTest : BaseUnitTest() {
 
             // THEN
             val rows = (viewModel.viewStateData.getOrAwaitValue()).rows
-            assertThat(rows.map { it.index }).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
+            assertThat(rows.map { it.index }).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
         }
 
     @Test
@@ -1732,7 +1741,7 @@ class PaymentsHubViewModelTest : BaseUnitTest() {
             )
         )
         assertThat(learnMoreListItems[0].icon).isEqualTo(R.drawable.ic_info_outline_20dp)
-        assertThat(learnMoreListItems[0].index).isEqualTo(13)
+        assertThat(learnMoreListItems[0].index).isEqualTo(14)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryRepositoryTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.payments.woo.WooPaymentsDepositsOverview
@@ -70,6 +71,7 @@ class PaymentsHubDepositSummaryRepositoryTest : BaseUnitTest() {
                     error
                 )
             )
+            verify(store).deleteDepositsOverview(site)
         }
 
     @Test
@@ -94,5 +96,6 @@ class PaymentsHubDepositSummaryRepositoryTest : BaseUnitTest() {
                     overview
                 )
             )
+            verify(store).insertDepositsOverview(site, overview)
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryStateMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryStateMapperTest.kt
@@ -1,11 +1,22 @@
 package com.woocommerce.android.ui.payments.hub.depositsummary
 
+import com.woocommerce.android.util.CurrencyFormatter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.mock
 import org.wordpress.android.fluxc.model.payments.woo.WooPaymentsDepositsOverview
 
 class PaymentsHubDepositSummaryStateMapperTest {
-    private val mapper = PaymentsHubDepositSummaryStateMapper()
+    private val currencyFormatter: CurrencyFormatter = mock {
+        on { formatCurrencyGivenInTheSmallestCurrencyUnit(100, "USD") }.thenReturn("100$")
+        on { formatCurrencyGivenInTheSmallestCurrencyUnit(200, "USD") }.thenReturn("200$")
+        on { formatCurrencyGivenInTheSmallestCurrencyUnit(300, "USD") }.thenReturn("300$")
+        on { formatCurrencyGivenInTheSmallestCurrencyUnit(0, "EUR") }.thenReturn("0€")
+        on { formatCurrencyGivenInTheSmallestCurrencyUnit(150, "EUR") }.thenReturn("150€")
+        on { formatCurrencyGivenInTheSmallestCurrencyUnit(250, "EUR") }.thenReturn("250€")
+        on { formatCurrencyGivenInTheSmallestCurrencyUnit(0, "USD") }.thenReturn("0$")
+    }
+    private val mapper = PaymentsHubDepositSummaryStateMapper(currencyFormatter)
 
     @Test
     fun `given overview without default currency, when mapDepositOverviewToViewModelOverviews, then return null`() {
@@ -90,8 +101,8 @@ class PaymentsHubDepositSummaryStateMapperTest {
         // THEN
         assertThat(result).isNotNull
         assertThat(result?.defaultCurrency).isEqualTo("USD")
-        assertThat(result?.infoPerCurrency?.get("USD")?.availableFunds).isEqualTo(100)
-        assertThat(result?.infoPerCurrency?.get("USD")?.pendingFunds).isEqualTo(300)
+        assertThat(result?.infoPerCurrency?.get("USD")?.availableFunds).isEqualTo("100$")
+        assertThat(result?.infoPerCurrency?.get("USD")?.pendingFunds).isEqualTo("300$")
         assertThat(result?.infoPerCurrency?.get("USD")?.pendingBalanceDepositsCount).isEqualTo(2)
         assertThat(result?.infoPerCurrency?.get("USD")?.fundsAvailableInDays).isEqualTo(
             PaymentsHubDepositSummaryState.Info.Interval.Days(
@@ -236,7 +247,7 @@ class PaymentsHubDepositSummaryStateMapperTest {
         assertThat(result?.infoPerCurrency?.get("USD")?.nextDeposit?.status).isEqualTo(
             PaymentsHubDepositSummaryState.Deposit.Status.ESTIMATED
         )
-        assertThat(result?.infoPerCurrency?.get("USD")?.availableFunds).isEqualTo(0)
-        assertThat(result?.infoPerCurrency?.get("USD")?.pendingFunds).isEqualTo(0)
+        assertThat(result?.infoPerCurrency?.get("USD")?.availableFunds).isEqualTo("0$")
+        assertThat(result?.infoPerCurrency?.get("USD")?.pendingFunds).isEqualTo("0$")
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryViewModelTest.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 class PaymentsHubDepositSummaryViewModelTest : BaseUnitTest() {
     private val repository: PaymentsHubDepositSummaryRepository = mock()
     private val mapper: PaymentsHubDepositSummaryStateMapper = mock()
+    private val isFeatureEnabled: IsFeatureEnabled = mock()
 
     @Test
     fun `given repository returns error, when viewmodel init, then error state emitted`() = testBlocking {
@@ -168,6 +169,7 @@ class PaymentsHubDepositSummaryViewModelTest : BaseUnitTest() {
     private fun initViewModel() = PaymentsHubDepositSummaryViewModel(
         savedState = mock(),
         repository = repository,
-        mapper = mapper
+        mapper = mapper,
+        isFeatureEnabled
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryViewModelTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.payments.woo.WooPaymentsDepositsOverview
 import org.wordpress.android.fluxc.network.BaseRequest
@@ -20,7 +21,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 class PaymentsHubDepositSummaryViewModelTest : BaseUnitTest() {
     private val repository: PaymentsHubDepositSummaryRepository = mock()
     private val mapper: PaymentsHubDepositSummaryStateMapper = mock()
-    private val isFeatureEnabled: IsFeatureEnabled = mock()
+    private val isFeatureEnabled: IsFeatureEnabled = mock() {
+        on { invoke() }.thenReturn(true)
+    }
 
     @Test
     fun `given repository returns error, when viewmodel init, then error state emitted`() = testBlocking {
@@ -164,6 +167,24 @@ class PaymentsHubDepositSummaryViewModelTest : BaseUnitTest() {
             assertThat((values[0] as PaymentsHubDepositSummaryState.Error).errorMessage).isEqualTo(
                 "Invalid data"
             )
+        }
+
+    @Test
+    fun `given feature flag off, when viewmodel init, then error is returned and not interactions with repository`() =
+        testBlocking {
+            // GIVEN
+            whenever(isFeatureEnabled()).thenReturn(false)
+
+            // WHEN
+            val viewModel = initViewModel()
+            advanceUntilIdle()
+
+            // THEN
+            val values = viewModel.viewState.captureValues()
+            assertThat((values[0] as PaymentsHubDepositSummaryState.Error).errorMessage).isEqualTo(
+                "Invalid data"
+            )
+            verifyNoInteractions(repository)
         }
 
     private fun initViewModel() = PaymentsHubDepositSummaryViewModel(

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2890-616dd71b79d4b61d1acf3ced2a5baa6a5491d3bb'
+    fluxCVersion = '2890-5ca88c9aa82b96dfc9c9cb83a71eb19045437225'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10068
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs, try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds deposit summary view to the Payments Hub screen. The view itself is not finalized yet and hidden behind feature flag.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Make sure that the view is not shown when the FF is off (in release)

Don't pay much attention to the UI itself as it's in progress and will be addressed in the following PRs

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="368" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/4923871/918b64d4-1aa7-4e39-9100-4ad3accaa02a">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
