### PR TITLE
Issue/10486 blaze products search

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductSelectorScreenTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductSelectorScreenTest.kt
@@ -30,7 +30,8 @@ class ProductSelectorScreenTest {
                     recentProducts = emptyList(),
                     selectedItemsCount = 0,
                     filterState = ProductSelectorViewModel.FilterState(emptyMap(), null),
-                    searchState = ProductSelectorViewModel.SearchState.EMPTY
+                    searchState = ProductSelectorViewModel.SearchState.EMPTY,
+                    selectionMode = ProductSelectorViewModel.SelectionMode.MULTIPLE
                 ),
                 onDoneButtonClick = {},
                 onClearButtonClick = {},
@@ -58,7 +59,8 @@ class ProductSelectorScreenTest {
                     recentProducts = emptyList(),
                     selectedItemsCount = 0,
                     filterState = ProductSelectorViewModel.FilterState(emptyMap(), null),
-                    searchState = ProductSelectorViewModel.SearchState.EMPTY
+                    searchState = ProductSelectorViewModel.SearchState.EMPTY,
+                    selectionMode = ProductSelectorViewModel.SelectionMode.MULTIPLE
                 ),
                 onDoneButtonClick = {},
                 onClearButtonClick = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/coupons/edit/EditCouponNavigator.kt
