### PR TITLE
[Scan to Update Inventory] Add undo option to success snackbar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryBarcodeScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryBarcodeScannerFragment.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.barcodescanner.BarcodeScanningViewModel
 import com.woocommerce.android.ui.barcodescanner.BarcodeScanningViewModel.PermissionState.Unknown
@@ -28,6 +29,7 @@ class ScanToUpdateInventoryBarcodeScannerFragment : BaseFragment() {
     private val viewModel: ScanToUpdateInventoryViewModel by viewModels()
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
+    private var undoSnackbar: Snackbar? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -65,6 +67,12 @@ class ScanToUpdateInventoryBarcodeScannerFragment : BaseFragment() {
         scannerViewModel.startCodesRecognition()
     }
 
+    override fun onStop() {
+        undoSnackbar?.dismiss()
+        super.onStop()
+
+    }
+
     override fun onPause() {
         scannerViewModel.stopCodesRecognition()
         super.onPause()
@@ -95,10 +103,31 @@ class ScanToUpdateInventoryBarcodeScannerFragment : BaseFragment() {
                 is MultiLiveEvent.Event.ShowUiStringSnackbar -> {
                     uiMessageResolver.showSnack(it.message)
                 }
+                is MultiLiveEvent.Event.ShowUndoSnackbar -> {
+                    showUndoSnackbar(
+                        message = it.message,
+                        actionListener = it.undoAction,
+                        dismissCallback = it.dismissAction
+                    )
+                }
                 is ScanToUpdateInventoryViewModel.NavigateToProductDetailsEvent -> {
                     (requireActivity() as? MainNavigationRouter)?.showProductDetail(it.productId)
                 }
             }
+        }
+    }
+
+    private fun showUndoSnackbar(
+        message: String,
+        actionListener: View.OnClickListener,
+        dismissCallback: Snackbar.Callback
+    ) {
+        undoSnackbar = uiMessageResolver.getUndoSnack(
+            message = message,
+            actionListener = actionListener,
+        ).also {
+            it.addCallback(dismissCallback)
+            it.show()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryBarcodeScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryBarcodeScannerFragment.kt
@@ -70,7 +70,6 @@ class ScanToUpdateInventoryBarcodeScannerFragment : BaseFragment() {
     override fun onStop() {
         undoSnackbar?.dismiss()
         super.onStop()
-
     }
 
     override fun onPause() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryBarcodeScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryBarcodeScannerFragment.kt
@@ -67,13 +67,9 @@ class ScanToUpdateInventoryBarcodeScannerFragment : BaseFragment() {
         scannerViewModel.startCodesRecognition()
     }
 
-    override fun onStop() {
-        undoSnackbar?.dismiss()
-        super.onStop()
-    }
-
     override fun onPause() {
         scannerViewModel.stopCodesRecognition()
+        undoSnackbar?.dismiss()
         super.onPause()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModel.kt
@@ -225,7 +225,7 @@ class ScanToUpdateInventoryViewModel @Inject constructor(
                             )
                         )
                     },
-                 )
+                )
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModel.kt
@@ -162,7 +162,7 @@ class ScanToUpdateInventoryViewModel @Inject constructor(
             }
             if (result.isSuccess) {
                 AnalyticsTracker.track(AnalyticsEvent.PRODUCT_QUICK_INVENTORY_QUANTITY_UPDATE_SUCCESS)
-                handleQuantityUpdateSuccess(
+                showQuantityUpdateSuccessSnackbar(
                     product.stockQuantity.toInt().toString(),
                     updatedProductInfo.quantity.toString(),
                     updatedProductInfo,
@@ -207,7 +207,7 @@ class ScanToUpdateInventoryViewModel @Inject constructor(
         }
     }
 
-    private fun handleQuantityUpdateSuccess(
+    private fun showQuantityUpdateSuccessSnackbar(
         oldQuantity: String,
         updatedQuantity: String,
         productInfo: ProductInfo,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModel.kt
@@ -129,7 +129,7 @@ class ScanToUpdateInventoryViewModel @Inject constructor(
         tracker.track(AnalyticsEvent.PRODUCT_QUICK_INVENTORY_UPDATE_INCREMENT_QUANTITY_TAPPED)
         val state = viewState.value
         if (state !is ViewState.QuickInventoryBottomSheetVisible) return
-        updateQuantity(state.product.copy(quantity = state.product.quantity + 1))
+        updateQuantity(state.product.copy(quantity = state.product.quantity + 1), isUndoUpdate = false)
     }
 
     fun onUpdateQuantityClicked() {
@@ -138,10 +138,10 @@ class ScanToUpdateInventoryViewModel @Inject constructor(
         if (state !is ViewState.QuickInventoryBottomSheetVisible) return
         // if user input is empty or invalid, do nothing
         val newQuantityValue = state.newQuantity.toIntOrNull() ?: return
-        updateQuantity(state.product.copy(quantity = newQuantityValue))
+        updateQuantity(state.product.copy(quantity = newQuantityValue), isUndoUpdate = false)
     }
 
-    private fun updateQuantity(updatedProductInfo: ProductInfo) = launch {
+    private fun updateQuantity(updatedProductInfo: ProductInfo, isUndoUpdate: Boolean) = launch {
         _viewState.value = ViewState.Loading
         scanToUpdateInventoryState.value = ScanToUpdateInventoryState.UpdatingProduct
         val product = productRepository.getProduct(updatedProductInfo.id)
@@ -159,7 +159,9 @@ class ScanToUpdateInventoryViewModel @Inject constructor(
                 AnalyticsTracker.track(AnalyticsEvent.PRODUCT_QUICK_INVENTORY_QUANTITY_UPDATE_SUCCESS)
                 handleQuantityUpdateSuccess(
                     product.stockQuantity.toInt().toString(),
-                    updatedProductInfo.quantity.toString()
+                    updatedProductInfo.quantity.toString(),
+                    updatedProductInfo,
+                    isUndoUpdate
                 )
             } else {
                 handleQuantityUpdateError()
@@ -198,18 +200,43 @@ class ScanToUpdateInventoryViewModel @Inject constructor(
         }
     }
 
-    private fun handleQuantityUpdateSuccess(oldQuantity: String, updatedQuantity: String) {
+    private fun handleQuantityUpdateSuccess(
+        oldQuantity: String,
+        updatedQuantity: String,
+        productInfo: ProductInfo,
+        isUndoUpdate: Boolean
+    ) {
         val quantityChangeString = "$oldQuantity ➡ $updatedQuantity"
         val message = resourceProvider.getString(
             R.string.scan_to_update_inventory_success_snackbar,
             quantityChangeString
         )
-        triggerEvent(ShowUiStringSnackbar(UiString.UiStringText(message)))
+        if (!isUndoUpdate) {
+            triggerEvent(
+                MultiLiveEvent.Event.ShowUndoSnackbar(
+                    message = message,
+                    undoAction = {
+                        onUpdateQuantityUndo(oldQuantity, productInfo)
+                        triggerEvent(
+                            ShowUiStringSnackbar(
+                                UiString.UiStringText(
+                                    resourceProvider.getString(R.string.scan_to_update_inventory_undo_snackbar)
+                                )
+                            )
+                        )
+                    },
+                 )
+            )
+        }
     }
 
     private fun handleQuantityUpdateError() {
         AnalyticsTracker.track(AnalyticsEvent.PRODUCT_QUICK_INVENTORY_QUANTITY_UPDATE_FAILURE)
         triggerEvent(ShowUiStringSnackbar(UiString.UiStringRes(R.string.scan_to_update_inventory_failure_snackbar)))
+    }
+
+    private fun onUpdateQuantityUndo(oldQuantity: String, productInfo: ProductInfo) {
+        updateQuantity(productInfo.copy(quantity = oldQuantity.toInt()), isUndoUpdate = true)
     }
 
     fun onManualQuantityEntered(newQuantity: String) {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3883,6 +3883,7 @@
     <string name="scan_to_update_inventory_update_quantity_button">Update Quantity</string>
     <string name="scan_to_update_inventory_product_details_button">View Product Details</string>
     <string name="scan_to_update_inventory_success_snackbar">Quantity updated: %s</string>
+    <string name="scan_to_update_inventory_undo_snackbar">Update Quantity Undone</string>
     <string name="scan_to_update_inventory_failure_snackbar">Something went wrong. Please try again</string>
     <string name="scan_to_update_inventory_original_quantity_label">Original quantity</string>
     <string name="scan_to_update_inventory_quantity_label">Quantity</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
@@ -338,13 +338,9 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
             ).thenReturn("Undo successful")
 
             val events = mutableListOf<MultiLiveEvent.Event>()
-            val observer = mock<Observer<MultiLiveEvent.Event>>()
-            doAnswer { invocation ->
-                val event = invocation.arguments[0] as MultiLiveEvent.Event
-                events.add(event)
-                null
-            }.whenever(observer).onChanged(any())
-            sut.event.observeForever(observer)
+            sut.event.observeForever {
+                events.add(it)
+            }
 
             sut.onBarcodeScanningResult(
                 CodeScannerStatus.Success(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
@@ -350,12 +350,7 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
 
             sut.onIncrementQuantityClicked()
 
-            val undoAction = (
-                events.first {
-                    it is MultiLiveEvent.Event.ShowUndoSnackbar
-                } as MultiLiveEvent.Event.ShowUndoSnackbar
-                ).undoAction
-            undoAction.onClick(null)
+            (events.first() as MultiLiveEvent.Event.ShowUndoSnackbar).undoAction.onClick(null)
 
             verify(productRepo).updateProduct(product.copy(stockQuantity = originalQuantity.toDouble()))
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
@@ -316,7 +316,7 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
     fun `given quantity updated, when undo action triggered, then should set quantity back to original`() =
         testBlocking {
             val originalQuantity = 5
-            val newQuantity = 10
+            val newQuantity = 6
             val productId = 1L
             val product = ProductTestUtils.generateProduct(
                 isStockManaged = true,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.products.inventory
 
-import androidx.lifecycle.Observer
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.woocommerce.android.R
@@ -26,7 +25,6 @@ import org.junit.Test
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
@@ -213,224 +213,243 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given bottom sheet shown, when bottom sheet dismissed, then should should start scanning again`() = testBlocking {
-        whenever(fetchProductBySKU(any(), any())).thenReturn(
-            Result.success(ProductTestUtils.generateProduct(isStockManaged = true))
-        )
-        sut.onBarcodeScanningResult(
-            CodeScannerStatus.Success(
-                "123",
-                GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
+    fun `given bottom sheet shown, when bottom sheet dismissed, then should should start scanning again`() =
+        testBlocking {
+            whenever(fetchProductBySKU(any(), any())).thenReturn(
+                Result.success(ProductTestUtils.generateProduct(isStockManaged = true))
             )
-        )
-        sut.viewState.test {
-            awaitItem().apply {
-                assertIs<QuickInventoryBottomSheetVisible>(this)
-            }
-        }
-        sut.onBottomSheetDismissed()
-        sut.viewState.test {
-            awaitItem().apply {
-                assertIs<QuickInventoryBottomSheetHidden>(this)
-            }
-        }
-        sut.onBarcodeScanningResult(
-            CodeScannerStatus.Success(
-                "123",
-                GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
+            sut.onBarcodeScanningResult(
+                CodeScannerStatus.Success(
+                    "123",
+                    GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
+                )
             )
-        )
-        verify(fetchProductBySKU, times(2)).invoke(any(), any())
-    }
+            sut.viewState.test {
+                awaitItem().apply {
+                    assertIs<QuickInventoryBottomSheetVisible>(this)
+                }
+            }
+            sut.onBottomSheetDismissed()
+            sut.viewState.test {
+                awaitItem().apply {
+                    assertIs<QuickInventoryBottomSheetHidden>(this)
+                }
+            }
+            sut.onBarcodeScanningResult(
+                CodeScannerStatus.Success(
+                    "123",
+                    GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
+                )
+            )
+            verify(fetchProductBySKU, times(2)).invoke(any(), any())
+        }
 
     @Test
-    fun `given bottom sheet with product shown, when increment quantity clicked, then should should update product`() = testBlocking {
-        val originalProduct = ProductTestUtils.generateProduct(isStockManaged = true)
-        whenever(fetchProductBySKU(any(), any())).thenReturn(
-            Result.success(originalProduct)
-        )
-        whenever(productRepo.getProduct(any())).thenReturn(originalProduct)
-        sut.onBarcodeScanningResult(
-            CodeScannerStatus.Success(
-                "123",
-                GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
+    fun `given bottom sheet with product shown, when increment quantity clicked, then should should update product`() =
+        testBlocking {
+            val originalProduct = ProductTestUtils.generateProduct(isStockManaged = true)
+            whenever(fetchProductBySKU(any(), any())).thenReturn(
+                Result.success(originalProduct)
             )
-        )
-        whenever(productRepo.updateProduct(any())).thenReturn(true)
-        whenever(
-            resourceProvider.getString(
-                R.string.scan_to_update_inventory_success_snackbar,
-                "${originalProduct.stockQuantity.toInt()} ➡ ${originalProduct.stockQuantity.toInt() + 1}"
+            whenever(productRepo.getProduct(any())).thenReturn(originalProduct)
+            sut.onBarcodeScanningResult(
+                CodeScannerStatus.Success(
+                    "123",
+                    GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
+                )
             )
-        ).thenReturn("Quantity updated")
-        sut.viewState.test {
-            awaitItem().apply {
-                assertIs<QuickInventoryBottomSheetVisible>(this)
+            whenever(productRepo.updateProduct(any())).thenReturn(true)
+            whenever(
+                resourceProvider.getString(
+                    R.string.scan_to_update_inventory_success_snackbar,
+                    "${originalProduct.stockQuantity.toInt()} ➡ ${originalProduct.stockQuantity.toInt() + 1}"
+                )
+            ).thenReturn("Quantity updated")
+            sut.viewState.test {
+                awaitItem().apply {
+                    assertIs<QuickInventoryBottomSheetVisible>(this)
+                }
             }
+
+            sut.onIncrementQuantityClicked()
+
+            val expectedProduct =
+                originalProduct.copy(stockQuantity = (originalProduct.stockQuantity.toInt() + 1).toDouble())
+            verify(productRepo).updateProduct(expectedProduct)
         }
 
-        sut.onIncrementQuantityClicked()
-
-        val expectedProduct =
-            originalProduct.copy(stockQuantity = (originalProduct.stockQuantity.toInt() + 1).toDouble())
-        verify(productRepo).updateProduct(expectedProduct)
-    }
-
     @Test
-    fun `given bottom sheet with product shown, when quantity entered manually, then should update product`() = testBlocking {
-        val originalProduct = ProductTestUtils.generateProduct(isStockManaged = true)
-        whenever(fetchProductBySKU(any(), any())).thenReturn(
-            Result.success(originalProduct)
-        )
-        whenever(productRepo.getProduct(any())).thenReturn(originalProduct)
-        sut.onBarcodeScanningResult(
-            CodeScannerStatus.Success(
-                "123",
-                GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
+    fun `given bottom sheet with product shown, when quantity entered manually, then should update product`() =
+        testBlocking {
+            val originalProduct = ProductTestUtils.generateProduct(isStockManaged = true)
+            whenever(fetchProductBySKU(any(), any())).thenReturn(
+                Result.success(originalProduct)
             )
-        )
-        whenever(productRepo.updateProduct(any())).thenReturn(true)
-        whenever(
-            resourceProvider.getString(
-                R.string.scan_to_update_inventory_success_snackbar,
-                "${originalProduct.stockQuantity.toInt()} ➡ 999"
+            whenever(productRepo.getProduct(any())).thenReturn(originalProduct)
+            sut.onBarcodeScanningResult(
+                CodeScannerStatus.Success(
+                    "123",
+                    GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
+                )
             )
-        ).thenReturn("Quantity updated")
-        sut.viewState.test {
-            awaitItem().apply {
-                assertIs<QuickInventoryBottomSheetVisible>(this)
+            whenever(productRepo.updateProduct(any())).thenReturn(true)
+            whenever(
+                resourceProvider.getString(
+                    R.string.scan_to_update_inventory_success_snackbar,
+                    "${originalProduct.stockQuantity.toInt()} ➡ 999"
+                )
+            ).thenReturn("Quantity updated")
+            sut.viewState.test {
+                awaitItem().apply {
+                    assertIs<QuickInventoryBottomSheetVisible>(this)
+                }
             }
+
+            sut.onManualQuantityEntered("999")
+            sut.onUpdateQuantityClicked()
+
+            val expectedProduct = originalProduct.copy(stockQuantity = (999).toDouble())
+            verify(productRepo).updateProduct(expectedProduct)
         }
 
-        sut.onManualQuantityEntered("999")
-        sut.onUpdateQuantityClicked()
-
-        val expectedProduct = originalProduct.copy(stockQuantity = (999).toDouble())
-        verify(productRepo).updateProduct(expectedProduct)
-    }
-
     @Test
-    fun `given quantity updated, when undo action triggered, then should set quantity back to original`() = testBlocking {
-        val originalQuantity = 5
-        val newQuantity = 10
-        val productId = 1L
-        val product = ProductTestUtils.generateProduct(
-            isStockManaged = true,
-        )
-
-        whenever(fetchProductBySKU(any(), any())).thenReturn(Result.success(product))
-        whenever(productRepo.getProduct(productId)).thenReturn(product)
-        whenever(productRepo.updateProduct(any())).thenReturn(true)
-        whenever(
-            resourceProvider.getString(
-                eq(R.string.scan_to_update_inventory_success_snackbar),
-                any()
+    fun `given quantity updated, when undo action triggered, then should set quantity back to original`() =
+        testBlocking {
+            val originalQuantity = 5
+            val newQuantity = 10
+            val productId = 1L
+            val product = ProductTestUtils.generateProduct(
+                isStockManaged = true,
             )
-        ).thenReturn("Quantity updated from $originalQuantity to $newQuantity")
-        whenever(
-            resourceProvider.getString(
-                eq(R.string.scan_to_update_inventory_undo_snackbar)
+
+            whenever(fetchProductBySKU(any(), any())).thenReturn(Result.success(product))
+            whenever(productRepo.getProduct(productId)).thenReturn(product)
+            whenever(productRepo.updateProduct(any())).thenReturn(true)
+            whenever(
+                resourceProvider.getString(
+                    eq(R.string.scan_to_update_inventory_success_snackbar),
+                    any()
+                )
+            ).thenReturn("Quantity updated from $originalQuantity to $newQuantity")
+            whenever(
+                resourceProvider.getString(
+                    eq(R.string.scan_to_update_inventory_undo_snackbar)
+                )
+            ).thenReturn("Undo successful")
+
+            val events = mutableListOf<MultiLiveEvent.Event>()
+            val observer = mock<Observer<MultiLiveEvent.Event>>()
+            doAnswer { invocation ->
+                val event = invocation.arguments[0] as MultiLiveEvent.Event
+                events.add(event)
+                null
+            }.whenever(observer).onChanged(any())
+            sut.event.observeForever(observer)
+
+            sut.onBarcodeScanningResult(
+                CodeScannerStatus.Success(
+                    product.sku, GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
+                )
             )
-        ).thenReturn("Undo successful")
 
-        val events = mutableListOf<MultiLiveEvent.Event>()
-        val observer = mock<Observer<MultiLiveEvent.Event>>()
-        doAnswer { invocation ->
-            val event = invocation.arguments[0] as MultiLiveEvent.Event
-            events.add(event)
-            null
-        }.whenever(observer).onChanged(any())
-        sut.event.observeForever(observer)
+            sut.onIncrementQuantityClicked()
 
-        sut.onBarcodeScanningResult(CodeScannerStatus.Success(product.sku, GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8))
+            val undoAction = (
+                events.first {
+                    it is MultiLiveEvent.Event.ShowUndoSnackbar
+                } as MultiLiveEvent.Event.ShowUndoSnackbar
+                ).undoAction
+            undoAction.onClick(null)
 
-        sut.onIncrementQuantityClicked()
-
-        val undoAction = (events.first { it is MultiLiveEvent.Event.ShowUndoSnackbar } as MultiLiveEvent.Event.ShowUndoSnackbar).undoAction
-        undoAction.onClick(null)
-
-        verify(productRepo).updateProduct(product.copy(stockQuantity = originalQuantity.toDouble()))
-    }
-
-
-    @Test
-    fun `given bottom sheet with variation shown, when increment quantity clicked, then should should update product`() = testBlocking {
-        val productId = 1L
-        val variationId = 2L
-        val originalProduct =
-            ProductTestUtils.generateProduct(isStockManaged = true, productId = variationId, parentID = productId)
-                .copy(stockQuantity = 1.0)
-        whenever(fetchProductBySKU(any(), any())).thenReturn(
-            Result.success(originalProduct)
-        )
-        whenever(productRepo.getProduct(any())).thenReturn(originalProduct)
-        sut.onBarcodeScanningResult(
-            CodeScannerStatus.Success(
-                "123",
-                GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
-            )
-        )
-        val originalVariation =
-            ProductTestUtils.generateProductVariation(productId = productId, variationId = variationId)
-                .copy(stockQuantity = originalProduct.stockQuantity)
-        whenever(variationRepo.getVariationOrNull(productId, variationId)).thenReturn(originalVariation)
-        whenever(variationRepo.updateVariation(any())).thenReturn(WCProductStore.OnVariationUpdated(1, 1, variationId))
-        whenever(
-            resourceProvider.getString(
-                R.string.scan_to_update_inventory_success_snackbar,
-                "${originalProduct.stockQuantity.toInt()} ➡ ${originalProduct.stockQuantity.toInt() + 1}"
-            )
-        ).thenReturn("Quantity updated")
-        sut.viewState.test {
-            awaitItem().apply {
-                assertIs<QuickInventoryBottomSheetVisible>(this)
-            }
+            verify(productRepo).updateProduct(product.copy(stockQuantity = originalQuantity.toDouble()))
         }
 
-        sut.onIncrementQuantityClicked()
-        sut.onUpdateQuantityClicked()
-
-        val argumentCaptor = argumentCaptor<ProductVariation>()
-        verify(variationRepo).updateVariation(argumentCaptor.capture())
-        assertEquals(originalVariation.stockQuantity + 1, argumentCaptor.firstValue.stockQuantity)
-    }
-
     @Test
-    fun `given bottom sheet with variation shown, when quantity entered manually, then should update product`() = testBlocking {
-        val originalProduct = ProductTestUtils.generateProduct(isStockManaged = true, productId = 2, parentID = 1)
-        whenever(fetchProductBySKU(any(), any())).thenReturn(
-            Result.success(originalProduct)
-        )
-        whenever(productRepo.getProduct(any())).thenReturn(originalProduct)
-        sut.onBarcodeScanningResult(
-            CodeScannerStatus.Success(
-                "123",
-                GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
+    fun `given bottom sheet with variation shown, when increment quantity clicked, then should should update product`() =
+        testBlocking {
+            val productId = 1L
+            val variationId = 2L
+            val originalProduct =
+                ProductTestUtils.generateProduct(isStockManaged = true, productId = variationId, parentID = productId)
+                    .copy(stockQuantity = 1.0)
+            whenever(fetchProductBySKU(any(), any())).thenReturn(
+                Result.success(originalProduct)
             )
-        )
-        val originalVariation =
-            ProductTestUtils.generateProductVariation(productId = 1, variationId = 2)
-                .copy(stockQuantity = 1.0)
-        whenever(variationRepo.getVariationOrNull(1, 2)).thenReturn(originalVariation)
-        whenever(variationRepo.updateVariation(any())).thenReturn(WCProductStore.OnVariationUpdated(1, 1, 2))
-        whenever(
-            resourceProvider.getString(
-                R.string.scan_to_update_inventory_success_snackbar,
-                "${originalProduct.stockQuantity.toInt()} ➡ 999"
+            whenever(productRepo.getProduct(any())).thenReturn(originalProduct)
+            sut.onBarcodeScanningResult(
+                CodeScannerStatus.Success(
+                    "123",
+                    GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
+                )
             )
-        ).thenReturn("Quantity updated")
-        sut.viewState.test {
-            awaitItem().apply {
-                assertIs<QuickInventoryBottomSheetVisible>(this)
+            val originalVariation =
+                ProductTestUtils.generateProductVariation(productId = productId, variationId = variationId)
+                    .copy(stockQuantity = originalProduct.stockQuantity)
+            whenever(variationRepo.getVariationOrNull(productId, variationId)).thenReturn(originalVariation)
+            whenever(variationRepo.updateVariation(any())).thenReturn(
+                WCProductStore.OnVariationUpdated(
+                    1,
+                    1,
+                    variationId
+                )
+            )
+            whenever(
+                resourceProvider.getString(
+                    R.string.scan_to_update_inventory_success_snackbar,
+                    "${originalProduct.stockQuantity.toInt()} ➡ ${originalProduct.stockQuantity.toInt() + 1}"
+                )
+            ).thenReturn("Quantity updated")
+            sut.viewState.test {
+                awaitItem().apply {
+                    assertIs<QuickInventoryBottomSheetVisible>(this)
+                }
             }
+
+            sut.onIncrementQuantityClicked()
+            sut.onUpdateQuantityClicked()
+
+            val argumentCaptor = argumentCaptor<ProductVariation>()
+            verify(variationRepo).updateVariation(argumentCaptor.capture())
+            assertEquals(originalVariation.stockQuantity + 1, argumentCaptor.firstValue.stockQuantity)
         }
 
-        sut.onManualQuantityEntered("999")
-        sut.onUpdateQuantityClicked()
+    @Test
+    fun `given bottom sheet with variation shown, when quantity entered manually, then should update product`() =
+        testBlocking {
+            val originalProduct = ProductTestUtils.generateProduct(isStockManaged = true, productId = 2, parentID = 1)
+            whenever(fetchProductBySKU(any(), any())).thenReturn(
+                Result.success(originalProduct)
+            )
+            whenever(productRepo.getProduct(any())).thenReturn(originalProduct)
+            sut.onBarcodeScanningResult(
+                CodeScannerStatus.Success(
+                    "123",
+                    GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
+                )
+            )
+            val originalVariation =
+                ProductTestUtils.generateProductVariation(productId = 1, variationId = 2)
+                    .copy(stockQuantity = 1.0)
+            whenever(variationRepo.getVariationOrNull(1, 2)).thenReturn(originalVariation)
+            whenever(variationRepo.updateVariation(any())).thenReturn(WCProductStore.OnVariationUpdated(1, 1, 2))
+            whenever(
+                resourceProvider.getString(
+                    R.string.scan_to_update_inventory_success_snackbar,
+                    "${originalProduct.stockQuantity.toInt()} ➡ 999"
+                )
+            ).thenReturn("Quantity updated")
+            sut.viewState.test {
+                awaitItem().apply {
+                    assertIs<QuickInventoryBottomSheetVisible>(this)
+                }
+            }
 
-        val expectedVariation = originalVariation.copy(stockQuantity = (999).toDouble())
-        verify(variationRepo).updateVariation(expectedVariation)
-    }
+            sut.onManualQuantityEntered("999")
+            sut.onUpdateQuantityClicked()
+
+            val expectedVariation = originalVariation.copy(stockQuantity = (999).toDouble())
+            verify(variationRepo).updateVariation(expectedVariation)
+        }
 
     @Test
     fun `when increment quantity button tapped, then proper tracking event is triggered`() = testBlocking {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10285 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR replaces the original Success snackbar on quantity increased with an Undo Snackbar that reverts the increase. It also adds a second snackbar after the undo option is clicked to cue the user that the action has been reverted. 

** Please note a bunch of tests have been changed but just to fix detekt issues.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Open product list
- Click "barcode scanner" icon
- Scan barcode with the SKU of existing stock-managed product (you can use online barcode generator like [this one](https://barcode.tec-it.com/en/?data=ACGADO))
- Verify product is found and the bottom sheet is opened
- change the quantity and verify the product quantity is updated successfully
- Verify the Undo snackbar is displayed
- click on the undo button
- verify the second snackbar is displayed telling the user the action has been reverted
- scan the code again to verify the quantity is the same as it was before the increase. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/30724184/649cfe5a-639f-4a94-b14d-7da7ed4744f8



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
