### PR TITLE
Bundle design feedback product selector

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationScreen.kt
@@ -3,8 +3,12 @@ package com.woocommerce.android.ui.orders.creation.configuration
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -50,10 +54,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -73,31 +79,19 @@ fun ProductConfigurationScreen(viewModel: ProductConfigurationViewModel) {
     val viewState by viewModel.viewState.collectAsState()
     BackHandler(onBack = viewModel::onCancel)
     Scaffold(topBar = {
-        Column {
-            val issues = (viewState as? ProductConfigurationViewModel.ViewState.DisplayConfiguration)
-                ?.configurationIssues ?: emptyList()
-
-            AnimatedVisibility(visible = issues.isEmpty().not()) {
-                ConfigurationIssues(
-                    issues = issues,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-
-            TopAppBar(
-                title = { Text(stringResource(id = R.string.product_configuration_title)) },
-                navigationIcon = {
-                    IconButton(viewModel::onCancel) {
-                        Icon(
-                            imageVector = Icons.Filled.Close,
-                            contentDescription = stringResource(id = R.string.close)
-                        )
-                    }
-                },
-                backgroundColor = colorResource(id = R.color.color_toolbar),
-                elevation = 0.dp,
-            )
-        }
+        TopAppBar(
+            title = { Text(stringResource(id = R.string.product_configuration_title)) },
+            navigationIcon = {
+                IconButton(viewModel::onCancel) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = stringResource(id = R.string.close)
+                    )
+                }
+            },
+            backgroundColor = colorResource(id = R.color.color_toolbar),
+            elevation = 0.dp,
+        )
     }) { padding ->
         when (val state = viewState) {
             is ProductConfigurationViewModel.ViewState.Error -> Text(text = state.message)
@@ -117,6 +111,7 @@ fun ProductConfigurationScreen(viewModel: ProductConfigurationViewModel) {
         }
     }
 }
+
 @Suppress("ComplexMethod")
 @Composable
 fun ProductConfigurationScreen(
@@ -260,6 +255,25 @@ fun ProductConfigurationScreen(
                     )
                 }
             }
