### PR TITLE
Improve permissions handling for `Terminal::discoverReaders`

### DIFF
--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.cardreader.internal
 
 import android.app.Application
+import androidx.annotation.RequiresPermission
 import com.stripe.stripeterminal.log.LogLevel
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.LogWrapper
@@ -80,6 +81,13 @@ internal class CardReaderManagerImpl(
         terminal.setupSimulator(updateFrequency, useInterac)
     }
 
+    @RequiresPermission(
+        allOf = [
+            "android.permission.ACCESS_FINE_LOCATION",
+            "android.permission.BLUETOOTH_CONNECT",
+            "android.permission.BLUETOOTH_SCAN"
+        ]
+    )
     override fun discoverReaders(
         isSimulated: Boolean,
         cardReaderTypesToDiscover: CardReaderTypesToDiscover,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.cardreader.internal.connection
 
+import androidx.annotation.RequiresPermission
 import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.callable.ReaderCallback
 import com.stripe.stripeterminal.external.models.ConnectionConfiguration.BluetoothConnectionConfiguration
@@ -39,6 +40,13 @@ internal class ConnectionManager(
     val batteryStatus = bluetoothReaderListener.batteryStatusEvents
     val displayBluetoothCardReaderMessages = bluetoothReaderListener.displayMessagesEvents
 
+    @RequiresPermission(
+        allOf = [
+            "android.permission.ACCESS_FINE_LOCATION",
+            "android.permission.BLUETOOTH_CONNECT",
+            "android.permission.BLUETOOTH_SCAN"
+        ]
+    )
     fun discoverReaders(isSimulated: Boolean, cardReaderTypesToDiscover: CardReaderTypesToDiscover) =
         when (cardReaderTypesToDiscover) {
             is SpecificReaders -> {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.cardreader.internal.connection.actions
 
+import androidx.annotation.RequiresPermission
 import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.callable.DiscoveryListener
 import com.stripe.stripeterminal.external.models.DiscoveryConfiguration
@@ -29,14 +30,35 @@ internal class DiscoverReadersAction(
         data class Failure(val exception: TerminalException) : DiscoverReadersStatus()
     }
 
+    @RequiresPermission(
+        allOf = [
+            "android.permission.ACCESS_FINE_LOCATION",
+            "android.permission.BLUETOOTH_CONNECT",
+            "android.permission.BLUETOOTH_SCAN"
+        ]
+    )
     fun discoverBuildInReaders(isSimulated: Boolean): Flow<DiscoverReadersStatus> =
         discoverReaders(DiscoveryConfiguration.LocalMobileDiscoveryConfiguration(isSimulated))
 
+    @RequiresPermission(
+        allOf = [
+            "android.permission.ACCESS_FINE_LOCATION",
+            "android.permission.BLUETOOTH_CONNECT",
+            "android.permission.BLUETOOTH_SCAN"
+        ]
+    )
     fun discoverExternalReaders(isSimulated: Boolean): Flow<DiscoverReadersStatus> =
         discoverReaders(
             DiscoveryConfiguration.BluetoothDiscoveryConfiguration(DISCOVERY_TIMEOUT_IN_SECONDS, isSimulated)
         )
 
+    @RequiresPermission(
+        allOf = [
+            "android.permission.ACCESS_FINE_LOCATION",
+            "android.permission.BLUETOOTH_CONNECT",
+            "android.permission.BLUETOOTH_SCAN"
+        ]
+    )
     private fun discoverReaders(config: DiscoveryConfiguration): Flow<DiscoverReadersStatus> {
         return callbackFlow {
             sendAndLog(Started, logWrapper)
@@ -64,7 +86,7 @@ internal class DiscoverReadersAction(
                 }
             )
             awaitClose {
-                cancelable.takeIf { !it!!.isCompleted }?.cancel(noopCallback)
+                cancelable.takeIf { !it.isCompleted }?.cancel(noopCallback)
             }
         }
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.cardreader.internal.wrappers
 
 import android.app.Application
-import android.util.Log
+import androidx.annotation.RequiresPermission
 import com.stripe.stripeterminal.Terminal
 import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.callable.Cancelable
@@ -41,18 +41,18 @@ internal class TerminalWrapper {
         listener: TerminalListener
     ) = Terminal.initTerminal(application, logLevel, tokenProvider, listener)
 
+    @RequiresPermission(
+        allOf = [
+            "android.permission.ACCESS_FINE_LOCATION",
+            "android.permission.BLUETOOTH_CONNECT",
+            "android.permission.BLUETOOTH_SCAN"
+        ]
+    )
     fun discoverReaders(
         config: DiscoveryConfiguration,
         discoveryListener: DiscoveryListener,
         callback: Callback
-    ): Cancelable? {
-        return try {
-            Terminal.getInstance().discoverReaders(config, discoveryListener, callback)
-        } catch (e: SecurityException) {
-            Log.e("Error", "Permission denied: ${e.message}")
-            null
-        }
-    }
+    ): Cancelable = Terminal.getInstance().discoverReaders(config, discoveryListener, callback)
 
     fun connectToReader(
         reader: Reader,


### PR DESCRIPTION
### Description
* This PR improves the way of handling permissions requirement when calling `Terminal::discoverReaders`. Required permissions check is now propagated down to the consumer of the `cardreader` module - the WooCommerce app. The app itself already asks for the permissions, and no modifications around runtime permission requests are required.

* It reverts the `Cancelable?` result of the `discoverReaders()` function.

### Testing
1. Verify the app compiles and runs without errors. 
2. Verify app asks for required permissions in runtime before connecting to a reader
3. Verify you can connect to a card reader and take a payment

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
