### PR TITLE
Updates a couple of tracking values

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.themes.ThemePickerViewModel.CarouselState.Success.CarouselItem
-import com.woocommerce.android.ui.themes.ThemePickerViewModel.CarouselState.Success.CarouselItem.Theme
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -128,7 +127,12 @@ class ThemePickerViewModel @Inject constructor(
     ) = if (carouselState is CarouselState.Success && currentThemeState is CurrentThemeState.Success) {
         carouselState.copy(
             carouselItems = carouselState.carouselItems
-                .filter { it is Theme && it.themeId != currentThemeState.themeId }
+                .filter {
+                    when (it) {
+                        is CarouselItem.Theme -> it.themeId != currentThemeState.themeId
+                        else -> true
+                    }
+                }
         )
     } else carouselState
 
@@ -140,7 +144,7 @@ class ThemePickerViewModel @Inject constructor(
         triggerEvent(NavigateToNextStep)
     }
 
-    fun onThemeTapped(theme: Theme) {
+    fun onThemeTapped(theme: CarouselItem.Theme) {
         analyticsTrackerWrapper.track(
             stat = AnalyticsEvent.THEME_PICKER_THEME_SELECTED,
             properties = mapOf(AnalyticsTracker.KEY_THEME_PICKER_THEME to theme.name)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description

Base on the discussion here:  , this PR adds a couple small changes for theme picker tracking feature:
- Change `source` property value when opening theme picker from store creation from `profiler` to `store_creation`
- Use `themeId` as property value instead of `themeName`


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open theme picker from store creation and check the following is tracked: `Tracked: theme_picker_screen_displayed, Properties: {"source":"store_creation"`
2. Select any theme from site picker and check the value used for `theme` property is the themeId: `theme_picker_theme_selected, Properties: {"theme":"thriving-artist"`
