### PR TITLE
Remove the specification of theme when creating a site

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStore.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.ui.login.storecreation.StoreCreationRepository.Si
 import com.woocommerce.android.ui.login.storecreation.StoreCreationResult.Failure
 import com.woocommerce.android.ui.login.storecreation.StoreCreationResult.Success
 import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_LANGUAGE_ID
-import com.woocommerce.android.ui.login.storecreation.plans.PlansViewModel.Companion.NEW_SITE_THEME
 import kotlinx.coroutines.flow.flow
 import java.util.TimeZone
 import javax.inject.Inject
@@ -35,7 +34,6 @@ class CreateFreeTrialStore @Inject constructor(
         val result = repository.createNewFreeTrialSite(
             SiteCreationData(
                 segmentId = null,
-                siteDesign = NEW_SITE_THEME,
                 domain = storeDomain,
                 title = storeName,
                 profilerData = profilerData,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/StoreCreationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/StoreCreationRepository.kt
@@ -229,7 +229,6 @@ class StoreCreationRepository @Inject constructor(
             timeZoneId = timeZoneId,
             visibility = siteVisibility,
             segmentId = siteData.segmentId,
-            siteDesign = siteData.siteDesign,
             dryRun = dryRun,
             siteCreationFlow = siteCreationFlow,
             findAvailableUrl = shouldFindAvailableUrl
@@ -260,7 +259,6 @@ class StoreCreationRepository @Inject constructor(
     @SuppressLint("ParcelCreator")
     data class SiteCreationData(
         val segmentId: Long?,
-        val siteDesign: String?,
         val domain: String?,
         val title: String?,
         val profilerData: NewStore.ProfilerData? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
@@ -60,7 +60,6 @@ class PlansViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle, iapManager) {
     companion object {
         const val NEW_SITE_LANGUAGE_ID = "en"
-        const val NEW_SITE_THEME = "premium/tsubaki"
         const val CART_URL = "https://wordpress.com/checkout"
         const val WEBVIEW_SUCCESS_TRIGGER_KEYWORD = "https://wordpress.com/checkout/thank-you/"
         const val WEBVIEW_EXIT_TRIGGER_KEYWORD = "https://woo.com/"
@@ -240,10 +239,9 @@ class PlansViewModel @Inject constructor(
 
         return repository.createNewSite(
             siteData = SiteCreationData(
-                siteDesign = NEW_SITE_THEME,
+                segmentId = null,
                 domain = newStore.data.domain,
-                title = newStore.data.name,
-                segmentId = null
+                title = newStore.data.name
             ),
             languageWordPressId = NEW_SITE_LANGUAGE_ID,
             timeZoneId = TimeZone.getDefault().id,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/CreateFreeTrialStoreTest.kt
@@ -34,10 +34,9 @@ internal class CreateFreeTrialStoreTest : BaseUnitTest() {
         val siteTitle = "test title"
         val expectedCreationResult = StoreCreationResult.Success(123L)
         val expectedSiteCreationData = SiteCreationData(
-            siteDesign = PlansViewModel.NEW_SITE_THEME,
+            segmentId = null,
             domain = siteDomain,
-            title = siteTitle,
-            segmentId = null
+            title = siteTitle
         )
         createSut(siteDomain, siteTitle, expectedCreationResult)
 
@@ -70,10 +69,9 @@ internal class CreateFreeTrialStoreTest : BaseUnitTest() {
             StoreCreationErrorType.FREE_TRIAL_ASSIGNMENT_FAILED
         )
         val expectedSiteCreationData = SiteCreationData(
-            siteDesign = PlansViewModel.NEW_SITE_THEME,
+            segmentId = null,
             domain = siteDomain,
-            title = siteTitle,
-            segmentId = null
+            title = siteTitle
         )
 
         createSut(siteDomain, siteTitle, expectedCreationResult)
@@ -106,10 +104,9 @@ internal class CreateFreeTrialStoreTest : BaseUnitTest() {
         val siteDomain = "test existent domain"
         val siteTitle = "test existent title"
         val expectedSiteCreationData = SiteCreationData(
-            siteDesign = PlansViewModel.NEW_SITE_THEME,
+            segmentId = null,
             domain = siteDomain,
-            title = siteTitle,
-            segmentId = null
+            title = siteTitle
         )
 
         createSut(
@@ -143,10 +140,9 @@ internal class CreateFreeTrialStoreTest : BaseUnitTest() {
         expectedCreationResult: StoreCreationResult<Long> = StoreCreationResult.Success(123)
     ) {
         val expectedSiteCreationData = SiteCreationData(
-            siteDesign = PlansViewModel.NEW_SITE_THEME,
+            segmentId = null,
             domain = siteDomain,
-            title = siteTitle,
-            segmentId = null
+            title = siteTitle
         )
 
         val siteModel = SiteModel().apply { siteId = expectedSiteId }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/PlansViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/PlansViewModelTest.kt
@@ -53,10 +53,9 @@ class PlansViewModelTest : BaseUnitTest() {
     }
 
     private val siteData = SiteCreationData(
-        siteDesign = PlansViewModel.NEW_SITE_THEME,
+        segmentId = null,
         domain = "woocommerce.com",
-        title = "WooCommerce",
-        segmentId = null
+        title = "WooCommerce"
     )
 
     private val plan = Plan(


### PR DESCRIPTION
### Description
As discussed internally p1702400758733119/1701419332.318959-slack-C03L1NF1EA3, this PR removes the specification of the theme when sending a request to create a new site, WooExpress always uses the default theme defined in the backend, and ignores what we send from the app.

### Testing instructions
Create a new free trial site (make sure to skip the theme selection) and confirm it has the correct theme (Tsubaki).

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->