### PR TITLE
[Custom amounts m2] Do not show fee lines warning when there are multiple custom amounts

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/DetermineMultipleLinesContext.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/DetermineMultipleLinesContext.kt
@@ -10,31 +10,6 @@ import javax.inject.Inject
 class DetermineMultipleLinesContext @Inject constructor(private val resourceProvider: ResourceProvider) {
     operator fun invoke(order: Order) =
         when {
-            order.hasMultipleShippingLines && order.hasMultipleFeeLines -> MultipleLinesContext.Warning(
-                header = resourceProvider.getString(
-                    R.string.lines_incomplete,
-                    String.format(
-                        Locale.getDefault(),
-                        "%s & %s",
-                        resourceProvider.getString(R.string.order_creation_payment_fee),
-                        resourceProvider.getString(R.string.orderdetail_shipping_details),
-                    )
-                ),
-                explanation = resourceProvider.getString(
-                    R.string.lines_incomplete_explanation,
-                    resourceProvider.getString(R.string.lines_all_details)
-                ),
-            )
-            order.hasMultipleFeeLines -> MultipleLinesContext.Warning(
-                header = resourceProvider.getString(
-                    R.string.lines_incomplete,
-                    resourceProvider.getString(R.string.order_creation_payment_fee)
-                ),
-                explanation = resourceProvider.getString(
-                    R.string.lines_incomplete_explanation,
-                    resourceProvider.getString(R.string.order_creation_payment_fee).lowercase()
-                )
-            )
             order.hasMultipleShippingLines -> MultipleLinesContext.Warning(
                 header = resourceProvider.getString(
                     R.string.lines_incomplete,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/DetermineMultipleLinesContext.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/DetermineMultipleLinesContext.kt
@@ -4,7 +4,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel.MultipleLinesContext
 import com.woocommerce.android.viewmodel.ResourceProvider
-import java.util.Locale
 import javax.inject.Inject
 
 class DetermineMultipleLinesContext @Inject constructor(private val resourceProvider: ResourceProvider) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -422,14 +422,15 @@ class OrderCreateEditFormFragment :
     }
 
     private fun customAmountAddedProductUnset(binding: FragmentOrderCreateEditFormBinding) {
-        binding.productsSection.removeCustomSectionButtons()
         binding.customAmountsSection.removeCustomSectionButtons()
         binding.customAmountsSection.show()
         binding.customAmountsSection.showHeader()
         binding.customAmountsSection.showAddAction()
 
+        binding.productsSection.removeCustomSectionButtons()
         binding.productsSection.hideAddProductsHeaderActions()
         binding.productsSection.hideHeader()
+        binding.productsSection.content = null
         binding.productsSection.setProductSectionButtons(
             addProductsButton = AddButton(
                 text = getString(R.string.order_creation_add_products),
@@ -473,6 +474,7 @@ class OrderCreateEditFormFragment :
     private fun bothProductsAndCustomAmountsAreUnset(binding: FragmentOrderCreateEditFormBinding) {
         binding.productsSection.hideAddProductsHeaderActions()
         binding.productsSection.hideHeader()
+        binding.productsSection.content = null
         binding.productsSection.setProductSectionButtons(
             addProductsButton = AddButton(
                 text = getString(R.string.order_creation_add_products),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/DetermineMultipleLinesContextTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/DetermineMultipleLinesContextTest.kt
@@ -47,8 +47,6 @@ class DetermineMultipleLinesContextTest : BaseUnitTest() {
                 AmbiguousLocation.EMPTY
             )
         )
-        whenever(resourceProvider.getString(any())).thenReturn("")
-        whenever(resourceProvider.getString(any(), any())).thenReturn("")
         val sut = DetermineMultipleLinesContext(resourceProvider)
 
         val result = sut.invoke(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/DetermineMultipleLinesContextTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/DetermineMultipleLinesContextTest.kt
@@ -38,4 +38,23 @@ class DetermineMultipleLinesContextTest : BaseUnitTest() {
 
         assertThat(result).isInstanceOf(OrderCreateEditViewModel.MultipleLinesContext.Warning::class.java)
     }
+
+    @Test
+    fun `when order does not have multiple shipping lines, then return None MultipleLinesContext`() {
+        whenever(location.invoke(any(), any())).thenReturn(
+            Pair(
+                Location(code = LocationCode(), name = ""),
+                AmbiguousLocation.EMPTY
+            )
+        )
+        whenever(resourceProvider.getString(any())).thenReturn("")
+        whenever(resourceProvider.getString(any(), any())).thenReturn("")
+        val sut = DetermineMultipleLinesContext(resourceProvider)
+
+        val result = sut.invoke(
+            OrderMapper(location).toAppModel(OrderTestUtils.generateOrder())
+        )
+
+        assertThat(result).isInstanceOf(OrderCreateEditViewModel.MultipleLinesContext.None::class.java)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/DetermineMultipleLinesContextTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/DetermineMultipleLinesContextTest.kt
@@ -1,0 +1,41 @@
+package com.woocommerce.android.ui.orders.creation
+
+import com.woocommerce.android.model.AmbiguousLocation
+import com.woocommerce.android.model.GetLocations
+import com.woocommerce.android.model.Location
+import com.woocommerce.android.model.OrderMapper
+import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.orders.details.editing.address.LocationCode
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class DetermineMultipleLinesContextTest : BaseUnitTest() {
+
+    private val location: GetLocations = mock()
+    private val resourceProvider: ResourceProvider = mock()
+    @Test
+    fun `when order has multiple shipping lines, then return proper multiple lines context`() {
+        whenever(location.invoke(any(), any())).thenReturn(
+            Pair(
+                Location(code = LocationCode(), name = ""),
+                AmbiguousLocation.EMPTY
+            )
+        )
+        whenever(resourceProvider.getString(any())).thenReturn("")
+        whenever(resourceProvider.getString(any(), any())).thenReturn("")
+        val sut = DetermineMultipleLinesContext(resourceProvider)
+
+        val result = sut.invoke(
+            OrderMapper(location).toAppModel(OrderTestUtils.generateOrderWithMultipleShippingLines())
+        )
+
+        assertThat(result).isInstanceOf(OrderCreateEditViewModel.MultipleLinesContext.Warning::class.java)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10120 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With the recent transition from fees to custom amounts in our order creation process, the flexibility of adding multiple custom amounts is now a feature without the constraints we previously had with fees. Consequently, the warning message that used to trigger when adding multiple fees is now obsolete.

This PR implements the removal of that warning, streamlining the order creation experience to align with the updated functionality.

Along with this PR, there's a minor UI fix in the products section on the order creation screen. This PR removes some additional margins in the products section.

<img width="288" alt="Screenshot 2023-11-08 at 9 20 48 AM" src="https://github.com/woocommerce/woocommerce-android/assets/1331230/b23aa2e0-d1d9-49c6-b560-c1e49d919bed">


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Navigate to the order creation screen
2. Add custom amounts multiple times
3. Ensure you don't see any warning related to fees.


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

**Before removing the margin in the Products section**
<img width="296" alt="Screenshot 2023-11-08 at 10 56 25 AM" src="https://github.com/woocommerce/woocommerce-android/assets/1331230/fbb252e1-5d68-4901-aa7e-5ac6d91da92c">


**After removing the margin in the Products section**
<img width="248" alt="Screenshot 2023-11-08 at 10 52 34 AM" src="https://github.com/woocommerce/woocommerce-android/assets/1331230/bff6c63e-e1ab-41c2-a761-4d2d201896e4">



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
