### PR TITLE
Create new theme preview screen (barebones for now)

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerFragment.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.profiler.BaseStoreProfilerViewModel.NavigateToNextStep
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.themes.ThemePickerViewModel.NavigateToThemePreview
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -44,6 +45,7 @@ class ThemePickerFragment : BaseFragment() {
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                 is NavigateToNextStep -> navigateToStoreInstallationStep()
+                is NavigateToThemePreview -> navigateToThemePreviewFragment(event.themeDemoUri)
             }
         }
     }
@@ -52,6 +54,15 @@ class ThemePickerFragment : BaseFragment() {
         findNavController().navigateSafely(
             ThemePickerFragmentDirections
                 .actionThemePickerFragmentToStoreCreationInstallationFragment()
+        )
+    }
+
+    private fun navigateToThemePreviewFragment(themeDemoUri: String) {
+        findNavController().navigateSafely(
+            ThemePickerFragmentDirections
+                .actionThemePickerFragmentToThemePreviewFragment(
+                    themeDemoUri = themeDemoUri
+                )
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.themes
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -63,11 +64,12 @@ fun ThemePickerScreen(viewModel: ThemePickerViewModel) {
             )
         }) { padding ->
             ThemePickerScreenCarousel(
+                items = viewState.carouselItems,
+                onThemeTapped = viewModel::onThemeTapped,
                 modifier = Modifier
                     .padding(padding)
                     .verticalScroll(rememberScrollState())
                     .background(MaterialTheme.colors.surface),
-                viewState.carouselItems
             )
         }
     }
