### PR TITLE
Blaze: Intro screen Learn more bottom sheet

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroScreen.kt
@@ -41,12 +41,15 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.FontWeight.Companion
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.BottomSheetHandle
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
@@ -85,7 +88,8 @@ fun BlazeCampaignCreationIntroScreen(
         val coroutineScope = rememberCoroutineScope()
         val modalSheetState = rememberModalBottomSheetState(
             initialValue = Hidden,
-            confirmValueChange = { it != HalfExpanded }
+            confirmValueChange = { it != HalfExpanded },
+            skipHalfExpanded = true
         )
 
         WCModalBottomSheetLayout(
@@ -93,8 +97,7 @@ fun BlazeCampaignCreationIntroScreen(
                 BlazeCampaignBottomSheetContent(
                     onDismissClick = {
                         coroutineScope.launch { modalSheetState.hide() }
-                    },
-                    onLearnMoreClick = { }
+                    }
                 )
             },
             sheetState = modalSheetState,
@@ -232,9 +235,16 @@ private fun BlazeCampaignBenefitPoint(
 
 @Composable
 private fun BlazeCampaignBottomSheetContent(
-    onDismissClick: () -> Unit,
-    onLearnMoreClick: () -> Unit
+    onDismissClick: () -> Unit
 ) {
+    val learnMoreItems = listOf(
+        annotatedStringRes(R.string.blaze_campaign_creation_new_intro_learn_item_1),
+        annotatedStringRes(R.string.blaze_campaign_creation_new_intro_learn_item_2),
+        annotatedStringRes(R.string.blaze_campaign_creation_new_intro_learn_item_3),
+        annotatedStringRes(R.string.blaze_campaign_creation_new_intro_learn_item_4),
+        annotatedStringRes(R.string.blaze_campaign_creation_new_intro_learn_item_5),
+    )
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
@@ -253,45 +263,29 @@ private fun BlazeCampaignBottomSheetContent(
             Text(
                 text = stringResource(id = R.string.blaze_campaign_creation_new_intro_learn_more),
                 textAlign = TextAlign.Center,
+                fontSize = 17.sp,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier
                     .align(Alignment.Center)
             )
 
-            CloseButton(onDismissClick, modifier = Modifier.align(Alignment.CenterEnd))
+            CloseButton(onDismissClick, modifier = Modifier.align(Alignment.CenterStart))
         }
 
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_150)))
 
-        StepItem(
-            number = 1,
-            text = stringResource(id = R.string.blaze_campaign_creation_new_intro_learn_point_1),
-            position = StepPosition.FIRST
-        )
 
-        Divider(color = colorResource(id = R.color.color_surface_elevated), thickness = 1.dp)
+        learnMoreItems.forEachIndexed { i, item ->
+            if (i > 0) {
+                Divider(color = colorResource(id = R.color.color_surface_elevated), thickness = 1.dp)
+            }
 
-        StepItem(
-            number = 2,
-            text = stringResource(id = R.string.blaze_campaign_creation_new_intro_learn_point_2),
-            position = StepPosition.MIDDLE
-        )
-
-        Divider(color = colorResource(id = R.color.color_surface_elevated), thickness = 1.dp)
-
-        StepItem(
-            number = 3,
-            text = stringResource(id = R.string.blaze_campaign_creation_new_intro_learn_point_3),
-            position = StepPosition.LAST
-        )
-
-        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_300)))
-
-        WCTextButton(
-            onClick = onLearnMoreClick,
-            text = stringResource(id = R.string.learn_more),
-            allCaps = false
-        )
+            StepItem(
+                currentStep = i,
+                steps = learnMoreItems.size,
+                text = item
+            )
+        }
     }
 }
 
