### PR TITLE
Crash fix: Product types bottom sheet

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypeBottomSheetBuilder.kt
@@ -9,15 +9,11 @@ import com.woocommerce.android.ui.products.ProductType.SUBSCRIPTION
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE_SUBSCRIPTION
 import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
-import com.woocommerce.android.ui.subscriptions.IsEligibleForSubscriptions
 import javax.inject.Inject
 
-@Suppress("ForbiddenComment")
 class ProductTypeBottomSheetBuilder @Inject constructor(
-    private val isEligibleForSubscriptions: IsEligibleForSubscriptions
 ) {
-    suspend fun buildBottomSheetList(): List<ProductTypesBottomSheetUiItem> {
-        val areSubscriptionsSupported = isEligibleForSubscriptions()
+    fun buildBottomSheetList(areSubscriptionsSupported: Boolean): List<ProductTypesBottomSheetUiItem> {
         return listOf(
             ProductTypesBottomSheetUiItem(
                 type = SIMPLE,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypeBottomSheetBuilder.kt
@@ -9,10 +9,8 @@ import com.woocommerce.android.ui.products.ProductType.SUBSCRIPTION
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE_SUBSCRIPTION
 import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
-import javax.inject.Inject
 
-class ProductTypeBottomSheetBuilder @Inject constructor(
-) {
+class ProductTypeBottomSheetBuilder {
     fun buildBottomSheetList(areSubscriptionsSupported: Boolean): List<ProductTypesBottomSheetUiItem> {
         return listOf(
             ProductTypesBottomSheetUiItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypeBottomSheetBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypeBottomSheetBuilder.kt
@@ -9,8 +9,9 @@ import com.woocommerce.android.ui.products.ProductType.SUBSCRIPTION
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE_SUBSCRIPTION
 import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
+import javax.inject.Inject
 
-class ProductTypeBottomSheetBuilder {
+class ProductTypeBottomSheetBuilder @Inject constructor() {
     fun buildBottomSheetList(areSubscriptionsSupported: Boolean): List<ProductTypesBottomSheetUiItem> {
         return listOf(
             ProductTypesBottomSheetUiItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetAdapter.kt
@@ -3,20 +3,15 @@ package com.woocommerce.android.ui.products
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.woocommerce.android.databinding.ProductDetailBottomSheetListItemBinding
 import com.woocommerce.android.ui.products.ProductTypesBottomSheetAdapter.ProductTypesBottomSheetViewHolder
 import com.woocommerce.android.ui.products.ProductTypesBottomSheetViewModel.ProductTypesBottomSheetUiItem
 
 class ProductTypesBottomSheetAdapter(
+    private val options: List<ProductTypesBottomSheetUiItem>,
     private val onItemClicked: (productTypeUiItem: ProductTypesBottomSheetUiItem) -> Unit
 ) : RecyclerView.Adapter<ProductTypesBottomSheetViewHolder>() {
-    private val options = ArrayList<ProductTypesBottomSheetUiItem>()
-
-    init {
-        setHasStableIds(true)
-    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductTypesBottomSheetViewHolder {
         return ProductTypesBottomSheetViewHolder(
@@ -32,20 +27,11 @@ class ProductTypesBottomSheetAdapter(
         holder.bind(options[position], onItemClicked)
     }
 
-    override fun getItemId(position: Int) = options[position].type.ordinal.toLong()
-
     override fun getItemCount() = options.size
 
-    fun setProductTypeOptions(optionList: List<ProductTypesBottomSheetUiItem>) {
-        val diffResult =
-            DiffUtil.calculateDiff(ProductTypesBottomSheetItemDiffUtil(options, optionList))
-        options.clear()
-        options.addAll(optionList.filter { it.isVisible })
-        diffResult.dispatchUpdatesTo(this)
-    }
-
-    class ProductTypesBottomSheetViewHolder(val viewBinder: ProductDetailBottomSheetListItemBinding) :
-        RecyclerView.ViewHolder(viewBinder.root) {
+    class ProductTypesBottomSheetViewHolder(
+        private val viewBinder: ProductDetailBottomSheetListItemBinding
+    ) : RecyclerView.ViewHolder(viewBinder.root) {
         fun bind(
             item: ProductTypesBottomSheetUiItem,
             onItemClicked: (productTypeUiItem: ProductTypesBottomSheetUiItem) -> Unit
@@ -58,24 +44,6 @@ class ProductTypesBottomSheetAdapter(
             itemView.setOnClickListener {
                 onItemClicked(item)
             }
-        }
-    }
-
-    private class ProductTypesBottomSheetItemDiffUtil(
-        val items: List<ProductTypesBottomSheetUiItem>,
-        val result: List<ProductTypesBottomSheetUiItem>
-    ) : DiffUtil.Callback() {
-        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
-            items[oldItemPosition].type == result[newItemPosition].type
-
-        override fun getOldListSize(): Int = items.size
-
-        override fun getNewListSize(): Int = result.size
-
-        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-            val oldItem = items[oldItemPosition]
-            val newItem = result[newItemPosition]
-            return oldItem == newItem
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.coroutineScope
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
@@ -30,8 +30,6 @@ class ProductTypesBottomSheetFragment : WCBottomSheetDialogFragment() {
     @Inject internal lateinit var navigator: ProductNavigator
     val viewModel: ProductTypesBottomSheetViewModel by viewModels()
 
-    private lateinit var productTypesBottomSheetAdapter: ProductTypesBottomSheetAdapter
-
     private val navArgs: ProductTypesBottomSheetFragmentArgs by navArgs()
 
     private var _binding: DialogProductDetailBottomSheetListBinding? = null
@@ -52,18 +50,7 @@ class ProductTypesBottomSheetFragment : WCBottomSheetDialogFragment() {
 
         setupObservers()
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.loadProductTypes()
-        }
-
         binding.productDetailInfoLblTitle.text = getString(R.string.product_type_list_header)
-        productTypesBottomSheetAdapter = ProductTypesBottomSheetAdapter(
-            viewModel::onProductTypeSelected
-        )
-        with(binding.productDetailInfoOptionsList) {
-            adapter = productTypesBottomSheetAdapter
-            layoutManager = LinearLayoutManager(activity)
-        }
     }
 
     private fun setupObservers() {
@@ -101,8 +88,14 @@ class ProductTypesBottomSheetFragment : WCBottomSheetDialogFragment() {
         }
     }
 
-    private fun showProductTypeOptions(productTypeOptions: List<ProductTypesBottomSheetUiItem>) {
-        productTypesBottomSheetAdapter.setProductTypeOptions(productTypeOptions)
+    private fun showProductTypeOptions(productTypes: List<ProductTypesBottomSheetUiItem>) {
+        with(binding.productDetailInfoOptionsList) {
+            adapter = ProductTypesBottomSheetAdapter(
+                productTypes,
+                viewModel::onProductTypeSelected
+            )
+            layoutManager = LinearLayoutManager(activity)
+        }
     }
 
     private fun navigateWithSelectedResult(productTypesBottomSheetUiItem: ProductTypesBottomSheetUiItem) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.coroutineScope
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
@@ -18,7 +17,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModel.kt
@@ -52,8 +52,8 @@ class ProductTypesBottomSheetViewModel @Inject constructor(
                     val currentProductType = navArgs.currentProductType
                         ?.let { nonNullProductType -> ProductType.fromString(nonNullProductType) }
 
-                    it.isVisible && (it.type != currentProductType ||
-                        (it.type == ProductType.SIMPLE && it.isVirtual != navArgs.isCurrentProductVirtual))
+                    return@filter it.isVisible &&
+                        (it.type != currentProductType || it.isVirtual != navArgs.isCurrentProductVirtual)
                 }
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTypesBottomSheetViewModelTest.kt
@@ -1,9 +1,11 @@
 package com.woocommerce.android.ui.products
 
 import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.ui.subscriptions.IsEligibleForSubscriptions
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -13,16 +15,20 @@ class ProductTypesBottomSheetViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: ProductTypesBottomSheetViewModel
     private val appPrefs: AppPrefs = mock()
     private val bottomSheetBuilder: ProductTypeBottomSheetBuilder = mock()
+    private val isEligibleForSubscriptions: IsEligibleForSubscriptions = mock()
+
+    @Before
+    fun setUp() = testBlocking {
+        whenever(isEligibleForSubscriptions()).thenReturn(false)
+        whenever(bottomSheetBuilder.buildBottomSheetList(false)).thenReturn(uiItems)
+    }
 
     @Test
     fun `given is Add Product flow, when loading product types, then product types not filtered`() = testBlocking {
         viewModel = ProductTypesBottomSheetViewModel(
             ProductTypesBottomSheetFragmentArgs(isAddProduct = true).toSavedStateHandle(),
-            appPrefs, bottomSheetBuilder
+            appPrefs, bottomSheetBuilder, isEligibleForSubscriptions
         )
-        whenever(bottomSheetBuilder.buildBottomSheetList()).thenReturn(uiItems)
-
-        viewModel.loadProductTypes()
 
         assertThat(viewModel.productTypesBottomSheetList.value).isEqualTo(uiItems)
     }
@@ -35,11 +41,8 @@ class ProductTypesBottomSheetViewModelTest : BaseUnitTest() {
                 currentProductType = "simple",
                 isCurrentProductVirtual = false
             ).toSavedStateHandle(),
-            appPrefs, bottomSheetBuilder
+            appPrefs, bottomSheetBuilder, isEligibleForSubscriptions
         )
-        whenever(bottomSheetBuilder.buildBottomSheetList()).thenReturn(uiItems)
-
-        viewModel.loadProductTypes()
 
         assertThat(viewModel.productTypesBottomSheetList.value!!.size).isEqualTo(uiItems.size - 1)
     }
@@ -52,11 +55,8 @@ class ProductTypesBottomSheetViewModelTest : BaseUnitTest() {
                 currentProductType = "simple",
                 isCurrentProductVirtual = true
             ).toSavedStateHandle(),
-            appPrefs, bottomSheetBuilder
+            appPrefs, bottomSheetBuilder, isEligibleForSubscriptions
         )
-        whenever(bottomSheetBuilder.buildBottomSheetList()).thenReturn(uiItems)
-
-        viewModel.loadProductTypes()
 
         assertThat(viewModel.productTypesBottomSheetList.value!!.size).isEqualTo(uiItems.size - 1)
         assertThat(viewModel.productTypesBottomSheetList.value!![0].isVirtual).isFalse


### PR DESCRIPTION
Fixes #10450. The crash occurred during configuration change if the product types bottom sheet was displayed. 

The problem was the a non-empty RecyclerView adapter was being cleared and reloaded without calling `notifyDatasetChanged()`. This PR refactors the adapter and simplifies the product types bottom sheet construction by removing the `DiffUtil`, since it's just a static list.

**To test:**
1. Start the app
2. Go to the Products tab
3. Tap on the Add product button
4. (If it's a WP.com site, tap on Add product manually option)
5. Notice the bottom sheet with product types is displayed
6. Rotate the device
7. Notice the app didn't crash