### PR TITLE
[Custom Amounts] RTL issue in the order creation screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 16.6
 -----
 - [***] Custom Amounts M4.2: Redesigned UI, Percentage based custom amounts support [https://github.com/woocommerce/woocommerce-android/pull/10298]
+- [*] [Internal] Custom Amounts: Fix RTL issue in the order creation screen [https://github.com/woocommerce/woocommerce-android/pull/10316]
 
 16.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
@@ -13,7 +13,7 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.res.use
 import androidx.core.view.children
 import androidx.core.view.isVisible
-import androidx.core.view.setPadding
+import androidx.core.view.setMargins
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
@@ -184,21 +184,15 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
         container: RelativeLayout
     ) {
         addProductsViaScanButton?.let {
-            val addingProductsViaScanningButton = MaterialButton(context, null, R.attr.secondaryTextButtonStyle)
-            addingProductsViaScanningButton.icon = AppCompatResources.getDrawable(context, R.drawable.ic_barcode)
-            addingProductsViaScanningButton.iconPadding = 0
-            addingProductsViaScanningButton.setPadding(
-                0,
-                0,
-                resources.getDimensionPixelSize(R.dimen.major_100),
-                0
-            )
-            addingProductsViaScanningButton.iconGravity = MaterialButton.ICON_GRAVITY_TEXT_END
+            val addingProductsViaScanningButton = ImageView(context, null)
+            addingProductsViaScanningButton.setImageResource(R.drawable.ic_barcode)
+            val margins = resources.getDimensionPixelSize(R.dimen.major_100)
             addingProductsViaScanningButton.setOnClickListener { addProductsViaScanButton.onClickListener() }
             val addProductsViaScanningButtonParams = RelativeLayout.LayoutParams(
                 LayoutParams.WRAP_CONTENT,
                 LayoutParams.WRAP_CONTENT
             )
+            addProductsViaScanningButtonParams.setMargins(margins)
             addProductsViaScanningButtonParams.addRule(RelativeLayout.ALIGN_PARENT_END)
             addingProductsViaScanningButton.layoutParams = addProductsViaScanningButtonParams
             container.addView(addingProductsViaScanningButton)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
@@ -170,7 +170,7 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
                 LayoutParams.WRAP_CONTENT,
                 LayoutParams.WRAP_CONTENT
             )
-            addCustomAmountsButtonParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT)
+            addCustomAmountsButtonParams.addRule(RelativeLayout.ALIGN_PARENT_START)
             addingProductsManuallyButtonId?.let {
                 addCustomAmountsButtonParams.addRule(RelativeLayout.BELOW, addingProductsManuallyButtonId)
             }
@@ -193,13 +193,13 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
                 resources.getDimensionPixelSize(R.dimen.major_100),
                 0
             )
-            addingProductsViaScanningButton.iconGravity = MaterialButton.ICON_GRAVITY_END
+            addingProductsViaScanningButton.iconGravity = MaterialButton.ICON_GRAVITY_TEXT_END
             addingProductsViaScanningButton.setOnClickListener { addProductsViaScanButton.onClickListener() }
             val addProductsViaScanningButtonParams = RelativeLayout.LayoutParams(
                 LayoutParams.WRAP_CONTENT,
                 LayoutParams.WRAP_CONTENT
             )
-            addProductsViaScanningButtonParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT)
+            addProductsViaScanningButtonParams.addRule(RelativeLayout.ALIGN_PARENT_END)
             addingProductsViaScanningButton.layoutParams = addProductsViaScanningButtonParams
             container.addView(addingProductsViaScanningButton)
         }
@@ -214,7 +214,7 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
             LayoutParams.WRAP_CONTENT,
             LayoutParams.WRAP_CONTENT
         )
-        addProductButtonsParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT)
+        addProductButtonsParams.addRule(RelativeLayout.ALIGN_PARENT_START)
         val addingProductsManuallyButton = MaterialButton(context, null, R.attr.secondaryTextButtonStyle)
         addingProductsManuallyButton.text = addProductsButton.text
         addingProductsManuallyButton.icon = AppCompatResources.getDrawable(context, R.drawable.ic_add)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsDialog.kt
@@ -89,13 +89,27 @@ class CustomAmountsDialog : PaymentsBaseDialogFragment(R.layout.dialog_custom_am
         isLandscape: Boolean,
         binding: DialogCustomAmountsBinding
     ) {
-        if (!isLandscape && binding.editPrice.editText.requestFocus()) {
-            binding.editPrice.postDelayed(
-                {
-                    ActivityUtils.showKeyboard(binding.editPrice.editText)
-                },
-                KEYBOARD_DELAY
-            )
+        when (arguments.customAmountUIModel.type) {
+            FIXED_CUSTOM_AMOUNT -> {
+                if (!isLandscape && binding.editPrice.editText.requestFocus()) {
+                    binding.editPrice.postDelayed(
+                        {
+                            ActivityUtils.showKeyboard(binding.editPrice.editText)
+                        },
+                        KEYBOARD_DELAY
+                    )
+                }
+            }
+            PERCENTAGE_CUSTOM_AMOUNT -> {
+                if (!isLandscape && binding.editPercentage.requestFocus()) {
+                    binding.editPercentage.postDelayed(
+                        {
+                            ActivityUtils.showKeyboard(binding.editPercentage)
+                        },
+                        KEYBOARD_DELAY
+                    )
+                }
+            }
         }
     }
 
@@ -257,7 +271,7 @@ class CustomAmountsDialog : PaymentsBaseDialogFragment(R.layout.dialog_custom_am
         private const val WIDTH_RATIO = 0.9
         private const val HEIGHT_RATIO_LANDSCAPE = 0.9
         private const val WIDTH_RATIO_LANDSCAPE = 0.6
-        private const val KEYBOARD_DELAY = 100L
+        private const val KEYBOARD_DELAY = 500L
 
         const val CUSTOM_AMOUNT = "Custom Amount"
         const val EDIT_PRICE_UPDATE_DELAY = 100L


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10315 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the RTL issue in the order creation screen - Especially in the products section where the barcode scan icon was overlapping with the buttons


This PR also increases the delay for showing the keyboard in the custom amount dialog.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Navigate to the order creation flow and switch the language to any RTL (Right-to-Left) language. Once done, kindly verify that the layout remains properly aligned and intact.

#### Keyboard check
Navigate to the custom amount dialog in the order creation screen and ensure the keyboard shows up automatically as soon as the dialog is opened for both Fixed and Percentage custom amount type. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
| ------ | ----- |
| ![Before](https://github.com/woocommerce/woocommerce-android/assets/1331230/0af1a77b-2ffb-4755-b745-30f05bb44dbc) | ![After](https://github.com/woocommerce/woocommerce-android/assets/1331230/8ac020cf-3fd9-4acd-8e9c-cfb45c8ae420) |



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
