### PR TITLE
Revert previous changes to permission handling as it was resulting in a crash on Android versions < 12

### DIFF
--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -75,7 +75,6 @@ object CardReaderManagerFactory {
                 bluetoothReaderListener,
                 DiscoverReadersAction(terminal, logWrapper),
                 terminalListener,
-                application,
             ),
             SoftwareUpdateManager(
                 terminal,

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.cardreader.internal.connection
 
-import android.app.Application
 import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.callable.ReaderCallback
 import com.stripe.stripeterminal.external.models.DeviceType
@@ -44,7 +43,6 @@ class ConnectionManagerTest : CardReaderBaseUnitTest() {
     private val terminalListenerImpl: TerminalListenerImpl = mock {
         on { readerStatus }.thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
     }
-    private val application: Application = mock()
 
     private val supportedReaders =
         CardReaderTypesToDiscover.SpecificReaders.ExternalReaders(
@@ -65,7 +63,6 @@ class ConnectionManagerTest : CardReaderBaseUnitTest() {
             bluetoothReaderListener,
             discoverReadersAction,
             terminalListenerImpl,
-            application,
         )
     }
 


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR addresses a critical issue in our app's permission handling mechanism. We previously updated our permission checks to rely on the BLUETOOTH_CONNECT permission, which is applicable for Android 12 (API level 31) and above. However, this resulted in an oversight for devices running on Android versions 9, 10, and 11 (API levels 28-30), where the BLUETOOTH_CONNECT permission does not exist. Consequently, attempting to check this permission on these earlier versions led to the app incorrectly throwing an error and crashing, as the permission check would invariably return PackageManager.PERMISSION_DENIED.

To resolve this, we are reverting to the previous method of handling permissions for devices running on Android versions lower than 12. This change ensures compatibility across all supported Android versions and prevents crashes on devices running versions earlier than Android 12.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Create an order that is eligible for IPP
2. Navigate to the order detail screen
3. Click on Collect payment
4. Select "Card Reader"
5. Give all the permission it asks
6. Ensure the the whole IPP flow works without any issue
7. Please check this on both Android version < 12 and >= 12



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
