### PR TITLE
Avoid displaying dropdown theme sections if only one page available

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -60,6 +60,7 @@ import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.BottomSheetHandle
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.themes.ThemePreviewViewModel.Companion.MINIMUM_NUMBER_OF_PAGE_SECTIONS_TO_DISPLAY_DROPDOWN
 import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ThemeDemoPage
 import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ViewState
 import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ViewState.PreviewType
@@ -235,14 +236,14 @@ private fun DemoSectionsToolbar(
         modifier = Modifier
             .wrapContentHeight()
             .padding(start = dimensionResource(id = dimen.major_150))
-            .clickable {
-                if (state.themePages.isNotEmpty()) {
-                    coroutineScope.launch {
-                        if (modalSheetState.isVisible)
-                            modalSheetState.hide()
-                        else {
-                            modalSheetState.show()
-                        }
+            .clickable(
+                enabled = state.themePages.size > MINIMUM_NUMBER_OF_PAGE_SECTIONS_TO_DISPLAY_DROPDOWN,
+            ) {
+                coroutineScope.launch {
+                    if (modalSheetState.isVisible)
+                        modalSheetState.hide()
+                    else {
+                        modalSheetState.show()
                     }
                 }
             }
@@ -251,23 +252,24 @@ private fun DemoSectionsToolbar(
             text = stringResource(id = string.theme_preview_title),
             style = MaterialTheme.typography.body1,
         )
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = state.currentPageTitle,
-                style = MaterialTheme.typography.caption,
-            )
-            Icon(
-                modifier = Modifier
-                    .size(dimensionResource(id = dimen.major_100))
-                    .padding(
-                        start = dimensionResource(id = dimen.minor_50),
-                        top = dimensionResource(id = dimen.minor_75),
-                    ),
-                painter = painterResource(drawable.ic_arrow_down),
-                contentDescription = "",
-                tint = colorResource(id = color.color_on_surface)
-            )
-        }
+        if (state.themePages.size > MINIMUM_NUMBER_OF_PAGE_SECTIONS_TO_DISPLAY_DROPDOWN)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = state.currentPageTitle,
+                    style = MaterialTheme.typography.caption,
+                )
+                Icon(
+                    modifier = Modifier
+                        .size(dimensionResource(id = dimen.major_100))
+                        .padding(
+                            start = dimensionResource(id = dimen.minor_50),
+                            top = dimensionResource(id = dimen.minor_75),
+                        ),
+                    painter = painterResource(drawable.ic_arrow_down),
+                    contentDescription = "",
+                    tint = colorResource(id = color.color_on_surface)
+                )
+            }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -60,7 +60,6 @@ import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.BottomSheetHandle
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
-import com.woocommerce.android.ui.themes.ThemePreviewViewModel.Companion.MINIMUM_NUMBER_OF_PAGE_SECTIONS_TO_DISPLAY_DROPDOWN
 import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ThemeDemoPage
 import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ViewState
 import com.woocommerce.android.ui.themes.ThemePreviewViewModel.ViewState.PreviewType
@@ -237,7 +236,7 @@ private fun DemoSectionsToolbar(
             .wrapContentHeight()
             .padding(start = dimensionResource(id = dimen.major_150))
             .clickable(
-                enabled = state.themePages.size > MINIMUM_NUMBER_OF_PAGE_SECTIONS_TO_DISPLAY_DROPDOWN,
+                enabled = state.shouldShowPagesDropdown,
             ) {
                 coroutineScope.launch {
                     if (modalSheetState.isVisible)
@@ -252,7 +251,7 @@ private fun DemoSectionsToolbar(
             text = stringResource(id = string.theme_preview_title),
             style = MaterialTheme.typography.body1,
         )
-        if (state.themePages.size > MINIMUM_NUMBER_OF_PAGE_SECTIONS_TO_DISPLAY_DROPDOWN)
+        if (state.shouldShowPagesDropdown)
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = state.currentPageTitle,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -49,7 +49,7 @@ class ThemePreviewViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
-        const val MINIMUM_NUMBER_OF_PAGE_SECTIONS_TO_DISPLAY_DROPDOWN = 1
+        private const val MINIMUM_NUMBER_OF_PAGE_SECTIONS_TO_DISPLAY_DROPDOWN = 1
     }
 
     private val navArgs: ThemePreviewFragmentArgs by savedStateHandle.navArgs()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -87,6 +87,7 @@ class ThemePreviewViewModel @Inject constructor(
             themePages = demoPages.map { page ->
                 page.copy(isLoaded = (selectedPage?.uri ?: theme.demoUrl) == page.uri)
             },
+            shouldShowPagesDropdown = demoPages.size > MINIMUM_NUMBER_OF_PAGE_SECTIONS_TO_DISPLAY_DROPDOWN,
             previewType = previewType
         )
     }.asLiveData()
@@ -191,6 +192,7 @@ class ThemePreviewViewModel @Inject constructor(
         val themeName: String,
         val isFromStoreCreation: Boolean,
         val themePages: List<ThemeDemoPage>,
+        val shouldShowPagesDropdown: Boolean,
         val isActivatingTheme: Boolean,
         val previewType: PreviewType = PreviewType.MOBILE
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -48,6 +48,10 @@ class ThemePreviewViewModel @Inject constructor(
     private val newStore: NewStore,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
+    companion object {
+        const val MINIMUM_NUMBER_OF_PAGE_SECTIONS_TO_DISPLAY_DROPDOWN = 1
+    }
+
     private val navArgs: ThemePreviewFragmentArgs by savedStateHandle.navArgs()
 
     private val theme = flow {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10413
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Hides the theme pages dropdown section when there's only one section available

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open theme picker
2. Select `Attar` theme and check how the dropdown section is not shown
3. Navigate back and select any other theme from the carousel. Check the dropdown is displayed in the toolbar.
4. Click on it and check the different sections are displayed. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/276cac9b-d2d6-4ea4-a2b7-77e5bd80c4a5
