### PR TITLE
Subscription products: Bottom sheet

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypeBottomSheetBuilder.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.Prod
 import com.woocommerce.android.ui.subscriptions.IsEligibleForSubscriptions
 import javax.inject.Inject
 
+@Suppress("ForbiddenComment")
 class ProductTypeBottomSheetBuilder @Inject constructor(
     private val isEligibleForSubscriptions: IsEligibleForSubscriptions
 ) {
@@ -35,7 +36,7 @@ class ProductTypeBottomSheetBuilder @Inject constructor(
                 type = SUBSCRIPTION,
                 titleResource = string.product_type_simple_subscription_title,
                 descResource = string.product_type_simple_subscription_desc,
-                iconResource = drawable.ic_gridicons_money,
+                iconResource = drawable.ic_gridicons_money, // TODO: update icon
                 isVisible = areSubscriptionsSupported
             ),
             ProductTypesBottomSheetUiItem(
@@ -49,7 +50,7 @@ class ProductTypeBottomSheetBuilder @Inject constructor(
                 type = VARIABLE_SUBSCRIPTION,
                 titleResource = string.product_type_variable_subscription_title,
                 descResource = string.product_type_variable_subscription_desc,
-                iconResource = drawable.ic_gridicons_money,
+                iconResource = drawable.ic_gridicons_money, // TODO: update icon
                 isVisible = areSubscriptionsSupported
             ),
             ProductTypesBottomSheetUiItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypeBottomSheetBuilder.kt
@@ -5,12 +5,18 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.products.ProductType.EXTERNAL
 import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
+import com.woocommerce.android.ui.products.ProductType.SUBSCRIPTION
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
+import com.woocommerce.android.ui.products.ProductType.VARIABLE_SUBSCRIPTION
 import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
+import com.woocommerce.android.ui.subscriptions.IsEligibleForSubscriptions
 import javax.inject.Inject
 
-class ProductTypeBottomSheetBuilder @Inject constructor() {
-    fun buildBottomSheetList(): List<ProductTypesBottomSheetUiItem> {
+class ProductTypeBottomSheetBuilder @Inject constructor(
+    private val isEligibleForSubscriptions: IsEligibleForSubscriptions
+) {
+    suspend fun buildBottomSheetList(): List<ProductTypesBottomSheetUiItem> {
+        val areSubscriptionsSupported = isEligibleForSubscriptions()
         return listOf(
             ProductTypesBottomSheetUiItem(
                 type = SIMPLE,
@@ -26,10 +32,25 @@ class ProductTypeBottomSheetBuilder @Inject constructor() {
                 isVirtual = true
             ),
             ProductTypesBottomSheetUiItem(
+                type = SUBSCRIPTION,
+                titleResource = string.product_type_simple_subscription_title,
+                descResource = string.product_type_simple_subscription_desc,
+                iconResource = drawable.ic_gridicons_money,
+                isVisible = areSubscriptionsSupported
+            ),
+            ProductTypesBottomSheetUiItem(
                 type = VARIABLE,
                 titleResource = string.product_type_variable_title,
                 descResource = string.product_type_variable_desc,
                 iconResource = drawable.ic_gridicons_types,
+            ),
+
+            ProductTypesBottomSheetUiItem(
+                type = VARIABLE_SUBSCRIPTION,
+                titleResource = string.product_type_variable_subscription_title,
+                descResource = string.product_type_variable_subscription_desc,
+                iconResource = drawable.ic_gridicons_money,
+                isVisible = areSubscriptionsSupported
             ),
             ProductTypesBottomSheetUiItem(
                 type = GROUPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetAdapter.kt
@@ -40,7 +40,7 @@ class ProductTypesBottomSheetAdapter(
         val diffResult =
             DiffUtil.calculateDiff(ProductTypesBottomSheetItemDiffUtil(options, optionList))
         options.clear()
-        options.addAll(optionList)
+        options.addAll(optionList.filter { it.isVisible })
         diffResult.dispatchUpdatesTo(this)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
@@ -63,48 +63,41 @@ class ProductTypesBottomSheetFragment : WCBottomSheetDialogFragment() {
     }
 
     private fun setupObservers() {
-        viewModel.productTypesBottomSheetList.observe(
-            viewLifecycleOwner,
-            {
-                showProductTypeOptions(it)
-            }
-        )
+        viewModel.productTypesBottomSheetList.observe(viewLifecycleOwner) {
+            showProductTypeOptions(it)
+        }
 
-        viewModel.event.observe(
-            viewLifecycleOwner,
-            { event ->
-                when (event) {
-                    is Exit -> {
-                        dismiss()
-                    }
-                    is ShowDialog -> WooDialog.showDialog(
-                        requireActivity(),
-                        event.positiveBtnAction,
-                        event.negativeBtnAction,
-                        event.neutralBtnAction,
-                        event.titleId,
-                        event.messageId,
-                        event.positiveButtonId,
-                        event.negativeButtonId,
-                        event.neutralButtonId
-                    )
-
-                    is ExitWithResult<*> -> {
-                        (event.data as? ProductTypesBottomSheetUiItem)?.let {
-                            navigateWithSelectedResult(productTypesBottomSheetUiItem = it)
-                        }
-                    }
-
-                    is ProductNavigationTarget -> navigator.navigate(this, event)
-                    else -> event.isHandled = false
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is Exit -> {
+                    dismiss()
                 }
+
+                is ShowDialog -> WooDialog.showDialog(
+                    requireActivity(),
+                    event.positiveBtnAction,
+                    event.negativeBtnAction,
+                    event.neutralBtnAction,
+                    event.titleId,
+                    event.messageId,
+                    event.positiveButtonId,
+                    event.negativeButtonId,
+                    event.neutralButtonId
+                )
+
+                is ExitWithResult<*> -> {
+                    (event.data as? ProductTypesBottomSheetUiItem)?.let {
+                        navigateWithSelectedResult(productTypesBottomSheetUiItem = it)
+                    }
+                }
+
+                is ProductNavigationTarget -> navigator.navigate(this, event)
+                else -> event.isHandled = false
             }
-        )
+        }
     }
 
-    private fun showProductTypeOptions(
-        productTypeOptions: List<ProductTypesBottomSheetUiItem>
-    ) {
+    private fun showProductTypeOptions(productTypeOptions: List<ProductTypesBottomSheetUiItem>) {
         productTypesBottomSheetAdapter.setProductTypeOptions(productTypeOptions)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
@@ -17,6 +18,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -50,7 +52,9 @@ class ProductTypesBottomSheetFragment : WCBottomSheetDialogFragment() {
 
         setupObservers()
 
-        viewModel.loadProductTypes()
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.loadProductTypes()
+        }
 
         binding.productDetailInfoLblTitle.text = getString(R.string.product_type_list_header)
         productTypesBottomSheetAdapter = ProductTypesBottomSheetAdapter(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -31,7 +31,7 @@ class ProductTypesBottomSheetViewModel @Inject constructor(
     private val _productTypesBottomSheetList = MutableLiveData<List<ProductTypesBottomSheetUiItem>>()
     val productTypesBottomSheetList: LiveData<List<ProductTypesBottomSheetUiItem>> = _productTypesBottomSheetList
 
-    fun loadProductTypes() {
+    suspend fun loadProductTypes() {
         _productTypesBottomSheetList.value = if (navArgs.isAddProduct) {
             productTypeBottomSheetBuilder.buildBottomSheetList()
         } else {
@@ -78,6 +78,7 @@ class ProductTypesBottomSheetViewModel @Inject constructor(
         @StringRes val titleResource: Int,
         @StringRes val descResource: Int,
         @DrawableRes val iconResource: Int,
-        val isVirtual: Boolean = false
+        val isVirtual: Boolean = false,
+        val isVisible: Boolean = true
     ) : Parcelable
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2478,10 +2478,14 @@
     <string name="product_type_list_header">Select a product type</string>
     <string name="product_type_simple_title">Simple physical product</string>
     <string name="product_type_simple_desc">A unique physical product that you may have to ship to the customer</string>
+    <string name="product_type_simple_subscription_title">Simple subscription product</string>
+    <string name="product_type_simple_subscription_desc">A unique product subscription that enables recurring payments</string>
     <string name="product_type_virtual_title">Simple virtual product</string>
     <string name="product_type_virtual_desc">A unique digital product like services, downloadable books, music or videos</string>
     <string name="product_type_variable_title">Variable product</string>
     <string name="product_type_variable_desc">A product with variations like color or size</string>
+    <string name="product_type_variable_subscription_title">Variable subscription product</string>
+    <string name="product_type_variable_subscription_desc">A product subscription with variations</string>
     <string name="product_type_grouped_title">Grouped product</string>
     <string name="product_type_grouped_desc">A collection of related products</string>
     <string name="product_type_external_title">External product</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModelTest.kt
@@ -16,7 +16,7 @@ class ProductTypesBottomSheetViewModelTest : BaseUnitTest() {
     private val bottomSheetBuilder: ProductTypeBottomSheetBuilder = mock()
 
     @Test
-    fun `given is Add Product flow, when loading product types, then product types not filtered`() {
+    fun `given is Add Product flow, when loading product types, then product types not filtered`() = testBlocking {
         viewModel = ProductTypesBottomSheetViewModel(
             ProductTypesBottomSheetFragmentArgs(isAddProduct = true).initSavedStateHandle(),
             appPrefs, bottomSheetBuilder
@@ -29,7 +29,7 @@ class ProductTypesBottomSheetViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given is not Add Product flow, when loading product types, then product types is filtered`() {
+    fun `given is not Add Product flow, when loading product types, then product types is filtered`() = testBlocking {
         viewModel = ProductTypesBottomSheetViewModel(
             ProductTypesBottomSheetFragmentArgs(
                 isAddProduct = false,
@@ -46,7 +46,7 @@ class ProductTypesBottomSheetViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given current type is virtual, when loading product types, then only virtual type is filtered out`() {
+    fun `given current type is virtual, when loading product types, then only virtual type is filtered out`() = testBlocking {
         viewModel = ProductTypesBottomSheetViewModel(
             ProductTypesBottomSheetFragmentArgs(
                 isAddProduct = false,


### PR DESCRIPTION
Closes #10114. The PR adds the 2 new subscription types to the add-product bottom sheet. The new types are only added to eligible sites.

<img src="https://github.com/woocommerce/woocommerce-android/assets/1522856/6a5d482a-d057-4853-b84e-f931fa0e906c" width="300" /><br />

**To test:**
1. Install the [WooCommerce Subscription](https://woo.com/products/woocommerce-subscriptions) plugin on a site
2. Start the app
3. Go to Products
4. Tap on Add new product FAB
5. Tap on Add manually option
6. Notice the bottom sheet now contains 2 new subscription product types
7. Deactivate the subscriptions plugin
8. Repeat steps 3-5
9. Notice the bottom sheet doesn't contain subscription product types

**Note:** Please merge #10116 first.