### PR TITLE
Design feedback bundle products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/GetProductConfiguration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/GetProductConfiguration.kt
@@ -31,6 +31,15 @@ class GetProductConfiguration @Inject constructor(
                 saveVariableConfiguration(configuration, child)
             }
         }
+        if (children?.isNotEmpty() == true) {
+            val includedChildren =
+                filteredChildren?.mapNotNull { child -> child.item.configurationKey }?.toSet() ?: emptySet()
+            val notIncludedChildren = childrenConfiguration?.keys?.let { it - includedChildren }
+            notIncludedChildren?.forEach { key ->
+                childrenConfiguration[key]?.let { configuration -> removeFromOrder(configuration) }
+            }
+        }
+
         val configurationType = rules.productType.getConfigurationType()
         return ProductConfiguration(rules, configurationType, itemConfiguration, childrenConfiguration)
     }
@@ -50,6 +59,14 @@ class GetProductConfiguration @Inject constructor(
     ) {
         if (configuration.containsKey(OptionalRule.KEY)) {
             configuration[OptionalRule.KEY] = true.toString()
+        }
+    }
+
+    private fun removeFromOrder(configuration: MutableMap<String, String?>) {
+        if (configuration.containsKey(OptionalRule.KEY)) {
+            configuration[OptionalRule.KEY] = false.toString()
+        } else if (configuration.containsKey(QuantityRule.KEY)) {
+            configuration[QuantityRule.KEY] = 0f.toString()
         }
     }
     private suspend fun saveVariableConfiguration(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductRules.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductRules.kt
@@ -179,7 +179,6 @@ class ProductConfiguration(
             val isVariable = entry.value.containsKey(VariableProductRule.KEY)
             val attributesAreNullOrEmpty = entry.value[VariableProductRule.KEY].isNullOrEmpty()
 
-
             if (isIncluded && itemQuantity > 0f && isVariable && attributesAreNullOrEmpty) {
                 result[entry.key] = resourceProvider.getString(R.string.configuration_variable_selection)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductRules.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductRules.kt
@@ -67,7 +67,7 @@ class QuantityRule(val quantityMin: Float?, val quantityMax: Float?, val quantit
 
     override fun getInitialValue(): String? = quantityDefault?.toString()
 
-    fun getRuleBounds(resourceProvider: ResourceProvider): String {
+    fun getRuleBounds(resourceProvider: ResourceProvider, childrenQuantity: Float): String {
         return when {
             quantityMin != null && quantityMax != null && quantityMin == quantityMax -> {
                 StringUtils.getQuantityString(
@@ -100,6 +100,9 @@ class QuantityRule(val quantityMin: Float?, val quantityMax: Float?, val quantit
                 )
             }
 
+            childrenQuantity == 0f -> {
+                resourceProvider.getString(R.string.configuration_quantity_item, 1)
+            }
             else -> StringUtils.EMPTY
         }
     }
@@ -163,8 +166,8 @@ class ProductConfiguration(
 
             val isMinimumOutOfBounds = childrenQuantity < (itemQuantityRule.quantityMin ?: Float.NEGATIVE_INFINITY)
             val isMaximumOutOfBounds = childrenQuantity > (itemQuantityRule.quantityMax ?: Float.MAX_VALUE)
-            if (isMinimumOutOfBounds || isMaximumOutOfBounds) {
-                val ruleBounds = itemQuantityRule.getRuleBounds(resourceProvider)
+            if (isMinimumOutOfBounds || isMaximumOutOfBounds || childrenQuantity == 0f) {
+                val ruleBounds = itemQuantityRule.getRuleBounds(resourceProvider, childrenQuantity)
                 result[PARENT_KEY] = resourceProvider.getString(R.string.configuration_quantity_rule_issue, ruleBounds)
             }
         }


### PR DESCRIPTION
## Description
This PR includes two main changes. The first one is a small workaround for optional variable products included in a bundle, and the second one is a validation to prevent the app from creating bundles without any product.

The workaround description: 

> When a bundle includes an optional variable item, even though the variable item isn't selected, the bundle can't be saved properly before this PR (the selected child item(s) don't appear in the order, only the parent bundle item). After some API testing (direct API requests to the site instead of Jetpack requests show an error), it looks like the API expects a **valid** variation ID and attributes (not just any placeholder values) even though a variable item isn't selected. Before this PR, if a variable item is optional and not selected, the item is skipped in the bundle configuration field in the API. This PR fixes this issue by introducing a workaround to include the optional & non-selected variable item by using a placeholder variation ID and attributes.

> This feels like an unexpected API behavior, I'll make sure to include this as a feature request to the extension owner after wrapping up the project. I also added this behavior to 
Pe5pgL-3Vd-p2#some-gotchas.

iOS PR: https://github.com/woocommerce/woocommerce-ios/pull/11222

The design request:

> I think that this might just be a badly set up bundle, but it’s possible to add this bundle without any child products.

pe5pgL-42P-p2#comment-3288


## Testing instructions
TC1
Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product with **1 optional variable item with non-empty variations** and another non-optional item.

- Go to the orders tab
- Tap `+` to create an order
- Tap `Add Products` and select the bundle product in the prerequisite
- Configure the non-optional item if needed so that configuration is valid and contains at least one child item, then tap `Done` to save the bundle
- Tap `1 Product Selected` to confirm product selection
- Tap `Create` to create the order --> the bundle product should be added with the child item(s) to the order

TC2
Prerequisite: the store has [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and also a bundle product where all the products as a min quantity of 0 and the default quantity is 0.

- Go to the orders tab
- Tap `+` to create an order
- Tap `Add Products` and select the bundle product in the prerequisite
- Check that you can't create the bundle unless you add at least one product to the bundle



<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->