### PR TITLE
Replace "Edit" text with Pencil icon for Customer and Customer notes section

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 16.7
 -----
 - [*] Tap To Pay test payments are not taxable by default [https://github.com/woocommerce/woocommerce-android/pull/10353]
+- [*][Internal] Replace "Edit" text with Pencil icon for Customer and Customer notes section [https://github.com/woocommerce/woocommerce-android/pull/10381]
 
 
 

--- a/WooCommerce/src/main/res/layout/order_creation_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_section.xml
@@ -18,17 +18,18 @@
         app:layout_constraintHorizontal_weight="2"
         tools:ignore="UnusedAttribute" />
 
-    <com.google.android.material.button.MaterialButton
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/edit_button"
-        style="@style/Woo.Button.TextButton.Secondary"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/edit"
+        android:layout_width="@dimen/major_150"
+        android:layout_height="@dimen/major_150"
+        android:layout_margin="@dimen/major_100"
+        android:padding="@dimen/minor_25"
         android:visibility="gone"
+        android:src="@drawable/ic_edit_pencil"
         app:layout_constraintHorizontal_weight="1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:visibility="visible" />
+        tools:visibility="visible"/>
 
     <ImageView
         android:id="@+id/barcode_icon"


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: #10380 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the Order Detail screen's edit mode by replacing the "Edit" text with a pencil icon.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Navigate to the order details screen
2. Enter into edit mode by clicking the "edit" text on the toolbar
3. Ensure you see "Pencil" icon instead of "Edit" text in Customer and Customer notes sections

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
|--------|-------|
| ![Before](https://github.com/woocommerce/woocommerce-android/assets/1331230/d8f5b24f-d14a-465d-a966-5135573f34f4) | ![After](https://github.com/woocommerce/woocommerce-android/assets/1331230/65d5a922-2730-48ea-a9cb-c661702dfcd3) |



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
