### PR TITLE
Issue/10123 subscription price

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionProductVariation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionProductVariation.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.model
 
 import com.woocommerce.android.extensions.fastStripHtml
+import com.woocommerce.android.extensions.isEquivalentTo
 import com.woocommerce.android.extensions.parseFromIso8601DateFormat
+import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.ui.products.ProductBackorderStatus
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductStockStatus
@@ -115,6 +117,73 @@ class SubscriptionProductVariation(
             weight = model.weight.toFloatOrNull() ?: 0f
         )
 
+    @Suppress("ComplexMethod")
+    override fun equals(other: Any?): Boolean {
+        val variation = other as? SubscriptionProductVariation
+        return variation?.let {
+            subscriptionDetails == variation.subscriptionDetails &&
+                remoteVariationId == variation.remoteVariationId &&
+                remoteProductId == variation.remoteProductId &&
+                sku == variation.sku &&
+                image?.id == variation.image?.id &&
+                regularPrice isEquivalentTo variation.regularPrice &&
+                salePrice isEquivalentTo variation.salePrice &&
+                isSaleScheduled == variation.isSaleScheduled &&
+                saleEndDateGmt == variation.saleEndDateGmt &&
+                saleStartDateGmt == variation.saleStartDateGmt &&
+                stockQuantity == variation.stockQuantity &&
+                stockStatus == variation.stockStatus &&
+                backorderStatus == variation.backorderStatus &&
+                isPurchasable == variation.isPurchasable &&
+                isVirtual == variation.isVirtual &&
+                isDownloadable == variation.isDownloadable &&
+                isStockManaged == variation.isStockManaged &&
+                description.fastStripHtml() == variation.description.fastStripHtml() &&
+                isVisible == variation.isVisible &&
+                shippingClass == variation.shippingClass &&
+                shippingClassId == variation.shippingClassId &&
+                attributes.contentEquals(variation.attributes) &&
+                weight == variation.weight &&
+                length == variation.length &&
+                height == variation.height &&
+                width == variation.width
+        } ?: false
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (subscriptionDetails?.hashCode() ?: 0)
+        result = 31 * result + remoteProductId.hashCode()
+        result = 31 * result + remoteVariationId.hashCode()
+        result = 31 * result + sku.hashCode()
+        result = 31 * result + (image?.hashCode() ?: 0)
+        result = 31 * result + (price?.hashCode() ?: 0)
+        result = 31 * result + (regularPrice?.hashCode() ?: 0)
+        result = 31 * result + (salePrice?.hashCode() ?: 0)
+        result = 31 * result + (saleEndDateGmt?.hashCode() ?: 0)
+        result = 31 * result + (saleStartDateGmt?.hashCode() ?: 0)
+        result = 31 * result + isSaleScheduled.hashCode()
+        result = 31 * result + stockStatus.hashCode()
+        result = 31 * result + backorderStatus.hashCode()
+        result = 31 * result + stockQuantity.hashCode()
+        result = 31 * result + (priceWithCurrency?.hashCode() ?: 0)
+        result = 31 * result + isPurchasable.hashCode()
+        result = 31 * result + isVirtual.hashCode()
+        result = 31 * result + isDownloadable.hashCode()
+        result = 31 * result + isStockManaged.hashCode()
+        result = 31 * result + description.hashCode()
+        result = 31 * result + isVisible.hashCode()
+        result = 31 * result + shippingClass.hashCode()
+        result = 31 * result + shippingClassId.hashCode()
+        result = 31 * result + menuOrder
+        result = 31 * result + attributes.contentHashCode()
+        result = 31 * result + length.hashCode()
+        result = 31 * result + width.hashCode()
+        result = 31 * result + height.hashCode()
+        result = 31 * result + weight.hashCode()
+        return result
+    }
+
     override fun copy(
         remoteProductId: Long,
         remoteVariationId: Long,
@@ -175,6 +244,70 @@ class SubscriptionProductVariation(
             height = height,
             weight = weight,
             subscriptionDetails = subscriptionDetails
+        )
+    }
+
+    fun copy(
+        subscriptionDetails: SubscriptionDetails? = this.subscriptionDetails,
+        remoteProductId: Long = this.remoteProductId,
+        remoteVariationId: Long = this.remoteVariationId,
+        sku: String = this.sku,
+        image: Image? = this.image,
+        price: BigDecimal? = this.price,
+        regularPrice: BigDecimal? = this.regularPrice,
+        salePrice: BigDecimal? = this.salePrice,
+        saleEndDateGmt: Date? = this.saleEndDateGmt,
+        saleStartDateGmt: Date? = this.saleStartDateGmt,
+        isSaleScheduled: Boolean = this.isSaleScheduled,
+        stockStatus: ProductStockStatus = this.stockStatus,
+        backorderStatus: ProductBackorderStatus = this.backorderStatus,
+        stockQuantity: Double = this.stockQuantity,
+        priceWithCurrency: String? = this.priceWithCurrency,
+        isPurchasable: Boolean = this.isPurchasable,
+        isVirtual: Boolean = this.isVirtual,
+        isDownloadable: Boolean = this.isDownloadable,
+        isStockManaged: Boolean = this.isStockManaged,
+        description: String = this.description,
+        isVisible: Boolean = this.isVisible,
+        shippingClass: String = this.shippingClass,
+        shippingClassId: Long = this.shippingClassId,
+        menuOrder: Int = this.menuOrder,
+        attributes: Array<VariantOption> = this.attributes,
+        length: Float = this.length,
+        width: Float = this.width,
+        height: Float = this.height,
+        weight: Float = this.weight
+    ): SubscriptionProductVariation {
+        return SubscriptionProductVariation(
+            subscriptionDetails = subscriptionDetails,
+            remoteProductId = remoteProductId,
+            remoteVariationId = remoteVariationId,
+            sku = sku,
+            image = image,
+            price = price,
+            regularPrice = regularPrice,
+            salePrice = salePrice,
+            saleEndDateGmt = saleEndDateGmt,
+            saleStartDateGmt = saleStartDateGmt,
+            isSaleScheduled = isSaleScheduled,
+            stockStatus = stockStatus,
+            backorderStatus = backorderStatus,
+            stockQuantity = stockQuantity,
+            priceWithCurrency = priceWithCurrency,
+            isPurchasable = isPurchasable,
+            isVirtual = isVirtual,
+            isDownloadable = isDownloadable,
+            isStockManaged = isStockManaged,
+            description = description,
+            isVisible = isVisible,
+            shippingClass = shippingClass,
+            shippingClassId = shippingClassId,
+            menuOrder = menuOrder,
+            attributes = attributes,
+            length = length,
+            width = width,
+            height = height,
+            weight = weight
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/TypedTextField.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.compose.component
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -144,7 +145,7 @@ interface TextFieldValueMapper<T> {
     }
 }
 
-class BigDecimalTextFieldValueMapper(
+class BigDecimalTextFieldValueMapper private constructor(
     private val supportsNegativeValue: Boolean = true
 ) : TextFieldValueMapper<BigDecimal> {
     override fun parseText(text: String): BigDecimal = text.toBigDecimal()
@@ -160,9 +161,16 @@ class BigDecimalTextFieldValueMapper(
             else -> oldText
         }
     }
+
+    companion object {
+        @Composable
+        fun create(supportsNegativeValue: Boolean) = remember(supportsNegativeValue) {
+            BigDecimalTextFieldValueMapper(supportsNegativeValue)
+        }
+    }
 }
 
-class NullableBigDecimalTextFieldValueMapper(
+class NullableBigDecimalTextFieldValueMapper private constructor(
     private val supportsNegativeValue: Boolean = true
 ) : TextFieldValueMapper<BigDecimal?> {
     override fun parseText(text: String): BigDecimal? = text.toBigDecimalOrNull()
@@ -176,9 +184,16 @@ class NullableBigDecimalTextFieldValueMapper(
             else -> oldText
         }
     }
+
+    companion object {
+        @Composable
+        fun create(supportsNegativeValue: Boolean) = remember(supportsNegativeValue) {
+            NullableBigDecimalTextFieldValueMapper(supportsNegativeValue)
+        }
+    }
 }
 
-class NullableCurrencyTextFieldValueMapper(
+class NullableCurrencyTextFieldValueMapper @VisibleForTesting constructor(
     private val decimalSeparator: String,
     private val numberOfDecimals: Int
 ) : TextFieldValueMapper<BigDecimal?> {
@@ -204,6 +219,13 @@ class NullableCurrencyTextFieldValueMapper(
     }
 
     private fun String.hasAllowedNumberOfDecimals() = substringAfter(decimalSeparator, "").length <= numberOfDecimals
+
+    companion object {
+        @Composable
+        fun create(decimalSeparator: String, numberOfDecimals: Int) = remember(decimalSeparator, numberOfDecimals) {
+            NullableCurrencyTextFieldValueMapper(decimalSeparator, numberOfDecimals)
+        }
+    }
 }
 
 class NullableIntTextFieldValueMapper(
@@ -238,7 +260,7 @@ private fun PreviewTypedTextFields() {
                 value = signedDecimal,
                 onValueChange = { signedDecimal = it },
                 label = "Signed BigDecimal",
-                valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = true),
+                valueMapper = BigDecimalTextFieldValueMapper.create(supportsNegativeValue = true),
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
             )
 
@@ -249,7 +271,7 @@ private fun PreviewTypedTextFields() {
                 value = nonSignedDecimal,
                 onValueChange = { nonSignedDecimal = it },
                 label = "Non-signed BigDecimal",
-                valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = false),
+                valueMapper = BigDecimalTextFieldValueMapper.create(supportsNegativeValue = false),
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
             )
 
@@ -260,7 +282,7 @@ private fun PreviewTypedTextFields() {
                 value = optionalDecimal,
                 onValueChange = { optionalDecimal = it },
                 label = "Optional BigDecimal",
-                valueMapper = NullableBigDecimalTextFieldValueMapper(supportsNegativeValue = true),
+                valueMapper = NullableBigDecimalTextFieldValueMapper.create(supportsNegativeValue = true),
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/CouponRestrictionsScreen.kt
@@ -158,7 +158,7 @@ private fun SpendingRestrictionField(
         value = value,
         onValueChange = onValueChange,
         label = label,
-        valueMapper = NullableBigDecimalTextFieldValueMapper(supportsNegativeValue = false),
+        valueMapper = NullableBigDecimalTextFieldValueMapper.create(supportsNegativeValue = false),
         modifier = modifier,
         // TODO use KeyboardType.Decimal after updating to Compose 1.2.0
         //  (https://issuetracker.google.com/issues/209835363)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponScreen.kt
@@ -302,7 +302,7 @@ private fun AmountField(amount: BigDecimal?, amountUnit: String, type: Type?, on
     WCOutlinedTypedTextField(
         value = amount ?: BigDecimal.ZERO,
         label = stringResource(id = R.string.coupon_edit_amount_hint, amountUnit),
-        valueMapper = BigDecimalTextFieldValueMapper(supportsNegativeValue = true),
+        valueMapper = BigDecimalTextFieldValueMapper.create(supportsNegativeValue = true),
         onValueChange = onAmountChanged,
         helperText = stringResource(
             if (type is Percent) R.string.coupon_edit_amount_percentage_helper

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountScreen.kt
@@ -114,7 +114,7 @@ fun OrderCreateEditProductDiscountScreen(
                             .focusRequester(focusRequester)
                             .weight(1f),
                         value = state.value.discountAmount,
-                        valueMapper = NullableCurrencyTextFieldValueMapper(
+                        valueMapper = NullableCurrencyTextFieldValueMapper.create(
                             discountInputFieldConfig.decimalSeparator,
                             discountInputFieldConfig.numberOfDecimals
                         ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -42,7 +42,6 @@ import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductSu
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductTags
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductTypes
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductVariations
-import com.woocommerce.android.ui.products.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.ProductType.BUNDLE
 import com.woocommerce.android.ui.products.ProductType.COMPOSITE
@@ -65,6 +64,7 @@ import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRIMARY
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
 import com.woocommerce.android.ui.products.models.SiteParameters
+import com.woocommerce.android.ui.products.price.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.settings.ProductVisibility
 import com.woocommerce.android.ui.products.variations.VariationRepository
 import com.woocommerce.android.util.CurrencyFormatter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -68,6 +68,7 @@ import com.woocommerce.android.ui.products.price.ProductPricingViewModel.Pricing
 import com.woocommerce.android.ui.products.settings.ProductVisibility
 import com.woocommerce.android.ui.products.variations.VariationRepository
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -254,6 +255,7 @@ class ProductDetailCardBuilder(
             type = SECONDARY,
             properties = listOf(
                 if (viewModel.isProductUnderCreation) null else product.productReviews(),
+                if (FeatureFlag.PRODUCT_SUBSCRIPTIONS.isEnabled()) product.price() else null,
                 product.subscription(),
                 product.inventory(SIMPLE),
                 product.addons(),
@@ -500,13 +502,16 @@ class ProductDetailCardBuilder(
             viewModel.onEditProductCardClicked(
                 ViewProductPricing(
                     PricingData(
-                        taxClass,
-                        taxStatus,
-                        isSaleScheduled,
-                        saleStartDateGmt,
-                        saleEndDateGmt,
-                        regularPrice,
-                        salePrice
+                        taxClass = taxClass,
+                        taxStatus = taxStatus,
+                        isSaleScheduled = isSaleScheduled,
+                        saleStartDate = saleStartDateGmt,
+                        saleEndDate = saleEndDateGmt,
+                        regularPrice = regularPrice,
+                        salePrice = salePrice,
+                        isSubscription = this.productType == SUBSCRIPTION,
+                        subscriptionPeriod = subscription?.period,
+                        subscriptionInterval = subscription?.periodInterval,
                     )
                 ),
                 AnalyticsEvent.PRODUCT_DETAIL_VIEW_PRICE_SETTINGS_TAPPED

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -209,6 +209,13 @@ class ProductDetailFragment :
                 taxClass = it.taxClass,
                 taxStatus = it.taxStatus
             )
+            if (it.isSubscription) {
+                viewModel.updateProductSubscription(
+                    price = it.regularPrice,
+                    period = it.subscriptionPeriod,
+                    periodInterval = it.subscriptionInterval
+                )
+            }
         }
         handleResult<InventoryData>(BaseProductEditorFragment.KEY_INVENTORY_DIALOG_RESULT) {
             viewModel.updateProductDraft(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -59,11 +59,11 @@ import com.woocommerce.android.ui.products.ProductDetailViewModel.ShowDuplicateP
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ShowLinkedProductPromoBanner
 import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductDetailBottomSheet
-import com.woocommerce.android.ui.products.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
 import com.woocommerce.android.ui.products.adapters.ProductPropertyCardsAdapter
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
+import com.woocommerce.android.ui.products.price.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.reviews.ProductReviewsFragment
 import com.woocommerce.android.ui.products.variations.VariationListFragment
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.VariationListData

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -46,6 +46,7 @@ import com.woocommerce.android.model.ProductFile
 import com.woocommerce.android.model.ProductGlobalAttribute
 import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.model.RequestResult
+import com.woocommerce.android.model.SubscriptionPeriod
 import com.woocommerce.android.model.addTags
 import com.woocommerce.android.model.sortCategories
 import com.woocommerce.android.model.toAppModel
@@ -1217,6 +1218,22 @@ class ProductDetailViewModel @Inject constructor(
                 numVariations = numVariation ?: product.numVariations
             )
             viewState = viewState.copy(productDraft = updatedProduct)
+        }
+    }
+
+    fun updateProductSubscription(
+        price: BigDecimal? = null,
+        period: SubscriptionPeriod? = null,
+        periodInterval: Int? = null,
+    ) {
+        viewState.productDraft?.let { product ->
+            val subscription = product.subscription ?: return
+            val updatedSubscription = subscription.copy(
+                price = price ?: subscription.price,
+                period = period ?: subscription.period,
+                periodInterval = periodInterval ?: subscription.periodInterval,
+            )
+            viewState = viewState.copy(productDraft = product.copy(subscription = updatedSubscription))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -5,9 +5,9 @@ import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.model.ProductFile
 import com.woocommerce.android.model.SubscriptionDetails
 import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
-import com.woocommerce.android.ui.products.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.models.QuantityRules
+import com.woocommerce.android.ui.products.price.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow
 import com.woocommerce.android.ui.products.selector.ProductSourceForTracking
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibility

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingFragment.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.products
+package com.woocommerce.android.ui.products.price
 
 import android.app.DatePickerDialog
 import android.app.DatePickerDialog.OnDateSetListener
@@ -7,6 +7,7 @@ import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
+import com.woocommerce.android.R.string
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.databinding.FragmentProductPricingBinding
 import com.woocommerce.android.extensions.collapse
@@ -18,8 +19,11 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.TaxClass
+import com.woocommerce.android.ui.products.BaseProductEditorFragment
+import com.woocommerce.android.ui.products.ProductItemSelectorDialog
 import com.woocommerce.android.ui.products.ProductItemSelectorDialog.ProductItemSelectorDialogListener
-import com.woocommerce.android.ui.products.ProductPricingViewModel.PricingData
+import com.woocommerce.android.ui.products.ProductTaxStatus
+import com.woocommerce.android.ui.products.price.ProductPricingViewModel.PricingData
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -197,7 +201,7 @@ class ProductPricingFragment :
                 setClickListener {
                     productTaxStatusSelectorDialog = ProductItemSelectorDialog.newInstance(
                         this@ProductPricingFragment, RequestCodes.PRODUCT_TAX_STATUS,
-                        getString(R.string.product_tax_status), ProductTaxStatus.toMap(requireContext()),
+                        getString(string.product_tax_status), ProductTaxStatus.toMap(requireContext()),
                         getText()
                     ).also { it.show(parentFragmentManager, ProductItemSelectorDialog.TAG) }
                 }
@@ -251,7 +255,7 @@ class ProductPricingFragment :
                 productTaxClassSelectorDialog = ProductItemSelectorDialog.newInstance(
                     this@ProductPricingFragment,
                     RequestCodes.PRODUCT_TAX_CLASS,
-                    getString(R.string.product_tax_class),
+                    getString(string.product_tax_class),
                     taxClasses.map { it.slug to it.name }.toMap(),
                     binding.productTaxClass.getText()
                 ).also { it.show(parentFragmentManager, ProductItemSelectorDialog.TAG) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingFragment.kt
@@ -119,9 +119,11 @@ class ProductPricingFragment :
             }
             new.pricingData.subscriptionInterval?.takeIfNotEqualTo(old?.pricingData?.subscriptionInterval) {
                 binding.subscriptionInterval.setText(it.formatSubscriptionInterval())
+                updateSubscriptionSaleHelperText()
             }
             new.pricingData.subscriptionPeriod?.takeIfNotEqualTo(old?.pricingData?.subscriptionPeriod) {
                 binding.subscriptionPeriod.setText(it.format())
+                updateSubscriptionSaleHelperText()
             }
         }
 
@@ -325,6 +327,17 @@ class ProductPricingFragment :
             onSelected = { viewModel.onDataChanged(subscriptionPeriod = it) },
             mapper = { it.format() }
         )
+    }
+
+    private fun updateSubscriptionSaleHelperText() {
+        val interval = viewModel.pricingData.subscriptionInterval
+        val period = viewModel.pricingData.subscriptionPeriod
+
+        if (interval == null || period == null) {
+            binding.productSalePrice.helperText = null
+            return
+        }
+        binding.productSalePrice.helperText = "${interval.formatSubscriptionInterval()} ${period.format()}"
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingFragment.kt
@@ -39,6 +39,10 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class ProductPricingFragment :
     BaseProductEditorFragment(R.layout.fragment_product_pricing), ProductItemSelectorDialogListener {
+    companion object {
+        private const val SUBSCRIPTION_INTERVAL_ITEMS_COUNT = 6
+    }
+
     private val viewModel: ProductPricingViewModel by viewModels()
 
     override val lastEvent: Event?
@@ -313,7 +317,7 @@ class ProductPricingFragment :
 
     private fun initSubscriptionViews() {
         binding.subscriptionInterval.setup(
-            values = Array(6) { it + 1 },
+            values = Array(SUBSCRIPTION_INTERVAL_ITEMS_COUNT) { it + 1 },
             onSelected = { viewModel.onDataChanged(subscriptionInterval = it) },
             mapper = { entry -> entry.formatSubscriptionInterval() }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModel.kt
@@ -229,7 +229,10 @@ class ProductPricingViewModel @Inject constructor(
                     saleStartDate == it.saleStartDate &&
                     saleEndDate == it.saleEndDate &&
                     regularPrice isEquivalentTo it.regularPrice &&
-                    salePrice isEquivalentTo it.salePrice
+                    salePrice isEquivalentTo it.salePrice &&
+                    isSubscription == it.isSubscription &&
+                    subscriptionPeriod == it.subscriptionPeriod &&
+                    subscriptionInterval == it.subscriptionInterval
             } ?: false
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModel.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.products
+package com.woocommerce.android.ui.products.price
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
@@ -13,6 +13,9 @@ import com.woocommerce.android.extensions.isNotSet
 import com.woocommerce.android.extensions.isSet
 import com.woocommerce.android.model.TaxClass
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.ui.products.ProductDetailRepository
+import com.woocommerce.android.ui.products.ProductTaxStatus
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModel.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.extensions.greaterThan
 import com.woocommerce.android.extensions.isEquivalentTo
 import com.woocommerce.android.extensions.isNotSet
 import com.woocommerce.android.extensions.isSet
+import com.woocommerce.android.model.SubscriptionPeriod
 import com.woocommerce.android.model.TaxClass
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ParameterRepository
@@ -76,6 +77,15 @@ class ProductPricingViewModel @Inject constructor(
         )
 
         originalPricingData = navArgs.pricingData
+
+        if (pricingData.isSubscription) {
+            viewState = viewState.copy(
+                pricingData = pricingData.copy(
+                    subscriptionPeriod = viewState.pricingData.subscriptionPeriod ?: SubscriptionPeriod.Month,
+                    subscriptionInterval = viewState.pricingData.subscriptionInterval ?: 1
+                )
+            )
+        }
     }
 
     fun getTaxClassBySlug(slug: String): TaxClass? {
@@ -89,17 +99,21 @@ class ProductPricingViewModel @Inject constructor(
         saleStartDate: Date? = pricingData.saleStartDate,
         saleEndDate: Date? = pricingData.saleEndDate,
         taxStatus: ProductTaxStatus? = pricingData.taxStatus,
-        taxClass: String? = pricingData.taxClass
+        taxClass: String? = pricingData.taxClass,
+        subscriptionPeriod: SubscriptionPeriod? = pricingData.subscriptionPeriod,
+        subscriptionInterval: Int? = pricingData.subscriptionInterval,
     ) {
         viewState = viewState.copy(
-            pricingData = PricingData(
+            pricingData = pricingData.copy(
                 regularPrice = regularPrice,
                 salePrice = salePrice,
                 isSaleScheduled = isSaleScheduled,
                 saleStartDate = saleStartDate,
                 saleEndDate = fixEndDateIfNecessary(saleStartDate, saleEndDate),
                 taxStatus = taxStatus,
-                taxClass = taxClass
+                taxClass = taxClass,
+                subscriptionPeriod = subscriptionPeriod,
+                subscriptionInterval = subscriptionInterval,
             )
         )
     }
@@ -201,7 +215,10 @@ class ProductPricingViewModel @Inject constructor(
         val saleStartDate: Date? = null,
         val saleEndDate: Date? = null,
         val regularPrice: BigDecimal? = null,
-        val salePrice: BigDecimal? = null
+        val salePrice: BigDecimal? = null,
+        val isSubscription: Boolean = false,
+        val subscriptionPeriod: SubscriptionPeriod? = null,
+        val subscriptionInterval: Int? = null,
     ) : Parcelable {
         override fun equals(other: Any?): Boolean {
             val data = other as? PricingData

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.model.SubscriptionProductVariation
 import com.woocommerce.android.ui.products.ProductBackorderStatus
 import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
-import com.woocommerce.android.ui.products.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.ui.products.SaleDetails
@@ -32,6 +31,7 @@ import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.PRIMARY
 import com.woocommerce.android.ui.products.models.ProductPropertyCard.Type.SECONDARY
 import com.woocommerce.android.ui.products.models.SiteParameters
+import com.woocommerce.android.ui.products.price.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewAttributes
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewDescriptionEditor
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewInventory

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailCardBuilder.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewShipping
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewSubscription
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -97,6 +98,7 @@ class VariationDetailCardBuilder(
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
+                if (FeatureFlag.PRODUCT_SUBSCRIPTIONS.isEnabled()) variation.price() else null,
                 variation.subscription(),
                 variation.warning(),
                 variation.attributes(),
@@ -196,6 +198,7 @@ class VariationDetailCardBuilder(
             isHighlighted = isWarningVisible,
             isDividerVisible = !isWarningVisible
         ) {
+            val subscriptionDetails = (this as? SubscriptionProductVariation)?.subscriptionDetails
             viewModel.onEditVariationCardClicked(
                 ViewPricing(
                     PricingData(
@@ -203,7 +206,10 @@ class VariationDetailCardBuilder(
                         saleStartDate = saleStartDateGmt,
                         saleEndDate = saleEndDateGmt,
                         regularPrice = regularPrice,
-                        salePrice = salePrice
+                        salePrice = salePrice,
+                        isSubscription = this is SubscriptionProductVariation,
+                        subscriptionPeriod = subscriptionDetails?.period,
+                        subscriptionInterval = subscriptionDetails?.periodInterval
                     )
                 ),
                 PRODUCT_VARIATION_VIEW_PRICE_SETTINGS_TAPPED

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -34,10 +34,10 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.BaseProductEditorFragment
 import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
-import com.woocommerce.android.ui.products.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.adapters.ProductPropertyCardsAdapter
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
+import com.woocommerce.android.ui.products.price.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.variations.VariationDetailViewModel.HideImageUploadErrorSnackbar
 import com.woocommerce.android.ui.products.variations.attributes.edit.EditVariationAttributesFragment.Companion.KEY_VARIATION_ATTRIBUTES_RESULT
 import com.woocommerce.android.util.Optional

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -163,6 +163,14 @@ class VariationDetailFragment :
                 saleStartDate = it.saleStartDate,
                 saleEndDate = it.saleEndDate
             )
+
+            if (it.isSubscription) {
+                viewModel.onVariationSubscriptionChanged(
+                    price = it.regularPrice,
+                    period = it.subscriptionPeriod,
+                    periodInterval = it.subscriptionInterval
+                )
+            }
         }
         handleResult<InventoryData>(BaseProductEditorFragment.KEY_INVENTORY_DIALOG_RESULT) {
             viewModel.onVariationChanged(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -16,6 +16,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_PRODUCT_
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.model.ProductVariation
+import com.woocommerce.android.model.SubscriptionPeriod
+import com.woocommerce.android.model.SubscriptionProductVariation
 import com.woocommerce.android.model.VariantOption
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.NetworkStatus
@@ -249,6 +251,22 @@ class VariationDetailViewModel @Inject constructor(
                     weight = weight ?: variation.weight
                 )
             )
+        }
+    }
+
+    fun onVariationSubscriptionChanged(
+        price: BigDecimal? = null,
+        period: SubscriptionPeriod? = null,
+        periodInterval: Int? = null,
+    ) {
+        viewState.variation?.let { variation ->
+            val subscription = (variation as? SubscriptionProductVariation)?.subscriptionDetails ?: return
+            val updatedSubscription = subscription.copy(
+                price = price ?: subscription.price,
+                period = period ?: subscription.period,
+                periodInterval = periodInterval ?: subscription.periodInterval,
+            )
+            viewState = viewState.copy(variation = variation.copy(subscriptionDetails = updatedSubscription))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationNavigationTarget.kt
@@ -3,10 +3,10 @@ package com.woocommerce.android.ui.products.variations
 import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.model.SubscriptionDetails
 import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
-import com.woocommerce.android.ui.products.ProductPricingViewModel.PricingData
 import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.SaleDetails
 import com.woocommerce.android.ui.products.models.QuantityRules
+import com.woocommerce.android.ui.products.price.ProductPricingViewModel.PricingData
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 
 /**

--- a/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
@@ -38,6 +38,25 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/product_price_heading" />
 
+            <View
+                android:id="@+id/divider_1"
+                style="@style/Woo.Divider"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                android:layout_marginTop="@dimen/major_100"
+                app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />
+
+            <!-- Product Sale Heading -->
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/product_sale_heading"
+                style="@style/Woo.TextView.Headline6"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/product_sale"
+                app:layout_constraintStart_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/divider_1" />
+
             <!-- Product Sale Price -->
             <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
                 android:id="@+id/product_sale_price"
@@ -51,7 +70,7 @@
                 android:inputType="numberDecimal|numberSigned"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />
+                app:layout_constraintTop_toBottomOf="@+id/product_sale_heading" />
 
             <!-- Managing Product Stock -->
             <com.woocommerce.android.widgets.WCToggleSingleOptionView
@@ -131,7 +150,7 @@
                 app:constraint_referenced_ids="scheduleSale_morePanel,scheduleSale_switch" />
 
             <View
-                android:id="@+id/divider"
+                android:id="@+id/divider_2"
                 style="@style/Woo.Divider"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -147,7 +166,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/divider" />
+                app:layout_constraintTop_toBottomOf="@+id/divider_2" />
 
             <!-- Product Tax Status -->
             <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
@@ -183,7 +202,7 @@
                 android:id="@+id/product_tax_section"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                app:constraint_referenced_ids="product_tax,product_tax_class,product_tax_status,divider" />
+                app:constraint_referenced_ids="product_tax,product_tax_class,product_tax_status,divider_2" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.card.MaterialCardView>

--- a/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
@@ -39,28 +39,28 @@
                 app:layout_constraintTop_toBottomOf="@+id/product_price_heading" />
 
             <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-                android:id="@+id/product_price_interval"
+                android:id="@+id/subscription_interval"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_marginTop="@dimen/major_75"
                 android:layout_marginEnd="@dimen/major_100"
                 android:hint="@string/product_subscription_interval"
-                app:layout_constraintEnd_toStartOf="@id/product_price_period"
+                app:layout_constraintEnd_toStartOf="@id/subscription_period"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />
 
             <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-                android:id="@+id/product_price_period"
+                android:id="@+id/subscription_period"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_marginEnd="@dimen/major_100"
                 android:hint="@string/product_subscription_period"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/product_price_interval"
-                app:layout_constraintTop_toTopOf="@id/product_price_interval"
-                app:layout_constraintBottom_toBottomOf="@id/product_price_interval"/>
+                app:layout_constraintStart_toEndOf="@id/subscription_interval"
+                app:layout_constraintTop_toTopOf="@id/subscription_interval"
+                app:layout_constraintBottom_toBottomOf="@id/subscription_interval"/>
 
             <View
                 android:id="@+id/divider_1"
@@ -68,7 +68,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 android:layout_marginTop="@dimen/major_100"
-                app:layout_constraintTop_toBottomOf="@+id/product_price_interval" />
+                app:layout_constraintTop_toBottomOf="@+id/subscription_interval" />
 
             <!-- Product Sale Heading -->
             <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
@@ -38,13 +38,37 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/product_price_heading" />
 
+            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                android:id="@+id/product_price_interval"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_75"
+                android:layout_marginEnd="@dimen/major_100"
+                android:hint="@string/product_subscription_interval"
+                app:layout_constraintEnd_toStartOf="@id/product_price_period"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />
+
+            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                android:id="@+id/product_price_period"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:hint="@string/product_subscription_period"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/product_price_interval"
+                app:layout_constraintTop_toTopOf="@id/product_price_interval"
+                app:layout_constraintBottom_toBottomOf="@id/product_price_interval"/>
+
             <View
                 android:id="@+id/divider_1"
                 style="@style/Woo.Divider"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 android:layout_marginTop="@dimen/major_100"
-                app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />
+                app:layout_constraintTop_toBottomOf="@+id/product_price_interval" />
 
             <!-- Product Sale Heading -->
             <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -391,14 +391,14 @@
     </fragment>
     <fragment
         android:id="@+id/productPricingFragment"
-        android:name="com.woocommerce.android.ui.products.ProductPricingFragment"
+        android:name="com.woocommerce.android.ui.products.price.ProductPricingFragment"
         tools:layout="@layout/fragment_product_pricing">
         <argument
             android:name="requestCode"
             app:argType="integer" />
         <argument
             android:name="pricingData"
-            app:argType="com.woocommerce.android.ui.products.ProductPricingViewModel$PricingData" />
+            app:argType="com.woocommerce.android.ui.products.price.ProductPricingViewModel$PricingData" />
     </fragment>
     <fragment
         android:id="@+id/productDownloadsFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3512,6 +3512,16 @@
     <string name="subscription_period_multiple_weeks">weeks</string>
     <string name="subscription_period_multiple_months">months</string>
     <string name="subscription_period_multiple_years">years</string>
+
+    <string-array name="subscription_interval_options">
+        <item>Every</item>
+        <item>Every 2nd</item>
+        <item>Every 3rd</item>
+        <item>Every 4th</item>
+        <item>Every 5th</item>
+        <item>Every 6th</item>
+    </string-array>
+
     <!--
     Subscription details
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1726,6 +1726,8 @@
     <string name="product_shipping_empty">Add shipping</string>
     <string name="product_regular_price">Regular price</string>
     <string name="product_sale_price">Sale price</string>
+    <string name="product_subscription_interval">Billing interval</string>
+    <string name="product_subscription_period">Period</string>
     <string name="product_schedule_sale_label">Schedule sale</string>
     <string name="product_schedule_sale_sublabel">Automatically start and end a sale</string>
     <string name="product_schedule_sale_from_label">From</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1716,6 +1716,7 @@
     <string name="product_inventory_empty">Add inventory</string>
     <string name="product_variants">Variants</string>
     <string name="product_price">Price</string>
+    <string name="product_sale">Sale</string>
     <string name="product_price_empty">Add price</string>
     <string name="variable_product_attributes">Variations attributes</string>
     <string name="product_attributes">Attributes</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModelTest.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.products
+package com.woocommerce.android.ui.products.price
 
 import com.woocommerce.android.R
 import com.woocommerce.android.RequestCodes
@@ -8,11 +8,13 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.initSavedStateHandle
 import com.woocommerce.android.model.TaxClass
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.products.ProductPricingViewModel.PricingData
-import com.woocommerce.android.ui.products.ProductPricingViewModel.ViewState
+import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.ui.products.ProductTaxStatus.Taxable
 import com.woocommerce.android.ui.products.models.CurrencyFormattingParameters
 import com.woocommerce.android.ui.products.models.SiteParameters
+import com.woocommerce.android.ui.products.price.ProductPricingViewModel.PricingData
+import com.woocommerce.android.ui.products.price.ProductPricingViewModel.ViewState
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10123 Closes: #10132 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates the Pricing Fragment to support subscriptions, and adds logic to handle the changes for both Subscriptions and Subscription Variations.

Some notes for the review:
1. The commit 02dbf96dbcf3e01cb420d5a9b839238d951a388c is unrelated to the changes of the PR, it's better to review it separately. I added this commit when I was planning to rewrite the screen in Compose, but I kept it as it's a good fix IMO, let me know what think.
2. It might be easier to review the last commit bf9b63888ca15c301583445b039e7bdef2c4f64d separately, as it concentrates on variations.
3. While the number of changes seem big, a lot of it are just boilerplate code that the IDE helped generate (like the `hashCode` and `equals` implementations).

### Testing instructions
##### Subscription
1. Make sure that the Woo Subscriptions plugin is installed in your store.
4. Create a Subscription product.
5. Open the app, then navigate to this product.
6. Click on the price button, and confirm it has the correct price and schedule.
7. Change some details.
8. Go back to the product, and confirm the change was reflected.

##### Variable Subscription
1. Make sure that the Woo Subscriptions plugin is installed in your store.
3. Create a Variable Subscription product, then create a variation (or more).
4. Open the app, then navigate to this product, then open one of the variations.
5. Click on the price button, and confirm it has the correct price and schedule.
6. Change some details.
7. Go back to the variation , and confirm the change was reflected.

**Note**: For both the above cases, clicking on save or update would reset the data, as we don't send it to the backend yet.

##### Non-regression
1. Open a simple product in the app.
2. Make some changes to the price and sale.
3. Confirm everything works as expected.

### Images/gif
##### Subscriptions
| Subscription | Subscription Variation |
| --- | --- | 
| <img src="https://github.com/woocommerce/woocommerce-android/assets/1657201/43b9eecd-66fe-41cd-b4a3-5f5b58b6081e" /> | ![Screenshot_20231110_105315](https://github.com/woocommerce/woocommerce-android/assets/1657201/1504af6c-dcc5-4174-a3ea-d2d5dfc8a7c6) |

##### Other types
| Product | Variation |
| --- | --- |
| ![Screenshot_20231110_105346](https://github.com/woocommerce/woocommerce-android/assets/1657201/e85a55cc-c8d5-41f8-a02d-c4ef7f4f6184) | ![Screenshot_20231110_105445](https://github.com/woocommerce/woocommerce-android/assets/1657201/8d02defa-5b40-4d34-82cf-288230250cd5) |

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->