### PR TITLE
Avoid NPE when OnJetpackTimeoutError#apiPath is null

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -388,7 +388,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     fun onJetpackTimeoutError(event: OnJetpackTimeoutError) {
         with(event) {
             // Replace numeric IDs with a placeholder so events can be aggregated
-            val genericPath = apiPath.replace(REGEX_API_NUMERIC_PARAM, "/ID/")
+            val genericPath = apiPath?.replace(REGEX_API_NUMERIC_PARAM, "/ID/")
             val protocol = REGEX_API_JETPACK_TUNNEL_METHOD.find(apiPath)?.groups?.get(1)?.value ?: ""
 
             val properties = mapOf(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10109 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This fixes the linked crash by avoiding reading apiPath when it's null, I'm not sure in which cases this would happen, but since it's just for tracking, we shouldn't crash the app when the path is not present in the error.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
