### PR TITLE
Replace Material3 CardView Style to fix crash

### DIFF
--- a/WooCommerce/src/main/res/layout/activity_support_request_form.xml
+++ b/WooCommerce/src/main/res/layout/activity_support_request_form.xml
@@ -154,12 +154,14 @@
                         app:errorEnabled="true" />
 
                     <com.google.android.material.card.MaterialCardView
-                        style="@style/Widget.Material3.CardView.Outlined"
+                        style="@style/Widget.MaterialComponents.CardView"
                         android:layout_width="match_parent"
                         android:layout_height="@dimen/support_request_message_height"
                         android:layout_marginHorizontal="@dimen/major_100"
                         android:layout_marginBottom="@dimen/minor_100"
-                        app:strokeColor="@color/gray_10">
+                        app:cardElevation="0dp"
+                        app:strokeColor="@color/gray_10"
+                        app:strokeWidth="1dp">
 
                         <EditText
                             android:id="@+id/request_message"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10419 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The app crashes when the user attempts to contact support. This is caused by a change in 16.5 in which we updated Material dependency ([this PR](https://github.com/woocommerce/woocommerce-android/pull/10103)).

The fix avoids using Material3 style, which isn't used anywhere else in the app and seems to be causing this issue.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Tap on More
2. Tap on Settings
3. Tap on Help & Support
4. Tap on Contact Support
5. Notice the app doesn't crash

- [] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
