### PR TITLE
[Custom Amounts M4.1] Add the ability to charge tax

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 16.4
 -----
 - [*] [Internal] Fixes push notification not opening the correct screen  [https://github.com/woocommerce/woocommerce-android/pull/10195]
+- [**] Custom Amounts M4.1: Add the ability to charge tax for custom amounts [https://github.com/woocommerce/woocommerce-android/pull/10222]
 
 16.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/CustomAmountUIModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/CustomAmountUIModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders
 
 import android.os.Parcelable
+import com.woocommerce.android.ui.payments.customamounts.CustomAmountsDialogViewModel.TaxStatus
 import kotlinx.parcelize.Parcelize
 import java.math.BigDecimal
 
@@ -9,5 +10,6 @@ data class CustomAmountUIModel(
     val id: Long,
     val amount: BigDecimal,
     val name: String,
-    val isLocked: Boolean = false
+    val isLocked: Boolean = false,
+    val taxStatus: TaxStatus = TaxStatus(),
 ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/AutoSyncOrder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/AutoSyncOrder.kt
@@ -38,7 +38,12 @@ class AutoSyncOrder @Inject constructor(val createUpdateOrderUseCase: CreateUpda
             .filter { it.name != null }
             .areSameAs(new.feesLines) { newLine ->
                 this.name == newLine.name &&
-                    this.total isEqualTo newLine.total
+                    this.total isEqualTo newLine.total &&
+                    this.taxStatus == newLine.taxStatus
+                // Verify the tax status for custom amounts to ensure accuracy.
+                // The final total amount may vary as users have the option to modify custom amounts
+                // by altering the tax status. This check is crucial to prevent discrepancies
+                // in tax calculations and maintain consistency in the user's entries.
             }
 
         val hasSameCouponLines = old.couponLines.areSameAs(new.couponLines) { newLine ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/AutoSyncPriceModifier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/AutoSyncPriceModifier.kt
@@ -45,7 +45,12 @@ class AutoSyncPriceModifier @Inject constructor(val createUpdateOrderUseCase: Cr
             .filter { it.name != null }
             .areSameAs(new.feesLines) { newLine ->
                 this.name == newLine.name &&
-                    this.total isEqualTo newLine.total
+                    this.total isEqualTo newLine.total &&
+                    this.taxStatus == newLine.taxStatus
+            // Verify the tax status for custom amounts to ensure accuracy.
+            // The final total amount may vary as users have the option to modify custom amounts
+            // by altering the tax status. This check is crucial to prevent discrepancies
+            // in tax calculations and maintain consistency in the user's entries.
             }
 
         val hasSameCouponLines = old.couponLines.areSameAs(new.couponLines) { newLine ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/AutoSyncPriceModifier.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/AutoSyncPriceModifier.kt
@@ -47,10 +47,10 @@ class AutoSyncPriceModifier @Inject constructor(val createUpdateOrderUseCase: Cr
                 this.name == newLine.name &&
                     this.total isEqualTo newLine.total &&
                     this.taxStatus == newLine.taxStatus
-            // Verify the tax status for custom amounts to ensure accuracy.
-            // The final total amount may vary as users have the option to modify custom amounts
-            // by altering the tax status. This check is crucial to prevent discrepancies
-            // in tax calculations and maintain consistency in the user's entries.
+                // Verify the tax status for custom amounts to ensure accuracy.
+                // The final total amount may vary as users have the option to modify custom amounts
+                // by altering the tax status. This check is crucial to prevent discrepancies
+                // in tax calculations and maintain consistency in the user's entries.
             }
 
         val hasSameCouponLines = old.couponLines.areSameAs(new.couponLines) { newLine ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/MapFeeLineToCustomAmountUiModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/MapFeeLineToCustomAmountUiModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.creation
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.CustomAmountUIModel
 import com.woocommerce.android.ui.payments.customamounts.CustomAmountsDialog.Companion.CUSTOM_AMOUNT
+import com.woocommerce.android.ui.payments.customamounts.CustomAmountsDialogViewModel.TaxStatus
 import javax.inject.Inject
 
 class MapFeeLineToCustomAmountUiModel @Inject constructor() {
@@ -11,7 +12,12 @@ class MapFeeLineToCustomAmountUiModel @Inject constructor() {
         return CustomAmountUIModel(
             id = feeLine.id,
             amount = feeLine.total,
-            name = feeLine.name ?: CUSTOM_AMOUNT
+            name = feeLine.name ?: CUSTOM_AMOUNT,
+            taxStatus = when (feeLine.taxStatus) {
+                Order.FeeLine.FeeLineTaxStatus.TAXABLE -> TaxStatus(isTaxable = true)
+                Order.FeeLine.FeeLineTaxStatus.NONE -> TaxStatus(isTaxable = false)
+                Order.FeeLine.FeeLineTaxStatus.UNKNOWN -> TaxStatus(isTaxable = false)
+            }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomAmountAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomAmountAdapter.kt
@@ -76,7 +76,8 @@ class OrderCreateEditCustomAmountAdapter(
         ): Boolean = (oldItem.id == newItem.id) &&
             (oldItem.name == newItem.name) &&
             (oldItem.amount == newItem.amount) &&
-            (oldItem.isLocked == newItem.isLocked)
+            (oldItem.isLocked == newItem.isLocked) &&
+            (oldItem.taxStatus.isTaxable == newItem.taxStatus.isTaxable)
 
         override fun areContentsTheSame(
             oldItem: CustomAmountUIModel,
@@ -84,6 +85,7 @@ class OrderCreateEditCustomAmountAdapter(
         ): Boolean = (oldItem.id == newItem.id) &&
             (oldItem.name == newItem.name) &&
             (oldItem.amount == newItem.amount) &&
-            (oldItem.isLocked == newItem.isLocked)
+            (oldItem.isLocked == newItem.isLocked) &&
+            (oldItem.taxStatus.isTaxable == newItem.taxStatus.isTaxable)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.util.WooLog.T
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
+import org.wordpress.android.fluxc.model.order.FeeLineTaxStatus
 import org.wordpress.android.fluxc.model.order.UpdateOrderRequest
 import org.wordpress.android.fluxc.model.taxes.TaxBasedOnSettingEntity
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
@@ -207,6 +208,11 @@ class OrderCreateEditRepository @Inject constructor(
         it.id = id
         it.name = name
         it.total = total.toPlainString()
+        it.taxStatus = when (taxStatus) {
+            Order.FeeLine.FeeLineTaxStatus.TAXABLE -> FeeLineTaxStatus.Taxable
+            Order.FeeLine.FeeLineTaxStatus.NONE -> FeeLineTaxStatus.None
+            else -> FeeLineTaxStatus.None
+        }
     }
 
     private fun Order.CouponLine.toDataModel() =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1238,7 +1238,11 @@ class OrderCreateEditViewModel @Inject constructor(
         add(
             Order.FeeLine.EMPTY.copy(
                 name = customAmountUIModel.name.ifEmpty { CUSTOM_AMOUNT },
-                total = customAmountUIModel.amount
+                total = customAmountUIModel.amount,
+                taxStatus = when (customAmountUIModel.taxStatus.isTaxable) {
+                    true -> Order.FeeLine.FeeLineTaxStatus.TAXABLE
+                    false -> Order.FeeLine.FeeLineTaxStatus.NONE
+                }
             )
         )
     }
@@ -1250,7 +1254,11 @@ class OrderCreateEditViewModel @Inject constructor(
         if (feeLine.id == customAmountUIModel.id) {
             feeLine.copy(
                 name = customAmountUIModel.name.ifEmpty { CUSTOM_AMOUNT },
-                total = customAmountUIModel.amount
+                total = customAmountUIModel.amount,
+                taxStatus = when (customAmountUIModel.taxStatus.isTaxable) {
+                    true -> Order.FeeLine.FeeLineTaxStatus.TAXABLE
+                    false -> Order.FeeLine.FeeLineTaxStatus.NONE
+                }
             )
         } else {
             feeLine

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsDialogViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsDialogViewModel.kt
@@ -64,7 +64,8 @@ class CustomAmountsDialogViewModel @Inject constructor(
         val customAmountUIModel: CustomAmountUIState = CustomAmountUIState(),
         val isDoneButtonEnabled: Boolean = false,
         val isProgressShowing: Boolean = false,
-        val createdOrder: Order? = null
+        val createdOrder: Order? = null,
+        val isTaxable: Boolean = false,
     ) : Parcelable
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsDialogViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsDialogViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.payments.customamounts
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_ADD_CUSTOM_AMOUNT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_CREATION_EDIT_CUSTOM_AMOUNT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -42,6 +43,18 @@ class CustomAmountsDialogViewModel @Inject constructor(
             )
         }
 
+    var taxToggleState: TaxStatus
+        get() = viewState.customAmountUIModel.taxStatus
+        set(value) {
+            viewState = viewState.copy(
+                customAmountUIModel = viewState.customAmountUIModel.copy(
+                    taxStatus = viewState.customAmountUIModel.taxStatus.copy(
+                        isTaxable = value.isTaxable
+                    )
+                )
+            )
+        }
+
     private val args: CustomAmountsDialogArgs by savedState.navArgs()
 
     init {
@@ -51,7 +64,8 @@ class CustomAmountsDialogViewModel @Inject constructor(
             viewState = viewState.copy(
                 customAmountUIModel = viewState.customAmountUIModel.copy(
                     id = it.id,
-                    name = it.name
+                    name = it.name,
+                    taxStatus = it.taxStatus
                 )
             )
             tracker.track(ORDER_CREATION_EDIT_CUSTOM_AMOUNT_TAPPED)
@@ -65,13 +79,19 @@ class CustomAmountsDialogViewModel @Inject constructor(
         val isDoneButtonEnabled: Boolean = false,
         val isProgressShowing: Boolean = false,
         val createdOrder: Order? = null,
-        val isTaxable: Boolean = false,
     ) : Parcelable
 
     @Parcelize
     data class CustomAmountUIState(
         val id: Long = 0,
         val currentPrice: BigDecimal = BigDecimal.ZERO,
-        val name: String = ""
+        val name: String = "",
+        val taxStatus: TaxStatus = TaxStatus()
+    ) : Parcelable
+
+    @Parcelize
+    data class TaxStatus(
+        val isTaxable: Boolean = false,
+        val text: Int = R.string.custom_amounts_tax_label,
     ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/views/TaxToggle.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/views/TaxToggle.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.ui.payments.customamounts.views
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.payments.customamounts.CustomAmountsDialogViewModel
+
+@Composable
+fun TaxToggle(
+    taxStatus: CustomAmountsDialogViewModel.TaxStatus,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row {
+        Text(text = stringResource(id = taxStatus.text))
+        Spacer(modifier = Modifier.width(8.dp))
+        Switch(
+            checked = taxStatus.isTaxable,
+            onCheckedChange = onCheckedChange
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/views/TaxToggle.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/views/TaxToggle.kt
@@ -2,22 +2,16 @@ package com.woocommerce.android.ui.payments.customamounts.views
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Switch
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCSwitch
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.payments.customamounts.CustomAmountsDialogViewModel
 
@@ -26,23 +20,15 @@ fun TaxToggle(
     taxStatus: CustomAmountsDialogViewModel.TaxStatus,
     onCheckedChange: (Boolean) -> Unit
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
+    WCSwitch(
+        text = stringResource(id = taxStatus.text),
+        checked = taxStatus.isTaxable,
+        onCheckedChange = onCheckedChange,
         modifier = Modifier
             .fillMaxWidth()
             .background(colorResource(id = R.color.color_surface))
             .padding(start = 8.dp, end = 8.dp)
-    ) {
-        Text(
-            text = stringResource(id = taxStatus.text),
-            style = MaterialTheme.typography.subtitle1
-        )
-        Spacer(modifier = Modifier.width(8.dp).weight(1f))
-        Switch(
-            checked = taxStatus.isTaxable,
-            onCheckedChange = onCheckedChange
-        )
-    }
+    )
 }
 
 @Preview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/views/TaxToggle.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/views/TaxToggle.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -32,7 +33,10 @@ fun TaxToggle(
             .background(colorResource(id = R.color.color_surface))
             .padding(start = 8.dp, end = 8.dp)
     ) {
-        Text(text = stringResource(id = taxStatus.text))
+        Text(
+            text = stringResource(id = taxStatus.text),
+            style = MaterialTheme.typography.subtitle1
+        )
         Spacer(modifier = Modifier.width(8.dp).weight(1f))
         Switch(
             checked = taxStatus.isTaxable,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/views/TaxToggle.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/views/TaxToggle.kt
@@ -52,8 +52,6 @@ fun TaxTogglePreview() {
     WooThemeWithBackground {
         TaxToggle(
             CustomAmountsDialogViewModel.TaxStatus(isTaxable = true)
-        ) {
-
-        }
+        ) {}
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/views/TaxToggle.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/views/TaxToggle.kt
@@ -1,14 +1,23 @@
 package com.woocommerce.android.ui.payments.customamounts.views
 
+import android.content.res.Configuration
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.payments.customamounts.CustomAmountsDialogViewModel
 
 @Composable
@@ -16,12 +25,31 @@ fun TaxToggle(
     taxStatus: CustomAmountsDialogViewModel.TaxStatus,
     onCheckedChange: (Boolean) -> Unit
 ) {
-    Row {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(colorResource(id = R.color.color_surface))
+            .padding(start = 8.dp, end = 8.dp)
+    ) {
         Text(text = stringResource(id = taxStatus.text))
-        Spacer(modifier = Modifier.width(8.dp))
+        Spacer(modifier = Modifier.width(8.dp).weight(1f))
         Switch(
             checked = taxStatus.isTaxable,
             onCheckedChange = onCheckedChange
         )
+    }
+}
+
+@Preview
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun TaxTogglePreview() {
+    WooThemeWithBackground {
+        TaxToggle(
+            CustomAmountsDialogViewModel.TaxStatus(isTaxable = true)
+        ) {
+
+        }
     }
 }

--- a/WooCommerce/src/main/res/layout/dialog_custom_amounts.xml
+++ b/WooCommerce/src/main/res/layout/dialog_custom_amounts.xml
@@ -70,7 +70,7 @@
                 android:layout_height="wrap_content"
                 android:gravity="center"
                 android:imeOptions="flagNoFullscreen"
-                android:textSize="@dimen/line_height_major_150"
+                android:textSize="@dimen/line_height_major_100"
                 app:boxBackgroundMode="none"
                 app:editTextLayoutMode="wrap"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/dialog_custom_amounts.xml
+++ b/WooCommerce/src/main/res/layout/dialog_custom_amounts.xml
@@ -81,6 +81,15 @@
                 app:usesFullFormatting="true"
                 tools:hint="0.00" />
 
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/taxToggleComposeView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/major_100"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/editPrice"/>
+
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/customAmountNameCaptionText"
                 style="@style/Woo.TextView.Caption"
@@ -92,7 +101,7 @@
                 android:textSize="@dimen/text_major_25"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/editPrice" />
+                app:layout_constraintTop_toBottomOf="@id/taxToggleComposeView" />
 
             <androidx.appcompat.widget.AppCompatEditText
                 android:id="@+id/customAmountNameText"

--- a/WooCommerce/src/main/res/layout/dialog_custom_amounts.xml
+++ b/WooCommerce/src/main/res/layout/dialog_custom_amounts.xml
@@ -56,7 +56,7 @@
                 style="@style/Woo.TextView.Caption"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/major_150"
+                android:layout_marginTop="@dimen/major_100"
                 android:gravity="center"
                 android:text="@string/custom_amounts_enter_amount"
                 android:textSize="@dimen/text_major_25"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -511,6 +511,7 @@
     <string name="custom_amounts_add_custom_amount">Add Custom Amount</string>
     <string name="custom_amounts_add_custom_name_hint">Enter Custom name</string>
     <string name="custom_amounts_creation_error">Unable to create custom amount order</string>
+    <string name="custom_amounts_tax_label">Charge Taxes</string>
 
     <!--
          Taxes

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/AutoSyncOrderStrategyTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/AutoSyncOrderStrategyTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.creation
 
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.launchIn
@@ -42,6 +43,21 @@ class AutoSyncOrderStrategyTest : SyncStrategyTest() {
         orderDraftChanges.value = change
         advanceUntilIdle()
         verify(orderCreateEditRepository, times(0)).createOrUpdateDraft(change)
+        job.cancel()
+    }
+
+    @Test
+    fun `WHEN the user commits a change in fee line tax THEN the change is submitted to the API`() = testBlocking {
+        val job = sut.syncOrderChanges(orderDraftChanges, retryTrigger)
+            .launchIn(this)
+        val updatedFeeLines = order.feesLines.map {
+            it.taxStatus = Order.FeeLine.FeeLineTaxStatus.TAXABLE
+            it
+        }
+        val change = order.copy(feesLines = updatedFeeLines)
+        orderDraftChanges.value = change
+        advanceUntilIdle()
+        verify(orderCreateEditRepository, times(1)).createOrUpdateDraft(change)
         job.cancel()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/AutoSyncPriceModifierStrategyTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/AutoSyncPriceModifierStrategyTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.creation
 
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.launchIn
@@ -45,4 +46,20 @@ class AutoSyncPriceModifierStrategyTest : SyncStrategyTest() {
         verify(orderCreateEditRepository, times(0)).createOrUpdateDraft(change)
         job.cancel()
     }
+
+    @Test
+    fun `WHEN the user commits a change in fee line tax status THEN the change is submitted to the API`() =
+        testBlocking {
+            val job = sut.syncOrderChanges(orderDraftChanges, retryTrigger)
+                .launchIn(this)
+            val updatedFeeLines = order.feesLines.map {
+                it.taxStatus = Order.FeeLine.FeeLineTaxStatus.TAXABLE
+                it
+            }
+            val change = order.copy(feesLines = updatedFeeLines)
+            orderDraftChanges.value = change
+            advanceUntilIdle()
+            verify(orderCreateEditRepository, times(1)).createOrUpdateDraft(change)
+            job.cancel()
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -34,6 +34,7 @@ import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavi
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.ShowCreatedOrder
 import com.woocommerce.android.ui.orders.creation.taxes.TaxBasedOnSetting
 import com.woocommerce.android.ui.payments.customamounts.CustomAmountsDialog.Companion.CUSTOM_AMOUNT
+import com.woocommerce.android.ui.payments.customamounts.CustomAmountsDialogViewModel
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
@@ -1527,6 +1528,25 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         sut.onCustomAmountUpsert(customAmountUIModel)
 
         assertThat(orderDraft?.feesLines?.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `when custom amount added with tax status as taxable, then fee line gets updated with proper tax status`() {
+        var orderDraft: Order? = null
+        sut.orderDraft.observeForever {
+            orderDraft = it
+        }
+        assertThat(orderDraft?.feesLines?.size).isEqualTo(0)
+        val customAmountUIModel = CustomAmountUIModel(
+            id = 0L,
+            amount = BigDecimal.TEN,
+            name = "Test amount",
+            taxStatus = CustomAmountsDialogViewModel.TaxStatus(isTaxable = true)
+        )
+
+        sut.onCustomAmountUpsert(customAmountUIModel)
+
+        assertThat(orderDraft?.feesLines?.first()?.taxStatus).isEqualTo(Order.FeeLine.FeeLineTaxStatus.TAXABLE)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -1680,6 +1680,32 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     }
 
     @Test
+    fun `when custom amount is updated with tax status, then fee line gets updated with proper tax status`() {
+        var orderDraft: Order? = null
+        sut.orderDraft.observeForever {
+            orderDraft = it
+        }
+        assertThat(orderDraft?.feesLines?.size).isEqualTo(0)
+        val customAmountUIModel = CustomAmountUIModel(
+            id = 0L,
+            amount = BigDecimal.TEN,
+            name = "Test amount",
+            taxStatus = CustomAmountsDialogViewModel.TaxStatus(isTaxable = false)
+        )
+        val updatedCustomAmountUIModel = CustomAmountUIModel(
+            id = 0L,
+            amount = BigDecimal.ONE,
+            name = "Test amount updated",
+            taxStatus = CustomAmountsDialogViewModel.TaxStatus(isTaxable = true)
+        )
+        sut.onCustomAmountUpsert(customAmountUIModel)
+
+        sut.onCustomAmountUpsert(updatedCustomAmountUIModel)
+
+        assertThat(orderDraft?.feesLines?.firstOrNull()?.taxStatus).isEqualTo(Order.FeeLine.FeeLineTaxStatus.TAXABLE)
+    }
+
+    @Test
     fun `when custom amount is updated with name, then fee line gets updated`() {
         var orderDraft: Order? = null
         sut.orderDraft.observeForever {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -1550,6 +1550,25 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     }
 
     @Test
+    fun `when custom amount added with tax status as false, then fee line gets updated with proper tax status`() {
+        var orderDraft: Order? = null
+        sut.orderDraft.observeForever {
+            orderDraft = it
+        }
+        assertThat(orderDraft?.feesLines?.size).isEqualTo(0)
+        val customAmountUIModel = CustomAmountUIModel(
+            id = 0L,
+            amount = BigDecimal.TEN,
+            name = "Test amount",
+            taxStatus = CustomAmountsDialogViewModel.TaxStatus(isTaxable = false)
+        )
+
+        sut.onCustomAmountUpsert(customAmountUIModel)
+
+        assertThat(orderDraft?.feesLines?.first()?.taxStatus).isEqualTo(Order.FeeLine.FeeLineTaxStatus.NONE)
+    }
+
+    @Test
     fun `when custom amount added, then fee line gets updated with proper amount`() {
         var orderDraft: Order? = null
         sut.orderDraft.observeForever {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/MapFeeLineToCustomAmountUIModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/MapFeeLineToCustomAmountUIModelTest.kt
@@ -53,4 +53,25 @@ class MapFeeLineToCustomAmountUIModelTest : BaseUnitTest() {
 
         assertThat(mapperResult).isEqualTo(expectedResult)
     }
+
+    @Test
+    fun `given fee line with tax status as TAXABLE, when mapper called, then map to custom amount UI model`() {
+        val feeLine = Order.FeeLine(
+            id = 1,
+            name = "Test Amount",
+            total = BigDecimal.TEN,
+            totalTax = BigDecimal.ZERO,
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.TAXABLE
+        )
+        val expectedResult = CustomAmountUIModel(
+            id = 1,
+            amount = BigDecimal.TEN,
+            name = "Test Amount",
+            taxStatus = CustomAmountsDialogViewModel.TaxStatus(isTaxable = true)
+        )
+
+        val mapperResult = MapFeeLineToCustomAmountUiModel().invoke(feeLine)
+
+        assertThat(mapperResult).isEqualTo(expectedResult)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/MapFeeLineToCustomAmountUIModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/MapFeeLineToCustomAmountUIModelTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.creation
 
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.CustomAmountUIModel
+import com.woocommerce.android.ui.payments.customamounts.CustomAmountsDialogViewModel
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -23,7 +24,29 @@ class MapFeeLineToCustomAmountUIModelTest : BaseUnitTest() {
         val expectedResult = CustomAmountUIModel(
             id = 1,
             amount = BigDecimal.TEN,
-            name = "Test Amount"
+            name = "Test Amount",
+            taxStatus = CustomAmountsDialogViewModel.TaxStatus(isTaxable = false)
+        )
+
+        val mapperResult = MapFeeLineToCustomAmountUiModel().invoke(feeLine)
+
+        assertThat(mapperResult).isEqualTo(expectedResult)
+    }
+
+    @Test
+    fun `given fee line with tax status as NONE, when mapper called, then map to custom amount UI model`() {
+        val feeLine = Order.FeeLine(
+            id = 1,
+            name = "Test Amount",
+            total = BigDecimal.TEN,
+            totalTax = BigDecimal.ZERO,
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.NONE
+        )
+        val expectedResult = CustomAmountUIModel(
+            id = 1,
+            amount = BigDecimal.TEN,
+            name = "Test Amount",
+            taxStatus = CustomAmountsDialogViewModel.TaxStatus(isTaxable = false)
         )
 
         val mapperResult = MapFeeLineToCustomAmountUiModel().invoke(feeLine)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10214 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This pull request introduces the capability to apply tax charges when creating custom amounts, thereby aligning the custom amounts feature with the Simple Payment functionality.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Navigate to Order creation screen
2. Tap on "Add custom amount" row
3. **Ensure you see "Charge Taxes" toggle in the custom amount dialog**
4. Enable the toggle and create custom amount
5. **Ensure the taxes are applied appropriately**
6. Repeat the steps 2 and 3. This time, disable the toggle
7. **Ensure the tax is not applied.**
8. **Ensure while editing custom amounts, the tax toggle state is saved appropriately.**

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/1331230/68514f2e-8ff9-4d46-8fa4-13deb98f5a9b



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