@@ -299,11 +293,6 @@ private fun BlazeCampaignBottomSheetContent(
 private fun CloseButton(onDismissClick: () -> Unit, modifier: Modifier = Modifier) {
     Box(
         modifier = modifier
-            .size(dimensionResource(id = R.dimen.major_200))
-            .background(
-                color = colorResource(id = R.color.blaze_campaign_bottom_sheet_highlight_background),
-                shape = CircleShape
-            )
             .clickable(
                 onClick = onDismissClick,
                 role = Role.Button,
@@ -317,7 +306,7 @@ private fun CloseButton(onDismissClick: () -> Unit, modifier: Modifier = Modifie
             tint = colorResource(id = R.color.color_on_surface_medium),
             modifier = Modifier
                 .align(Alignment.Center)
-                .size(dimensionResource(id = R.dimen.major_100))
+                .size(dimensionResource(id = R.dimen.major_150))
         )
     }
 }
@@ -340,17 +329,17 @@ fun CircleNumber(number: String) {
 }
 
 @Composable
-fun StepItem(number: Int, text: String, position: StepPosition) {
-    val shape = when (position) {
-        StepPosition.FIRST -> RoundedCornerShape(
+fun StepItem(currentStep: Int, steps: Int, text: AnnotatedString) {
+    val shape = when {
+        currentStep == 0 -> RoundedCornerShape(
             topStart = dimensionResource(id = R.dimen.minor_100),
             topEnd = dimensionResource(id = R.dimen.minor_100)
         )
-        StepPosition.MIDDLE -> RoundedCornerShape(0.dp)
-        StepPosition.LAST -> RoundedCornerShape(
+        currentStep + 1 == steps -> RoundedCornerShape(
             bottomStart = dimensionResource(id = R.dimen.minor_100),
             bottomEnd = dimensionResource(id = R.dimen.minor_100)
         )
+        else -> RoundedCornerShape(0.dp)
     }
 
     Row(
@@ -363,19 +352,13 @@ fun StepItem(number: Int, text: String, position: StepPosition) {
             )
             .padding(dimensionResource(id = R.dimen.major_100))
     ) {
-        CircleNumber(number = number.toString())
+        CircleNumber(number = (currentStep + 1).toString())
         Text(
             text = text,
             style = MaterialTheme.typography.body1,
             modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_100))
         )
     }
-}
-
-enum class StepPosition {
-    FIRST,
-    MIDDLE,
-    LAST
 }
 
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
@@ -395,6 +378,8 @@ private fun BlazeCampaignCreationIntroScreenPreview() {
 @Composable
 private fun BlazeCampaignBottomSheetContentPreview() {
     WooThemeWithBackground {
-        BlazeCampaignBottomSheetContent(onDismissClick = {}, onLearnMoreClick = {})
+        BlazeCampaignBottomSheetContent(
+            onDismissClick = {}
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroScreen.kt
@@ -274,7 +274,6 @@ private fun BlazeCampaignBottomSheetContent(
 
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_150)))
 
-
         learnMoreItems.forEachIndexed { i, item ->
             if (i > 0) {
                 Divider(color = colorResource(id = R.color.color_surface_elevated), thickness = 1.dp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroScreen.kt
@@ -3,14 +3,20 @@ package com.woocommerce.android.ui.blaze.creation.intro
 import android.content.res.Configuration
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
@@ -22,18 +28,26 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.FontWeight.Companion
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.BottomSheetHandle
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCModalBottomSheetLayout
@@ -79,7 +93,8 @@ fun BlazeCampaignCreationIntroScreen(
                 BlazeCampaignBottomSheetContent(
                     onDismissClick = {
                         coroutineScope.launch { modalSheetState.hide() }
-                    }
+                    },
+                    onLearnMoreClick = { }
                 )
             },
             sheetState = modalSheetState,
@@ -179,7 +194,7 @@ private fun BlazeCampaignCreationIntroContent(
         )
         WCTextButton(
             onClick = onLearnMoreClick,
-            text = stringResource(id = R.string.blaze_campaign_creation_new_intro_learn_more_button),
+            text = stringResource(id = R.string.blaze_campaign_creation_new_intro_learn_more),
             allCaps = false,
             modifier = Modifier
                 .fillMaxWidth()
@@ -216,11 +231,151 @@ private fun BlazeCampaignBenefitPoint(
 }
 
 @Composable
-@Suppress("UNUSED_PARAMETER")
 private fun BlazeCampaignBottomSheetContent(
-    onDismissClick: () -> Unit
+    onDismissClick: () -> Unit,
+    onLearnMoreClick: () -> Unit
 ) {
-    // TODO
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(dimensionResource(id = R.dimen.major_100))
+    ) {
+        BottomSheetHandle(
+            modifier = Modifier
+                .padding(bottom = dimensionResource(id = R.dimen.major_100))
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+        ) {
+            Text(
+                text = stringResource(id = R.string.blaze_campaign_creation_new_intro_learn_more),
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier
+                    .align(Alignment.Center)
+            )
+
+            CloseButton(onDismissClick, modifier = Modifier.align(Alignment.CenterEnd))
+        }
+
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_150)))
+
+        StepItem(
+            number = 1,
+            text = stringResource(id = R.string.blaze_campaign_creation_new_intro_learn_point_1),
+            position = StepPosition.FIRST
+        )
+
+        Divider(color = colorResource(id = R.color.color_surface_elevated), thickness = 1.dp)
+
+        StepItem(
+            number = 2,
+            text = stringResource(id = R.string.blaze_campaign_creation_new_intro_learn_point_2),
+            position = StepPosition.MIDDLE
+        )
+
+        Divider(color = colorResource(id = R.color.color_surface_elevated), thickness = 1.dp)
+
+        StepItem(
+            number = 3,
+            text = stringResource(id = R.string.blaze_campaign_creation_new_intro_learn_point_3),
+            position = StepPosition.LAST
+        )
+
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_300)))
+
+        WCTextButton(
+            onClick = onLearnMoreClick,
+            text = stringResource(id = R.string.learn_more),
+            allCaps = false
+        )
+    }
+}
+
+@Composable
+private fun CloseButton(onDismissClick: () -> Unit, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .size(dimensionResource(id = R.dimen.major_200))
+            .background(
+                color = colorResource(id = R.color.blaze_campaign_bottom_sheet_highlight_background),
+                shape = CircleShape
+            )
+            .clickable(
+                onClick = onDismissClick,
+                role = Role.Button,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = rememberRipple(bounded = false, radius = dimensionResource(id = R.dimen.major_150))
+            )
+    ) {
+        Icon(
+            Icons.Filled.Close,
+            contentDescription = stringResource(R.string.close),
+            tint = colorResource(id = R.color.color_on_surface_medium),
+            modifier = Modifier
+                .align(Alignment.Center)
+                .size(dimensionResource(id = R.dimen.major_100))
+        )
+    }
+}
+
+@Composable
+fun CircleNumber(number: String) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .size(dimensionResource(id = R.dimen.major_150))
+            .background(color = colorResource(id = R.color.color_surface_elevated), shape = CircleShape)
+    ) {
+        Text(
+            text = number,
+            color = MaterialTheme.colors.onBackground,
+            style = MaterialTheme.typography.caption,
+            fontWeight = FontWeight.SemiBold
+        )
+    }
+}
+
+@Composable
+fun StepItem(number: Int, text: String, position: StepPosition) {
+    val shape = when (position) {
+        StepPosition.FIRST -> RoundedCornerShape(
+            topStart = dimensionResource(id = R.dimen.minor_100),
+            topEnd = dimensionResource(id = R.dimen.minor_100)
+        )
+        StepPosition.MIDDLE -> RoundedCornerShape(0.dp)
+        StepPosition.LAST -> RoundedCornerShape(
+            bottomStart = dimensionResource(id = R.dimen.minor_100),
+            bottomEnd = dimensionResource(id = R.dimen.minor_100)
+        )
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = colorResource(id = R.color.blaze_campaign_bottom_sheet_highlight_background),
+                shape = shape
+            )
+            .padding(dimensionResource(id = R.dimen.major_100))
+    ) {
+        CircleNumber(number = number.toString())
+        Text(
+            text = text,
+            style = MaterialTheme.typography.body1,
+            modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_100))
+        )
+    }
+}
+
+enum class StepPosition {
+    FIRST,
+    MIDDLE,
+    LAST
 }
 
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
@@ -232,5 +387,14 @@ private fun BlazeCampaignCreationIntroScreenPreview() {
             onContinueClick = {},
             onDismissClick = {}
         )
