### PR TITLE
Fix crash when using shortcuts while no site is selected yet

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -100,6 +100,7 @@ class MainActivityViewModel @Inject constructor(
     val trialStatusBarState = determineTrialStatusBarState(_bottomBarState).asLiveData()
 
     fun handleShortcutAction(action: String?) {
+        if (!selectedSite.exists()) return
         when (action) {
             SHORTCUT_PAYMENTS -> {
                 analyticsTrackerWrapper.track(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -458,6 +458,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
     fun `given payments shortcut, when app opened, then trigger ViewPayments event`() {
         testBlocking {
             // GIVEN
+            whenever(selectedSite.exists()).thenReturn(true)
             createViewModel()
 
             // WHEN
@@ -472,6 +473,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
     fun `given order creation shortcut, when app opened, then trigger OpenOrderCreation event`() {
         testBlocking {
             // GIVEN
+            whenever(selectedSite.exists()).thenReturn(true)
             createViewModel()
 
             // WHEN
@@ -486,6 +488,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
     fun `given irrelevant shortcut, when app opened, then do not trigger any event`() {
         testBlocking {
             // GIVEN
+            whenever(selectedSite.exists()).thenReturn(true)
             createViewModel()
 
             // WHEN
@@ -500,6 +503,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
     fun `given payments shortcut, when app opened, then track payments opened event`() {
         testBlocking {
             // GIVEN
+            whenever(selectedSite.exists()).thenReturn(true)
             createViewModel()
 
             // WHEN
@@ -516,6 +520,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
     fun `given order creation shortcut, when app opened, then track orders add new event`() {
         testBlocking {
             // GIVEN
+            whenever(selectedSite.exists()).thenReturn(true)
             createViewModel()
 
             // WHEN
@@ -525,6 +530,21 @@ class MainActivityViewModelTest : BaseUnitTest() {
             verify(analyticsTrackerWrapper).track(
                 AnalyticsEvent.SHORTCUT_ORDERS_ADD_NEW
             )
+        }
+    }
+
+    @Test
+    fun `given no selected site, when shortcut used, then skip it`() {
+        testBlocking {
+            // GIVEN
+            whenever(selectedSite.exists()).thenReturn(false)
+            createViewModel()
+
+            // WHEN
+            viewModel.handleShortcutAction("com.woocommerce.android.ordercreation")
+
+            // THEN
+            assertThat(viewModel.event.value).isNull()
         }
     }
 


### PR DESCRIPTION
Closes: #10150 Closes: #10320
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes an issue where the app will crash when the user attempts to use shortcuts but not site has been selected yet.

### Testing instructions
1. Open the app then sign in using WordPress.com (an account that has multiple accounts)
2. When reaching the site picker, close the app.
3. Long tap on the app's icon in the launcher, then pick one of the shortcuts.
4. Confirm the app doesn't crash.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
