### PR TITLE
[HACK][Tap To Pay] Makes simple payments order non taxable if created from testing TTP

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 16.7
 -----
+- [*] Tap To Pay test payments are not taxable by default [https://github.com/woocommerce/woocommerce-android/pull/10353]
 
 16.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
@@ -69,6 +69,7 @@ class OrderCreateEditRepository @Inject constructor(
     suspend fun createSimplePaymentOrder(
         currentPrice: BigDecimal,
         customerNote: String? = null,
+        isTaxable: Boolean = true
     ): Result<Order> {
         val status = if (isAutoDraftSupported()) {
             WCOrderStatusModel(statusKey = AUTO_DRAFT)
@@ -79,7 +80,7 @@ class OrderCreateEditRepository @Inject constructor(
         val result = orderUpdateStore.createSimplePayment(
             site = selectedSite.get(),
             amount = currentPrice.toString(),
-            isTaxable = true,
+            isTaxable = isTaxable,
             status = status,
             customerNote = customerNote
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModel.kt
@@ -80,7 +80,8 @@ class TapToPaySummaryViewModel @Inject constructor(
             _viewState.value = _viewState.value!!.copy(isProgressVisible = true)
             val result = orderCreateEditRepository.createSimplePaymentOrder(
                 countryConfig.minimumAllowedChargeAmount,
-                customerNote = resourceProvider.getString(R.string.card_reader_tap_to_pay_test_payment_note)
+                customerNote = resourceProvider.getString(R.string.card_reader_tap_to_pay_test_payment_note),
+                isTaxable = false,
             )
             result.fold(
                 onSuccess = {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
@@ -94,7 +94,8 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
         whenever(
             orderCreateEditRepository.createSimplePaymentOrder(
                 BigDecimal.valueOf(0.5),
-                customerNote = "Test payment"
+                customerNote = "Test payment",
+                isTaxable = false,
             )
         ).thenReturn(
             Result.failure(Exception())
@@ -118,7 +119,8 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
             whenever(
                 orderCreateEditRepository.createSimplePaymentOrder(
                     BigDecimal.valueOf(0.5),
-                    customerNote = "Test payment"
+                    customerNote = "Test payment",
+                    isTaxable = false,
                 )
             ).thenReturn(
                 Result.success(order)
@@ -138,7 +140,8 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
         whenever(
             orderCreateEditRepository.createSimplePaymentOrder(
                 BigDecimal.valueOf(0.5),
-                customerNote = "Test payment"
+                customerNote = "Test payment",
+                isTaxable = false,
             )
         ).thenReturn(
             Result.failure(Exception())
@@ -162,7 +165,8 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
         whenever(
             orderCreateEditRepository.createSimplePaymentOrder(
                 BigDecimal.valueOf(0.5),
-                customerNote = "Test payment"
+                customerNote = "Test payment",
+                isTaxable = false,
             )
         ).thenReturn(
             Result.failure(Exception())
@@ -184,7 +188,8 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
         whenever(
             orderCreateEditRepository.createSimplePaymentOrder(
                 BigDecimal.valueOf(0.5),
-                customerNote = "Test payment"
+                customerNote = "Test payment",
+                isTaxable = false,
             )
         ).thenReturn(
             Result.failure(Exception())
@@ -224,7 +229,8 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
             // THEN
             verify(orderCreateEditRepository).createSimplePaymentOrder(
                 BigDecimal.valueOf(0.3),
-                customerNote = "Test payment"
+                customerNote = "Test payment",
+                isTaxable = false,
             )
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10352
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
To make it more logical, test TTP simple orders are created without taxes included

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* More -> Payments -> Try Tap To Pay
* Notice that taxes are not included
* Try collection payment

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

##### Before

https://github.com/woocommerce/woocommerce-android/assets/4923871/7cbec9fd-8f43-4b07-843f-7b56782b2b1b

##### After
https://github.com/woocommerce/woocommerce-android/assets/4923871/3a4ac949-4d86-4bc2-9417-93c70be1a587

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->