+
+            val density = LocalDensity.current
+            AnimatedVisibility(
+                visible = configurationIssues.isEmpty().not(),
+                enter = slideInVertically {
+                    with(density) { -40.dp.roundToPx() }
+                } + expandVertically(
+                    expandFrom = Alignment.Top
+                ) + fadeIn(initialAlpha = 0.3f),
+                exit = slideOutVertically {
+                    with(density) { 10.dp.roundToPx() }
+                } + fadeOut()
+            ) {
+                ConfigurationIssues(
+                    issues = configurationIssues,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
             Divider(
                 color = colorResource(id = R.color.divider_color),
                 thickness = dimensionResource(id = R.dimen.minor_10)
@@ -675,18 +689,29 @@ fun ConfigurationIssues(
     issues: List<String>,
     modifier: Modifier = Modifier
 ) {
-    Row(
+    Column(
         modifier = modifier
-            .background(colorResource(id = R.color.woo_blue_5))
-            .padding(start = 18.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
+            .padding(all = 16.dp)
+            .background(
+                shape = RoundedCornerShape(8.dp),
+                color = colorResource(id = R.color.woo_blue_5)
+            )
+            .padding(all = 16.dp)
+            .animateContentSize()
     ) {
-        Icon(
-            painter = painterResource(id = R.drawable.ic_info_outline_20dp),
-            contentDescription = stringResource(id = R.string.configuration_issues),
-            tint = colorResource(id = R.color.blaze_blue_60)
+        Text(
+            text = stringResource(id = R.string.configuration_required),
+            style = MaterialTheme.typography.subtitle1,
+            fontWeight = FontWeight.Bold
         )
-        LazyColumn(modifier = Modifier.padding(start = 8.dp)) {
-            items(issues) { issue -> Text(text = " • $issue", color = MaterialTheme.colors.onSurface) }
+        LazyColumn(modifier = Modifier.padding(top = 8.dp)) {
+            items(issues) { issue ->
+                Text(
+                    text = issue,
+                    style = MaterialTheme.typography.body1,
+                    color = MaterialTheme.colors.onSurface
+                )
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -163,6 +163,7 @@ fun ProductSelectorScreen(
                 onLoadMore = onLoadMore,
                 trackConfigurableProduct = trackConfigurableProduct
             )
+
             state.products.isEmpty() && state.loadingState == LOADING -> ProductListSkeleton()
             else -> EmptyProductList(state, onClearFiltersButtonClick)
         }
@@ -256,6 +257,7 @@ private fun displayProductsSection(
             stringResource(id = string.product_selector_popular_products_heading),
             ProductSourceForTracking.POPULAR
         )
+
         ProductType.RECENT -> Triple(
             state.recentProducts,
             stringResource(id = string.product_selector_recent_products_heading),
@@ -289,9 +291,10 @@ private fun displayProductsSection(
                     stringResource(string.product_selector_sku_value, it)
                 },
                 selectionState = product.selectionState,
-                isArrowVisible = product.hasVariations() || product is ListItem.ConfigurableListItem,
+                isArrowVisible = product.hasVariations(),
                 onClickLabel = stringResource(id = string.product_selector_select_product_label, product.title),
-                imageContentDescription = stringResource(string.product_image_content_description)
+                imageContentDescription = stringResource(string.product_image_content_description),
+                isCogwheelVisible = product is ListItem.ConfigurableListItem
             ) {
                 onProductClick(product, productSectionForTracking)
             }
@@ -398,9 +401,10 @@ private fun ProductList(
                         stringResource(string.product_selector_sku_value, it)
                     },
                     selectionState = product.selectionState,
-                    isArrowVisible = product.hasVariations() || product is ListItem.ConfigurableListItem,
+                    isArrowVisible = product.hasVariations(),
                     onClickLabel = stringResource(id = string.product_selector_select_product_label, product.title),
-                    imageContentDescription = stringResource(string.product_image_content_description)
+                    imageContentDescription = stringResource(string.product_image_content_description),
+                    isCogwheelVisible = product is ListItem.ConfigurableListItem
                 ) {
                     onProductClick(product, ProductSourceForTracking.ALPHABETICAL)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -286,7 +286,7 @@ private fun displayProductsSection(
             SelectorListItem(
                 title = product.title,
                 imageUrl = product.imageUrl,
-                infoLine1 = product.stockAndPrice,
+                infoLine1 = product.getInformation(),
                 infoLine2 = product.sku?.let {
                     stringResource(string.product_selector_sku_value, it)
                 },
@@ -396,7 +396,7 @@ private fun ProductList(
                 SelectorListItem(
                     title = product.title,
                     imageUrl = product.imageUrl,
-                    infoLine1 = product.stockAndPrice,
+                    infoLine1 = product.getInformation(),
                     infoLine2 = product.sku?.let {
                         stringResource(string.product_selector_sku_value, it)
                     },
@@ -716,4 +716,14 @@ fun ProductListEmptyPreview() {
 @Composable
 fun ProductListSkeletonPreview() {
     ProductListSkeleton()
+}
+
+@Composable
+fun ListItem.getInformation(): String? {
+    return if (type == com.woocommerce.android.ui.products.ProductType.BUNDLE) {
+        listOfNotNull(stringResource(id = string.product_type_bundle), stockAndPrice)
+            .joinToString(" \u2022 ")
+    } else {
+        stockAndPrice
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/components/SelectorListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/components/SelectorListItem.kt
@@ -47,6 +47,7 @@ fun SelectorListItem(
     imageContentDescription: String?,
     selectionState: SelectionState,
     isArrowVisible: Boolean,
+    isCogwheelVisible: Boolean,
     onItemClick: () -> Unit
 ) {
     Row(
@@ -117,10 +118,22 @@ fun SelectorListItem(
             }
         }
 
-        if (isArrowVisible) {
+        if (isArrowVisible || isCogwheelVisible) {
+            val painter = if (isArrowVisible) {
+                painterResource(id = drawable.ic_arrow_right)
+            } else {
+                painterResource(id = drawable.ic_configuration)
+            }
+
+            val contentDescription = if (isArrowVisible) {
+                stringResource(id = string.product_selector_arrow_content_description)
+            } else {
+                stringResource(id = string.extension_configure_button)
+            }
+
             Image(
-                painter = painterResource(id = drawable.ic_arrow_right),
-                contentDescription = stringResource(id = string.product_selector_arrow_content_description),
+                painter = painter,
+                contentDescription = contentDescription,
                 modifier = Modifier
                     .size(dimensionResource(id = dimen.major_200))
                     .align(Alignment.CenterVertically),
@@ -153,5 +166,6 @@ private fun SelectorListItemPreview() =
         isArrowVisible = true,
         onItemClick = {},
         onClickLabel = null,
-        imageContentDescription = null
+        imageContentDescription = null,
+        isCogwheelVisible = false
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorScreen.kt
@@ -145,7 +145,8 @@ private fun VariationList(
                     selectionState = variation.selectionState,
                     isArrowVisible = false,
                     onClickLabel = stringResource(id = string.product_selector_select_variation_label, variation.title),
-                    imageContentDescription = stringResource(string.product_image_content_description)
+                    imageContentDescription = stringResource(string.product_image_content_description),
+                    isCogwheelVisible = false
                 ) {
                     onVariationClick(variation)
                 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3830,6 +3830,6 @@
     <string name="configuration_quantity_items_selected_plural"> %1$s items selected </string>
     <string name="configuration_variable_selection"> please select a variation </string>
     <string name="configuration_children_issue"> "%1$s " -&gt; %2$s </string>
-    <string name="configuration_variable_update">Update variation</string>
+    <string name="configuration_variable_update">Choose variation</string>
     <string name="product_variation_picker_title">Select a variation</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3818,7 +3818,7 @@
     <string name="product_configuration_title">Configuration</string>
     <string name="save_configuration">Save configuration</string>
     <string name="order_configuration_change_product_quantity">Change the product quantity from %1$f to %2$f</string>
-    <string name="configuration_issues">Configuration issues</string>
+    <string name="configuration_required">Configuration required</string>
     <string name="configuration_quantity_item">%d item</string>
     <string name="configuration_quantity_item_plural">%d items</string>
     <string name="configuration_quantity_between"> between %1$s and %2$s items </string>
@@ -3829,7 +3829,7 @@
     <string name="configuration_quantity_items_selected"> %1$s item selected </string>
     <string name="configuration_quantity_items_selected_plural"> %1$s items selected </string>
     <string name="configuration_variable_selection"> please select a variation </string>
-    <string name="configuration_children_issue"> " %1$s " -&gt; %2$s </string>
+    <string name="configuration_children_issue"> "%1$s " -&gt; %2$s </string>
     <string name="configuration_variable_update">Update variation</string>
     <string name="product_variation_picker_title">Select a variation</string>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### Why
This PR addresses the feedback received from design related to the bundled products selection flow
More context here: pe5pgL-42P-p2#comment-3267

### Description
![image](https://github.com/woocommerce/woocommerce-android/assets/18119390/4238d8a1-f0df-4248-84dd-a6674eb24b23)

From the design review: 
> #### In the product selector
> 1. Use a cog icon for configure indicator.
> 2. Identify the product as a Bundle (where the variation information would otherwise go).
> 3. Use a large button at the bottom of the screen to save.
> 4. Use the configuration instructions like on Android, but lock them to the bottom of the screen above the button (this will stop the config options from moving up and down when you interact with them, the way they do on Android right now).
> 5. Disable the save button until config is complete.
> 6. Disable “+” and “–” buttons when limits have been reached.
> 7. Don’t show steppers until product has been selected.
> 8. Don’t show variation button until product has been selected. Tidy up the layout of this button, and change it to “Choose variation”.

The changes on the product selection are divided into 4 commits:
1. Use a cog icon for configure indicator.  https://github.com/woocommerce/woocommerce-android/pull/10220/commits/d4d08943579c2605934260c03a4e7eea2cfb7146
2. Identify the product as a Bundle (where the variation information would otherwise go). https://github.com/woocommerce/woocommerce-android/pull/10220/commits/efbec4333526ae005d2455fc5b82ea173b6d998a
3. Use the configuration instructions like on Android, but lock them to the bottom of the screen above the button (this will stop the config options from moving up and down when you interact with them, the way they do on Android right now). https://github.com/woocommerce/woocommerce-android/pull/10220/commits/92c43426053565197bb3425150b9d36f0a60620f
4.  Don’t show variation button until product has been selected. Tidy up the layout of this button, and change it to “Choose variation”. https://github.com/woocommerce/woocommerce-android/pull/10220/commits/d1068e8bb17c0003d255f791decf3e7837104a49

### Testing instructions
#### Prerequisites
1. Install the product bundles extensions
2. Create some bundle products with at least one containing variable inner products

#### Testing
1. Open the Orders screen
2. Tap on create order (+)
3. Tap on select products
4. Check that configurable bundled products display a cog icon
5. Check that bundled products are identified as Bundle 
6. Tap on a bundled product that requires a configuration
7. Check that configuration issues are displayed at the bottom of the screen, and the save configuration button is disabled
8. Check that when the configuration is OK, the configuration issues component hides, and the save configuration button is enabled
9. Open a bundled product containing a variable product
10. Check that the UI matches the new changes
11. Update the variable selection
12. Check that the list of options selected (the variation) is displayed in the format `Option Name Option Value`
13. Check that when the quantity is 0, the stepper control and select variation control are hidden 

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/5f9b32c6-c0fc-4280-8df4-1a10823ee3c2


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->