### PR TITLE
Feature/10262 display theme pages in bottom sheet

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -180,7 +180,10 @@ private fun DemoSectionsToolbar(
                 Icon(
                     modifier = Modifier
                         .size(dimensionResource(id = R.dimen.major_100))
-                        .padding(start = dimensionResource(id = R.dimen.minor_50)),
+                        .padding(
+                            start = dimensionResource(id = R.dimen.minor_50),
+                            top = dimensionResource(id = R.dimen.minor_75),
+                        ),
                     painter = painterResource(drawable.ic_arrow_down),
                     contentDescription = "",
                     tint = colorResource(id = color.color_on_surface)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -121,6 +121,7 @@ fun ThemePreviewScreen(
                 userAgent = userAgent,
                 wpComAuthenticator = wpComWebViewAuthenticator,
                 activityRegistry = activityRegistry,
+                captureBackPresses = false,
                 modifier = Modifier
                     .padding(paddingValues)
                     .fillMaxSize()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -5,12 +5,15 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -32,12 +35,15 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.compose.component.BottomSheetHandle
 import com.woocommerce.android.ui.compose.component.WCWebView
+import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ThemeDemoPage
 import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ViewState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -69,7 +75,7 @@ fun ThemePreviewScreen(
     userAgent: UserAgent,
     wpComWebViewAuthenticator: WPComWebViewAuthenticator,
     activityRegistry: ActivityResultRegistry,
-    onPageSelected: (String) -> Unit,
+    onPageSelected: (ThemeDemoPage) -> Unit,
     onBackNavigationClicked: () -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -91,16 +97,19 @@ fun ThemePreviewScreen(
         else ModalBottomSheetDefaults.scrimColor,
         sheetContent = {
             ThemeDemoPagesBottomSheet(
+                pages = state.themePages,
                 onPageSelected = {
                     coroutineScope.launch { modalSheetState.hide() }
                     onPageSelected(it)
-                }
+                },
+                modifier = Modifier.fillMaxWidth()
             )
         }
     ) {
         Scaffold(
             topBar = {
                 CustomToolbar(
+                    state,
                     coroutineScope,
                     modalSheetState,
                     onBackNavigationClicked
@@ -124,6 +133,7 @@ fun ThemePreviewScreen(
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun CustomToolbar(
+    state: ViewState,
     coroutineScope: CoroutineScope,
     modalSheetState: ModalBottomSheetState,
     onBackNavigationClicked: () -> Unit
@@ -145,11 +155,13 @@ private fun CustomToolbar(
             modifier = Modifier
                 .padding(start = 24.dp)
                 .clickable {
-                    coroutineScope.launch {
-                        if (modalSheetState.isVisible)
-                            modalSheetState.hide()
-                        else {
-                            modalSheetState.show()
+                    if (state.themePages.isNotEmpty()) {
+                        coroutineScope.launch {
+                            if (modalSheetState.isVisible)
+                                modalSheetState.hide()
+                            else {
+                                modalSheetState.show()
+                            }
                         }
                     }
                 }
@@ -161,11 +173,13 @@ private fun CustomToolbar(
             )
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = "Home ",
+                    text = "Home",
                     style = MaterialTheme.typography.caption,
                 )
                 Icon(
-                    modifier = Modifier.size(16.dp),
+                    modifier = Modifier
+                        .size(16.dp)
+                        .padding(start = 4.dp),
                     painter = painterResource(drawable.ic_arrow_down),
                     contentDescription = "",
                     tint = colorResource(id = color.color_on_surface)
@@ -176,9 +190,46 @@ private fun CustomToolbar(
 }
 
 @Composable
-@Suppress("UNUSED_PARAMETER")
 private fun ThemeDemoPagesBottomSheet(
-    onPageSelected: (String) -> Unit,
+    pages: List<ThemeDemoPage>,
+    onPageSelected: (ThemeDemoPage) -> Unit,
+    modifier: Modifier = Modifier
 ) {
-    Text(text = "ThemeDemoPagesBottomSheet")
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+        BottomSheetHandle(Modifier.align(Alignment.CenterHorizontally))
+        Text(
+            modifier = Modifier
+                .padding(
+                    start = dimensionResource(id = R.dimen.major_100),
+                    bottom = dimensionResource(id = R.dimen.minor_100)
+                )
+                .align(Alignment.CenterHorizontally),
+            text = stringResource(id = R.string.theme_preview_bottom_sheet_pages_title),
+            style = MaterialTheme.typography.h6,
+        )
+        Text(
+            modifier = Modifier
+                .padding(
+                    start = dimensionResource(id = R.dimen.major_100),
+                    bottom = dimensionResource(id = R.dimen.minor_100)
+                )
+                .align(Alignment.CenterHorizontally),
+            text = stringResource(id = R.string.theme_preview_bottom_sheet_pages_subtitle),
+            style = MaterialTheme.typography.subtitle2,
+        )
+        Divider()
+        pages.forEach { page ->
+            Text(
+                text = page.title,
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier
+                    .clickable { onPageSelected(page) }
+                    .padding(dimensionResource(id = R.dimen.minor_100))
+            )
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -173,7 +173,7 @@ private fun DemoSectionsToolbar(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = state.themePages.firstOrNull { it.isLoaded }?.title
-                        ?: stringResource(id = R.string.theme_preview_default_page_loaded),
+                        ?: stringResource(id = R.string.theme_preview_bottom_sheet_home_section),
                     style = MaterialTheme.typography.caption,
                 )
                 Icon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -107,7 +107,7 @@ fun ThemePreviewScreen(
     ) {
         Scaffold(
             topBar = {
-                CustomToolbar(
+                DemoSectionsToolbar(
                     state,
                     coroutineScope,
                     modalSheetState,
@@ -131,7 +131,7 @@ fun ThemePreviewScreen(
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-private fun CustomToolbar(
+private fun DemoSectionsToolbar(
     state: ViewState,
     coroutineScope: CoroutineScope,
     modalSheetState: ModalBottomSheetState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
@@ -149,11 +148,11 @@ private fun CustomToolbar(
             contentDescription = "",
             modifier = Modifier
                 .clickable { onBackNavigationClicked() }
-                .padding(16.dp)
+                .padding(dimensionResource(id = R.dimen.major_100))
         )
         Column(
             modifier = Modifier
-                .padding(start = 24.dp)
+                .padding(start = dimensionResource(id = R.dimen.major_150))
                 .clickable {
                     if (state.themePages.isNotEmpty()) {
                         coroutineScope.launch {
@@ -165,7 +164,7 @@ private fun CustomToolbar(
                         }
                     }
                 }
-                .padding(16.dp)
+                .padding(dimensionResource(id = R.dimen.major_100))
         ) {
             Text(
                 text = stringResource(id = string.theme_preview_title),
@@ -179,8 +178,8 @@ private fun CustomToolbar(
                 )
                 Icon(
                     modifier = Modifier
-                        .size(16.dp)
-                        .padding(start = 4.dp),
+                        .size(dimensionResource(id = R.dimen.major_100))
+                        .padding(start = dimensionResource(id = R.dimen.minor_50)),
                     painter = painterResource(drawable.ic_arrow_down),
                     contentDescription = "",
                     tint = colorResource(id = color.color_on_surface)
@@ -199,14 +198,13 @@ private fun ThemeDemoPagesBottomSheet(
     Column(modifier = modifier) {
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
         BottomSheetHandle(Modifier.align(Alignment.CenterHorizontally))
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
         Text(
             modifier = Modifier
                 .padding(
                     start = dimensionResource(id = R.dimen.major_100),
-                    bottom = dimensionResource(id = R.dimen.minor_100),
                     top = dimensionResource(id = R.dimen.minor_100)
-                )
-                .align(Alignment.CenterHorizontally),
+                ),
             text = stringResource(id = R.string.theme_preview_bottom_sheet_pages_title),
             style = MaterialTheme.typography.h6,
         )
@@ -215,22 +213,29 @@ private fun ThemeDemoPagesBottomSheet(
                 .padding(
                     start = dimensionResource(id = R.dimen.major_100),
                     bottom = dimensionResource(id = R.dimen.minor_100)
-                )
-                .align(Alignment.CenterHorizontally),
+                ),
             text = stringResource(id = R.string.theme_preview_bottom_sheet_pages_subtitle),
             style = MaterialTheme.typography.subtitle2,
             color = colorResource(id = R.color.color_on_surface_medium)
         )
         Divider()
-        pages.forEach { page ->
+        pages.forEachIndexed { index, page ->
             Text(
                 text = page.title,
                 style = MaterialTheme.typography.body1,
                 modifier = Modifier
                     .clickable { onPageSelected(page) }
                     .fillMaxWidth()
-                    .padding(dimensionResource(id = R.dimen.minor_100))
+                    .padding(
+                        top = dimensionResource(id = R.dimen.major_85),
+                        start = dimensionResource(id = R.dimen.major_100),
+                        end = dimensionResource(id = R.dimen.major_100),
+                        bottom = dimensionResource(id = R.dimen.major_85)
+                    )
             )
+            if (index == pages.lastIndex) {
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_150)))
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -173,7 +173,8 @@ private fun CustomToolbar(
             )
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = "Home",
+                    text = state.themePages.firstOrNull { it.isLoaded }?.title
+                        ?: stringResource(id = R.string.theme_preview_default_page_loaded),
                     style = MaterialTheme.typography.caption,
                 )
                 Icon(
@@ -195,17 +196,15 @@ private fun ThemeDemoPagesBottomSheet(
     onPageSelected: (ThemeDemoPage) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
+    Column(modifier = modifier) {
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
         BottomSheetHandle(Modifier.align(Alignment.CenterHorizontally))
         Text(
             modifier = Modifier
                 .padding(
                     start = dimensionResource(id = R.dimen.major_100),
-                    bottom = dimensionResource(id = R.dimen.minor_100)
+                    bottom = dimensionResource(id = R.dimen.minor_100),
+                    top = dimensionResource(id = R.dimen.minor_100)
                 )
                 .align(Alignment.CenterHorizontally),
             text = stringResource(id = R.string.theme_preview_bottom_sheet_pages_title),
@@ -220,6 +219,7 @@ private fun ThemeDemoPagesBottomSheet(
                 .align(Alignment.CenterHorizontally),
             text = stringResource(id = R.string.theme_preview_bottom_sheet_pages_subtitle),
             style = MaterialTheme.typography.subtitle2,
+            color = colorResource(id = R.color.color_on_surface_medium)
         )
         Divider()
         pages.forEach { page ->
@@ -228,6 +228,7 @@ private fun ThemeDemoPagesBottomSheet(
                 style = MaterialTheme.typography.body1,
                 modifier = Modifier
                     .clickable { onPageSelected(page) }
+                    .fillMaxWidth()
                     .padding(dimensionResource(id = R.dimen.minor_100))
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -1,34 +1,45 @@
 package com.woocommerce.android.ui.themes
 
 import androidx.activity.result.ActivityResultRegistry
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetDefaults
 import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material.ModalBottomSheetValue.HalfExpanded
 import androidx.compose.material.ModalBottomSheetValue.Hidden
 import androidx.compose.material.Scaffold
-import androidx.compose.material.icons.Icons.Filled
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.Text
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
+import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
-import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCWebView
 import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ViewState
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.UserAgent
 
@@ -89,10 +100,10 @@ fun ThemePreviewScreen(
     ) {
         Scaffold(
             topBar = {
-                Toolbar(
-                    title = stringResource(id = string.theme_preview_title),
-                    navigationIcon = Filled.ArrowBack,
-                    onNavigationButtonClick = onBackNavigationClicked,
+                CustomToolbar(
+                    coroutineScope,
+                    modalSheetState,
+                    onBackNavigationClicked
                 )
             },
             backgroundColor = MaterialTheme.colors.surface
@@ -110,10 +121,64 @@ fun ThemePreviewScreen(
     }
 }
 
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun CustomToolbar(
+    coroutineScope: CoroutineScope,
+    modalSheetState: ModalBottomSheetState,
+    onBackNavigationClicked: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .wrapContentHeight()
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(drawable.ic_gridicons_cross_24dp),
+            contentDescription = "",
+            modifier = Modifier
+                .clickable { onBackNavigationClicked() }
+                .padding(16.dp)
+        )
+        Column(
+            modifier = Modifier
+                .padding(start = 24.dp)
+                .clickable {
+                    coroutineScope.launch {
+                        if (modalSheetState.isVisible)
+                            modalSheetState.hide()
+                        else {
+                            modalSheetState.show()
+                        }
+                    }
+                }
+                .padding(16.dp)
+        ) {
+            Text(
+                text = stringResource(id = string.theme_preview_title),
+                style = MaterialTheme.typography.body1,
+            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "Home ",
+                    style = MaterialTheme.typography.caption,
+                )
+                Icon(
+                    modifier = Modifier.size(16.dp),
+                    painter = painterResource(drawable.ic_arrow_down),
+                    contentDescription = "",
+                    tint = colorResource(id = color.color_on_surface)
+                )
+            }
+        }
+    }
+}
+
 @Composable
 @Suppress("UNUSED_PARAMETER")
 private fun ThemeDemoPagesBottomSheet(
     onPageSelected: (String) -> Unit,
 ) {
-    // TODO display demo pager here
+    Text(text = "ThemeDemoPagesBottomSheet")
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -4,8 +4,10 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
@@ -22,6 +24,7 @@ class ThemePreviewViewModel @Inject constructor(
     val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
     val userAgent: UserAgent,
     val themeCoroutineStore: ThemeCoroutineStore,
+    val resourceProvider: ResourceProvider
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: ThemePreviewFragmentArgs by savedStateHandle.navArgs()
     private val _viewState = savedStateHandle.getStateFlow(
@@ -37,7 +40,14 @@ class ThemePreviewViewModel @Inject constructor(
         launch {
             val themePages = themeCoroutineStore.fetchDemoThemePages(navArgs.themeDemoUri)
             _viewState.value = _viewState.value.copy(
-                themePages = themePages.map {
+                themePages =
+                listOf(
+                    ThemeDemoPage(
+                        uri = navArgs.themeDemoUri,
+                        title = resourceProvider.getString(R.string.theme_preview_bottom_sheet_home_section),
+                        isLoaded = true
+                    )
+                ) + themePages.map {
                     ThemeDemoPage(
                         uri = it.link,
                         title = it.title,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -64,7 +64,7 @@ class ThemePreviewViewModel @Inject constructor(
             themePages = _viewState.value.themePages.map {
                 if (it.uri == demoPage.uri)
                     it.copy(isLoaded = true)
-                else it
+                else it.copy(isLoaded = false)
             }
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -40,15 +40,23 @@ class ThemePreviewViewModel @Inject constructor(
                 themePages = themePages.map {
                     ThemeDemoPage(
                         uri = it.link,
-                        title = it.title
+                        title = it.title,
+                        isLoaded = false
                     )
                 }
             )
         }
     }
 
-    fun onPageSelected(updatedDemoUri: String) {
-        _viewState.value = _viewState.value.copy(demoUri = updatedDemoUri)
+    fun onPageSelected(demoPage: ThemeDemoPage) {
+        _viewState.value = _viewState.value.copy(
+            demoUri = demoPage.uri,
+            themePages = _viewState.value.themePages.map {
+                if (it.uri == demoPage.uri)
+                    it.copy(isLoaded = true)
+                else it
+            }
+        )
     }
 
     fun onBackNavigationClicked() {
@@ -64,6 +72,7 @@ class ThemePreviewViewModel @Inject constructor(
     @Parcelize
     data class ThemeDemoPage(
         val uri: String,
-        val title: String
+        val title: String,
+        val isLoaded: Boolean
     ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -10,8 +10,10 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.store.ThemeCoroutineStore
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,13 +21,31 @@ class ThemePreviewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
     val userAgent: UserAgent,
+    val themeCoroutineStore: ThemeCoroutineStore,
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: ThemePreviewFragmentArgs by savedStateHandle.navArgs()
     private val _viewState = savedStateHandle.getStateFlow(
         viewModelScope,
-        ViewState(demoUri = navArgs.themeDemoUri)
+        ViewState(
+            demoUri = navArgs.themeDemoUri,
+            themePages = emptyList()
+        )
     )
     val viewState = _viewState.asLiveData()
+
+    init {
+        launch {
+            val themePages = themeCoroutineStore.fetchDemoThemePages(navArgs.themeDemoUri)
+            _viewState.value = _viewState.value.copy(
+                themePages = themePages.map {
+                    ThemeDemoPage(
+                        uri = it.link,
+                        title = it.title
+                    )
+                }
+            )
+        }
+    }
 
     fun onPageSelected(updatedDemoUri: String) {
         _viewState.value = _viewState.value.copy(demoUri = updatedDemoUri)
@@ -38,5 +58,12 @@ class ThemePreviewViewModel @Inject constructor(
     @Parcelize
     data class ViewState(
         val demoUri: String,
+        val themePages: List<ThemeDemoPage>
+    ) : Parcelable
+
+    @Parcelize
+    data class ThemeDemoPage(
+        val uri: String,
+        val title: String
     ) : Parcelable
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3378,6 +3378,7 @@
     <string name="theme_picker_error_title">An error occurred</string>
     <string name="theme_picker_error_message">Unable to load themes at this time.</string>
     <string name="theme_preview_title">Preview</string>
+    <string name="theme_preview_default_page_loaded">Home</string>
     <string name="theme_preview_bottom_sheet_pages_title">Pages on this template</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">Tap to view</string>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3378,6 +3378,8 @@
     <string name="theme_picker_error_title">An error occurred</string>
     <string name="theme_picker_error_message">Unable to load themes at this time.</string>
     <string name="theme_preview_title">Preview</string>
+    <string name="theme_preview_bottom_sheet_pages_title">Pages on this template</string>
+    <string name="theme_preview_bottom_sheet_pages_subtitle">Tap to view</string>
 
     <!--
     Store onboarding

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3381,6 +3381,7 @@
     <string name="theme_preview_default_page_loaded">Home</string>
     <string name="theme_preview_bottom_sheet_pages_title">Pages on this template</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">Tap to view</string>
+    <string name="theme_preview_bottom_sheet_home_section">Home</string>
 
     <!--
     Store onboarding

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3378,7 +3378,6 @@
     <string name="theme_picker_error_title">An error occurred</string>
     <string name="theme_picker_error_message">Unable to load themes at this time.</string>
     <string name="theme_preview_title">Preview</string>
-    <string name="theme_preview_default_page_loaded">Home</string>
     <string name="theme_preview_bottom_sheet_pages_title">Pages on this template</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">Tap to view</string>
     <string name="theme_preview_bottom_sheet_home_section">Home</string>

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-18c68443fe3c2cf2ff87e55592ea449f60c9472b'
+    fluxCVersion = '2910-3505370c8a9cd2428a35a62f8e1591ae86ec4dda'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2910-3505370c8a9cd2428a35a62f8e1591ae86ec4dda'
+    fluxCVersion = 'trunk-059925004026943c8bb4b42e6637da21fb1463e3'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10262 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds bottomsheet displaying the different sections the demo theme has available. Clicking on any of the sections will load that theme section. Note that I haven't added translations for the different sections because I think they should be displayed exactly as they are rendered in the webview. So, IMO we should display the pages names using the value that comes directly from the API. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Navigate to theme picker from settings (you'll need to be logged in a WP.com site) 
2. Select any theme from the carousel 
3. Click on the toolbar section and select any of the pages displayed in the bottom sheet. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/eabc179b-04ed-466e-b1d1-23e9fb4e3a8b

