### PR TITLE
Handle the nullable ThemeModel.demoUrl

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Theme.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Theme.kt
@@ -5,7 +5,7 @@ import org.wordpress.android.fluxc.model.ThemeModel
 data class Theme(
     val id: String,
     val name: String,
-    val demoUrl: String
+    val demoUrl: String?
 )
 
 fun ThemeModel.toAppModel(): Theme {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -44,23 +44,26 @@ class ThemePickerViewModel @Inject constructor(
             onSuccess = { result ->
                 _viewState.update {
                     Success(
-                        carouselItems = result.map { theme ->
-                            CarouselItem.Theme(
-                                themeId = theme.id,
-                                name = theme.name,
-                                screenshotUrl = AppUrls.getScreenshotUrl(theme.demoUrl),
-                                demoUri = theme.demoUrl
-                            )
-                        }.plus(
-                            CarouselItem.Message(
-                                title = resourceProvider.getString(
-                                    string.theme_picker_carousel_info_item_title
-                                ),
-                                description = resourceProvider.getString(
-                                    string.theme_picker_carousel_info_item_description
+                        carouselItems = result
+                            .filter { theme -> theme.demoUrl != null }
+                            .map { theme ->
+                                CarouselItem.Theme(
+                                    themeId = theme.id,
+                                    name = theme.name,
+                                    screenshotUrl = AppUrls.getScreenshotUrl(theme.demoUrl!!),
+                                    demoUri = theme.demoUrl
+                                )
+                            }
+                            .plus(
+                                CarouselItem.Message(
+                                    title = resourceProvider.getString(
+                                        string.theme_picker_carousel_info_item_title
+                                    ),
+                                    description = resourceProvider.getString(
+                                        string.theme_picker_carousel_info_item_description
+                                    )
                                 )
                             )
-                        )
                     )
                 }
             },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -106,7 +106,7 @@ class ThemePreviewViewModel @Inject constructor(
 
     private suspend fun Theme.prepareThemeDemoPages(): Flow<List<ThemeDemoPage>> = flow {
         val homePage = ThemeDemoPage(
-            uri = demoUrl,
+            uri = requireNotNull(demoUrl),
             title = resourceProvider.getString(R.string.theme_preview_bottom_sheet_home_section),
             isLoaded = true
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemeRepository.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload
 import org.wordpress.android.fluxc.store.ThemeStore.ThemeErrorType
 import javax.inject.Inject
 
+@Suppress("DEPRECATION")
 class ThemeRepository @Inject constructor(
     private val themeStore: ThemeStore,
     private val dispatcher: Dispatcher,
@@ -108,6 +109,8 @@ class ThemeRepository @Inject constructor(
     private suspend fun installThemeIfNeeded(themeId: String): Result<Unit> {
         val installationResult: OnThemeInstalled = dispatcher.dispatchAndAwait(
             ThemeActionBuilder.newInstallThemeAction(
+                // The Default constructor ThemeModel() is deprecated.
+                // We should add a new method to ThemeStore install a theme by themeId
                 SiteThemePayload(selectedSite.get(), ThemeModel().apply { this.themeId = themeId })
             )
         )

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-2f304118ff4776274b83f6e34c66180cdc16eb40'
+    fluxCVersion = 'trunk-3f65981193242842166b7428f409fd2d290076ac'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
This PR fixes a build issue caused by [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2897), which changes the nullability of the `ThemeModel.demoUrl` property.

I filtered out the themes without a demo URL in the theme picker since it'd defeat the purpose of the preview feature.

**To test:**
1. Go to More menu -> Settings -> Themes
2. Verify 6 themes are loaded in a carousel
3. Try to tap on one of them to see a preview
4. Notice a preview is shown