### PR TITLE
Fix MediaModel#url NPE crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-059925004026943c8bb4b42e6637da21fb1463e3'
+    fluxCVersion = 'trunk-2f304118ff4776274b83f6e34c66180cdc16eb40'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10264 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This fixes the linked issue by updating FluxC, check the https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2908 for more information on the change.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