+    }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Composable
+private fun BlazeCampaignBottomSheetContentPreview() {
+    WooThemeWithBackground {
+        BlazeCampaignBottomSheetContent(onDismissClick = {}, onLearnMoreClick = {})
     }
 }

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -228,4 +228,9 @@
     <color name="deposit_summary_status_failed_text">@color/woo_red_5</color>
     <color name="deposit_summary_status_unknown_background">@color/woo_gray_80</color>
     <color name="deposit_summary_status_unknown_text">@color/woo_gray_6</color>
+
+    <!--
+    Blaze
+    -->
+    <color name="blaze_campaign_bottom_sheet_highlight_background">@color/woo_black_90_alpha_038</color>
 </resources>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -290,6 +290,7 @@
     <color name="blaze_campaign_status_completed_text">@color/blaze_blue_60</color>
     <color name="blaze_campaign_status_rejected_background">@color/blaze_red_5</color>
     <color name="blaze_campaign_status_rejected_text">@color/blaze_red_6</color>
+    <color name="blaze_campaign_bottom_sheet_highlight_background">@color/woo_gray_6</color>
 
     <!--
     Deposit summary

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3932,5 +3932,8 @@
     <string name="blaze_campaign_creation_new_intro_benefit_3_title">Access a vast audience</string>
     <string name="blaze_campaign_creation_new_intro_benefit_3_subtitle">Your ads on millions of sites within the WordPress.com and Tumblr networks.</string>
     <string name="blaze_campaign_creation_new_intro_start_button">Start your campaign</string>
