### PR TITLE
Update Ruby Tooling Configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,6 @@ Layout/LineLength:
 Naming/VariableNumber:
   Exclude:
     - fastlane/Fastfile
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never

--- a/Dangerfile
+++ b/Dangerfile
@@ -37,6 +37,6 @@ pr_size_checker.check_diff_size(
 android_unit_test_checker.check_missing_tests
 
 # skip check for draft PRs and for WIP features unless the PR is against the main branch or release branch
-milestone_checker.check_milestone_due_date(days_before_due: 2) if !github.pr_draft? && (!wip_feature? || (release_branch? || main_branch?))
+milestone_checker.check_milestone_due_date(days_before_due: 2) unless github.pr_draft? || (wip_feature? && !(release_branch? || main_branch?))
 
 rubocop.lint(inline_comment: true, fail_on_inline_comment: true, include_cop_names: true)

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'danger-dangermattic', git: 'https://github.com/Automattic/dangermattic'
-gem 'fastlane', '~> 2'
+gem 'fastlane', '~> 2.216'
 gem 'nokogiri'
 gem 'rubocop', '~> 1.56'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Automattic/dangermattic
-  revision: 451932e8870ef3c52de0d8bea80edcfa3d879e53
+  revision: 06a54db4f546d20c0465e4d144049d061a2a1e20
   specs:
     danger-dangermattic (0.0.1)
       danger (~> 9.3)
@@ -282,9 +282,9 @@ GEM
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (5.0.3)
-    racc (1.7.1)
+    racc (1.7.3)
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.1.0)
     rake-compiler (1.2.5)
       rake
     rchardet (1.8.0)
@@ -297,8 +297,7 @@ GEM
     rexml (3.2.6)
     rmagick (4.3.0)
     rouge (2.0.7)
-    rubocop (1.57.1)
-      base64 (~> 0.1.1)
+    rubocop (1.57.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -309,7 +308,7 @@ GEM
       rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.29.0)
+    rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,7 +363,7 @@ PLATFORMS
 
 DEPENDENCIES
   danger-dangermattic!
-  fastlane (~> 2)
+  fastlane (~> 2.216)
   fastlane-plugin-wpmreleasetoolkit (~> 9.2)
   nokogiri
   rmagick (~> 4.1)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -156,7 +156,7 @@ platform :android do
       extracted_notes_file_path: RELEASE_NOTES_PATH
     )
     android_update_release_notes(
-      new_version:,
+      new_version: new_version,
       release_notes_file_path: RELEASE_NOTES_SOURCE_PATH
     )
 
@@ -419,9 +419,7 @@ platform :android do
   #####################################################################################
   desc 'Updates store metadata and runs the release checks'
   lane :finalize_release do |options|
-    if android_current_branch_is_hotfix(version_properties_path: VERSION_PROPERTIES_PATH)
-      UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes')
-    end
+    UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if android_current_branch_is_hotfix(version_properties_path: VERSION_PROPERTIES_PATH)
 
     UI.user_error!("Current branch - '#{git_branch}' - is not a release branch. Abort.") unless git_branch.start_with?('release/')
 
@@ -453,7 +451,7 @@ platform :android do
     version = current_release_version
 
     download_metadata_strings(
-      version:,
+      version: version,
       build_number: current_build_code
     )
 
@@ -564,7 +562,7 @@ platform :android do
 
     # Create the file names
     version = current_version_name
-    build_bundle(version:, flavor: 'Vanilla')
+    build_bundle(version: version, flavor: 'Vanilla')
 
     aab_file_path = File.join(PROJECT_ROOT_FOLDER, 'artifacts', aab_file_name(version))
 
@@ -582,7 +580,7 @@ platform :android do
       json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
     )
 
-    create_gh_release(version:) if options[:create_release]
+    create_gh_release(version: version) if options[:create_release]
   end
 
   #####################################################################################
@@ -617,7 +615,7 @@ platform :android do
 
     # Create the file names
     version = current_version_name
-    build_bundle(version:, flavor: 'Vanilla')
+    build_bundle(version: version, flavor: 'Vanilla')
 
     aab_file_path = File.join(PROJECT_ROOT_FOLDER, 'artifacts', aab_file_name(version))
     UI.error("Unable to find a build artifact at #{aab_file_path}") unless File.exist? aab_file_path
@@ -634,7 +632,7 @@ platform :android do
       json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
     )
 
-    create_gh_release(version:, prerelease: true) if options[:create_release]
+    create_gh_release(version: version, prerelease: true) if options[:create_release]
   end
 
   #####################################################################################
@@ -729,7 +727,7 @@ platform :android do
       project_url: GLOTPRESS_PLAYSTORE_METADATA_PROJECT_URL,
       target_files: files,
       locales: SUPPORTED_LOCALES.map { |hsh| [hsh[:glotpress], hsh[:google_play]] },
-      download_path:
+      download_path: download_path
     )
 
     # Copy the source `.txt` files (used as source of truth when we generated the `.po`) to the `fastlane/*metadata/android/en-US` dir,
@@ -740,7 +738,7 @@ platform :android do
     end
 
     android_create_xml_release_notes(
-      download_path:,
+      download_path: download_path,
       build_number: options[:build_number].to_s,
       locales: SUPPORTED_LOCALES.to_h { |hsh| [hsh[:glotpress], hsh[:google_play]] }
     )
@@ -851,7 +849,7 @@ platform :android do
       clear_previous_screenshots: options.fetch(:clear_previous_screenshots, false),
       # Needs to be root to save screenshots consistently
       use_adb_root: true,
-      locales:,
+      locales: locales,
       use_timestamp_suffix: false,
       test_instrumentation_runner: "#{APP_PACKAGE_NAME}.WooCommerceTestRunner",
       # Don't care about the .html summary
@@ -917,7 +915,7 @@ platform :android do
 
     gp_downloadmetadata(project_url: GLOTPRESS_PLAYSTORE_METADATA_PROJECT_URL,
                         target_files: files,
-                        locales:,
+                        locales: locales,
                         source_locale: 'en-US',
                         download_path: SCREENSHOTS_METADATA_DIR_PATH)
 
@@ -1138,9 +1136,9 @@ platform :android do
 
     create_release(
       repository: GHHELPER_REPO,
-      version:,
+      version: version,
       release_notes_file_path: RELEASE_NOTES_PATH,
-      prerelease:,
+      prerelease: prerelease,
       release_assets: release_assets.join(',')
     )
   end


### PR DESCRIPTION
## Description

The main goal of this PR is to align the Ruby setup and standard syntax (preventing Ruby 3.1 new hash syntax, as discussed on paaHJt-5yi-p2)  with other projects, mainly by configuring RuboCop with:
```yaml
Style/HashSyntax:
  EnforcedShorthandSyntax: never
```
And adjusting Ruby files accordingly.

I also took the chance to update `Dangermattic` to the latest version.


## Testing instructions
Make sure CI is green.