@@ -31,8 +31,8 @@ object EditCouponNavigator {
             is EditIncludedProducts -> {
                 navController.navigateSafely(
                     EditCouponFragmentDirections.actionEditCouponFragmentToProductSelectorFragment(
-                        target.selectedItems.toTypedArray(),
-                        ProductSelectorViewModel.ProductSelectorFlow.CouponEdition
+                        selectedItems = target.selectedItems.toTypedArray(),
+                        productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.CouponEdition
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryDa
 import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.models.QuantityRules
 import com.woocommerce.android.ui.products.price.ProductPricingViewModel.PricingData
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow
 import com.woocommerce.android.ui.products.selector.ProductSourceForTracking
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibility
@@ -131,6 +132,7 @@ sealed class ProductNavigationTarget : Event() {
         val selectedVariationIds: Set<Long>,
         val productSelectorFlow: ProductSelectorFlow = ProductSelectorFlow.Undefined,
         val productSourceForTracking: ProductSourceForTracking,
+        val selectionMode: ProductSelectorViewModel.SelectionMode
     ) : ProductNavigationTarget()
 
     data class NavigateToProductConfiguration(val productId: Long) : ProductNavigationTarget()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.products.GroupedProductListType.GROUPED
 import com.woocommerce.android.ui.products.categories.ProductCategoriesFragmentDirections
 import com.woocommerce.android.ui.products.downloads.ProductDownloadsFragmentDirections
 import com.woocommerce.android.ui.products.selector.ProductSelectorFragmentDirections
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
 import com.woocommerce.android.ui.products.settings.ProductSettingsFragmentDirections
 import com.woocommerce.android.ui.products.variations.attributes.AddAttributeTermsFragmentDirections
 import com.woocommerce.android.ui.products.variations.attributes.AttributeListFragmentDirections
@@ -345,14 +346,23 @@ class ProductNavigator @Inject constructor() {
             }
 
             is ProductNavigationTarget.NavigateToVariationSelector -> {
-                fragment.findNavController().navigateSafely(
-                    ProductSelectorFragmentDirections.actionProductSelectorFragmentToVariationSelectorFragment(
-                        target.productId,
-                        target.selectedVariationIds.toLongArray(),
-                        target.productSelectorFlow,
-                        target.productSourceForTracking,
-                    )
-                )
+                val action = when (target.selectionMode) {
+                    ProductSelectorViewModel.SelectionMode.MULTIPLE -> {
+                        ProductSelectorFragmentDirections.actionProductSelectorFragmentToVariationSelectorFragment(
+                            target.productId,
+                            target.selectedVariationIds.toLongArray(),
+                            target.productSelectorFlow,
+                            target.productSourceForTracking,
+                        )
+                    }
+                    ProductSelectorViewModel.SelectionMode.SINGLE -> {
+                        ProductSelectorFragmentDirections.actionProductSelectorFragmentToVariationPickerFragment(
+                            target.productId
+                        )
+                    }
+                }
+
+                fragment.findNavController().navigateSafely(action)
             }
 
             is ProductNavigationTarget.NavigateToProductConfiguration -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -349,15 +349,15 @@ class ProductNavigator @Inject constructor() {
                 val action = when (target.selectionMode) {
                     ProductSelectorViewModel.SelectionMode.MULTIPLE -> {
                         ProductSelectorFragmentDirections.actionProductSelectorFragmentToVariationSelectorFragment(
-                            target.productId,
-                            target.selectedVariationIds.toLongArray(),
-                            target.productSelectorFlow,
-                            target.productSourceForTracking,
+                            productId = target.productId,
+                            variationIds = target.selectedVariationIds.toLongArray(),
+                            productSelectorFlow = target.productSelectorFlow,
+                            productSource = target.productSourceForTracking,
                         )
                     }
                     ProductSelectorViewModel.SelectionMode.SINGLE -> {
                         ProductSelectorFragmentDirections.actionProductSelectorFragmentToVariationPickerFragment(
-                            target.productId
+                            productId = target.productId
                         )
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
@@ -21,6 +21,8 @@ import com.woocommerce.android.ui.products.ProductListFragment.Companion.PRODUCT
 import com.woocommerce.android.ui.products.ProductNavigationTarget
 import com.woocommerce.android.ui.products.ProductNavigator
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
+import com.woocommerce.android.ui.products.variations.picker.VariationPickerFragment
+import com.woocommerce.android.ui.products.variations.picker.VariationPickerViewModel.VariationPickerResult
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorFragment
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorViewModel.VariationSelectionResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -80,6 +82,14 @@ class ProductSelectorFragment : BaseFragment() {
     private fun handleResults() {
         handleResult<VariationSelectionResult>(VariationSelectorFragment.VARIATION_SELECTOR_RESULT) {
             viewModel.onSelectedVariationsUpdated(it)
+        }
+
+        handleResult<VariationPickerResult>(VariationPickerFragment.VARIATION_PICKER_RESULT) {
+            // This means we are in the single-selection mode, return result immediately
+            navigateBackWithResult(
+                PRODUCT_SELECTOR_RESULT,
+                listOf(SelectedItem.ProductVariation(it.productId, it.variationId))
+            )
         }
 
         handleResult<ProductFilterResult>(PRODUCT_FILTER_RESULT_KEY) { result ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -335,13 +335,15 @@ private fun ProductList(
                 .padding(horizontal = dimensionResource(dimen.minor_100))
                 .fillMaxWidth()
         ) {
-            WCTextButton(
-                onClick = onClearButtonClick,
-                text = stringResource(id = string.product_selector_clear_button_title),
-                allCaps = false,
-                enabled = state.selectedItemsCount > 0,
-                modifier = Modifier.align(Alignment.CenterStart)
-            )
+            if (state.selectionMode == ProductSelectorViewModel.SelectionMode.MULTIPLE) {
+                WCTextButton(
+                    onClick = onClearButtonClick,
+                    text = stringResource(id = string.product_selector_clear_button_title),
+                    allCaps = false,
+                    enabled = state.selectedItemsCount > 0,
+                    modifier = Modifier.align(Alignment.CenterStart)
+                )
+            }
             if (state.searchState.searchQuery.isEmpty()) {
                 WCTextButton(
                     onClick = onFilterButtonClick,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -551,13 +551,14 @@ fun PopularProductsListPreview() {
             searchState = ProductSelectorViewModel.SearchState(),
             popularProducts = products,
             recentProducts = emptyList(),
+            selectionMode = ProductSelectorViewModel.SelectionMode.MULTIPLE
         ),
-        {},
-        {},
-        {},
-        { _, _ -> },
-        {},
-        {}
+        onDoneButtonClick = {},
+        onClearButtonClick = {},
+        onFilterButtonClick = {},
+        onProductClick = { _, _ -> },
+        onLoadMore = {},
+        trackConfigurableProduct = {}
     )
 }
 
@@ -619,13 +620,14 @@ fun RecentProductsListPreview() {
             searchState = ProductSelectorViewModel.SearchState(),
             popularProducts = emptyList(),
             recentProducts = products,
+            selectionMode = ProductSelectorViewModel.SelectionMode.MULTIPLE
         ),
-        {},
-        {},
-        {},
-        { _, _ -> },
-        {},
-        {}
+        onDoneButtonClick = {},
+        onClearButtonClick = {},
+        onFilterButtonClick = {},
+        onProductClick = { _, _ -> },
+        onLoadMore = {},
+        trackConfigurableProduct = {}
     )
 }
 
@@ -686,13 +688,14 @@ fun ProductListPreview() {
             searchState = ProductSelectorViewModel.SearchState(),
             popularProducts = products,
             recentProducts = products,
+            selectionMode = ProductSelectorViewModel.SelectionMode.MULTIPLE
         ),
-        {},
-        {},
-        {},
-        { _, _ -> },
-        {},
-        {}
+        onDoneButtonClick = {},
+        onClearButtonClick = {},
+        onFilterButtonClick = {},
+        onProductClick = { _, _ -> },
+        onLoadMore = {},
+        trackConfigurableProduct = {}
     )
 }
 
@@ -700,7 +703,7 @@ fun ProductListPreview() {
 @Composable
 fun ProductListEmptyPreview() {
     EmptyProductList(
-        ViewState(
+        state = ViewState(
             products = emptyList(),
             selectedItemsCount = 3,
             loadingState = IDLE,
@@ -708,8 +711,10 @@ fun ProductListEmptyPreview() {
             searchState = ProductSelectorViewModel.SearchState(),
             popularProducts = emptyList(),
             recentProducts = emptyList(),
-        )
-    ) {}
+            selectionMode = ProductSelectorViewModel.SelectionMode.MULTIPLE
+        ),
+        onClearFiltersButtonClick = {}
+    )
 }
 
 @Preview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -437,12 +437,17 @@ private fun ProductList(
 
         WCColoredButton(
             onClick = onDoneButtonClick,
-            text = StringUtils.getQuantityString(
-                quantity = state.selectedItemsCount,
-                default = string.product_selector_select_button_title_default,
-                one = string.product_selector_select_button_title_one,
-                zero = string.done
-            ),
+            text = when (state.selectionMode) {
+                ProductSelectorViewModel.SelectionMode.MULTIPLE -> StringUtils.getQuantityString(
+                    quantity = state.selectedItemsCount,
+                    default = string.product_selector_select_button_title_default,
+                    one = string.product_selector_select_button_title_one,
+                    zero = string.done
+                )
+
+                ProductSelectorViewModel.SelectionMode.SINGLE -> stringResource(id = R.string.done)
+            },
+            enabled = state.isDoneButtonEnabled,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(dimensionResource(id = dimen.major_100))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -76,7 +76,12 @@ fun ProductSelectorScreen(viewModel: ProductSelectorViewModel) {
     viewState?.let { state ->
         Scaffold(topBar = {
             TopAppBar(
-                title = { Text(stringResource(id = string.coupon_conditions_products_select_products_title)) },
+                title = {
+                    Text(
+                        text = state.screenTitleOverride
+                            ?: stringResource(id = string.coupon_conditions_products_select_products_title)
+                    )
+                },
                 navigationIcon = {
                     IconButton(viewModel::onNavigateBack) {
                         Icon(
@@ -394,7 +399,9 @@ private fun ProductList(
                 }
             }
             itemsIndexed(state.products) { _, product ->
-                if (product is ListItem.ConfigurableListItem) { trackConfigurableProduct() }
+                if (product is ListItem.ConfigurableListItem) {
+                    trackConfigurableProduct()
+                }
                 SelectorListItem(
                     title = product.title,
                     imageUrl = product.imageUrl,
@@ -439,7 +446,7 @@ private fun ProductList(
 
         WCColoredButton(
             onClick = onDoneButtonClick,
-            text = when (state.selectionMode) {
+            text = state.ctaButtonTextOverride ?: when (state.selectionMode) {
                 ProductSelectorViewModel.SelectionMode.MULTIPLE -> StringUtils.getQuantityString(
                     quantity = state.selectedItemsCount,
                     default = string.product_selector_select_button_title_default,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -142,6 +142,9 @@ class ProductSelectorViewModel @Inject constructor(
     }.asLiveData()
 
     init {
+        if (navArgs.selectionMode == SelectionMode.SINGLE && (navArgs.selectedItems?.size ?: 0) > 1) {
+            error("Single selection mode can only be used with a single selected item")
+        }
         monitorSearchQuery()
         monitorProductFilters()
         viewModelScope.launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -579,7 +579,9 @@ class ProductSelectorViewModel @Inject constructor(
         val filterState: FilterState,
         val searchState: SearchState,
         val selectionMode: SelectionMode
-    )
+    ) {
+        val isDoneButtonEnabled: Boolean = selectionMode == SelectionMode.MULTIPLE || selectedItemsCount > 0
+    }
 
     @Parcelize
     data class SearchState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -289,6 +289,7 @@ class ProductSelectorViewModel @Inject constructor(
     }
 
     private fun Product.toSimpleUiModel(selectedItems: Collection<SelectedItem>): ListItem {
+        val stockStatus = getStockText(resourceProvider)
         val price = price?.let { PriceUtils.formatCurrency(price, currencyCode, currencyFormatter) }
         val stockAndPrice = listOfNotNull(stockStatus, price).joinToString(" \u2022 ")
 
@@ -300,7 +301,6 @@ class ProductSelectorViewModel @Inject constructor(
             sku = sku.takeIf { it.isNotBlank() },
             stockAndPrice = stockAndPrice,
             numVariations = 0,
-            selectedVariationIds = variationIds.intersect(selectedItems.variationIds.toSet()),
             selectionState = if (selectedItems.any { it.id == remoteId }) SELECTED else UNSELECTED
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -135,7 +135,9 @@ class ProductSelectorViewModel @Inject constructor(
             selectedItemsCount = selectedIds.size,
             filterState = filterState,
             searchState = searchState,
-            selectionMode = navArgs.selectionMode
+            selectionMode = navArgs.selectionMode,
+            screenTitleOverride = navArgs.screenTitleOverride,
+            ctaButtonTextOverride = navArgs.ctaButtonTextOverride,
         )
     }.asLiveData()
 
@@ -600,7 +602,9 @@ class ProductSelectorViewModel @Inject constructor(
         val selectedItemsCount: Int,
         val filterState: FilterState,
         val searchState: SearchState,
-        val selectionMode: SelectionMode
+        val selectionMode: SelectionMode,
+        val screenTitleOverride: String? = null,
+        val ctaButtonTextOverride: String? = null,
     ) {
         val isDoneButtonEnabled: Boolean = selectionMode == SelectionMode.MULTIPLE || selectedItemsCount > 0
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -354,7 +354,7 @@ class ProductSelectorViewModel @Inject constructor(
     }
 
     private fun handleConfigurableItemTap(item: ListItem.ConfigurableListItem) {
-        if (selectedItems.value.containsItemWith(item.id)) {
+        if (selectedItems.value.containsItemWith(item.id) && navArgs.selectionMode == SelectionMode.MULTIPLE) {
             tracker.trackItemUnselected(productSelectorFlow)
             selectedItemsSource.remove(item.id)
             selectedItems.update { items -> items.filter { it.id != item.id } }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -91,7 +91,7 @@ class ProductSelectorViewModel @Inject constructor(
     private val loadingState = MutableStateFlow(IDLE)
     private val selectedItems: MutableStateFlow<List<SelectedItem>> = savedState.getStateFlow(
         viewModelScope,
-        navArgs.selectedItems.toList(),
+        navArgs.selectedItems?.toList() ?: emptyList(),
         "key_selected_items"
     )
     private val filterState = savedState.getStateFlow(viewModelScope, FilterState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -368,7 +368,7 @@ class ProductSelectorViewModel @Inject constructor(
                     selectionMode = navArgs.selectionMode
                 )
             )
-        } else if (!item.isVariable()) {
+        } else {
             updateItemSelection(SelectedItem.Product(item.id), productSource)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/picker/VariationPickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/picker/VariationPickerViewModel.kt
@@ -87,9 +87,10 @@ class VariationPickerViewModel @Inject constructor(
         triggerEvent(
             MultiLiveEvent.Event.ExitWithResult(
                 VariationPickerResult(
-                    navArgs.itemId,
-                    variation.id,
-                    variation.attributes
+                    itemId = navArgs.itemId,
+                    productId = navArgs.productId,
+                    variationId = variation.id,
+                    attributes = variation.attributes
                 )
             )
         )
@@ -114,6 +115,7 @@ class VariationPickerViewModel @Inject constructor(
     @Parcelize
     data class VariationPickerResult(
         val itemId: Long,
+        val productId: Long,
         val variationId: Long,
         val attributes: List<VariantOption>
     ) : Parcelable

--- a/WooCommerce/src/main/res/navigation/nav_graph_product_selector.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_product_selector.xml
@@ -34,6 +34,16 @@
             android:defaultValue="NORMAL"
             app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectionHandling" />
         <argument
+            android:name="screenTitleOverride"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
+        <argument
+            android:name="ctaButtonTextOverride"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
+        <argument
             android:name="selectedItems"
             app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectedItem[]" />
         <argument

--- a/WooCommerce/src/main/res/navigation/nav_graph_product_selector.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_product_selector.xml
@@ -30,6 +30,10 @@
             android:defaultValue="MULTIPLE"
             app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectionMode" />
         <argument
+            android:name="selectionHandling"
+            android:defaultValue="NORMAL"
+            app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectionHandling" />
+        <argument
             android:name="selectedItems"
             app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectedItem[]" />
         <argument

--- a/WooCommerce/src/main/res/navigation/nav_graph_product_selector.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_product_selector.xml
@@ -45,7 +45,9 @@
             app:nullable="true" />
         <argument
             android:name="selectedItems"
-            app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectedItem[]" />
+            android:defaultValue="@null"
+            app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectedItem[]"
+            app:nullable="true" />
         <argument
             android:name="productSelectorFlow"
             app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$ProductSelectorFlow" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_product_selector.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_product_selector.xml
@@ -26,11 +26,15 @@
         android:name="com.woocommerce.android.ui.products.selector.ProductSelectorFragment"
         android:label="ProductSelectorFragment">
         <argument
+            android:name="selectionMode"
+            android:defaultValue="MULTIPLE"
+            app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectionMode" />
+        <argument
             android:name="selectedItems"
             app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectedItem[]" />
         <argument
             android:name="productSelectorFlow"
-            app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$ProductSelectorFlow"/>
+            app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$ProductSelectorFlow" />
         <action
             android:id="@+id/action_productSelectorFragment_to_variationSelectorFragment"
             app:destination="@id/variationSelectorFragment" />
@@ -61,6 +65,9 @@
         <action
             android:id="@+id/action_productSelectorFragment_to_productConfigurationFragment"
             app:destination="@id/productConfigurationFragment" />
+        <action
+            android:id="@+id/action_productSelectorFragment_to_variationPickerFragment"
+            app:destination="@id/variationPickerFragment" />
     </fragment>
     <include app:graph="@navigation/nav_graph_product_filters" />
     <fragment

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -336,13 +336,13 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         val navArgs = ProductSelectorFragmentArgs(
             selectedItems = emptyArray(),
             productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
-        ).toSavedStateHandle()
+        )
         val popularOrdersList = generatePopularOrders()
         val ordersList = generateTestOrders()
         val totalOrders = ordersList + popularOrdersList
         whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
 
-        val sut = createViewModel(navArgs)
+        val sut = createViewModel(navArgs.toSavedStateHandle())
         sut.onProductClick(
             item = ProductListItem(productId = 1, numVariations = 2, title = "", type = ProductType.VARIABLE),
             productSourceForTracking = ProductSourceForTracking.ALPHABETICAL
@@ -353,7 +353,8 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
                 productId = 1,
                 selectedVariationIds = emptySet(),
                 productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
-                productSourceForTracking = ProductSourceForTracking.ALPHABETICAL
+                productSourceForTracking = ProductSourceForTracking.ALPHABETICAL,
+                selectionMode = navArgs.selectionMode
             )
         )
     }
@@ -363,13 +364,13 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         val navArgs = ProductSelectorFragmentArgs(
             selectedItems = emptyArray(),
             productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
-        ).toSavedStateHandle()
+        )
         val popularOrdersList = generatePopularOrders()
         val ordersList = generateTestOrders()
         val totalOrders = ordersList + popularOrdersList
         whenever(orderStore.getPaidOrdersForSiteDesc(selectedSite.get())).thenReturn(totalOrders)
 
-        val sut = createViewModel(navArgs)
+        val sut = createViewModel(navArgs.toSavedStateHandle())
         sut.onProductClick(
             item = ProductListItem(
                 productId = 23,
@@ -385,7 +386,8 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
                 productId = 23,
                 selectedVariationIds = emptySet(),
                 productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
-                productSourceForTracking = ProductSourceForTracking.ALPHABETICAL
+                productSourceForTracking = ProductSourceForTracking.ALPHABETICAL,
+                selectionMode = navArgs.selectionMode
             )
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.Lis
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorRepository
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorViewModel
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -1457,6 +1458,23 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         assertThat(event).isInstanceOf(ProductNavigationTarget.NavigateToVariationSelector::class.java)
         assertThat((event as ProductNavigationTarget.NavigateToVariationSelector).selectionMode)
             .isEqualTo(ProductSelectorViewModel.SelectionMode.SINGLE)
+    }
+
+    @Test
+    fun `when using simple handling, then treat all products as single items`() {
+        val navArgs = ProductSelectorFragmentArgs(
+            selectionHandling = ProductSelectorViewModel.SelectionHandling.SIMPLE,
+            selectedItems = emptyArray(),
+            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
+        ).toSavedStateHandle()
+
+        val sut = createViewModel(navArgs)
+
+        val state = sut.viewState.captureValues().last()
+
+        assertThat(state.products).allMatch {
+            it is ProductListItem && it.numVariations == 0
+        }
     }
 
     private fun generateProductListItem(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -1459,7 +1459,6 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
             .isEqualTo(ProductSelectorViewModel.SelectionMode.SINGLE)
     }
 
-
     private fun generateProductListItem(
         id: Long,
     ) = ProductListItem(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/picker/VariationPickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/picker/VariationPickerViewModelTest.kt
@@ -89,7 +89,12 @@ class VariationPickerViewModelTest : BaseUnitTest() {
 
         // Assert
         val expectedEvent = MultiLiveEvent.Event.ExitWithResult(
-            VariationPickerViewModel.VariationPickerResult(navArgs.itemId, variation.id, variation.attributes)
+            VariationPickerViewModel.VariationPickerResult(
+                itemId = navArgs.itemId,
+                productId = navArgs.productId,
+                variationId = variation.id,
+                attributes = variation.attributes
+            )
         )
         verify(observer).onChanged(expectedEvent)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10486 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates the `ProductSelectorFragment` with the following changes:
1. Adds support for single selection mode.
2. When single selection mode is used, we hide the clear selection button, and update the CTA text to `done` always.
3. Adds a `simple` mode where all products are treated as simple products, and selecting them will simply return the product ID.
4. Allows overriding the screen title and the text of the CTA button.

Even though it's not needed for the Blaze project, the PR attempts to allow for the changes to work independently so we can use single selection mode while keeping the normal handling of advanced product types (variable and bundle products).

### Testing instructions
##### TC1: test new behavior
1. Apply the following patch
<details>
<summary>Patch</summary>

```patch
Subject: [PATCH] ignored
---
Index: WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml	(revision b2688917bce9651cd8993120a93436225918645d)
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml	(date 1703576818538)
@@ -41,11 +41,23 @@
             android:id="@+id/action_orderCreationFragment_to_productSelectorFragment"
             app:destination="@id/nav_graph_product_selector" >
             <argument
+                android:name="selectionMode"
+                app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectionMode" />
+            <argument
+                android:name="selectionHandling"
+                app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectionHandling" />
+            <argument
                 android:name="selectedItems"
                 app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$SelectedItem[]" />
             <argument
                 android:name="productSelectorFlow"
                 app:argType="com.woocommerce.android.ui.products.selector.ProductSelectorViewModel$ProductSelectorFlow" />
+            <argument
+                android:name="screenTitleOverride"
+                app:argType="string" />
+            <argument
+                android:name="ctaButtonTextOverride"
+                app:argType="string" />
         </action>
         <action
             android:id="@+id/action_orderCreationFragment_to_orderCreationCustomerFragment"
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt	(revision b2688917bce9651cd8993120a93436225918645d)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt	(date 1703576831410)
@@ -37,8 +37,12 @@
                     is OrderCreateEditViewModel.Mode.Edit -> ProductSelectorViewModel.ProductSelectorFlow.OrderEditing
                 }
                 OrderCreateEditFormFragmentDirections.actionOrderCreationFragmentToProductSelectorFragment(
+                    selectionMode = ProductSelectorViewModel.SelectionMode.SINGLE,
+                    selectionHandling = ProductSelectorViewModel.SelectionHandling.SIMPLE,
                     selectedItems = target.selectedItems.toTypedArray(),
-                    productSelectorFlow = flow
+                    productSelectorFlow = flow,
+                    screenTitleOverride = "Ready to promote",
+                    ctaButtonTextOverride = "Promote"
                 )
             }
 
```

</details>
2. Open the order list screen.
3. Click on Add order.
4. Click on Add products.
6. Confirm the product selector title and CTA text has been overriden.
7. Text the product selector behavior, and confirm it works as expected.

##### TC2: non-regression
1. Revert the patch.
2. Test adding products during order creation.
3. Confirm the selector works well as a multi-selection component.

### Images/gif
<img src="https://github.com/woocommerce/woocommerce-android/assets/1657201/a78899a6-2a91-4502-a4dc-02f02a37ac92" width=360/>


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
