### PR TITLE
Fix card reader permission crash in Android versions < 12

### DIFF
--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -102,12 +102,15 @@ internal class ConnectionManager(
     private fun checkIfNecessaryPermissionsAreGranted() {
         val isAtLeastAndroidS = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
         val permissionsToCheck = mutableMapOf(
-            Manifest.permission.ACCESS_FINE_LOCATION to "ACCESS_FINE_LOCATION permission is required to discover external readers"
+            Manifest.permission.ACCESS_FINE_LOCATION to "ACCESS_FINE_LOCATION permission is " +
+                "required to discover external readers"
         )
 
         if (isAtLeastAndroidS) {
-            permissionsToCheck[Manifest.permission.BLUETOOTH_CONNECT] = "BLUETOOTH_CONNECT permission is required to discover external readers"
-            permissionsToCheck[Manifest.permission.BLUETOOTH_SCAN] = "BLUETOOTH_SCAN permission is required to discover external readers"
+            permissionsToCheck[Manifest.permission.BLUETOOTH_CONNECT] = "BLUETOOTH_CONNECT permission is " +
+                "required to discover external readers"
+            permissionsToCheck[Manifest.permission.BLUETOOTH_SCAN] = "BLUETOOTH_SCAN permission is " +
+                "required to discover external readers"
         }
 
         permissionsToCheck.forEach { (permission, errorMessage) ->

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.cardreader.internal.connection
 import android.Manifest
 import android.app.Application
 import android.content.pm.PackageManager
+import android.os.Build
 import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.callable.ReaderCallback
 import com.stripe.stripeterminal.external.models.ConnectionConfiguration.BluetoothConnectionConfiguration
@@ -58,36 +59,14 @@ internal class ConnectionManager(
                     }
 
                     is ExternalReaders -> {
-                        if (application.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
-                            != PackageManager.PERMISSION_GRANTED ||
-                            application.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT)
-                            != PackageManager.PERMISSION_GRANTED ||
-                            application.checkSelfPermission(Manifest.permission.BLUETOOTH_SCAN)
-                            != PackageManager.PERMISSION_GRANTED
-                        ) {
-                            error(
-                                "ACCESS_FINE_LOCATION, BLUETOOTH_CONNECT, BLUETOOTH_SCAN " +
-                                    "permission is required to discover external readers"
-                            )
-                        }
+                        checkIfNecessaryPermissionsAreGranted()
                         discoverReadersAction.discoverExternalReaders(isSimulated)
                     }
                 }
             }
 
             UnspecifiedReaders -> {
-                if (application.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
-                    != PackageManager.PERMISSION_GRANTED ||
-                    application.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT)
-                    != PackageManager.PERMISSION_GRANTED ||
-                    application.checkSelfPermission(Manifest.permission.BLUETOOTH_SCAN)
-                    != PackageManager.PERMISSION_GRANTED
-                ) {
-                    error(
-                        "ACCESS_FINE_LOCATION, BLUETOOTH_CONNECT, BLUETOOTH_SCAN " +
-                            "permission is required to discover external readers"
-                    )
-                }
+                checkIfNecessaryPermissionsAreGranted()
                 merge(
                     discoverReadersAction.discoverBuildInReaders(isSimulated),
                     discoverReadersAction.discoverExternalReaders(isSimulated)
@@ -119,6 +98,24 @@ internal class ConnectionManager(
                 }
             }
         }
+
+    private fun checkIfNecessaryPermissionsAreGranted() {
+        val isAtLeastAndroidS = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+        val permissionsToCheck = mutableMapOf(
+            Manifest.permission.ACCESS_FINE_LOCATION to "ACCESS_FINE_LOCATION permission is required to discover external readers"
+        )
+
+        if (isAtLeastAndroidS) {
+            permissionsToCheck[Manifest.permission.BLUETOOTH_CONNECT] = "BLUETOOTH_CONNECT permission is required to discover external readers"
+            permissionsToCheck[Manifest.permission.BLUETOOTH_SCAN] = "BLUETOOTH_SCAN permission is required to discover external readers"
+        }
+
+        permissionsToCheck.forEach { (permission, errorMessage) ->
+            if (application.checkSelfPermission(permission) != PackageManager.PERMISSION_GRANTED) {
+                error(errorMessage)
+            }
+        }
+    }
 
     fun startConnectionToReader(cardReader: CardReader, locationId: String) {
         (cardReader as CardReaderImpl).let {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -43,8 +43,6 @@ internal class ConnectionManager(
     val softwareUpdateAvailability = bluetoothReaderListener.updateAvailabilityEvents
     val batteryStatus = bluetoothReaderListener.batteryStatusEvents
     val displayBluetoothCardReaderMessages = bluetoothReaderListener.displayMessagesEvents
-
-    @Suppress("ComplexMethod", "LongMethod")
     fun discoverReaders(isSimulated: Boolean, cardReaderTypesToDiscover: CardReaderTypesToDiscover) =
         when (cardReaderTypesToDiscover) {
             is SpecificReaders -> {


### PR DESCRIPTION
Closes #10448

### **NOTE: The base branch is set to `trunk` since the `release/16.6` branch has already been removed. Please set the base branch to the new release branch branch once it is created and remove the `do not merge` label, before merging this PR**
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR addresses a critical issue in our app's permission handling mechanism. We previously updated our permission checks to rely on the BLUETOOTH_CONNECT permission, which is applicable for Android 12 (API level 31) and above. However, this resulted in an oversight for devices running on Android versions 9, 10, and 11 (API levels 28-30), where the BLUETOOTH_CONNECT permission does not exist. Consequently, attempting to check this permission on these earlier versions led to the app incorrectly throwing an error and crashing, as the permission check would invariably return PackageManager.PERMISSION_DENIED.

To resolve this, we are checking the Android versions and check permissions accordingly. This change ensures compatibility across all supported Android versions and prevents crashes on devices running versions earlier than Android 12.


### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Create an order that is eligible for IPP
2. Navigate to the order detail screen
3. Click on Collect payment
4. Select "Card Reader"
5. Give all the permission it asks
6. Ensure the the whole IPP flow works without any issue
7. Please check this on both Android version < 12 and >= 12



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
