### PR TITLE
Issue/10407 onboarding task changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingRepository.kt
@@ -146,9 +146,9 @@ class StoreOnboardingRepository @Inject constructor(
     )
 
     enum class OnboardingTaskType(val id: String, val order: Int) {
-        LOCAL_NAME_STORE(id = "local_name_store", order = 1),
-        ABOUT_YOUR_STORE(id = "store_details", order = 2),
-        ADD_FIRST_PRODUCT(id = "products", order = 3),
+        ADD_FIRST_PRODUCT(id = "products", order = 1),
+        LOCAL_NAME_STORE(id = "local_name_store", order = 2),
+        ABOUT_YOUR_STORE(id = "store_details", order = 3),
         WC_PAYMENTS(id = "woocommerce-payments", order = 4),
         LAUNCH_YOUR_STORE(id = "launch_site", order = 5),
         CUSTOMIZE_DOMAIN(id = "add_domain", order = 6),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingScreen.kt
@@ -273,36 +273,6 @@ private fun TaskItem(
                 text = stringResource(id = task.taskUiResources.description),
                 style = MaterialTheme.typography.body1,
             )
-
-            if (task.isLabelVisible) {
-                Box(
-                    modifier = Modifier
-                        .background(
-                            color = colorResource(id = R.color.tag_task_label),
-                            shape = RoundedCornerShape(dimensionResource(id = dimen.minor_100))
-                        )
-                        .padding(dimensionResource(id = dimen.minor_50))
-                ) {
-                    Row(
-                        modifier = Modifier.padding(
-                            vertical = dimensionResource(id = dimen.minor_25),
-                            horizontal = dimensionResource(id = dimen.minor_100)
-                        ),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Image(
-                            painter = painterResource(task.taskUiResources.labelIcon),
-                            contentDescription = ""
-                        )
-                        Text(
-                            modifier = Modifier.padding(start = dimensionResource(id = dimen.minor_25)),
-                            text = stringResource(id = task.taskUiResources.labelText),
-                            style = MaterialTheme.typography.body2,
-                            color = colorResource(id = R.color.tag_task_label_text)
-                        )
-                    }
-                }
-            }
         }
         if (!task.isCompleted) {
             Image(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModel.kt
@@ -17,8 +17,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUC
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STORE_DETAILS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_WOO_PAYMENTS
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.extensions.isEligibleForAI
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.onboarding.ShouldShowOnboarding.Source.ONBOARDING_LIST
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTask
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType.ABOUT_YOUR_STORE
@@ -39,7 +37,6 @@ import javax.inject.Inject
 @HiltViewModel
 class StoreOnboardingViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val selectedSite: SelectedSite,
     private val onboardingRepository: StoreOnboardingRepository,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val shouldShowOnboarding: ShouldShowOnboarding
@@ -81,18 +78,8 @@ class StoreOnboardingViewModel @Inject constructor(
             CUSTOMIZE_DOMAIN -> OnboardingTaskUi(CustomizeDomainTaskRes, isCompleted = task.isComplete)
             WC_PAYMENTS -> OnboardingTaskUi(SetupWooPaymentsTaskRes, isCompleted = task.isComplete)
             PAYMENTS -> OnboardingTaskUi(SetupPaymentsTaskRes, isCompleted = task.isComplete)
-
-            ADD_FIRST_PRODUCT -> OnboardingTaskUi(
-                taskUiResources = AddProductTaskRes,
-                isCompleted = task.isComplete,
-                isLabelVisible = selectedSite.get().isEligibleForAI
-            )
-
-            LOCAL_NAME_STORE -> OnboardingTaskUi(
-                taskUiResources = NameYourStoreTaskRes,
-                isCompleted = task.isComplete
-            )
-
+            ADD_FIRST_PRODUCT -> OnboardingTaskUi(AddProductTaskRes, isCompleted = task.isComplete)
+            LOCAL_NAME_STORE -> OnboardingTaskUi(NameYourStoreTaskRes, isCompleted = task.isComplete)
             MOBILE_UNSUPPORTED -> error("Unknown task type is not allowed in UI layer")
         }
 
@@ -178,7 +165,6 @@ class StoreOnboardingViewModel @Inject constructor(
     data class OnboardingTaskUi(
         val taskUiResources: OnboardingTaskUiResources,
         val isCompleted: Boolean,
-        val isLabelVisible: Boolean = false,
     )
 
     sealed class OnboardingTaskUiResources(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/StoreOnboardingViewModelTest.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.analytics.AnalyticsEvent.STORE_ONBOARDING_TASK_TA
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.ONBOARDING_TASK_KEY
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTask
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingRepository.OnboardingTaskType
 import com.woocommerce.android.ui.login.storecreation.onboarding.StoreOnboardingViewModel.AboutYourStoreTaskRes
@@ -17,12 +16,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.SiteModel
 
 @ExperimentalCoroutinesApi
 class StoreOnboardingViewModelTest : BaseUnitTest() {
@@ -70,9 +67,6 @@ class StoreOnboardingViewModelTest : BaseUnitTest() {
     private val onboardingRepository: StoreOnboardingRepository = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val shouldShowOnboarding: ShouldShowOnboarding = mock()
-    private val selectedSite: SelectedSite = mock {
-        on { get() } doReturn SiteModel()
-    }
 
     private lateinit var viewModel: StoreOnboardingViewModel
 
@@ -167,7 +161,6 @@ class StoreOnboardingViewModelTest : BaseUnitTest() {
     private fun whenViewModelIsCreated() {
         viewModel = StoreOnboardingViewModel(
             savedState,
-            selectedSite,
             onboardingRepository,
             analyticsTrackerWrapper,
             shouldShowOnboarding,


### PR DESCRIPTION
Closes: #10407 

### Description
This PR adds two changes:

1. It moves the Add your first product to the first position in the onboarding tasks list.
2. It removes the AI tag from the product entry.

### Testing instructions
1. Open the app using a new store.
2. Confirm the Add your first product is shown in the top of the list.

### Images/gif
<img src="https://github.com/woocommerce/woocommerce-android/assets/1657201/40d4544b-c774-4394-9de7-56fbe4c2894b" width=360 />

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
