### PR TITLE
Issue/10199 variable subscriptions shipping

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 16.4
 -----
 - [*] [Internal] Fixes push notification not opening the correct screen  [https://github.com/woocommerce/woocommerce-android/pull/10195]
+- [*] Add ability to set the option "one-time shipping" for subscription products [https://github.com/woocommerce/woocommerce-android/issues/10199]
 
 16.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -479,7 +479,9 @@ fun Product.toDataModel(storedProductModel: WCProductModel? = null): WCProductMo
 
 fun WCProductModel.toAppModel(): Product {
     val productType = ProductType.fromString(type)
-    val subscription = if (productType == ProductType.SUBSCRIPTION) {
+    val subscription = if (
+        productType == ProductType.SUBSCRIPTION || productType == ProductType.VARIABLE_SUBSCRIPTION
+    ) {
         SubscriptionDetailsMapper.toAppModel(this.metadata)
     } else {
         null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Product.kt
@@ -157,7 +157,8 @@ data class Product(
         get() {
             return weight > 0 ||
                 length > 0 || width > 0 || height > 0 ||
-                shippingClass.isNotEmpty()
+                shippingClass.isNotEmpty() ||
+                subscription?.oneTimeShipping == true
         }
     val productType get() = ProductType.fromString(type)
     val variationEnabledAttributes

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetailsMapper.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.fluxc.model.WCProductModel.SubscriptionMetadataKeys
 object SubscriptionDetailsMapper {
     private val gson by lazy { Gson() }
     fun toAppModel(metadata: String): SubscriptionDetails? {
-        val jsonArray = gson.fromJson(metadata, JsonArray::class.java)
+        val jsonArray = gson.fromJson(metadata, JsonArray::class.java) ?: return null
 
         val subscriptionInformation = jsonArray
             .mapNotNull { it as? JsonObject }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -69,17 +69,9 @@ class ProductDetailBottomSheetBuilder(
                     product.getLinkedProducts()
                 )
             }
-            VARIABLE -> {
+            VARIABLE, VARIABLE_SUBSCRIPTION -> {
                 listOfNotNull(
                     product.getShipping(),
-                    product.getCategories(),
-                    product.getTags(),
-                    product.getShortDescription(),
-                    product.getLinkedProducts()
-                )
-            }
-            VARIABLE_SUBSCRIPTION -> {
-                listOfNotNull(
                     product.getCategories(),
                     product.getTags(),
                     product.getShortDescription(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailBottomSheetBuilder.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.model.SubscriptionProductVariation
 import com.woocommerce.android.ui.products.ProductNavigationTarget.AddProductDownloadableFile
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewLinkedProducts
 import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductCategories
@@ -17,10 +18,12 @@ import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.ProductType.SUBSCRIPTION
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE_SUBSCRIPTION
+import com.woocommerce.android.ui.products.variations.VariationRepository
 import com.woocommerce.android.viewmodel.ResourceProvider
 
 class ProductDetailBottomSheetBuilder(
-    private val resources: ResourceProvider
+    private val resources: ResourceProvider,
+    private val variationRepository: VariationRepository
 ) {
     enum class ProductDetailBottomSheetType(
         @StringRes val titleResource: Int,
@@ -94,12 +97,28 @@ class ProductDetailBottomSheetBuilder(
                 ProductDetailBottomSheetType.PRODUCT_SHIPPING,
                 ViewProductShipping(
                     ShippingData(
-                        weight,
-                        length,
-                        width,
-                        height,
-                        shippingClass,
-                        shippingClassId
+                        weight = weight,
+                        length = length,
+                        width = width,
+                        height = height,
+                        shippingClassSlug = shippingClass,
+                        shippingClassId = shippingClassId,
+                        subscriptionShippingData = if (productType == SUBSCRIPTION ||
+                            this.productType == VARIABLE_SUBSCRIPTION
+                        ) {
+                            ShippingData.SubscriptionShippingData(
+                                oneTimeShipping = subscription?.oneTimeShipping ?: false,
+                                canEnableOneTimeShipping = if (productType == SUBSCRIPTION) {
+                                    subscription?.supportsOneTimeShipping ?: false
+                                } else {
+                                    // For variable subscription products, we need to check against the variations
+                                    variationRepository.getProductVariationList(remoteId).all {
+                                        (it as? SubscriptionProductVariation)?.subscriptionDetails
+                                            ?.supportsOneTimeShipping ?: false
+                                    }
+                                }
+                            )
+                        } else null
                     )
                 ),
                 AnalyticsEvent.PRODUCT_DETAIL_VIEW_SHIPPING_SETTINGS_TAPPED

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.extensions.filterNotEmpty
 import com.woocommerce.android.extensions.isEligibleForAI
 import com.woocommerce.android.extensions.isSet
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.model.SubscriptionProductVariation
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
@@ -286,6 +287,7 @@ class ProductDetailCardBuilder(
                 product.inventory(VARIABLE),
                 product.addons(),
                 product.quantityRules(),
+                product.shipping(),
                 product.categories(),
                 product.tags(),
                 product.shortDescription(),
@@ -469,10 +471,20 @@ class ProductDetailCardBuilder(
                             height = height,
                             shippingClassSlug = shippingClass,
                             shippingClassId = shippingClassId,
-                            subscriptionShippingData = if (this.productType == SUBSCRIPTION) {
+                            subscriptionShippingData = if (productType == SUBSCRIPTION ||
+                                this.productType == VARIABLE_SUBSCRIPTION
+                            ) {
                                 ShippingData.SubscriptionShippingData(
-                                    oneTimeShipping = this.subscription?.oneTimeShipping ?: false,
-                                    canEnableOneTimeShipping = this.subscription?.supportsOneTimeShipping ?: false
+                                    oneTimeShipping = subscription?.oneTimeShipping ?: false,
+                                    canEnableOneTimeShipping = if (productType == SUBSCRIPTION) {
+                                        subscription?.supportsOneTimeShipping ?: false
+                                    } else {
+                                        // For variable subscription products, we need to check against the variations
+                                        variationRepository.getProductVariationList(remoteId).all {
+                                            (it as? SubscriptionProductVariation)?.subscriptionDetails
+                                                ?.supportsOneTimeShipping ?: false
+                                        }
+                                    }
                                 )
                             } else null
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailCardBuilder.kt
@@ -454,6 +454,12 @@ class ProductDetailCardBuilder(
                 Pair(
                     resources.getString(string.product_shipping_class),
                     viewModel.getShippingClassByRemoteShippingClassId(this.shippingClassId)
+                ),
+                Pair(
+                    resources.getString(string.subscription_one_time_shipping),
+                    if (subscription?.oneTimeShipping == true) {
+                        resources.getString(string.subscription_one_time_shipping_enabled)
+                    } else ""
                 )
             )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -231,7 +231,7 @@ class ProductDetailViewModel @Inject constructor(
     val productDetailBottomSheetList: LiveData<List<ProductDetailBottomSheetUiItem>> = _productDetailBottomSheetList
 
     private val productDetailBottomSheetBuilder by lazy {
-        ProductDetailBottomSheetBuilder(resources)
+        ProductDetailBottomSheetBuilder(resources, variationRepository)
     }
 
     private val _hasChanges = storedProduct

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductHelper.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.ui.products.ProductStatus.DRAFT
 import com.woocommerce.android.ui.products.ProductStatus.PUBLISH
 import com.woocommerce.android.ui.products.ProductStockStatus.InStock
 import com.woocommerce.android.ui.products.ProductType.SUBSCRIPTION
+import com.woocommerce.android.ui.products.ProductType.VARIABLE_SUBSCRIPTION
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibility.VISIBLE
 import java.math.BigDecimal
 import java.util.Date
@@ -93,9 +94,7 @@ object ProductHelper {
             downloads = listOf(),
             isPurchasable = false,
             subscription =
-            // Adding data only for subscription not variable subscription.
-            // Variable subscription will have its details for each of the variations
-            if (productType == SUBSCRIPTION) getDefaultSubscriptionDetails()
+            if (productType == SUBSCRIPTION || productType == VARIABLE_SUBSCRIPTION) getDefaultSubscriptionDetails()
             else null,
             isSampleProduct = false,
             parentId = 0,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailRepository.kt
@@ -79,36 +79,21 @@ class VariationDetailRepository @Inject constructor(
             .model?.let { true }
             ?: false
 
-    private fun getCachedWCVariation(remoteProductId: Long, remoteVariationId: Long): WCProductVariationModel? =
-        productStore.getVariationByRemoteId(selectedSite.get(), remoteProductId, remoteVariationId)
-
     suspend fun getVariation(remoteProductId: Long, remoteVariationId: Long): ProductVariation? =
         withContext(coroutineDispatchers.io) {
-            getCachedWCVariation(remoteProductId, remoteVariationId)?.toAppModel()
-        }
-
-    private suspend fun getSubscriptionProductVariation(
-        remoteProductId: Long,
-        remoteVariationId: Long
-    ): SubscriptionProductVariation? {
-        return withContext(coroutineDispatchers.io) {
-            productStore.getVariationByRemoteId(selectedSite.get(), remoteProductId, remoteVariationId)?.let { model ->
-                SubscriptionProductVariation(model)
-            }
-        }
-    }
-
-    suspend fun getVariationByProductType(remoteProductId: Long, remoteVariationId: Long): ProductVariation? {
-        return withContext(coroutineDispatchers.io) {
             val productType = productStore.getProductByRemoteId(selectedSite.get(), remoteProductId).let { model ->
                 ProductType.fromString(model?.type ?: "")
             }
-            when (productType) {
-                ProductType.VARIABLE_SUBSCRIPTION -> getSubscriptionProductVariation(remoteProductId, remoteVariationId)
-                else -> getVariation(remoteProductId, remoteVariationId)
+            getCachedWCVariation(remoteProductId, remoteVariationId)?.let { model ->
+                when (productType) {
+                    ProductType.VARIABLE_SUBSCRIPTION -> SubscriptionProductVariation(model)
+                    else -> model.toAppModel()
+                }
             }
         }
-    }
+
+    private fun getCachedWCVariation(remoteProductId: Long, remoteVariationId: Long): WCProductVariationModel? =
+        productStore.getVariationByRemoteId(selectedSite.get(), remoteProductId, remoteVariationId)
 
     suspend fun getQuantityRules(remoteProductId: Long, remoteVariationId: Long): QuantityRules? {
         return withContext(coroutineDispatchers.io) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -355,7 +355,7 @@ class VariationDetailViewModel @Inject constructor(
 
     private fun loadVariation(remoteProductId: Long, remoteVariationId: Long) {
         launch {
-            val variationInDb = variationRepository.getVariationByProductType(remoteProductId, remoteVariationId)
+            val variationInDb = variationRepository.getVariation(remoteProductId, remoteVariationId)
             if (variationInDb != null) {
                 originalVariation = variationInDb
                 showVariation(variationInDb)
@@ -379,7 +379,7 @@ class VariationDetailViewModel @Inject constructor(
     private suspend fun fetchVariation(remoteProductId: Long, remoteVariationId: Long) {
         if (networkStatus.isConnected()) {
             variationRepository.fetchVariation(remoteProductId, remoteVariationId)
-            originalVariation = variationRepository.getVariationByProductType(remoteProductId, remoteVariationId)
+            originalVariation = variationRepository.getVariation(remoteProductId, remoteVariationId)
         } else {
             triggerEvent(Event.ShowSnackbar(string.offline_error))
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationRepository.kt
@@ -10,9 +10,11 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_PRODUCT_
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.model.RequestResult
+import com.woocommerce.android.model.SubscriptionProductVariation
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.model.toDataModel
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.variations.domain.VariationCandidate
 import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.Dispatchers
@@ -73,8 +75,15 @@ class VariationRepository @Inject constructor(
      * Returns all product variations for a product and current site that are in the database
      */
     fun getProductVariationList(remoteProductId: Long): List<ProductVariation> {
+        val product = productStore.getProductByRemoteId(selectedSite.get(), remoteProductId)
         return productStore.getVariationsForProduct(selectedSite.get(), remoteProductId)
-            .map { it.toAppModel() }
+            .map {
+                if (product?.type == ProductType.VARIABLE_SUBSCRIPTION.value) {
+                    SubscriptionProductVariation(it)
+                } else {
+                    it.toAppModel()
+                }
+            }
             .sorted()
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3547,6 +3547,7 @@
     <string name="subscription_sign_up_fee_explanation">Optional, the sign-up fee will be charged immediately, even if the product has a free trial or the payment dates are synced.</string>
     <string name="subscription_free_trial">Free trial</string>
     <string name="subscription_one_time_shipping">One time shipping</string>
+    <string name="subscription_one_time_shipping_enabled">Enabled</string>
     <string name="subscription_one_time_shipping_description">Enable this to only charge shipping once on the initial order.</string>
     <string name="subscription_one_time_shipping_note">Note: for this setting to be enabled the subscription must not have a free trial or a synced renewal date.</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -198,7 +198,8 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                             resources.getString(R.string.product_dimensions),
                             productWithParameters.productDraft?.getSizeWithUnits(siteParams.dimensionUnit) ?: ""
                         ),
-                        Pair(resources.getString(R.string.product_shipping_class), "")
+                        Pair(resources.getString(R.string.product_shipping_class), ""),
+                        Pair(resources.getString(R.string.subscription_one_time_shipping), "")
                     ),
                     R.drawable.ic_gridicons_shipping,
                     true

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModelTest.kt
@@ -68,7 +68,7 @@ class VariationDetailViewModelTest : BaseUnitTest() {
         on { getParameters(any(), any<SavedStateHandle>()) } doReturn (siteParams)
     }
     private val variationRepository: VariationDetailRepository = mock {
-        onBlocking { getVariationByProductType(any(), any()) } doReturn TEST_VARIATION
+        onBlocking { getVariation(any(), any()) } doReturn TEST_VARIATION
         onBlocking { fetchVariation(any(), any()) } doAnswer {
             OnVariationChanged(it.arguments[0] as Long, it.arguments[1] as Long)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10199 

⚠️ please don't merge until #10208 is merged

### Description
This PR adds support for editing the "one-time shipping" option for variable products, the option lives in the product's details, unlike the rest of the subscription fields which are available as part of the variations themselves.

**Important**: please review d1d298c2ab33a98a59637f9c81bd05018b1e2c3f separately, it just fixes an issue that I noticed, which is an inconsistency in how we map the DB model to the domain model, and where some of the repository functions would skip parsing the metadata and return a plain `ProductVariation` instead of a `SubscriptionProductVariation`.

### Testing instructions
##### Normal path
1. Open a variable subscription product.
2. Confirm the shipping option is shown for the product.
3. Click on it.
5. Edit the "one-time shipping" option.
6. Go back to the product then save.
7. Confirm the option was saved.

##### Variation with a free trial
1. Open a variable subscription product.
2. Add free trial to one of its variations.
3. Go back to the parent product details.
4. Open shipping options.
5. Confirm the "one time shipping" option is disabled.

##### Variation with synced renewals
1. Enable synced renewals option from the plugin's settings (https://woo.com/document/subscriptions/renewal-synchronisation/#section-2)
2. Open a variable subscription in wp-admin, and enable synced renewals for one of its variants.
3. Open the product in the app.
4. Click on the variations to confirm that they are fetched.
5. Go back to the product details.
6. Open the shipping options.
7. Confirm the "one time shipping" option is disabled.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
