### PR TITLE
[Tablet Orders] Order creation and payment flow start on the button click

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -176,7 +176,12 @@ class OrderCreateEditFormFragment :
             title = resources.getString(
                 when (viewModel.mode) {
                     Creation -> R.string.create
-                    is Edit -> R.string.done
+                    is Edit -> {
+                        if (FeatureFlag.TABLET_ORDERS_M1.isEnabled()) {
+                            isVisible = false
+                        }
+                        R.string.done
+                    }
                 }
             )
             isEnabled = viewModel.viewStateData.liveData.value?.canCreateOrder ?: false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -69,8 +69,7 @@ import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavi
 import com.woocommerce.android.ui.orders.creation.product.discount.OrderCreateEditProductDiscountFragment.Companion.KEY_PRODUCT_DISCOUNT_RESULT
 import com.woocommerce.android.ui.orders.creation.taxes.rates.TaxRate
 import com.woocommerce.android.ui.orders.creation.taxes.rates.TaxRateSelectorFragment.Companion.KEY_SELECTED_TAX_RATE
-import com.woocommerce.android.ui.orders.creation.totals.OrderCreateEditTotalsFullView
-import com.woocommerce.android.ui.orders.creation.totals.OrderCreateEditTotalsMinimisedView
+import com.woocommerce.android.ui.orders.creation.totals.OrderCreateEditTotalsView
 import com.woocommerce.android.ui.orders.creation.totals.TotalsSectionsState
 import com.woocommerce.android.ui.orders.creation.views.ExpandableGroupedProductCard
 import com.woocommerce.android.ui.orders.creation.views.ExpandableGroupedProductCardLoading
