### PR TITLE
[Tablet Orders] Remove order status from the order creation screen

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/UnifiedOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/UnifiedOrderScreen.kt
@@ -26,7 +26,7 @@ class UnifiedOrderScreen : Screen(R.id.order_creation_root) {
     }
 
     fun updateOrderStatus(newOrderStatus: String): UnifiedOrderScreen {
-        clickOn(R.id.orderStatus_editButton)
+        clickOn(R.id.orderStatus_editImage)
         waitForElementToBeDisplayed(androidx.appcompat.R.id.select_dialog_listview)
         Espresso.onView(withText(newOrderStatus))
             .perform(click())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -215,18 +215,32 @@ class OrderCreateEditFormFragment :
     }
 
     private fun FragmentOrderCreateEditFormBinding.initOrderStatusView() {
-        val mode = when (viewModel.mode) {
-            Creation -> OrderDetailOrderStatusView.Mode.OrderCreation
-            is Edit -> OrderDetailOrderStatusView.Mode.OrderEdit
-        }
-        orderStatusView.initView(
-            mode = mode,
-            editOrderStatusClickListener = {
-                viewModel.orderStatusData.value?.let {
-                    viewModel.onEditOrderStatusClicked(it)
+        when (viewModel.mode) {
+            Creation -> {
+                if (FeatureFlag.TABLET_ORDERS_M1.isEnabled()) {
+                    orderStatusView.visibility = View.GONE
+                } else {
+                    orderStatusView.initView(
+                        mode = OrderDetailOrderStatusView.Mode.OrderCreation,
+                        editOrderStatusClickListener = {
+                            viewModel.orderStatusData.value?.let {
+                                viewModel.onEditOrderStatusClicked(it)
+                            }
+                        }
+                    )
                 }
             }
-        )
+            is Edit -> {
+                orderStatusView.initView(
+                    mode = OrderDetailOrderStatusView.Mode.OrderEdit,
+                    editOrderStatusClickListener = {
+                        viewModel.orderStatusData.value?.let {
+                            viewModel.onEditOrderStatusClicked(it)
+                        }
+                    }
+                )
+            }
+        }
     }
 
     private fun FragmentOrderCreateEditFormBinding.initNotesSection() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -61,7 +61,6 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
         this.mode = mode
         when (mode) {
             Mode.OrderEdit -> {
-                binding.orderStatusEditButton.isVisible = false
                 binding.orderStatusEditImage.isVisible = true
                 with(binding.orderStatusContainer) {
                     isClickable = true
@@ -70,7 +69,6 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
                 }
             }
             Mode.OrderCreation -> {
-                binding.orderStatusEditButton.isVisible = false
                 with(binding.orderStatusEditImage) {
                     isVisible = true
                     setOnClickListener(editOrderStatusClickListener)

--- a/WooCommerce/src/main/res/layout/order_detail_order_status.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_order_status.xml
@@ -53,17 +53,6 @@
                 android:paddingVertical="@dimen/major_75"
                 android:src="@drawable/ic_edit_pencil"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@+id/orderStatus_editButton"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/orderStatus_editButton"
-                style="@style/Woo.Button.TextButton.Secondary"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/order_creation_status_edit_content_description"
-                android:text="@string/edit"
-                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10491
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
* The PR removes order status from order creation flow (behind FF for now)
* Also I removed unused "edit" button that was there but never been shown

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Start order creation flow -> notice missing order status section
* Start order editing flow -> notice order status section still here
* Build release -> notice that both flows have order status section

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="365" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/4923871/ec804fe4-44d7-4b04-8ff7-c2b82a1970f8">
<img width="363" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/4923871/819bbb07-97be-47b0-a4d1-b5c1945050ea">

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
