### PR TITLE
Using site timezone in order details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -390,8 +390,8 @@ data class Order(
             )
         }
 
-        val EMPTY
-            get() = DEFAULT_EMPTY_ORDER.copy(dateCreated = Date(), dateModified = Date())
+        fun getEmptyOrder(dateCreated: Date, dateModified: Date) =
+            DEFAULT_EMPTY_ORDER.copy(dateCreated = dateCreated, dateModified = dateModified)
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.model
 import com.woocommerce.android.extensions.CASH_PAYMENTS
 import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.model.Order.Item
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.StringUtils
 import org.wordpress.android.fluxc.model.OrderEntity
 import org.wordpress.android.fluxc.model.WCMetaData
@@ -11,7 +12,6 @@ import org.wordpress.android.fluxc.model.order.OrderAddress
 import org.wordpress.android.fluxc.model.order.TaxLine
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.CHARGE_ID_KEY
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderMappingConst.SHIPPING_PHONE_KEY
-import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
 import java.util.Date
 import javax.inject.Inject
@@ -20,15 +20,18 @@ import org.wordpress.android.fluxc.model.order.FeeLine as WCFeeLine
 import org.wordpress.android.fluxc.model.order.LineItem as WCLineItem
 import org.wordpress.android.fluxc.model.order.ShippingLine as WCShippingLine
 
