### PR TITLE
[Themes] - Fix the current theme filter

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -128,7 +128,7 @@ class ThemePickerViewModel @Inject constructor(
     ) = if (carouselState is CarouselState.Success && currentThemeState is CurrentThemeState.Success) {
         carouselState.copy(
             carouselItems = carouselState.carouselItems
-                .filter { it is Theme && it.themeId != currentThemeState.themeId }
+                .filterNot { it is Theme && it.themeId == currentThemeState.themeId }
         )
     } else carouselState
 


### PR DESCRIPTION
This PR fixes the current theme filter, which inadvertently removed the `Message` carousel items.

| Before | After |
| --- | --- |
| ![image](https://github.com/woocommerce/woocommerce-android/assets/1522856/f87972f3-6b89-4b7b-9baf-acf1d1ed4780) | ![image](https://github.com/woocommerce/woocommerce-android/assets/1522856/5e8a32fa-d411-40c8-bf87-b8f0a912c0e2) |

**To test:**
1. Log in to an existing site
2. Go to More menu -> Settings -> Themes
3. Scroll the carousel to the right
4. Notice the last item is a message "Looking for more?"