### PR TITLE
Avoid NPE when OnJetpackTimeoutError#apiPath is null (second part)

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -385,7 +385,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         with(event) {
             // Replace numeric IDs with a placeholder so events can be aggregated
             val genericPath = apiPath?.replace(REGEX_API_NUMERIC_PARAM, "/ID/")
-            val protocol = REGEX_API_JETPACK_TUNNEL_METHOD.find(apiPath)?.groups?.get(1)?.value ?: ""
+            val protocol = REGEX_API_JETPACK_TUNNEL_METHOD.find(apiPath ?: "")?.groups?.get(1)?.value ?: ""
 
             val properties = mapOf(
                 "path" to genericPath,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10109 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
In the past PR fixing the above issue #10267, I missed the second usage of `apiPath`, this PR fixes it.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
