### PR TITLE
[Deposit Summary] Add tabs per currency

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
@@ -174,7 +174,7 @@ private fun FundsOverview(
             )
             Text(
                 style = MaterialTheme.typography.h6,
-                fontWeight = FontWeight(700),
+                fontWeight = FontWeight.Bold,
                 text = currencyInfo.availableFunds,
                 color = colorResource(id = R.color.color_on_surface)
             )
@@ -190,7 +190,7 @@ private fun FundsOverview(
             )
             Text(
                 style = MaterialTheme.typography.h6,
-                fontWeight = FontWeight(700),
+                fontWeight = FontWeight.Bold,
                 text = currencyInfo.pendingFunds,
                 color = colorResource(id = R.color.color_on_surface)
             )
@@ -464,7 +464,7 @@ private fun CurrenciesTabs(
                     Text(
                         style = MaterialTheme.typography.body1,
                         text = title,
-                        fontWeight = if (isSelected) FontWeight(600) else FontWeight(400),
+                        fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
                         color = if (isSelected) {
                             colorResource(id = R.color.color_primary)
                         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
@@ -93,16 +93,19 @@ fun PaymentsHubDepositSummaryView(
             .background(colorResource(id = R.color.color_surface))
     ) {
         val pagerState = rememberPagerState()
+        val currencies = overview.infoPerCurrency.keys.toList()
+        val selectedCurrencyInfo = overview.infoPerCurrency[currencies[pagerState.currentPage]] ?: return@Column
 
         AnimatedVisibility(
             visible = (isExpanded || isPreview) && pageCount > 1,
             modifier = Modifier.fillMaxWidth(),
         ) {
             CurrenciesTabs(
-                currencies = overview.infoPerCurrency.keys.map { it.uppercase() }.toList(),
+                currencies = currencies.map { it.uppercase() }.toList(),
                 pagerState = pagerState
             )
         }
+
 
         HorizontalPager(
             pageCount = pageCount,
@@ -113,15 +116,15 @@ fun PaymentsHubDepositSummaryView(
                     .fillMaxWidth()
                     .background(colorResource(id = R.color.color_surface))
             ) {
-                AlwaysVisiblePart(overview, isExpanded) { isExpanded = !isExpanded }
+                AlwaysVisiblePart(selectedCurrencyInfo, isExpanded) { isExpanded = !isExpanded }
 
                 AnimatedVisibility(
                     visible = isExpanded || isPreview,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     AdditionInfo(
-                        nextDeposit = overview.infoPerCurrency[overview.defaultCurrency]?.nextDeposit,
-                        lastDeposit = overview.infoPerCurrency[overview.defaultCurrency]?.lastDeposit,
+                        nextDeposit = selectedCurrencyInfo.nextDeposit,
+                        lastDeposit = selectedCurrencyInfo.lastDeposit,
                     )
                 }
             }
@@ -131,7 +134,7 @@ fun PaymentsHubDepositSummaryView(
 
 @Composable
 private fun AlwaysVisiblePart(
-    overview: PaymentsHubDepositSummaryState.Overview,
+    currencyInfo: PaymentsHubDepositSummaryState.Info,
     isExpanded: Boolean,
     onExpandCollapseClick: () -> Unit,
 ) {
@@ -167,7 +170,7 @@ private fun AlwaysVisiblePart(
             Text(
                 style = MaterialTheme.typography.h6,
                 fontWeight = FontWeight(700),
-                text = overview.infoPerCurrency[overview.defaultCurrency]?.availableFunds.toString(),
+                text = currencyInfo.availableFunds,
                 color = colorResource(id = R.color.color_on_surface)
             )
         }
@@ -183,15 +186,14 @@ private fun AlwaysVisiblePart(
             Text(
                 style = MaterialTheme.typography.h6,
                 fontWeight = FontWeight(700),
-                text = overview.infoPerCurrency[overview.defaultCurrency]?.pendingFunds.toString(),
+                text = currencyInfo.pendingFunds,
                 color = colorResource(id = R.color.color_on_surface)
             )
             Text(
                 style = MaterialTheme.typography.caption,
                 text = StringUtils.getQuantityString(
                     context = LocalContext.current,
-                    quantity = overview.infoPerCurrency[overview.defaultCurrency]?.pendingBalanceDepositsCount
-                        ?: 0,
+                    quantity = currencyInfo.pendingBalanceDepositsCount,
                     default = R.string.card_reader_hub_deposit_summary_pending_deposits_plural,
                     one = R.string.card_reader_hub_deposit_summary_pending_deposits_one,
                 ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
@@ -158,11 +158,11 @@ private fun AlwaysVisiblePart(
                 onExpandCollapseClick()
             }
             .padding(
-                    start = dimensionResource(id = R.dimen.major_100),
-                    end = dimensionResource(id = R.dimen.major_100),
-                    top = dimensionResource(id = R.dimen.major_150),
-                    bottom = dimensionResource(id = R.dimen.major_100)
-                )
+                start = dimensionResource(id = R.dimen.major_100),
+                end = dimensionResource(id = R.dimen.major_100),
+                top = dimensionResource(id = R.dimen.major_150),
+                bottom = dimensionResource(id = R.dimen.major_100)
+            )
     ) {
         Column(
             modifier = Modifier.weight(1f)
@@ -226,8 +226,12 @@ private fun AlwaysVisiblePart(
         }
     }
     val dividerPaddingAnimation by animateDpAsState(
-        if (isExpanded) dimensionResource(id = R.dimen.major_100) else dimensionResource(id = R.dimen.minor_00),
-            label = "dividerPaddingAnimation"
+        targetValue = if (isExpanded) {
+            dimensionResource(id = R.dimen.major_100)
+        } else {
+            dimensionResource(id = R.dimen.minor_00)
+        },
+        label = "dividerPaddingAnimation"
     )
 
     Divider(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.TabRow
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -44,6 +45,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -81,11 +83,16 @@ fun PaymentsHubDepositSummaryView(
     val topRowIS = remember { MutableInteractionSource() }
     val topRowCoroutineScope = rememberCoroutineScope()
 
+    val pagerState = rememberPagerState(pageCount = { 10 })
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .background(colorResource(id = R.color.color_surface))
     ) {
+        if ((isExpanded || isPreview) && overview.infoPerCurrency.size > 1)
+            CurrenciesTabs()
+        }
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -367,6 +374,34 @@ private fun Deposit(
                 color = colorResource(id = textColor),
                 fontWeight = FontWeight(600),
             )
+        }
+    }
+}
+
+@Composable
+private fun CurrenciesTabs(
+    currencies: List<String>,
+    pagerState: PagerState,
+) {
+    TabRow(
+        modifier = Modifier.fillMaxWidth(),
+        selectedTabIndex = pagerState.currentPage
+    ) {
+        currencies.forEachIndexed { index, title ->
+            Tab(selected = pagerState.currentPage == index,
+                onClick = {
+                    coroutineScope.launch {
+                        pagerState.animateScrollToPage(index)
+                    }
+                },
+                text = {
+                    Text(
+                        text = title,
+                        color = Color.White,
+                        fontSize = 14.sp,
+                        fontFamily = Helvetica
+                    )
+                })
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
@@ -116,13 +116,13 @@ fun PaymentsHubDepositSummaryView(
                     .fillMaxWidth()
                     .background(colorResource(id = R.color.color_surface))
             ) {
-                AlwaysVisiblePart(selectedCurrencyInfo, isExpanded) { isExpanded = !isExpanded }
+                FundsOverview(selectedCurrencyInfo, isExpanded) { isExpanded = !isExpanded }
 
                 AnimatedVisibility(
                     visible = isExpanded || isPreview,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    AdditionInfo(
+                    DepositsInfo(
                         nextDeposit = selectedCurrencyInfo.nextDeposit,
                         lastDeposit = selectedCurrencyInfo.lastDeposit,
                     )
@@ -133,7 +133,7 @@ fun PaymentsHubDepositSummaryView(
 }
 
 @Composable
-private fun AlwaysVisiblePart(
+private fun FundsOverview(
     currencyInfo: PaymentsHubDepositSummaryState.Info,
     isExpanded: Boolean,
     onExpandCollapseClick: () -> Unit,
@@ -242,7 +242,7 @@ private fun AlwaysVisiblePart(
 }
 
 @Composable
-private fun AdditionInfo(
+private fun DepositsInfo(
     nextDeposit: PaymentsHubDepositSummaryState.Deposit?,
     lastDeposit: PaymentsHubDepositSummaryState.Deposit?,
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryScreen.kt
@@ -106,7 +106,6 @@ fun PaymentsHubDepositSummaryView(
             )
         }
 
-
         HorizontalPager(
             pageCount = pageCount,
             state = pagerState


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10131
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR wraps all the you in the "view pager" and adds tabs, for the cases when more than 1 currency returned from the API

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* If you have a site where more than one currency was used, then use this or ask me to invite you
* More -> Payments
* Notice that you can swipe and see data for other currencies

Also, try this with the site with just 1 currency -> it should behave the same way as before the change

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/4923871/ec3fc5a2-86e1-44ec-9225-46fbfb186d46


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
