### PR TITLE
Merge 16.6 final (2nd build) into trunk

### DIFF
--- a/WooCommerce/src/main/res/layout/activity_support_request_form.xml
+++ b/WooCommerce/src/main/res/layout/activity_support_request_form.xml
@@ -154,12 +154,14 @@
                         app:errorEnabled="true" />
 
                     <com.google.android.material.card.MaterialCardView
-                        style="@style/Widget.Material3.CardView.Outlined"
+                        style="@style/Widget.MaterialComponents.CardView"
                         android:layout_width="match_parent"
                         android:layout_height="@dimen/support_request_message_height"
                         android:layout_marginHorizontal="@dimen/major_100"
                         android:layout_marginBottom="@dimen/minor_100"
-                        app:strokeColor="@color/gray_10">
+                        app:cardElevation="0dp"
+                        app:strokeColor="@color/gray_10"
+                        app:strokeWidth="1dp">
 
                         <EditText
                             android:id="@+id/request_message"

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
 versionName=16.6
-versionCode=485
+versionCode=487


### PR DESCRIPTION
This PR merges the changes from the `16.6` finalization into `trunk`, after I've done a new build for the final 16.6 today to include a last-minute fix from @malinajirka.

See p1702882595757289-slack-C6H8C3G23 for context

- https://github.com/woocommerce/woocommerce-android/pull/10422
- Manual version bump to do a new final release of 16.6 that would include ☝️ that fix.