### PR TITLE
Update theme screenshot error UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -50,6 +51,7 @@ import coil.util.DebugLogger
 import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.ui.compose.animations.SkeletonView
+import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.themes.ThemePickerViewModel.CarouselState
@@ -227,7 +229,7 @@ private fun ColumnScope.Error() {
             .fillMaxWidth()
             .weight(1f),
         title = stringResource(id = R.string.theme_picker_error_title),
-        description = stringResource(id = R.string.theme_picker_error_message),
+        description = annotatedStringRes(stringResId = R.string.theme_picker_error_message),
         color = color.color_error
     )
 }
@@ -244,7 +246,11 @@ private fun Carousel(items: List<CarouselItem>, onThemeTapped: (String) -> Unit)
         items(items) { item ->
             when (item) {
                 is CarouselItem.Theme -> Theme(item, onThemeTapped)
-                is CarouselItem.Message -> Message(modifier = Modifier.width(320.dp), item.title, item.description)
+                is CarouselItem.Message -> Message(
+                    title = item.title,
+                    description = AnnotatedString(item.description),
+                    modifier = Modifier.width(320.dp)
+                )
             }
         }
     }
@@ -252,9 +258,9 @@ private fun Carousel(items: List<CarouselItem>, onThemeTapped: (String) -> Unit)
 
 @Composable
 private fun Message(
-    modifier: Modifier = Modifier,
     title: String,
-    description: String,
+    description: AnnotatedString,
+    modifier: Modifier = Modifier,
     color: Int = R.color.color_on_surface_medium
 ) {
     Box(
@@ -323,9 +329,9 @@ private fun Theme(
             when (painter.state) {
                 is AsyncImagePainter.State.Error -> {
                     Message(
-                        modifier = themeModifier,
                         title = stringResource(id = R.string.theme_picker_carousel_placeholder_title, theme.name),
-                        description = stringResource(id = R.string.theme_picker_carousel_placeholder_message)
+                        description = annotatedStringRes(stringResId = R.string.theme_picker_carousel_placeholder_message),
+                        modifier = themeModifier
                     )
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
@@ -38,16 +38,17 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
-import coil.compose.AsyncImagePainter
 import coil.compose.SubcomposeAsyncImage
-import coil.compose.SubcomposeAsyncImageContent
 import coil.request.ImageRequest
 import coil.util.DebugLogger
+import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.ui.compose.animations.SkeletonView
@@ -311,7 +312,7 @@ private fun Theme(
                     .followRedirects(false)
                     .build()
             }
-            .logger(DebugLogger())
+            .logger(if (BuildConfig.DEBUG) DebugLogger() else null)
             .build()
 
         val request = ImageRequest.Builder(LocalContext.current)
@@ -323,23 +324,27 @@ private fun Theme(
             model = request,
             imageLoader = imageLoader,
             contentDescription = stringResource(R.string.settings_app_theme_title),
-            contentScale = ContentScale.FillHeight,
-            modifier = Modifier.fillMaxHeight()
-        ) {
-            when (painter.state) {
-                is AsyncImagePainter.State.Error -> {
-                    Message(
-                        title = stringResource(id = R.string.theme_picker_carousel_placeholder_title, theme.name),
-                        description = annotatedStringRes(stringResId = R.string.theme_picker_carousel_placeholder_message),
-                        modifier = themeModifier
+            error = {
+                val errorMessage = buildAnnotatedString {
+                    val ctaText = stringResource(id = R.string.theme_picker_carousel_error_placeholder_message_cta)
+                    val message = stringResource(id = R.string.theme_picker_carousel_error_placeholder_message, ctaText)
+                    append(message)
+                    addStyle(
+                        SpanStyle(color = MaterialTheme.colors.primary),
+                        message.indexOf(ctaText),
+                        message.indexOf(ctaText) + ctaText.length
                     )
                 }
 
-                else -> {
-                    SubcomposeAsyncImageContent()
-                }
-            }
-        }
+                Message(
+                    title = theme.name,
+                    description = errorMessage,
+                    modifier = themeModifier
+                )
+            },
+            contentScale = ContentScale.FillHeight,
+            modifier = Modifier.fillMaxHeight()
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -24,6 +24,7 @@ class ThemePickerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val themeRepository: ThemeRepository,
     private val resourceProvider: ResourceProvider,
+    private val crashLogger: CrashLogging
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: ThemePickerFragmentArgs by savedStateHandle.navArgs()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.themes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import coil.network.HttpException
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.themes.ThemePickerViewModel.CarouselState.Success.CarouselItem
@@ -110,6 +112,17 @@ class ThemePickerViewModel @Inject constructor(
 
     fun onThemeTapped(themeUri: String) {
         triggerEvent(NavigateToThemePreview(themeUri, navArgs.isFromStoreCreation))
+    }
+
+    fun onThemeScreenshotFailure(themeName: String, throwable: Throwable) {
+        @Suppress("MagicNumber")
+        fun Int.isRedirect() = this in 300..399
+
+        if (throwable is HttpException && throwable.response.code.isRedirect()) {
+            // A redirect means that the screenshot is not cached by MShot
+            val message = "Screenshot for theme $themeName is unavailable"
+            crashLogger.sendReport(Exception(message))
+        }
     }
 
     data class ViewState(

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -16,8 +16,6 @@ Language: ar
     <string name="theme_preview_title">معاينة</string>
     <string name="theme_picker_error_message">يتعذر تحميل القوالب في الوقت الحالي.</string>
     <string name="theme_picker_error_title">حدث خطأ</string>
-    <string name="theme_picker_carousel_placeholder_message">اضغط للحصول على عرض توضيحي فوري.</string>
-    <string name="theme_picker_carousel_placeholder_title">القالب \"%s\" </string>
     <string name="theme_picker_carousel_info_item_description">بمجرد إعداد متجرك، اعثر على قالبك المثالي في متجر قوالب WooCommerce.</string>
     <string name="theme_picker_carousel_info_item_title">هل تبحث عن المزيد؟</string>
     <string name="theme_picker_description">يمكنك دومًا تغييره لاحقًا ضمن الإعدادات.</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -16,8 +16,6 @@ Language: de
     <string name="theme_preview_title">Vorschau</string>
     <string name="theme_picker_error_message">Derzeit können keine Themes geladen werden.</string>
     <string name="theme_picker_error_title">Ein Fehler ist aufgetreten</string>
-    <string name="theme_picker_carousel_placeholder_message">Tippe, um dir eine Live-Demo anzusehen.</string>
-    <string name="theme_picker_carousel_placeholder_title">Theme „%s“</string>
     <string name="theme_picker_carousel_info_item_description">Sobald dein Shop eingerichtet ist, kannst du dir im WooCommerce-Theme-Shop dein perfektes Theme aussuchen.</string>
     <string name="theme_picker_carousel_info_item_title">Du suchst mehr?</string>
     <string name="theme_picker_description">In deinen Einstellungen kannst du dein Theme später jederzeit ändern.</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -16,8 +16,6 @@ Language: es
     <string name="theme_preview_title">Vista previa</string>
     <string name="theme_picker_error_message">No se han podido cargar los temas en este momento.</string>
     <string name="theme_picker_error_title">Se ha producido un error</string>
-    <string name="theme_picker_carousel_placeholder_message">Toca para ver una demostración en directo.</string>
-    <string name="theme_picker_carousel_placeholder_title">Tema \"%s\"</string>
     <string name="theme_picker_carousel_info_item_description">Cuando hayas configurado tu tienda, busca el tema perfecto en la tienda de temas de WooCommerce.</string>
     <string name="theme_picker_carousel_info_item_title">¿Quieres más opciones?</string>
     <string name="theme_picker_description">Podrás cambiarlo más tarde en la configuración.</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -16,8 +16,6 @@ Language: fr
     <string name="theme_preview_title">Aperçu</string>
     <string name="theme_picker_error_message">Impossible de charger des thèmes pour l’instant.</string>
     <string name="theme_picker_error_title">Une erreur s’est produite</string>
-    <string name="theme_picker_carousel_placeholder_message">Appuyez pour une démo en direct.</string>
-    <string name="theme_picker_carousel_placeholder_title">Thème « %s »</string>
     <string name="theme_picker_carousel_info_item_description">Lorsque votre boutique est configurée, trouvez le thème parfait dans la boutique de thèmes WooCommerce.</string>
     <string name="theme_picker_carousel_info_item_title">Vous cherchez le truc en plus ?</string>
     <string name="theme_picker_description">Vous pouvez toujours le changer plus tard dans les réglages.</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -16,8 +16,6 @@ Language: he_IL
     <string name="theme_preview_title">תצוגה מקדימה</string>
     <string name="theme_picker_error_message">כרגע לא ניתן לטעון ערכות עיצוב.</string>
     <string name="theme_picker_error_title">אירעה שגיאה</string>
-    <string name="theme_picker_carousel_placeholder_message">יש להקיש כדי להציג הדגמה חיה.</string>
-    <string name="theme_picker_carousel_placeholder_title">ערכת העיצוב \'%s\'</string>
     <string name="theme_picker_carousel_info_item_description">לאחר הגדרת החנות אפשר למצוא את ערכת העיצוב המושלמת בחנות ערכות העיצוב של WooCommerce.</string>
     <string name="theme_picker_carousel_info_item_title">יש משהו נוסף שמעניין אותך?</string>
     <string name="theme_picker_description">תמיד אפשר להחליף ערכה בהמשך, דרך ההגדרות.</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -16,8 +16,6 @@ Language: id
     <string name="theme_preview_title">Pratinjau</string>
     <string name="theme_picker_error_message">Tidak dapat memuat tema saat ini.</string>
     <string name="theme_picker_error_title">Terjadi kesalahan</string>
-    <string name="theme_picker_carousel_placeholder_message">Ketuk untuk demo langsung.</string>
-    <string name="theme_picker_carousel_placeholder_title">Tema \"%s\"</string>
     <string name="theme_picker_carousel_info_item_description">Setelah menyiapkan toko Anda, temukan tema yang ideal di Toko Tema WooCommerce.</string>
     <string name="theme_picker_carousel_info_item_title">Mencari lainnya?</string>
     <string name="theme_picker_description">Anda bebas mengubahnya di pengaturan kapan saja.</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -16,8 +16,6 @@ Language: it
     <string name="theme_preview_title">Anteprima</string>
     <string name="theme_picker_error_message">Impossibile caricare i temi in questo momento.</string>
     <string name="theme_picker_error_title">Si è verificato un errore</string>
-    <string name="theme_picker_carousel_placeholder_message">Tocca per la demo live.</string>
-    <string name="theme_picker_carousel_placeholder_title">Tema \"%s\"</string>
     <string name="theme_picker_carousel_info_item_description">Una volta configurato il negozio, trova il tema perfetto nel negozio di temi WooCommerce.</string>
     <string name="theme_picker_carousel_info_item_title">Cerchi altro?</string>
     <string name="theme_picker_description">Puoi sempre modificare il tema nelle impostazioni in un secondo momento.</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -16,8 +16,6 @@ Language: ja_JP
     <string name="theme_preview_title">プレビュー</string>
     <string name="theme_picker_error_message">現時点ではテーマを読み込むことができません。</string>
     <string name="theme_picker_error_title">エラーが発生しました</string>
-    <string name="theme_picker_carousel_placeholder_message">タップするとライブデモが表示されます。</string>
-    <string name="theme_picker_carousel_placeholder_title">テーマ「%s」</string>
     <string name="theme_picker_carousel_info_item_description">ストアをセットアップしたら、WooCommerce テーマストアでご自身にぴったりなテーマを見つけましょう。</string>
     <string name="theme_picker_carousel_info_item_title">もっと知りたいですか ?</string>
     <string name="theme_picker_description">設定で後でいつでも変更できます。</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -16,8 +16,6 @@ Language: ko_KR
     <string name="theme_preview_title">미리보기</string>
     <string name="theme_picker_error_message">지금은 테마를 로드할 수 없습니다.</string>
     <string name="theme_picker_error_title">오류 발생</string>
-    <string name="theme_picker_carousel_placeholder_message">실시간 데모를 눌러보세요.</string>
-    <string name="theme_picker_carousel_placeholder_title">\"%s\" 테마</string>
     <string name="theme_picker_carousel_info_item_description">스토어를 설정했으면 우커머스 테마 스토어에서 완벽한 테마를 찾아보세요.</string>
     <string name="theme_picker_carousel_info_item_title">자세한 정보를 원하시나요?</string>
     <string name="theme_picker_description">나중에 언제든지 설정에서 변경하실 수 있습니다.</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -16,8 +16,6 @@ Language: nl
     <string name="theme_preview_title">Voorbeeld</string>
     <string name="theme_picker_error_message">Thema\'s kunnen op dit moment niet worden geladen.</string>
     <string name="theme_picker_error_title">Er is een fout opgetreden</string>
-    <string name="theme_picker_carousel_placeholder_message">Tik voor een live demonstratie.</string>
-    <string name="theme_picker_carousel_placeholder_title">Thema \'%s\'</string>
     <string name="theme_picker_carousel_info_item_description">Wanneer je winkel is ingesteld, zoek je jouw perfecte thema op in de WooCommerce Theme Store.</string>
     <string name="theme_picker_carousel_info_item_title">Zoek je naar iets anders?</string>
     <string name="theme_picker_description">Je kan later altijd nog wijzigen in de instellingen.</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -16,8 +16,6 @@ Language: pt_BR
     <string name="theme_preview_title">Visualizar</string>
     <string name="theme_picker_error_message">Não é possível carregar os temas no momento.</string>
     <string name="theme_picker_error_title">Ocorreu um erro</string>
-    <string name="theme_picker_carousel_placeholder_message">Toque para ver a demonstração ao vivo.</string>
-    <string name="theme_picker_carousel_placeholder_title">Tema \"%s\"</string>
     <string name="theme_picker_carousel_info_item_description">Assim que sua loja estiver configurada, encontre o tema perfeito na loja de temas do WooCommerce.</string>
     <string name="theme_picker_carousel_info_item_title">Quer mais?</string>
     <string name="theme_picker_description">Você pode mudar isso depois nas configurações.</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -16,8 +16,6 @@ Language: ru
     <string name="theme_preview_title">Предварительный просмотр</string>
     <string name="theme_picker_error_message">Не удалось загрузить темы.</string>
     <string name="theme_picker_error_title">Произошла ошибка</string>
-    <string name="theme_picker_carousel_placeholder_message">Нажмите, чтобы просмотреть демонстрацию в реальном времени.</string>
-    <string name="theme_picker_carousel_placeholder_title">Тема «%s»</string>
     <string name="theme_picker_carousel_info_item_description">Настроив магазин, найдите для него самую подходящую тему в магазине тем WooCommerce.</string>
     <string name="theme_picker_carousel_info_item_title">Ищете что-то другое?</string>
     <string name="theme_picker_description">Вы можете изменить настройки в любой момент.</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -16,8 +16,6 @@ Language: sv_SE
     <string name="theme_preview_title">Förhandsgranska</string>
     <string name="theme_picker_error_message">Kan inte att ladda teman just nu.</string>
     <string name="theme_picker_error_title">Ett fel uppstod</string>
-    <string name="theme_picker_carousel_placeholder_message">Tryck för live-demo.</string>
-    <string name="theme_picker_carousel_placeholder_title">Tema ”%s”</string>
     <string name="theme_picker_carousel_info_item_description">När din butik har konfigurerats kan du hitta ditt perfekta tema i WooCommerce-temabutiken.</string>
     <string name="theme_picker_carousel_info_item_title">Letar du efter fler?</string>
     <string name="theme_picker_description">Du kan alltid ändra det senare i inställningar</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -16,8 +16,6 @@ Language: tr
     <string name="theme_preview_title">Önizleme</string>
     <string name="theme_picker_error_message">Temalar şu anda yüklenemiyor.</string>
     <string name="theme_picker_error_title">Bir hata oluştu</string>
-    <string name="theme_picker_carousel_placeholder_message">Canlı demo için dokunun.</string>
-    <string name="theme_picker_carousel_placeholder_title">\"%s\" teması</string>
     <string name="theme_picker_carousel_info_item_description">Mağazanız kurulduğunda WooCommerce Tema Mağazasından mükemmel temanızı bulun.</string>
     <string name="theme_picker_carousel_info_item_title">Daha fazlasını mı arıyorsunuz?</string>
     <string name="theme_picker_description">Daha sonra ayarlardan değiştirebilirsiniz.</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -16,8 +16,6 @@ Language: zh_CN
     <string name="theme_preview_title">预览</string>
     <string name="theme_picker_error_message">暂时无法加载主题。</string>
     <string name="theme_picker_error_title">出现错误</string>
-    <string name="theme_picker_carousel_placeholder_message">点击观看实时演示。</string>
-    <string name="theme_picker_carousel_placeholder_title">主题“%s”</string>
     <string name="theme_picker_carousel_info_item_description">完成商店设置后，请在 WooCommerce 主题商店中找到最适合您的主题。</string>
     <string name="theme_picker_carousel_info_item_title">想要获得更多信息？</string>
     <string name="theme_picker_description">之后您可以随时在设置中进行更改。</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -16,8 +16,6 @@ Language: zh_TW
     <string name="theme_preview_title">預覽</string>
     <string name="theme_picker_error_message">目前無法載入佈景主題。</string>
     <string name="theme_picker_error_title">發生錯誤</string>
-    <string name="theme_picker_carousel_placeholder_message">點選查看即時示範。</string>
-    <string name="theme_picker_carousel_placeholder_title">佈景主題「%s」</string>
     <string name="theme_picker_carousel_info_item_description">商店設定完畢後，請前往 WooCommerce 佈景主題商店，尋找最適合你的佈景主題。</string>
     <string name="theme_picker_carousel_info_item_title">想探索更多選項嗎？</string>
     <string name="theme_picker_description">你之後可以隨時在設定中變更。</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3394,8 +3394,8 @@
     <string name="theme_picker_carousel_info_item_title">Looking for more?</string>
     <string name="theme_picker_carousel_info_item_description">Once your store is set up, find your perfect theme in the WooCommerce Theme Store.</string>
     <string name="theme_picker_carousel_info_item_description_settings">You can find your perfect theme in the WooCommerce Theme Store.</string>
-    <string name="theme_picker_carousel_placeholder_title">Theme "%s"</string>
-    <string name="theme_picker_carousel_placeholder_message">Tap for live demo.</string>
+    <string name="theme_picker_carousel_error_placeholder_message">Sorry, it seems there is an issue with the template loading. Please %1$s for a live demo.</string>
+    <string name="theme_picker_carousel_error_placeholder_message_cta">tap here</string>
     <string name="theme_picker_error_title">An error occurred</string>
     <string name="theme_picker_error_message">Unable to load themes at this time.</string>
     <string name="theme_preview_title">Preview</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10383 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR implements two changes:
1. It updates the design for screenshot failures to match the new specs: IpVQ5OMMkktucysPCWr9pK-fi-1633_10007
2. It adds logic to report MShot failures to Sentry.

### Testing instructions
1. Apply the patch from below.
2. Open the theme picker.
3. Confirm the error UI matches the one from Figma.
4. Check logcat and confirm the message "Sentry event reported" was logged.
5. Crash logging is by default disabled on debug builds, but in case it was enabled for your case, this will send an event to Sentry.

```patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt	(revision ad235c957147f1db3f6cdbf8440392e557aa3fbf)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt	(date 1702492580986)
@@ -60,7 +60,7 @@
                             CarouselItem.Theme(
                                 themeId = theme.id,
                                 name = theme.name,
-                                screenshotUrl = AppUrls.getScreenshotUrl(theme.demoUrl!!)
+                                screenshotUrl = AppUrls.getScreenshotUrl(if (theme.id == "tsubaki") "https://notworking.co" else theme.demoUrl!!)
                             )
                         }
                         .plus(
@@ -122,6 +122,8 @@
             // A redirect means that the screenshot is not cached by MShot
             val message = "Screenshot for theme $themeName is unavailable"
             crashLogger.sendReport(Exception(message))
+            
+            println("Sentry event reported")
         }
     }
 
```

### Images/gif
<img width=360 src="https://github.com/woocommerce/woocommerce-android/assets/1657201/c9ce7326-e691-4793-8741-b124e641414f" />


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->