### PR TITLE
HACK: Add overlay to barcode scanner screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScanner.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.barcodescanner
 
-import androidx.camera.core.Preview as CameraPreview
 import android.content.res.Configuration
 import android.util.Size
 import androidx.camera.core.CameraSelector
@@ -34,6 +33,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import androidx.camera.core.Preview as CameraPreview
 
 @Suppress("TooGenericExceptionCaught")
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScanner.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.barcodescanner
 
+import androidx.camera.core.Preview as CameraPreview
 import android.content.res.Configuration
 import android.util.Size
 import androidx.camera.core.CameraSelector
@@ -8,20 +9,31 @@ import androidx.camera.core.ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST
 import androidx.camera.core.ImageProxy
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import androidx.camera.core.Preview as CameraPreview
 
 @Suppress("TooGenericExceptionCaught")
 @Composable
@@ -75,10 +87,38 @@ fun BarcodeScanner(
         }
     }
 
-    AndroidView(
-        factory = { previewView },
-        modifier = Modifier.fillMaxSize()
-    )
+    Box {
+        AndroidView(
+            factory = { previewView },
+            modifier = Modifier.fillMaxSize()
+        )
+        ScannerOverlay()
+    }
+}
+
+@Composable
+private fun ScannerOverlay() {
+    Column {
+        Box(
+            modifier = Modifier
+                .weight(0.24F)
+                .fillMaxWidth()
+                .background(colorResource(id = R.color.color_scrim_background))
+        )
+        Spacer(modifier = Modifier.weight(0.52F))
+        Box(
+            modifier = Modifier
+                .weight(0.24F)
+                .fillMaxWidth()
+                .background(colorResource(id = R.color.color_scrim_background)),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            Text(
+                modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100)),
+                text = stringResource(R.string.barcode_scanning_scan_product_barcode_label)
+            )
+        }
+    }
 }
 
 @Preview(name = "Light mode")

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -645,6 +645,8 @@
     <string name="barcode_scanning_alert_dialog_rationale_cta_label">Grant</string>
     <string name="barcode_scanning_alert_dialog_dismiss_label">Cancel</string>
     <string name="barcode_scanning_alert_dialog_permanently_denied_cta_label">Go to settings</string>
+    <string name="barcode_scanning_scan_product_barcode_label">Scan Product Barcode</string>
+
     <!--
         Domains
     -->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

##### HACK: barcode scanner view UI polish
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds overlay with hint / call to action to barcode scanning screen.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Dark | Light |
|----|----|
| <img src=https://github.com/woocommerce/woocommerce-android/assets/4527432/548fab0c-4700-465c-8e13-df997bcbd2c3 width=300/> | <img src=https://github.com/woocommerce/woocommerce-android/assets/4527432/6133a362-83f2-4b80-b61d-32769252148f width=300/> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
