### PR TITLE
[Product Subscriptions] Handle downloadable files + fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -40,6 +40,7 @@ class ProductDetailBottomSheetBuilder(
         val stat: AnalyticsEvent? = null
     )
 
+    @Suppress("LongMethod")
     fun buildBottomSheetList(product: Product): List<ProductDetailBottomSheetUiItem> {
         return when (product.productType) {
             SIMPLE -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.ProductType.EXTERNAL
 import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
+import com.woocommerce.android.ui.products.ProductType.SUBSCRIPTION
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.viewmodel.ResourceProvider
 
@@ -73,6 +74,14 @@ class ProductDetailBottomSheetBuilder(
                     product.getTags(),
                     product.getShortDescription(),
                     product.getLinkedProducts()
+                )
+            }
+            SUBSCRIPTION -> {
+                listOfNotNull(
+                    product.getCategories(),
+                    product.getTags(),
+                    product.getShortDescription(),
+                    product.getDownloadableFiles()
                 )
             }
             else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -81,6 +81,7 @@ class ProductDetailBottomSheetBuilder(
                     product.getCategories(),
                     product.getTags(),
                     product.getShortDescription(),
+                    product.getLinkedProducts(),
                     product.getDownloadableFiles()
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.ProductType.SUBSCRIPTION
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
+import com.woocommerce.android.ui.products.ProductType.VARIABLE_SUBSCRIPTION
 import com.woocommerce.android.viewmodel.ResourceProvider
 
 class ProductDetailBottomSheetBuilder(
@@ -83,6 +84,14 @@ class ProductDetailBottomSheetBuilder(
                     product.getShortDescription(),
                     product.getLinkedProducts(),
                     product.getDownloadableFiles()
+                )
+            }
+            VARIABLE_SUBSCRIPTION -> {
+                listOfNotNull(
+                    product.getCategories(),
+                    product.getTags(),
+                    product.getShortDescription(),
+                    product.getLinkedProducts()
                 )
             }
             else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -256,9 +256,9 @@ class ProductDetailCardBuilder(
         return ProductPropertyCard(
             type = SECONDARY,
             properties = listOf(
-                if (viewModel.isProductUnderCreation) null else product.productReviews(),
                 if (FeatureFlag.PRODUCT_SUBSCRIPTIONS.isEnabled()) product.price() else null,
                 if (FeatureFlag.PRODUCT_SUBSCRIPTIONS.isEnabled()) product.subscriptionExpirationDate() else null,
+                if (viewModel.isProductUnderCreation) null else product.productReviews(),
                 product.subscription(),
                 product.inventory(SIMPLE),
                 product.addons(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -111,10 +111,11 @@ class ProductDetailCardBuilder(
 
         when (product.productType) {
             SIMPLE -> cards.addIfNotEmpty(getSimpleProductCard(product))
-            VARIABLE, VARIABLE_SUBSCRIPTION -> cards.addIfNotEmpty(getVariableProductCard(product))
+            VARIABLE -> cards.addIfNotEmpty(getVariableProductCard(product))
             GROUPED -> cards.addIfNotEmpty(getGroupedProductCard(product))
             EXTERNAL -> cards.addIfNotEmpty(getExternalProductCard(product))
             SUBSCRIPTION -> cards.addIfNotEmpty(getSubscriptionProductCard(product))
+            VARIABLE_SUBSCRIPTION -> cards.addIfNotEmpty(getVariableSubscriptionProductCard(product))
             BUNDLE -> cards.addIfNotEmpty(getBundleProductsCard(product))
             COMPOSITE -> cards.addIfNotEmpty(getCompositeProductsCard(product))
             else -> cards.addIfNotEmpty(getOtherProductCard(product))
@@ -268,6 +269,26 @@ class ProductDetailCardBuilder(
                 product.shortDescription(),
                 product.linkedProducts(),
                 product.downloads(),
+                product.productType()
+            ).filterNotEmpty()
+        )
+    }
+
+    private suspend fun getVariableSubscriptionProductCard(product: Product): ProductPropertyCard {
+        return ProductPropertyCard(
+            type = SECONDARY,
+            properties = listOf(
+                product.warning(),
+                product.variations(),
+                product.variationAttributes(),
+                if (viewModel.isProductUnderCreation) null else product.productReviews(),
+                product.inventory(VARIABLE),
+                product.addons(),
+                product.quantityRules(),
+                product.categories(),
+                product.tags(),
+                product.shortDescription(),
+                product.linkedProducts(),
                 product.productType()
             ).filterNotEmpty()
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -188,8 +188,8 @@ class ProductDetailCardBuilder(
                 product.tags(),
                 product.shortDescription(),
                 product.linkedProducts(),
-                product.productType(),
-                product.downloads()
+                product.downloads(),
+                product.productType()
             ).filterNotEmpty()
         )
     }
@@ -267,6 +267,7 @@ class ProductDetailCardBuilder(
                 product.tags(),
                 product.shortDescription(),
                 product.linkedProducts(),
+                product.downloads(),
                 product.productType()
             ).filterNotEmpty()
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
@@ -16,7 +16,7 @@ import com.woocommerce.android.ui.products.BaseProductFragment
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitSettings
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductPurchaseNoteEditor
 import com.woocommerce.android.ui.products.ProductStatus
-import com.woocommerce.android.ui.products.ProductType.SIMPLE
+import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibilityFragment.Companion.ARG_CATALOG_VISIBILITY
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -31,6 +31,8 @@ class ProductSettingsFragment : BaseProductFragment(R.layout.fragment_product_se
         _binding = FragmentProductSettingsBinding.bind(view)
 
         setupObservers()
+
+        val productDraft = viewModel.getProduct().productDraft
 
         binding.productStatus.setOnClickListener {
             AnalyticsTracker.track(AnalyticsEvent.PRODUCT_SETTINGS_STATUS_TAPPED)
@@ -61,7 +63,7 @@ class ProductSettingsFragment : BaseProductFragment(R.layout.fragment_product_se
             activity?.invalidateOptionsMenu()
         }
 
-        if (viewModel.getProduct().productDraft?.productType == SIMPLE) {
+        if (productDraft?.productType == ProductType.SIMPLE || productDraft?.productType == ProductType.SUBSCRIPTION) {
             binding.productIsDownloadable.visibility = View.VISIBLE
             binding.productIsDownloadableDivider.visibility = View.VISIBLE
             binding.productIsDownloadable.setOnCheckedChangeListener { checkbox, isChecked ->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -221,15 +221,15 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                     R.drawable.ic_gridicons_align_left
                 ),
                 ComplexProperty(
+                    R.string.product_downloadable_files,
+                    resources.getString(R.string.product_downloadable_files_value_single),
+                    R.drawable.ic_gridicons_cloud
+                ),
+                ComplexProperty(
                     R.string.product_type,
                     resources.getString(R.string.product_detail_product_type_hint),
                     R.drawable.ic_gridicons_product,
                     true
-                ),
-                ComplexProperty(
-                    R.string.product_downloadable_files,
-                    resources.getString(R.string.product_downloadable_files_value_single),
-                    R.drawable.ic_gridicons_cloud
                 )
             )
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10174 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR has three main changes:
1. Allows adding downloadable files to subscription products 4ebe63b and 86ef049.
2.  Adds "Linked Products" to the "more details" bottom sheet for subscriptions, we were allowing editing the option, but not adding it. bebffa2
3. Hides the "shipping" section for variable subscriptions p1700123140841619/1700057044.683779-slack-C03L1NF1EA3 536aadd

I also aligned the order of the fields between the different product types.

### Testing instructions

### Images/gif
| Before | After |
| --- | --- |
| ![Screenshot_20231116_095957](https://github.com/woocommerce/woocommerce-android/assets/1657201/dc16431d-0486-427c-a498-91ea8079cc00) |![Screenshot_20231116_095825](https://github.com/woocommerce/woocommerce-android/assets/1657201/579c25dd-5284-4e41-9aa9-9e44a4c233f5) |
| ![Screenshot_20231116_100006](https://github.com/woocommerce/woocommerce-android/assets/1657201/7b5fd7e7-5dcc-4415-bd73-d42c34fdf811) | ![Screenshot_20231116_095848](https://github.com/woocommerce/woocommerce-android/assets/1657201/958ed798-a55d-4b05-addc-25acb79da4e7) |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->