### PR TITLE
[Themes] Handle theme activation during store creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -120,6 +120,8 @@ object AppPrefs {
         AI_PRODUCT_CREATION_IS_FIRST_ATTEMPT,
         BLAZE_CELEBRATION_SCREEN_SHOWN,
         MY_STORE_BLAZE_VIEW_DISMISSED,
+        CREATED_STORE_SITE_ID,
+        CREATED_STORE_THEME_ID,
     }
 
     /**
@@ -278,6 +280,22 @@ object AppPrefs {
                 remove(DeletablePrefKey.STORE_CREATION_PROFILER_ANSWERS)
             }
         }
+
+    /**
+     * Persists the ID of the last created site in case the app was closed while the site was being created.
+     * This allows to switch to the newly created site when the app is opened again.
+     */
+    var createdStoreSiteId: Long?
+        get() = getLong(DeletablePrefKey.CREATED_STORE_SITE_ID, -1).takeIf { it != -1L }
+        set(value) = setLong(DeletablePrefKey.CREATED_STORE_SITE_ID, value ?: -1)
+
+    /**
+     * Persists the ID of the selected theme for the last created site in case the app was closed while the
+     * site was being created.
+     */
+    var themeIdForCreatedStore: String?
+        get() = getString(DeletablePrefKey.CREATED_STORE_THEME_ID).orNullIfEmpty()
+        set(value) = setString(DeletablePrefKey.CREATED_STORE_THEME_ID, value ?: "")
 
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -289,14 +289,6 @@ object AppPrefs {
         get() = getLong(DeletablePrefKey.CREATED_STORE_SITE_ID, -1).takeIf { it != -1L }
         set(value) = setLong(DeletablePrefKey.CREATED_STORE_SITE_ID, value ?: -1)
 
-    /**
-     * Persists the ID of the selected theme for the last created site in case the app was closed while the
-     * site was being created.
-     */
-    var themeIdForCreatedStore: String?
-        get() = getString(DeletablePrefKey.CREATED_STORE_THEME_ID).orNullIfEmpty()
-        set(value) = setString(DeletablePrefKey.CREATED_STORE_THEME_ID, value ?: "")
-
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()
 
     fun setProductSortingChoice(currentSiteId: Int, value: String) {
@@ -1161,6 +1153,25 @@ object AppPrefs {
 
     fun disableAutoTaxRate() {
         remove(AUTO_TAX_RATE_ID)
+    }
+
+    fun saveThemeIdForStoreCreation(siteId: Long, themeId: String) {
+        setString(DeletablePrefKey.CREATED_STORE_THEME_ID, "$siteId:$themeId")
+    }
+
+    fun clearThemeIdForStoreCreation() {
+        remove(DeletablePrefKey.CREATED_STORE_THEME_ID)
+    }
+
+    fun getThemeIdForStoreCreation(siteId: Long): String? {
+        return getString(DeletablePrefKey.CREATED_STORE_THEME_ID).orNullIfEmpty()?.let {
+            val split = it.split(":")
+            if (split.size == 2 && split[0].toLong() == siteId) {
+                split[1]
+            } else {
+                null
+            }
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -24,7 +24,6 @@ class AppPrefsWrapper @Inject constructor() {
      */
     var themeIdForCreatedStore: String? by AppPrefs::themeIdForCreatedStore
 
-
     fun getAppInstallationDate() = AppPrefs.installationDate
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -18,11 +18,6 @@ class AppPrefsWrapper @Inject constructor() {
      * This allows to switch to the newly created site when the app is opened again.
      */
     var createdStoreSiteId: Long? by AppPrefs::createdStoreSiteId
-    /**
-     * Persists the ID of the selected theme for the last created site in case the app was closed while the
-     * site was being created.
-     */
-    var themeIdForCreatedStore: String? by AppPrefs::themeIdForCreatedStore
 
     fun getAppInstallationDate() = AppPrefs.installationDate
 
@@ -380,4 +375,11 @@ class AppPrefsWrapper @Inject constructor() {
         AppPrefs.isTimezoneTrackEventTriggeredFor(siteId, localTimezone, storeTimezone).not()
 
     var wasAIProductDescriptionCelebrationShown by AppPrefs::wasAIProductDescriptionCelebrationShown
+
+    fun saveThemeIdForStoreCreation(siteId: Long, themeId: String) =
+        AppPrefs.saveThemeIdForStoreCreation(siteId, themeId)
+
+    fun clearThemeIdForStoreCreation() = AppPrefs.clearThemeIdForStoreCreation()
+
+    fun getThemeIdForStoreCreation(siteId: Long): String? = AppPrefs.getThemeIdForStoreCreation(siteId)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -13,6 +13,18 @@ import javax.inject.Inject
 class AppPrefsWrapper @Inject constructor() {
     var storeCreationProfilerAnswers by AppPrefs::storeCreationProfilerAnswers
 
+    /**
+     * Persists the ID of the last created site in case the app was closed while the site was being created.
+     * This allows to switch to the newly created site when the app is opened again.
+     */
+    var createdStoreSiteId: Long? by AppPrefs::createdStoreSiteId
+    /**
+     * Persists the ID of the selected theme for the last created site in case the app was closed while the
+     * site was being created.
+     */
+    var themeIdForCreatedStore: String? by AppPrefs::themeIdForCreatedStore
+
+
     fun getAppInstallationDate() = AppPrefs.installationDate
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -19,6 +19,22 @@ class AppPrefsWrapper @Inject constructor() {
      */
     var createdStoreSiteId: Long? by AppPrefs::createdStoreSiteId
 
+    var savedPrivacyBannerSettings by AppPrefs::savedPrivacySettings
+
+    var wasAIProductDescriptionPromoDialogShown by AppPrefs::wasAIProductDescriptionPromoDialogShown
+
+    var isAIProductDescriptionTooltipDismissed by AppPrefs::isAIProductDescriptionTooltipDismissed
+
+    var aiContentGenerationTone by AppPrefs::aiContentGenerationTone
+
+    var aiProductCreationIsFirstAttempt by AppPrefs::aiProductCreationIsFirstAttempt
+
+    var isBlazeCelebrationScreenShown by AppPrefs::isBlazeCelebrationScreenShown
+
+    var isMyStoreBlazeViewDismissed by AppPrefs::isMyStoreBlazeViewDismissed
+
+    var wasAIProductDescriptionCelebrationShown by AppPrefs::wasAIProductDescriptionCelebrationShown
+
     fun getAppInstallationDate() = AppPrefs.installationDate
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =
@@ -344,20 +360,6 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun getStorePhoneNumber(siteId: Int): String = AppPrefs.getStorePhoneNumber(siteId)
 
-    var savedPrivacyBannerSettings by AppPrefs::savedPrivacySettings
-
-    var wasAIProductDescriptionPromoDialogShown by AppPrefs::wasAIProductDescriptionPromoDialogShown
-
-    var isAIProductDescriptionTooltipDismissed by AppPrefs::isAIProductDescriptionTooltipDismissed
-
-    var aiContentGenerationTone by AppPrefs::aiContentGenerationTone
-
-    var aiProductCreationIsFirstAttempt by AppPrefs::aiProductCreationIsFirstAttempt
-
-    var isBlazeCelebrationScreenShown by AppPrefs::isBlazeCelebrationScreenShown
-
-    var isMyStoreBlazeViewDismissed by AppPrefs::isMyStoreBlazeViewDismissed
-
     fun recordAIDescriptionTooltipShown() = AppPrefs.incrementAIDescriptionTooltipShownNumber()
     fun getAIDescriptionTooltipShownNumber() = AppPrefs.getAIDescriptionTooltipShownNumber()
 
@@ -373,8 +375,6 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun isTimezoneTrackEventNeverTriggeredFor(siteId: Long, localTimezone: String, storeTimezone: String) =
         AppPrefs.isTimezoneTrackEventTriggeredFor(siteId, localTimezone, storeTimezone).not()
-
-    var wasAIProductDescriptionCelebrationShown by AppPrefs::wasAIProductDescriptionCelebrationShown
 
     fun saveThemeIdForStoreCreation(siteId: Long, themeId: String) =
         AppPrefs.saveThemeIdForStoreCreation(siteId, themeId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
@@ -69,3 +69,9 @@ val SiteModel?.isSitePublic: Boolean
 
 val SiteModel.isEligibleForAI: Boolean
     get() = isWPComAtomic || planActiveFeatures.orEmpty().contains("ai-assistant")
+
+val SiteModel?.isWooExpressSiteReadyToUse: Boolean
+    get() = this?.isJetpackInstalled == true &&
+        this.isJetpackConnected &&
+        this.isWpComStore &&
+        this.hasWooCommerce

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/ComposeViewBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/ComposeViewBuilder.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.ui.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+/**
+ * Creates a [ComposeView] with the [ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed] composition strategy,
+ * and the [WooThemeWithBackground] as the root composable.
+ *
+ * @param content The content of the [WooThemeWithBackground].
+ */
+fun Fragment.composeView(content: @Composable () -> Unit) = ComposeView(requireContext()).apply {
+    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+    setContent {
+        WooThemeWithBackground(content = content)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/ComposeViewBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/ComposeViewBuilder.kt
@@ -10,10 +10,14 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
  * Creates a [ComposeView] with the [ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed] composition strategy,
  * and the [WooThemeWithBackground] as the root composable.
  *
+ * @param compositionStrategy To override the composition strategy.
  * @param content The content of the [WooThemeWithBackground].
  */
-fun Fragment.composeView(content: @Composable () -> Unit) = ComposeView(requireContext()).apply {
-    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+fun Fragment.composeView(
+    compositionStrategy: ViewCompositionStrategy = ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed,
+    content: @Composable () -> Unit
+) = ComposeView(requireContext()).apply {
+    setViewCompositionStrategy(compositionStrategy)
 
     setContent {
         WooThemeWithBackground(content = content)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/ObserveSiteInstallation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/ObserveSiteInstallation.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.login.storecreation.installation
 
+import com.woocommerce.android.extensions.isWooExpressSiteReadyToUse
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.STORE_LOADING_FAILED
 import com.woocommerce.android.ui.login.storecreation.StoreCreationErrorType.STORE_NOT_READY
@@ -48,7 +49,7 @@ class ObserveSiteInstallation @Inject constructor(
                             emit(InstallationState.OutOfSync)
                         }
 
-                        if (site.isReadyToUse) {
+                        if (site.isWooExpressSiteReadyToUse) {
                             emit(InstallationState.Success)
                             return@flow
                         }
@@ -64,12 +65,6 @@ class ObserveSiteInstallation @Inject constructor(
             }
         }
     }
-
-    private val SiteModel?.isReadyToUse: Boolean
-        get() = this?.isJetpackInstalled == true &&
-            this.isJetpackConnected &&
-            this.isWpComStore &&
-            this.hasWooCommerce
 
     private fun SiteModel?.isDesynced(expectedName: String): Boolean =
         this?.isJetpackInstalled == true && this.isJetpackConnected &&

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationFragment.kt
@@ -8,11 +8,15 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.NavGraphMainDirections
+import com.woocommerce.android.extensions.handleNotice
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationViewModel.NavigateToNewStore
 import com.woocommerce.android.ui.login.storecreation.installation.StoreInstallationViewModel.OpenStore
+import com.woocommerce.android.ui.login.storecreation.theme.ThemeActivationFragmentDialog
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -25,8 +29,10 @@ import javax.inject.Inject
 class StoreInstallationFragment : BaseFragment() {
     private val viewModel: StoreInstallationViewModel by viewModels()
 
-    @Inject lateinit var userAgent: UserAgent
-    @Inject lateinit var authenticator: WPComWebViewAuthenticator
+    @Inject
+    lateinit var userAgent: UserAgent
+    @Inject
+    lateinit var authenticator: WPComWebViewAuthenticator
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
@@ -50,6 +56,7 @@ class StoreInstallationFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers()
+        handleResults()
     }
 
     private fun setupObservers() {
@@ -57,8 +64,21 @@ class StoreInstallationFragment : BaseFragment() {
             when (event) {
                 is Exit -> findNavController().popBackStack()
                 is OpenStore -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
+                is StoreInstallationViewModel.LaunchThemeActivation -> launchThemeActivation(event.themeId)
                 NavigateToNewStore -> (activity as? MainActivity)?.handleSitePickerResult()
             }
         }
+    }
+
+    private fun handleResults() {
+        handleNotice(ThemeActivationFragmentDialog.THEME_ACTIVATION_FINISHED) {
+            viewModel.onThemeActivationFinished()
+        }
+    }
+
+    private fun launchThemeActivation(themeId: String) {
+        findNavController().navigateSafely(
+            NavGraphMainDirections.actionGlobalThemeActivationFragmentDialog(themeId)
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
@@ -114,7 +114,7 @@ class StoreInstallationViewModel @Inject constructor(
                     // Launch theme activation flow, the installation will continue after the theme is activated
                     triggerEvent(LaunchThemeActivation(it))
                 } ?: run {
-                    _viewState.update { SuccessState(newStoreUrl) }
+                    _viewState.update { SuccessState(newStoreWpAdminUrl) }
                 }
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
@@ -110,10 +110,10 @@ class StoreInstallationViewModel @Inject constructor(
                 )
                 installationTransactionLauncher.onStoreInstalled(properties)
 
-                if (appPrefsWrapper.themeIdForCreatedStore != null) {
+                appPrefsWrapper.getThemeIdForStoreCreation(storeData.siteId!!)?.let {
                     // Launch theme activation flow, the installation will continue after the theme is activated
-                    triggerEvent(LaunchThemeActivation(appPrefsWrapper.themeIdForCreatedStore!!))
-                } else {
+                    triggerEvent(LaunchThemeActivation(it))
+                } ?: run {
                     _viewState.update { SuccessState(newStoreUrl) }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
@@ -85,8 +85,6 @@ class StoreInstallationViewModel @Inject constructor(
             storeData = newStore.data
         }
 
-        appPrefsWrapper.createdStoreSiteId = storeData.siteId
-
         analyticsTrackerWrapper.track(
             AnalyticsEvent.SITE_CREATION_STEP,
             mapOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
@@ -85,6 +85,8 @@ class StoreInstallationViewModel @Inject constructor(
             storeData = newStore.data
         }
 
+        appPrefsWrapper.createdStoreSiteId = storeData.siteId
+
         analyticsTrackerWrapper.track(
             AnalyticsEvent.SITE_CREATION_STEP,
             mapOf(
@@ -98,6 +100,7 @@ class StoreInstallationViewModel @Inject constructor(
         when (result) {
             is InstallationState.Success -> {
                 repository.selectSite(storeData.siteId!!)
+                appPrefsWrapper.createdStoreSiteId = null
 
                 val properties = mapOf(
                     AnalyticsTracker.KEY_SOURCE to appPrefsWrapper.getStoreCreationSource(),
@@ -107,7 +110,12 @@ class StoreInstallationViewModel @Inject constructor(
                 )
                 installationTransactionLauncher.onStoreInstalled(properties)
 
-                _viewState.update { SuccessState(newStoreWpAdminUrl) }
+                if (appPrefsWrapper.themeIdForCreatedStore != null) {
+                    // Launch theme activation flow, the installation will continue after the theme is activated
+                    triggerEvent(LaunchThemeActivation(appPrefsWrapper.themeIdForCreatedStore!!))
+                } else {
+                    _viewState.update { SuccessState(newStoreUrl) }
+                }
             }
 
             is InstallationState.Failure -> {
@@ -191,6 +199,10 @@ class StoreInstallationViewModel @Inject constructor(
         loadNewStore()
     }
 
+    fun onThemeActivationFinished() {
+        _viewState.update { SuccessState(newStoreUrl) }
+    }
+
     sealed interface ViewState : Parcelable {
         @Parcelize
         data class StoreCreationLoadingState(
@@ -210,6 +222,7 @@ class StoreInstallationViewModel @Inject constructor(
 
     data class OpenStore(val url: String) : Event()
     object NavigateToNewStore : Event()
+    data class LaunchThemeActivation(val themeId: String) : Event()
 
     companion object {
         const val TRIAL_LENGTH_IN_DAYS = 14L

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.login.storecreation.summary
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -44,7 +45,8 @@ class StoreCreationSummaryViewModel @Inject constructor(
     private val localNotificationScheduler: LocalNotificationScheduler,
     private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
     private val accountStore: AccountStore,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val appPrefs: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val _isLoading = savedStateHandle.getStateFlow(scope = this, initialValue = false)
     val isLoading = _isLoading.asLiveData()
@@ -77,6 +79,7 @@ class StoreCreationSummaryViewModel @Inject constructor(
                 when (creationState) {
                     is Finished -> {
                         newStore.update(siteId = creationState.siteId)
+                        appPrefs.createdStoreSiteId = creationState.siteId
                         tracker.track(
                             stat = AnalyticsEvent.SITE_CREATION_FREE_TRIAL_CREATED_SUCCESS,
                             properties = mapOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationFragmentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationFragmentDialog.kt
@@ -4,18 +4,36 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class ThemeActivationFragmentDialog : DialogFragment() {
     private val viewModel: ThemeActivationViewModel by viewModels()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        isCancelable = false
+
         return composeView {
             ThemeActivationScreen(viewModel = viewModel)
         }
@@ -25,6 +43,63 @@ class ThemeActivationFragmentDialog : DialogFragment() {
 @Composable
 private fun ThemeActivationScreen(viewModel: ThemeActivationViewModel) {
     viewModel.viewState.observeAsState().value?.let { state ->
-        TODO()
+        when (state) {
+            is ThemeActivationViewModel.ViewState.LoadingState -> ThemeActivationLoading()
+            is ThemeActivationViewModel.ViewState.ErrorState -> ThemeActivationError(onRetry = state.onRetry)
+        }
+    }
+}
+
+@Composable
+private fun ThemeActivationLoading() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(dimensionResource(id = R.dimen.major_100))
+    ) {
+        Text(
+            text = stringResource(id = R.string.store_creation_theme_activation_loading),
+            textAlign = TextAlign.Center
+        )
+
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun ThemeActivationError(
+    onRetry: () -> Unit
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(dimensionResource(id = R.dimen.major_100))
+    ) {
+        Text(
+            text = stringResource(id = R.string.store_creation_theme_activation_error),
+            textAlign = TextAlign.Center
+        )
+
+        WCColoredButton(onClick = onRetry, text = stringResource(id = R.string.retry))
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun ThemeActivationLoadingPreview() {
+    WooThemeWithBackground {
+        ThemeActivationLoading()
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun ThemeActivationErrorPreview() {
+    WooThemeWithBackground {
+        ThemeActivationError(onRetry = {})
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationFragmentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationFragmentDialog.kt
@@ -6,7 +6,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
@@ -24,6 +26,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -64,7 +67,10 @@ private fun ThemeActivationScreen(viewModel: ThemeActivationViewModel) {
     viewModel.viewState.observeAsState().value?.let { state ->
         when (state) {
             is ThemeActivationViewModel.ViewState.LoadingState -> ThemeActivationLoading()
-            is ThemeActivationViewModel.ViewState.ErrorState -> ThemeActivationError(onRetry = state.onRetry)
+            is ThemeActivationViewModel.ViewState.ErrorState -> ThemeActivationError(
+                onRetry = state.onRetry,
+                onDismiss = state.onDismiss
+            )
         }
     }
 }
@@ -89,11 +95,11 @@ private fun ThemeActivationLoading() {
 
 @Composable
 private fun ThemeActivationError(
-    onRetry: () -> Unit
+    onRetry: () -> Unit,
+    onDismiss: () -> Unit
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
         modifier = Modifier
             .fillMaxWidth()
             .padding(dimensionResource(id = R.dimen.major_100))
@@ -102,8 +108,10 @@ private fun ThemeActivationError(
             text = stringResource(id = R.string.store_creation_theme_activation_error),
             textAlign = TextAlign.Center
         )
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_150)))
 
         WCColoredButton(onClick = onRetry, text = stringResource(id = R.string.retry))
+        WCTextButton(onClick = onDismiss, text = stringResource(id = R.string.dismiss))
     }
 }
 
@@ -119,6 +127,6 @@ private fun ThemeActivationLoadingPreview() {
 @Preview(showBackground = true)
 private fun ThemeActivationErrorPreview() {
     WooThemeWithBackground {
-        ThemeActivationError(onRetry = {})
+        ThemeActivationError(onRetry = {}, onDismiss = {})
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationFragmentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationFragmentDialog.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.ui.login.storecreation.theme
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.ui.compose.composeView
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class ThemeActivationFragmentDialog : DialogFragment() {
+    private val viewModel: ThemeActivationViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return composeView {
+            ThemeActivationScreen(viewModel = viewModel)
+        }
+    }
+}
+
+@Composable
+private fun ThemeActivationScreen(viewModel: ThemeActivationViewModel) {
+    viewModel.viewState.observeAsState().value?.let { state ->
+        TODO()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationFragmentDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationFragmentDialog.kt
@@ -21,21 +21,40 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.navigateBackWithNotice
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class ThemeActivationFragmentDialog : DialogFragment() {
+    companion object {
+        const val THEME_ACTIVATION_FINISHED = "theme_activation_finished"
+    }
+
     private val viewModel: ThemeActivationViewModel by viewModels()
 
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         isCancelable = false
 
         return composeView {
             ThemeActivationScreen(viewModel = viewModel)
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                is Event.Exit -> navigateBackWithNotice(THEME_ACTIVATION_FINISHED)
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationViewModel.kt
@@ -3,17 +3,35 @@ package com.woocommerce.android.ui.login.storecreation.theme
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.ui.login.storecreation.theme.ThemeActivationViewModel.ViewState.LoadingState
+import com.woocommerce.android.ui.themes.ThemeRepository
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ThemeActivationViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val themeRepository: ThemeRepository
 ) : ScopedViewModel(savedStateHandle) {
-    private val _viewState = MutableStateFlow(LoadingState)
+    private val _viewState = MutableStateFlow<ViewState>(LoadingState)
     val viewState = _viewState.asLiveData()
+
+    private val args by savedStateHandle.navArgs<ThemeActivationFragmentDialogArgs>()
+
+    init {
+        startThemeInstallation()
+    }
+
+    private fun startThemeInstallation() = launch {
+        _viewState.value = LoadingState
+        themeRepository.activateTheme(args.themeId).fold(
+            onSuccess = { TODO() },
+            onFailure = { _viewState.value = ViewState.ErrorState(onRetry = ::startThemeInstallation) }
+        )
+    }
 
     sealed interface ViewState {
         object LoadingState : ViewState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationViewModel.kt
@@ -37,12 +37,23 @@ class ThemeActivationViewModel @Inject constructor(
                 triggerEvent(Event.ShowSnackbar(R.string.theme_activated_successfully))
                 triggerEvent(Event.Exit)
             },
-            onFailure = { _viewState.value = ViewState.ErrorState(onRetry = ::startThemeInstallation) }
+            onFailure = {
+                _viewState.value = ViewState.ErrorState(
+                    onRetry = ::startThemeInstallation,
+                    onDismiss = {
+                        appPrefsWrapper.clearThemeIdForStoreCreation()
+                        triggerEvent(Event.Exit)
+                    }
+                )
+            }
         )
     }
 
     sealed interface ViewState {
         object LoadingState : ViewState
-        data class ErrorState(val onRetry: () -> Unit) : ViewState
+        data class ErrorState(
+            val onRetry: () -> Unit,
+            val onDismiss: () -> Unit
+        ) : ViewState
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationViewModel.kt
@@ -33,7 +33,7 @@ class ThemeActivationViewModel @Inject constructor(
         _viewState.value = LoadingState
         themeRepository.activateTheme(args.themeId).fold(
             onSuccess = {
-                appPrefsWrapper.themeIdForCreatedStore = null
+                appPrefsWrapper.clearThemeIdForStoreCreation()
                 triggerEvent(Event.ShowSnackbar(R.string.theme_activated_successfully))
                 triggerEvent(Event.Exit)
             },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationViewModel.kt
@@ -1,0 +1,22 @@
+package com.woocommerce.android.ui.login.storecreation.theme
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import com.woocommerce.android.ui.login.storecreation.theme.ThemeActivationViewModel.ViewState.LoadingState
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class ThemeActivationViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedStateHandle) {
+    private val _viewState = MutableStateFlow(LoadingState)
+    val viewState = _viewState.asLiveData()
+
+    sealed interface ViewState {
+        object LoadingState : ViewState
+        data class ErrorState(val onRetry: () -> Unit) : ViewState
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationViewModel.kt
@@ -2,8 +2,11 @@ package com.woocommerce.android.ui.login.storecreation.theme
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.login.storecreation.theme.ThemeActivationViewModel.ViewState.LoadingState
 import com.woocommerce.android.ui.themes.ThemeRepository
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -14,7 +17,8 @@ import javax.inject.Inject
 @HiltViewModel
 class ThemeActivationViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val themeRepository: ThemeRepository
+    private val themeRepository: ThemeRepository,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val _viewState = MutableStateFlow<ViewState>(LoadingState)
     val viewState = _viewState.asLiveData()
@@ -28,7 +32,11 @@ class ThemeActivationViewModel @Inject constructor(
     private fun startThemeInstallation() = launch {
         _viewState.value = LoadingState
         themeRepository.activateTheme(args.themeId).fold(
-            onSuccess = { TODO() },
+            onSuccess = {
+                appPrefsWrapper.themeIdForCreatedStore = null
+                triggerEvent(Event.ShowSnackbar(R.string.theme_activated_successfully))
+                triggerEvent(Event.Exit)
+            },
             onFailure = { _viewState.value = ViewState.ErrorState(onRetry = ::startThemeInstallation) }
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -759,9 +759,7 @@ class MainActivity :
                 is ViewOrderDetail -> showOrderDetail(event)
                 is ViewReviewDetail -> showReviewDetail(event.uniqueId, launchedFromNotification = true)
                 is ViewReviewList -> showReviewList()
-                is RestartActivityForPushNotification -> onRestartActivityEvent(event)
-                is RestartActivityForLocalNotification -> onRestartActivityEvent(event)
-                is RestartActivityForAppLink -> onRestartActivityEvent(event)
+                is RestartActivityEvent -> onRestartActivityEvent(event)
                 is ShowFeatureAnnouncement -> navigateToFeatureAnnouncement(event)
                 is ViewUrlInWebView -> navigateToWebView(event)
                 is RequestNotificationsPermission -> requestNotificationsPermission()
@@ -788,6 +786,7 @@ class MainActivity :
                 }
 
                 is OpenFreeTrialSurvey -> openFreeTrialSurvey()
+                is MainActivityViewModel.LaunchThemeActivation -> startThemeActivation(event.themeId)
             }
         }
 
@@ -896,6 +895,12 @@ class MainActivity :
         startActivity(HelpActivity.createIntent(this, HelpOrigin.ZENDESK_NOTIFICATION, null))
     }
 
+    private fun startThemeActivation(themeId: String) {
+        navController.navigateSafely(
+            NavGraphMainDirections.actionGlobalThemeActivationFragmentDialog(themeId)
+        )
+    }
+
     private fun onRestartActivityEvent(event: RestartActivityEvent) {
         intent.apply {
             when (event) {
@@ -905,6 +910,9 @@ class MainActivity :
                     putExtra(FIELD_OPENED_FROM_PUSH, true)
                     putExtra(FIELD_REMOTE_NOTIFICATION, event.notification)
                     putExtra(FIELD_PUSH_ID, event.pushId)
+                }
+                else -> {
+                    // continue to restart the activity
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -190,9 +190,9 @@ class MainActivityViewModel @Inject constructor(
         if (selectedSite.exists()) {
             // Upload any pending store profiler answers
             storeProfilerRepository.uploadAnswers()
-            if (prefs.themeIdForCreatedStore != null) {
+            prefs.getThemeIdForStoreCreation(selectedSite.get().siteId)?.let {
                 withContext(dispatchers.main) {
-                    triggerEvent(LaunchThemeActivation(prefs.themeIdForCreatedStore!!))
+                    triggerEvent(LaunchThemeActivation(it))
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.REVIEW_OPEN
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.exhaustive
+import com.woocommerce.android.extensions.isWooExpressSiteReadyToUse
 import com.woocommerce.android.model.FeatureAnnouncement
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.notifications.NotificationChannelType
@@ -176,7 +177,7 @@ class MainActivityViewModel @Inject constructor(
     private fun handlePostStoreCreationTasks() = launch(dispatchers.io) {
         val createdStoreSiteId = prefs.createdStoreSiteId
         if (createdStoreSiteId != null &&
-            siteStore.getSiteBySiteId(createdStoreSiteId)?.hasWooCommerce == true
+            siteStore.getSiteBySiteId(createdStoreSiteId).isWooExpressSiteReadyToUse
         ) {
             prefs.createdStoreSiteId = null
             if (selectedSite.get().siteId != createdStoreSiteId) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerFragment.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -38,6 +39,7 @@ class ThemePickerFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupObservers()
+        handleResults()
     }
 
     private fun setupObservers() {
@@ -47,6 +49,12 @@ class ThemePickerFragment : BaseFragment() {
                 is NavigateToNextStep -> navigateToStoreInstallationStep()
                 is NavigateToThemePreview -> navigateToThemePreviewFragment(event.themeId)
             }
+        }
+    }
+
+    private fun handleResults() {
+        handleNotice(ThemePreviewFragment.THEME_SELECTED_NOTICE) {
+            navigateToStoreInstallationStep()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerFragment.kt
@@ -45,7 +45,7 @@ class ThemePickerFragment : BaseFragment() {
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                 is NavigateToNextStep -> navigateToStoreInstallationStep()
-                is NavigateToThemePreview -> navigateToThemePreviewFragment(event.themeDemoUri)
+                is NavigateToThemePreview -> navigateToThemePreviewFragment(event.themeId)
             }
         }
     }
@@ -57,11 +57,11 @@ class ThemePickerFragment : BaseFragment() {
         )
     }
 
-    private fun navigateToThemePreviewFragment(themeDemoUri: String) {
+    private fun navigateToThemePreviewFragment(themeId: String) {
         findNavController().navigateSafely(
             ThemePickerFragmentDirections
                 .actionThemePickerFragmentToThemePreviewFragment(
-                    themeDemoUri = themeDemoUri
+                    themeId = themeId
                 )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
@@ -219,7 +219,7 @@ private fun Theme(
     Card(
         shape = RoundedCornerShape(dimensionResource(id = dimen.minor_100)),
         elevation = dimensionResource(id = dimen.minor_50),
-        modifier = themeModifier.clickable { onThemeTapped(theme.demoUri) }
+        modifier = themeModifier.clickable { onThemeTapped(theme.themeId) }
     ) {
         val imageLoader = ImageLoader.Builder(LocalContext.current)
             .okHttpClient {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -43,6 +43,7 @@ class ThemePickerViewModel @Inject constructor(
                     Success(
                         carouselItems = result.map { theme ->
                             CarouselItem.Theme(
+                                themeId = theme.id,
                                 name = theme.name,
                                 screenshotUrl = AppUrls.getScreenshotUrl(theme.demoUrl),
                                 demoUri = theme.demoUrl
@@ -92,6 +93,7 @@ class ThemePickerViewModel @Inject constructor(
             sealed class CarouselItem : Parcelable {
                 @Parcelize
                 data class Theme(
+                    val themeId: String,
                     val name: String,
                     val screenshotUrl: String,
                     val demoUri: String
@@ -104,5 +106,5 @@ class ThemePickerViewModel @Inject constructor(
     }
 
     object MoveToNextStep : Event()
-    data class NavigateToThemePreview(val themeDemoUri: String) : Event()
+    data class NavigateToThemePreview(val themeId: String) : Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewFragment.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -16,6 +17,9 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class ThemePreviewFragment : BaseFragment() {
+    companion object {
+        val THEME_SELECTED_NOTICE = "theme-selected"
+    }
     private val viewModel: ThemePreviewViewModel by viewModels()
 
     override val activityAppBarStatus: AppBarStatus
@@ -45,8 +49,13 @@ class ThemePreviewFragment : BaseFragment() {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
+                is ThemePreviewViewModel.ContinueStoreCreationWithTheme -> continueStoreCreation()
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
             }
         }
+    }
+
+    private fun continueStoreCreation() {
+        navigateBackWithNotice(THEME_SELECTED_NOTICE)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewFragment.kt
@@ -18,7 +18,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class ThemePreviewFragment : BaseFragment() {
     companion object {
-        val THEME_SELECTED_NOTICE = "theme-selected"
+        const val THEME_SELECTED_NOTICE = "theme-selected"
     }
     private val viewModel: ThemePreviewViewModel by viewModels()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -2,9 +2,15 @@ package com.woocommerce.android.ui.themes
 
 import androidx.activity.result.ActivityResultRegistry
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetDefaults
@@ -12,6 +18,7 @@ import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue.HalfExpanded
 import androidx.compose.material.ModalBottomSheetValue.Hidden
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.rememberModalBottomSheetState
@@ -22,11 +29,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
-import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCWebView
 import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ViewState
 import kotlinx.coroutines.launch
@@ -47,6 +56,7 @@ fun ThemePreviewScreen(
             activityRegistry = activityRegistry,
             viewModel::onPageSelected,
             viewModel::onBackNavigationClicked,
+            viewModel::onActivateThemeClicked
         )
     }
 }
@@ -60,6 +70,7 @@ fun ThemePreviewScreen(
     activityRegistry: ActivityResultRegistry,
     onPageSelected: (String) -> Unit,
     onBackNavigationClicked: () -> Unit,
+    onActivateThemeClicked: () -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     val modalSheetState = rememberModalBottomSheetState(
@@ -90,23 +101,74 @@ fun ThemePreviewScreen(
         Scaffold(
             topBar = {
                 Toolbar(
-                    title = stringResource(id = string.theme_preview_title),
+                    title = stringResource(id = R.string.theme_preview_title),
                     navigationIcon = Filled.ArrowBack,
                     onNavigationButtonClick = onBackNavigationClicked,
                 )
             },
             backgroundColor = MaterialTheme.colors.surface
         ) { paddingValues ->
-            WCWebView(
-                url = state.demoUri,
-                userAgent = userAgent,
-                wpComAuthenticator = wpComWebViewAuthenticator,
-                activityRegistry = activityRegistry,
-                modifier = Modifier
+            Column(
+                Modifier
                     .padding(paddingValues)
                     .fillMaxSize()
-            )
+            ) {
+                WCWebView(
+                    url = state.demoUri,
+                    userAgent = userAgent,
+                    wpComAuthenticator = wpComWebViewAuthenticator,
+                    activityRegistry = activityRegistry,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                )
+
+                ThemePreviewBottomSection(
+                    isFromStoreCreation = state.isFromStoreCreation,
+                    themeName = state.themeName,
+                    onActivateThemeClicked = onActivateThemeClicked,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                )
+            }
         }
+    }
+}
+
+@Composable
+private fun ThemePreviewBottomSection(
+    isFromStoreCreation: Boolean,
+    themeName: String,
+    onActivateThemeClicked: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(
+            dimensionResource(id = dimen.major_100)
+        ),
+        modifier = modifier
+    ) {
+        Divider()
+        WCColoredButton(
+            onClick = onActivateThemeClicked,
+            text = stringResource(
+                id = if (isFromStoreCreation) R.string.store_creation_use_theme_button
+                else R.string.theme_preview_activate_theme_button
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = dimensionResource(id = dimen.major_100))
+        )
+
+        Text(
+            text = stringResource(id = R.string.theme_preview_theme_name, themeName),
+            style = MaterialTheme.typography.body2,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = dimensionResource(id = dimen.major_100))
+        )
+        Spacer(modifier = Modifier.height(dimensionResource(id = dimen.major_100)))
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -127,7 +127,7 @@ fun ThemePreviewScreen(
                     .fillMaxSize()
             ) {
                 WCWebView(
-                    url = state.demoUri,
+                    url = state.currentPage.uri,
                     userAgent = userAgent,
                     wpComAuthenticator = wpComWebViewAuthenticator,
                     activityRegistry = activityRegistry,
@@ -229,8 +229,7 @@ private fun DemoSectionsToolbar(
             )
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = state.themePages.firstOrNull { it.isLoaded }?.title
-                        ?: stringResource(id = R.string.theme_preview_bottom_sheet_home_section),
+                    text = state.currentPage.title,
                     style = MaterialTheme.typography.caption,
                 )
                 Icon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -5,11 +5,14 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
-import com.woocommerce.android.viewmodel.getStateFlow
+import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flow
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.network.UserAgent
 import javax.inject.Inject
@@ -19,16 +22,35 @@ class ThemePreviewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
     val userAgent: UserAgent,
+    val themeRepository: ThemeRepository
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: ThemePreviewFragmentArgs by savedStateHandle.navArgs()
-    private val _viewState = savedStateHandle.getStateFlow(
+
+    private val theme = flow {
+        val theme = themeRepository.getTheme(navArgs.themeId) ?: run {
+            WooLog.w(WooLog.T.THEMES, "Theme not found!!")
+            triggerEvent(MultiLiveEvent.Event.Exit)
+            return@flow
+        }
+        emit(theme)
+    }
+    private val _selectedPage = savedStateHandle.getNullableStateFlow(
         viewModelScope,
-        ViewState(demoUri = navArgs.themeDemoUri)
+        null,
+        String::class.java,
+        "selectedPage"
     )
-    val viewState = _viewState.asLiveData()
+
+    val viewState = combine(theme, _selectedPage) { theme, selectedPage ->
+        ViewState(
+            demoUri = selectedPage ?: theme.demoUrl,
+            themeName = theme.name,
+            isFromStoreCreation = true // TODO: Pass this from the previous screen
+        )
+    }.asLiveData()
 
     fun onPageSelected(updatedDemoUri: String) {
-        _viewState.value = _viewState.value.copy(demoUri = updatedDemoUri)
+        _selectedPage.value = updatedDemoUri
     }
 
     fun onBackNavigationClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -47,7 +47,7 @@ class ThemePreviewViewModel @Inject constructor(
         ViewState(
             demoUri = selectedPage ?: theme.demoUrl,
             themeName = theme.name,
-            isFromStoreCreation = true // TODO: Pass this from the previous screen
+            isFromStoreCreation = true // TODO Pass this from the previous screen
         )
     }.asLiveData()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -60,8 +60,8 @@ class ThemePreviewViewModel @Inject constructor(
         ViewState(
             themeName = theme.name,
             isFromStoreCreation = true, // TODO Pass this from the previous screen
-            themePages = demoPages.mapIndexed { index, page ->
-                page.copy(isLoaded = if (selectedPage == null) index == 0 else page.uri == selectedPage.uri)
+            themePages = demoPages.map { page ->
+                page.copy(isLoaded = (selectedPage?.uri ?: theme.demoUrl) == page.uri)
             }
         )
     }.asLiveData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
+import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -23,8 +24,9 @@ class ThemePreviewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
     val userAgent: UserAgent,
-    val themeRepository: ThemeRepository,
-    val appPrefsWrapper: AppPrefsWrapper
+    private val themeRepository: ThemeRepository,
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val newStore: NewStore
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: ThemePreviewFragmentArgs by savedStateHandle.navArgs()
 
@@ -61,7 +63,7 @@ class ThemePreviewViewModel @Inject constructor(
 
     fun onActivateThemeClicked() {
         if (viewState.value?.isFromStoreCreation == true) {
-            appPrefsWrapper.themeIdForCreatedStore = navArgs.themeId
+            appPrefsWrapper.saveThemeIdForStoreCreation(newStore.data.siteId!!, navArgs.themeId)
             triggerEvent(ContinueStoreCreationWithTheme)
         } else {
             TODO()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -111,8 +111,8 @@ class ThemePreviewViewModel @Inject constructor(
         val isFromStoreCreation: Boolean,
         val themePages: List<ThemeDemoPage>
     ) {
-        val demoUri: String
-            get() = themePages.first { it.isLoaded }.uri
+        val currentPage: ThemeDemoPage
+            get() = themePages.first { it.isLoaded }
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -35,8 +35,14 @@ class ThemePreviewViewModel @Inject constructor(
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
+    fun onActivateThemeClicked() {
+        // TODO
+    }
+
     @Parcelize
     data class ViewState(
         val demoUri: String,
+        val themeName: String,
+        val isFromStoreCreation: Boolean
     ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -22,7 +23,8 @@ class ThemePreviewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
     val userAgent: UserAgent,
-    val themeRepository: ThemeRepository
+    val themeRepository: ThemeRepository,
+    val appPrefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: ThemePreviewFragmentArgs by savedStateHandle.navArgs()
 
@@ -58,7 +60,12 @@ class ThemePreviewViewModel @Inject constructor(
     }
 
     fun onActivateThemeClicked() {
-        // TODO
+        if (viewState.value?.isFromStoreCreation == true) {
+            appPrefsWrapper.themeIdForCreatedStore = navArgs.themeId
+            triggerEvent(ContinueStoreCreationWithTheme)
+        } else {
+            TODO()
+        }
     }
 
     @Parcelize
@@ -67,4 +74,6 @@ class ThemePreviewViewModel @Inject constructor(
         val themeName: String,
         val isFromStoreCreation: Boolean
     ) : Parcelable
+
+    object ContinueStoreCreationWithTheme : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemeRepository.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.ThemeModel
 import org.wordpress.android.fluxc.store.ThemeStore
 import org.wordpress.android.fluxc.store.ThemeStore.FetchWPComThemesPayload
 import org.wordpress.android.fluxc.store.ThemeStore.OnCurrentThemeFetched
+import org.wordpress.android.fluxc.store.ThemeStore.OnThemeActivated
 import org.wordpress.android.fluxc.store.ThemeStore.OnThemeInstalled
 import org.wordpress.android.fluxc.store.ThemeStore.OnWpComThemesChanged
 import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload
@@ -83,7 +84,7 @@ class ThemeRepository @Inject constructor(
     suspend fun activateTheme(themeId: String): Result<Unit> {
         installThemeIfNeeded(themeId).onFailure { return Result.failure(it) }
 
-        val activationResult: OnThemeInstalled = dispatcher.dispatchAndAwait(
+        val activationResult: OnThemeActivated = dispatcher.dispatchAndAwait(
             ThemeActionBuilder.newActivateThemeAction(
                 SiteThemePayload(selectedSite.get(), ThemeModel().apply { this.themeId = themeId })
             )

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -645,9 +645,9 @@
         <action
             android:id="@+id/action_blazeCampaignCreationFragment_to_blazeCampaignListFragment"
             app:destination="@id/blazeCampaignListFragment"
+            app:launchSingleTop="true"
             app:popUpTo="@id/blazeCampaignCreationFragment"
-            app:popUpToInclusive="true"
-            app:launchSingleTop="true" />
+            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/freeTrialSurveyFragment"
@@ -725,7 +725,7 @@
     <dialog
         android:id="@+id/packagePhotoBottomSheetFragment"
         android:name="com.woocommerce.android.ui.products.ai.PackagePhotoBottomSheetFragment"
-        android:label="PackagePhotoBottomSheetFragment" >
+        android:label="PackagePhotoBottomSheetFragment">
         <argument
             android:name="imageUrl"
             app:argType="string" />
@@ -733,10 +733,21 @@
     <fragment
         android:id="@+id/blazeCampaignListFragment"
         android:name="com.woocommerce.android.ui.blaze.campaigs.BlazeCampaignListFragment"
-        android:label="BlazeCampaignListFragment" >
+        android:label="BlazeCampaignListFragment">
         <argument
             android:name="isPostCampaignCreation"
             android:defaultValue="false"
             app:argType="boolean" />
     </fragment>
+    <dialog
+        android:id="@+id/themeActivationFragmentDialog"
+        android:name="com.woocommerce.android.ui.login.storecreation.theme.ThemeActivationFragmentDialog"
+        android:label="ThemeActivationFragmentDialog">
+        <argument
+            android:name="themeId"
+            app:argType="string" />
+    </dialog>
+    <action
+        android:id="@+id/action_global_themeActivationFragmentDialog"
+        app:destination="@id/themeActivationFragmentDialog" />
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_themes.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_themes.xml
@@ -12,18 +12,14 @@
             app:destination="@id/storeCreationInstallationFragment" />
         <action
             android:id="@+id/action_themePickerFragment_to_themePreviewFragment"
-            app:destination="@id/themePreviewFragment">
-            <argument
-                android:name="themeDemoUri"
-                app:argType="string" />
-        </action>
+            app:destination="@id/themePreviewFragment" />
     </fragment>
     <fragment
         android:id="@+id/themePreviewFragment"
         android:name="com.woocommerce.android.ui.themes.ThemePreviewFragment"
         android:label="ThemePreviewFragment">
         <argument
-            android:name="themeDemoUri"
+            android:name="themeId"
             app:argType="string" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3365,6 +3365,8 @@
     <string name="store_creation_profiler_merchant_journey_starting_business">I\'m just starting my business</string>
     <string name="store_creation_profiler_merchant_journey_selling_not_online">I\'m already selling, but not online</string>
     <string name="store_creation_profiler_merchant_journey_selling_online">I\'m already selling online</string>
+    <string name="store_creation_theme_activation_loading">Activating your store\'s theme…</string>
+    <string name="store_creation_theme_activation_error">An error occurred while activating the theme you selected, please retry again!</string>
 
     <!--
     Store theme

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3380,6 +3380,8 @@
     <string name="theme_picker_error_title">An error occurred</string>
     <string name="theme_picker_error_message">Unable to load themes at this time.</string>
     <string name="theme_preview_title">Preview</string>
+    <string name="theme_preview_activate_theme_button">Use this theme</string>
+    <string name="theme_preview_theme_name">Theme: %1$s</string>
 
     <!--
     Store onboarding
@@ -3867,4 +3869,5 @@
     <string name="configuration_children_issue"> "%1$s " -&gt; %2$s </string>
     <string name="configuration_variable_update">Choose variation</string>
     <string name="product_variation_picker_title">Select a variation</string>
+    <string name="store_creation_use_theme_button">Start with this theme</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3382,6 +3382,7 @@
     <string name="theme_preview_title">Preview</string>
     <string name="theme_preview_activate_theme_button">Use this theme</string>
     <string name="theme_preview_theme_name">Theme: %1$s</string>
+    <string name="theme_activated_successfully">Theme activated successfully</string>
 
     <!--
     Store onboarding

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/summary/StoreCreationSummaryViewModelTest.kt
@@ -244,7 +244,8 @@ internal class StoreCreationSummaryViewModelTest : BaseUnitTest() {
             localNotificationScheduler = localNotificationScheduler,
             isRemoteFeatureFlagEnabled = isRemoteFeatureFlagEnabled,
             accountStore = accountStore,
-            resourceProvider = resourceProvider
+            resourceProvider = resourceProvider,
+            appPrefs = mock()
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationViewModelTests.kt
@@ -1,0 +1,92 @@
+package com.woocommerce.android.ui.login.storecreation.theme
+
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.themes.ThemeRepository
+import com.woocommerce.android.util.captureValues
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ThemeActivationViewModelTests : BaseUnitTest() {
+    private val themeRepository: ThemeRepository = mock()
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
+    private lateinit var viewModel: ThemeActivationViewModel
+
+    private val themeId: String = "tsubaki"
+
+    private suspend fun setup(setupMocks: suspend () -> Unit = {}) {
+        setupMocks()
+
+        viewModel = ThemeActivationViewModel(
+            savedStateHandle = ThemeActivationFragmentDialogArgs(themeId).toSavedStateHandle(),
+            themeRepository = themeRepository,
+            appPrefsWrapper = appPrefsWrapper
+        )
+    }
+
+    @Test
+    fun `when dialog is shown, then start theme installation`() = testBlocking {
+        setup()
+
+        verify(themeRepository).activateTheme(themeId)
+    }
+
+    @Test
+    fun `when theme installation is successful, then clear theme id and exit`() = testBlocking {
+        setup {
+            whenever(themeRepository.activateTheme(themeId)).doSuspendableAnswer {
+                // The duration is not important, we need the delay just to pause the coroutine
+                delay(10L)
+                Result.success(Unit)
+            }
+        }
+
+        val events = viewModel.event.runAndCaptureValues {
+            advanceUntilIdle()
+        }
+
+        verify(appPrefsWrapper).clearThemeIdForStoreCreation()
+        assertThat(events).containsExactly(
+            Event.ShowSnackbar(R.string.theme_activated_successfully),
+            Event.Exit
+        )
+    }
+
+    @Test
+    fun `given theme installation fails, when retry is clicked, then retry theme installation`() = testBlocking {
+        setup {
+            whenever(themeRepository.activateTheme(themeId)).thenReturn(Result.failure(Throwable()))
+        }
+
+        val state = viewModel.viewState.captureValues().last()
+        (state as ThemeActivationViewModel.ViewState.ErrorState).onRetry()
+
+        verify(themeRepository, times(2)).activateTheme(themeId)
+    }
+
+    @Test
+    fun `given theme installation fails, when dismiss is clicked, then clear theme id and exit`() = testBlocking {
+        setup {
+            whenever(themeRepository.activateTheme(themeId)).thenReturn(Result.failure(Throwable()))
+        }
+
+        val state = viewModel.viewState.captureValues().last()
+        (state as ThemeActivationViewModel.ViewState.ErrorState).onDismiss()
+        val event = viewModel.event.captureValues().last()
+
+        verify(appPrefsWrapper).clearThemeIdForStoreCreation()
+        assertThat(event).isEqualTo(Event.Exit)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10283
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds handling of the theme activation during the store creation, and which has two paths:
1. The user waits for the store installation to finish: theme activation starts right after the successful installation. (this flow could be changed depending on the result of this discussion p1701357329516039/1701248581.545709-slack-C03L1NF1EA3)
2. The user closes the app during the store installation: on next launch, assuming the site creation was done, the app will switch to the new site, and then will start the theme activation.

I needed to make few changes to the ThemePreview screen, and the main change is that we pass the them ID to it instead of the demo URL.

Sorry the PR got bigger than expected.

### Testing instructions
##### TC 1
1. Open the app.
2. Create a new site.
3. During the flow, choose a new theme, and click on "Start with this theme"
4. During the store installation, wait for the app to finish.
5. Notice a dialog that handles the theme activation.
6. The app will then switch to the new site.
7. Visit the new site in a browser, and confirm the new theme was set correctly.

##### TC 2
1. Open the app.
2. Create a new site.
3. During the flow, choose a new theme, and click on "Start with this theme"
4. During the store installation, close the app.
5. Wait for few minutes, then open the app.
6. Notice that the app will switch to the new site, then show a dialog that handles the theme activation.
7. Visit the new site in a browser, and confirm the new theme was set correctly.

### Images/gif
##### Foreground installation

https://github.com/woocommerce/woocommerce-android/assets/1657201/71cddc4c-1819-4b06-a2f4-c1e0f72cd6a5


##### Background installation

https://github.com/woocommerce/woocommerce-android/assets/1657201/f2c6d7d2-7278-4870-ad0d-6938599e0232



- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->