### PR TITLE
build: integrate `measure-builds` plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ measureBuilds {
     enable = findProperty('tracksEnabled')?.toBoolean() ?: false
     automatticProject = MeasureBuildsExtension.AutomatticProject.WooCommerce
     attachGradleScanId = true
+    authToken = findProperty('appsMetricsToken')
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,19 @@
-import io.github.wzieba.tracks.plugin.TracksExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import com.automattic.android.measure.MeasureBuildsExtension
 
 plugins {
     id 'io.gitlab.arturbosch.detekt'
-    id 'io.github.wzieba.tracks.plugin'
+    id 'com.automattic.android.measure-builds'
     id 'com.android.application' apply false
     id 'org.jetbrains.kotlin.android' apply false
     id 'com.google.dagger.hilt.android' apply false
     id 'com.google.gms.google-services' apply false
 }
 
-tracks {
-    automatticProject.set(TracksExtension.AutomatticProject.WooCommerce)
-    enabled.set((findProperty('tracksEnabled') ?: false).toBoolean())
+measureBuilds {
+    enable.set((findProperty('tracksEnabled') ?: false).toBoolean())
+    automatticProject.set(MeasureBuildsExtension.AutomatticProject.WooCommerce)
+    attachGradleScanId.set(true)
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,9 @@ plugins {
 }
 
 measureBuilds {
-    enable.set((findProperty('tracksEnabled') ?: false).toBoolean())
-    automatticProject.set(MeasureBuildsExtension.AutomatticProject.WooCommerce)
-    attachGradleScanId.set(true)
+    enable = findProperty('tracksEnabled')?.toBoolean() ?: false
+    automatticProject = MeasureBuildsExtension.AutomatticProject.WooCommerce
+    attachGradleScanId = true
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import com.automattic.android.measure.MeasureBuildsExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id 'io.gitlab.arturbosch.detekt'

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,10 +4,10 @@ pluginManagement {
     gradle.ext.daggerVersion = '2.45'
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.kotlinVersion = '1.8.21'
+    gradle.ext.measureBuildsVersion = '2.0.0'
     gradle.ext.navigationVersion = '2.5.3'
     gradle.ext.sentryVersion = '3.5.0'
     gradle.ext.violationCommentsVersion = '1.69.0'
-    gradle.ext.wziebaTracksVersion = '1.2.1'
 
     repositories {
         google()
@@ -19,6 +19,7 @@ pluginManagement {
             }
             filter {
                 includeGroup "com.automattic.android"
+                includeGroup "com.automattic.android.measure-builds"
             }
         }
         gradlePluginPortal()
@@ -29,7 +30,7 @@ pluginManagement {
         id 'com.android.application' version gradle.ext.agpVersion
         id 'com.android.library' version gradle.ext.agpVersion
         id 'com.google.gms.google-services' version gradle.ext.googleServicesVersion
-        id 'io.github.wzieba.tracks.plugin' version gradle.ext.wziebaTracksVersion
+        id "com.automattic.android.measure-builds" version gradle.ext.measureBuildsVersion
         id 'io.gitlab.arturbosch.detekt' version gradle.ext.detektVersion
         id 'io.sentry.android.gradle' version gradle.ext.sentryVersion
         id 'org.jetbrains.kotlin.android' version gradle.ext.kotlinVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     gradle.ext.daggerVersion = '2.45'
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.kotlinVersion = '1.8.21'
-    gradle.ext.measureBuildsVersion = '2.0.0'
+    gradle.ext.measureBuildsVersion = '2.0.1'
     gradle.ext.navigationVersion = '2.5.3'
     gradle.ext.sentryVersion = '3.5.0'
     gradle.ext.violationCommentsVersion = '1.69.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     gradle.ext.daggerVersion = '2.45'
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.kotlinVersion = '1.8.21'
-    gradle.ext.measureBuildsVersion = '2.0.2'
+    gradle.ext.measureBuildsVersion = '2.0.3'
     gradle.ext.navigationVersion = '2.5.3'
     gradle.ext.sentryVersion = '3.5.0'
     gradle.ext.violationCommentsVersion = '1.69.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,8 +29,8 @@ pluginManagement {
         id 'androidx.navigation.safeargs.kotlin' version gradle.ext.navigationVersion
         id 'com.android.application' version gradle.ext.agpVersion
         id 'com.android.library' version gradle.ext.agpVersion
+        id 'com.automattic.android.measure-builds' version gradle.ext.measureBuildsVersion
         id 'com.google.gms.google-services' version gradle.ext.googleServicesVersion
-        id "com.automattic.android.measure-builds" version gradle.ext.measureBuildsVersion
         id 'io.gitlab.arturbosch.detekt' version gradle.ext.detektVersion
         id 'io.sentry.android.gradle' version gradle.ext.sentryVersion
         id 'org.jetbrains.kotlin.android' version gradle.ext.kotlinVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     gradle.ext.daggerVersion = '2.45'
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.kotlinVersion = '1.8.21'
-    gradle.ext.measureBuildsVersion = '2.0.1'
+    gradle.ext.measureBuildsVersion = '2.0.2'
     gradle.ext.navigationVersion = '2.5.3'
     gradle.ext.sentryVersion = '3.5.0'
     gradle.ext.violationCommentsVersion = '1.69.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR replaces `tracks-gradle` with the new, updated plugin: [measure-builds-gradle-plugin](https://github.com/Automattic/measure-builds-gradle-plugin).


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Make sure you updated secrets and you have `appsMetricsToken` value in `gradle.properties`.
2. Run any task with `--debug` flag, e.g. `./gradlew help --debug`
3. Find `REQUEST: https://metrics.a8c-ci.services/api/grouped-metrics` log and assert, that in the sent payload, there's `{"name":"woocommerce-gradle-scan-id","value":"<id of uploaded scan>"}` object.

Please be mindful, that the connection can timeout due to backend issue. Please don't worry about it, it's a known issue that we'll address it later.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="776" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/5845095/fa9d1e6c-a9aa-4fee-bbe5-2e5678891c2f">


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
