### PR TITLE
[Jetpack Connection] Move release entry to the correct version

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 16.2
 -----
-
+- [*] [Internal] Improve handling of Jetpack Connection for Jetpack CP sites when using Application Passwords [https://github.com/woocommerce/woocommerce-android/pull/10083]
 
 16.1
 -----
@@ -9,7 +9,6 @@
 - [*] [Internal] Fixed a crash during store creation flow [https://github.com/woocommerce/woocommerce-android/pull/10039]
 - [***] Introduce functionality to input custom amounts during the order creation process. [https://github.com/woocommerce/woocommerce-android/pull/10035]
 - [*] [Internal] Improve error handling during Jetpack Connection when using a custom admin URL [https://github.com/woocommerce/woocommerce-android/pull/10077]
-- [*] [Internal] Improve handling of Jetpack Connection for Jetpack CP sites when using Application Passwords [https://github.com/woocommerce/woocommerce-android/pull/10083]
 
 16.0
 -----


### PR DESCRIPTION
### Description
The PR https://github.com/woocommerce/woocommerce-android/pull/10083 added a release notes entry to the past version, this PR just fixes this by moving it to the correct version.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
