### PR TITLE
[Hack Week] Allow fixing cha-ching issue from order list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -125,6 +125,7 @@ object AppPrefs {
         WC_STORE_ID,
         CREATED_STORE_SITE_ID,
         CREATED_STORE_THEME_ID,
+        CHA_CHING_SOUND_ISSUE_DIALOG_DISMISSED,
     }
 
     /**
@@ -291,6 +292,10 @@ object AppPrefs {
     var createdStoreSiteId: Long?
         get() = getLong(DeletablePrefKey.CREATED_STORE_SITE_ID, -1).takeIf { it != -1L }
         set(value) = setLong(DeletablePrefKey.CREATED_STORE_SITE_ID, value ?: -1)
+
+    var chaChingSoundIssueDialogDismissed: Boolean
+        get() = getBoolean(DeletablePrefKey.CHA_CHING_SOUND_ISSUE_DIALOG_DISMISSED, false)
+        set(value) = setBoolean(DeletablePrefKey.CHA_CHING_SOUND_ISSUE_DIALOG_DISMISSED, value)
 
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -36,6 +36,8 @@ class AppPrefsWrapper @Inject constructor() {
 
     var wasAIProductDescriptionCelebrationShown by AppPrefs::wasAIProductDescriptionCelebrationShown
 
+    var chaChingSoundIssueDialogDismissed by AppPrefs::chaChingSoundIssueDialogDismissed
+
     fun getAppInstallationDate() = AppPrefs.installationDate
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationChannelsHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationChannelsHandler.kt
@@ -26,14 +26,12 @@ class NotificationChannelsHandler @Inject constructor(
         createChannels()
     }
 
-    @Suppress("unused")
     fun recreateNotificationChannel(channelType: NotificationChannelType) {
         notificationManagerCompat.deleteNotificationChannel(channelType.getChannelId())
         appPrefsWrapper.incrementNotificationChannelTypeSuffix(channelType)
         createChannel(channelType)
     }
 
-    @Suppress("unused")
     fun checkNotificationChannelSound(channelType: NotificationChannelType): Boolean {
         val channel = notificationManagerCompat.getNotificationChannel(channelType.getChannelId())
             ?: return true // If the notification is not created yet, then it'll have the correct sound when created

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/ShowTestNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/ShowTestNotification.kt
@@ -1,0 +1,50 @@
+package com.woocommerce.android.notifications
+
+import android.Manifest.permission
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.woocommerce.android.R
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import kotlin.random.Random
+import kotlin.time.Duration
+
+class ShowTestNotification @Inject constructor(
+    private val context: Context,
+    private val notificationChannelsHandler: NotificationChannelsHandler
+) {
+    suspend operator fun invoke(
+        title: String,
+        message: String,
+        channelType: NotificationChannelType,
+        dismissDelay: Duration? = null
+    ) {
+        if (context.checkSelfPermission(permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+            return
+        }
+
+        val notificationManager = NotificationManagerCompat.from(context)
+        val notificationId = Random.nextInt()
+
+        val notification = NotificationCompat.Builder(
+            context,
+            with(notificationChannelsHandler) { channelType.getChannelId() }
+        )
+            .setSmallIcon(R.drawable.ic_woo_w_notification)
+            .setContentTitle(title)
+            .setContentText(message)
+            .build()
+
+        notificationManager.notify(notificationId, notification)
+
+        dismissDelay?.let {
+            withContext(NonCancellable) {
+                kotlinx.coroutines.delay(it)
+                notificationManager.cancel(notificationId)
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/BaseFragment.kt
@@ -62,7 +62,11 @@ open class BaseFragment : Fragment, BaseFragmentView {
             positiveButtonId = this.positiveButtonId,
             posBtnAction = this.positiveBtnAction,
             negativeButtonId = this.negativeButtonId,
-            negBtnAction = this.negativeBtnAction
+            negBtnAction = this.negativeBtnAction,
+            neutralButtonId = this.neutralButtonId,
+            neutBtAction = this.neutralBtnAction,
+            cancellable = this.cancelable,
+            onDismiss = this.onDismiss
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/UIMessageResolver.kt
@@ -269,6 +269,30 @@ interface UIMessageResolver {
         }
         snackbar.show()
     }
+
+    /**
+     * Shows a Snackbar with an action.
+     * The Snackbar will use a length: [BaseTransientBottomBar.LENGTH_LONG].
+     *
+     * @param message the message to display
+     * @param actionText the action text
+     * @param action the callback to invoke when the action is clicked
+     */
+    fun showActionSnack(
+        message: String,
+        actionText: String,
+        action: View.OnClickListener
+    ) {
+        val snackbar = getSnackbarWithAction(
+            view = snackbarRoot,
+            msg = message,
+            actionString = actionText,
+            actionListener = action,
+            anchorViewId = anchorViewId
+        )
+
+        snackbar.show()
+    }
 }
 private fun getIndefiniteSnackbarWithAction(
     view: View,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dialog/WooDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dialog/WooDialog.kt
@@ -24,7 +24,9 @@ object WooDialog {
         @StringRes messageId: Int? = null,
         @StringRes positiveButtonId: Int? = null,
         @StringRes negativeButtonId: Int? = null,
-        @StringRes neutralButtonId: Int? = null
+        @StringRes neutralButtonId: Int? = null,
+        cancellable: Boolean = true,
+        onDismiss: (() -> Unit)? = null
     ) {
         dialogRef?.get()?.let {
             // Dialog is already present
@@ -32,7 +34,7 @@ object WooDialog {
         }
 
         val builder = MaterialAlertDialogBuilder(activity)
-            .setCancelable(true)
+            .setCancelable(cancellable)
             .setOnDismissListener { onCleared() }
             .apply {
                 titleId?.let { setTitle(it) }
@@ -48,6 +50,9 @@ object WooDialog {
             }
             .apply {
                 neutralButtonId?.let { setNeutralButton(it, neutBtAction) }
+            }
+            .apply {
+                onDismiss?.let { setOnDismissListener { it() } }
             }
 
         dialogRef = WeakReference(builder.show())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -379,6 +379,7 @@ class OrderListFragment :
                 is OrderListViewModel.OrderListEvent.OpenBarcodeScanningFragment -> {
                     openBarcodeScanningFragment()
                 }
+                is MultiLiveEvent.Event.ShowDialog -> event.showDialog()
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -380,6 +380,11 @@ class OrderListFragment :
                     openBarcodeScanningFragment()
                 }
                 is MultiLiveEvent.Event.ShowDialog -> event.showDialog()
+                is MultiLiveEvent.Event.ShowActionSnackbar -> uiMessageResolver.showActionSnack(
+                    message = event.message,
+                    actionText = event.actionText,
+                    action = event.action
+                )
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagedList
 import com.google.android.material.snackbar.Snackbar
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -99,7 +100,8 @@ class OrderListViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val feedbackPrefs: FeedbackPrefs,
     private val barcodeScanningTracker: BarcodeScanningTracker,
-    private val notificationChannelsHandler: NotificationChannelsHandler
+    private val notificationChannelsHandler: NotificationChannelsHandler,
+    private val appPrefs: AppPrefsWrapper
 ) : ScopedViewModel(savedState), LifecycleOwner {
     private val lifecycleRegistry: LifecycleRegistry by lazy {
         LifecycleRegistry(this)
@@ -690,7 +692,9 @@ class OrderListViewModel @Inject constructor(
         // The notification channels are only available on Oreo and above, so no need to check when below.
         if (!SystemVersionUtils.isAtLeastO()) return
 
-        if (!notificationChannelsHandler.checkNotificationChannelSound(NotificationChannelType.NEW_ORDER)) {
+        if (!notificationChannelsHandler.checkNotificationChannelSound(NotificationChannelType.NEW_ORDER) &&
+            !appPrefs.chaChingSoundIssueDialogDismissed
+        ) {
             triggerEvent(
                 Event.ShowDialog(
                     titleId = R.string.cha_ching_sound_issue_dialog_title,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -702,14 +702,12 @@ class OrderListViewModel @Inject constructor(
                     positiveButtonId = R.string.cha_ching_sound_issue_dialog_turn_on_sound,
                     negativeButtonId = R.string.cha_ching_sound_issue_dialog_keep_silent,
                     positiveBtnAction = { _, _ ->
-                        TODO()
+                        notificationChannelsHandler.recreateNotificationChannel(NotificationChannelType.NEW_ORDER)
                     },
                     negativeBtnAction = { _, _ ->
-                        TODO()
+                        appPrefs.chaChingSoundIssueDialogDismissed = true
                     },
-                    onDismiss = {
-                        TODO()
-                    }
+                    cancelable = false
                 )
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -418,7 +418,6 @@ class OrderListViewModel @Inject constructor(
         }
     }
 
-
     private fun clearLiveDataSources(pagedListWrapper: PagedListWrapper<OrderListItemUIType>?) {
         pagedListWrapper?.apply {
             _pagedListData.removeSource(data)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -48,7 +48,6 @@ import com.woocommerce.android.ui.orders.filters.domain.ShouldShowCreateTestOrde
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowErrorSnack
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowOrderFilters
 import com.woocommerce.android.util.CoroutineDispatchers
-import com.woocommerce.android.util.SystemVersionUtils
 import com.woocommerce.android.util.ThrottleLiveData
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -692,9 +691,6 @@ class OrderListViewModel @Inject constructor(
     }
 
     private fun checkChaChingSoundSettings() {
-        // The notification channels are only available on Oreo and above, so no need to check when below.
-        if (!SystemVersionUtils.isAtLeastO()) return
-
         fun recreateNotificationChannel() {
             notificationChannelsHandler.recreateNotificationChannel(NotificationChannelType.NEW_ORDER)
             triggerEvent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsFragment.kt
@@ -67,7 +67,7 @@ class PrivacySettingsFragment : BaseFragment() {
                 is MultiLiveEvent.Event.ShowActionSnackbar ->
                     snackbar = uiMessageResolver.getIndefiniteActionSnack(
                         event.message,
-                        actionText = getString(R.string.retry),
+                        actionText = event.actionText,
                         actionListener = event.action
                     ).apply {
                         show()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModel.kt
@@ -57,7 +57,8 @@ class PrivacySettingsViewModel @Inject constructor(
                 event.onFailure {
                     triggerEvent(
                         MultiLiveEvent.Event.ShowActionSnackbar(
-                            resourceProvider.getString(R.string.settings_tracking_analytics_error_fetch)
+                            message = resourceProvider.getString(R.string.settings_tracking_analytics_error_fetch),
+                            actionText = resourceProvider.getString(R.string.retry),
                         ) {
                             initialize()
                         }
@@ -70,7 +71,8 @@ class PrivacySettingsViewModel @Inject constructor(
 
                     triggerEvent(
                         MultiLiveEvent.Event.ShowActionSnackbar(
-                            resourceProvider.getString(R.string.settings_tracking_analytics_error_update)
+                            message = resourceProvider.getString(R.string.settings_tracking_analytics_error_update),
+                            actionText = resourceProvider.getString(R.string.retry),
                         ) { onSendStatsSettingChanged(checked) }
                     )
                 }
@@ -121,7 +123,8 @@ class PrivacySettingsViewModel @Inject constructor(
                         analyticsTrackerWrapper.sendUsageStats = !checked
                         triggerEvent(
                             MultiLiveEvent.Event.ShowActionSnackbar(
-                                resourceProvider.getString(R.string.settings_tracking_analytics_error_update)
+                                message = resourceProvider.getString(R.string.settings_tracking_analytics_error_update),
+                                actionText = resourceProvider.getString(R.string.retry),
                             ) { onSendStatsSettingChanged(checked) }
                         )
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -345,7 +345,11 @@ class ProductDetailFragment :
                     )
                 }
 
-                is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(event.message, event.action)
+                is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(
+                    event.message,
+                    event.actionText,
+                    event.action
+                )
                 is HideImageUploadErrorSnackbar -> imageUploadErrorsSnackbar?.dismiss()
                 is ShowLinkedProductPromoBanner -> showLinkedProductPromoBanner()
                 is OpenProductDetails -> openProductDetails(event.productRemoteId)
@@ -432,12 +436,13 @@ class ProductDetailFragment :
 
     private fun displayProductImageUploadErrorSnackBar(
         message: String,
+        actionText: String,
         actionListener: View.OnClickListener
     ) {
         if (imageUploadErrorsSnackbar == null) {
             imageUploadErrorsSnackbar = uiMessageResolver.getIndefiniteActionSnack(
                 message = message,
-                actionText = getString(R.string.details),
+                actionText = actionText,
                 actionListener = actionListener
             )
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1971,9 +1971,11 @@ class ProductDetailViewModel @Inject constructor(
                             if (errorList.isEmpty()) {
                                 triggerEvent(HideImageUploadErrorSnackbar)
                             } else {
-                                val errorMsg = resources.getMediaUploadErrorMessage(errorList.size)
                                 triggerEvent(
-                                    ShowActionSnackbar(errorMsg) {
+                                    ShowActionSnackbar(
+                                        message = resources.getMediaUploadErrorMessage(errorList.size),
+                                        actionText = resources.getString(R.string.details)
+                                    ) {
                                         triggerEvent(ProductNavigationTarget.ViewMediaUploadErrors(productId))
                                     }
                                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -189,7 +189,11 @@ class ProductImagesFragment :
             when (event) {
                 is Exit -> findNavController().navigateUp()
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
-                is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(event.message, event.action)
+                is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(
+                    event.message,
+                    event.actionText,
+                    event.action
+                )
                 is ProductNavigationTarget -> navigator.navigate(this, event)
                 is ExitWithResult<*> -> navigateBackWithResult(KEY_IMAGES_DIALOG_RESULT, event.data)
                 is ShowDialog -> event.showDialog()
@@ -214,12 +218,13 @@ class ProductImagesFragment :
 
     private fun displayProductImageUploadErrorSnackBar(
         message: String,
+        actionText: String,
         actionListener: View.OnClickListener
     ) {
         if (imageUploadErrorsSnackbar == null) {
             imageUploadErrorsSnackbar = uiMessageResolver.getIndefiniteActionSnack(
                 message = message,
-                actionText = getString(R.string.details),
+                actionText = actionText,
                 actionListener = actionListener
             )
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesViewModel.kt
@@ -216,9 +216,11 @@ class ProductImagesViewModel @Inject constructor(
         mediaFileUploadHandler.observeCurrentUploadErrors(remoteProductId)
             .filter { it.isNotEmpty() }
             .onEach {
-                val errorMsg = resourceProvider.getMediaUploadErrorMessage(it.size)
                 triggerEvent(
-                    ShowActionSnackbar(errorMsg) { triggerEvent(ViewMediaUploadErrors(remoteProductId)) }
+                    ShowActionSnackbar(
+                        message = resourceProvider.getMediaUploadErrorMessage(it.size),
+                        actionText = resourceProvider.getString(R.string.details)
+                    ) { triggerEvent(ViewMediaUploadErrors(remoteProductId)) }
                 )
             }
             .launchIn(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -67,8 +67,10 @@ class VariationDetailFragment :
         const val KEY_VARIATION_DETAILS_RESULT = "key_variation_details_result"
     }
 
-    @Inject lateinit var uiMessageResolver: UIMessageResolver
-    @Inject lateinit var navigator: VariationNavigator
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
+    @Inject
+    lateinit var navigator: VariationNavigator
 
     private var doneOrUpdateMenuItem: MenuItem? = null
 
@@ -261,7 +263,12 @@ class VariationDetailFragment :
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
-                is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(event.message, event.action)
+                is ShowActionSnackbar -> displayProductImageUploadErrorSnackBar(
+                    event.message,
+                    event.actionText,
+                    event.action
+                )
+
                 is HideImageUploadErrorSnackbar -> imageUploadErrorsSnackbar?.dismiss()
                 is VariationNavigationTarget -> {
                     navigator.navigate(this, event)
@@ -338,12 +345,13 @@ class VariationDetailFragment :
 
     private fun displayProductImageUploadErrorSnackBar(
         message: String,
+        actionText: String,
         actionListener: View.OnClickListener
     ) {
         if (imageUploadErrorsSnackbar == null) {
             imageUploadErrorsSnackbar = uiMessageResolver.getIndefiniteActionSnack(
                 message = message,
-                actionText = getString(R.string.details),
+                actionText = actionText,
                 actionListener = actionListener
             )
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -447,9 +447,11 @@ class VariationDetailViewModel @Inject constructor(
                 if (errorList.isEmpty()) {
                     triggerEvent(HideImageUploadErrorSnackbar)
                 } else {
-                    val errorMsg = resources.getMediaUploadErrorMessage(errorList.size)
                     triggerEvent(
-                        Event.ShowActionSnackbar(errorMsg) {
+                        Event.ShowActionSnackbar(
+                            message = resources.getMediaUploadErrorMessage(errorList.size),
+                            actionText = resources.getString(string.details),
+                        ) {
                             triggerEvent(ViewMediaUploadErrors(navArgs.remoteVariationId))
                         }
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
@@ -134,7 +134,9 @@ open class MultiLiveEvent<T : Event> : MutableLiveData<T>() {
             @StringRes val neutralButtonId: Int? = null,
             val positiveBtnAction: OnClickListener? = null,
             val negativeBtnAction: OnClickListener? = null,
-            val neutralBtnAction: OnClickListener? = null
+            val neutralBtnAction: OnClickListener? = null,
+            val cancelable: Boolean = true,
+            val onDismiss: (() -> Unit)? = null
         ) : Event() {
             companion object {
                 fun buildDiscardDialogEvent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
@@ -112,6 +112,7 @@ open class MultiLiveEvent<T : Event> : MutableLiveData<T>() {
 
         data class ShowActionSnackbar(
             val message: String,
+            val actionText: String,
             val action: View.OnClickListener
         ) : Event()
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1693,6 +1693,9 @@
     <string name="cha_ching_sound_issue_dialog_turn_on_sound">ENABLE SOUND</string>
     <string name="cha_ching_sound_issue_dialog_keep_silent">KEEP SILENT</string>
     <string name="cha_ching_sound_succcess_snackbar">All set! The \'cha-ching\' will now sound for every new order.</string>
+    <string name="cha_ching_sound_succcess_snackbar_action">TEST SOUND</string>
+    <string name="cha_ching_sound_test_notification_title">Test notification</string>
+    <string name="cha_ching_sound_test_notification_message">This is just a test notification to check the Cha-Ching sound.\nYou can swipe it away.</string>
     <!--
         Product Review Detail
     -->
@@ -3879,7 +3882,4 @@
     <string name="configuration_variable_update">Choose variation</string>
     <string name="product_variation_picker_title">Select a variation</string>
     <string name="store_creation_use_theme_button">Start with this theme</string>
-    <string name="cha_ching_sound_succcess_snackbar_action">TEST SOUND</string>
-    <string name="cha_ching_sound_test_notification_title">Test notification</string>
-    <string name="cha_ching_sound_test_notification_message">This is just a test notification to check the Cha-Ching sound.\nYou can swipe it away.</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1688,6 +1688,10 @@
     <string name="more_notifications">and %d more.</string>
     <string name="notification_order_title">You have a new order! 🎉</string>
     <string name="notification_review_title">You have a new review! 🌟</string>
+    <string name="cha_ching_sound_issue_dialog_title">Cha-ching sound off</string>
+    <string name="cha_ching_sound_issue_dialog_message">Turn it back on to hear the \'cha-ching\' with every new sale. Keep in tune with your customers\' orders!</string>
+    <string name="cha_ching_sound_issue_dialog_turn_on_sound">ENABLE SOUND</string>
+    <string name="cha_ching_sound_issue_dialog_keep_silent">KEEP SILENT</string>
     <!--
         Product Review Detail
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1692,6 +1692,7 @@
     <string name="cha_ching_sound_issue_dialog_message">Turn it back on to hear the \'cha-ching\' with every new sale. Keep in tune with your customers\' orders!</string>
     <string name="cha_ching_sound_issue_dialog_turn_on_sound">ENABLE SOUND</string>
     <string name="cha_ching_sound_issue_dialog_keep_silent">KEEP SILENT</string>
+    <string name="cha_ching_sound_succcess_snackbar">All set! The \'cha-ching\' will now sound for every new order.</string>
     <!--
         Product Review Detail
     -->
@@ -3878,4 +3879,7 @@
     <string name="configuration_variable_update">Choose variation</string>
     <string name="product_variation_picker_title">Select a variation</string>
     <string name="store_creation_use_theme_button">Start with this theme</string>
+    <string name="cha_ching_sound_succcess_snackbar_action">TEST SOUND</string>
+    <string name="cha_ching_sound_test_notification_title">Test notification</string>
+    <string name="cha_ching_sound_test_notification_message">This is just a test notification to check the Cha-Ching sound.\nYou can swipe it away.</string>
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -92,7 +92,7 @@ class OrderListViewModelTest : BaseUnitTest() {
     private val dispatcher: Dispatcher = mock()
     private val orderStore: WCOrderStore = mock()
     private val resourceProvider: ResourceProvider = mock {
-        on { getString(any())} doAnswer { it.arguments[0].toString() }
+        on { getString(any()) } doAnswer { it.arguments[0].toString() }
     }
     private val savedStateHandle: SavedStateHandle = SavedStateHandle()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10327
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR is the second step to implement the soltuon of #10327, this adds logic that allows the user to re-created the orders notification channel, and thus fixing the Cha-ching sound issue from the Order list screen.

**Important:** It would be helpful to review both e92c71598910b050220104926aa2ac4f1cda7da4 and df3a0b75f1d62f9716a970fffbdb7461efb2573c separately, they both just add more properties to some common Event classes that I needed in the PR.

### Testing instructions
1. Open the app information screen on your device, then go to the Notifications menu, then update the "New Order" category to make it silent.
2. Open the app, then open orders list.
3. Notice the dialog.
4. Click on "turn on sound"
5. Click on the "Test sound" button of the snackbar.
6. Confirm a test notification is posted, and uses the Cha-ching sound.
7. Go back to the app information screen, and check that the "New Order" category has been re-created and has the correct sound now.
8. Optional: test a push notification, and confirm it uses the Cha-ching sound.
9. Repeat steps 1 and 2.
10. Click on "Keep silent"
11. Close and re-open the app, then open orders list, and confirm the dialos is not shown.

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/1657201/46c7d73a-a19a-4756-ae5e-fa0758f7418d



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
