### PR TITLE
Remove pre API 26 code

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/notifications/NotificationsScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/notifications/NotificationsScreen.kt
@@ -24,7 +24,6 @@ class NotificationsScreen(private val wooNotificationBuilder: WooNotificationBui
     private fun displayNotification() {
         wooNotificationBuilder.buildAndDisplayWooNotification(
             0,
-            0,
             notification = Notification(
                 noteId = 1,
                 uniqueId = 1L,
@@ -36,7 +35,6 @@ class NotificationsScreen(private val wooNotificationBuilder: WooNotificationBui
                 noteType = NEW_ORDER,
                 channelType = NotificationChannelType.NEW_ORDER
             ),
-            addCustomNotificationSound = false,
             isGroupNotification = false
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -149,15 +149,6 @@ object AppPrefs {
         // Whether or not automatic crash reporting is enabled
         ENABLE_CRASH_REPORTING,
 
-        // Enable notifications for new orders
-        NOTIFS_ORDERS_ENABLED,
-
-        // Enable notifications for new reviews
-        NOTIFS_REVIEWS_ENABLED,
-
-        // Play cha-ching sound on new order notifications
-        NOTIFS_ORDERS_CHA_CHING_ENABLED,
-
         // The app update for this version was cancelled by the user
         CANCELLED_APP_VERSION_CODE,
 
@@ -502,24 +493,6 @@ object AppPrefs {
 
     fun setCrashReportingEnabled(enabled: Boolean) {
         setBoolean(UndeletablePrefKey.ENABLE_CRASH_REPORTING, enabled)
-    }
-
-    fun isOrderNotificationsEnabled() = getBoolean(UndeletablePrefKey.NOTIFS_ORDERS_ENABLED, true)
-
-    fun setOrderNotificationsEnabled(enabled: Boolean) {
-        setBoolean(UndeletablePrefKey.NOTIFS_ORDERS_ENABLED, enabled)
-    }
-
-    fun isReviewNotificationsEnabled() = getBoolean(UndeletablePrefKey.NOTIFS_REVIEWS_ENABLED, true)
-
-    fun setReviewNotificationsEnabled(enabled: Boolean) {
-        setBoolean(UndeletablePrefKey.NOTIFS_REVIEWS_ENABLED, enabled)
-    }
-
-    fun isOrderNotificationsChaChingEnabled() = getBoolean(UndeletablePrefKey.NOTIFS_ORDERS_CHA_CHING_ENABLED, true)
-
-    fun setOrderNotificationsChaChingEnabled(enabled: Boolean) {
-        setBoolean(UndeletablePrefKey.NOTIFS_ORDERS_CHA_CHING_ENABLED, enabled)
     }
 
     fun getSelectedShipmentTrackingProviderName(): String =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -143,12 +143,6 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun removeLastConnectedCardReaderId() = AppPrefs.removeLastConnectedCardReaderId()
 
-    fun isOrderNotificationsEnabled() = AppPrefs.isOrderNotificationsEnabled()
-
-    fun isReviewNotificationsEnabled() = AppPrefs.isReviewNotificationsEnabled()
-
-    fun isOrderNotificationsChaChingEnabled() = AppPrefs.isOrderNotificationsChaChingEnabled()
-
     fun getJetpackBenefitsDismissalDate(): Long {
         return AppPrefs.getJetpackBenefitsDismissalDate()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesNotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesNotificationHandler.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.ui.media.MediaFileUploadHandler.ProductImageUploa
 import com.woocommerce.android.ui.media.MediaUploadErrorListFragmentArgs
 import com.woocommerce.android.ui.products.ProductDetailFragmentArgs
 import com.woocommerce.android.util.StringUtils
-import com.woocommerce.android.util.SystemVersionUtils
 import org.wordpress.android.util.SystemServiceFactory
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -198,16 +197,14 @@ class ProductImagesNotificationHandler @Inject constructor(
      * Ensures the notification channel for image uploads is created - only required for Android O+
      */
     private fun createChannel() {
-        if (SystemVersionUtils.isAtLeastO()) {
-            // first check if the channel already exists
-            notificationManager.getNotificationChannel(CHANNEL_ID)?.let {
-                return
-            }
-
-            val channelName = context.getString(R.string.product_images_upload_channel_title)
-            val channel = NotificationChannel(CHANNEL_ID, channelName, NotificationManager.IMPORTANCE_DEFAULT)
-            notificationManager.createNotificationChannel(channel)
+        // first check if the channel already exists
+        notificationManager.getNotificationChannel(CHANNEL_ID)?.let {
+            return
         }
+
+        val channelName = context.getString(R.string.product_images_upload_channel_title)
+        val channel = NotificationChannel(CHANNEL_ID, channelName, NotificationManager.IMPORTANCE_DEFAULT)
+        notificationManager.createNotificationChannel(channel)
     }
 
     fun removeForegroundNotification() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationChannelType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationChannelType.kt
@@ -1,8 +1,6 @@
 package com.woocommerce.android.notifications
 
 import androidx.annotation.StringRes
-import androidx.core.app.NotificationCompat
-import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.notifications.NotificationChannelType.NEW_ORDER
 import com.woocommerce.android.notifications.NotificationChannelType.OTHER
 import com.woocommerce.android.notifications.NotificationChannelType.REVIEW
@@ -30,13 +28,5 @@ fun NotificationChannelType.shouldCircularizeNoteIcon(): Boolean {
     return when (this) {
         REVIEW -> true
         else -> false
-    }
-}
-
-fun NotificationChannelType.getDefaults(appPrefsWrapper: AppPrefsWrapper): Int {
-    return when {
-        this == NEW_ORDER && appPrefsWrapper.isOrderNotificationsChaChingEnabled() -> {
-            NotificationCompat.DEFAULT_LIGHTS or NotificationCompat.DEFAULT_VIBRATE
-        } else -> NotificationCompat.DEFAULT_ALL
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
@@ -4,7 +4,6 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import android.media.AudioManager
 import android.os.RemoteException
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -99,18 +98,13 @@ class WooNotificationBuilder @Inject constructor(
 
     fun buildAndDisplayWooNotification(
         pushId: Int,
-        defaults: Int,
         notification: Notification,
-        addCustomNotificationSound: Boolean,
         isGroupNotification: Boolean
     ) {
         val channelType = notification.channelType
         getNotificationBuilder(notification).apply {
             setLargeIcon(getLargeIconBitmap(context, notification.icon, channelType.shouldCircularizeNoteIcon()))
-            setDefaults(defaults)
-            if (addCustomNotificationSound) {
-                setSound(context.getChaChingUri(), AudioManager.STREAM_NOTIFICATION)
-            }
+            setDefaults(NotificationCompat.DEFAULT_ALL)
         }.apply {
             showNotification(pushId, notification, this)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -27,7 +27,6 @@ import com.woocommerce.android.analytics.AnalyticsEvent.SETTINGS_IMAGE_OPTIMIZAT
 import com.woocommerce.android.analytics.AnalyticsEvent.SETTINGS_LOGOUT_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.SETTINGS_PRIVACY_SETTINGS_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.SETTINGS_WE_ARE_HIRING_BUTTON_TAPPED
-import com.woocommerce.android.analytics.AnalyticsEvent.SETTING_CHANGE
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentSettingsMainBinding
 import com.woocommerce.android.extensions.hide
@@ -40,7 +39,6 @@ import com.woocommerce.android.util.AnalyticsUtils
 import com.woocommerce.android.util.AppThemeUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.PackageUtils
-import com.woocommerce.android.util.SystemVersionUtils
 import com.woocommerce.android.util.ThemeOption
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
@@ -53,9 +51,6 @@ import javax.inject.Inject
 class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSettingsContract.View {
     companion object {
         const val TAG = "main-settings"
-        private const val SETTING_NOTIFS_ORDERS = "notifications_orders"
-        private const val SETTING_NOTIFS_REVIEWS = "notifications_reviews"
-        private const val SETTING_NOTIFS_TONE = "notifications_tone"
     }
 
     @Inject
@@ -133,46 +128,18 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             startActivity(HelpActivity.createIntent(requireActivity(), HelpOrigin.SETTINGS, null))
         }
 
-        // on API 26+ we show the device notification settings, on older devices we have in-app settings
-        if (SystemVersionUtils.isAtLeastO()) {
-            binding.containerNotifsOld.visibility = View.GONE
-            binding.containerNotifsNew.visibility = View.VISIBLE
-            binding.optionNotifications.optionTitle = if (presenter.isChaChingSoundEnabled) {
-                getString(R.string.settings_notifs_device)
-            } else {
-                getString(R.string.settings_notifs)
-            }
-            binding.optionNotifications.optionValue = if (presenter.isChaChingSoundEnabled) {
-                getString(R.string.settings_notifs_device_detail)
-            } else {
-                null
-            }
-            binding.optionNotifications.setOnClickListener {
-                presenter.onNotificationsClicked()
-            }
+        binding.optionNotifications.optionTitle = if (presenter.isChaChingSoundEnabled) {
+            getString(R.string.settings_notifs_device)
         } else {
-            binding.containerNotifsOld.visibility = View.VISIBLE
-            binding.containerNotifsNew.visibility = View.GONE
-
-            binding.optionNotifsOrders.isChecked = AppPrefs.isOrderNotificationsEnabled()
-            binding.optionNotifsOrders.setOnCheckedChangeListener { _, isChecked ->
-                trackSettingToggled(SETTING_NOTIFS_ORDERS, isChecked)
-                AppPrefs.setOrderNotificationsEnabled(isChecked)
-                binding.optionNotifsTone.isEnabled = isChecked
-            }
-
-            binding.optionNotifsReviews.isChecked = AppPrefs.isReviewNotificationsEnabled()
-            binding.optionNotifsReviews.setOnCheckedChangeListener { _, isChecked ->
-                trackSettingToggled(SETTING_NOTIFS_REVIEWS, isChecked)
-                AppPrefs.setReviewNotificationsEnabled(isChecked)
-            }
-
-            binding.optionNotifsTone.isChecked = AppPrefs.isOrderNotificationsChaChingEnabled()
-            binding.optionNotifsTone.isEnabled = AppPrefs.isOrderNotificationsEnabled()
-            binding.optionNotifsTone.setOnCheckedChangeListener { _, isChecked ->
-                trackSettingToggled(SETTING_NOTIFS_TONE, isChecked)
-                AppPrefs.setOrderNotificationsChaChingEnabled(isChecked)
-            }
+            getString(R.string.settings_notifs)
+        }
+        binding.optionNotifications.optionValue = if (presenter.isChaChingSoundEnabled) {
+            getString(R.string.settings_notifs_device_detail)
+        } else {
+            null
+        }
+        binding.optionNotifications.setOnClickListener {
+            presenter.onNotificationsClicked()
         }
 
         if (PackageUtils.isDebugBuild()) {
@@ -285,12 +252,10 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
      * this on API 26+ devices (will do nothing on older devices)
      */
     override fun showDeviceAppNotificationSettings() {
-        if (SystemVersionUtils.isAtLeastO()) {
-            val intent = Intent()
-            intent.action = "android.settings.APP_NOTIFICATION_SETTINGS"
-            intent.putExtra("android.provider.extra.APP_PACKAGE", activity?.packageName)
-            activity?.startActivity(intent)
-        }
+        val intent = Intent()
+        intent.action = "android.settings.APP_NOTIFICATION_SETTINGS"
+        intent.putExtra("android.provider.extra.APP_PACKAGE", activity?.packageName)
+        activity?.startActivity(intent)
     }
 
     override fun showNotificationsSettingsScreen() {
@@ -353,20 +318,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         mutableListOf<String>().apply {
             add(getString(R.string.beta_features_add_ons))
         }
-
-    /**
-     * Called when a boolean setting is changed so we can track it
-     */
-    private fun trackSettingToggled(keyName: String, newValue: Boolean) {
-        AnalyticsTracker.track(
-            SETTING_CHANGE,
-            mapOf(
-                AnalyticsTracker.KEY_NAME to keyName,
-                AnalyticsTracker.KEY_FROM to !newValue,
-                AnalyticsTracker.KEY_TO to newValue
-            )
-        )
-    }
 
     private fun showThemeChooser() {
         val currentTheme = AppPrefs.getAppTheme()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/SystemVersionUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/SystemVersionUtils.kt
@@ -23,7 +23,4 @@ object SystemVersionUtils {
 
     fun isAtLeastP() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
     fun isAtMostP() = Build.VERSION.SDK_INT <= Build.VERSION_CODES.P
-
-    fun isAtLeastO() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
-    fun isAtMostO() = Build.VERSION.SDK_INT <= Build.VERSION_CODES.O
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/SystemVersionUtilsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/SystemVersionUtilsWrapper.kt
@@ -13,11 +13,8 @@ class SystemVersionUtilsWrapper @Inject constructor() {
     fun isAtMostR() = SystemVersionUtils.isAtMostR()
 
     fun isAtLeastQ() = SystemVersionUtils.isAtLeastQ()
-    fun isAtMostQ() = SystemVersionUtils.isAtMostO()
+    fun isAtMostQ() = SystemVersionUtils.isAtMostQ()
 
     fun isAtLeastP() = SystemVersionUtils.isAtLeastP()
     fun isAtMostP() = SystemVersionUtils.isAtMostP()
-
-    fun isAtLeastO() = SystemVersionUtils.isAtLeastO()
-    fun isAtMostO() = SystemVersionUtils.isAtMostO()
 }

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -99,46 +99,7 @@
         </LinearLayout>
 
         <!--
-            Notifications (pre- API 26)
-        -->
-        <LinearLayout
-            android:id="@+id/container_notifs_old"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            tools:visibility="visible">
-
-            <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/settings_notifs" />
-
-            <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
-                android:id="@+id/option_notifs_orders"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:toggleOptionDesc="@string/settings_notifs_orders_detail"
-                app:toggleOptionTitle="@string/settings_notifs_orders" />
-
-            <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
-                android:id="@+id/option_notifs_tone"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:toggleOptionDesc="@string/settings_notifs_tone_detail"
-                app:toggleOptionTitle="@string/settings_notifs_tone" />
-
-            <com.woocommerce.android.ui.prefs.WCSettingsToggleOptionView
-                android:id="@+id/option_notifs_reviews"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:toggleOptionDesc="@string/settings_notifs_reviews_detail"
-                app:toggleOptionTitle="@string/settings_notifs_reviews" />
-
-            <View style="@style/Woo.Divider" />
-        </LinearLayout>
-
-        <!--
-            Notifications (API 26+)
+            Notifications
         -->
         <LinearLayout
             android:id="@+id/container_notifs_new"

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -2955,12 +2955,6 @@ Language: ar
     <string name="wc_approve">موافقة</string>
     <string name="wc_view_the_product_external">عرض المنتج</string>
     <string name="support_help">المساعدة والدعم</string>
-    <string name="settings_notifs_reviews_detail">اتسالم تنبيهات لمراجعات المنتجات الجديدة</string>
-    <string name="settings_notifs_reviews">مراجعات المنتجات</string>
-    <string name="settings_notifs_tone_detail">تشغيل صوت \"تشا تشينج\" عند وصول طلب جديد</string>
-    <string name="settings_notifs_tone">نغمة</string>
-    <string name="settings_notifs_orders_detail">استلام التنبيهات عندما تظهر طلبات جديدة</string>
-    <string name="settings_notifs_orders">الطلبات</string>
     <string name="settings_notifs_device_detail">الأصوات والضرورة ونقطة الإخطار</string>
     <string name="settings_notifs_device">إدارة الإخطارات</string>
     <string name="settings_notifs">الإخطارات</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -2955,12 +2955,6 @@ Language: de
     <string name="wc_approve">Genehmigen</string>
     <string name="wc_view_the_product_external">Produkt anzeigen</string>
     <string name="support_help">Hilfe und Support</string>
-    <string name="settings_notifs_reviews_detail">Benachrichtigungen bei neuen Produktbewertungen</string>
-    <string name="settings_notifs_reviews">Produktbewertungen</string>
-    <string name="settings_notifs_tone_detail">Bei neuer Bestellung Ka-tsching-Geräusch abspielen </string>
-    <string name="settings_notifs_tone">Ton</string>
-    <string name="settings_notifs_orders_detail">Benachrichtigungen beim Eingang neuer Bestellungen</string>
-    <string name="settings_notifs_orders">Bestellungen</string>
     <string name="settings_notifs_device_detail">Töne, Priorität und Benachrichtigungspunkt</string>
     <string name="settings_notifs_device">Verwalten von Benachrichtigungen</string>
     <string name="settings_notifs">Benachrichtigungen</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -2955,12 +2955,6 @@ Language: es
     <string name="wc_approve">Aprobar</string>
     <string name="wc_view_the_product_external">Ver el producto</string>
     <string name="support_help">Ayuda y soporte</string>
-    <string name="settings_notifs_reviews_detail">Recibir alertas para las nuevas reseñas de productos</string>
-    <string name="settings_notifs_reviews">Reseñas de productos</string>
-    <string name="settings_notifs_tone_detail">Reproducir sonido cuando haya un nuevo pedido</string>
-    <string name="settings_notifs_tone">Tono</string>
-    <string name="settings_notifs_orders_detail">Recibir alertas cuando lleguen nuevos pedidos</string>
-    <string name="settings_notifs_orders">Pedidos</string>
     <string name="settings_notifs_device_detail">Sonidos, urgencia y punto de notificación</string>
     <string name="settings_notifs_device">Gestionar notificaciones</string>
     <string name="settings_notifs">Notificaciones</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -2955,12 +2955,6 @@ Language: fr
     <string name="wc_approve">Approuver</string>
     <string name="wc_view_the_product_external">Voir le produit</string>
     <string name="support_help">Aide et assistance</string>
-    <string name="settings_notifs_reviews_detail">Obtenir des alertes concernant les nouveaux avis sur les produits</string>
-    <string name="settings_notifs_reviews">Avis sur le produit</string>
-    <string name="settings_notifs_tone_detail">Exécuter le son Cha-Ching lors d’une nouvelle commande</string>
-    <string name="settings_notifs_tone">Tonalité</string>
-    <string name="settings_notifs_orders_detail">Obtenir des alertes à l’arrivée de nouvelles commandes</string>
-    <string name="settings_notifs_orders">Commandes</string>
     <string name="settings_notifs_device_detail">Sons, urgence et point de notification</string>
     <string name="settings_notifs_device">Gérer les notifications</string>
     <string name="settings_notifs">Notifications</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -2955,12 +2955,6 @@ Language: he_IL
     <string name="wc_approve">אישור</string>
     <string name="wc_view_the_product_external">הצגת המוצר</string>
     <string name="support_help">עזרה ותמיכה</string>
-    <string name="settings_notifs_reviews_detail">קבלת התראות על ביקורות חדשות למוצר</string>
-    <string name="settings_notifs_reviews">ביקורות על מוצר</string>
-    <string name="settings_notifs_tone_detail">הפעלת אפקט קולי של קופה רושמת בביצוע הזמנה חדשה</string>
-    <string name="settings_notifs_tone">צליל</string>
-    <string name="settings_notifs_orders_detail">קבלת התראות בביצוע של הזמנות חדשות</string>
-    <string name="settings_notifs_orders">הזמנות</string>
     <string name="settings_notifs_device_detail">קולות, דחיפות ונקודה לציון הודעות</string>
     <string name="settings_notifs_device">ניהול הודעות</string>
     <string name="settings_notifs">הודעות</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -2955,12 +2955,6 @@ Language: id
     <string name="wc_approve">Setujui</string>
     <string name="wc_view_the_product_external">Tampilkan produk</string>
     <string name="support_help">Bantuan &amp; dukungan</string>
-    <string name="settings_notifs_reviews_detail">Dapatkan pemberitahuan untuk ulasan produk baru</string>
-    <string name="settings_notifs_reviews">Tinjauan produk</string>
-    <string name="settings_notifs_tone_detail">Mainkan suara Cha-Ching saat ada pesanan baru</string>
-    <string name="settings_notifs_tone">Nada</string>
-    <string name="settings_notifs_orders_detail">Dapatkan pemberitahuan saat ada pesanan baru</string>
-    <string name="settings_notifs_orders">Pesanan</string>
     <string name="settings_notifs_device_detail">Suara, tingkat kepentingan, dan titik pemberitahuan</string>
     <string name="settings_notifs_device">Kelola pemberitahuan</string>
     <string name="settings_notifs">Pemberitahuan</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -2955,12 +2955,6 @@ Language: it
     <string name="wc_approve">Approva</string>
     <string name="wc_view_the_product_external">Visualizza il prodotto</string>
     <string name="support_help">Aiuto e supporto</string>
-    <string name="settings_notifs_reviews_detail">Ottieni avvisi relativi alle nuove recensioni del prodotto</string>
-    <string name="settings_notifs_reviews">Recensioni del prodotto</string>
-    <string name="settings_notifs_tone_detail">Riproduci Cha-Ching per il nuovo ordine</string>
-    <string name="settings_notifs_tone">Tono</string>
-    <string name="settings_notifs_orders_detail">Ottieni avvisi quando arrivano nuovi ordini</string>
-    <string name="settings_notifs_orders">Ordini</string>
     <string name="settings_notifs_device_detail">Suoni, urgenza e punto di notifica</string>
     <string name="settings_notifs_device">Gestisci notifiche</string>
     <string name="settings_notifs">Notifiche</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -2955,12 +2955,6 @@ Language: ja_JP
     <string name="wc_approve">承認</string>
     <string name="wc_view_the_product_external">製品を表示する</string>
     <string name="support_help">ヘルプ &amp; サポート</string>
-    <string name="settings_notifs_reviews_detail">新しい製品レビューのアラートを有効にする</string>
-    <string name="settings_notifs_reviews">製品レビュー</string>
-    <string name="settings_notifs_tone_detail">新しい注文が入った際の効果音を有効にする</string>
-    <string name="settings_notifs_tone">トーン</string>
-    <string name="settings_notifs_orders_detail">新しい注文が入った際のアラートを有効にする</string>
-    <string name="settings_notifs_orders">注文</string>
     <string name="settings_notifs_device_detail">サウンド、緊急性、通知ドット</string>
     <string name="settings_notifs_device">通知の管理</string>
     <string name="settings_notifs">通知</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -2955,12 +2955,6 @@ Language: ko_KR
     <string name="wc_approve">승인하기</string>
     <string name="wc_view_the_product_external">제품 보기</string>
     <string name="support_help">도움 및 지원</string>
-    <string name="settings_notifs_reviews_detail">새 제품 리뷰 알림 받기</string>
-    <string name="settings_notifs_reviews">제품 리뷰</string>
-    <string name="settings_notifs_tone_detail">새 주문에 대해 금전 등록기 소리 재생</string>
-    <string name="settings_notifs_tone">톤</string>
-    <string name="settings_notifs_orders_detail">새 주문이 들어올 때 알림 받기</string>
-    <string name="settings_notifs_orders">주문</string>
     <string name="settings_notifs_device_detail">소리, 긴급 및 알림 점</string>
     <string name="settings_notifs_device">알림 관리</string>
     <string name="settings_notifs">알림</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -2937,12 +2937,6 @@ Language: nl
     <string name="wc_approve">Goedkeuren</string>
     <string name="wc_view_the_product_external">Het product weergeven</string>
     <string name="support_help">Hulp en ondersteuning</string>
-    <string name="settings_notifs_reviews_detail">Meldingen voor nieuwe productbeoordelingen ontvangen</string>
-    <string name="settings_notifs_reviews">Productbeoordelingen</string>
-    <string name="settings_notifs_tone_detail">\'Cha-Ching\'-geluid afspelen bij nieuwe bestelling</string>
-    <string name="settings_notifs_tone">Pieptoon</string>
-    <string name="settings_notifs_orders_detail">Ontvang meldingen bij nieuwe bestellingen</string>
-    <string name="settings_notifs_orders">Bestellingen</string>
     <string name="settings_notifs_device_detail">Punt voor geluiden, urgentie en meldingen</string>
     <string name="settings_notifs_device">Meldingen beheren</string>
     <string name="settings_notifs">Meldingen</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -2955,12 +2955,6 @@ Language: pt_BR
     <string name="wc_approve">Aprovar</string>
     <string name="wc_view_the_product_external">Visualizar o produto</string>
     <string name="support_help">Ajuda e suporte</string>
-    <string name="settings_notifs_reviews_detail">Receba alertas de novas avaliações de produtos</string>
-    <string name="settings_notifs_reviews">Avaliações de produto</string>
-    <string name="settings_notifs_tone_detail">Reproduzir o som da caixa registradora ao receber um novo pedido</string>
-    <string name="settings_notifs_tone">Tom</string>
-    <string name="settings_notifs_orders_detail">Receba alertas sobre o recebimento de novos pedidos</string>
-    <string name="settings_notifs_orders">Pedidos</string>
     <string name="settings_notifs_device_detail">Sons, urgência e ponto de notificação</string>
     <string name="settings_notifs_device">Gerenciar notificações</string>
     <string name="settings_notifs">Notificações</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -2955,12 +2955,6 @@ Language: ru
     <string name="wc_approve">Одобрить</string>
     <string name="wc_view_the_product_external">Просмотреть товар</string>
     <string name="support_help">Помощь и техническая поддержка</string>
-    <string name="settings_notifs_reviews_detail">Получение оповещений о новых обзорах товаров</string>
-    <string name="settings_notifs_reviews">Обзоры товаров</string>
-    <string name="settings_notifs_tone_detail">Звук сыплющихся монет при новом заказе</string>
-    <string name="settings_notifs_tone">Звук</string>
-    <string name="settings_notifs_orders_detail">Получение оповещений при появлении новых заказов</string>
-    <string name="settings_notifs_orders">Заказы</string>
     <string name="settings_notifs_device_detail">Звуки, значки срочности и уведомлений</string>
     <string name="settings_notifs_device">Управление уведомлениями</string>
     <string name="settings_notifs">Уведомления</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -2955,12 +2955,6 @@ Language: sv_SE
     <string name="wc_approve">Godkänn</string>
     <string name="wc_view_the_product_external">Visa produkten</string>
     <string name="support_help">Hjälp och support</string>
-    <string name="settings_notifs_reviews_detail">Få aviseringar om nya produktrecensioner</string>
-    <string name="settings_notifs_reviews">Produktrecensioner</string>
-    <string name="settings_notifs_tone_detail">Spela upp ka-ching-ljud vid ny order</string>
-    <string name="settings_notifs_tone">Ton</string>
-    <string name="settings_notifs_orders_detail">Få aviseringar när nya ordrar kommer in</string>
-    <string name="settings_notifs_orders">Ordrar</string>
     <string name="settings_notifs_device_detail">Ljud, brådskande och aviseringspunkt</string>
     <string name="settings_notifs_device">Hantera notifikationer</string>
     <string name="settings_notifs">Aviseringar</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -2955,12 +2955,6 @@ Language: tr
     <string name="wc_approve">Onayla</string>
     <string name="wc_view_the_product_external">Ürünü görüntüle</string>
     <string name="support_help">Yardım ve destek</string>
-    <string name="settings_notifs_reviews_detail">Yeni ürün incelemeleri için uyarı al</string>
-    <string name="settings_notifs_reviews">Ürün incelemeleri</string>
-    <string name="settings_notifs_tone_detail">Yeni siparişte Cha-Ching sesini çal</string>
-    <string name="settings_notifs_tone">Bildirim sesi</string>
-    <string name="settings_notifs_orders_detail">Yeni sipariş alındığında uyarı al</string>
-    <string name="settings_notifs_orders">Siparişler</string>
     <string name="settings_notifs_device_detail">Sesler, acil durum ve bildirim noktası</string>
     <string name="settings_notifs_device">Bildirimleri yönet</string>
     <string name="settings_notifs">Bildirimler</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -2955,12 +2955,6 @@ Language: zh_CN
     <string name="wc_approve">批准</string>
     <string name="wc_view_the_product_external">查看产品</string>
     <string name="support_help">帮助与支持</string>
-    <string name="settings_notifs_reviews_detail">有新的产品评论时收到提醒</string>
-    <string name="settings_notifs_reviews">产品评论</string>
-    <string name="settings_notifs_tone_detail">有新订单时播放收银机打开的声音</string>
-    <string name="settings_notifs_tone">音调</string>
-    <string name="settings_notifs_orders_detail">有新订单时收到提醒</string>
-    <string name="settings_notifs_orders">订单</string>
     <string name="settings_notifs_device_detail">声音、紧急和通知点</string>
     <string name="settings_notifs_device">管理通知</string>
     <string name="settings_notifs">通知</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -2955,12 +2955,6 @@ Language: zh_TW
     <string name="wc_approve">核准</string>
     <string name="wc_view_the_product_external">檢視產品</string>
     <string name="support_help">說明與支援</string>
-    <string name="settings_notifs_reviews_detail">出現新的產品評論時收到提醒</string>
-    <string name="settings_notifs_reviews">產品評論</string>
-    <string name="settings_notifs_tone_detail">收到新訂單時播放收銀機音效</string>
-    <string name="settings_notifs_tone">音調</string>
-    <string name="settings_notifs_orders_detail">收到新訂單時收到提醒</string>
-    <string name="settings_notifs_orders">訂單</string>
     <string name="settings_notifs_device_detail">音效、緊急狀況和通知圓點</string>
     <string name="settings_notifs_device">管理通知</string>
     <string name="settings_notifs">通知</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2248,12 +2248,6 @@
     <string name="settings_notifs">Notifications</string>
     <string name="settings_notifs_device">Manage notifications</string>
     <string name="settings_notifs_device_detail">Sounds, urgency, and notification dot</string>
-    <string name="settings_notifs_orders">Orders</string>
-    <string name="settings_notifs_orders_detail">Get alerts when new orders come in</string>
-    <string name="settings_notifs_tone">Tone</string>
-    <string name="settings_notifs_tone_detail">Play Cha-Ching sound on new order</string>
-    <string name="settings_notifs_reviews">Product reviews</string>
-    <string name="settings_notifs_reviews_detail">Get alerts for new product reviews</string>
     <string name="settings_notifs_enable_chaching_sound">Enable Cha-Ching sound</string>
     <string name="settings_notifs_enable_chaching_sound_description">Orders notifications sound has been disabled, turn it back on to hear the \'cha-ching\' with every new sale.</string>
     <string name="settings_image_optimization_title">Image optimization</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -1,11 +1,9 @@
 package com.woocommerce.android.notifications.push
 
-import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.notifications.WooNotificationBuilder
-import com.woocommerce.android.notifications.getDefaults
 import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_ORDER_NOTE_FULL_DATA_2
 import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_ORDER_NOTE_FULL_DATA_SITE_2
 import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_REVIEW_NOTE_FULL_DATA_2
@@ -57,7 +55,6 @@ class NotificationMessageHandlerTest {
     private val dispatcher: Dispatcher = mock()
     private val actionCaptor: KArgumentCaptor<Action<*>> = argumentCaptor()
     private val wooLogWrapper: WooLogWrapper = mock()
-    private val appPrefsWrapper: AppPrefsWrapper = mock()
     private val resourceProvider: ResourceProvider = mock {
         on { getString(any()) } doAnswer { invocationOnMock -> invocationOnMock.arguments[0].toString() }
         on { getString(any(), any()) } doAnswer { invocationOnMock ->
@@ -97,7 +94,6 @@ class NotificationMessageHandlerTest {
             wooLogWrapper = wooLogWrapper,
             dispatcher = dispatcher,
             siteStore = siteStore,
-            appPrefsWrapper = appPrefsWrapper,
             resourceProvider = resourceProvider,
             notificationBuilder = notificationBuilder,
             analyticsTracker = notificationAnalyticsTracker,
@@ -108,10 +104,6 @@ class NotificationMessageHandlerTest {
 
         doReturn(true).whenever(accountStore).hasAccessToken()
         doReturn(accountModel).whenever(accountStore).account
-        doReturn(true).whenever(appPrefsWrapper).isOrderNotificationsEnabled()
-        doReturn(true).whenever(appPrefsWrapper).isOrderNotificationsEnabled()
-        doReturn(true).whenever(appPrefsWrapper).isReviewNotificationsEnabled()
-        doReturn(true).whenever(appPrefsWrapper).isOrderNotificationsChaChingEnabled()
         doReturn(true).whenever(notificationBuilder).isNotificationsEnabled()
     }
 
@@ -243,42 +235,16 @@ class NotificationMessageHandlerTest {
     }
 
     @Test
-    fun `when order notification is received but not enabled, then do not display notification`() {
-        doReturn(false).whenever(appPrefsWrapper).isOrderNotificationsEnabled()
-
-        notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
-        verify(wooLogWrapper, only()).i(
-            eq(WooLog.T.NOTIFS),
-            eq("Skipped ${orderNotification.noteType.name} notification")
-        )
-    }
-
-    @Test
-    fun `when review notification is received but not enabled, then do not display notification`() {
-        doReturn(false).whenever(appPrefsWrapper).isReviewNotificationsEnabled()
-
-        notificationMessageHandler.onNewMessageReceived(reviewNotificationPayload)
-        verify(wooLogWrapper, only()).i(
-            eq(WooLog.T.NOTIFS),
-            eq("Skipped ${reviewNotification.noteType.name} notification")
-        )
-    }
-
-    @Test
     fun `when order and review notifications are received together, then display notification details correctly`() {
         // clear all notifications
         notificationMessageHandler.removeAllNotificationsFromSystemsBar()
 
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
 
-        val orderDefaults = orderNotification.channelType.getDefaults(appPrefsWrapper)
-
         // verify that the contents for a new order notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            defaults = eq(orderDefaults),
             notification = eq(orderNotification),
-            addCustomNotificationSound = eq(true),
             isGroupNotification = eq(false)
         )
 
@@ -289,14 +255,10 @@ class NotificationMessageHandlerTest {
         // new incoming review notification
         notificationMessageHandler.onNewMessageReceived(reviewNotificationPayload)
 
-        val reviewDefaults = reviewNotification.channelType.getDefaults(appPrefsWrapper)
-
         // verify that the contents for a new review notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            defaults = eq(reviewDefaults),
             notification = eq(reviewNotification),
-            addCustomNotificationSound = eq(true),
             isGroupNotification = eq(true)
         )
 
@@ -317,14 +279,10 @@ class NotificationMessageHandlerTest {
 
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
 
-        val orderDefaults = orderNotification.channelType.getDefaults(appPrefsWrapper)
-
         // verify that the contents for a new order notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            defaults = eq(orderDefaults),
             notification = eq(orderNotification),
-            addCustomNotificationSound = eq(true),
             isGroupNotification = eq(false)
         )
 
@@ -344,9 +302,7 @@ class NotificationMessageHandlerTest {
         // verify that the contents for a new order notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            defaults = eq(orderDefaults),
             notification = eq(orderNotification2),
-            addCustomNotificationSound = eq(true),
             isGroupNotification = eq(true)
         )
 
@@ -367,14 +323,10 @@ class NotificationMessageHandlerTest {
 
         notificationMessageHandler.onNewMessageReceived(reviewNotificationPayload)
 
-        val reviewDefaults = reviewNotification.channelType.getDefaults(appPrefsWrapper)
-
         // verify that the contents for a new review notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            defaults = eq(reviewDefaults),
             notification = eq(reviewNotification),
-            addCustomNotificationSound = eq(true),
             isGroupNotification = eq(false)
         )
 
@@ -394,9 +346,7 @@ class NotificationMessageHandlerTest {
         // verify that the contents for a new review notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            defaults = eq(reviewDefaults),
             notification = eq(reviewNotification2),
-            addCustomNotificationSound = eq(true),
             isGroupNotification = eq(true)
         )
 
@@ -417,14 +367,10 @@ class NotificationMessageHandlerTest {
 
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
 
-        val orderDefaults = orderNotification.channelType.getDefaults(appPrefsWrapper)
-
         // verify that the contents for a new order notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            defaults = eq(orderDefaults),
             notification = eq(orderNotification),
-            addCustomNotificationSound = eq(true),
             isGroupNotification = eq(false)
         )
 
@@ -444,9 +390,7 @@ class NotificationMessageHandlerTest {
         // verify that the contents for a new order notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            defaults = eq(orderDefaults),
             notification = eq(orderNotification2),
-            addCustomNotificationSound = eq(true),
             isGroupNotification = eq(true)
         )
 
@@ -467,14 +411,10 @@ class NotificationMessageHandlerTest {
 
         notificationMessageHandler.onNewMessageReceived(reviewNotificationPayload)
 
-        val reviewDefaults = reviewNotification.channelType.getDefaults(appPrefsWrapper)
-
         // verify that the contents for a new review notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            defaults = eq(reviewDefaults),
             notification = eq(reviewNotification),
-            addCustomNotificationSound = eq(true),
             isGroupNotification = eq(false)
         )
 
@@ -494,9 +434,7 @@ class NotificationMessageHandlerTest {
         // verify that the contents for a new review notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            defaults = eq(reviewDefaults),
             notification = eq(reviewNotification2),
-            addCustomNotificationSound = eq(true),
             isGroupNotification = eq(true)
         )
 


### PR DESCRIPTION
### Description
We updated the minSdkVersion to 26 recently, this PR is just to cleanup the unused code that we had for dealing with older APIs.

### Testing instructions
Just smoke test the app, and test push notifications.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