@@ -355,20 +354,11 @@ class OrderCreateEditFormFragment :
 
         viewModel.totalsData.observe(viewLifecycleOwner) {
             when (it) {
-                is TotalsSectionsState.Full -> {
-                    binding.totalsSection.show()
-                    binding.totalsSection.setContent {
-                        OrderCreateEditTotalsFullView(state = it)
-                    }
-                    binding.scrollView.post {
-                        binding.scrollView.setPadding(0, 0, 0, binding.totalsSection.height)
-                    }
-                }
-
+                is TotalsSectionsState.Full,
                 is TotalsSectionsState.Minimised -> {
                     binding.totalsSection.show()
                     binding.totalsSection.setContent {
-                        OrderCreateEditTotalsMinimisedView(state = it)
+                        OrderCreateEditTotalsView(state = it)
                     }
                     binding.scrollView.post {
                         binding.scrollView.setPadding(0, 0, 0, binding.totalsSection.height)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -360,12 +360,18 @@ class OrderCreateEditFormFragment :
                     binding.totalsSection.setContent {
                         OrderCreateEditTotalsFullView(state = it)
                     }
+                    binding.scrollView.post {
+                        binding.scrollView.setPadding(0, 0, 0, binding.totalsSection.height)
+                    }
                 }
 
                 is TotalsSectionsState.Minimised -> {
                     binding.totalsSection.show()
                     binding.totalsSection.setContent {
                         OrderCreateEditTotalsMinimisedView(state = it)
+                    }
+                    binding.scrollView.post {
+                        binding.scrollView.setPadding(0, 0, 0, binding.totalsSection.height)
                     }
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -98,6 +98,7 @@ import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavi
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.EditShipping
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.SelectItems
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.ShowCreatedOrder
+import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.ShowCreatedOrderAndStartPaymentFlow
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.TaxRateSelector
 import com.woocommerce.android.ui.orders.creation.product.discount.CurrencySymbolFinder
 import com.woocommerce.android.ui.orders.creation.taxes.GetAddressFromTaxRate
@@ -251,7 +252,7 @@ class OrderCreateEditViewModel @Inject constructor(
                 onCouponsClicked = { onCouponButtonClicked() },
                 onGiftClicked = { onEditGiftCardButtonClicked(order.selectedGiftCard) },
                 onTaxesLearnMore = { onTaxHelpButtonClicked() },
-                onMainButtonClicked = {},
+                onMainButtonClicked = { onPrimaryButtonClicked() },
             )
         }
 
@@ -1097,24 +1098,27 @@ class OrderCreateEditViewModel @Inject constructor(
 
     fun onCreateOrderClicked(order: Order) {
         when (mode) {
-            Mode.Creation -> viewModelScope.launch {
+            Mode.Creation -> {
                 trackCreateOrderButtonClick()
-                viewState = viewState.copy(isProgressDialogShown = true)
-                val giftCard = _selectedGiftCard.value
-                orderCreateEditRepository.placeOrder(order, giftCard).fold(
-                    onSuccess = {
-                        trackOrderCreationSuccess()
-                        triggerEvent(ShowSnackbar(string.order_creation_success_snackbar))
-                        triggerEvent(ShowCreatedOrder(it.id))
-                    },
-                    onFailure = {
-                        trackOrderCreationFailure(it)
-                        viewState = viewState.copy(isProgressDialogShown = false)
-                        triggerEvent(ShowSnackbar(string.order_creation_failure_snackbar))
-                    }
-                )
+                createOrder(order) {
+                    triggerEvent(ShowSnackbar(string.order_creation_success_snackbar))
+                    triggerEvent(ShowCreatedOrder(it.id))
+                }
             }
 
+            is Mode.Edit -> {
+                triggerEvent(Exit)
+            }
+        }
+    }
+
+    private fun onPrimaryButtonClicked() {
+        when (mode) {
+            Mode.Creation -> {
+                createOrder(currentDraft) {
+                    triggerEvent(ShowCreatedOrderAndStartPaymentFlow(it.id))
+                }
+            }
             is Mode.Edit -> {
                 triggerEvent(Exit)
             }
@@ -1132,6 +1136,24 @@ class OrderCreateEditViewModel @Inject constructor(
                 mutableMap[KEY_COUPONS_COUNT] = orderDraft.value?.couponLines?.size ?: 0
             }
         )
+    }
+
+    private fun createOrder(order: Order, onSuccess: (Order) -> Unit) {
+        launch {
+            viewState = viewState.copy(isProgressDialogShown = true)
+            val giftCard = _selectedGiftCard.value
+            orderCreateEditRepository.placeOrder(order, giftCard).fold(
+                onSuccess = {
+                    trackOrderCreationSuccess()
+                    onSuccess(it)
+                },
+                onFailure = {
+                    trackOrderCreationFailure(it)
+                    viewState = viewState.copy(isProgressDialogShown = false)
+                    triggerEvent(ShowSnackbar(string.order_creation_failure_snackbar))
+                }
+            )
+        }
     }
 
     fun onBackButtonClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -98,7 +98,6 @@ import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavi
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.EditShipping
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.SelectItems
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.ShowCreatedOrder
-import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.ShowCreatedOrderAndStartPaymentFlow
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.TaxRateSelector
 import com.woocommerce.android.ui.orders.creation.product.discount.CurrencySymbolFinder
 import com.woocommerce.android.ui.orders.creation.taxes.GetAddressFromTaxRate
@@ -1102,7 +1101,7 @@ class OrderCreateEditViewModel @Inject constructor(
                 trackCreateOrderButtonClick()
                 createOrder(order) {
                     triggerEvent(ShowSnackbar(string.order_creation_success_snackbar))
-                    triggerEvent(ShowCreatedOrder(it.id))
+                    triggerEvent(ShowCreatedOrder(it.id, startPaymentFlow = false))
                 }
             }
 
@@ -1116,7 +1115,7 @@ class OrderCreateEditViewModel @Inject constructor(
         when (mode) {
             Mode.Creation -> {
                 createOrder(currentDraft) {
-                    triggerEvent(ShowCreatedOrderAndStartPaymentFlow(it.id))
+                    triggerEvent(ShowCreatedOrder(it.id, startPaymentFlow = true))
                 }
             }
             is Mode.Edit -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigationTarget.kt
@@ -24,6 +24,7 @@ sealed class OrderCreateEditNavigationTarget : Event() {
     ) : OrderCreateEditNavigationTarget()
 
     data class ShowCreatedOrder(val orderId: Long) : OrderCreateEditNavigationTarget()
+    data class ShowCreatedOrderAndStartPaymentFlow(val orderId: Long) : OrderCreateEditNavigationTarget()
     data class EditShipping(val currentShippingLine: ShippingLine?) :
         OrderCreateEditNavigationTarget()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigationTarget.kt
@@ -23,8 +23,10 @@ sealed class OrderCreateEditNavigationTarget : Event() {
         val mode: OrderCreateEditViewModel.Mode
     ) : OrderCreateEditNavigationTarget()
 
-    data class ShowCreatedOrder(val orderId: Long) : OrderCreateEditNavigationTarget()
-    data class ShowCreatedOrderAndStartPaymentFlow(val orderId: Long) : OrderCreateEditNavigationTarget()
+    data class ShowCreatedOrder(
+        val orderId: Long,
+        val startPaymentFlow: Boolean,
+    ) : OrderCreateEditNavigationTarget()
     data class EditShipping(val currentShippingLine: ShippingLine?) :
         OrderCreateEditNavigationTarget()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt
@@ -50,7 +50,7 @@ object OrderCreateEditNavigator {
 
             is ShowCreatedOrder ->
                 OrderCreateEditFormFragmentDirections
-                    .actionOrderCreationFragmentToOrderDetailFragment(target.orderId)
+                    .actionOrderCreationFragmentToOrderDetailFragment(target.orderId, target.startPaymentFlow)
 
             is EditShipping ->
                 OrderCreateEditFormFragmentDirections

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsFullView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsFullView.kt
@@ -1,8 +1,13 @@
 package com.woocommerce.android.ui.orders.creation.totals
 
 import android.content.res.Configuration
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -55,14 +60,37 @@ import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooTheme
 
 @Composable
-fun OrderCreateEditTotalsFullView(state: TotalsSectionsState.Full) {
+fun OrderCreateEditTotalsView(state: TotalsSectionsState) {
+    AnimatedVisibility(
+        visible = state is TotalsSectionsState.Full,
+        enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
+        exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut()
+    ) {
+        if (state is TotalsSectionsState.Full) {
+            OrderCreateEditTotalsFullView(state)
+        }
+    }
+
+    AnimatedVisibility(
+        visible = state is TotalsSectionsState.Minimised,
+        enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
+        exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut()
+    ) {
+        if (state is TotalsSectionsState.Minimised) {
+            OrderCreateEditTotalsMinimisedView(state)
+        }
+    }
+}
+
+@Composable
+private fun OrderCreateEditTotalsFullView(state: TotalsSectionsState.Full) {
     PanelWithShadow {
         TotalsView(state)
     }
 }
 
 @Composable
-fun OrderCreateEditTotalsMinimisedView(
+private fun OrderCreateEditTotalsMinimisedView(
     state: TotalsSectionsState.Minimised
 ) {
     PanelWithShadow {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
@@ -204,7 +204,7 @@ class OrderCreateEditTotalsHelper @Inject constructor(
                 R.string.order_creation_collect_payment_button
             )
 
-            is OrderCreateEditViewModel.Mode.Edit -> resourceProvider.getString(R.string.save)
+            is OrderCreateEditViewModel.Mode.Edit -> resourceProvider.getString(R.string.done)
         }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
@@ -63,7 +63,7 @@ class OrderCreateEditTotalsHelper @Inject constructor(
                     orderTotal = order.toOrderTotals(bigDecimalFormatter),
                     mainButton = TotalsSectionsState.Button(
                         text = mode.toButtonText(),
-                        enabled = true,
+                        enabled = viewState.canCreateOrder,
                         onClick = onMainButtonClicked,
                     )
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -456,9 +456,7 @@ class OrderDetailFragment :
                 viewModel.onSeeReceiptClicked()
             },
             onCollectPaymentClickListener = {
-                cardReaderManager.let {
-                    viewModel.onAcceptCardPresentPaymentClicked()
-                }
+                viewModel.onCollectPaymentClicked()
             },
             onPrintingInstructionsClickListener = {
                 viewModel.onPrintingInstructionsClicked()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -455,7 +455,7 @@ class OrderDetailFragment :
             onSeeReceiptClickListener = {
                 viewModel.onSeeReceiptClicked()
             },
-            onCollectCardPresentPaymentClickListener = {
+            onCollectPaymentClickListener = {
                 cardReaderManager.let {
                     viewModel.onAcceptCardPresentPaymentClicked()
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -322,7 +322,7 @@ class OrderDetailViewModel @Inject constructor(
         it.contains(navArgs.orderId) && it.last() != navArgs.orderId
     } ?: false
 
-    fun onAcceptCardPresentPaymentClicked() {
+    fun onCollectPaymentClicked() {
         cardReaderTracker.trackCollectPaymentTapped()
         triggerEvent(StartPaymentFlow(orderId = order.id))
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -162,6 +162,10 @@ class OrderDetailViewModel @Inject constructor(
             pluginsInformation = orderDetailRepository.getOrderDetailsPluginsInfo()
         }
         _productList.distinctUntilChanged().observeForever(productListObserver)
+
+        if (navArgs.startPaymentFlow) {
+            triggerEvent(StartPaymentFlow(orderId = navArgs.orderId))
+        }
     }
 
     fun start() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -41,7 +41,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         formatCurrencyForDisplay: (BigDecimal) -> String,
         onSeeReceiptClickListener: (view: View) -> Unit,
         onIssueRefundClickListener: (view: View) -> Unit,
-        onCollectCardPresentPaymentClickListener: (view: View) -> Unit,
+        onCollectPaymentClickListener: (view: View) -> Unit,
         onPrintingInstructionsClickListener: (view: View) -> Unit
     ) {
         binding.paymentInfoProductsTotal.text = formatCurrencyForDisplay(order.productsTotal)
@@ -87,7 +87,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         updateDiscountsSection(order, formatCurrencyForDisplay)
         updateFeesSection(order, formatCurrencyForDisplay)
         updateRefundSection(order, formatCurrencyForDisplay, onIssueRefundClickListener)
-        updateCollectPaymentSection(order, onCollectCardPresentPaymentClickListener)
+        updateCollectPaymentSection(order, onCollectPaymentClickListener)
         updateSeeReceiptSection(isReceiptAvailable, onSeeReceiptClickListener)
         updatePrintingInstructionSection(isPaymentCollectableWithCardReader, onPrintingInstructionsClickListener)
     }
@@ -180,14 +180,14 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
 
     private fun updateCollectPaymentSection(
         order: Order,
-        onCollectCardPresentPaymentClickListener: (view: View) -> Unit
+        onCollectPaymentClickListener: (view: View) -> Unit
     ) {
         if (order.isOrderPaid) {
             binding.paymentInfoCollectCardPresentPaymentButton.visibility = GONE
         } else {
             binding.paymentInfoCollectCardPresentPaymentButton.visibility = VISIBLE
             binding.paymentInfoCollectCardPresentPaymentButton.setOnClickListener(
-                onCollectCardPresentPaymentClickListener
+                onCollectPaymentClickListener
             )
         }
     }

--- a/WooCommerce/src/main/res/layout/fragment_order_create_edit_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_create_edit_form.xml
@@ -20,6 +20,7 @@
         android:id="@+id/scrollView"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:clipToPadding="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -65,6 +65,9 @@
             <argument
                 android:name="orderId"
                 app:argType="long" />
+            <argument
+                android:name="startPaymentFlow"
+                app:argType="boolean" />
         </action>
         <action
             android:id="@+id/action_orderCreationFragment_to_orderCreationShippingFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -174,6 +174,10 @@
             android:name="remoteNoteId"
             android:defaultValue="0L"
             app:argType="long" />
+        <argument
+            android:name="startPaymentFlow"
+            android:defaultValue="false"
+            app:argType="boolean" />
         <action
             android:id="@+id/action_orderDetailFragment_to_orderDetailFragment"
             app:destination="@+id/orderDetailFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1339,7 +1339,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             viewModel.start()
 
             // When
-            viewModel.onAcceptCardPresentPaymentClicked()
+            viewModel.onCollectPaymentClicked()
 
             // Then
             assertThat(viewModel.event.value).isInstanceOf(OrderNavigationTarget.StartPaymentFlow::class.java)
@@ -1353,7 +1353,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             viewModel.start()
 
             // When
-            viewModel.onAcceptCardPresentPaymentClicked()
+            viewModel.onCollectPaymentClicked()
 
             // Then
             verify(cardReaderTracker).trackCollectPaymentTapped()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10487
Closes: #10469 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
* Implements "collect payment" and "done" actions on the main button
* Adds bottom padding so the whole content is reachable

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Try order creation and editing
* Notice that the main button in this drawer is now functional
* Make sure that in release mode, everything as it used to be

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/4923871/3447eaa6-67a7-44a8-852d-ba4a70724777



- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
