### PR TITLE
Fix loading state when publishing a WooExpress site

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/onboarding/launchstore/LaunchStoreViewModel.kt
@@ -88,8 +88,8 @@ class LaunchStoreViewModel @Inject constructor(
                     }
                 }
             }
+            _viewState.value = _viewState.value.copy(isLoading = false)
         }
-        _viewState.value = _viewState.value.copy(isLoading = false)
     }
 
     fun onUpgradePlanBannerClicked() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description

I noticed a minor bug when launching a Woo Express site. When clicking on the "Publish store" button from the launch store onboarding task, the loading indicator state for the button was not properly set, providing a UX-frozen experience after tapping on the button. See the recording: 


https://github.com/woocommerce/woocommerce-android/assets/2663464/9fd8c42e-1432-46a0-a804-a5a30fd9bd06

This one-line change fixes that. 
