### PR TITLE
Align the Custom amounts currency input text with Simple payments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsDialog.kt
@@ -112,7 +112,10 @@ class CustomAmountsDialog : PaymentsBaseDialogFragment(R.layout.dialog_custom_am
                     binding.customAmountNameText.setText(it.name)
                     binding.customAmountNameText.setSelection(it.name.length)
                 }
-                binding.editPrice.setValue(it.currentPrice)
+                if (binding.editPrice.editText.text.toString() != it.currentPrice.toString()) {
+                    binding.editPrice.setValue(it.currentPrice)
+                    binding.editPrice.editText.setSelection(binding.editPrice.editText.text?.length ?: 0)
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10143 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Align the Custom amounts currency input text with Simple payments. In this PR the cursor is managed and often set to the end of the text after text changes. This behavior aligns with common user expectations for text input, especially in fields like currency inputs where users typically append or edit the existing text.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Navigate to Custom amounts dialog screen and ensure the currency input behaves similar to Simple payments

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/1331230/e6fdcad8-5e28-4ad6-b775-095dea913174



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
