### PR TITLE
Feature/10287 open theme picker from settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -245,7 +245,10 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
 
         binding.optionSiteThemes.isVisible = presenter.isThemePickerOptionVisible
         binding.optionSiteThemes.setOnClickListener {
-            // TODO open store themes picker
+            findNavController()
+                .navigateSafely(
+                    MainSettingsFragmentDirections.actionMainSettingsFragmentToThemePickerFragment()
+                )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
@@ -165,7 +165,7 @@ private fun Carousel(items: List<CarouselItem>, onThemeTapped: (String) -> Unit)
     ) {
         items(items) { item ->
             when (item) {
-                is CarouselItem.Theme -> Theme(item.name, item.screenshotUrl, onThemeTapped)
+                is CarouselItem.Theme -> Theme(item, onThemeTapped)
                 is CarouselItem.Message -> Message(modifier = Modifier.width(320.dp), item.title, item.description)
             }
         }
@@ -212,15 +212,14 @@ private fun Message(
 
 @Composable
 private fun Theme(
-    name: String,
-    screenshotUrl: String,
+    theme: CarouselItem.Theme,
     onThemeTapped: (String) -> Unit
 ) {
     val themeModifier = Modifier.width(240.dp)
     Card(
         shape = RoundedCornerShape(dimensionResource(id = dimen.minor_100)),
         elevation = dimensionResource(id = dimen.minor_50),
-        modifier = themeModifier.clickable { onThemeTapped(screenshotUrl) }
+        modifier = themeModifier.clickable { onThemeTapped(theme.demoUri) }
     ) {
         val imageLoader = ImageLoader.Builder(LocalContext.current)
             .okHttpClient {
@@ -232,7 +231,7 @@ private fun Theme(
             .build()
 
         val request = ImageRequest.Builder(LocalContext.current)
-            .data(screenshotUrl)
+            .data(theme.screenshotUrl)
             .crossfade(true)
             .build()
 
@@ -247,7 +246,7 @@ private fun Theme(
                 is AsyncImagePainter.State.Error -> {
                     Message(
                         modifier = themeModifier,
-                        title = stringResource(id = string.theme_picker_carousel_placeholder_title, name),
+                        title = stringResource(id = string.theme_picker_carousel_placeholder_title, theme.name),
                         description = stringResource(id = string.theme_picker_carousel_placeholder_message)
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -44,7 +44,8 @@ class ThemePickerViewModel @Inject constructor(
                         carouselItems = result.map { theme ->
                             CarouselItem.Theme(
                                 name = theme.name,
-                                screenshotUrl = AppUrls.getScreenshotUrl(theme.demoUrl)
+                                screenshotUrl = AppUrls.getScreenshotUrl(theme.demoUrl),
+                                demoUri = theme.demoUrl
                             )
                         }.plus(
                             CarouselItem.Message(
@@ -90,7 +91,11 @@ class ThemePickerViewModel @Inject constructor(
         ) : ViewState {
             sealed class CarouselItem : Parcelable {
                 @Parcelize
-                data class Theme(val name: String, val screenshotUrl: String) : CarouselItem()
+                data class Theme(
+                    val name: String,
+                    val screenshotUrl: String,
+                    val demoUri: String
+                ) : CarouselItem()
 
                 @Parcelize
                 data class Message(val title: String, val description: String) : CarouselItem()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.network.UserAgent
@@ -19,11 +20,10 @@ class ThemePreviewViewModel @Inject constructor(
     val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
     val userAgent: UserAgent,
 ) : ScopedViewModel(savedStateHandle) {
+    private val navArgs: ThemePreviewFragmentArgs by savedStateHandle.navArgs()
     private val _viewState = savedStateHandle.getStateFlow(
         viewModelScope,
-        ViewState(
-            demoUri = "https://zainodemo.wpcomstaging.com/\" // TODO pass this as argument from previous screen"
-        )
+        ViewState(demoUri = navArgs.themeDemoUri)
     )
     val viewState = _viewState.asLiveData()
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -4,6 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph_settings"
     app:startDestination="@id/mainSettingsFragment">
+    <include app:graph="@navigation/nav_graph_jetpack_install" />
+    <include app:graph="@navigation/nav_graph_domain_change" />
+    <include app:graph="@navigation/nav_graph_themes" />
     <fragment
         android:id="@+id/mainSettingsFragment"
         android:name="com.woocommerce.android.ui.prefs.MainSettingsFragment"
@@ -48,6 +51,9 @@
         <action
             android:id="@+id/action_mainSettingsFragment_to_nameYourStoreDialogFragment"
             app:destination="@id/nameYourStoreDialogFragment" />
+        <action
+            android:id="@+id/action_mainSettingsFragment_to_themePickerFragment"
+            app:destination="@id/nav_graph_themes" />
     </fragment>
     <fragment
         android:id="@+id/privacySettingsFragment"
@@ -153,16 +159,14 @@
     <action
         android:id="@+id/action_global_WPComWebViewFragment"
         app:destination="@id/WPComWebViewFragment" />
-    <include app:graph="@navigation/nav_graph_jetpack_install" />
     <fragment
         android:id="@+id/developerOptionsFragment"
         android:name="com.woocommerce.android.ui.prefs.DeveloperOptionsFragment"
         android:label="DeveloperOptionsFragment" />
-    <include app:graph="@navigation/nav_graph_domain_change" />
     <fragment
         android:id="@+id/accountSettingsFragment"
         android:name="com.woocommerce.android.ui.prefs.account.AccountSettingsFragment"
-        android:label="AccountSettingsFragment" >
+        android:label="AccountSettingsFragment">
         <action
             android:id="@+id/action_accountSettingsFragment_to_closeAccountDialogFragment"
             app:destination="@id/closeAccountDialogFragment" />
@@ -174,11 +178,10 @@
     <dialog
         android:id="@+id/nameYourStoreDialogFragment"
         android:name="com.woocommerce.android.ui.login.storecreation.onboarding.NameYourStoreDialogFragment"
-        android:label="NameYourStoreDialogFragment" >
+        android:label="NameYourStoreDialogFragment">
         <argument
             android:name="fromOnboarding"
-            app:argType="boolean"
-            android:defaultValue="false" />
+            android:defaultValue="false"
+            app:argType="boolean" />
     </dialog>
-
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/nav_graph_store_creation"
     app:startDestination="@id/checkIapEligibilityFragment">
+    <include app:graph="@navigation/nav_graph_themes" />
 
     <fragment
         android:id="@+id/checkIapEligibilityFragment"
@@ -79,7 +80,7 @@
             app:destination="@id/storeCreationInstallationFragment" />
         <action
             android:id="@+id/action_storeProfilerFeaturesFragment_to_themePickerFragment"
-            app:destination="@id/themePickerFragment" />
+            app:destination="@id/nav_graph_themes" />
     </fragment>
 
     <fragment
@@ -146,23 +147,4 @@
             android:name="currentLocationCode"
             app:argType="string" />
     </fragment>
-    <fragment
-        android:id="@+id/themePickerFragment"
-        android:name="com.woocommerce.android.ui.themes.ThemePickerFragment"
-        android:label="ThemePickerFragment">
-        <action
-            android:id="@+id/action_themePickerFragment_to_storeCreationInstallationFragment"
-            app:destination="@id/storeCreationInstallationFragment" />
-        <action
-            android:id="@+id/action_themePickerFragment_to_themePreviewFragment"
-            app:destination="@id/themePreviewFragment">
-            <argument
-                android:name="themeDemoUri"
-                app:argType="string" />
-        </action>
-    </fragment>
-    <fragment
-        android:id="@+id/themePreviewFragment"
-        android:name="com.woocommerce.android.ui.themes.ThemePreviewFragment"
-        android:label="ThemePreviewFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_themes.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_themes.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph_themes"
+    app:startDestination="@id/themePickerFragment">
+    <fragment
+        android:id="@+id/themePickerFragment"
+        android:name="com.woocommerce.android.ui.themes.ThemePickerFragment"
+        android:label="ThemePickerFragment">
+        <action
+            android:id="@+id/action_themePickerFragment_to_storeCreationInstallationFragment"
+            app:destination="@id/storeCreationInstallationFragment" />
+        <action
+            android:id="@+id/action_themePickerFragment_to_themePreviewFragment"
+            app:destination="@id/themePreviewFragment">
+            <argument
+                android:name="themeDemoUri"
+                app:argType="string" />
+        </action>
+    </fragment>
+    <fragment
+        android:id="@+id/themePreviewFragment"
+        android:name="com.woocommerce.android.ui.themes.ThemePreviewFragment"
+        android:label="ThemePreviewFragment" />
+</navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_themes.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_themes.xml
@@ -21,5 +21,9 @@
     <fragment
         android:id="@+id/themePreviewFragment"
         android:name="com.woocommerce.android.ui.themes.ThemePreviewFragment"
-        android:label="ThemePreviewFragment" />
+        android:label="ThemePreviewFragment">
+        <argument
+            android:name="themeDemoUri"
+            app:argType="string" />
+    </fragment>
 </navigation>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10287 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the required changes to open the theme picker from settings. 
- Extracted `ThemePickerFragment` in the nav_graphs XML to its own `nav_graph_themes` so it can be reused from store creation flow and settings
- Adds minor refactor to pass the correct URL to the ThemePrevierw screen

### Testing instructions
1. Log into a WP.com Atomic site 
2. Go to settings and click on `Themes` option
3. Check the theme picker is opened
4. Click on any of the themes from the carousel and check the correct URL is loaded

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/2663464/1d269d2f-1a88-4ddd-8af5-6c7e08027f6e

