### PR TITLE
Dynamically recalculate subscription options when periodInterval changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionPeriod.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionPeriod.kt
@@ -108,10 +108,10 @@ sealed class SubscriptionPeriod(val value: String) : Parcelable {
     @Suppress("MagicNumber")
     fun getRangeForPeriod(): IntRange {
         return when (this) {
-            Day -> 1..90
-            Week -> 1..52
-            Month -> 1..24
-            Year -> 1..5
+            Day -> 0..90
+            Week -> 0..52
+            Month -> 0..24
+            Year -> 0..5
             is Custom -> 0..1
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -46,7 +46,6 @@ import com.woocommerce.android.model.ProductFile
 import com.woocommerce.android.model.ProductGlobalAttribute
 import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.model.RequestResult
-import com.woocommerce.android.model.SubscriptionDetails
 import com.woocommerce.android.model.SubscriptionPeriod
 import com.woocommerce.android.model.addTags
 import com.woocommerce.android.model.sortCategories
@@ -72,6 +71,7 @@ import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibility
 import com.woocommerce.android.ui.products.settings.ProductVisibility
 import com.woocommerce.android.ui.products.settings.ProductVisibility.PUBLIC
+import com.woocommerce.android.ui.products.subscriptions.resetSubscriptionLengthIfThePeriodOrIntervalChanged
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
 import com.woocommerce.android.ui.products.variations.VariationListViewModel
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.ProgressDialogState
@@ -1232,7 +1232,13 @@ class ProductDetailViewModel @Inject constructor(
     ) {
         viewState.productDraft?.let { product ->
             val subscription = product.subscription ?: return
-            val updatedLength = resetSubscriptionLengthIfThePeriodChanged(period, subscription, length)
+            // The length ranges depend on the subscription period (days,weeks,months,years) and interval. If these
+            // change we need to reset the length to "Never expire". This replicates web behavior
+            val updatedLength = subscription.resetSubscriptionLengthIfThePeriodOrIntervalChanged(
+                period,
+                periodInterval,
+                length
+            )
             val updatedSubscription = subscription.copy(
                 price = price ?: subscription.price,
                 period = period ?: subscription.period,
@@ -1243,15 +1249,6 @@ class ProductDetailViewModel @Inject constructor(
             viewState = viewState.copy(productDraft = product.copy(subscription = updatedSubscription))
         }
     }
-
-    // The length ranges depend on the subscription period (days,weeks,months,years) so if period changes we need
-    // need to reset the length to "Never expire". This replicates the behavior of the Woo subscription extension
-    private fun resetSubscriptionLengthIfThePeriodChanged(
-        period: SubscriptionPeriod?,
-        subscription: SubscriptionDetails,
-        length: Int?
-    ) = if (period != null && period != subscription.period) null
-    else length ?: subscription.length
 
     private fun productHasSale(
         isSaleScheduled: Boolean?,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/ProductSubscriptionExpirationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/ProductSubscriptionExpirationFragment.kt
@@ -77,7 +77,7 @@ class ProductSubscriptionExpirationFragment : BaseProductFragment() {
 
     @Composable
     private fun SubscriptionExpirationPicker(
-        items: List<String>,
+        items: Map<String, Int>,
         currentValue: String
     ) {
         Box(
@@ -94,8 +94,8 @@ class ProductSubscriptionExpirationFragment : BaseProductFragment() {
             ) {
                 Text(stringResource(id = string.subscription_expire))
                 WcExposedDropDown(
-                    items = items.toTypedArray(),
-                    onSelected = { selectedExpiration = items.indexOf(it) },
+                    items = items.keys.toTypedArray(),
+                    onSelected = { selectedExpiration = items[it] },
                     currentValue = currentValue,
                     modifier = Modifier
                         .background(colorResource(id = color.color_surface))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/SubscriptionProductUiExtensions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/SubscriptionProductUiExtensions.kt
@@ -31,5 +31,8 @@ fun SubscriptionDetails.resetSubscriptionLengthIfThePeriodOrIntervalChanged(
     newPeriod: SubscriptionPeriod?,
     newInterval: Int?,
     newLength: Int?
-) = if (newPeriod != period || newInterval != periodInterval) null
-else newLength ?: length
+) = when {
+    newPeriod != null && newPeriod != period -> null
+    newInterval != null && newInterval != periodInterval -> null
+    else -> newLength ?: length
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/SubscriptionProductUiExtensions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/SubscriptionProductUiExtensions.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.products.subscriptions
 
 import com.woocommerce.android.R
 import com.woocommerce.android.model.SubscriptionDetails
+import com.woocommerce.android.model.SubscriptionPeriod
 import com.woocommerce.android.viewmodel.ResourceProvider
 
 fun SubscriptionDetails.expirationDisplayValue(resProvider: ResourceProvider): String {
@@ -25,3 +26,13 @@ fun SubscriptionDetails.expirationDisplayOptions(resources: ResourceProvider): L
     }
     return options
 }
+
+fun SubscriptionDetails.resetSubscriptionLengthIfThePeriodOrIntervalChanged(
+    newPeriod: SubscriptionPeriod?,
+    newInterval: Int?,
+    newLength: Int?
+) = if (
+    (newPeriod != null && newPeriod != period)
+    || (newInterval != null && newInterval != periodInterval)
+) null
+else newLength ?: length

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/SubscriptionProductUiExtensions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/SubscriptionProductUiExtensions.kt
@@ -31,8 +31,5 @@ fun SubscriptionDetails.resetSubscriptionLengthIfThePeriodOrIntervalChanged(
     newPeriod: SubscriptionPeriod?,
     newInterval: Int?,
     newLength: Int?
-) = if (
-    (newPeriod != null && newPeriod != period)
-    || (newInterval != null && newInterval != periodInterval)
-) null
+) = if (newPeriod != period || newInterval != periodInterval) null
 else newLength ?: length

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/SubscriptionProductUiExtensions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/SubscriptionProductUiExtensions.kt
@@ -14,14 +14,14 @@ fun SubscriptionDetails.expirationDisplayValue(resProvider: ResourceProvider): S
     }
 }
 
-fun SubscriptionDetails.expirationDisplayOptions(resources: ResourceProvider): List<String> {
-    val options = mutableListOf(
-        resources.getString(R.string.subscription_never_expire)
+fun SubscriptionDetails.expirationDisplayOptions(resources: ResourceProvider): Map<String, Int> {
+    val options = mutableMapOf(
+        resources.getString(R.string.subscription_never_expire) to 0
     )
     for (index in period.getRangeForPeriod() step periodInterval) {
         if (index >= periodInterval) {
             val periodString = period.getPeriodString(resources, index)
-            options.add(resources.getString(R.string.subscription_period, index, periodString))
+            options[resources.getString(R.string.subscription_period, index, periodString)] = index
         }
     }
     return options

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/SubscriptionProductUiExtensions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/SubscriptionProductUiExtensions.kt
@@ -17,9 +17,11 @@ fun SubscriptionDetails.expirationDisplayOptions(resources: ResourceProvider): L
     val options = mutableListOf(
         resources.getString(R.string.subscription_never_expire)
     )
-    period.getRangeForPeriod().forEach { index ->
-        val periodString = period.getPeriodString(resources, index)
-        options.add(resources.getString(R.string.subscription_period, index, periodString))
+    for (index in period.getRangeForPeriod() step periodInterval) {
+        if (index >= periodInterval) {
+            val periodString = period.getPeriodString(resources, index)
+            options.add(resources.getString(R.string.subscription_period, index, periodString))
+        }
     }
     return options
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_PRODUCT_
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.model.ProductVariation
-import com.woocommerce.android.model.SubscriptionDetails
 import com.woocommerce.android.model.SubscriptionPeriod
 import com.woocommerce.android.model.SubscriptionProductVariation
 import com.woocommerce.android.model.VariantOption
@@ -31,6 +30,7 @@ import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.ui.products.models.ProductPropertyCard
 import com.woocommerce.android.ui.products.models.QuantityRules
 import com.woocommerce.android.ui.products.models.SiteParameters
+import com.woocommerce.android.ui.products.subscriptions.resetSubscriptionLengthIfThePeriodOrIntervalChanged
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewImageGallery
 import com.woocommerce.android.ui.products.variations.VariationNavigationTarget.ViewMediaUploadErrors
 import com.woocommerce.android.util.CurrencyFormatter
@@ -266,7 +266,13 @@ class VariationDetailViewModel @Inject constructor(
     ) {
         viewState.variation?.let { variation ->
             val subscription = (variation as? SubscriptionProductVariation)?.subscriptionDetails ?: return
-            val updatedLength = resetSubscriptionLengthIfThePeriodChanged(period, subscription, length)
+            // The length ranges depend on the subscription period (days,weeks,months,years) and interval. If these
+            // change we need to reset the length to "Never expire". This replicates web behavior
+            val updatedLength = subscription.resetSubscriptionLengthIfThePeriodOrIntervalChanged(
+                period,
+                periodInterval,
+                length
+            )
             val updatedSubscription = subscription.copy(
                 price = price ?: subscription.price,
                 period = period ?: subscription.period,
@@ -290,15 +296,6 @@ class VariationDetailViewModel @Inject constructor(
             }
         }
     }
-
-    // The length ranges depend on the subscription period (days,weeks,months,years) so if period changes we need
-    // need to reset the length to "Never expire". This replicates the behavior of the Woo subscription extension
-    private fun resetSubscriptionLengthIfThePeriodChanged(
-        period: SubscriptionPeriod?,
-        subscription: SubscriptionDetails,
-        length: Int?
-    ) = if (period != null && period != subscription.period) -1
-    else length ?: subscription.length
 
     private suspend fun updateVariation(variation: ProductVariation) {
         if (networkStatus.isConnected()) {


### PR DESCRIPTION
Closes: #10129

<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Updates the dropdown option for subscription expiration `length` so that they take into account the current selected `period` as well as the `interval`. This should replicate the following behavior from the web (thanks @selanthiraiyan for bringing this up 👍🏼 ): 

https://github.com/woocommerce/woocommerce-android/assets/2663464/8ee09be6-9eaa-4d7f-ac14-2775fb207d4a

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open a subscription product from the app
2. Change subscription `period` or `interval` randomly as done in the video above and verify that the dropdown option displayed in subscription expiration section match the selected `interval`


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/2663464/038a222c-71e5-4b11-9d1b-07e760a7cf90


