### PR TITLE
[Subscriptions] Don't send null values when updating subscription fields

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetails.kt
@@ -26,9 +26,9 @@ fun SubscriptionDetails.toMetadataJson(): JsonArray {
         SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD to period.value,
         SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD_INTERVAL to periodInterval,
         SubscriptionMetadataKeys.SUBSCRIPTION_LENGTH to length,
-        SubscriptionMetadataKeys.SUBSCRIPTION_SIGN_UP_FEE to signUpFee,
+        SubscriptionMetadataKeys.SUBSCRIPTION_SIGN_UP_FEE to signUpFee?.toString().orEmpty(),
         SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_PERIOD to trialPeriod?.value,
-        SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH to trialLength,
+        SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH to (trialLength ?: 0),
         SubscriptionMetadataKeys.SUBSCRIPTION_ONE_TIME_SHIPPING to oneTimeShipping
     )
     val jsonArray = JsonArray()


### PR DESCRIPTION
### Description
While working on the one-time shipping option, I faced some issues where the option would become disabled in the web while it shouldn't, after investigating I found out that the cause is that we send `null` values for some values where we shouldn't, and the backend doesn't have any logic to handle this, it treats `null` as a String directly!!

This PR fixes those cases.

### Testing instructions
##### TC1
1. Open a subscription product that has a free trial.
2. Open the free trial screen, and remove it.
3. Click on Save.
4. Open the product in wp-admin.
5. Confirm the free trial has the expected value of `0`.

##### TC2
1. Open a subscription that has a sign-up fee.
2. Open the price screen, and remove the sign-up fee (make it empty)
3. Click on Save.
4. Open the product in wp-admin.
5. Confirm the sign-up fee is empty.


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
