### PR TITLE
[Themes] - Integrate theme repository in the UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -111,4 +111,7 @@ object AppUrls {
     const val STORE_ONBOARDING_WCPAY_SETUP_GUIDE = "https://woo.com/document/woopayments/startup-guide/"
     const val STORE_ONBOARDING_PAYMENTS_SETUP_GUIDE =
         "https://woo.com/documentation/woocommerce/getting-started/sell-products/core-payment-options/"
+
+    fun getScreenshotUrl(themeDemoUrl: String) =
+        "https://s0.wp.com/mshots/v1/$themeDemoUrl?demo=true/?w=1200&h=2400&vpw=400&vph=800"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -17,6 +18,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Card
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
@@ -34,17 +36,21 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
 import coil.compose.AsyncImagePainter
 import coil.compose.SubcomposeAsyncImage
 import coil.compose.SubcomposeAsyncImageContent
 import coil.request.ImageRequest
+import coil.util.DebugLogger
+import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.compose.component.Toolbar
-import com.woocommerce.android.ui.themes.ThemePickerViewModel.ViewState.CarouselItem
+import com.woocommerce.android.ui.themes.ThemePickerViewModel.ViewState
+import com.woocommerce.android.ui.themes.ThemePickerViewModel.ViewState.Success.CarouselItem
 import okhttp3.OkHttpClient
 
 @Composable
@@ -62,21 +68,22 @@ fun ThemePickerScreen(viewModel: ThemePickerViewModel) {
                 }
             )
         }) { padding ->
-            ThemePickerScreenCarousel(
+            ThemePicker(
+                viewState = viewState,
                 modifier = Modifier
                     .padding(padding)
+                    .fillMaxSize()
                     .verticalScroll(rememberScrollState())
-                    .background(MaterialTheme.colors.surface),
-                viewState.carouselItems
+                    .background(MaterialTheme.colors.surface)
             )
         }
     }
 }
 
 @Composable
