### PR TITLE
Update downloadable file options

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/AddProductDownloadBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/AddProductDownloadBottomSheetFragment.kt
@@ -23,11 +23,11 @@ import com.woocommerce.android.ui.products.downloads.AddProductDownloadViewModel
 import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.DEVICE
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.SYSTEM_PICKER
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource.WP_MEDIA_LIBRARY
-import org.wordpress.android.mediapicker.model.MediaTypes.DOCUMENTS
 import org.wordpress.android.mediapicker.model.MediaTypes.EVERYTHING
-import org.wordpress.android.mediapicker.model.MediaTypes.MEDIA
+import org.wordpress.android.mediapicker.model.MediaTypes.IMAGES_AND_VIDEOS
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -72,12 +72,12 @@ class AddProductDownloadBottomSheetFragment : WCBottomSheetDialogFragment(), Med
                     mediaTypes = EVERYTHING
                 )
                 is PickMediaFileFromDevice -> mediaPickerHelper.showMediaPicker(
-                    source = SYSTEM_PICKER,
-                    mediaTypes = MEDIA
+                    source = DEVICE,
+                    mediaTypes = IMAGES_AND_VIDEOS
                 )
                 is PickDocumentFromDevice -> mediaPickerHelper.showMediaPicker(
                     source = SYSTEM_PICKER,
-                    mediaTypes = DOCUMENTS
+                    mediaTypes = EVERYTHING
                 )
                 is AddFile -> {
                     findNavController().navigateUp()

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3163,8 +3163,8 @@
     <string name="product_downloadable_files_upload_dialog_title">Uploading files</string>
     <string name="product_downloadable_files_upload_dialog_message">Please wait…</string>
     <string name="product_downloadable_files_url_invalid">Check that the url entered is valid</string>
-    <string name="product_downloadable_files_add_media_from_device">Media files on device</string>
-    <string name="product_downloadable_files_add_documents_from_device">Documents on device</string>
+    <string name="product_downloadable_files_add_media_from_device">Images and videos on device</string>
+    <string name="product_downloadable_files_add_documents_from_device">Documents and other files on device</string>
     <string name="product_downloadable_files_add_from_wpmedia_library">WordPress Media Library</string>
     <string name="product_downloadable_files_add_manually">Enter file URL</string>
     <string name="product_downloadable_files_name_invalid">Please enter a valid name</string>


### PR DESCRIPTION
This PR updates the downloadable file picker for virtual products and uses a photo picker for images and videos. Audio files are not supported by the photo picker, so a system picker must be used. I've changed the `Documents` option to include everything so that audio files could be selected (using `DOCUMENTS + AUDIO` didn't make a difference, as images/videos were also listed and could be selected 🤷). 

I've updated the option titles to reflect the changes.

<image src="https://github.com/woocommerce/woocommerce-android/assets/1522856/6ce5deb9-0be9-4e56-8129-76aa62ee2c4f" width="300" />

**Note:** This updates changes in the release branch. Since it's a minor change, let's wait until the changes are merged back to `trunk`.