### PR TITLE
[FIX] Toolbar hight is incorrect on the site picker screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -16,7 +16,8 @@ abstract class TopLevelFragment : BaseFragment, TopLevelFragmentView {
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Visible(
             navigationIcon = null,
-            hasShadow = false
+            hasShadow = false,
+            animateAppearance = true,
         )
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -17,7 +17,6 @@ abstract class TopLevelFragment : BaseFragment, TopLevelFragmentView {
         get() = AppBarStatus.Visible(
             navigationIcon = null,
             hasShadow = false,
-            animateAppearance = true,
         )
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/AppBarStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/AppBarStatus.kt
@@ -10,6 +10,5 @@ sealed class AppBarStatus {
         val navigationIcon: Int? = R.drawable.ic_back_24dp,
         val hasShadow: Boolean = true,
         val hasDivider: Boolean = false,
-        val animateAppearance: Boolean = false,
     ) : AppBarStatus()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/AppBarStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/AppBarStatus.kt
@@ -9,6 +9,7 @@ sealed class AppBarStatus {
         @DrawableRes
         val navigationIcon: Int? = R.drawable.ic_back_24dp,
         val hasShadow: Boolean = true,
-        val hasDivider: Boolean = false
+        val hasDivider: Boolean = false,
+        val animateAppearance: Boolean = false,
     ) : AppBarStatus()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -208,7 +208,7 @@ class MainActivity :
 
             when (val appBarStatus = (f as? BaseFragment)?.activityAppBarStatus ?: AppBarStatus.Visible()) {
                 is AppBarStatus.Visible -> {
-                    showToolbar(appBarStatus.animateAppearance)
+                    showToolbar(f is TopLevelFragment)
                     // re-expand the AppBar when returning to top level fragment,
                     // collapse it when entering a child fragment
                     if (f is TopLevelFragment) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -208,7 +208,7 @@ class MainActivity :
 
             when (val appBarStatus = (f as? BaseFragment)?.activityAppBarStatus ?: AppBarStatus.Visible()) {
                 is AppBarStatus.Visible -> {
-                    showToolbar()
+                    showToolbar(appBarStatus.animateAppearance)
                     // re-expand the AppBar when returning to top level fragment,
                     // collapse it when entering a child fragment
                     if (f is TopLevelFragment) {
@@ -484,11 +484,17 @@ class MainActivity :
         return null
     }
 
-    private fun showToolbar() {
+    private fun showToolbar(animate: Boolean) {
         if (binding.collapsingToolbar.layoutParams.height == animatorHelper.toolbarHeight) return
-        animatorHelper.animateToolbarHeight(show = true) {
+        if (animate) {
+            animatorHelper.animateToolbarHeight(show = true) {
+                binding.collapsingToolbar.updateLayoutParams {
+                    height = it
+                }
+            }
+        } else {
             binding.collapsingToolbar.updateLayoutParams {
-                height = it
+                height = animatorHelper.toolbarHeight
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -150,7 +150,6 @@ class MyStoreFragment :
         get() = AppBarStatus.Visible(
             navigationIcon = null,
             hasShadow = true,
-            animateAppearance = true,
         )
 
     private var isEmptyViewVisible: Boolean = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -149,7 +149,8 @@ class MyStoreFragment :
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Visible(
             navigationIcon = null,
-            hasShadow = true
+            hasShadow = true,
+            animateAppearance = true,
         )
 
     private var isEmptyViewVisible: Boolean = false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adding animation to the hiding/showing toolbar, caused toolbar being tall on the site selector screen

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Click from/to "more" screen and other main fragments -> notice that animation is playing nicely
* Open "site selector" and other screens from the "more" fragment -> notice normal size of the toolbar

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

## Before

https://github.com/woocommerce/woocommerce-android/assets/4923871/eb1a4f45-163b-496e-93ac-59709aadc414



## After
https://github.com/woocommerce/woocommerce-android/assets/4923871/22c7b78f-0f27-43b5-b92c-f24de4356b52



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
