### PR TITLE
Fix/theme picker analytics updates

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -631,7 +631,7 @@ class AnalyticsTracker private constructor(
 
         // Theme picker
         const val KEY_THEME_PICKER_SOURCE = "source"
-        const val VALUE_THEME_PICKER_SOURCE_PROFILER = "profiler"
+        const val VALUE_THEME_PICKER_SOURCE_STORE_CREATION = "store_creation"
         const val VALUE_THEME_PICKER_SOURCE_SETTINGS = "settings"
         const val KEY_THEME_PICKER_THEME = "theme"
         const val KEY_THEME_PICKER_LAYOUT_PREVIEW = "layout"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/theme/ThemeActivationViewModel.kt
@@ -40,7 +40,7 @@ class ThemeActivationViewModel @Inject constructor(
                 analyticsTrackerWrapper.track(
                     stat = AnalyticsEvent.THEME_INSTALLATION_COMPLETED,
                     properties = mapOf(
-                        AnalyticsTracker.KEY_THEME_PICKER_THEME to themeRepository.getTheme(args.themeId)?.name
+                        AnalyticsTracker.KEY_THEME_PICKER_THEME to args.themeId
                     )
                 )
                 appPrefsWrapper.clearThemeIdForStoreCreation()
@@ -51,7 +51,7 @@ class ThemeActivationViewModel @Inject constructor(
                 analyticsTrackerWrapper.track(
                     stat = AnalyticsEvent.THEME_INSTALLATION_FAILED,
                     properties = mapOf(
-                        AnalyticsTracker.KEY_THEME_PICKER_THEME to themeRepository.getTheme(args.themeId)?.name
+                        AnalyticsTracker.KEY_THEME_PICKER_THEME to args.themeId
                     )
                 )
                 _viewState.value = ViewState.ErrorState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -59,7 +59,7 @@ class ThemePickerViewModel @Inject constructor(
             stat = AnalyticsEvent.THEME_PICKER_SCREEN_DISPLAYED,
             properties = mapOf(
                 AnalyticsTracker.KEY_THEME_PICKER_SOURCE to when (navArgs.isFromStoreCreation) {
-                    true -> AnalyticsTracker.VALUE_THEME_PICKER_SOURCE_PROFILER
+                    true -> AnalyticsTracker.VALUE_THEME_PICKER_SOURCE_STORE_CREATION
                     false -> AnalyticsTracker.VALUE_THEME_PICKER_SOURCE_SETTINGS
                 }
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -147,7 +147,7 @@ class ThemePickerViewModel @Inject constructor(
     fun onThemeTapped(theme: CarouselItem.Theme) {
         analyticsTrackerWrapper.track(
             stat = AnalyticsEvent.THEME_PICKER_THEME_SELECTED,
-            properties = mapOf(AnalyticsTracker.KEY_THEME_PICKER_THEME to theme.name)
+            properties = mapOf(AnalyticsTracker.KEY_THEME_PICKER_THEME to theme.themeId)
         )
         triggerEvent(NavigateToThemePreview(theme.themeId, navArgs.isFromStoreCreation))
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -116,7 +116,7 @@ class ThemePreviewViewModel @Inject constructor(
         analyticsTrackerWrapper.track(
             stat = AnalyticsEvent.THEME_PREVIEW_START_WITH_THEME_BUTTON_TAPPED,
             properties = mapOf(
-                AnalyticsTracker.KEY_THEME_PICKER_THEME to viewState.value?.themeName
+                AnalyticsTracker.KEY_THEME_PICKER_THEME to navArgs.themeId
             )
         )
         if (viewState.value?.isFromStoreCreation == true) {
@@ -130,7 +130,7 @@ class ThemePreviewViewModel @Inject constructor(
                         analyticsTrackerWrapper.track(
                             stat = AnalyticsEvent.THEME_INSTALLATION_COMPLETED,
                             properties = mapOf(
-                                AnalyticsTracker.KEY_THEME_PICKER_THEME to viewState.value?.themeName
+                                AnalyticsTracker.KEY_THEME_PICKER_THEME to navArgs.themeId
                             )
                         )
                         triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.theme_activated_successfully))
@@ -144,7 +144,7 @@ class ThemePreviewViewModel @Inject constructor(
                         analyticsTrackerWrapper.track(
                             stat = AnalyticsEvent.THEME_INSTALLATION_FAILED,
                             properties = mapOf(
-                                AnalyticsTracker.KEY_THEME_PICKER_THEME to viewState.value?.themeName
+                                AnalyticsTracker.KEY_THEME_PICKER_THEME to navArgs.themeId
                             )
                         )
                         triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.theme_activation_failed))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description

Base on the discussion here:  p1702955464357419-slack-C03L1NF1EA3, this PR adds a couple small changes for theme picker tracking feature:
- Change `source` property value when opening theme picker from store creation from `profiler` to `store_creation`
- Use `themeId` as property value instead of `themeName`


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Open theme picker from store creation and check the following is tracked: `Tracked: theme_picker_screen_displayed, Properties: {"source":"store_creation"`
2. Select any theme from site picker and check the value used for `theme` property is the themeId: `theme_picker_theme_selected, Properties: {"theme":"thriving-artist"`