### PR TITLE
Fix READ_EXTERNAL_STORAGE permission

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -17,10 +17,6 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission
-        android:name="android.permission.READ_EXTERNAL_STORAGE"
-        tools:ignore="ScopedStorage"
-        tools:node="remove" />
 
     <application
         android:name=".WooCommerce"

--- a/WooCommerce/src/release/AndroidManifest.xml
+++ b/WooCommerce/src/release/AndroidManifest.xml
@@ -3,6 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.woocommerce.android">
 
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage"
+        tools:node="remove" />
+
     <application
         android:name=".WooCommerceRelease"
         tools:replace="android:name">


### PR DESCRIPTION
This PR moves the READ_EXTERNAL_STORAGE permission removal (added by Zendesk) to the release manifest. Although the permission is not used by the app, it's used by the screenshot creation script so it should only be removed from the release builds.