### PR TITLE
Add the date type parameter to fetch stats

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-dae4b39bd59ee84747ef438471d98613efc9092a'
+    fluxCVersion = '2932-ad5e4105b6e72505839aad7094d4cd893f0a48a5'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Closes: #10455 

⚠️ Depends on this FluxC PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2932

## Why
As described in pe5pgL-49w-p2, because the app displays the revenue and product stats on the same analytics screen, when the revenue stats are fetched with the WC date type option from the analytics settings (`date_paid` by default) that's different from the date column (`date_created`) used in product stats, the data could look inconsistent for orders completed on a different date from the creation date. As a relatively simpler solution, a new parameter `date_type` was added to the revenue stats endpoint in core https://github.com/woocommerce/woocommerce/pull/42938 that we can set to `date_created` so that the revenue stats can always be based on the same date column as product stats.

## How
This PR just updates the FluxC version to use the one sending the `date_type` parameter when fetching the revenue stats.

## Testing instructions
Hand-testing is optional, as the parameter doesn't have any effect in existing stores right now.

Prerequisite: in the store analytics settings `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fsettings`, `Date type` option is `Date paid`. The store has at least one order with at least one product, created on a different day, but the status is pending / not completed.

### Store with parameter support

Additional prerequisite: the store has a WC version that includes the change in https://github.com/woocommerce/woocommerce/pull/42938
You can find one here: https://drive.google.com/file/d/1qIaCFbk_41b7TSfB6kpOO89IIQ97P7dK/view?usp=sharing


- In core or mobile, mark the order in the prerequisite as paid (in core, you can go to the order page and update the order status to `Processing` or one of the statuses in the analytics settings > `Actionable statuses`. in mobile, tap `Collect Payment` > `Cash` > `Mark as paid`)
- In the app, go to the My store tab and refresh the dashboard stats after 0.5-1 minute of the last step --> there should not be revenue shown in the dashboard
- Tap `See More`, then set the date range to include the creation date of the order in the prerequisite --> the revenue and product stats should be shown for the order

### Backward compatibility testing

Additional prerequisite: the store does not have a WC version that includes the change in https://github.com/woocommerce/woocommerce/pull/42938

- In the app, go to the My store tab --> the revenue/product stats should be shown as before

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

For example, in the screenshots below, the order was created on December 20 but paid on December 26 (Today).

before | after
-- | --
<img src="https://github.com/woocommerce/woocommerce-android/assets/18119390/ae0edbb8-14d6-4855-9b2b-588377ae0cfa" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-android/assets/18119390/e269c3ae-3620-4dbc-9d31-074cc878a7c7" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

