### PR TITLE
[Product Subscriptions] Supply default values for nullable fields when saving

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetails.kt
@@ -30,12 +30,12 @@ data class SubscriptionDetails(
 
 fun SubscriptionDetails.toMetadataJson(): JsonArray {
     val subscriptionValues = mapOf(
-        SubscriptionMetadataKeys.SUBSCRIPTION_PRICE to price,
+        SubscriptionMetadataKeys.SUBSCRIPTION_PRICE to price?.toString().orEmpty(),
         SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD to period.value,
         SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD_INTERVAL to periodInterval,
-        SubscriptionMetadataKeys.SUBSCRIPTION_LENGTH to length,
+        SubscriptionMetadataKeys.SUBSCRIPTION_LENGTH to (length ?: 0),
         SubscriptionMetadataKeys.SUBSCRIPTION_SIGN_UP_FEE to signUpFee?.toString().orEmpty(),
-        SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_PERIOD to trialPeriod?.value,
+        SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_PERIOD to (trialPeriod ?: SubscriptionPeriod.Day).value,
         SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH to (trialLength ?: 0),
         SubscriptionMetadataKeys.SUBSCRIPTION_ONE_TIME_SHIPPING to if (oneTimeShipping) "yes" else "no",
     )


### PR DESCRIPTION
Closes: #10231 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR is a continuation of https://github.com/woocommerce/woocommerce-android/pull/10203, it handles more nullable fields, which fixes the linked issue.

I tried to get the default values from what we get from the API when creating an new subscription product in wp-admin:

```json
[
      {
        "id": 46064,
        "key": "_subscription_price",
        "value": ""
      },
      {
        "id": 46069,
        "key": "_subscription_trial_length",
        "value": "0"
      },
      {
        "id": 46070,
        "key": "_subscription_sign_up_fee",
        "value": ""
      },
      {
        "id": 46071,
        "key": "_subscription_period",
        "value": "month"
      },
      {
        "id": 46072,
        "key": "_subscription_period_interval",
        "value": "1"
      },
      {
        "id": 46073,
        "key": "_subscription_length",
        "value": "0"
      },
      {
        "id": 46074,
        "key": "_subscription_trial_period",
        "value": "day"
      },
      {
        "id": 46075,
        "key": "_subscription_limit",
        "value": "no"
      },
      {
        "id": 46076,
        "key": "_subscription_one_time_shipping",
        "value": "no"
      }
]
```

### Testing instructions

1. Open the app, then create a simple subscription.
2. Save the product as draft.
3. Open the free trial screen.
4. Confirm the free trial interval is set to `day`.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
