### PR TITLE
Merge 16.5 code freeze into trunk

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+16.6
+-----
+
+
 16.5
 -----
 - [*] [Internal] Always use default currency as first choice to show in the deposits summary in the cases multiple currencies used [https://github.com/woocommerce/woocommerce-android/pull/10251]

--- a/WooCommerce/metadata/PlayStoreStrings.pot
+++ b/WooCommerce/metadata/PlayStoreStrings.pot
@@ -11,16 +11,16 @@ msgstr ""
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
+msgctxt "release_note_165"
+msgid ""
+"16.5:\n"
+"The latest WooCommerce app version focuses on stability improvements! Additionally, WooPayments users can now seamlessly switch between currencies on the Deposits Summary view. Upgrade now for a smoother WooCommerce experience!\n"
+msgstr ""
+
 msgctxt "release_note_164"
 msgid ""
 "16.4:\n"
 "We're excited to introduce some new features! Our latest update allows you to charge tax for custom amounts and set one-time shipping for subscription products. You can also set subscription products as "virtual products". Plus, we've added an AI feature that generates a thank-you note on the completed order's details screen. Enjoy our new and improved WooCommerce app!\n"
-msgstr ""
-
-msgctxt "release_note_163"
-msgid ""
-"16.3:\n"
-"In this update, we've made managing your WooCommerce store even easier! You can now view your balances and deposits directly on the Payments screen if you're a WooCommerce Payments user. Additionally, we've added the ability to create or edit subscription products. And, to make order creation smoother, we now support bundle products. Enjoy the improved functionality and keep your feedback coming!\n"
 msgstr ""
 
 #. translators: Short description of the app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,5 +1,1 @@
-- [*] [Internal] Always use default currency as first choice to show in the deposits summary in the cases multiple currencies used [https://github.com/woocommerce/woocommerce-android/pull/10251]
-- [*] [Internal] Changes in the minSdkVersion from 24 to 26 and coroutines library update to version 1.7.3 [https://github.com/woocommerce/woocommerce-android/pull/10187]
-- [*] [Internal] Stripe SDK Migration to version 3.1.1 [https://github.com/woocommerce/woocommerce-android/pull/10103]
-- [*] [Internal] Send `store_id` in track events when available. [https://github.com/woocommerce/woocommerce-android/pull/10286]
-
+The latest WooCommerce app version focuses on stability improvements! Additionally, WooPayments users can now seamlessly switch between currencies on the Deposits Summary view. Upgrade now for a smoother WooCommerce experience!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,1 +1,5 @@
-We're excited to introduce some new features! Our latest update allows you to charge tax for custom amounts and set one-time shipping for subscription products. You can also set subscription products as "virtual products". Plus, we've added an AI feature that generates a thank-you note on the completed order's details screen. Enjoy our new and improved WooCommerce app!
+- [*] [Internal] Always use default currency as first choice to show in the deposits summary in the cases multiple currencies used [https://github.com/woocommerce/woocommerce-android/pull/10251]
+- [*] [Internal] Changes in the minSdkVersion from 24 to 26 and coroutines library update to version 1.7.3 [https://github.com/woocommerce/woocommerce-android/pull/10187]
+- [*] [Internal] Stripe SDK Migration to version 3.1.1 [https://github.com/woocommerce/woocommerce-android/pull/10103]
+- [*] [Internal] Send `store_id` in track events when available. [https://github.com/woocommerce/woocommerce-android/pull/10286]
+

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-059925004026943c8bb4b42e6637da21fb1463e3'
+    fluxCVersion = '2.58.0'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -577,7 +577,9 @@ platform :android do
       skip_upload_changelogs: true,
       skip_upload_images: true,
       skip_upload_screenshots: true,
-      json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
+      json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY,
+      # We're retaining version 16.4 - 480 because 16.5 increases the minSDKVersion from Android 7 to Android 8
+      version_codes_to_retain: [480]
     )
 
     create_gh_release(version: version) if options[:create_release]
@@ -629,7 +631,9 @@ platform :android do
       skip_upload_changelogs: true,
       skip_upload_images: true,
       skip_upload_screenshots: true,
-      json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
+      json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY,
+      # We're retaining version 16.4 - 480 because 16.5 increases the minSDKVersion from Android 7 to Android 8
+      version_codes_to_retain: [480]
     )
 
     create_gh_release(version: version, prerelease: true) if options[:create_release]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -631,9 +631,7 @@ platform :android do
       skip_upload_changelogs: true,
       skip_upload_images: true,
       skip_upload_screenshots: true,
-      json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY,
-      # We're retaining version 16.4 - 480 because 16.5 increases the minSDKVersion from Android 7 to Android 8
-      version_codes_to_retain: [480]
+      json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
     )
 
     create_gh_release(version: version, prerelease: true) if options[:create_release]

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -2015,6 +2015,7 @@
     <string name="product_creation_package_photo_keywords_info">Tweak your text: Unselect the scans you don\'t need or tap to edit</string>
     <string name="product_creation_package_photo_no_text_detected">No text detected. Please select another packaging photo or enter product details manually.</string>
     <string name="product_creation_package_photo_error">An error occurred while generating product name &amp; description.</string>
+    <string name="product_filter_explore_plugin">Explore!</string>
 
     <!--
         Product Add more details Bottom sheet
@@ -2259,6 +2260,7 @@
     <string name="settings_about_recommend_app_message">Hey! Here is a link to download the WooCommerce app. I\'m really enjoying it and thought you might too. %1$s</string>
     <string name="dev_options">Developer Options</string>
     <string name="settings_account">Account Settings</string>
+    <string name="settings_themes">Themes</string>
 
     <!--
         Developer Options Screen
@@ -3363,6 +3365,27 @@
     <string name="store_creation_profiler_merchant_journey_starting_business">I\'m just starting my business</string>
     <string name="store_creation_profiler_merchant_journey_selling_not_online">I\'m already selling, but not online</string>
     <string name="store_creation_profiler_merchant_journey_selling_online">I\'m already selling online</string>
+    <string name="store_creation_theme_activation_loading">Activating your store\'s theme…</string>
+    <string name="store_creation_theme_activation_error">An error occurred while activating the theme you selected, please retry again!</string>
+
+    <!--
+    Store theme
+    -->
+    <string name="theme_picker_title">Choose a theme</string>
+    <string name="theme_picker_description">You can always change it later in the settings.</string>
+    <string name="theme_picker_carousel_info_item_title">Looking for more?</string>
+    <string name="theme_picker_carousel_info_item_description">Once your store is set up, find your perfect theme in the WooCommerce Theme Store.</string>
+    <string name="theme_picker_carousel_placeholder_title">Theme "%s"</string>
+    <string name="theme_picker_carousel_placeholder_message">Tap for live demo.</string>
+    <string name="theme_picker_error_title">An error occurred</string>
+    <string name="theme_picker_error_message">Unable to load themes at this time.</string>
+    <string name="theme_preview_title">Preview</string>
+    <string name="theme_preview_bottom_sheet_pages_title">Pages on this template</string>
+    <string name="theme_preview_bottom_sheet_pages_subtitle">Tap to view</string>
+    <string name="theme_preview_bottom_sheet_home_section">Home</string>
+    <string name="theme_preview_activate_theme_button">Use this theme</string>
+    <string name="theme_preview_theme_name">Theme: %1$s</string>
+    <string name="theme_activated_successfully">Theme activated successfully</string>
 
     <!--
     Store onboarding
@@ -3850,4 +3873,5 @@
     <string name="configuration_children_issue"> "%1$s " -&gt; %2$s </string>
     <string name="configuration_variable_update">Choose variation</string>
     <string name="product_variation_picker_title">Select a variation</string>
+    <string name="store_creation_use_theme_button">Start with this theme</string>
 </resources>

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-versionName=16.4
-versionCode=480
+versionName=16.5-rc-1
+versionCode=481


### PR DESCRIPTION
This PR merges the changes from the 16.5 code freeze into `trunk`. Includes:
- Version bump
- Updated release notes
- Frozen app strings for translation
- Updated FluxC to a tagged version
- Added the 16.4 - 480 version code to retain because the minSDKVersion is increasing from Android 7 to Android 8 in 16.5 - See p91TBi-aME-p2