### PR TITLE
Parse subscription details into persisted metadata

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -19,10 +19,8 @@ import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibility
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.MediaModel
-import org.wordpress.android.fluxc.model.WCMetaData
 import org.wordpress.android.fluxc.model.WCProductFileModel
 import org.wordpress.android.fluxc.model.WCProductModel
-import org.wordpress.android.fluxc.model.WCProductModel.SubscriptionMetadataKeys
 import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
 import java.util.Date
@@ -405,31 +403,6 @@ fun Product.toDataModel(storedProductModel: WCProductModel? = null): WCProductMo
             if (it.options.isNotEmpty()) {
                 jsonArray.add(it.toJson())
             }
-        }
-        return jsonArray.toString()
-    }
-
-    // Add any other editable product metadata here.
-    // Currently, only subscription details metadata is editable from the app. The rest is read only
-    fun SubscriptionDetails.toMetadataJson(): String {
-        val jsonArray = JsonArray()
-        val subscriptionValues = mapOf(
-            SubscriptionMetadataKeys.SUBSCRIPTION_PRICE to price,
-            SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD to period.value,
-            SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD_INTERVAL to periodInterval,
-            SubscriptionMetadataKeys.SUBSCRIPTION_LENGTH to length,
-            SubscriptionMetadataKeys.SUBSCRIPTION_SIGN_UP_FEE to signUpFee,
-            SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_PERIOD to trialPeriod?.value,
-            SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH to trialLength,
-            SubscriptionMetadataKeys.SUBSCRIPTION_ONE_TIME_SHIPPING to oneTimeShipping
-        )
-        subscriptionValues.forEach { (key, value) ->
-            jsonArray.add(
-                JsonObject().also { json ->
-                    json.addProperty(WCMetaData.KEY, key)
-                    json.addProperty(WCMetaData.VALUE, value.toString())
-                }
-            )
         }
         return jsonArray.toString()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -410,7 +410,7 @@ fun Product.toDataModel(storedProductModel: WCProductModel? = null): WCProductMo
     }
 
     // Add any other editable product metadata here.
