### PR TITLE
[Tablet Orders] Display tax calculated based on address

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
@@ -58,7 +58,11 @@ class OrderCreateEditTotalsHelper @Inject constructor(
                             bigDecimalFormatter,
                             onClick = onGiftClicked
                         ),
-                        order.toTaxesSection(bigDecimalFormatter, onClick = onTaxesLearnMore),
+                        order.toTaxesSection(
+                            bigDecimalFormatter,
+                            viewState.taxBasedOnSettingLabel,
+                            onClick = onTaxesLearnMore
+                        ),
                         order.toDiscountSection(bigDecimalFormatter),
                     ),
                     orderTotal = order.toOrderTotals(bigDecimalFormatter),
@@ -163,6 +167,7 @@ class OrderCreateEditTotalsHelper @Inject constructor(
 
     private fun Order.toTaxesSection(
         bigDecimalFormatter: (BigDecimal) -> String,
+        taxBasedOnSettingLabel: String,
         onClick: () -> Unit
     ): TotalsSectionsState.Line =
         TotalsSectionsState.Line.Block(
@@ -177,9 +182,7 @@ class OrderCreateEditTotalsHelper @Inject constructor(
                     value = bigDecimalFormatter(BigDecimal(it.taxTotal))
                 )
             } + TotalsSectionsState.Line.LearnMore(
-                text = resourceProvider.getString(
-                    R.string.order_creation_tax_based_on_billing_address
-                ),
+                text = taxBasedOnSettingLabel,
                 buttonText = resourceProvider.getString(R.string.learn_more),
                 onClick = onClick
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelperTest.kt
@@ -152,11 +152,15 @@ class OrderCreateEditTotalsHelperTest {
         val onMainButtonClicked = mock<() -> Unit>()
         val onExpandCollapseClicked = mock<(Boolean) -> Unit>()
 
+        val taxBasedOnSettingLabel = "tax based on billing address"
+
         // WHEN
         val actual = helper.mapToPaymentTotalsState(
             localOrder,
             OrderCreateEditViewModel.Mode.Creation,
-            OrderCreateEditViewModel.ViewState(),
+            OrderCreateEditViewModel.ViewState(
+                taxBasedOnSettingLabel = taxBasedOnSettingLabel
+            ),
             onShippingClicked,
             onCouponsClicked,
             onGiftClicked,
@@ -206,7 +210,7 @@ class OrderCreateEditTotalsHelperTest {
         assertThat((taxesLines[1] as TotalsSectionsState.Line.SimpleSmall).value).isEqualTo("10.00$")
         assertThat((taxesLines[2] as TotalsSectionsState.Line.SimpleSmall).label).isEqualTo("tax 2 · 6.0")
         assertThat((taxesLines[2] as TotalsSectionsState.Line.SimpleSmall).value).isEqualTo("11.00$")
-        assertThat((taxesLines[3] as TotalsSectionsState.Line.LearnMore).text).isEqualTo("tax based on billing address")
+        assertThat((taxesLines[3] as TotalsSectionsState.Line.LearnMore).text).isEqualTo(taxBasedOnSettingLabel)
         assertThat((taxesLines[3] as TotalsSectionsState.Line.LearnMore).buttonText).isEqualTo("learn More")
         assertThat((taxesLines[3] as TotalsSectionsState.Line.LearnMore).onClick == onTaxesLearnMore).isTrue()
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10501
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I noticed that I have a hardcoded the `Calculated on {xxx} address` string. This PR fixes that bug

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Start order creation
* Notice `Calculated on {xxx} address` next to learn more set

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="361" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/4923871/8f39bb02-319b-4992-b70b-1db34e7573d3">

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
