### PR TITLE
Merge 16.6-rc-2 into trunk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.59.0'
+    fluxCVersion = '2.59.1'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-versionName=16.6-rc-1
-versionCode=483
+versionName=16.6-rc-2
+versionCode=484


### PR DESCRIPTION
This PR merges the changes from the 16.6-rc-2 build into `trunk`. Includes:
- Version bump
- Beta fix: https://github.com/woocommerce/woocommerce-android/pull/10373