@@ -75,8 +77,9 @@ fun ThemePickerScreen(viewModel: ThemePickerViewModel) {
 
 @Composable
 private fun ThemePickerScreenCarousel(
-    modifier: Modifier,
-    items: List<CarouselItem>
+    items: List<CarouselItem>,
+    onThemeTapped: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier
@@ -109,7 +112,7 @@ private fun ThemePickerScreenCarousel(
         ) {
             items(items) { item ->
                 when (item) {
-                    is CarouselItem.Theme -> Theme(item.name, item.screenshotUrl)
+                    is CarouselItem.Theme -> Theme(item.name, item.screenshotUrl, onThemeTapped)
                     is CarouselItem.Message -> Message(item.title, item.description, Modifier.width(320.dp))
                 }
             }
@@ -151,12 +154,16 @@ private fun Message(title: String, description: String, modifier: Modifier = Mod
 }
 
 @Composable
-private fun Theme(name: String, screenshotUrl: String) {
+private fun Theme(
+    name: String,
+    screenshotUrl: String,
+    onThemeTapped: (String) -> Unit
+) {
     val themeModifier = Modifier.width(240.dp)
     Card(
         shape = RoundedCornerShape(dimensionResource(id = dimen.minor_100)),
         elevation = dimensionResource(id = dimen.minor_50),
-        modifier = themeModifier
+        modifier = themeModifier.clickable { onThemeTapped(screenshotUrl) }
     ) {
         val imageLoader = ImageLoader.Builder(LocalContext.current)
             .okHttpClient {
@@ -186,6 +193,7 @@ private fun Theme(name: String, screenshotUrl: String) {
                         themeModifier
                     )
                 }
+
                 else -> {
                     SubcomposeAsyncImageContent()
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -58,6 +58,10 @@ class ThemePickerViewModel @Inject constructor(
         triggerEvent(MoveToNextStep)
     }
 
+    fun onThemeTapped(themeUri: String) {
+        triggerEvent(NavigateToThemePreview(themeUri))
+    }
+
     @Parcelize
     data class ViewState(
         val carouselItems: List<CarouselItem> = emptyList(),
@@ -73,4 +77,5 @@ class ThemePickerViewModel @Inject constructor(
     }
 
     object MoveToNextStep : Event()
+    data class NavigateToThemePreview(val themeDemoUri: String) : Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewFragment.kt
@@ -1,0 +1,47 @@
+package com.woocommerce.android.ui.themes
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class ThemePreviewFragment : BaseFragment() {
+    private val viewModel: ThemePreviewViewModel by viewModels()
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                WooThemeWithBackground {
+                    ThemePreviewScreen(viewModel)
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewFragment.kt
@@ -26,7 +26,12 @@ class ThemePreviewFragment : BaseFragment() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 WooThemeWithBackground {
-                    ThemePreviewScreen(viewModel)
+                    ThemePreviewScreen(
+                        viewModel = viewModel,
+                        userAgent = viewModel.userAgent,
+                        wpcomWebViewAuthenticator = viewModel.wpComWebViewAuthenticator,
+                        activityRegistry = requireActivity().activityResultRegistry,
+                    )
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -1,0 +1,116 @@
+package com.woocommerce.android.ui.themes
+
+import androidx.activity.result.ActivityResultRegistry
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ModalBottomSheetDefaults
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetValue.HalfExpanded
+import androidx.compose.material.ModalBottomSheetValue.Hidden
+import androidx.compose.material.Scaffold
+import androidx.compose.material.icons.Icons.Filled
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.R.color
+import com.woocommerce.android.R.dimen
+import com.woocommerce.android.R.string
+import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCWebView
+import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ViewState
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.network.UserAgent
+
+@Composable
+fun ThemePreviewScreen(
+    viewModel: ThemePreviewViewModel,
+    userAgent: UserAgent,
+    wpcomWebViewAuthenticator: WPComWebViewAuthenticator,
+    activityRegistry: ActivityResultRegistry,
+) {
+    viewModel.viewState.observeAsState().value?.let { viewState ->
+        ThemePreviewScreen(
+            state = viewState,
+            userAgent = userAgent,
+            wpcomWebViewAuthenticator = wpcomWebViewAuthenticator,
+            activityRegistry = activityRegistry,
+            viewModel::onPageSelected
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun ThemePreviewScreen(
+    state: ViewState,
+    userAgent: UserAgent,
+    wpcomWebViewAuthenticator: WPComWebViewAuthenticator,
+    activityRegistry: ActivityResultRegistry,
+    onPageSelected: (String) -> Unit
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val modalSheetState = rememberModalBottomSheetState(
+        initialValue = Hidden,
+        confirmValueChange = { it != HalfExpanded }
+    )
+
+    ModalBottomSheetLayout(
+        sheetState = modalSheetState,
+        sheetShape = RoundedCornerShape(
+            topStart = dimensionResource(id = dimen.minor_100),
+            topEnd = dimensionResource(id = dimen.minor_100)
+        ),
+        scrimColor =
+        // Overriding scrim color for dark theme because of the following bug affecting ModalBottomSheetLayout:
+        // https://issuetracker.google.com/issues/183697056
+        if (isSystemInDarkTheme()) colorResource(id = color.color_scrim_background)
+        else ModalBottomSheetDefaults.scrimColor,
+        sheetContent = {
+            ThemeDemoPagesBottomSheet(
+                onPageSelected = {
+                    coroutineScope.launch { modalSheetState.hide() }
+                    onPageSelected(it)
+                }
+            )
+        }
+    ) {
+        Scaffold(
+            topBar = {
+                Toolbar(
+                    title = stringResource(id = string.more_menu_button_blaze),
+                    navigationIcon = Filled.ArrowBack
+                )
+            },
+            backgroundColor = MaterialTheme.colors.surface
+        ) { paddingValues ->
+            WCWebView(
+                url = state.demoUri,
+                userAgent = userAgent,
+                wpComAuthenticator = wpcomWebViewAuthenticator,
+                activityRegistry = activityRegistry,
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .fillMaxSize()
+            )
+        }
+    }
+}
+
+@Composable
+@Suppress("unused")
+private fun ThemeDemoPagesBottomSheet(
+    onPageSelected: (String) -> Unit,
+) {
+    // TODO display demo pager here
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -108,7 +108,7 @@ fun ThemePreviewScreen(
 }
 
 @Composable
-@Suppress("unused")
+@Suppress("UNUSED_PARAMETER")
 private fun ThemeDemoPagesBottomSheet(
     onPageSelected: (String) -> Unit,
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -43,7 +43,7 @@ fun ThemePreviewScreen(
         ThemePreviewScreen(
             state = viewState,
             userAgent = userAgent,
-            wpcomWebViewAuthenticator = wpcomWebViewAuthenticator,
+            wpComWebViewAuthenticator = wpcomWebViewAuthenticator,
             activityRegistry = activityRegistry,
             viewModel::onPageSelected,
             viewModel::onBackNavigationClicked,
@@ -56,7 +56,7 @@ fun ThemePreviewScreen(
 fun ThemePreviewScreen(
     state: ViewState,
     userAgent: UserAgent,
-    wpcomWebViewAuthenticator: WPComWebViewAuthenticator,
+    wpComWebViewAuthenticator: WPComWebViewAuthenticator,
     activityRegistry: ActivityResultRegistry,
     onPageSelected: (String) -> Unit,
     onBackNavigationClicked: () -> Unit,
@@ -100,7 +100,7 @@ fun ThemePreviewScreen(
             WCWebView(
                 url = state.demoUri,
                 userAgent = userAgent,
-                wpComAuthenticator = wpcomWebViewAuthenticator,
+                wpComAuthenticator = wpComWebViewAuthenticator,
                 activityRegistry = activityRegistry,
                 modifier = Modifier
                     .padding(paddingValues)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -30,7 +30,6 @@ import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCWebView
 import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ViewState
 import kotlinx.coroutines.launch
-import okhttp3.internal.userAgent
 import org.wordpress.android.fluxc.network.UserAgent
 
 @Composable
@@ -91,7 +90,7 @@ fun ThemePreviewScreen(
         Scaffold(
             topBar = {
                 Toolbar(
-                    title = stringResource(id = string.more_menu_button_blaze),
+                    title = stringResource(id = string.theme_preview_title),
                     navigationIcon = Filled.ArrowBack,
                     onNavigationButtonClick = onBackNavigationClicked,
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -30,6 +30,7 @@ import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCWebView
 import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ViewState
 import kotlinx.coroutines.launch
+import okhttp3.internal.userAgent
 import org.wordpress.android.fluxc.network.UserAgent
 
 @Composable
@@ -45,7 +46,8 @@ fun ThemePreviewScreen(
             userAgent = userAgent,
             wpcomWebViewAuthenticator = wpcomWebViewAuthenticator,
             activityRegistry = activityRegistry,
-            viewModel::onPageSelected
+            viewModel::onPageSelected,
+            viewModel::onBackNavigationClicked,
         )
     }
 }
@@ -57,7 +59,8 @@ fun ThemePreviewScreen(
     userAgent: UserAgent,
     wpcomWebViewAuthenticator: WPComWebViewAuthenticator,
     activityRegistry: ActivityResultRegistry,
-    onPageSelected: (String) -> Unit
+    onPageSelected: (String) -> Unit,
+    onBackNavigationClicked: () -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val modalSheetState = rememberModalBottomSheetState(
@@ -89,7 +92,8 @@ fun ThemePreviewScreen(
             topBar = {
                 Toolbar(
                     title = stringResource(id = string.more_menu_button_blaze),
-                    navigationIcon = Filled.ArrowBack
+                    navigationIcon = Filled.ArrowBack,
+                    onNavigationButtonClick = onBackNavigationClicked,
                 )
             },
             backgroundColor = MaterialTheme.colors.surface

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -8,7 +8,7 @@ import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.network.UserAgent
 import javax.inject.Inject
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -28,6 +29,10 @@ class ThemePreviewViewModel @Inject constructor(
 
     fun onPageSelected(updatedDemoUri: String) {
         _viewState.value = _viewState.value.copy(demoUri = updatedDemoUri)
+    }
+
+    fun onBackNavigationClicked() {
+        triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.themes
 
+import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
@@ -7,6 +8,7 @@ import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.android.parcel.Parcelize
 import org.wordpress.android.fluxc.network.UserAgent
 import javax.inject.Inject
 
@@ -28,7 +30,8 @@ class ThemePreviewViewModel @Inject constructor(
         _viewState.value = _viewState.value.copy(demoUri = updatedDemoUri)
     }
 
+    @Parcelize
     data class ViewState(
         val demoUri: String,
-    )
+    ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -3,14 +3,18 @@ package com.woocommerce.android.ui.themes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import org.wordpress.android.fluxc.network.UserAgent
 import javax.inject.Inject
 
 @HiltViewModel
 class ThemePreviewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
+    val userAgent: UserAgent,
 ) : ScopedViewModel(savedStateHandle) {
     private val _viewState = savedStateHandle.getStateFlow(
         viewModelScope,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.ui.themes
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ThemePreviewViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : ScopedViewModel(savedStateHandle) {
+    private val _viewState = savedStateHandle.getStateFlow(
+        viewModelScope,
+        ViewState(
+            demoUri = "https://zainodemo.wpcomstaging.com/\" // TODO pass this as argument from previous screen"
+        )
+    )
+    val viewState = _viewState.asLiveData()
+
+    fun onPageSelected(updatedDemoUri: String) {
+        _viewState.value = _viewState.value.copy(demoUri = updatedDemoUri)
+    }
+
+    data class ViewState(
+        val demoUri: String,
+    )
+}

--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
@@ -155,7 +155,7 @@
             app:destination="@id/storeCreationInstallationFragment" />
         <action
             android:id="@+id/action_themePickerFragment_to_themePreviewFragment"
-            app:destination="@id/storeCreationInstallationFragment">
+            app:destination="@id/themePreviewFragment">
             <argument
                 android:name="themeDemoUri"
                 app:argType="string" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
@@ -149,9 +149,20 @@
     <fragment
         android:id="@+id/themePickerFragment"
         android:name="com.woocommerce.android.ui.themes.ThemePickerFragment"
-        android:label="ThemePickerFragment" >
+        android:label="ThemePickerFragment">
         <action
             android:id="@+id/action_themePickerFragment_to_storeCreationInstallationFragment"
             app:destination="@id/storeCreationInstallationFragment" />
+        <action
+            android:id="@+id/action_themePickerFragment_to_themePreviewFragment"
+            app:destination="@id/storeCreationInstallationFragment">
+            <argument
+                android:name="themeDemoUri"
+                app:argType="string" />
+        </action>
     </fragment>
+    <fragment
+        android:id="@+id/themePreviewFragment"
+        android:name="com.woocommerce.android.ui.themes.ThemePreviewFragment"
+        android:label="ThemePreviewFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3374,6 +3374,7 @@
     <string name="theme_picker_carousel_info_item_description">Once your store is set up, find your perfect theme in the WooCommerce Theme Store.</string>
     <string name="theme_picker_carousel_placeholder_title">Theme "%s"</string>
     <string name="theme_picker_carousel_placeholder_message">Tap for live demo.</string>
+    <string name="theme_preview_title">Preview</string>
 
     <!--
     Store onboarding


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10259 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the barebones to load the theme preview upong tapping on any of the themes from the theme picker screen. The goal of this is to allow for parallel work on the preview screen, avoiding as many conflicts as possible. For now, please don't pay much attention to the URL loaded by the webview, which is just a hardcoded URL that will soon be replaced. 

### Testing instructions

Just run the store creation flow, and when reaching the theme picker step, tap on any of the themes from the carousel and check the new theme preview screen is displayed

