### PR TITLE
[Product Subscriptions] Fix bug about determining if sync renewals are enabled or not

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetailsMapper.kt
@@ -70,7 +70,7 @@ object SubscriptionDetailsMapper {
             isJsonObject -> asJsonObject.let {
                 val day = it["day"].asInt
                 val month = it["month"].asInt
-                if (month == 0) SubscriptionPaymentSyncDate.None
+                if (day == 0) SubscriptionPaymentSyncDate.None
                 else SubscriptionPaymentSyncDate.MonthDay(day, month)
             }
 


### PR DESCRIPTION
### Description
During beta testing, @itsmeichigo identified a bug where the app shows the "one-time shipping" toggle as disabled in the app, even though it was enabled and checked in the backend, we found out that the plugin sets the following default value for the sync date when a subscription has a yearly schedule, regardless of whether synced renewals are enabled or not:
```json
{
        "key": "_subscription_payment_sync_date",
        "value": {
          "day": 0,
          "month": "01"
        }
}
```

This PR updates the logic of the app to check against the `day` value when determining if synced renewals are disabled for a given product, this also aligns with the plugin's [behavior](https://github.com/Automattic/woocommerce-subscriptions-core/blob/b064d6ec03cf29f86d9635e5ab7277a3f703743c/assets/js/admin/admin.js#L562-L564).

### Testing instructions
1. Create a new simple subscription with a yearly schedule.
2. Open the product in the app.
3. Open the Shipping section.
4. Confirm the "one-time shipping" is togglable, and has the correct value.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
