### PR TITLE
Fastfile: Fix release version name

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -419,9 +419,7 @@ platform :android do
   #####################################################################################
   desc 'Updates store metadata and runs the release checks'
   lane :finalize_release do |options|
-    if android_current_branch_is_hotfix(version_properties_path: VERSION_PROPERTIES_PATH)
-      UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes')
-    end
+    UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if android_current_branch_is_hotfix(version_properties_path: VERSION_PROPERTIES_PATH)
 
     UI.user_error!("Current branch - '#{git_branch}' - is not a release branch. Abort.") unless git_branch.start_with?('release/')
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -308,7 +308,7 @@ platform :android do
 
     push_to_git_remote_with_confirmation
 
-    trigger_release_build(branch_to_build: "release/#{new_version}")
+    trigger_release_build(branch_to_build: "release/#{current_release_version}")
   end
 
   #####################################################################################


### PR DESCRIPTION
The `new_beta_release` lane was referencing the `new_version` variable, which hadn't actually been assigned. This PR updates it to `current_release_version`, which is the current method call for this part of the Fastfile. 

I'm merging this into the `release/16.1` branch in case any further intermediate builds need to be created during the code freeze. 