### PR TITLE
[Custom Amounts M4.2] Move `delete custom amount` button from OrderCreation to CustomAmount dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1335,6 +1335,7 @@ class OrderCreateEditViewModel @Inject constructor(
             draft.copy(feesLines = feesList)
         }
         tracker.track(ORDER_CREATION_REMOVE_CUSTOM_AMOUNT_TAPPED)
+        triggerEvent(Exit)
     }
 
     fun onFeeRemoved() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsDialog.kt
@@ -118,6 +118,15 @@ class CustomAmountsDialog : PaymentsBaseDialogFragment(R.layout.dialog_custom_am
         bindPercentageLabel(binding)
         setupTaxToggleView(binding)
         setupPrimaryEditView(binding)
+        setupDeleteCustomAmountView(binding)
+    }
+
+    private fun setupDeleteCustomAmountView(binding: DialogCustomAmountsBinding) {
+        if (viewModel.isInCreateMode()) {
+            binding.buttonDelete.hide()
+        } else {
+            binding.buttonDelete.show()
+        }
     }
 
     private fun bindPercentageLabel(binding: DialogCustomAmountsBinding) {
@@ -137,6 +146,17 @@ class CustomAmountsDialog : PaymentsBaseDialogFragment(R.layout.dialog_custom_am
     private fun setupClickListeners(binding: DialogCustomAmountsBinding) {
         binding.buttonDone.setOnClickListener {
             sharedViewModel.onCustomAmountUpsert(
+                CustomAmountUIModel(
+                    id = viewModel.viewState.customAmountUIModel.id,
+                    amount = viewModel.viewState.customAmountUIModel.currentPrice,
+                    name = viewModel.viewState.customAmountUIModel.name,
+                    taxStatus = viewModel.viewState.customAmountUIModel.taxStatus,
+                    type = viewModel.viewState.customAmountUIModel.type
+                )
+            )
+        }
+        binding.buttonDelete.setOnClickListener {
+            sharedViewModel.onCustomAmountRemoved(
                 CustomAmountUIModel(
                     id = viewModel.viewState.customAmountUIModel.id,
                     amount = viewModel.viewState.customAmountUIModel.currentPrice,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsDialogViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsDialogViewModel.kt
@@ -120,7 +120,7 @@ class CustomAmountsDialogViewModel @Inject constructor(
         triggerEvent(PopulatePercentage(customAmountUIModel))
     }
 
-    private fun isInCreateMode() = args.customAmountUIModel.amount.compareTo(BigDecimal.ZERO) == 0
+    fun isInCreateMode() = args.customAmountUIModel.amount.compareTo(BigDecimal.ZERO) == 0
 
     @Parcelize
     data class ViewState(

--- a/WooCommerce/src/main/res/layout/dialog_custom_amounts.xml
+++ b/WooCommerce/src/main/res/layout/dialog_custom_amounts.xml
@@ -222,8 +222,8 @@
                 android:layout_marginHorizontal="@dimen/major_100"
                 android:layout_marginTop="@dimen/major_75"
                 android:text="@string/custom_amounts_delete_custom_amount"
-                android:textColor="@color/woo_red_70"
-                app:strokeColor="@color/woo_red_70"
+                android:textColor="@color/woo_red_50"
+                app:strokeColor="@color/woo_red_50"
                 app:layout_constraintTop_toBottomOf="@id/custom_amount_name_divider"
                 tools:visibility="visible"/>
 

--- a/WooCommerce/src/main/res/layout/dialog_custom_amounts.xml
+++ b/WooCommerce/src/main/res/layout/dialog_custom_amounts.xml
@@ -213,6 +213,20 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/customAmountNameText" />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonDelete"
+                style="@style/Woo.Button.Outlined"
+                android:visibility="gone"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_75"
+                android:text="@string/custom_amounts_delete_custom_amount"
+                android:textColor="@color/woo_red_70"
+                app:strokeColor="@color/woo_red_70"
+                app:layout_constraintTop_toBottomOf="@id/custom_amount_name_divider"
+                tools:visibility="visible"/>
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </ScrollView>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -509,6 +509,7 @@
     <string name="custom_amounts_enter_amount">Amount</string>
     <string name="custom_amounts_name">Name</string>
     <string name="custom_amounts_add_custom_amount">Add Custom Amount</string>
+    <string name="custom_amounts_delete_custom_amount">Delete custom amount</string>
     <string name="custom_amounts_add_custom_name_hint">Enter Custom name</string>
     <string name="custom_amounts_creation_error">Unable to create custom amount order</string>
     <string name="custom_amounts_tax_label">Charge Taxes</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -1777,6 +1777,33 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
 
         assertThat(orderDraft?.feesLines?.filter { it.name != null }?.size).isEqualTo(0)
     }
+
+    @Test
+    fun `when custom amount removed, then exit event is triggered`() {
+        var orderDraft: Order? = null
+        sut.orderDraft.observeForever {
+            orderDraft = it
+        }
+        val customAmountUIModel = CustomAmountUIModel(
+            id = 0L,
+            amount = BigDecimal.TEN,
+            name = "Test amount",
+            type = CustomAmountsDialogViewModel.CustomAmountType.FIXED_CUSTOM_AMOUNT
+        )
+        sut.onCustomAmountUpsert(customAmountUIModel)
+        assertThat(orderDraft?.feesLines?.size).isEqualTo(1)
+
+        sut.onCustomAmountRemoved(
+            CustomAmountUIModel(
+                id = 0L,
+                amount = BigDecimal.TEN,
+                name = "Test amount",
+                type = CustomAmountsDialogViewModel.CustomAmountType.FIXED_CUSTOM_AMOUNT
+            )
+        )
+
+        assertThat(sut.event.value).isInstanceOf(Exit::class.java)
+    }
     @Test
     fun `when custom amount is added, then proper event is tracked`() {
         val customAmountUIModel = CustomAmountUIModel(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10323 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR moves the custom amount remove button from `OrderCreation` screen into `CustomAmountDialog` screen.

Design: ichqhxDjbmZZmvJaJkGhkj-fi-626%3A21619

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Navigate to the order creation screen
2. Open custom amount dialog
3. Ensure you don't see `Delete custom amount` button while adding custom amount button
4. After adding custom amount, edit the custom amount
5. Ensure you see delete custom amount button
6. Try deleting and make sure it works as expected 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/1331230/1b28824d-4e7a-46dc-8bbc-03e660af8ae7



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->