### PR TITLE
Feature/display tabs below onboarding list

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/StatsComponent.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/StatsComponent.kt
@@ -46,7 +46,7 @@ class StatsComponent : Screen(R.id.dashboardStats_root) {
     }
 
     private fun switchToStatsDashboardTab(tabName: Int): MyStoreScreen {
-        selectItemWithTitleInTabLayout(tabName, R.id.app_bar_layout)
+        selectItemWithTitleInTabLayout(tabName, R.id.my_store_stats_container)
         waitForGraphToLoad()
         return MyStoreScreen()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -174,7 +174,6 @@ class MyStoreFragment :
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        initTabLayout()
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
         _binding = FragmentMyStoreBinding.bind(view)
@@ -189,6 +188,7 @@ class MyStoreFragment :
         }
 
         // Create tabs and add to appbar
+        initTabLayout()
         StatsGranularity.values().forEach { granularity ->
             val tab = tabLayout.newTab().apply {
                 setText(binding.myStoreStats.getStringForGranularity(granularity))
@@ -717,17 +717,15 @@ class MyStoreFragment :
     }
 
     private fun addTabLayoutToAppBar() {
-        appBarLayout
-            ?.takeIf { !it.children.contains(tabLayout) }
+        val indexOfMyStoreStatsView = binding.myStoreStatsContainer.indexOfChild(binding.myStoreStats)
+        binding.myStoreStatsContainer
+            .takeIf { !it.children.contains(tabLayout) }
             ?.takeIf { AppPrefs.isV4StatsSupported() }
-            ?.let { appBar ->
-                appBar.addView(tabLayout, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT))
-                appBar.post {
-                    if (context != null) {
-                        appBar.elevation = resources.getDimensionPixelSize(R.dimen.appbar_elevation).toFloat()
-                    }
-                }
-            }
+            ?.addView(
+                tabLayout,
+                indexOfMyStoreStatsView,
+                LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
+            )
     }
 
     private fun removeTabLayoutFromAppBar() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -520,7 +520,7 @@ class MyStoreFragment :
 
     private fun initTabLayout() {
         _tabLayout = TabLayout(requireContext(), null, attr.scrollableTabStyle)
-        addTabLayoutToAppBar()
+        addStatsGranularityTabs()
     }
 
     override fun onResume() {
@@ -555,7 +555,7 @@ class MyStoreFragment :
     }
 
     private fun showStats(revenueStatsModel: RevenueStatsUiModel?) {
-        addTabLayoutToAppBar()
+        addStatsGranularityTabs()
         binding.myStoreStats.showErrorView(false)
         showChartSkeleton(false)
 
@@ -713,7 +713,7 @@ class MyStoreFragment :
         isEmptyViewVisible = show
     }
 
-    private fun addTabLayoutToAppBar() {
+    private fun addStatsGranularityTabs() {
         val indexOfMyStoreStatsView = binding.myStoreStatsContainer.indexOfChild(binding.myStoreStats)
         binding.myStoreStatsContainer
             .takeIf { !it.children.contains(tabLayout) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -140,9 +140,6 @@ class MyStoreFragment :
     private val tabLayout
         get() = _tabLayout!!
 
-    private val appBarLayout
-        get() = activity?.findViewById<View>(R.id.app_bar_layout) as? AppBarLayout
-
     private val mainNavigationRouter
         get() = activity as? MainNavigationRouter
 
@@ -502,7 +499,6 @@ class MyStoreFragment :
             appPrefsWrapper.setJetpackInstallationIsFromBanner(true)
             findNavController().navigateSafely(MyStoreFragmentDirections.actionMyStoreToJetpackBenefitsDialog())
         }
-        val appBarLayout = appBarLayout ?: return
         // For the banner to be above the bottom navigation view when the toolbar is expanded
         viewLifecycleOwner.lifecycleScope.launch {
             // Due to this issue https://issuetracker.google.com/issues/181325977, we need to make sure
@@ -510,13 +506,14 @@ class MyStoreFragment :
             // the scope will not get cancelled.
             // TODO: revisit this once https://issuetracker.google.com/issues/127528777 is implemented
             // (no update as of Oct 2023)
+            val appBarLayout = requireActivity().findViewById<View>(R.id.app_bar_layout) as? AppBarLayout
             withCreated {
-                appBarLayout.verticalOffsetChanges()
-                    .onEach { verticalOffset ->
+                appBarLayout?.verticalOffsetChanges()
+                    ?.onEach { verticalOffset ->
                         binding.jetpackBenefitsBanner.root.translationY =
                             (abs(verticalOffset) - appBarLayout.totalScrollRange).toFloat()
                     }
-                    .launchIn(this)
+                    ?.launchIn(this)
             }
         }
     }
@@ -729,10 +726,7 @@ class MyStoreFragment :
     }
 
     private fun removeTabLayoutFromAppBar() {
-        appBarLayout?.let { appBar ->
-            appBar.removeView(tabLayout)
-            appBar.elevation = 0f
-        }
+        binding.myStoreStatsContainer.removeView(tabLayout)
     }
 
     override fun shouldExpandToolbar() = binding.statsScrollView.scrollY == 0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -412,7 +412,9 @@ class MyStoreViewModel @Inject constructor(
         )
 
     private fun getSelectedStatsGranularityIfAny(): StatsGranularity {
-        return runCatching { _activeStatsGranularity.value }.getOrDefault(StatsGranularity.DAYS)
+        val previouslySelectedGranularity = appPrefsWrapper.getActiveStatsGranularity()
+        return runCatching { StatsGranularity.valueOf(previouslySelectedGranularity.uppercase()) }
+            .getOrDefault(StatsGranularity.DAYS)
     }
 
     private fun StatsGranularity.toAnalyticTimePeriod() = when (this) {

--- a/WooCommerce/src/main/res/layout/fragment_my_store.xml
+++ b/WooCommerce/src/main/res/layout/fragment_my_store.xml
@@ -27,6 +27,7 @@
                 android:transitionGroup="true">
 
                 <LinearLayout
+                    android:id="@+id/my_store_stats_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:animateLayoutChanges="true"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10404
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Displays the My Store granularity tabs below the onboarding list. 
Additionally it, brings back the logic to restore the last selected granularity tab between app sessions. I'm not sure why it was removed, I think it was accidental. 

### Testing instructions
<!-- Step by step testing instructions. When necessary, break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Log into a site that has the onboarding list visible (any Woo Express site should work) 
2. Check the tabs are displayed below the onboarding screen. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/ca9f4dce-b14c-4523-a71e-98b3aad464b4