-    // Currently now only subscription metadata is supported the rest is read only
+    // Currently, only subscription details metadata is editable from the app. The rest is read only
     fun SubscriptionDetails.toMetadataJson(): String {
         val jsonArray = JsonArray()
         val subscriptionValues = mapOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -411,27 +411,25 @@ fun Product.toDataModel(storedProductModel: WCProductModel? = null): WCProductMo
 
     // Add any other editable product metadata here.
     // Currently now only subscription metadata is supported the rest is read only
-    fun metadataToJson(): String {
+    fun SubscriptionDetails.toMetadataJson(): String {
         val jsonArray = JsonArray()
-        subscription?.let {
-            val subscriptionValues = mapOf(
-                SubscriptionMetadataKeys.SUBSCRIPTION_PRICE to it.price,
-                SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD to it.period.value,
-                SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD_INTERVAL to it.periodInterval,
-                SubscriptionMetadataKeys.SUBSCRIPTION_LENGTH to it.length,
-                SubscriptionMetadataKeys.SUBSCRIPTION_SIGN_UP_FEE to it.signUpFee,
-                SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_PERIOD to it.trialPeriod?.value,
-                SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH to it.trialLength,
-                SubscriptionMetadataKeys.SUBSCRIPTION_ONE_TIME_SHIPPING to it.oneTimeShipping
+        val subscriptionValues = mapOf(
+            SubscriptionMetadataKeys.SUBSCRIPTION_PRICE to price,
+            SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD to period.value,
+            SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD_INTERVAL to periodInterval,
+            SubscriptionMetadataKeys.SUBSCRIPTION_LENGTH to length,
+            SubscriptionMetadataKeys.SUBSCRIPTION_SIGN_UP_FEE to signUpFee,
+            SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_PERIOD to trialPeriod?.value,
+            SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH to trialLength,
+            SubscriptionMetadataKeys.SUBSCRIPTION_ONE_TIME_SHIPPING to oneTimeShipping
+        )
+        subscriptionValues.forEach { (key, value) ->
+            jsonArray.add(
+                JsonObject().also { json ->
+                    json.addProperty(WCMetaData.KEY, key)
+                    json.addProperty(WCMetaData.VALUE, value.toString())
+                }
             )
-            subscriptionValues.forEach { (key, value) ->
-                jsonArray.add(
-                    JsonObject().also { json ->
-                        json.addProperty(WCMetaData.KEY, key)
-                        json.addProperty(WCMetaData.VALUE, value.toString())
-                    }
-                )
-            }
         }
         return jsonArray.toString()
     }
@@ -500,7 +498,7 @@ fun Product.toDataModel(storedProductModel: WCProductModel? = null): WCProductMo
         it.downloadable = isDownloadable
         it.attributes = attributesToJson()
         it.purchasable = isPurchasable
-        it.metadata = metadataToJson()
+        it.metadata = subscription?.toMetadataJson() ?: ""
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -424,7 +424,7 @@ fun Product.toDataModel(storedProductModel: WCProductModel? = null): WCProductMo
                 SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH to it.trialLength,
                 SubscriptionMetadataKeys.SUBSCRIPTION_ONE_TIME_SHIPPING to it.oneTimeShipping
             )
-            for ((key, value) in subscriptionValues) {
+            subscriptionValues.forEach { (key, value) ->
                 jsonArray.add(
                     JsonObject().also { json ->
                         json.addProperty(WCMetaData.KEY, key)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -471,7 +471,8 @@ fun Product.toDataModel(storedProductModel: WCProductModel? = null): WCProductMo
         it.downloadable = isDownloadable
         it.attributes = attributesToJson()
         it.purchasable = isPurchasable
-        it.metadata = subscription?.toMetadataJson() ?: ""
+        // Only subscription details are editable from the app, so we only need to parse that info into metadata
+        it.metadata = subscription?.toMetadataJson().toString()
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -471,7 +471,7 @@ fun Product.toDataModel(storedProductModel: WCProductModel? = null): WCProductMo
         it.downloadable = isDownloadable
         it.attributes = attributesToJson()
         it.purchasable = isPurchasable
-        // Only subscription details are editable from the app, so we only need to parse that info into metadata
+        // Subscription details are currently the only editable metadata fields from the app.
         it.metadata = subscription?.toMetadataJson().toString()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -19,8 +19,10 @@ import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibility
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.WCMetaData
 import org.wordpress.android.fluxc.model.WCProductFileModel
 import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.model.WCProductModel.SubscriptionMetadataKeys
 import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
 import java.util.Date
@@ -407,6 +409,33 @@ fun Product.toDataModel(storedProductModel: WCProductModel? = null): WCProductMo
         return jsonArray.toString()
     }
 
+    // Add any other editable product metadata here.
+    // Currently now only subscription metadata is supported the rest is read only
+    fun metadataToJson(): String {
+        val jsonArray = JsonArray()
+        subscription?.let {
+            val subscriptionValues = mapOf(
+                SubscriptionMetadataKeys.SUBSCRIPTION_PRICE to it.price,
+                SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD to it.period.value,
+                SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD_INTERVAL to it.periodInterval,
+                SubscriptionMetadataKeys.SUBSCRIPTION_LENGTH to it.length,
+                SubscriptionMetadataKeys.SUBSCRIPTION_SIGN_UP_FEE to it.signUpFee,
+                SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_PERIOD to it.trialPeriod?.value,
+                SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH to it.trialLength,
+                SubscriptionMetadataKeys.SUBSCRIPTION_ONE_TIME_SHIPPING to it.oneTimeShipping
+            )
+            for ((key, value) in subscriptionValues) {
+                jsonArray.add(
+                    JsonObject().also { json ->
+                        json.addProperty(WCMetaData.KEY, key)
+                        json.addProperty(WCMetaData.VALUE, value.toString())
+                    }
+                )
+            }
+        }
+        return jsonArray.toString()
+    }
+
     return (storedProductModel ?: WCProductModel()).also {
         it.remoteProductId = remoteId
         it.description = description
@@ -471,6 +500,7 @@ fun Product.toDataModel(storedProductModel: WCProductModel? = null): WCProductMo
         it.downloadable = isDownloadable
         it.attributes = attributesToJson()
         it.purchasable = isPurchasable
+        it.metadata = metadataToJson()
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariation.kt
@@ -155,7 +155,8 @@ open class ProductVariation(
             it.weight = if (weight == 0f) "" else weight.formatToString()
             it.height = if (height == 0f) "" else height.formatToString()
             if (this is SubscriptionProductVariation) {
-                it.metadata = subscriptionDetails?.toMetadataJson()
+                // Only subscription details are editable from the app, so we only need to parse that info into metadata
+                it.metadata = subscriptionDetails?.toMetadataJson().toString()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariation.kt
@@ -17,8 +17,6 @@ import com.woocommerce.android.ui.products.ProductStatus.PRIVATE
 import com.woocommerce.android.ui.products.ProductStatus.PUBLISH
 import com.woocommerce.android.ui.products.ProductStockStatus
 import kotlinx.parcelize.Parcelize
-import org.wordpress.android.fluxc.model.WCMetaData
-import org.wordpress.android.fluxc.model.WCProductModel.SubscriptionMetadataKeys
 import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
@@ -119,31 +117,6 @@ open class ProductVariation(
                     json.addProperty("date_created_gmt", variantImage.dateCreated.formatToYYYYmmDDhhmmss())
                 }.toString()
             } ?: ""
-        }
-
-        // Add any other editable variation metadata here.
-        // Currently, only subscription details metadata is editable from the app. The rest is read only
-        fun SubscriptionDetails.toMetadataJson(): String {
-            val jsonArray = JsonArray()
-            val subscriptionValues = mapOf(
-                SubscriptionMetadataKeys.SUBSCRIPTION_PRICE to price,
-                SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD to period.value,
-                SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD_INTERVAL to periodInterval,
-                SubscriptionMetadataKeys.SUBSCRIPTION_LENGTH to length,
-                SubscriptionMetadataKeys.SUBSCRIPTION_SIGN_UP_FEE to signUpFee,
-                SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_PERIOD to trialPeriod?.value,
-                SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH to trialLength,
-                SubscriptionMetadataKeys.SUBSCRIPTION_ONE_TIME_SHIPPING to oneTimeShipping
-            )
-            subscriptionValues.forEach { (key, value) ->
-                jsonArray.add(
-                    JsonObject().also { json ->
-                        json.addProperty(WCMetaData.KEY, key)
-                        json.addProperty(WCMetaData.VALUE, value.toString())
-                    }
-                )
-            }
-            return jsonArray.toString()
         }
 
         return (cachedVariation ?: WCProductVariationModel()).also {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductVariation.kt
@@ -155,7 +155,7 @@ open class ProductVariation(
             it.weight = if (weight == 0f) "" else weight.formatToString()
             it.height = if (height == 0f) "" else height.formatToString()
             if (this is SubscriptionProductVariation) {
-                // Only subscription details are editable from the app, so we only need to parse that info into metadata
+                // Subscription details are currently the only editable metadata fields from the app.
                 it.metadata = subscriptionDetails?.toMetadataJson().toString()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetails.kt
@@ -20,10 +20,7 @@ data class SubscriptionDetails(
     val oneTimeShipping: Boolean
 ) : Parcelable
 
-// Currently, only subscription details metadata is editable from the app. The rest is read only and thus
-// not included in the persisted metadata.
-fun SubscriptionDetails.toMetadataJson(): String {
-    val jsonArray = JsonArray()
+fun SubscriptionDetails.toMetadataJson(): JsonArray {
     val subscriptionValues = mapOf(
         SubscriptionMetadataKeys.SUBSCRIPTION_PRICE to price,
         SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD to period.value,
@@ -34,6 +31,7 @@ fun SubscriptionDetails.toMetadataJson(): String {
         SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH to trialLength,
         SubscriptionMetadataKeys.SUBSCRIPTION_ONE_TIME_SHIPPING to oneTimeShipping
     )
+    val jsonArray = JsonArray()
     subscriptionValues.forEach { (key, value) ->
         jsonArray.add(
             JsonObject().also { json ->
@@ -42,5 +40,5 @@ fun SubscriptionDetails.toMetadataJson(): String {
             }
         )
     }
-    return jsonArray.toString()
+    return jsonArray
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetails.kt
@@ -1,7 +1,11 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
 import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.model.WCMetaData
+import org.wordpress.android.fluxc.model.WCProductModel.SubscriptionMetadataKeys
 import java.math.BigDecimal
 
 @Parcelize
@@ -15,3 +19,28 @@ data class SubscriptionDetails(
     val trialLength: Int?,
     val oneTimeShipping: Boolean
 ) : Parcelable
+
+// Currently, only subscription details metadata is editable from the app. The rest is read only and thus
+// not included in the persisted metadata.
+fun SubscriptionDetails.toMetadataJson(): String {
+    val jsonArray = JsonArray()
+    val subscriptionValues = mapOf(
+        SubscriptionMetadataKeys.SUBSCRIPTION_PRICE to price,
+        SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD to period.value,
+        SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD_INTERVAL to periodInterval,
+        SubscriptionMetadataKeys.SUBSCRIPTION_LENGTH to length,
+        SubscriptionMetadataKeys.SUBSCRIPTION_SIGN_UP_FEE to signUpFee,
+        SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_PERIOD to trialPeriod?.value,
+        SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH to trialLength,
+        SubscriptionMetadataKeys.SUBSCRIPTION_ONE_TIME_SHIPPING to oneTimeShipping
+    )
+    subscriptionValues.forEach { (key, value) ->
+        jsonArray.add(
+            JsonObject().also { json ->
+                json.addProperty(WCMetaData.KEY, key)
+                json.addProperty(WCMetaData.VALUE, value.toString())
+            }
+        )
+    }
+    return jsonArray.toString()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -272,7 +272,11 @@ class VariationDetailViewModel @Inject constructor(
                 periodInterval = periodInterval ?: subscription.periodInterval,
                 length = updatedLength
             )
-            viewState = viewState.copy(variation = variation.copy(subscriptionDetails = updatedSubscription))
+            val updatedVariation = variation.copy(subscriptionDetails = updatedSubscription)
+            viewState = viewState.copy(
+                variation = updatedVariation,
+                isDoneButtonVisible = updatedVariation != variation
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -445,8 +445,7 @@ class VariationDetailViewModel @Inject constructor(
     }
 
     fun onSubscriptionExpirationChanged(selectedExpirationValue: Int) {
-        val newLength = if (selectedExpirationValue == 0) -1 else selectedExpirationValue
-        onVariationSubscriptionChanged(length = newLength)
+        onVariationSubscriptionChanged(length = selectedExpirationValue)
     }
 
     object HideImageUploadErrorSnackbar : Event()

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2902-50e4e388bc41948a6dcf9d654a051dc7a74fa360'
+    fluxCVersion = 'trunk-ba81ec8e793a0c191402580e41632135dd446fc1'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2902-61f0c3ef223f8aea9890538405c72ba4f090d1ec'
+    fluxCVersion = '2902-50e4e388bc41948a6dcf9d654a051dc7a74fa360'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2874-591479f60ddcf1aad966a6711fcafcb4aee8f849'
+    fluxCVersion = '2902-61f0c3ef223f8aea9890538405c72ba4f090d1ec'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION


Part of: #10124 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Parses `SubscriptionDetails` values into `metadata` field so we can then sync any updated values for subscription products with the API

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open an existing subscription product
2. Edit either the price or the expiration date
3. Save the product
4. Check that the values have been correctly updated, either by checking the product in web wp-admin or refreshing the product list and checking the updated values are still there. 

 🔂  Repeat the same steps for a product variation and verify the variation values are synced

