### PR TITLE
Fix/fetch products from api upon creating campaign

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/BlazeCampaignCreationDispatcher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/BlazeCampaignCreationDispatcher.kt
@@ -72,7 +72,13 @@ class BlazeCampaignCreationDispatcher @Inject constructor(
                 handler(BlazeCampaignCreationDispatcherEvent.ShowProductSelectorScreen)
             }
             else -> {
-                WooLog.w(WooLog.T.BLAZE, "No products available to create a campaign")
+                WooLog.w(WooLog.T.BLAZE, "Fetching products from the API")
+                val fetchedProducts = productListRepository.fetchProductList()
+                if (fetchedProducts.isNotEmpty()) {
+                    handler(BlazeCampaignCreationDispatcherEvent.ShowProductSelectorScreen)
+                } else {
+                    WooLog.w(WooLog.T.BLAZE, "No products available to create a campaign")
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/BlazeCampaignCreationDispatcher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/BlazeCampaignCreationDispatcher.kt
@@ -59,7 +59,7 @@ class BlazeCampaignCreationDispatcher @Inject constructor(
         productId: Long?,
         handler: (BlazeCampaignCreationDispatcherEvent) -> Unit
     ) {
-        val products = getPublishedProducts()
+        val products = getPublishedCachedProducts()
 
         when {
             productId != null -> {
@@ -83,11 +83,11 @@ class BlazeCampaignCreationDispatcher @Inject constructor(
         }
     }
 
-    private suspend fun getPublishedProducts() = withContext(coroutineDispatchers.io) {
+    private suspend fun getPublishedCachedProducts() = withContext(coroutineDispatchers.io) {
         productListRepository.getProductList(
             productFilterOptions = mapOf(ProductFilterOption.STATUS to ProductStatus.PUBLISH.value),
             sortType = ProductSorting.DATE_DESC,
-        )
+        ).filterNot { it.isSampleProduct }
     }
 
     private fun handleEvent(event: BlazeCampaignCreationDispatcherEvent) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/BlazeCampaignCreationDispatcher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/BlazeCampaignCreationDispatcher.kt
@@ -72,13 +72,9 @@ class BlazeCampaignCreationDispatcher @Inject constructor(
                 handler(BlazeCampaignCreationDispatcherEvent.ShowProductSelectorScreen)
             }
             else -> {
-                WooLog.w(WooLog.T.BLAZE, "Fetching products from the API")
-                val fetchedProducts = productListRepository.fetchProductList()
-                if (fetchedProducts.isNotEmpty()) {
-                    handler(BlazeCampaignCreationDispatcherEvent.ShowProductSelectorScreen)
-                } else {
-                    WooLog.w(WooLog.T.BLAZE, "No products available to create a campaign")
-                }
+                // If there are no cached products at this point, we should ensure the code triggering
+                // this code, has previously refreshed the products from the API.
+                WooLog.w(WooLog.T.BLAZE, "No products available to create a campaign")
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Coming from this PR, we found a bug: https://github.com/woocommerce/woocommerce-android/pull/10512#issuecomment-1876714489 where products are not fetched from the API when displaying Blaze view, leading to several unexpected behaviors. 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

**The bug**
Clicking on "Create campaign" from My Store Blaze view is not working.

**Steps to reproduce:** 

1. Clear the app's data
2. Log into a site that has products published and existing Blaze campaigns.
3. Do not open the products tab.
4. Try to create a campaign from Blaze My Store view. If you had campaigns previously created, tapping on "Create campaign" won't do anything. 

https://github.com/woocommerce/woocommerce-android/assets/2663464/06b4f365-06ca-4c12-aaea-e0f43c9fd7aa

**The reason** why this happens is because in the scenario above, the product DB is empty and we are not fetching the products from the API in getPublishedProducts from BlazeCampaignCreationDispatcher. This bug is unrelated to the changes from the PR. I'll handle the fix in a different PR.

This PR also fixes another bug which is a corner case: 
- With existing Blaze campaigns remove all the published products from the store
- My store Blaze view is still shown in My Store tab. 

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Clear the app's data
2. Log into a site that has products published and existing Blaze campaigns.
3. Do not open the products tab.
4. When tapping on "Create campaign" from My Store Blaze view, the product selector screen should be opened correctly.
