### PR TITLE
Feature/10257 new setting for theme selection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -16,6 +16,7 @@ interface MainSettingsContract {
 
         val isDomainOptionVisible: Boolean
         val isCloseAccountOptionVisible: Boolean
+        val isThemePickerOptionVisible: Boolean
     }
 
     interface View : BaseView<Presenter> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -244,7 +244,8 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         }
 
         binding.optionSiteThemes.isVisible = presenter.isThemePickerOptionVisible
-        binding.optionSiteThemes.setOnClickListener {// TODO
+        binding.optionSiteThemes.setOnClickListener {
+            // TODO open store themes picker
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -242,6 +242,11 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
                     MainSettingsFragmentDirections.actionMainSettingsFragmentToNameYourStoreDialogFragment()
                 )
         }
+
+        binding.optionTheme.isVisible = presenter.isThemePickerOptionVisible
+        binding.optionTheme.setOnClickListener {
+
+        }
     }
 
     private fun showDomainDashboard() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -243,9 +243,8 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
                 )
         }
 
-        binding.optionTheme.isVisible = presenter.isThemePickerOptionVisible
-        binding.optionTheme.setOnClickListener {
-
+        binding.optionThemePicker.isVisible = presenter.isThemePickerOptionVisible
+        binding.optionThemePicker.setOnClickListener {// TODO
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -243,8 +243,8 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
                 )
         }
 
-        binding.optionThemePicker.isVisible = presenter.isThemePickerOptionVisible
-        binding.optionThemePicker.setOnClickListener {// TODO
+        binding.optionSiteThemes.isVisible = presenter.isThemePickerOptionVisible
+        binding.optionSiteThemes.setOnClickListener {// TODO
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -90,5 +90,5 @@ class MainSettingsPresenter @Inject constructor(
         get() = selectedSite.connectionType != SiteConnectionType.ApplicationPasswords &&
             accountRepository.getUserAccount()?.userName != null
     override val isThemePickerOptionVisible: Boolean
-        get() = selectedSite.get().isWpComStore && FeatureFlag.THEME_PICKER.isEnabled()
+        get() = selectedSite.get().isWPComAtomic && FeatureFlag.THEME_PICKER.isEnabled()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -89,4 +89,6 @@ class MainSettingsPresenter @Inject constructor(
     override val isCloseAccountOptionVisible: Boolean
         get() = selectedSite.connectionType != SiteConnectionType.ApplicationPasswords &&
             accountRepository.getUserAccount()?.userName != null
+    override val isThemePickerOptionVisible: Boolean
+        get() = FeatureFlag.THEME_PICKER.isEnabled()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -90,5 +90,5 @@ class MainSettingsPresenter @Inject constructor(
         get() = selectedSite.connectionType != SiteConnectionType.ApplicationPasswords &&
             accountRepository.getUserAccount()?.userName != null
     override val isThemePickerOptionVisible: Boolean
-        get() = FeatureFlag.THEME_PICKER.isEnabled()
+        get() = selectedSite.get().isWpComStore && FeatureFlag.THEME_PICKER.isEnabled()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -25,7 +25,8 @@ enum class FeatureFlag {
     ORDER_CREATION_AUTO_TAX_RATE,
     CUSTOM_AMOUNTS_M1,
     PRODUCT_CREATION_AI,
-    PACKAGE_PHOTO_SCANNING;
+    PACKAGE_PHOTO_SCANNING,
+    THEME_PICKER;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -51,7 +52,8 @@ enum class FeatureFlag {
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
-            ORDER_CREATION_AUTO_TAX_RATE -> PackageUtils.isDebugBuild()
+            ORDER_CREATION_AUTO_TAX_RATE,
+            THEME_PICKER -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false
         }

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -78,7 +78,7 @@
                 Themes configuration
             -->
             <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-                android:id="@+id/option_theme_picker"
+                android:id="@+id/option_site_themes"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:optionTitle="@string/settings_themes" />

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -62,7 +62,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:visibility="gone"
-                app:optionTitle="@string/settings_install_jetpack"
+                app:optionTitle="@string/settings_themes"
                 tools:visibility="visible" />
 
             <!--
@@ -70,6 +70,15 @@
             -->
             <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
                 android:id="@+id/option_domain"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:optionTitle="@string/domain" />
+
+            <!--
+                Domain configuration
+            -->
+            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                android:id="@+id/option_theme_picker"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:optionTitle="@string/domain" />

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -62,7 +62,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:visibility="gone"
-                app:optionTitle="@string/settings_themes"
+                app:optionTitle="@string/settings_install_jetpack"
                 tools:visibility="visible" />
 
             <!--
@@ -75,13 +75,13 @@
                 app:optionTitle="@string/domain" />
 
             <!--
-                Domain configuration
+                Themes configuration
             -->
             <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
                 android:id="@+id/option_theme_picker"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:optionTitle="@string/domain" />
+                app:optionTitle="@string/settings_themes" />
 
             <!--
                 Store onboarding list visibility

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2259,6 +2259,7 @@
     <string name="settings_about_recommend_app_message">Hey! Here is a link to download the WooCommerce app. I\'m really enjoying it and thought you might too. %1$s</string>
     <string name="dev_options">Developer Options</string>
     <string name="settings_account">Account Settings</string>
+    <string name="settings_themes">Themes</string>
 
     <!--
         Developer Options Screen


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10257 and #10258
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds a new setting for opening the theme picker from settings. Only available from WP.com stores. 
Additionally, it adds a feature flag to handle the visibility of any entry point related to themes. 
### Testing instructions
1. Log into a self-hosted site and go to settings. Check that `Themes` options is not displayed
2. Log into a WP.com hosted site (like a Woo Express trial site) and navigate to settings. Check that the new `Themes` option is available. 

NOTE: clicking on this option won't do anything for now. 


### Images/gif

<img width="250"  src="https://github.com/woocommerce/woocommerce-android/assets/2663464/66ef57d8-f7d4-49b5-9875-d673d65127f6">

