### PR TITLE
Fix release builds

### DIFF
--- a/WooCommerce/proguard-rules.pro
+++ b/WooCommerce/proguard-rules.pro
@@ -88,8 +88,9 @@
 # This is generated automatically by the Android Gradle plugin. (8.1.0)
 -dontwarn com.google.auto.service.AutoService
 -dontwarn com.squareup.kotlinpoet.FileSpec
--dontwarn com.squareup.kotlinpoet.OriginatingElementsHolder$Builder
 -dontwarn com.squareup.kotlinpoet.OriginatingElementsHolder
+-dontwarn com.squareup.kotlinpoet.OriginatingElementsHolder$Builder
+-dontwarn com.squareup.kotlinpoet.javapoet.J2kInteropKt
 -dontwarn java.beans.ConstructorProperties
 -dontwarn java.beans.Transient
 -dontwarn javax.lang.model.SourceVersion
@@ -135,8 +136,11 @@
 -dontwarn javax.lang.model.util.SimpleTypeVisitor8
 -dontwarn javax.lang.model.util.Types
 -dontwarn javax.tools.Diagnostic$Kind
--dontwarn javax.tools.JavaFileObject$Kind
+-dontwarn javax.tools.FileObject
+-dontwarn javax.tools.JavaFileManager$Location
 -dontwarn javax.tools.JavaFileObject
+-dontwarn javax.tools.JavaFileObject$Kind
 -dontwarn javax.tools.SimpleJavaFileObject
+-dontwarn javax.tools.StandardLocation
 -dontwarn org.slf4j.impl.StaticLoggerBinder
 -dontwarn org.slf4j.impl.StaticMDCBinder


### PR DESCRIPTION
### Description
This PR fixes the release builds, the builds started failing in the `release/16.2` branch, probably due to the PR #10141 which updated a bunch of libraries.
The fix adds rules to ignore warnings about missing classes, the rules are generated by AGP in the file "missing_rules.txt" after the failure, I smoke-tested the app, and everything works fine, which confirms these are false warnings.

### Testing instructions
Confirm release builds succeed, and smoke test the app using it.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
