### PR TITLE
[Themes] Remove some profiler steps

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerFragment.kt
@@ -15,7 +15,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.storecreation.NewStore
 import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.NavigateToDomainListPicker
-import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.NavigateToSummaryStep
+import com.woocommerce.android.ui.login.storecreation.countrypicker.CountryPickerViewModel.NavigateToNextStep
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
@@ -51,7 +51,7 @@ class CountryPickerFragment : BaseFragment() {
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                 is MultiLiveEvent.Event.NavigateToHelpScreen -> navigateToHelpScreen(event.origin)
-                is NavigateToSummaryStep -> navigateToStoreChallengesStep()
+                is NavigateToNextStep -> navigateToNextStep()
                 is NavigateToDomainListPicker -> navigateToDomainListPicker(event.locationCode)
             }
         }
@@ -71,9 +71,9 @@ class CountryPickerFragment : BaseFragment() {
         )
     }
 
-    private fun navigateToStoreChallengesStep() {
+    private fun navigateToNextStep() {
         findNavController().navigateSafely(
-            CountryPickerFragmentDirections.actionCountryPickerFragmentToStoreProfilerChallengesFragment()
+            CountryPickerFragmentDirections.actionCountryPickerFragmentToNavGraphThemes()
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/countrypicker/CountryPickerViewModel.kt
@@ -86,7 +86,7 @@ class CountryPickerViewModel @Inject constructor(
             profilerAnswers = newStore.data.profilerData
         )
 
-        triggerEvent(NavigateToSummaryStep)
+        triggerEvent(NavigateToNextStep)
     }
 
     fun onCurrentCountryClicked() {
@@ -102,5 +102,5 @@ class CountryPickerViewModel @Inject constructor(
     }
 
     data class NavigateToDomainListPicker(val locationCode: String) : MultiLiveEvent.Event()
-    object NavigateToSummaryStep : MultiLiveEvent.Event()
+    object NavigateToNextStep : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_store_creation_native.xml
@@ -93,6 +93,9 @@
         <action
             android:id="@+id/action_countryPickerFragment_to_countryListPickerFragment"
             app:destination="@id/countryListPickerFragment" />
+        <action
+            android:id="@+id/action_countryPickerFragment_to_nav_graph_themes"
+            app:destination="@id/nav_graph_themes" />
     </fragment>
 
     <fragment


### PR DESCRIPTION
Fixes #10295. 

To match the design, this PR removes the challenges and features profiler steps during store creation.

**To test:**
1. Trigger the store creation
2. Notice that after selection the location, the next step is the theme picker
3. Verify a store is created successfully