### PR TITLE
Add icon in custom amount section disappears on screen rotation 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.OrderCreationSectionBinding
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.show
-import com.woocommerce.android.util.getDensityPixel
 
 class OrderCreateEditSectionView @JvmOverloads constructor(
     ctx: Context,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
@@ -188,7 +188,12 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
             val addingProductsViaScanningButton = MaterialButton(context, null, R.attr.secondaryTextButtonStyle)
             addingProductsViaScanningButton.icon = AppCompatResources.getDrawable(context, R.drawable.ic_barcode)
             addingProductsViaScanningButton.iconPadding = 0
-            addingProductsViaScanningButton.setPadding(0, 0, getDensityPixel(context, 16), 0)
+            addingProductsViaScanningButton.setPadding(
+                0,
+                0,
+                resources.getDimensionPixelSize(R.dimen.major_100),
+                0
+            )
             addingProductsViaScanningButton.iconGravity = MaterialButton.ICON_GRAVITY_END
             addingProductsViaScanningButton.setOnClickListener { addProductsViaScanButton.onClickListener() }
             val addProductsViaScanningButtonParams = RelativeLayout.LayoutParams(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.OrderCreationSectionBinding
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.show
+import com.woocommerce.android.util.getDensityPixel
 
 class OrderCreateEditSectionView @JvmOverloads constructor(
     ctx: Context,
@@ -85,7 +86,8 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
     }
 
     fun showAddProductsHeaderActions() {
-        binding.productsAdd.show()
+        binding.addIcon.show()
+        binding.barcodeIcon.show()
     }
 
     fun showAddAction() {
@@ -97,7 +99,8 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
     }
 
     fun hideAddProductsHeaderActions() {
-        binding.productsAdd.hide()
+        binding.addIcon.hide()
+        binding.barcodeIcon.hide()
     }
     fun hideHeader() {
         binding.headerLabel.hide()
@@ -185,8 +188,8 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
             val addingProductsViaScanningButton = MaterialButton(context, null, R.attr.secondaryTextButtonStyle)
             addingProductsViaScanningButton.icon = AppCompatResources.getDrawable(context, R.drawable.ic_barcode)
             addingProductsViaScanningButton.iconPadding = 0
-            addingProductsViaScanningButton.setPadding(0)
-            addingProductsViaScanningButton.iconGravity = MaterialButton.ICON_GRAVITY_TEXT_START
+            addingProductsViaScanningButton.setPadding(0, 0, getDensityPixel(context, 16), 0)
+            addingProductsViaScanningButton.iconGravity = MaterialButton.ICON_GRAVITY_END
             addingProductsViaScanningButton.setOnClickListener { addProductsViaScanButton.onClickListener() }
             val addProductsViaScanningButtonParams = RelativeLayout.LayoutParams(
                 LayoutParams.WRAP_CONTENT,

--- a/WooCommerce/src/main/res/layout/order_creation_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_section.xml
@@ -30,18 +30,11 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 
-    <androidx.constraintlayout.widget.Group
-        android:id="@+id/products_add"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:constraint_referenced_ids="add_icon, barcode_icon"/>
-
     <ImageView
         android:id="@+id/barcode_icon"
         android:layout_width="@dimen/image_minor_50"
         android:layout_height="@dimen/image_minor_50"
-        android:layout_marginEnd="@dimen/major_150"
+        android:layout_marginEnd="@dimen/major_100"
         android:src="@drawable/ic_barcode"
         android:visibility="gone"
         android:contentDescription="@string/order_editing_barcode_content_description"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10244 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
During the order creation process, if a custom amount is added and subsequently the screen orientation is changed, the add icon in the custom amount section vanishes. This PR fixes this bug

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Navigate to the order creation screen
2. Add custom amount
3. Rotate the screen
4. Ensure the add icon is still visible in the custom amounts section

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/1331230/fae97cff-492b-485c-9d1d-3b58fd6d0695






- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
