### PR TITLE
Send the new store_id property in track events

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,8 +3,7 @@
 -----
 - [*] [Internal] Changes in the minSdkVersion from 24 to 26 and coroutines library update to version 1.7.3 [https://github.com/woocommerce/woocommerce-android/pull/10187]
 - [*] [Internal] Stripe SDK Migration to version 3.1.1 [https://github.com/woocommerce/woocommerce-android/pull/10103]
-
-- [*] [Internal] Send `store_id` in track events when available.
+- [*] [Internal] Send `store_id` in track events when available. [https://github.com/woocommerce/woocommerce-android/pull/10286]
 
 16.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 - [*] [Internal] Changes in the minSdkVersion from 24 to 26 and coroutines library update to version 1.7.3 [https://github.com/woocommerce/woocommerce-android/pull/10187]
 - [*] [Internal] Stripe SDK Migration to version 3.1.1 [https://github.com/woocommerce/woocommerce-android/pull/10103]
 
+- [*] [Internal] Send `store_id` in track events when available.
 
 16.4
 -----

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/system_status.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wc/system_status.json
@@ -8,10 +8,10 @@
             },
             "path": {
                 "matches": "/wc/v3/system_status(.*)"
-            },  
+            },
             "query": {
-                "matches": "(.*)active_plugins(.*)"
-            }, 
+                "matches": "(.*)(active_plugins|environment)(.*)"
+            },
             "locale": {
                 "matches": "(.*)"
             }
@@ -293,6 +293,9 @@
                     "author_url": "https://automattic.com/wordpress-plugins/",
                     "network_activated": false
                 }]
+            },
+            "environment": {
+                "store_id": "sample-store-uuid"
             }
         },
         "headers": {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -320,7 +320,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     }
 
     private fun initAnalytics() {
-        AnalyticsTracker.init(application, selectedSite)
+        AnalyticsTracker.init(application, selectedSite, prefs)
 
         AnalyticsTracker.refreshMetadata(accountStore.account?.userName)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -1132,7 +1132,7 @@ object AppPrefs {
         key = PrefKeyString(
             "$WC_STORE_ID:$siteID"
         )
-    )
+    ).orNullIfEmpty()
 
     fun setWCStoreID(siteID: Long, storeID: String?) {
         val key = PrefKeyString("$WC_STORE_ID:$siteID")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -1134,12 +1134,14 @@ object AppPrefs {
         )
     )
 
