### PR TITLE
Themes: miscellaneous fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerScreen.kt
@@ -110,8 +110,8 @@ private fun ThemePicker(
             .fillMaxSize(),
     ) {
         CurrentTheme(viewState.currentThemeState)
+        Header(viewState.isFromStoreCreation)
         Carousel(
-            viewState.isFromStoreCreation,
             viewState.carouselState,
             onThemeTapped,
             onThemeScreenshotFailure,
@@ -195,7 +195,6 @@ private fun Header(
 
 @Composable
 private fun Carousel(
-    isFromStoreCreation: Boolean,
     state: CarouselState,
     onThemeTapped: (CarouselItem.Theme) -> Unit,
     onThemeScreenshotFailure: (String, Throwable) -> Unit,
@@ -211,7 +210,7 @@ private fun Carousel(
         }
 
         is CarouselState.Success -> {
-            Carousel(isFromStoreCreation, state.carouselItems, onThemeTapped, onThemeScreenshotFailure)
+            Carousel(state.carouselItems, onThemeTapped, onThemeScreenshotFailure)
         }
     }
 }
@@ -272,7 +271,6 @@ private fun Error(onRetryClick: () -> Unit) {
 
 @Composable
 private fun Carousel(
-    isFromStoreCreation: Boolean,
     items: List<CarouselItem>,
     onThemeTapped: (CarouselItem.Theme) -> Unit,
     onThemeScreenshotFailure: (String, Throwable) -> Unit
@@ -282,10 +280,6 @@ private fun Carousel(
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
     ) {
-        Header(
-            isFromStoreCreation = isFromStoreCreation,
-            modifier = Modifier.fillMaxWidth()
-        )
         LazyRow(
             modifier = Modifier
                 .height(480.dp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModel.kt
@@ -163,7 +163,7 @@ class ThemePickerViewModel @Inject constructor(
     }
 
     fun onCurrentThemeUpdated(themeId: String, themeName: String) {
-        currentTheme.value = CurrentThemeState.Success(themeId, themeName)
+        currentTheme.value = CurrentThemeState.Success(themeName = themeName, themeId = themeId)
     }
 
     fun onThemeScreenshotFailure(themeName: String, throwable: Throwable) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewScreen.kt
@@ -50,7 +50,6 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
@@ -196,6 +195,7 @@ private fun ThemePreviewBottomSection(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = dimensionResource(id = dimen.major_100))
+                .padding(bottom = dimensionResource(id = dimen.major_100))
         ) {
             if (isActivatingTheme) {
                 CircularProgressIndicator(
@@ -205,22 +205,13 @@ private fun ThemePreviewBottomSection(
             } else {
                 Text(
                     text = stringResource(
-                        id = if (isFromStoreCreation) R.string.store_creation_use_theme_button
-                        else R.string.theme_preview_activate_theme_button
+                        id = if (isFromStoreCreation) R.string.theme_preview_activate_theme_button_store_creation
+                        else R.string.theme_preview_activate_theme_button_settings,
+                        themeName
                     )
                 )
             }
         }
-
-        Text(
-            text = stringResource(id = string.theme_preview_theme_name, themeName),
-            style = MaterialTheme.typography.body2,
-            textAlign = TextAlign.Center,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = dimensionResource(id = dimen.major_100))
-        )
-        Spacer(modifier = Modifier.height(dimensionResource(id = dimen.major_100)))
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/themes/ThemePreviewViewModel.kt
@@ -182,7 +182,7 @@ class ThemePreviewViewModel @Inject constructor(
                             title = it.title,
                             isLoaded = false
                         )
-                    }
+                    }.filter { it.uri != homePage.uri }
                 )
             }
         )

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -36,10 +36,7 @@ Language: ar
     <string name="custom_amounts_bottom_sheet_heading">كيف تريد إضافة مبلغك المخصص؟</string>
     <string name="custom_amounts_percentage_label">نسبة مئوية من إجمالي الطلبات (⁦%1$s⁩)</string>
     <string name="custom_amounts_delete_custom_amount">حذف المبلغ المخصص</string>
-    <string name="store_creation_use_theme_button">البدء باستخدام هذا القالب</string>
     <string name="theme_activated_successfully">تم تفعيل القالب بنجاح</string>
-    <string name="theme_preview_theme_name">القالب: ⁦%1$s⁩</string>
-    <string name="theme_preview_activate_theme_button">استخدام هذا القالب</string>
     <string name="theme_preview_bottom_sheet_home_section">الصفحة الرئيسية</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">الضغط للعرض</string>
     <string name="theme_preview_bottom_sheet_pages_title">الصحفات الموجودة على هذا القالب</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -36,10 +36,7 @@ Language: de
     <string name="custom_amounts_bottom_sheet_heading">Wie möchtest du deinen individuellen Betrag hinzufügen?</string>
     <string name="custom_amounts_percentage_label">Prozentsatz der Gesamtbestellung (%1$s)</string>
     <string name="custom_amounts_delete_custom_amount">Individuellen Betrag löschen</string>
-    <string name="store_creation_use_theme_button">Mit diesem Theme starten</string>
     <string name="theme_activated_successfully">Theme erfolgreich aktiviert</string>
-    <string name="theme_preview_theme_name">Theme: %1$s</string>
-    <string name="theme_preview_activate_theme_button">Dieses Theme verwenden</string>
     <string name="theme_preview_bottom_sheet_home_section">Startseite</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">Zum Anzeigen tippen</string>
     <string name="theme_preview_bottom_sheet_pages_title">Seiten auf diesem Template</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -36,10 +36,7 @@ Language: es
     <string name="custom_amounts_bottom_sheet_heading">¿Cómo deseas añadir el importe personalizado?</string>
     <string name="custom_amounts_percentage_label">Porcentaje del total del pedido (%1$s)</string>
     <string name="custom_amounts_delete_custom_amount">Eliminar importe personalizado</string>
-    <string name="store_creation_use_theme_button">Comenzar con este tema</string>
     <string name="theme_activated_successfully">El tema se ha activado correctamente</string>
-    <string name="theme_preview_theme_name">Tema: %1$s</string>
-    <string name="theme_preview_activate_theme_button">Usar este tema</string>
     <string name="theme_preview_bottom_sheet_home_section">Inicio</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">Toca para ver</string>
     <string name="theme_preview_bottom_sheet_pages_title">Páginas de esta plantilla</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -36,10 +36,7 @@ Language: fr
     <string name="custom_amounts_bottom_sheet_heading">Comment souhaitez-vous ajouter votre montant personnalisé ?</string>
     <string name="custom_amounts_percentage_label">Pourcentage du total de la commande (%1$s)</string>
     <string name="custom_amounts_delete_custom_amount">Supprimer le montant personnalisé</string>
-    <string name="store_creation_use_theme_button">Commencer avec ce thème</string>
     <string name="theme_activated_successfully">Thème activé avec succès</string>
-    <string name="theme_preview_theme_name">Thème : %1$s</string>
-    <string name="theme_preview_activate_theme_button">Utiliser ce thème</string>
     <string name="theme_preview_bottom_sheet_home_section">Accueil</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">Toucher pour prévisualiser</string>
     <string name="theme_preview_bottom_sheet_pages_title">Pages sur ce modèle</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -36,10 +36,7 @@ Language: he_IL
     <string name="custom_amounts_bottom_sheet_heading">איך ברצונך להוסיף את הסכום בהתאמה אישית?</string>
     <string name="custom_amounts_percentage_label">אחוז מהסכום הכולל של ההזמנה (⁦%1$s⁩)</string>
     <string name="custom_amounts_delete_custom_amount">למחוק סכום בהתאמה אישית</string>
-    <string name="store_creation_use_theme_button">להתחיל עם ערכת עיצוב זאת</string>
     <string name="theme_activated_successfully">הפעלת ערכת העיצוב בוצעה בהצלחה</string>
-    <string name="theme_preview_theme_name">ערכת עיצוב: ⁦%1$s⁩</string>
-    <string name="theme_preview_activate_theme_button">להשתמש בערכת עיצוב זו</string>
     <string name="theme_preview_bottom_sheet_home_section">עמוד הבית</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">להקיש כדי להציג</string>
     <string name="theme_preview_bottom_sheet_pages_title">עמודים בתבנית זו</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -36,10 +36,7 @@ Language: id
     <string name="custom_amounts_bottom_sheet_heading">Bagaimana Anda ingin menambahkan jumlah kustom?</string>
     <string name="custom_amounts_percentage_label">Persentase dari total pesanan (%1$s)</string>
     <string name="custom_amounts_delete_custom_amount">Hapus jumlah kustom</string>
-    <string name="store_creation_use_theme_button">Memulai dengan tema ini</string>
     <string name="theme_activated_successfully">Tema berhasil diaktifkan</string>
-    <string name="theme_preview_theme_name">Tema: %1$s</string>
-    <string name="theme_preview_activate_theme_button">Gunakan tema ini</string>
     <string name="theme_preview_bottom_sheet_home_section">Beranda</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">Ketuk untuk melihat</string>
     <string name="theme_preview_bottom_sheet_pages_title">Halaman dengan templat ini</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -36,10 +36,7 @@ Language: it
     <string name="custom_amounts_bottom_sheet_heading">Come desideri aggiungere l\'importo personalizzato?</string>
     <string name="custom_amounts_percentage_label">Percentuale del totale dell\'ordine (%1$s)</string>
     <string name="custom_amounts_delete_custom_amount">Elimina importo personalizzato</string>
-    <string name="store_creation_use_theme_button">Inizia scegliendo questo tema</string>
     <string name="theme_activated_successfully">Tema attivato correttamente</string>
-    <string name="theme_preview_theme_name">Tema: %1$s</string>
-    <string name="theme_preview_activate_theme_button">Usa questo tema</string>
     <string name="theme_preview_bottom_sheet_home_section">Home</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">Tocca per visualizzare</string>
     <string name="theme_preview_bottom_sheet_pages_title">Pagine su questo template</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -36,10 +36,7 @@ Language: ja_JP
     <string name="custom_amounts_bottom_sheet_heading">カスタム金額をどのように追加しますか ?</string>
     <string name="custom_amounts_percentage_label">注文合計に対するパーセンテージ (%1$s)</string>
     <string name="custom_amounts_delete_custom_amount">カスタム金額を削除</string>
-    <string name="store_creation_use_theme_button">このテーマで始める</string>
     <string name="theme_activated_successfully">テーマが正常に有効化されました</string>
-    <string name="theme_preview_theme_name">テーマ: %1$s</string>
-    <string name="theme_preview_activate_theme_button">このテーマを使用</string>
     <string name="theme_preview_bottom_sheet_home_section">ホーム</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">タップして表示</string>
     <string name="theme_preview_bottom_sheet_pages_title">このテンプレートのページ</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -36,10 +36,7 @@ Language: ko_KR
     <string name="custom_amounts_bottom_sheet_heading">사용자 정의 금액을 어떻게 추가하시겠어요?</string>
     <string name="custom_amounts_percentage_label">주문 합계 백분율(%1$s)</string>
     <string name="custom_amounts_delete_custom_amount">사용자 정의 금액 삭제</string>
-    <string name="store_creation_use_theme_button">이 테마로 시작</string>
     <string name="theme_activated_successfully">테마 활성화됨</string>
-    <string name="theme_preview_theme_name">테마: %1$s</string>
-    <string name="theme_preview_activate_theme_button">이 테마 사용</string>
     <string name="theme_preview_bottom_sheet_home_section">홈</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">눌러서 보기</string>
     <string name="theme_preview_bottom_sheet_pages_title">이 템플릿의 페이지</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -36,10 +36,7 @@ Language: nl
     <string name="custom_amounts_bottom_sheet_heading">Hoe wil je je aangepaste bedrag toevoegen?</string>
     <string name="custom_amounts_percentage_label">Percentage van het totaalaantal bestellingen (%1$s)</string>
     <string name="custom_amounts_delete_custom_amount">Aangepast bedrag verwijderen</string>
-    <string name="store_creation_use_theme_button">Begin met dit thema</string>
     <string name="theme_activated_successfully">Thema geactiveerd</string>
-    <string name="theme_preview_theme_name">Thema: %1$s</string>
-    <string name="theme_preview_activate_theme_button">Gebruik dit thema</string>
     <string name="theme_preview_bottom_sheet_home_section">Home</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">Tik om te bekijken</string>
     <string name="theme_preview_bottom_sheet_pages_title">Pagina\'s op dit sjabloon</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -36,10 +36,7 @@ Language: pt_BR
     <string name="custom_amounts_bottom_sheet_heading">Como deseja adicionar seu valor personalizado?</string>
     <string name="custom_amounts_percentage_label">Porcentagem do total do pedido (%1$s)</string>
     <string name="custom_amounts_delete_custom_amount">Excluir valor personalizado</string>
-    <string name="store_creation_use_theme_button">Começar com este tema</string>
     <string name="theme_activated_successfully">Tema ativado com sucesso</string>
-    <string name="theme_preview_theme_name">Tema: %1$s</string>
-    <string name="theme_preview_activate_theme_button">Usar este tema</string>
     <string name="theme_preview_bottom_sheet_home_section">Início</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">Toque para visualizar</string>
     <string name="theme_preview_bottom_sheet_pages_title">Páginas neste modelo</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -36,10 +36,7 @@ Language: ru
     <string name="custom_amounts_bottom_sheet_heading">Как вы хотите добавить индивидуальную сумму?</string>
     <string name="custom_amounts_percentage_label">Процент от общей суммы заказа (%1$s)</string>
     <string name="custom_amounts_delete_custom_amount">Удалить индивидуальную сумму</string>
-    <string name="store_creation_use_theme_button">Начать с этой темой</string>
     <string name="theme_activated_successfully">Тема успешно активирована</string>
-    <string name="theme_preview_theme_name">Тема: %1$s</string>
-    <string name="theme_preview_activate_theme_button">Использовать эту тему</string>
     <string name="theme_preview_bottom_sheet_home_section">Главная страница</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">Коснитесь для просмотра</string>
     <string name="theme_preview_bottom_sheet_pages_title">Страницы в этом шаблоне</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -36,10 +36,7 @@ Language: sv_SE
     <string name="custom_amounts_bottom_sheet_heading">Hur vill du lägga till ditt anpassade belopp?</string>
     <string name="custom_amounts_percentage_label">Procentandel av beställningens totala belopp %1$s</string>
     <string name="custom_amounts_delete_custom_amount">Ta bort anpassat belopp</string>
-    <string name="store_creation_use_theme_button">Börja med detta tema</string>
     <string name="theme_activated_successfully">Temat har aktiverats</string>
-    <string name="theme_preview_theme_name">Tema: %1$s</string>
-    <string name="theme_preview_activate_theme_button">Använd detta tema</string>
     <string name="theme_preview_bottom_sheet_home_section">Hem</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">Tryck för att visa</string>
     <string name="theme_preview_bottom_sheet_pages_title">Sidor på denna mall</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -36,10 +36,7 @@ Language: tr
     <string name="custom_amounts_bottom_sheet_heading">Özel tutarınızı nasıl eklemek istersiniz?</string>
     <string name="custom_amounts_percentage_label">Sipariş toplamının yüzdesi (%1$s)</string>
     <string name="custom_amounts_delete_custom_amount">Özel tutarı sil</string>
-    <string name="store_creation_use_theme_button">Bu tema ile başla</string>
     <string name="theme_activated_successfully">Tema başarıyla etkinleştirildi</string>
-    <string name="theme_preview_theme_name">Tema: %1$s</string>
-    <string name="theme_preview_activate_theme_button">Bu temayı kullan</string>
     <string name="theme_preview_bottom_sheet_home_section">Ana Sayfa</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">Görüntülemek için dokunun</string>
     <string name="theme_preview_bottom_sheet_pages_title">Bu şablondaki sayfalar</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -36,10 +36,7 @@ Language: zh_CN
     <string name="custom_amounts_bottom_sheet_heading">您想怎样添加自定义金额？</string>
     <string name="custom_amounts_delete_custom_amount">删除自定义金额</string>
     <string name="custom_amounts_percentage_label">订单总额百分比 (%1$s)</string>
-    <string name="store_creation_use_theme_button">从此主题开始</string>
     <string name="theme_activated_successfully">主题激活成功</string>
-    <string name="theme_preview_theme_name">主题：%1$s</string>
-    <string name="theme_preview_activate_theme_button">使用此主题</string>
     <string name="theme_preview_bottom_sheet_home_section">主页</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">轻点以查看</string>
     <string name="theme_preview_bottom_sheet_pages_title">此模板上的页面</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -36,10 +36,7 @@ Language: zh_TW
     <string name="custom_amounts_bottom_sheet_heading">你想要如何新增自訂金額？</string>
     <string name="custom_amounts_percentage_label">訂單總計的百分比 (%1$s)</string>
     <string name="custom_amounts_delete_custom_amount">刪除自訂金額</string>
-    <string name="store_creation_use_theme_button">開始使用此佈景主題</string>
     <string name="theme_activated_successfully">已成功啟用佈景主題</string>
-    <string name="theme_preview_theme_name">佈景主題：%1$s</string>
-    <string name="theme_preview_activate_theme_button">使用此佈景主題</string>
     <string name="theme_preview_bottom_sheet_home_section">首頁</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">點選以檢視</string>
     <string name="theme_preview_bottom_sheet_pages_title">此範本上的頁面</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3410,12 +3410,12 @@
     <string name="theme_preview_bottom_sheet_pages_title">Pages on this template</string>
     <string name="theme_preview_bottom_sheet_pages_subtitle">Tap to view</string>
     <string name="theme_preview_bottom_sheet_home_section">Home</string>
-    <string name="theme_preview_activate_theme_button">Use this theme</string>
-    <string name="theme_preview_theme_name">Theme: %1$s</string>
     <string name="theme_activated_successfully">Theme activated successfully</string>
     <string name="theme_preview_type_mobile">Mobile</string>
     <string name="theme_preview_type_tablet">Tablet</string>
     <string name="theme_preview_type_desktop">Desktop</string>
+    <string name="theme_preview_activate_theme_button_store_creation">Start with %1$s</string>
+    <string name="theme_preview_activate_theme_button_settings">Use %1$s</string>
     <string name="theme_activation_failed">Theme activation failed, please try again!</string>
 
     <!--
@@ -3919,5 +3919,4 @@
     <string name="configuration_children_issue"> "%1$s " -&gt; %2$s </string>
     <string name="configuration_variable_update">Choose variation</string>
     <string name="product_variation_picker_title">Select a variation</string>
-    <string name="store_creation_use_theme_button">Start with this theme</string>
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/themes/ThemePickerViewModelTest.kt
@@ -229,4 +229,20 @@ class ThemePickerViewModelTest : BaseUnitTest() {
 
             assertThat((carouseItems)).noneMatch { it is CarouselItem.Theme && it.themeId == currentTheme.id }
         }
+
+    @Test
+    fun `when a new theme is installed, then update current theme state`() = testBlocking {
+        setup(isFromStoreCreation = false) {
+            whenever(themeRepository.fetchThemes())
+                .thenReturn(Result.success(listOf(sampleTheme, sampleTheme2)))
+            whenever(themeRepository.fetchCurrentTheme()).thenReturn(Result.success(currentTheme))
+        }
+
+        val viewState = viewModel.viewState.runAndCaptureValues {
+            viewModel.onCurrentThemeUpdated(sampleTheme2.id, sampleTheme2.name)
+        }.last()
+
+        assertThat(viewState.currentThemeState)
+            .isEqualTo(ThemePickerViewModel.CurrentThemeState.Success(sampleTheme2.name, sampleTheme2.id))
+    }
 }


### PR DESCRIPTION
### Description
This PR has two fixes of the issues discovered by @selanthiraiyan during the beta testing + two other changes:

- Fixes the issue raised here p1702956334444379/1702956082.222529-slack-C03L1NF1EA3, we now show the theme ID instead of the theme name after the installation.
- Fixes the issue raised here p1702956889157039/1702956082.222529-slack-C03L1NF1EA3, when theme page's response has the `Home` entry, we'll exclude it to avoid duplication.
- It updates the theme preview's screen bottom section according to this p1703132755602819-slack-C03L1NF1EA3
- It update the theme preview screen to show the header during the loading, I'm not sure why Ondrej did this change in #10414, but it resulted in the views jumping after the loading, and I missed it in the PR Review. (check the video below)

### Testing instructions
1. Open theme picker from the settings.
2. Click on the Amulet theme.
3. Check the pages list, and confirm there is no duplication.
4. Confirm the bottom section matches the new design.
5. Click on Use Amulet.
6. Confirm the current theme section has the correct name now.

### Images/gif
| Before | After |
| --- | --- |
| ![Screenshot_20231221_131941](https://github.com/woocommerce/woocommerce-android/assets/1657201/7dd87ffc-81af-47e5-a16e-a165394238d3) | ![Screenshot_20231221_131611](https://github.com/woocommerce/woocommerce-android/assets/1657201/8e796b61-fcdf-41d0-a16c-d39cf45ba5a1) |
| ![Screenshot_20231221_131958](https://github.com/woocommerce/woocommerce-android/assets/1657201/0b1c3de9-6a00-4453-839a-1cac7b55a86a) | ![Screenshot_20231221_131603](https://github.com/woocommerce/woocommerce-android/assets/1657201/d61298ab-87d1-499c-985d-fc136e10e234) |
| <video src="https://github.com/woocommerce/woocommerce-android/assets/1657201/47163f86-7941-483e-878a-0f824955376b" /> | <video src="https://github.com/woocommerce/woocommerce-android/assets/1657201/4390f901-033d-4c53-848e-52f0a500f7ce" />  |


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->