### PR TITLE
[Scan to update inventory] Fix for cases when variation is not stock-managed and parent product is stock-managed

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModel.kt
@@ -72,14 +72,7 @@ class ScanToUpdateInventoryViewModel @Inject constructor(
                     sku = product.sku,
                     quantity = product.stockQuantity.toInt(),
                 )
-                val isStockManaged = if (product.isVariation()) {
-                    variationRepository.getVariationOrNull(product.parentId, product.remoteId).let {
-                        it?.isStockManaged ?: return@launch
-                    }
-                } else {
-                    product.isStockManaged
-                }
-                if (isStockManaged) {
+                if (isItemStockManaged(product)) {
                     _viewState.value = ViewState.QuickInventoryBottomSheetVisible(productInfo)
                 } else {
                     handleProductIsNotStockManaged(product)
@@ -99,6 +92,15 @@ class ScanToUpdateInventoryViewModel @Inject constructor(
             handleProductNotFound(status.code)
         }
     }
+
+    private suspend fun isItemStockManaged(product: Product): Boolean =
+        if (product.isVariation()) {
+            variationRepository.getVariationOrNull(product.parentId, product.remoteId).let {
+                it?.isStockManaged == true
+            }
+        } else {
+            product.isStockManaged
+        }
 
     private suspend fun handleProductIsNotStockManaged(product: Product) {
         triggerProductNotStockManagedSnackBar(product)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModel.kt
@@ -72,7 +72,14 @@ class ScanToUpdateInventoryViewModel @Inject constructor(
                     sku = product.sku,
                     quantity = product.stockQuantity.toInt(),
                 )
-                if (product.isStockManaged) {
+                val isStockManaged = if (product.isVariation()) {
+                    variationRepository.getVariationOrNull(product.parentId, product.remoteId).let {
+                        it?.isStockManaged ?: return@launch
+                    }
+                } else {
+                    product.isStockManaged
+                }
+                if (isStockManaged) {
                     _viewState.value = ViewState.QuickInventoryBottomSheetVisible(productInfo)
                 } else {
                     handleProductIsNotStockManaged(product)
@@ -156,7 +163,7 @@ class ScanToUpdateInventoryViewModel @Inject constructor(
             _viewState.value = ViewState.QuickInventoryBottomSheetHidden
             scanToUpdateInventoryState.value = ScanToUpdateInventoryState.Idle
         } else {
-            val result = if (product.isVariable()) {
+            val result = if (product.isVariation()) {
                 product.updateVariation(updatedProductInfo)
             } else {
                 product.updateProduct(updatedProductInfo)
@@ -273,7 +280,7 @@ class ScanToUpdateInventoryViewModel @Inject constructor(
         } catch (_: NumberFormatException) {}
     }
 
-    private fun Product.isVariable(): Boolean {
+    private fun Product.isVariation(): Boolean {
         return this.parentId != 0L
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
@@ -365,12 +365,6 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
                 Result.success(originalProduct)
             )
             whenever(productRepo.getProduct(any())).thenReturn(originalProduct)
-            sut.onBarcodeScanningResult(
-                CodeScannerStatus.Success(
-                    "123",
-                    GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
-                )
-            )
             val originalVariation =
                 ProductTestUtils.generateProductVariation(productId = productId, variationId = variationId)
                     .copy(stockQuantity = originalProduct.stockQuantity, isStockManaged = true)
@@ -388,6 +382,12 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
                     "${originalProduct.stockQuantity.toInt()} ➡ ${originalProduct.stockQuantity.toInt() + 1}"
                 )
             ).thenReturn("Quantity updated")
+            sut.onBarcodeScanningResult(
+                CodeScannerStatus.Success(
+                    "123",
+                    GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
+                )
+            )
             sut.viewState.test {
                 awaitItem().apply {
                     assertIs<QuickInventoryBottomSheetVisible>(this)
@@ -421,7 +421,6 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
                     "${originalProduct.stockQuantity.toInt()} ➡ 999"
                 )
             ).thenReturn("Quantity updated")
-            whenever(variationRepo.getVariationOrNull(any(), any())).thenReturn(originalVariation)
 
             sut.onBarcodeScanningResult(
                 CodeScannerStatus.Success(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
@@ -447,7 +447,11 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
         testBlocking {
             whenever(fetchProductBySKU(any(), any())).thenReturn(
                 Result.success(
-                    ProductTestUtils.generateProduct(isStockManaged = true, parentID = 1, productId = 2).copy(sku = "123")
+                    ProductTestUtils.generateProduct(
+                        isStockManaged = true,
+                        parentID = 1,
+                        productId = 2
+                    ).copy(sku = "123")
                 )
             )
             whenever(variationRepo.getVariationOrNull(1, 2)).thenReturn(
@@ -473,11 +477,15 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given barcode scanned, when variation is found which is not stock-managed, then should not show bottom sheet`() =
+    fun `when variation is found which is not stock-managed, then should not show bottom sheet`() =
         testBlocking {
             whenever(fetchProductBySKU(any(), any())).thenReturn(
                 Result.success(
-                    ProductTestUtils.generateProduct(isStockManaged = true, parentID = 1, productId = 2).copy(sku = "123")
+                    ProductTestUtils.generateProduct(
+                        isStockManaged = true,
+                        parentID = 1,
+                        productId = 2
+                    ).copy(sku = "123")
                 )
             )
             whenever(variationRepo.getVariationOrNull(1, 2)).thenReturn(
@@ -486,10 +494,12 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
                     variationId = 2
                 ).copy(isStockManaged = false)
             )
-            whenever(resourceProvider.getString(
-                R.string.scan_to_update_inventory_product_not_stock_managed,
-                "123"
-            )).thenReturn("Product not stock managed")
+            whenever(
+                resourceProvider.getString(
+                    R.string.scan_to_update_inventory_product_not_stock_managed,
+                    "123"
+                )
+            ).thenReturn("Product not stock managed")
             sut.viewState.test {
                 sut.onBarcodeScanningResult(
                     CodeScannerStatus.Success(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Fix for cases when variation is not managed and the parent product is stock-managed

Closes: #10403 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a logic of recognising if the item is stock-managed in the Scan to update inventory flow.
The problem was that a variation that is not stock-managed was incorrectly recognised as stock managed in case its parent product was stock-managed.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Create a variation that is not stock-managed, and its parent product is stock-managed
2. Scan a barcode with a value corresponding to the variation's SKU (click "scan" in the products screen)
3. Verify that it is correctly detected as not stock-managed – the snackbar with information should be shown 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
