### PR TITLE
[Scan to Update Inventory] Add undo option to success snackbar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModel.kt
@@ -217,6 +217,13 @@ class ScanToUpdateInventoryViewModel @Inject constructor(
                     message = message,
                     undoAction = {
                         onQuantityUpdateUndo(oldQuantity, productInfo)
+                        triggerEvent(
+                            ShowUiStringSnackbar(
+                                UiString.UiStringText(
+                                    resourceProvider.getString(R.string.scan_to_update_inventory_undo_snackbar)
+                                )
+                            )
+                        )
                     },
                 )
             )
@@ -226,17 +233,7 @@ class ScanToUpdateInventoryViewModel @Inject constructor(
     private fun onQuantityUpdateUndo(oldQuantity: String, productInfo: ProductInfo) {
         updateQuantity(productInfo.copy(quantity = oldQuantity.toInt()), isUndoAction = true)
         val result = productInfo.quantity == oldQuantity.toInt()
-        if (result) {
-            Result.success(Unit)
-            // Display Message post Undo Action to let user know the action has been reverted
-            triggerEvent(
-                ShowUiStringSnackbar(
-                    UiString.UiStringText(
-                        resourceProvider.getString(R.string.scan_to_update_inventory_undo_snackbar)
-                    )
-                )
-            )
-        } else {
+        if (!result) {
             handleQuantityUpdateError()
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3883,6 +3883,7 @@
     <string name="scan_to_update_inventory_update_quantity_button">Update Quantity</string>
     <string name="scan_to_update_inventory_product_details_button">View Product Details</string>
     <string name="scan_to_update_inventory_success_snackbar">Quantity updated: %s</string>
+    <string name="scan_to_update_inventory_undo_snackbar">Update quantity undone</string>
     <string name="scan_to_update_inventory_failure_snackbar">Something went wrong. Please try again</string>
     <string name="scan_to_update_inventory_original_quantity_label">Original quantity</string>
     <string name="scan_to_update_inventory_quantity_label">Quantity</string>
@@ -3908,5 +3909,4 @@
     <string name="configuration_variable_update">Choose variation</string>
     <string name="product_variation_picker_title">Select a variation</string>
     <string name="store_creation_use_theme_button">Start with this theme</string>
-    <string name="scan_to_update_inventory_undo_snackbar">Update quantity undone</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3908,4 +3908,5 @@
     <string name="configuration_variable_update">Choose variation</string>
     <string name="product_variation_picker_title">Select a variation</string>
     <string name="store_creation_use_theme_button">Start with this theme</string>
+    <string name="scan_to_update_inventory_undo_snackbar">Update quantity undone</string>
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
@@ -280,7 +280,6 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given quantity updated, when undo action triggered, then should set quantity back to original`() = testBlocking {
-        // Arrange
         val originalQuantity = 5
         val newQuantity = 10
         val productId = 1L
@@ -303,7 +302,6 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
             )
         ).thenReturn("Undo successful")
 
-        // Emulate live data event observer
         val events = mutableListOf<MultiLiveEvent.Event>()
         val observer = mock<Observer<MultiLiveEvent.Event>>()
         doAnswer { invocation ->
@@ -313,15 +311,12 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
         }.whenever(observer).onChanged(any())
         sut.event.observeForever(observer)
 
-        // Act: Simulate successful scan and quantity update
         sut.onBarcodeScanningResult(
             CodeScannerStatus.Success(product.sku, GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8)
         )
 
-        // Simulate user incrementing quantity
         sut.onIncrementQuantityClicked()
 
-        // Perform the undo action
         val undoAction = (
             events.first {
                 it is MultiLiveEvent.Event.ShowUndoSnackbar
@@ -329,11 +324,7 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
             ).undoAction
         undoAction.onClick(null)
 
-        // Verify the product quantity is reverted back to the original quantity.
         verify(productRepo).updateProduct(product.copy(stockQuantity = originalQuantity.toDouble()))
-
-        // Clean up the observer
-        sut.event.removeObserver(observer)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10285 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR replaces the regular snackbar we were displaying upon a successful inventory update with an Undo Snackbar and the option to revert the quantity increase. It also adds a second snackbar to cue the user that the action has been reverted. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- go to the Product list
- click on the Scan icon
- Scan an existing stock-managed product (you can use online barcode generator like [this one](https://barcode.tec-it.com/en/?data=ACGADO))
- make sure the snackbar with an undo option is displayed
- click undo
- make sure the second snackbar warning of the reverted action is displayed
- scan the same product again and make sure the quantity stayed the same (meaning it was increased and reverted back)
- test on a regular and a variable product

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
