### PR TITLE
[Themes] Handle activation from app settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerFeaturesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/profiler/StoreProfilerFeaturesFragment.kt
@@ -60,7 +60,9 @@ class StoreProfilerFeaturesFragment : BaseFragment() {
     private fun navigateToThemePicker() {
         findNavController().navigateSafely(
             StoreProfilerFeaturesFragmentDirections
-                .actionStoreProfilerFeaturesFragmentToThemePickerFragment()
+                .actionStoreProfilerFeaturesFragmentToThemePickerFragment(
+                    isFromStoreCreation = true
+                )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -247,7 +247,9 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         binding.optionSiteThemes.setOnClickListener {
             findNavController()
                 .navigateSafely(
-                    MainSettingsFragmentDirections.actionMainSettingsFragmentToThemePickerFragment()
+                    MainSettingsFragmentDirections.actionMainSettingsFragmentToThemePickerFragment(
+                        isFromStoreCreation = false
+                    )
                 )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerFragment.kt
@@ -47,7 +47,7 @@ class ThemePickerFragment : BaseFragment() {
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                 is NavigateToNextStep -> navigateToStoreInstallationStep()
-                is NavigateToThemePreview -> navigateToThemePreviewFragment(event.themeId)
+                is NavigateToThemePreview -> navigateToThemePreviewFragment(event)
             }
         }
     }
@@ -65,11 +65,12 @@ class ThemePickerFragment : BaseFragment() {
         )
     }
 
-    private fun navigateToThemePreviewFragment(themeId: String) {
+    private fun navigateToThemePreviewFragment(event: NavigateToThemePreview) {
         findNavController().navigateSafely(
             ThemePickerFragmentDirections
                 .actionThemePickerFragmentToThemePreviewFragment(
-                    themeId = themeId
+                    themeId = event.themeId,
+                    isFromStoreCreation = event.isFromStoreCreation
                 )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -29,6 +30,8 @@ class ThemePickerViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
     private val _viewState = savedStateHandle.getStateFlow<ViewState>(viewModelScope, Loading)
     val viewState = _viewState.asLiveData()
+
+    private val navArgs: ThemePickerFragmentArgs by savedStateHandle.navArgs()
 
     init {
         viewModelScope.launch {
@@ -76,7 +79,7 @@ class ThemePickerViewModel @Inject constructor(
     }
 
     fun onThemeTapped(themeUri: String) {
-        triggerEvent(NavigateToThemePreview(themeUri))
+        triggerEvent(NavigateToThemePreview(themeUri, navArgs.isFromStoreCreation))
     }
 
     sealed interface ViewState : Parcelable {
@@ -106,5 +109,5 @@ class ThemePickerViewModel @Inject constructor(
     }
 
     object MoveToNextStep : Event()
-    data class NavigateToThemePreview(val themeId: String) : Event()
+    data class NavigateToThemePreview(val themeId: String, val isFromStoreCreation: Boolean) : Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewFragment.kt
@@ -10,10 +10,12 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class ThemePreviewFragment : BaseFragment() {
@@ -21,6 +23,8 @@ class ThemePreviewFragment : BaseFragment() {
         const val THEME_SELECTED_NOTICE = "theme-selected"
     }
     private val viewModel: ThemePreviewViewModel by viewModels()
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
@@ -50,6 +54,7 @@ class ThemePreviewFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ThemePreviewViewModel.ContinueStoreCreationWithTheme -> continueStoreCreation()
+                is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -14,9 +14,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetDefaults
 import androidx.compose.material.ModalBottomSheetLayout
@@ -140,6 +142,7 @@ fun ThemePreviewScreen(
                 ThemePreviewBottomSection(
                     isFromStoreCreation = state.isFromStoreCreation,
                     themeName = state.themeName,
+                    isActivatingTheme = state.isActivatingTheme,
                     onActivateThemeClicked = onActivateThemeClicked,
                     modifier = Modifier
                         .fillMaxWidth()
@@ -153,26 +156,37 @@ fun ThemePreviewScreen(
 private fun ThemePreviewBottomSection(
     isFromStoreCreation: Boolean,
     themeName: String,
+    isActivatingTheme: Boolean,
     onActivateThemeClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(
-            dimensionResource(id = dimen.major_100)
+            dimensionResource(id = R.dimen.major_100)
         ),
         modifier = modifier
     ) {
         Divider()
         WCColoredButton(
             onClick = onActivateThemeClicked,
-            text = stringResource(
-                id = if (isFromStoreCreation) R.string.store_creation_use_theme_button
-                else R.string.theme_preview_activate_theme_button
-            ),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = dimensionResource(id = dimen.major_100))
-        )
+                .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+        ) {
+            if (isActivatingTheme) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(size = dimensionResource(id = R.dimen.major_150)),
+                    color = LocalContentColor.current,
+                )
+            } else {
+                Text(
+                    text = stringResource(
+                        id = if (isFromStoreCreation) R.string.store_creation_use_theme_button
+                        else R.string.theme_preview_activate_theme_button
+                    )
+                )
+            }
+        }
 
         Text(
             text = stringResource(id = R.string.theme_preview_theme_name, themeName),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -67,7 +67,7 @@ class ThemePreviewViewModel @Inject constructor(
     ) { theme, selectedPage, isActivatingTheme, demoPages ->
         ViewState(
             themeName = theme.name,
-            isFromStoreCreation = true, // TODO Pass this from the previous screen
+            isFromStoreCreation = navArgs.isFromStoreCreation,
             isActivatingTheme = isActivatingTheme,
             themePages = demoPages.map { page ->
                 page.copy(isLoaded = (selectedPage?.uri ?: theme.demoUrl) == page.uri)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -92,7 +92,6 @@ class ThemePreviewViewModel @Inject constructor(
                 isActivatingTheme.value = true
                 themeRepository.activateTheme(navArgs.themeId).fold(
                     onSuccess = {
-                        appPrefsWrapper.clearThemeIdForStoreCreation()
                         triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.theme_activated_successfully))
                         triggerEvent(MultiLiveEvent.Event.Exit)
                     },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
+import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,6 +22,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.store.ThemeCoroutineStore
@@ -49,17 +51,24 @@ class ThemePreviewViewModel @Inject constructor(
         emit(theme)
     }
     private val themePages = theme.flatMapLatest { it.prepareThemeDemoPages() }
-    private val _selectedPage = savedStateHandle.getNullableStateFlow(
+    private val selectedPage = savedStateHandle.getNullableStateFlow(
         viewModelScope,
         null,
         ThemeDemoPage::class.java,
         "selectedPage"
     )
+    private val isActivatingTheme = savedStateHandle.getStateFlow(viewModelScope, false, "isActivatingTheme")
 
-    val viewState = combine(theme, _selectedPage, themePages) { theme, selectedPage, demoPages ->
+    val viewState = combine(
+        theme,
+        selectedPage,
+        isActivatingTheme,
+        themePages
+    ) { theme, selectedPage, isActivatingTheme, demoPages ->
         ViewState(
             themeName = theme.name,
             isFromStoreCreation = true, // TODO Pass this from the previous screen
+            isActivatingTheme = isActivatingTheme,
             themePages = demoPages.map { page ->
                 page.copy(isLoaded = (selectedPage?.uri ?: theme.demoUrl) == page.uri)
             }
@@ -67,7 +76,7 @@ class ThemePreviewViewModel @Inject constructor(
     }.asLiveData()
 
     fun onPageSelected(demoPage: ThemeDemoPage) {
-        _selectedPage.value = demoPage
+        selectedPage.value = demoPage
     }
 
     fun onBackNavigationClicked() {
@@ -79,7 +88,20 @@ class ThemePreviewViewModel @Inject constructor(
             appPrefsWrapper.saveThemeIdForStoreCreation(newStore.data.siteId!!, navArgs.themeId)
             triggerEvent(ContinueStoreCreationWithTheme)
         } else {
-            TODO()
+            launch {
+                isActivatingTheme.value = true
+                themeRepository.activateTheme(navArgs.themeId).fold(
+                    onSuccess = {
+                        appPrefsWrapper.clearThemeIdForStoreCreation()
+                        triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.theme_activated_successfully))
+                        triggerEvent(MultiLiveEvent.Event.Exit)
+                    },
+                    onFailure = {
+                        triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.theme_activation_failed))
+                    }
+                )
+                isActivatingTheme.value = false
+            }
         }
     }
 
@@ -109,7 +131,8 @@ class ThemePreviewViewModel @Inject constructor(
     data class ViewState(
         val themeName: String,
         val isFromStoreCreation: Boolean,
-        val themePages: List<ThemeDemoPage>
+        val themePages: List<ThemeDemoPage>,
+        val isActivatingTheme: Boolean
     ) {
         val currentPage: ThemeDemoPage
             get() = themePages.first { it.isLoaded }

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -53,7 +53,11 @@
             app:destination="@id/nameYourStoreDialogFragment" />
         <action
             android:id="@+id/action_mainSettingsFragment_to_themePickerFragment"
-            app:destination="@id/nav_graph_themes" />
+            app:destination="@id/nav_graph_themes" >
+            <argument
+                android:name="isFromStoreCreation"
+                app:argType="boolean" />
+        </action>
     </fragment>
     <fragment
         android:id="@+id/privacySettingsFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
@@ -80,7 +80,11 @@
             app:destination="@id/storeCreationInstallationFragment" />
         <action
             android:id="@+id/action_storeProfilerFeaturesFragment_to_themePickerFragment"
-            app:destination="@id/nav_graph_themes" />
+            app:destination="@id/nav_graph_themes" >
+            <argument
+                android:name="isFromStoreCreation"
+                app:argType="boolean" />
+        </action>
     </fragment>
 
     <fragment

--- a/WooCommerce/src/main/res/navigation/nav_graph_themes.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_themes.xml
@@ -7,6 +7,9 @@
         android:id="@+id/themePickerFragment"
         android:name="com.woocommerce.android.ui.themes.ThemePickerFragment"
         android:label="ThemePickerFragment">
+        <argument
+            android:name="isFromStoreCreation"
+            app:argType="boolean" />
         <action
             android:id="@+id/action_themePickerFragment_to_storeCreationInstallationFragment"
             app:destination="@id/storeCreationInstallationFragment" />
@@ -21,5 +24,8 @@
         <argument
             android:name="themeId"
             app:argType="string" />
+        <argument
+            android:name="isFromStoreCreation"
+            app:argType="boolean" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3386,6 +3386,7 @@
     <string name="theme_preview_activate_theme_button">Use this theme</string>
     <string name="theme_preview_theme_name">Theme: %1$s</string>
     <string name="theme_activated_successfully">Theme activated successfully</string>
+    <string name="theme_activation_failed">Theme activation failed, please try again!</string>
 
     <!--
     Store onboarding


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10304

### Description
This PR adds logic to handle the theme activation when the picker is opened from the app settings.

### Testing instructions
1. Open a WPCom site in the app.
2. Open the Settings screen.
3. Click on Themes.
4. Pick one of the themes.
5. Click on "Use this theme"
6. Confirm the installation works, and a Snackbar is shown.

### Images/gif
https://github.com/woocommerce/woocommerce-android/assets/1657201/2405b7e7-9f98-4d83-8995-a1d157ff8f6d


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