-private fun ThemePickerScreenCarousel(
-    modifier: Modifier,
-    items: List<CarouselItem>
+private fun ThemePicker(
+    viewState: ViewState,
+    modifier: Modifier
 ) {
     Column(
         modifier = modifier
@@ -99,31 +106,80 @@ private fun ThemePickerScreenCarousel(
             modifier = Modifier.padding(dimensionResource(id = dimen.major_100))
         )
 
-        LazyRow(
-            modifier = Modifier
-                .padding(top = dimensionResource(id = dimen.major_150))
-                .height(480.dp)
-                .fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = dimen.major_100)),
-            contentPadding = PaddingValues(start = dimensionResource(id = dimen.major_100))
-        ) {
-            items(items) { item ->
-                when (item) {
-                    is CarouselItem.Theme -> Theme(item.name, item.screenshotUrl)
-                    is CarouselItem.Message -> Message(item.title, item.description, Modifier.width(320.dp))
-                }
+        when (viewState) {
+            is ViewState.Loading -> {
+                Loading()
+            }
+
+            is ViewState.Error -> {
+                Error()
+            }
+
+            is ViewState.Success -> {
+                Carousel(viewState.carouselItems)
             }
         }
     }
 }
 
 @Composable
-private fun Message(title: String, description: String, modifier: Modifier = Modifier) {
+private fun ColumnScope.Loading() {
+    Box(
+        modifier = Modifier
+            .background(MaterialTheme.colors.surface)
+            .fillMaxWidth()
+            .weight(1f)
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier
+                .align(Alignment.Center)
+        )
+    }
+}
+
+@Composable
+private fun ColumnScope.Error() {
+    Message(
+        title = stringResource(id = string.theme_picker_error_title),
+        description = stringResource(id = string.theme_picker_error_message),
+        modifier = Modifier
+            .fillMaxWidth()
+            .weight(1f),
+        color = color.color_error
+    )
+}
+
+@Composable
+private fun Carousel(items: List<CarouselItem>) {
+    LazyRow(
+        modifier = Modifier
+            .padding(top = dimensionResource(id = dimen.major_150))
+            .height(480.dp)
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = dimen.major_100)),
+        contentPadding = PaddingValues(start = dimensionResource(id = dimen.major_100))
+    ) {
+        items(items) { item ->
+            when (item) {
+                is CarouselItem.Theme -> Theme(item.name, item.screenshotUrl)
+                is CarouselItem.Message -> Message(item.title, item.description, modifier = Modifier.width(320.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun Message(
+    title: String,
+    description: String,
+    color: Int = R.color.color_on_surface_medium,
+    modifier: Modifier = Modifier
+) {
     Box(
         modifier = modifier
             .fillMaxHeight()
             .padding(dimensionResource(id = dimen.major_100)),
-        contentAlignment = Alignment.Center
+        contentAlignment = Alignment.Center,
     ) {
         Column(
             modifier = Modifier
@@ -132,7 +188,7 @@ private fun Message(title: String, description: String, modifier: Modifier = Mod
             Text(
                 text = title,
                 style = MaterialTheme.typography.subtitle1,
-                color = colorResource(id = color.color_on_surface_medium),
+                color = colorResource(id = color),
                 textAlign = TextAlign.Center,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier
@@ -141,7 +197,7 @@ private fun Message(title: String, description: String, modifier: Modifier = Mod
             )
             Text(
                 text = description,
-                color = colorResource(id = color.color_on_surface_medium),
+                color = colorResource(id = color),
                 textAlign = TextAlign.Center,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -164,6 +220,7 @@ private fun Theme(name: String, screenshotUrl: String) {
                     .followRedirects(false)
                     .build()
             }
+            .logger(DebugLogger())
             .build()
 
         val request = ImageRequest.Builder(LocalContext.current)
@@ -183,7 +240,7 @@ private fun Theme(name: String, screenshotUrl: String) {
                     Message(
                         title = stringResource(id = string.theme_picker_carousel_placeholder_title, name),
                         description = stringResource(id = string.theme_picker_carousel_placeholder_message),
-                        themeModifier
+                        modifier = themeModifier
                     )
                 }
                 else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
@@ -193,3 +193,15 @@ private fun Theme(name: String, screenshotUrl: String) {
         }
     }
 }
+
+@Preview
+@Composable
+private fun PreviewThemePickerError() {
+    ThemePicker(ViewState.Error, Modifier)
+}
+
+@Preview
+@Composable
+private fun PreviewThemePickerLoading() {
+    ThemePicker(ViewState.Loading, Modifier)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
@@ -49,6 +49,7 @@ import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.themes.ThemePickerViewModel.ViewState
 import com.woocommerce.android.ui.themes.ThemePickerViewModel.ViewState.Success.CarouselItem
 import okhttp3.OkHttpClient
@@ -140,11 +141,11 @@ private fun ColumnScope.Loading() {
 @Composable
 private fun ColumnScope.Error() {
     Message(
-        title = stringResource(id = string.theme_picker_error_title),
-        description = stringResource(id = string.theme_picker_error_message),
         modifier = Modifier
             .fillMaxWidth()
             .weight(1f),
+        title = stringResource(id = string.theme_picker_error_title),
+        description = stringResource(id = string.theme_picker_error_message),
         color = color.color_error
     )
 }
@@ -162,7 +163,7 @@ private fun Carousel(items: List<CarouselItem>) {
         items(items) { item ->
             when (item) {
                 is CarouselItem.Theme -> Theme(item.name, item.screenshotUrl)
-                is CarouselItem.Message -> Message(item.title, item.description, modifier = Modifier.width(320.dp))
+                is CarouselItem.Message -> Message(modifier = Modifier.width(320.dp), item.title, item.description)
             }
         }
     }
@@ -170,10 +171,10 @@ private fun Carousel(items: List<CarouselItem>) {
 
 @Composable
 private fun Message(
+    modifier: Modifier = Modifier,
     title: String,
     description: String,
-    color: Int = R.color.color_on_surface_medium,
-    modifier: Modifier = Modifier
+    color: Int = R.color.color_on_surface_medium
 ) {
     Box(
         modifier = modifier
@@ -238,9 +239,9 @@ private fun Theme(name: String, screenshotUrl: String) {
             when (painter.state) {
                 is AsyncImagePainter.State.Error -> {
                     Message(
+                        modifier = themeModifier,
                         title = stringResource(id = string.theme_picker_carousel_placeholder_title, name),
-                        description = stringResource(id = string.theme_picker_carousel_placeholder_message),
-                        modifier = themeModifier
+                        description = stringResource(id = string.theme_picker_carousel_placeholder_message)
                     )
                 }
                 else -> {
@@ -251,14 +252,18 @@ private fun Theme(name: String, screenshotUrl: String) {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun PreviewThemePickerError() {
-    ThemePicker(ViewState.Error, Modifier)
+    WooThemeWithBackground {
+        ThemePicker(ViewState.Error, Modifier)
+    }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun PreviewThemePickerLoading() {
-    ThemePicker(ViewState.Loading, Modifier)
+    WooThemeWithBackground {
+        ThemePicker(ViewState.Loading, Modifier)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -58,17 +58,24 @@ class ThemePickerViewModel @Inject constructor(
         triggerEvent(MoveToNextStep)
     }
 
-    @Parcelize
-    data class ViewState(
-        val carouselItems: List<CarouselItem> = emptyList(),
-        val isLoading: Boolean = false
-    ) : Parcelable {
-        sealed class CarouselItem : Parcelable {
-            @Parcelize
-            data class Theme(val name: String, val screenshotUrl: String) : CarouselItem()
+    sealed interface ViewState : Parcelable {
+        @Parcelize
+        object Loading : ViewState
 
-            @Parcelize
-            data class Message(val title: String, val description: String) : CarouselItem()
+        @Parcelize
+        object Error : ViewState
+
+        @Parcelize
+        data class Success(
+            val carouselItems: List<CarouselItem> = emptyList()
+        ) : ViewState {
+            sealed class CarouselItem : Parcelable {
+                @Parcelize
+                data class Theme(val name: String, val screenshotUrl: String) : CarouselItem()
+
+                @Parcelize
+                data class Message(val title: String, val description: String) : CarouselItem()
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -4,8 +4,11 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.R
-import com.woocommerce.android.ui.themes.ThemePickerViewModel.ViewState.CarouselItem
+import com.woocommerce.android.R.string
+import com.woocommerce.android.ui.themes.ThemePickerViewModel.ViewState.Error
+import com.woocommerce.android.ui.themes.ThemePickerViewModel.ViewState.Loading
+import com.woocommerce.android.ui.themes.ThemePickerViewModel.ViewState.Success
+import com.woocommerce.android.ui.themes.ThemePickerViewModel.ViewState.Success.CarouselItem
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -13,42 +16,56 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
 class ThemePickerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    private val themeRepository: ThemeRepository,
     private val resourceProvider: ResourceProvider,
 ) : ScopedViewModel(savedStateHandle) {
-    private val _viewState = savedStateHandle.getStateFlow(viewModelScope, ViewState())
+    private val _viewState = savedStateHandle.getStateFlow<ViewState>(viewModelScope, Loading)
     val viewState = _viewState.asLiveData()
 
     init {
-        _viewState.update {
-            _viewState.value.copy(
-                carouselItems = listOf(
-                    CarouselItem.Theme(name = "tsubaki", screenshotUrl = getThemeUrl(themeUrl = "wordpress.org")),
-                    CarouselItem.Theme(name = "tazza", screenshotUrl = getThemeUrl(themeUrl = "facebook.com")),
-                    CarouselItem.Theme(name = "amulet", screenshotUrl = getThemeUrl(themeUrl = "twitter.com")),
-                    CarouselItem.Theme(name = "zaino", screenshotUrl = getThemeUrl(themeUrl = "apple.com")),
-                    CarouselItem.Theme(name = "thriving-artist", screenshotUrl = getThemeUrl(themeUrl = "dennikn.sk")),
-                    CarouselItem.Theme(name = "attar", screenshotUrl = getThemeUrl(themeUrl = "android.com")),
-                    CarouselItem.Message(
-                        title = resourceProvider.getString(
-                            R.string.theme_picker_carousel_info_item_title
-                        ),
-                        description = resourceProvider.getString(
-                            R.string.theme_picker_carousel_info_item_description
-                        ),
-                    ),
-                )
-            )
+        viewModelScope.launch {
+            loadThemes()
         }
     }
 
-    private fun getThemeUrl(themeUrl: String) =
-        "https://s0.wp.com/mshots/v1/https://$themeUrl?demo=true/?w=1200&h=2400&vpw=400&vph=800"
+    private suspend fun loadThemes() {
+        themeRepository.fetchThemes().fold(
+            onSuccess = { result ->
+                _viewState.update {
+                    Success(
+                        carouselItems = result.map { theme ->
+                            CarouselItem.Theme(
+                                name = theme.name,
+                                screenshotUrl = getScreenshotUrl(theme.demoUrl)
+                            )
+                        }.plus(
+                            CarouselItem.Message(
+                                title = resourceProvider.getString(
+                                    string.theme_picker_carousel_info_item_title
+                                ),
+                                description = resourceProvider.getString(
+                                    string.theme_picker_carousel_info_item_description
+                                )
+                            )
+                        )
+                    )
+                }
+            },
+            onFailure = {
+                _viewState.update { Error }
+            }
+        )
+    }
+
+    private fun getScreenshotUrl(themeDemoUrl: String) =
+        "https://s0.wp.com/mshots/v1/$themeDemoUrl?demo=true/?w=1200&h=2400&vpw=400&vph=800"
 
     fun onArrowBackPressed() {
         triggerEvent(Exit)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.themes.ThemePickerViewModel.ViewState.Error
 import com.woocommerce.android.ui.themes.ThemePickerViewModel.ViewState.Loading
@@ -43,7 +44,7 @@ class ThemePickerViewModel @Inject constructor(
                         carouselItems = result.map { theme ->
                             CarouselItem.Theme(
                                 name = theme.name,
-                                screenshotUrl = getScreenshotUrl(theme.demoUrl)
+                                screenshotUrl = AppUrls.getScreenshotUrl(theme.demoUrl)
                             )
                         }.plus(
                             CarouselItem.Message(
@@ -63,9 +64,6 @@ class ThemePickerViewModel @Inject constructor(
             }
         )
     }
-
-    private fun getScreenshotUrl(themeDemoUrl: String) =
-        "https://s0.wp.com/mshots/v1/$themeDemoUrl?demo=true/?w=1200&h=2400&vpw=400&vph=800"
 
     fun onArrowBackPressed() {
         triggerEvent(Exit)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3374,6 +3374,8 @@
     <string name="theme_picker_carousel_info_item_description">Once your store is set up, find your perfect theme in the WooCommerce Theme Store.</string>
     <string name="theme_picker_carousel_placeholder_title">Theme "%s"</string>
     <string name="theme_picker_carousel_placeholder_message">Tap for live demo.</string>
+    <string name="theme_picker_error_title">An error occurred</string>
+    <string name="theme_picker_error_message">Unable to load themes at this time.</string>
 
     <!--
     Store onboarding


### PR DESCRIPTION
Fixes #10273. The PR integrates `ThemeRepository` and fetches the available themes and displays them in a carousel.

There are also new loading and error UI states (can be seen in the previews).

**To test:**
1. Start the app and trigger the store creation
2. Continue through the creation wizard until you get to the theme picker
3. Verify the theme screenshots are loaded correctly