### PR TITLE
Product title race condition

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/adapters/ProductPropertiesDiffCallback.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/adapters/ProductPropertiesDiffCallback.kt
@@ -19,7 +19,13 @@ class ProductPropertiesDiffCallback(
     override fun getNewListSize(): Int = newList.size
 
     override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        return oldList[oldItemPosition] == newList[newItemPosition]
+        val newItem = newList[newItemPosition]
+        val oldItem = oldList[oldItemPosition]
+        return if (oldItem is Editable && newItem is Editable && oldItem.text.isNotEmpty()) {
+            true
+        } else {
+            oldItem == newItem
+        }
     }
 
     override fun getChangePayload(oldItemPosition: Int, newItemPosition: Int): Any? {


### PR DESCRIPTION
Closes: #10387 

### Why
During beta release 16.6 testing, it was found that editing the product title was not working as expected.
> In beta release 16.6 (though I’m unsure if this issue was present in previous releases), I encountered an issue on an Android device when typing the title of a product. The issue persists for about a minute and then stops, but will restart if typing continues.

More context here:  peaMlT-kV-p2

### Description
After testing the product edit screen, I found a race condition when updating the title. The problem is that we maintain two sources of truth for the product's title: the product in the view model and the EditText control. When changes in the EditText happen faster than what we consume on the ViewModel, the UI becomes inconsistent, adding and removing the last updated character.

The changes introduced in this PR aim to fix this race condition by using the EditText text as the single source of truth for the title displayed. When the EditText value is not empty, we will prevent the EditText control from updating and will maintain the current EditText value.

IMO, a better solution could be refactoring the Edit/Create Product screen and using Jetpack Compose due to the stateless nature of compose components. However, this refactor needs further discussion due to the high effort it involves.

### Testing instructions
1. Open the product tab
2. Tap on add new product (+)
3. Tap on Add manually -> Simple physical product
4. Tap on Enter Product Title
5. Type a big title
6. Hold the delete text button
7. Check that the title is updated

### Images/gif

#### Before


https://github.com/woocommerce/woocommerce-android/assets/18119390/7acdcddc-ee28-450b-9952-0ba371e937ac

#### After

https://github.com/woocommerce/woocommerce-android/assets/18119390/b7362e39-58d2-40ba-b780-48832442d20d

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