-class OrderMapper @Inject constructor(private val getLocations: GetLocations) {
+class OrderMapper @Inject constructor(
+    private val getLocations: GetLocations,
+    private val dateUtils: DateUtils
+) {
     fun toAppModel(databaseEntity: OrderEntity): Order {
         val metaDataList = databaseEntity.getMetaDataList()
         return Order(
             id = databaseEntity.orderId,
             number = databaseEntity.number,
-            dateCreated = DateTimeUtils.dateUTCFromIso8601(databaseEntity.dateCreated) ?: Date(),
-            dateModified = DateTimeUtils.dateUTCFromIso8601(databaseEntity.dateModified) ?: Date(),
-            datePaid = DateTimeUtils.dateUTCFromIso8601(databaseEntity.datePaid),
+            dateCreated = dateUtils.getDateUsingSiteTimeZone(databaseEntity.dateCreated) ?: Date(),
+            dateModified = dateUtils.getDateUsingSiteTimeZone(databaseEntity.dateModified) ?: Date(),
+            datePaid = dateUtils.getDateUsingSiteTimeZone(databaseEntity.datePaid),
             status = Order.Status.fromValue(databaseEntity.status),
             total = databaseEntity.total.toBigDecimalOrNull() ?: BigDecimal.ZERO,
             productsTotal = databaseEntity.getOrderSubtotal().toBigDecimal(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -124,6 +124,7 @@ import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.Sel
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem.Product
 import com.woocommerce.android.ui.products.selector.variationIds
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -156,6 +157,7 @@ import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WooCommerceStore.WooPlugin.WOO_GIFT_CARDS
 import org.wordpress.android.fluxc.utils.putIfNotNull
 import java.math.BigDecimal
+import java.util.Date
 import javax.inject.Inject
 import com.woocommerce.android.model.Product as ModelProduct
 
@@ -184,6 +186,7 @@ class OrderCreateEditViewModel @Inject constructor(
     private val adjustProductQuantity: AdjustProductQuantity,
     private val mapFeeLineToCustomAmountUiModel: MapFeeLineToCustomAmountUiModel,
     private val currencySymbolFinder: CurrencySymbolFinder,
+    private val dateUtils: DateUtils,
     autoSyncOrder: AutoSyncOrder,
     autoSyncPriceModifier: AutoSyncPriceModifier,
     parameterRepository: ParameterRepository,
@@ -219,7 +222,11 @@ class OrderCreateEditViewModel @Inject constructor(
         initialValue = args.giftCardCode.orEmpty()
     )
 
-    private val _orderDraft = savedState.getStateFlow(viewModelScope, Order.EMPTY)
+    private val _orderDraft = savedState.getStateFlow(viewModelScope, Order.getEmptyOrder(
+        dateCreated = dateUtils.getCurrentDateInSiteTimeZone() ?: Date(),
+        dateModified = dateUtils.getCurrentDateInSiteTimeZone() ?: Date()
+    ))
+
     val orderDraft = _orderDraft
         .combine(_selectedGiftCard) { order, giftCard ->
             order.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -186,7 +186,7 @@ class OrderCreateEditViewModel @Inject constructor(
     private val adjustProductQuantity: AdjustProductQuantity,
     private val mapFeeLineToCustomAmountUiModel: MapFeeLineToCustomAmountUiModel,
     private val currencySymbolFinder: CurrencySymbolFinder,
-    private val dateUtils: DateUtils,
+    dateUtils: DateUtils,
     autoSyncOrder: AutoSyncOrder,
     autoSyncPriceModifier: AutoSyncPriceModifier,
     parameterRepository: ParameterRepository,
@@ -222,10 +222,13 @@ class OrderCreateEditViewModel @Inject constructor(
         initialValue = args.giftCardCode.orEmpty()
     )
 
-    private val _orderDraft = savedState.getStateFlow(viewModelScope, Order.getEmptyOrder(
-        dateCreated = dateUtils.getCurrentDateInSiteTimeZone() ?: Date(),
-        dateModified = dateUtils.getCurrentDateInSiteTimeZone() ?: Date()
-    ))
+    private val _orderDraft = savedState.getStateFlow(
+        viewModelScope,
+        Order.getEmptyOrder(
+            dateCreated = dateUtils.getCurrentDateInSiteTimeZone() ?: Date(),
+            dateModified = dateUtils.getCurrentDateInSiteTimeZone() ?: Date()
+        )
+    )
 
     val orderDraft = _orderDraft
         .combine(_selectedGiftCard) { order, giftCard ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -373,6 +373,7 @@ class DateUtils @Inject constructor(
         }
 
     fun getDateUsingSiteTimeZone(isoStringDate: String): Date? {
+        if(isoStringDate.isEmpty()) return null
         val iso8601DateString = iso8601OnSiteTimeZoneFromIso8601UTC(isoStringDate)
         return getDateFromFullDateString(iso8601DateString)
     }
@@ -411,7 +412,7 @@ class DateUtils @Inject constructor(
 
             // Format the result as a string
             zonedDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
-        } catch (e: ParseException) {
+        } catch (e: Exception) {
             iso8601date
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.util.WooLog.T.UTILS
 import org.apache.commons.lang3.time.DateUtils
 import org.wordpress.android.fluxc.utils.SiteUtils
 import java.text.DateFormatSymbols
-import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -373,7 +372,7 @@ class DateUtils @Inject constructor(
         }
 
     fun getDateUsingSiteTimeZone(isoStringDate: String): Date? {
-        if(isoStringDate.isEmpty()) return null
+        if (isoStringDate.isEmpty()) return null
         val iso8601DateString = iso8601OnSiteTimeZoneFromIso8601UTC(isoStringDate)
         return getDateFromFullDateString(iso8601DateString)
     }
@@ -398,6 +397,7 @@ class DateUtils @Inject constructor(
             null
         }
     }
+    @Suppress("SwallowedException")
     private fun iso8601OnSiteTimeZoneFromIso8601UTC(iso8601date: String): String {
         return try {
             val site = selectedSite.getOrNull() ?: return iso8601date

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
@@ -148,7 +148,7 @@ object OrderTestUtils {
     }
 
     fun generateTestOrder(orderId: Long = 1): Order {
-        return Order.EMPTY.copy(
+        return Order.getEmptyOrder(Date(),Date()).copy(
             id = orderId,
             customer = Order.Customer(
                 billingAddress = Address.EMPTY.copy(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderTestUtils.kt
@@ -148,7 +148,7 @@ object OrderTestUtils {
     }
 
     fun generateTestOrder(orderId: Long = 1): Order {
-        return Order.getEmptyOrder(Date(),Date()).copy(
+        return Order.getEmptyOrder(Date(), Date()).copy(
             id = orderId,
             customer = Order.Customer(
                 billingAddress = Address.EMPTY.copy(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/AdjustProductQuantityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/AdjustProductQuantityTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.math.BigDecimal
+import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AdjustProductQuantityTest : BaseUnitTest() {
@@ -234,7 +235,8 @@ class AdjustProductQuantityTest : BaseUnitTest() {
         )
     }
 
-    private val order = Order.EMPTY.copy(items = listOf(simpleItem, bundleItem, bundleChildItem))
+    private val order = Order.getEmptyOrder(Date(), Date())
+        .copy(items = listOf(simpleItem, bundleItem, bundleChildItem))
 
     private val defaultProductInfo = ProductInfo(
         imageUrl = "",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreateUpdateOrderTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreateUpdateOrderTests.kt
@@ -24,6 +24,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
+import java.util.Date
 
 @ExperimentalCoroutinesApi
 class CreateUpdateOrderTests : BaseUnitTest() {
@@ -33,7 +34,7 @@ class CreateUpdateOrderTests : BaseUnitTest() {
             Result.success(order.copy(total = order.total + BigDecimal.TEN))
         }
     }
-    private val order = Order.EMPTY.copy(items = OrderTestUtils.generateTestOrderItems())
+    private val order = Order.getEmptyOrder(Date(), Date()).copy(items = OrderTestUtils.generateTestOrderItems())
     private val orderDraftChanges = MutableStateFlow(order)
     private val retryTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -69,6 +69,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.WCProductStore
 import java.math.BigDecimal
+import java.util.Date
 import java.util.function.Consumer
 
 @ExperimentalCoroutinesApi
@@ -799,7 +800,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
-                    Order.EMPTY.copy(
+                    Order.getEmptyOrder(Date(), Date()).copy(
                         feesLines = listOf(
                             Order.FeeLine.EMPTY.copy(id = 1, total = BigDecimal(1)),
                             Order.FeeLine.EMPTY.copy(id = 2, total = BigDecimal(2)),
@@ -834,7 +835,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
-                    Order.EMPTY.copy(
+                    Order.getEmptyOrder(Date(),Date()).copy(
                         feesLines = listOf(
                             Order.FeeLine.EMPTY.copy(id = 1, total = BigDecimal(1)),
                             Order.FeeLine.EMPTY.copy(id = 2, total = BigDecimal(2)),
@@ -930,7 +931,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
-                    Order.EMPTY.copy(
+                    Order.getEmptyOrder(Date(),Date()).copy(
                         shippingLines = listOf(
                             Order.ShippingLine("first", "first", BigDecimal(1)),
                             Order.ShippingLine("second", "second", BigDecimal(2)),
@@ -978,7 +979,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
-                    Order.EMPTY.copy(
+                    Order.getEmptyOrder(Date(),Date()).copy(
                         shippingLines = listOf(
                             Order.ShippingLine("first", "first", BigDecimal(1)),
                             Order.ShippingLine("second", "second", BigDecimal(2)),
@@ -1128,7 +1129,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         assertThat(sut.orderDraft.value)
             .usingRecursiveComparison()
             .ignoringFields("dateCreated", "dateModified")
-            .isEqualTo(Order.EMPTY)
+            .isEqualTo(Order.getEmptyOrder(Date(),Date()))
     }
 
     @Test
@@ -1823,7 +1824,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
-                    Order.EMPTY.copy(
+                    Order.getEmptyOrder(Date(),Date()).copy(
                         feesLines = listOf(
                             Order.FeeLine.EMPTY.copy(
                                 id = 1,
@@ -1853,7 +1854,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
-                    Order.EMPTY.copy(
+                    Order.getEmptyOrder(Date(),Date()).copy(
                         feesLines = listOf(
                             Order.FeeLine.EMPTY.copy(
                                 id = 1,
@@ -1889,7 +1890,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
-                    Order.EMPTY.copy(
+                    Order.getEmptyOrder(Date(),Date()).copy(
                         feesLines = listOf(
                             Order.FeeLine.EMPTY.copy(
                                 id = 1,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -835,7 +835,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
-                    Order.getEmptyOrder(Date(),Date()).copy(
+                    Order.getEmptyOrder(Date(), Date()).copy(
                         feesLines = listOf(
                             Order.FeeLine.EMPTY.copy(id = 1, total = BigDecimal(1)),
                             Order.FeeLine.EMPTY.copy(id = 2, total = BigDecimal(2)),
@@ -931,7 +931,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
-                    Order.getEmptyOrder(Date(),Date()).copy(
+                    Order.getEmptyOrder(Date(), Date()).copy(
                         shippingLines = listOf(
                             Order.ShippingLine("first", "first", BigDecimal(1)),
                             Order.ShippingLine("second", "second", BigDecimal(2)),
@@ -979,7 +979,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
-                    Order.getEmptyOrder(Date(),Date()).copy(
+                    Order.getEmptyOrder(Date(), Date()).copy(
                         shippingLines = listOf(
                             Order.ShippingLine("first", "first", BigDecimal(1)),
                             Order.ShippingLine("second", "second", BigDecimal(2)),
@@ -1129,7 +1129,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         assertThat(sut.orderDraft.value)
             .usingRecursiveComparison()
             .ignoringFields("dateCreated", "dateModified")
-            .isEqualTo(Order.getEmptyOrder(Date(),Date()))
+            .isEqualTo(Order.getEmptyOrder(Date(), Date()))
     }
 
     @Test
@@ -1824,7 +1824,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
-                    Order.getEmptyOrder(Date(),Date()).copy(
+                    Order.getEmptyOrder(Date(), Date()).copy(
                         feesLines = listOf(
                             Order.FeeLine.EMPTY.copy(
                                 id = 1,
@@ -1854,7 +1854,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
-                    Order.getEmptyOrder(Date(),Date()).copy(
+                    Order.getEmptyOrder(Date(), Date()).copy(
                         feesLines = listOf(
                             Order.FeeLine.EMPTY.copy(
                                 id = 1,
@@ -1890,7 +1890,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
-                    Order.getEmptyOrder(Date(),Date()).copy(
+                    Order.getEmptyOrder(Date(), Date()).copy(
                         feesLines = listOf(
                             Order.FeeLine.EMPTY.copy(
                                 id = 1,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/DetermineMultipleLinesContextTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/DetermineMultipleLinesContextTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.model.Location
 import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.details.editing.address.LocationCode
+import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -20,6 +21,7 @@ class DetermineMultipleLinesContextTest : BaseUnitTest() {
 
     private val location: GetLocations = mock()
     private val resourceProvider: ResourceProvider = mock()
+    private val dateUtils: DateUtils = mock()
     @Test
     fun `when order has multiple shipping lines, then return proper multiple lines context`() {
         whenever(location.invoke(any(), any())).thenReturn(
@@ -33,7 +35,7 @@ class DetermineMultipleLinesContextTest : BaseUnitTest() {
         val sut = DetermineMultipleLinesContext(resourceProvider)
 
         val result = sut.invoke(
-            OrderMapper(location).toAppModel(OrderTestUtils.generateOrderWithMultipleShippingLines())
+            OrderMapper(location, dateUtils).toAppModel(OrderTestUtils.generateOrderWithMultipleShippingLines())
         )
 
         assertThat(result).isInstanceOf(OrderCreateEditViewModel.MultipleLinesContext.Warning::class.java)
@@ -50,7 +52,7 @@ class DetermineMultipleLinesContextTest : BaseUnitTest() {
         val sut = DetermineMultipleLinesContext(resourceProvider)
 
         val result = sut.invoke(
-            OrderMapper(location).toAppModel(OrderTestUtils.generateOrder())
+            OrderMapper(location, dateUtils).toAppModel(OrderTestUtils.generateOrder())
         )
 
         assertThat(result).isInstanceOf(OrderCreateEditViewModel.MultipleLinesContext.None::class.java)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.fluxc.store.OrderUpdateStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WooCommerceStore.WooPlugin.WOO_GIFT_CARDS
 import java.math.BigDecimal
+import java.util.Date
 
 @ExperimentalCoroutinesApi
 class OrderCreateEditRepositoryTest : BaseUnitTest() {
@@ -119,7 +120,7 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
         whenever(orderUpdateStore.createOrder(any(), any()))
             .thenReturn(WooResult(OrderTestUtils.generateOrder()))
 
-        val order = Order.EMPTY.copy(
+        val order = Order.getEmptyOrder(Date(), Date()).copy(
             id = 0L,
             status = Order.Status.Custom(Order.Status.AUTO_DRAFT)
         )
@@ -150,7 +151,7 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
         whenever(orderUpdateStore.createOrder(any(), any()))
             .thenReturn(WooResult(OrderTestUtils.generateOrder()))
 
-        val order = Order.EMPTY.copy(
+        val order = Order.getEmptyOrder(Date(),Date()).copy(
             id = 0L,
             status = Order.Status.Custom(Order.Status.AUTO_DRAFT)
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
@@ -151,7 +151,7 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
         whenever(orderUpdateStore.createOrder(any(), any()))
             .thenReturn(WooResult(OrderTestUtils.generateOrder()))
 
-        val order = Order.getEmptyOrder(Date(),Date()).copy(
+        val order = Order.getEmptyOrder(Date(), Date()).copy(
             id = 0L,
             status = Order.Status.Custom(Order.Status.AUTO_DRAFT)
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/SyncStrategyTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/SyncStrategyTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 import java.math.BigDecimal
+import java.util.Date
 
 @ExperimentalCoroutinesApi
 abstract class SyncStrategyTest : BaseUnitTest() {
@@ -20,7 +21,8 @@ abstract class SyncStrategyTest : BaseUnitTest() {
             Result.success(order.copy(total = order.total + BigDecimal.TEN))
         }
     }
-    protected val order = Order.EMPTY.copy(items = OrderTestUtils.generateTestOrderItems())
+
+    protected val order = Order.getEmptyOrder(Date(), Date()).copy(items = OrderTestUtils.generateTestOrderItems())
     protected val orderDraftChanges = MutableStateFlow(order)
     protected val retryTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -66,6 +66,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.store.WCProductStore
 import java.math.BigDecimal
+import java.util.Date
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -98,7 +99,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     val currencySymbolFinder: CurrencySymbolFinder = mock()
     private lateinit var mapFeeLineToCustomAmountUiModel: MapFeeLineToCustomAmountUiModel
 
-    protected val defaultOrderValue = Order.EMPTY.copy(id = 123)
+    protected val defaultOrderValue = Order.getEmptyOrder(Date(), Date()).copy(id = 123)
 
     @Before
     fun setUp() {
@@ -113,14 +114,19 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     @Suppress("LongMethod")
     private fun initMocks() {
         val defaultOrderItem = createOrderItem()
-        val emptyOrder = Order.EMPTY
+        val emptyOrder = Order.getEmptyOrder(Date(), Date())
         viewState = OrderCreateEditViewModel.ViewState()
         savedState = spy(OrderCreateEditFormFragmentArgs(mode, sku, barcodeFormat).toSavedStateHandle()) {
             on { getLiveData(viewState.javaClass.name, viewState) } doReturn MutableLiveData(viewState)
-            on { getLiveData(eq(Order.EMPTY.javaClass.name), any<Order>()) } doReturn MutableLiveData(emptyOrder)
+            on {
+                getLiveData(
+                    eq(Order.getEmptyOrder(Date(), Date()).javaClass.name),
+                    any<Order>()
+                )
+            } doReturn MutableLiveData(emptyOrder)
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(Order.EMPTY))
+            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(Order.getEmptyOrder(Date(), Date())))
         }
         createOrderItemUseCase = mock {
             onBlocking { invoke(123, null) } doReturn defaultOrderItem
@@ -2411,7 +2417,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             orderCreationProductMapper = orderCreationProductMapper,
             adjustProductQuantity = AdjustProductQuantity(),
             mapFeeLineToCustomAmountUiModel = mapFeeLineToCustomAmountUiModel,
-            currencySymbolFinder = currencySymbolFinder
+            currencySymbolFinder = currencySymbolFinder,
+            dateUtils = mock()
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepositoryTest.kt
@@ -14,6 +14,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.Date
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -23,7 +24,7 @@ class ShippingLabelOnboardingRepositoryTest : BaseUnitTest() {
         const val SITE_ID = 1
         const val DEFAULT_SUPPORTED_WCS_VERSION = "1.25.11"
         val ELIGIBLE_ORDER_FOR_WCS_LABELS =
-            Order.EMPTY.copy(
+            Order.getEmptyOrder(Date(), Date()).copy(
                 id = 123L,
                 currency = SUPPORTED_WCS_CURRENCY,
                 isCashPayment = false,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModelTest.kt
@@ -92,7 +92,8 @@ class CreateShippingLabelViewModelTest : BaseUnitTest() {
     private val orderMapper = OrderMapper(
         getLocations = mock {
             on { invoke(any(), any()) } doReturn (Location.EMPTY to AmbiguousLocation.EMPTY)
-        }
+        },
+        mock()
     )
     private val checkEUShippingScenario: CheckEUShippingScenario = mock {
         on { invoke(any()) } doReturn flowOf(false)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelsStateMachineTest.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsS
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelsStateMachine.StepStatus.*
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions.assertThat
@@ -28,7 +27,8 @@ class ShippingLabelsStateMachineTest : BaseUnitTest() {
     private val orderMapper = OrderMapper(
         getLocations = mock {
             on { invoke(any(), any()) } doReturn (Location.EMPTY to AmbiguousLocation.EMPTY)
-        }
+        },
+        mock()
     )
     private val order = OrderTestUtils.generateOrder().let { orderMapper.toAppModel(it) }
     private val originAddress = CreateShippingLabelTestUtils.generateAddress()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/banner/CheckEUShippingScenarioTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.test.TestScope
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class CheckEUShippingScenarioTest : BaseUnitTest() {
@@ -267,7 +268,7 @@ internal class CheckEUShippingScenarioTest : BaseUnitTest() {
         destinationCountryCode: String
     ) = WaitingForInput(
         data = StateMachineData(
-            order = Order.EMPTY,
+            order = Order.getEmptyOrder(Date(), Date()),
             stepsState = emptyStepState.copy(
                 originAddressStep = OriginAddressStep(
                     StepStatus.READY,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModelTest.kt
@@ -67,7 +67,8 @@ class IssueRefundViewModelTest : BaseUnitTest() {
     private val orderMapper = OrderMapper(
         getLocations = mock {
             on { invoke(any(), any()) } doReturn (Location.EMPTY to AmbiguousLocation.EMPTY)
-        }
+        },
+        mock()
     )
 
     private val paymentChargeRepository: PaymentChargeRepository = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/addons/AddonRepositoryTest.kt
@@ -47,7 +47,8 @@ class AddonRepositoryTest : BaseUnitTest() {
     private val orderMapper = OrderMapper(
         getLocations = mock {
             on { invoke(any(), any()) } doReturn (Location.EMPTY to AmbiguousLocation.EMPTY)
-        }
+        },
+        mock()
     )
 
     @Before


### PR DESCRIPTION
Part of: #9887

### Why
This PR continues the work of using the store's time zone on the app.  As discussed here pe5pgL-4bG-p2, besides the stats, we also want to use the store time zone for the order date:
> we will use the store time zone for everything order-related (orders, order notes, etc.)

### Description
This PR updates the order mapper class to use the store's timezone when mapping the order model date fields (date created, date modified, date paid). This way, we will achieve consistency between the dates displayed in the order list and those displayed in the order details. Besides that change, I also removed the EMPTY order object property and turned it into a function receiving the created and modified dates. This way, we can pass those dates into the new order and use the store timezone to generate those dates.

⚠️ Customer notes are not handled in this PR and will be tackled in a different one. 

### Testing instructions
To test these changes, you must set your device to a different time zone than your store. I used a store in the US and set the device time zone to Australia. This will create a time zone difference of one day (Thursday in the store should be Friday on the device)

1. Open the order list screen
2. Tap on add new order (+)
3. Check that the date on top of the order is using the store's time zone
4. Add some products and create the order
5. Check that the date on top of the order is using the store's time zone
6. Tap on collect payment
7. Tap on cash 
8. Refresh the orders list and select the order you just created
9. Check that the paid date is using the store's time zone

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/c2c4c8e1-0f7d-4d77-8851-fd01a43548ca

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
