### PR TITLE
Handle fetching variations when duplicating variable products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] [Internal] Fixes push notification not opening the correct screen  [https://github.com/woocommerce/woocommerce-android/pull/10195]
 - [*] Add ability to set the option "one-time shipping" for subscription products [https://github.com/woocommerce/woocommerce-android/issues/10199]
 - [*] Add ability to set subscription products as "virtual products" [https://github.com/woocommerce/woocommerce-android/pull/10219]
+- [*] [Internal] Fix a bug that caused a failure when duplicating variable products [https://github.com/woocommerce/woocommerce-android/pull/10235]
 
 16.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/DuplicateProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/DuplicateProduct.kt
@@ -46,6 +46,7 @@ class DuplicateProduct @Inject constructor(
         }
     }
 
+    @Suppress("MagicNumber")
     private suspend fun duplicateVariations(
         product: Product,
         duplicatedProductRemoteId: Long
@@ -62,8 +63,8 @@ class DuplicateProduct @Inject constructor(
             if (it.size > 100) {
                 // The API doesn't allow to create more than 100 variations at once
                 WooLog.w(
-                    WooLog.T.PRODUCTS, "Variations list is too big: ${it.size}, " +
-                        "the duplicate will have only the first 100 variations"
+                    WooLog.T.PRODUCTS,
+                    "Variations list is too big: ${it.size}, the duplicate will have only the first 100 variations"
                 )
             }
         }.take(100)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/DuplicateProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/DuplicateProduct.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.WooException
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.products.variations.VariationRepository
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.ResourceProvider
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
@@ -49,9 +50,23 @@ class DuplicateProduct @Inject constructor(
         product: Product,
         duplicatedProductRemoteId: Long
     ): Result<Long> {
-        val duplicatedVariations = variationRepository.getAllVariations(product.remoteId).map {
-            it.copy(remoteProductId = duplicatedProductRemoteId, sku = "")
-        }
+        var isLoadingMore = false
+        val duplicatedVariations = buildList {
+            do {
+                val variations = variationRepository.fetchProductVariations(product.remoteId, isLoadingMore)
+                    .map { it.copy(remoteProductId = duplicatedProductRemoteId, sku = "") }
+                addAll(variations)
+                isLoadingMore = true
+            } while (variationRepository.canLoadMoreProductVariations)
+        }.also {
+            if (it.size > 100) {
+                // The API doesn't allow to create more than 100 variations at once
+                WooLog.w(
+                    WooLog.T.PRODUCTS, "Variations list is too big: ${it.size}, " +
+                        "the duplicate will have only the first 100 variations"
+                )
+            }
+        }.take(100)
 
         val variationsDuplicationResult = variationRepository.createVariations(
             duplicatedProductRemoteId,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/DuplicateProductTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/DuplicateProductTest.kt
@@ -75,7 +75,7 @@ class DuplicateProductTest : BaseUnitTest() {
                 ProductTestUtils.generateProductVariationList(productToDuplicate.remoteId)
                     .map { it.copy(sku = "not an empty value") }
             variationRepository.stub {
-                onBlocking { getAllVariations(productToDuplicate.remoteId) } doReturn variationsOfProductToDuplicate
+                onBlocking { fetchProductVariations(eq(productToDuplicate.remoteId), any()) } doReturn variationsOfProductToDuplicate
                 onBlocking { createVariations(any(), any()) } doReturn Result.success(Unit)
             }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/DuplicateProductTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/DuplicateProductTest.kt
@@ -75,7 +75,9 @@ class DuplicateProductTest : BaseUnitTest() {
                 ProductTestUtils.generateProductVariationList(productToDuplicate.remoteId)
                     .map { it.copy(sku = "not an empty value") }
             variationRepository.stub {
-                onBlocking { fetchProductVariations(eq(productToDuplicate.remoteId), any()) } doReturn variationsOfProductToDuplicate
+                onBlocking {
+                    fetchProductVariations(eq(productToDuplicate.remoteId), any())
+                } doReturn variationsOfProductToDuplicate
                 onBlocking { createVariations(any(), any()) } doReturn Result.success(Unit)
             }
 


### PR DESCRIPTION
Closes: #10232 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Currently, when trying to duplicate a variable product, we use try to duplicate just the list of cached variations, which causes two issues:
1. The request fails when we try to duplicate a product for which we didn't fetch the variations yet.
2. We might use outdated data when the cached data is not up-to-date.

This PR adds logic to actually fetch variations before proceeding to duplicating them.

### Testing instructions
1. Create a variable product and some variations in wp-admin.
2. Open the product in the app.
3. Click on Duplicate.
4. Confirm the duplication works correctly, and the variations have correct data.

**Repeat also for a variable subscription.**

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