-    <string name="blaze_campaign_creation_new_intro_learn_more_button">Learn how Blaze works</string>
+    <string name="blaze_campaign_creation_new_intro_learn_more">Learn how Blaze works</string>
+    <string name="blaze_campaign_creation_new_intro_learn_point_1">Choose a product to promote with Blaze.</string>
+    <string name="blaze_campaign_creation_new_intro_learn_point_2">Our moderators review your campaign. (Usually no longer than 24 hours)</string>
+    <string name="blaze_campaign_creation_new_intro_learn_point_3">Your promotion goes live.</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3933,7 +3933,9 @@
     <string name="blaze_campaign_creation_new_intro_benefit_3_subtitle">Your ads on millions of sites within the WordPress.com and Tumblr networks.</string>
     <string name="blaze_campaign_creation_new_intro_start_button">Start your campaign</string>
     <string name="blaze_campaign_creation_new_intro_learn_more">Learn how Blaze works</string>
-    <string name="blaze_campaign_creation_new_intro_learn_point_1">Choose a product to promote with Blaze.</string>
-    <string name="blaze_campaign_creation_new_intro_learn_point_2">Our moderators review your campaign. (Usually no longer than 24 hours)</string>
-    <string name="blaze_campaign_creation_new_intro_learn_point_3">Your promotion goes live.</string>
+    <string name="blaze_campaign_creation_new_intro_learn_item_1"><![CDATA[<b>Choose a product:</b> Choose what to promote with Blaze.]]></string>
+    <string name="blaze_campaign_creation_new_intro_learn_item_2"><![CDATA[<b>Customize targeting:</b> Select audience by location or interests, and see potential reach.]]></string>
+    <string name="blaze_campaign_creation_new_intro_learn_item_3"><![CDATA[<b>Set your budget:</b> Decide on your spend and campaign length.]]></string>
+    <string name="blaze_campaign_creation_new_intro_learn_item_4"><![CDATA[<b>Quick review:</b> Submit your ad for a fast moderator check.]]></string>
+    <string name="blaze_campaign_creation_new_intro_learn_item_5"><![CDATA[<b>Go live:</b> Watch as your promotion begins and track its success.]]></string>
 </resources>


### PR DESCRIPTION
Resolves #10514 and adds a bottom sheet which shows up when Learn more button is tapped.

| Light theme | Dark theme |
| --- | --- |
| ![image](https://github.com/woocommerce/woocommerce-android/assets/1522856/dcc40612-d41c-4acc-b4bc-f74deba441d3) | ![image](https://github.com/woocommerce/woocommerce-android/assets/1522856/e2e1c62c-9bc3-4b2b-b624-fa7a88850b5e) |

**To test:**
1. Open the app.
2. Trigger the blaze campaign creation (from MyStore or More menu)
3. Tap on the `Learn how Blaze works` button
4. Notice the bottom sheet appears
