### PR TITLE
Use correct versioning calculator 

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,7 +56,7 @@ APP_PACKAGE_NAME = 'com.woocommerce.android'
 GOOGLE_FIREBASE_SECRETS_PATH = File.join(PROJECT_ROOT_FOLDER, '.configure-files', 'firebase.secrets.json')
 
 # Instanstiate versioning classes
-VERSION_CALCULATOR = Fastlane::Wpmreleasetoolkit::Versioning::DateVersionCalculator.new
+VERSION_CALCULATOR = Fastlane::Wpmreleasetoolkit::Versioning::MarketingVersionCalculator.new
 VERSION_FORMATTER = Fastlane::Wpmreleasetoolkit::Versioning::RCNotationVersionFormatter.new
 BUILD_CODE_FORMATTER = Fastlane::Wpmreleasetoolkit::Versioning::SimpleBuildCodeFormatter.new
 BUILD_CODE_CALCULATOR = Fastlane::Wpmreleasetoolkit::Versioning::SimpleBuildCodeCalculator.new


### PR DESCRIPTION
@jkmassel reported a few releases ago that the versioning didn't rollover correctly from `15.9` to `16.0`. Instead, it went from `15.9` to `15.10`. It turns out that I accidentally used the `DateVersionCalculator` for WCAndroid instead of the `MarketingVersionCalculator` when I added the new versioning methods. This PR just updates it to use the correct calculator. 

The `Date` calculator only bumps the major version at the end of the year. The `Marketing` calculator increments the major version number once the minor version number hits `x.9`. 
