### PR TITLE
[Order Creation] Fix the bug when lock icon half visible

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,8 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+17.0
+-----
+- [*] [Internal] "Lock" icon is fully visible after a product is deleted from an order [https://github.com/woocommerce/woocommerce-android/pull/10508]
+
 16.8
 -----
 - [*] [Internal] Deposit summary on the payments screen got some design improvements [https://github.com/woocommerce/woocommerce-android/pull/10408]

--- a/WooCommerce/src/main/res/layout/order_creation_section.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_section.xml
@@ -13,10 +13,11 @@
         android:layout_marginTop="@dimen/major_75"
         android:accessibilityHeading="true"
         android:textAppearance="?attr/textAppearanceHeadline6"
+        app:layout_constraintHorizontal_weight="2"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintHorizontal_weight="2"
-        tools:ignore="UnusedAttribute" />
+        tools:ignore="UnusedAttribute"
+        tools:text="Header" />
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/edit_button"
@@ -24,49 +25,58 @@
         android:layout_height="@dimen/major_150"
         android:layout_margin="@dimen/major_100"
         android:padding="@dimen/minor_25"
-        android:visibility="gone"
         android:src="@drawable/ic_edit_pencil"
-        app:layout_constraintHorizontal_weight="1"
+        android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_weight="1"
         app:layout_constraintTop_toTopOf="parent"
-        tools:visibility="visible"/>
+        tools:visibility="visible" />
 
     <ImageView
         android:id="@+id/barcode_icon"
         android:layout_width="@dimen/image_minor_50"
         android:layout_height="@dimen/image_minor_50"
         android:layout_marginEnd="@dimen/major_100"
+        android:contentDescription="@string/order_editing_barcode_content_description"
         android:src="@drawable/ic_barcode"
         android:visibility="gone"
-        android:contentDescription="@string/order_editing_barcode_content_description"
         app:layout_constraintBottom_toBottomOf="@+id/header_label"
         app:layout_constraintEnd_toStartOf="@id/add_icon"
-        app:layout_constraintTop_toTopOf="@+id/header_label" />
+        app:layout_constraintTop_toTopOf="@+id/header_label"
+        tools:visibility="visible" />
 
     <ImageView
         android:id="@+id/add_icon"
         android:layout_width="@dimen/image_minor_50"
         android:layout_height="@dimen/image_minor_50"
         android:layout_marginEnd="@dimen/major_100"
-        android:src="@drawable/ic_add"
         android:contentDescription="@string/order_editing_add_content_description"
+        android:src="@drawable/ic_add"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@+id/header_label"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/header_label" />
-
+        app:layout_constraintEnd_toStartOf="@id/lock_icon"
+        app:layout_constraintTop_toTopOf="@+id/header_label"
+        tools:visibility="visible" />
 
     <ImageView
         android:id="@+id/lock_icon"
         android:layout_width="@dimen/image_minor_40"
         android:layout_height="@dimen/image_minor_40"
+        android:layout_marginTop="@dimen/major_100"
         android:layout_marginEnd="@dimen/major_100"
-        android:src="@drawable/ic_lock"
         android:contentDescription="@string/order_editing_locked_content_description"
+        android:src="@drawable/ic_lock"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="@+id/header_label"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/header_label" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/barrier"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="header_label,edit_button,barcode_icon,add_icon,lock_icon" />
 
     <FrameLayout
         android:id="@+id/content_layout"
@@ -78,14 +88,15 @@
         app:layout_constraintBottom_toTopOf="@id/add_buttons_layout"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/header_label"
-        app:layout_goneMarginBottom="@dimen/major_100" />
+        app:layout_constraintTop_toBottomOf="@id/barrier"
+        app:layout_goneMarginBottom="@dimen/major_100"
+        tools:visibility="visible" />
 
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/add_buttons_layout"
-        android:orientation="vertical"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10506 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes layout so lock icon is fully visible

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Start order creation 
* Add a product
* Click "remove product."
* Notice that the lock icon is fully visible
* Make sure that there are no UI regression

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

![image](https://github.com/woocommerce/woocommerce-android/assets/4923871/f8363447-2d7b-4ade-a3e2-a263c938aafe)

https://github.com/woocommerce/woocommerce-android/assets/4923871/1a666fee-df15-4b3c-bfa4-053980b63ec4

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
