### PR TITLE
Site not selected crash fix attempt

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -25,7 +25,7 @@ class SelectedSite(
 ) {
     companion object {
         const val SELECTED_SITE_LOCAL_ID = "SELECTED_SITE_LOCAL_ID"
-        private const val RESET_DELAY = 1000L
+        private const val RESET_DELAY = 5000L
 
         fun getEventBus(): EventBus = EventBus.getDefault()
     }


### PR DESCRIPTION
This PR increases the site reset delay to 5 seconds to allow all background jobs to complete gracefully and prevent a crash. Previous 1s delay was not sufficient.