### PR TITLE
Enhance UI for not synced order items

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1564,4 +1564,4 @@ private fun ModelProduct.isNotPublished() = status != ProductStatus.PUBLISH
 
 private fun ModelProduct.hasNoPrice() = price == null
 
-fun Order.Item.isSynced() = this.itemId != 0L
+fun Order.Item.isSynced() = this.itemId != Order.Item.EMPTY.itemId

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -64,6 +64,7 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 import com.woocommerce.android.ui.orders.creation.OrderCreationProduct
 import com.woocommerce.android.ui.orders.creation.ProductInfo
+import com.woocommerce.android.ui.orders.creation.isSynced
 import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.util.getStockText
@@ -322,12 +323,17 @@ fun ExtendedProductCardContent(
                 text = "Order count",
                 color = MaterialTheme.colors.onSurface
             )
+            val areAmountButtonsEnabled = if (isBundledProduct) {
+                editableControlsEnabled
+            } else {
+                product.item.isSynced()
+            }
             AmountPicker(
                 onIncreaseClicked = onIncreaseItemAmountClicked,
                 onDecreaseClicked = onDecreaseItemAmountClicked,
                 product = product,
-                isDecreaseButtonEnabled = (editableControlsEnabled && isBundledProduct) || isBundledProduct.not(),
-                isIncreaseButtonEnabled = (editableControlsEnabled && isBundledProduct) || isBundledProduct.not()
+                isDecreaseButtonEnabled = areAmountButtonsEnabled,
+                isIncreaseButtonEnabled = areAmountButtonsEnabled
             )
         }
         Row(


### PR DESCRIPTION
### Description
This small PR enhances the product creation UI by disabling the amount buttons while the order items are syncing with the API. Because of the complexity involved in updating product bundle items, these order items (Bundles) will follow the same behavior as editable controls.

### Testing instructions
You can use this patch to test the changes for regular products:
<details>
  <summary>Patch</summary>

```
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt	(revision adfbc7cbd6b2d07285a012466904d9287439edf6)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt	(date 1701140837488)
@@ -129,6 +129,7 @@
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Dispatchers.Main
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
@@ -1048,6 +1049,7 @@
                     // When we are in the order creation flow, we need to keep the order status as auto-draft.
                     // In this way, when the draft of the created order needs to synchronize the price modifiers,
                     // the application does not send notifications or synchronize its status on other devices.
+                    delay(20000)
                     _orderDraft.map { order -> order.copy(status = orderCreationStatus) }
                 }
             syncStrategy.syncOrderChanges(changes, retryOrderDraftUpdateTrigger)

```
</details>

1. Apply the patch and install the app
2. Open the orders tab
3. Tap on create new order (+)
4. Select a product (not a bundle product)
5. With the patch, the code will wait for 20 seconds to send the update request and sync the order item with the API; during these 20 seconds, the increase and decrease buttons should be disabled.

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/c3013c73-5007-4775-bb53-a02f739633ef



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