-    fun setWCStoreID(siteID: Long, storeID: String) = setString(
-        key = PrefKeyString(
-            "$WC_STORE_ID:$siteID"
-        ),
-        value = storeID
-    )
+    fun setWCStoreID(siteID: Long, storeID: String?) {
+        val key = PrefKeyString("$WC_STORE_ID:$siteID")
+        if (storeID.isNullOrEmpty()) {
+            remove(key)
+        } else {
+            setString(key, storeID)
+        }
+    }
 
     /**
      * Auto-tax-rate setting

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.AppPrefs.DeletablePrefKey.ORDER_FILTER_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.PRODUCT_SORTING_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.RECEIPT_PREFIX
 import com.woocommerce.android.AppPrefs.DeletablePrefKey.UPDATE_SIMULATED_READER_OPTION
+import com.woocommerce.android.AppPrefs.DeletablePrefKey.WC_STORE_ID
 import com.woocommerce.android.AppPrefs.DeletableSitePrefKey.AUTO_TAX_RATE_ID
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.APPLICATION_STORE_SNAPSHOT_TRACKED_FOR_SITE
 import com.woocommerce.android.AppPrefs.UndeletablePrefKey.ONBOARDING_CAROUSEL_DISPLAYED
@@ -120,6 +121,7 @@ object AppPrefs {
         AI_PRODUCT_CREATION_IS_FIRST_ATTEMPT,
         BLAZE_CELEBRATION_SCREEN_SHOWN,
         MY_STORE_BLAZE_VIEW_DISMISSED,
+        WC_STORE_ID,
     }
 
     /**
@@ -1124,6 +1126,19 @@ object AppPrefs {
             "$APPLICATION_STORE_SNAPSHOT_TRACKED_FOR_SITE:$localSiteId:$remoteSiteId:$selfHostedSiteId"
         ),
         default = false
+    )
+
+    fun getWCStoreID(siteID: Long): String? = getString(
+        key = PrefKeyString(
+            "$WC_STORE_ID:$siteID"
+        )
+    )
+
+    fun setWCStoreID(siteID: Long, storeID: String) = setString(
+        key = PrefKeyString(
+            "$WC_STORE_ID:$siteID"
+        ),
+        value = storeID
     )
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -370,7 +370,7 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun getWCStoreID(siteID: Long) = AppPrefs.getWCStoreID(siteID)
 
-    fun setWCStoreID(siteID: Long, storeID: String) {
+    fun setWCStoreID(siteID: Long, storeID: String?) {
         AppPrefs.setWCStoreID(siteID, storeID)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -368,5 +368,11 @@ class AppPrefsWrapper @Inject constructor() {
     fun isTimezoneTrackEventNeverTriggeredFor(siteId: Long, localTimezone: String, storeTimezone: String) =
         AppPrefs.isTimezoneTrackEventTriggeredFor(siteId, localTimezone, storeTimezone).not()
 
+    fun getWCStoreID(siteID: Long) = AppPrefs.getWCStoreID(siteID)
+
+    fun setWCStoreID(siteID: Long, storeID: String) {
+        AppPrefs.setWCStoreID(siteID, storeID)
+    }
+
     var wasAIProductDescriptionCelebrationShown by AppPrefs::wasAIProductDescriptionCelebrationShown
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/SiteObserver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/SiteObserver.kt
@@ -31,8 +31,7 @@ class SiteObserver @Inject constructor(
                 // Makes sure the store ID is fetched for the site.
                 environmentRepository.fetchOrGetStoreID(site)
                     .takeIf { result -> result.isError.not() }
-                    ?.let { result ->
-                        val storeID = result.model ?: return@let
+                    ?.model?.let { storeID ->
                         WooLog.d(WooLog.T.UTILS, "Fetched StoreID $storeID for site ${site.name}")
                     }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/SiteObserver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/SiteObserver.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android
 
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.environment.EnvironmentRepository
-import com.woocommerce.android.ui.common.giftcard.GiftCardRepository
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/SiteObserver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/SiteObserver.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android
 
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.common.environment.EnvironmentRepository
+import com.woocommerce.android.ui.common.giftcard.GiftCardRepository
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
@@ -16,7 +18,8 @@ import javax.inject.Inject
  */
 class SiteObserver @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val wooCommerceStore: WooCommerceStore
