### PR TITLE
Fix issue of removing the theme picker's message

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.themes.ThemePickerViewModel.CarouselState.Success.CarouselItem
-import com.woocommerce.android.ui.themes.ThemePickerViewModel.CarouselState.Success.CarouselItem.Theme
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -128,7 +127,12 @@ class ThemePickerViewModel @Inject constructor(
     ) = if (carouselState is CarouselState.Success && currentThemeState is CurrentThemeState.Success) {
         carouselState.copy(
             carouselItems = carouselState.carouselItems
-                .filter { it is Theme && it.themeId != currentThemeState.themeId }
+                .filter {
+                    when (it) {
+                        is CarouselItem.Theme -> it.themeId != currentThemeState.themeId
+                        else -> true
+                    }
+                }
         )
     } else carouselState
 
@@ -140,7 +144,7 @@ class ThemePickerViewModel @Inject constructor(
         triggerEvent(NavigateToNextStep)
     }
 
-    fun onThemeTapped(theme: Theme) {
+    fun onThemeTapped(theme: CarouselItem.Theme) {
         analyticsTrackerWrapper.track(
             stat = AnalyticsEvent.THEME_PICKER_THEME_SELECTED,
             properties = mapOf(AnalyticsTracker.KEY_THEME_PICKER_THEME to theme.name)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10428 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The PR https://github.com/woocommerce/woocommerce-android/pull/10400 caused an issue where we remove the picker's last message when the current theme is loaded, as the message doesn't pass the filter used.

This PR fixes the logic.

### Testing instructions
1. Open the theme picker from the app's settings.
2. Confirm the last message is shown as expected


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
