### PR TITLE
[Custom Amounts M4] Refunds - Update text and refund toggle state based on items in the order

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
@@ -268,6 +268,13 @@ class IssueRefundViewModel @Inject constructor(
             .filter { refundableFeeLineIds.contains(it.feeLine.id) }
         _refundFeeLines.value = feeLines
 
+        if (feeLines.isNotEmpty() && items.isEmpty()) {
+            refundByItemsState = refundByItemsState.copy(
+                isFeesMainSwitchChecked = true,
+                isFeesRefundAvailable = true
+            )
+        }
+
         if (productsRefundLiveData.hasInitialValue) {
             val decimals = wooStore.getSiteSettings(selectedSite.get())?.currencyDecimalNumber
                 ?: DEFAULT_DECIMAL_PRECISION

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
@@ -268,7 +268,7 @@ class IssueRefundViewModel @Inject constructor(
             .filter { refundableFeeLineIds.contains(it.feeLine.id) }
         _refundFeeLines.value = feeLines
 
-        if (feeLines.isNotEmpty() && items.isEmpty()) {
+        if (orderContainsOnlyCustomAmounts()) {
             refundByItemsState = refundByItemsState.copy(
                 isFeesMainSwitchChecked = true,
                 isFeesRefundAvailable = true
@@ -284,6 +284,10 @@ class IssueRefundViewModel @Inject constructor(
                 decimals = decimals
             )
         }
+    }
+
+    private fun orderContainsOnlyCustomAmounts(): Boolean {
+        return order.items.isEmpty() && order.shippingLines.isEmpty() && order.feesLines.isNotEmpty()
     }
 
     private fun initRefundSummaryState() {

--- a/WooCommerce/src/main/res/layout/fragment_refund_by_items.xml
+++ b/WooCommerce/src/main/res/layout/fragment_refund_by_items.xml
@@ -104,7 +104,7 @@
                     android:layout_height="wrap_content"
                     android:gravity="center_vertical"
                     android:importantForAccessibility="no"
-                    android:text="@string/order_refunds_refund_fees" />
+                    android:text="@string/order_refunds_refund_custom_amount" />
 
                 <include
                     android:id="@+id/issueRefund_feesSection"

--- a/WooCommerce/src/main/res/layout/refund_by_items_fees.xml
+++ b/WooCommerce/src/main/res/layout/refund_by_items_fees.xml
@@ -119,7 +119,7 @@
             android:layout_weight="1"
             android:layout_marginTop="@dimen/major_75"
             android:layout_marginBottom="@dimen/major_75"
-            android:text="@string/order_refunds_fees_refund" />
+            android:text="@string/order_refunds_custom_amount_refund" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/issueRefund_feesTotal"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1203,6 +1203,7 @@
     <string name="order_refunds_select_quantity">Select quantity</string>
     <string name="order_refunds_refund_shipping">Refund shipping</string>
     <string name="order_refunds_refund_fees">Refund fees</string>
+    <string name="order_refunds_refund_custom_amount">Refund Custom Amount</string>
     <string name="order_refunds_refund_in_progress">Refund in progress, please wait…</string>
     <string name="order_refunds_refund_info_description_one">%d item</string>
     <string name="order_refunds_refund_info_description_many">%d items</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1200,6 +1200,7 @@
     <string name="order_refunds_products_refund">Products refund</string>
     <string name="order_refunds_shipping_refund">Shipping refund</string>
     <string name="order_refunds_fees_refund">Fees refund</string>
+    <string name="order_refunds_custom_amount_refund">Custom amount refund</string>
     <string name="order_refunds_select_quantity">Select quantity</string>
     <string name="order_refunds_refund_shipping">Refund shipping</string>
     <string name="order_refunds_refund_fees">Refund fees</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
@@ -211,6 +211,42 @@ object OrderTestUtils {
         )
     }
 
+    fun generateOrderWithCustomAmount(): OrderEntity {
+        val feeLine =
+            "[{\n" +
+                "    \"id\":1,\n" +
+                "    \"name\":\"A test\",\n" +
+                "    \"product_id\":15,\n" +
+                "    \"quantity\":1,\n" +
+                "    \"tax_class\":\"\",\n" +
+                "    \"subtotal\":\"10.00\",\n" +
+                "    \"subtotal_tax\":\"0.00\",\n" +
+                "    \"total\":\"10.00\",\n" +
+                "    \"total_tax\":\"0.00\",\n" +
+                "    \"taxes\":[],\n" +
+                "    \"meta_data\":[],\n" +
+                "    \"sku\":null,\n" +
+                "    \"price\":10\n" +
+                "  }]"
+
+        return OrderEntity(
+            billingFirstName = "Carissa",
+            billingLastName = "King",
+            currency = "USD",
+            dateCreated = "2018-02-02T16:11:13Z",
+            localSiteId = LocalOrRemoteId.LocalId(1),
+            orderId = 1,
+            number = "55",
+            status = "complete",
+            total = "106.00",
+            shippingTotal = "10.00",
+            lineItems = "",
+            refundTotal = -BigDecimal.TEN,
+            feeLines = feeLine,
+            shippingLines = ""
+        )
+    }
+
     fun generateOrderWithMultipleShippingLines(): OrderEntity {
         return OrderEntity(
             billingFirstName = "Carissa",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModelTest.kt
@@ -100,6 +100,22 @@ class IssueRefundViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given order has only custom amt, when refund button clicked, then refund custom amount toggle is enabled`() {
+        testBlocking {
+            val orderWithCustomAmount = OrderTestUtils.generateOrderWithCustomAmount()
+            whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderWithCustomAmount)
+
+            initViewModel()
+
+            var viewState: RefundByItemsViewState? = null
+            viewModel.refundByItemsStateLiveData.observeForever { _, new -> viewState = new }
+
+            viewState!!.isFeesRefundAvailable?.let { assertTrue(it) }
+            assertTrue(viewState!!.isFeesMainSwitchChecked)
+        }
+    }
+
+    @Test
     fun `when order has no shipping, then refund notice is not visible`() {
         testBlocking {
             whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(OrderTestUtils.generateOrder())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10227 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the Refund Fee label to Refund Custom Amount and changes the logic of the refund Custom Amount switch button to comply with this:

When the order only has items, custom amounts are not enabled to refund by default
When the order only has custom amounts, they’re enabled to refund by default
When the order only has both items and custom amounts, nothing is enabled to refund by default

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Go to an order that has only a custom amount added
- verify the Refund custom amount switch is enabled by default
- verify the label says Refund Custom amount (and not fee)
- Go to an order that has both a product and custom amount added
- verify the switch is not enabled by default
- go to an order that has only a product 
- verify the switch is not enabled by default
- verify all related labels in this flow say custom amount instead of fee

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
| ---- | ---- |
| <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/d976ecb4-0d21-49c3-b420-e5a41a1d8dc5" width="350"/> | <img src="https://github.com/woocommerce/woocommerce-android/assets/30724184/b1b8e67f-8eaa-4ee6-a325-c2715c586c4d" width="350"/> |

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.



<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