+    private val wooCommerceStore: WooCommerceStore,
+    private val environmentRepository: EnvironmentRepository
 ) {
     suspend fun observeAndUpdateSelectedSiteData() {
         selectedSite.observe()
@@ -25,6 +28,14 @@ class SiteObserver @Inject constructor(
             .collect { site ->
                 WooLog.d(WooLog.T.UTILS, "Fetch plugins for site ${site.name}")
                 wooCommerceStore.fetchSitePlugins(site)
+
+                // Makes sure the store ID is fetched for the site.
+                environmentRepository.fetchOrGetStoreID(site)
+                    .takeIf { result -> result.isError.not() }
+                    ?.let { result ->
+                        val storeID = result.model ?: return@let
+                        WooLog.d(WooLog.T.UTILS, "Fetched StoreID $storeID for site ${site.name}")
+                    }
             }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -4,7 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import androidx.preference.PreferenceManager
 import com.automattic.android.tracks.TracksClient
-import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.analytics.AnalyticsEvent.BACK_PRESSED
 import com.woocommerce.android.analytics.AnalyticsEvent.VIEW_SHOWN
@@ -18,6 +18,7 @@ import java.util.UUID
 class AnalyticsTracker private constructor(
     private val context: Context,
     private val selectedSite: SelectedSite,
+    private val appPrefs: AppPrefs,
 ) {
     private var tracksClient: TracksClient? = TracksClient.getClient(context)
     private var username: String? = null
@@ -84,7 +85,7 @@ class AnalyticsTracker private constructor(
                 finalProperties[KEY_IS_WPCOM_STORE] = it.isWpComStore
                 finalProperties[KEY_WAS_ECOMMERCE_TRIAL] = it.wasEcommerceTrial
                 finalProperties[KEY_PLAN_PRODUCT_SLUG] = it.planProductSlug
-                AppPrefsWrapper().getWCStoreID(it.siteId)?.let { id -> finalProperties[KEY_STORE_ID] = id }
+                appPrefs.getWCStoreID(it.siteId)?.let { id -> finalProperties[KEY_STORE_ID] = id }
             }
         }
         finalProperties[IS_DEBUG] = BuildConfig.DEBUG
@@ -653,8 +654,8 @@ class AnalyticsTracker private constructor(
                 }
             }
 
-        fun init(context: Context, selectedSite: SelectedSite) {
-            instance = AnalyticsTracker(context.applicationContext, selectedSite)
+        fun init(context: Context, selectedSite: SelectedSite, appPrefs: AppPrefs) {
+            instance = AnalyticsTracker(context.applicationContext, selectedSite, appPrefs)
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
             sendUsageStats = prefs.getBoolean(PREFKEY_SEND_USAGE_STATS, true)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import androidx.preference.PreferenceManager
 import com.automattic.android.tracks.TracksClient
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.analytics.AnalyticsEvent.BACK_PRESSED
 import com.woocommerce.android.analytics.AnalyticsEvent.VIEW_SHOWN
@@ -83,6 +84,7 @@ class AnalyticsTracker private constructor(
                 finalProperties[KEY_IS_WPCOM_STORE] = it.isWpComStore
                 finalProperties[KEY_WAS_ECOMMERCE_TRIAL] = it.wasEcommerceTrial
                 finalProperties[KEY_PLAN_PRODUCT_SLUG] = it.planProductSlug
+                finalProperties[KEY_STORE_ID] = AppPrefsWrapper().getWCStoreID(it.siteId)
             }
         }
         finalProperties[IS_DEBUG] = BuildConfig.DEBUG
@@ -138,6 +140,7 @@ class AnalyticsTracker private constructor(
         const val IS_DEBUG = "is_debug"
         const val KEY_ALREADY_READ = "already_read"
         const val KEY_BLOG_ID = "blog_id"
+        const val KEY_STORE_ID = "store_id"
         const val KEY_CONTEXT = "context"
         const val KEY_ERROR = "error"
         const val KEY_ERROR_CONTEXT = "error_context"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -84,7 +84,7 @@ class AnalyticsTracker private constructor(
                 finalProperties[KEY_IS_WPCOM_STORE] = it.isWpComStore
                 finalProperties[KEY_WAS_ECOMMERCE_TRIAL] = it.wasEcommerceTrial
                 finalProperties[KEY_PLAN_PRODUCT_SLUG] = it.planProductSlug
-                finalProperties[KEY_STORE_ID] = AppPrefsWrapper().getWCStoreID(it.siteId)
+                AppPrefsWrapper().getWCStoreID(it.siteId)?.let { id -> finalProperties[KEY_STORE_ID] = id }
             }
         }
         finalProperties[IS_DEBUG] = BuildConfig.DEBUG

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/environment/EnvironmentRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/environment/EnvironmentRestClient.kt
@@ -1,0 +1,39 @@
+package com.woocommerce.android.network.environment
+
+import com.google.gson.annotations.SerializedName
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.utils.toWooPayload
+import javax.inject.Inject
+
+/**
+ * Client that fetches the store environment from the system status API.
+ */
+class EnvironmentRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
+
+    /**
+     * Fetches the store environment. Currently, Only used to get the `store_id`
+     */
+    suspend fun fetchStoreEnvironment(site: SiteModel): WooPayload<EnvironmentDto> {
+        val url = WOOCOMMERCE.system_status.pathV3
+        val params = mapOf("_fields" to "environment")
+
+        return wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = EnvironmentResponse::class.java,
+            params = params
+        ).toWooPayload { environmentResponse ->
+            environmentResponse.environment
+        }
+    }
+
+    data class EnvironmentResponse(
+        @SerializedName("environment") val environment: EnvironmentDto
+    )
+
+    data class EnvironmentDto(
+        @SerializedName("store_id") var storeID: String? = null
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/environment/EnvironmentRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/environment/EnvironmentRestClient.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.network.environment
 
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.utils.toWooPayload

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -2,8 +2,6 @@ package com.woocommerce.android.tools
 
 import android.content.Context
 import androidx.preference.PreferenceManager
-import com.woocommerce.android.AppPrefs
-import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.util.PreferenceUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.tools
 
 import android.content.Context
 import androidx.preference.PreferenceManager
+import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.util.PreferenceUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/environment/EnvironmentRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/environment/EnvironmentRepository.kt
@@ -33,7 +33,7 @@ class EnvironmentRepository @Inject constructor(
                     WooResult(environmentResponse.error)
                 }
                 environmentResponse.result != null -> {
-                    val storeID = environmentResponse.result.storeID
+                    val storeID = environmentResponse.result!!.storeID
                     WooResult(storeID)
                 }
                 else -> WooResult(WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/environment/EnvironmentRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/environment/EnvironmentRepository.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.common.environment
 
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.network.environment.EnvironmentRestClient
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CoroutineDispatchers
@@ -28,7 +29,7 @@ class EnvironmentRepository @Inject constructor(
     suspend fun fetchOrGetStoreID(site: SiteModel = selectedSite.get()): WooResult<String?> {
         // If exists locally return it.
         val storedStoreID = appPrefsWrapper.getWCStoreID(site.siteId)
-        if (storedStoreID != null) {
+        if (storedStoreID.isNotNullOrEmpty()) {
             return WooResult(storedStoreID)
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/environment/EnvironmentRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/environment/EnvironmentRepository.kt
@@ -21,7 +21,7 @@ class EnvironmentRepository @Inject constructor(
     private val environmentRestClient: EnvironmentRestClient,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val dispatchers: CoroutineDispatchers
-){
+) {
     /**
      * Gets the `storeID`.
      * Can be retrieved locally or fetched from the remote source.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/environment/EnvironmentRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/environment/EnvironmentRepository.kt
@@ -1,0 +1,43 @@
+package com.woocommerce.android.ui.common.environment
+
+import com.woocommerce.android.network.environment.EnvironmentRestClient
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.CoroutineDispatchers
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import javax.inject.Inject
+
+/**
+ * Fetches, stores and delivers data from the Environment Rest Client.
+ */
+class EnvironmentRepository @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val environmentRestClient: EnvironmentRestClient,
+    private val dispatchers: CoroutineDispatchers
+){
+    /**
+     * Gets the `storeID`.
+     * Can be retrieved locally or fetched from the remote source.
+     */
+    suspend fun fetchOrGetStoreID(site: SiteModel = selectedSite.get()): WooResult<String?> {
+        // TODO: Store `storeID` locally
+        // TODO: Get `storeID` if locally available
+        return withContext(dispatchers.io) {
+            val environmentResponse = environmentRestClient.fetchStoreEnvironment(site)
+            when {
+                environmentResponse.isError -> {
+                    WooResult(environmentResponse.error)
+                }
+                environmentResponse.result != null -> {
+                    val storeID = environmentResponse.result.storeID
+                    WooResult(storeID)
+                }
+                else -> WooResult(WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes: #10159
<!-- Id number of the GitHub issue this PR addresses. -->

# Why 

This PR sends the newly added `store_id` property in every track event as requested in peaMlT-fG-p2.

This property will be available from WC 8.4 + version, since `8,4` has not been released yet, you will need the `WooCommerce Beta Tester` plugin to install it.

# How

- Created a new `EnvironmentRestClient` that will fetch the `store_id` property.

- Created some new methods on `AppPrefsWrapper` to save the `store_id` locally.

- Created a new `EnvironmentRepository` that orchestrates fetching and saving the `store_id`.

- Update `SiteObserver` to fetch or get the `store_id` when the site changes.

- Update `AnalyticsTracker` to inject the saved `store_id` into the track properties object.

# Screenshots

<img width="1667" alt="Screenshot 2023-11-29 at 12 51 51 PM" src="https://github.com/woocommerce/woocommerce-android/assets/562080/318328f3-ba4d-4ec2-ad0e-dffb03148fd8">

# Testing Steps

**Note: Make sure to update your WC store to a 8.4+ version using the `WooCommerce Beta Tester` plugin**

- Log in to the app and select your 8.4+ store
- Start navigating and tapping buttons
- See that the track events contains the `store_id` property.

- Log in to a store that has a 8.3- version
- Start navigating and tapping buttons
- See that the track events contain **do not** contain the `store_id` property.


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
