### PR TITLE
Edit configuration in the product selection screen

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductSelectorScreenTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductSelectorScreenTest.kt
@@ -41,7 +41,8 @@ class ProductSelectorScreenTest {
                 onSearchQueryChanged = {},
                 onSearchTypeChanged = {},
                 onClearFiltersButtonClick = {},
-                trackConfigurableProduct = {}
+                trackConfigurableProduct = {},
+                onEditConfiguration = { _ -> }
             )
         }
 
@@ -70,7 +71,8 @@ class ProductSelectorScreenTest {
                 onSearchQueryChanged = {},
                 onSearchTypeChanged = {},
                 onClearFiltersButtonClick = {},
-                trackConfigurableProduct = {}
+                trackConfigurableProduct = {},
+                onEditConfiguration = { _ -> }
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/AdjustProductQuantity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/AdjustProductQuantity.kt
@@ -34,7 +34,7 @@ class AdjustProductQuantity @Inject constructor() {
                     quantity = newQuantity,
                     subtotal = newSubtotal,
                     total = newSubtotal - discountAmount,
-                    configuration = groupedProduct.configuration
+                    configuration = groupedProduct.getConfiguration()
                 )
             }
             for (child in product.children) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -678,7 +678,7 @@ class OrderCreateEditFormFragment :
                         var isExpanded by rememberSaveable { mutableStateOf(false) }
                         when {
                             item is OrderCreationProduct.ProductItemWithRules &&
-                                item.configuration.childrenConfiguration?.keys?.size?.compareTo(0) == 1 -> {
+                                item.getConfiguration().childrenConfiguration?.keys?.size?.compareTo(0) == 1 -> {
                                 val modifier = if (isExpanded) {
                                     Modifier.border(
                                         1.dp,
@@ -692,7 +692,7 @@ class OrderCreateEditFormFragment :
                                 ExpandableGroupedProductCardLoading(
                                     state = viewModel.viewStateData.liveData.observeAsState(),
                                     product = item,
-                                    childrenSize = item.configuration.childrenConfiguration?.keys?.size ?: 0,
+                                    childrenSize = item.getConfiguration().childrenConfiguration?.keys?.size ?: 0,
                                     onRemoveProductClicked = { viewModel.onRemoveProduct(item) },
                                     onDiscountButtonClicked = { viewModel.onDiscountButtonClicked(item) },
                                     onItemAmountChanged = { viewModel.onItemAmountChanged(item, it) },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -932,7 +932,7 @@ class OrderCreateEditFormFragment :
             viewModel.handleBarcodeScannedStatus(status)
         }
         handleResult<EditProductConfigurationResult>(
-            ProductConfigurationFragment.PRODUCT_CONFIGURATION_RESULT
+            ProductConfigurationFragment.PRODUCT_CONFIGURATION_EDITED_RESULT
         ) { result ->
             viewModel.onConfigurationChanged(result.itemId, result.productConfiguration)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1028,7 +1028,7 @@ class OrderCreateEditViewModel @Inject constructor(
 
     fun onAddProductClicked() {
         val selectedItems = products.value?.map { product ->
-            val configuration = product.item.configuration
+            val configuration = product.getConfiguration()
             when {
                 configuration != null -> {
                     SelectedItem.ConfigurableProduct(product.item.productId, configuration)
@@ -1140,6 +1140,7 @@ class OrderCreateEditViewModel @Inject constructor(
                     triggerEvent(ShowCreatedOrder(it.id, startPaymentFlow = true))
                 }
             }
+
             is Mode.Edit -> {
                 triggerEvent(Exit)
             }
@@ -1627,7 +1628,7 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     fun onEditConfiguration(product: OrderCreationProduct) {
-        (product as? OrderCreationProduct.GroupedProductItemWithRules)?.configuration?.let {
+        product.getConfiguration()?.let {
             if (product.productInfo.productType == ProductType.BUNDLE) {
                 tracker.track(
                     AnalyticsEvent.ORDER_FORM_BUNDLE_PRODUCT_CONFIGURE_CTA_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -638,10 +638,21 @@ class OrderCreateEditViewModel @Inject constructor(
                 }
 
                 val itemsToAdd = selectedItems.filter { selectedItem ->
-                    if (selectedItem is SelectedItem.ProductVariation) {
-                        none { it.variationId == selectedItem.variationId }
-                    } else {
-                        none { it.parent == null && it.productId == selectedItem.id }
+                    when (selectedItem) {
+                        is SelectedItem.ProductVariation -> {
+                            none { it.variationId == selectedItem.variationId }
+                        }
+
+                        is SelectedItem.ConfigurableProduct -> {
+                            products.value?.none {
+                                it.item.productId == selectedItem.id &&
+                                    selectedItem.configuration == it.getConfiguration()
+                            } ?: true
+                        }
+
+                        else -> {
+                            none { it.parent == null && it.productId == selectedItem.id }
+                        }
                     }
                 }.map {
                     when (it) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreationProduct.kt
@@ -26,6 +26,8 @@ sealed class OrderCreationProduct(
         productInfo: ProductInfo = this.productInfo
     ): OrderCreationProduct
 
+    abstract fun getConfiguration(): ProductConfiguration?
+
     data class ProductItem(
         override val item: Order.Item,
         override val productInfo: ProductInfo
@@ -34,6 +36,8 @@ sealed class OrderCreationProduct(
             item: Order.Item,
             productInfo: ProductInfo
         ) = copy(item = item, productInfo = productInfo)
+
+        override fun getConfiguration() = null
     }
 
     data class GroupedProductItem(
@@ -45,18 +49,22 @@ sealed class OrderCreationProduct(
             item: Order.Item,
             productInfo: ProductInfo
         ) = copy(item = item, productInfo = productInfo)
+
+        override fun getConfiguration() = null
     }
 
     data class ProductItemWithRules(
         override val item: Order.Item,
         override val productInfo: ProductInfo,
         val rules: ProductRules,
-        var configuration: ProductConfiguration
+        private var configuration: ProductConfiguration
     ) : OrderCreationProduct(item, productInfo) {
         override fun copyProduct(
             item: Order.Item,
             productInfo: ProductInfo
         ) = copy(item = item, productInfo = productInfo)
+
+        override fun getConfiguration() = configuration
     }
 
     data class GroupedProductItemWithRules(
@@ -64,12 +72,14 @@ sealed class OrderCreationProduct(
         override val productInfo: ProductInfo,
         val children: List<ProductItem>,
         val rules: ProductRules,
-        var configuration: ProductConfiguration
+        private var configuration: ProductConfiguration
     ) : OrderCreationProduct(item, productInfo) {
         override fun copyProduct(
             item: Order.Item,
             productInfo: ProductInfo
         ) = copy(item = item, productInfo = productInfo)
+
+        override fun getConfiguration() = configuration
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationFragment.kt
@@ -24,6 +24,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class ProductConfigurationFragment : BaseFragment() {
     companion object {
         const val PRODUCT_CONFIGURATION_RESULT = "product-configuration-result"
+        const val PRODUCT_CONFIGURATION_EDITED_RESULT = "product-configuration-edited-result"
     }
 
     private val viewModel: ProductConfigurationViewModel by viewModels()
@@ -57,7 +58,17 @@ class ProductConfigurationFragment : BaseFragment() {
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
                 is MultiLiveEvent.Event.ExitWithResult<*> -> {
-                    navigateBackWithResult(PRODUCT_CONFIGURATION_RESULT, event.data)
+                    when (event.data) {
+                        is SelectProductConfigurationResult -> navigateBackWithResult(
+                            PRODUCT_CONFIGURATION_RESULT,
+                            event.data
+                        )
+
+                        is EditProductConfigurationResult -> navigateBackWithResult(
+                            PRODUCT_CONFIGURATION_EDITED_RESULT,
+                            event.data
+                        )
+                    }
                 }
 
                 is ProductConfigurationNavigationTarget -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigationTarget.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.model.Component
 import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.model.ProductFile
 import com.woocommerce.android.model.SubscriptionDetails
+import com.woocommerce.android.ui.orders.creation.configuration.ProductConfiguration
 import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
 import com.woocommerce.android.ui.products.ProductShippingViewModel.ShippingData
 import com.woocommerce.android.ui.products.models.QuantityRules
@@ -136,6 +137,11 @@ sealed class ProductNavigationTarget : Event() {
     ) : ProductNavigationTarget()
 
     data class NavigateToProductConfiguration(val productId: Long) : ProductNavigationTarget()
+    data class EditProductConfiguration(
+        val itemId: Long,
+        val productId: Long,
+        val configuration: ProductConfiguration
+    ) : ProductNavigationTarget()
 
     data class NavigateToProductFilter(
         val stockStatus: String?,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -371,6 +371,18 @@ class ProductNavigator @Inject constructor() {
                     ProductSelectorFragmentDirections.actionProductSelectorFragmentToProductConfigurationFragment(flow)
                 )
             }
+
+            is ProductNavigationTarget.EditProductConfiguration -> {
+                val flow = Flow.Edit(
+                    itemId = target.itemId,
+                    productID = target.productId,
+                    configuration = target.configuration
+                )
+                fragment.findNavController().navigateSafely(
+                    ProductSelectorFragmentDirections.actionProductSelectorFragmentToProductConfigurationFragment(flow)
+                )
+            }
+
             is ProductNavigationTarget.NavigateToProductFilter -> {
                 fragment.findNavController().navigateSafely(
                     ProductSelectorFragmentDirections.actionProductSelectorFragmentToNavGraphProductFilters(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
@@ -14,6 +14,8 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.orders.creation.configuration.EditProductConfigurationResult
+import com.woocommerce.android.ui.orders.creation.configuration.ProductConfigurationFragment.Companion.PRODUCT_CONFIGURATION_EDITED_RESULT
 import com.woocommerce.android.ui.orders.creation.configuration.ProductConfigurationFragment.Companion.PRODUCT_CONFIGURATION_RESULT
 import com.woocommerce.android.ui.orders.creation.configuration.SelectProductConfigurationResult
 import com.woocommerce.android.ui.products.ProductFilterResult
@@ -103,7 +105,11 @@ class ProductSelectorFragment : BaseFragment() {
         }
 
         handleResult<SelectProductConfigurationResult>(PRODUCT_CONFIGURATION_RESULT) { result ->
-            viewModel.onConfigurationChanged(result.productId, result.productConfiguration)
+            viewModel.onConfigurationSaved(result.productId, result.productConfiguration)
+        }
+
+        handleResult<EditProductConfigurationResult>(PRODUCT_CONFIGURATION_EDITED_RESULT) { result ->
+            viewModel.onConfigurationEdited(result.productId, result.productConfiguration)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -54,6 +54,7 @@ import com.woocommerce.android.ui.compose.component.SearchLayoutWithParams
 import com.woocommerce.android.ui.compose.component.SearchLayoutWithParamsState
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.products.ProductType.BUNDLE
 import com.woocommerce.android.ui.products.ProductType.GROUPED
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
 import com.woocommerce.android.ui.products.ProductType.VARIABLE
@@ -109,7 +110,8 @@ fun ProductSelectorScreen(viewModel: ProductSelectorViewModel) {
                 onSearchQueryChanged = viewModel::onSearchQueryChanged,
                 onClearFiltersButtonClick = viewModel::onClearFiltersButtonClick,
                 onSearchTypeChanged = viewModel::onSearchTypeChanged,
-                trackConfigurableProduct = viewModel::trackConfigurableProduct
+                trackConfigurableProduct = viewModel::trackConfigurableProduct,
+                onEditConfiguration = viewModel::onEditConfiguration,
             )
         }
     }
@@ -127,7 +129,8 @@ fun ProductSelectorScreen(
     onSearchQueryChanged: (String) -> Unit,
     onSearchTypeChanged: (Int) -> Unit,
     onClearFiltersButtonClick: () -> Unit,
-    trackConfigurableProduct: () -> Unit
+    trackConfigurableProduct: () -> Unit,
+    onEditConfiguration: (ListItem.ConfigurableListItem) -> Unit
 ) {
     Column(
         modifier = modifier
@@ -166,7 +169,8 @@ fun ProductSelectorScreen(
                 onFilterButtonClick = onFilterButtonClick,
                 onProductClick = onProductClick,
                 onLoadMore = onLoadMore,
-                trackConfigurableProduct = trackConfigurableProduct
+                trackConfigurableProduct = trackConfigurableProduct,
+                onEditConfiguration = onEditConfiguration
             )
 
             state.products.isEmpty() && state.loadingState == LOADING -> ProductListSkeleton()
@@ -230,11 +234,13 @@ private fun EmptyProductList(
 private fun PopularProductsList(
     state: ViewState,
     onProductClick: (ListItem, ProductSourceForTracking) -> Unit,
+    onEditConfiguration: (ListItem.ConfigurableListItem) -> Unit
 ) {
     displayProductsSection(
         type = ProductType.POPULAR,
         state = state,
-        onProductClick = onProductClick
+        onProductClick = onProductClick,
+        onEditConfiguration = onEditConfiguration
     )
 }
 
@@ -242,11 +248,13 @@ private fun PopularProductsList(
 private fun RecentlySoldProductsList(
     state: ViewState,
     onProductClick: (ListItem, ProductSourceForTracking) -> Unit,
+    onEditConfiguration: (ListItem.ConfigurableListItem) -> Unit
 ) {
     displayProductsSection(
         type = ProductType.RECENT,
         state = state,
-        onProductClick = onProductClick
+        onProductClick = onProductClick,
+        onEditConfiguration = onEditConfiguration
     )
 }
 
@@ -255,6 +263,7 @@ private fun displayProductsSection(
     type: ProductType,
     state: ViewState,
     onProductClick: (ListItem, ProductSourceForTracking) -> Unit,
+    onEditConfiguration: (ListItem.ConfigurableListItem) -> Unit
 ) {
     val (productsList, heading, productSectionForTracking) = when (type) {
         ProductType.POPULAR -> Triple(
@@ -299,7 +308,10 @@ private fun displayProductsSection(
                 isArrowVisible = product.hasVariations(),
                 onClickLabel = stringResource(id = string.product_selector_select_product_label, product.title),
                 imageContentDescription = stringResource(string.product_image_content_description),
-                isCogwheelVisible = product is ListItem.ConfigurableListItem
+                isCogwheelVisible = product is ListItem.ConfigurableListItem,
+                onEditConfiguration = {
+                    (product as? ListItem.ConfigurableListItem)?.let(onEditConfiguration)
+                }
             ) {
                 onProductClick(product, productSectionForTracking)
             }
@@ -327,7 +339,8 @@ private fun ProductList(
     onFilterButtonClick: () -> Unit,
     onProductClick: (ListItem, ProductSourceForTracking) -> Unit,
     onLoadMore: () -> Unit,
-    trackConfigurableProduct: () -> Unit
+    trackConfigurableProduct: () -> Unit,
+    onEditConfiguration: (ListItem.ConfigurableListItem) -> Unit
 ) {
     val listState = rememberLazyListState()
     Column(
@@ -372,7 +385,8 @@ private fun ProductList(
                 item {
                     PopularProductsList(
                         state = state,
-                        onProductClick = onProductClick
+                        onProductClick = onProductClick,
+                        onEditConfiguration = onEditConfiguration
                     )
                 }
             }
@@ -380,7 +394,8 @@ private fun ProductList(
                 item {
                     RecentlySoldProductsList(
                         state = state,
-                        onProductClick = onProductClick
+                        onProductClick = onProductClick,
+                        onEditConfiguration = onEditConfiguration
                     )
                 }
             }
@@ -413,7 +428,10 @@ private fun ProductList(
                     isArrowVisible = product.hasVariations(),
                     onClickLabel = stringResource(id = string.product_selector_select_product_label, product.title),
                     imageContentDescription = stringResource(string.product_image_content_description),
-                    isCogwheelVisible = product is ListItem.ConfigurableListItem
+                    isCogwheelVisible = product is ListItem.ConfigurableListItem,
+                    onEditConfiguration = {
+                        (product as? ListItem.ConfigurableListItem)?.let(onEditConfiguration)
+                    }
                 ) {
                     onProductClick(product, ProductSourceForTracking.ALPHABETICAL)
                 }
@@ -572,7 +590,8 @@ fun PopularProductsListPreview() {
         onFilterButtonClick = {},
         onProductClick = { _, _ -> },
         onLoadMore = {},
-        trackConfigurableProduct = {}
+        trackConfigurableProduct = {},
+        onEditConfiguration = {}
     )
 }
 
@@ -641,7 +660,8 @@ fun RecentProductsListPreview() {
         onFilterButtonClick = {},
         onProductClick = { _, _ -> },
         onLoadMore = {},
-        trackConfigurableProduct = {}
+        trackConfigurableProduct = {},
+        onEditConfiguration = {}
     )
 }
 
@@ -690,6 +710,15 @@ fun ProductListPreview() {
             numVariations = 0,
             stockAndPrice = null,
             sku = null
+        ),
+
+        ListItem.ConfigurableListItem(
+            productId = 5,
+            title = "Product 5",
+            type = BUNDLE,
+            imageUrl = null,
+            stockAndPrice = null,
+            sku = null
         )
     )
 
@@ -709,7 +738,8 @@ fun ProductListPreview() {
         onFilterButtonClick = {},
         onProductClick = { _, _ -> },
         onLoadMore = {},
-        trackConfigurableProduct = {}
+        trackConfigurableProduct = {},
+        onEditConfiguration = {}
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -351,6 +351,19 @@ class ProductSelectorViewModel @Inject constructor(
         }
     }
 
+    fun onEditConfiguration(item: ListItem.ConfigurableListItem) {
+        val selectedItem = selectedItems.value.firstOrNull { it.id == item.id } as? SelectedItem.ConfigurableProduct
+        selectedItem?.configuration?.let {
+            triggerEvent(
+                ProductNavigationTarget.EditProductConfiguration(
+                    itemId = item.id,
+                    productId = item.productId,
+                    configuration = it
+                )
+            )
+        } ?: triggerEvent(ProductNavigationTarget.NavigateToProductConfiguration(item.id))
+    }
+
     private fun handleProductTap(
         item: ListItem.ProductListItem,
         productSource: ProductSourceForTracking
@@ -400,6 +413,7 @@ class ProductSelectorViewModel @Inject constructor(
                 selectedItemsSource[item.id] = productSource
                 selectedItems.value = listOf(item)
             }
+
             SelectionMode.MULTIPLE -> {
                 selectedItems.update { items ->
                     if (items.containsItemWith(item.id)) {
@@ -582,7 +596,7 @@ class ProductSelectorViewModel @Inject constructor(
         }
     }
 
-    fun onConfigurationChanged(productId: Long, productConfiguration: ProductConfiguration) {
+    fun onConfigurationSaved(productId: Long, productConfiguration: ProductConfiguration) {
         tracker.trackItemSelected(productSelectorFlow)
         selectedItems.update { items ->
             val newItem = SelectedItem.ConfigurableProduct(productId, productConfiguration)
@@ -591,6 +605,15 @@ class ProductSelectorViewModel @Inject constructor(
                 SelectionMode.MULTIPLE -> items + newItem
             }
         }
+    }
+
+    fun onConfigurationEdited(productId: Long, productConfiguration: ProductConfiguration) {
+        val items = selectedItems.value.map { item ->
+            if (item.id == productId && item is SelectedItem.ConfigurableProduct) {
+                item.copy(configuration = productConfiguration)
+            } else item
+        }
+        selectedItems.update { items }
     }
 
     fun trackConfigurableProduct() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/components/SelectorListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/components/SelectorListItem.kt
@@ -52,7 +52,8 @@ fun SelectorListItem(
     selectionState: SelectionState,
     isArrowVisible: Boolean,
     isCogwheelVisible: Boolean,
-    onItemClick: () -> Unit
+    onEditConfiguration: () -> Unit,
+    onItemClick: () -> Unit,
 ) {
     Row(
         modifier = Modifier
@@ -146,7 +147,8 @@ fun SelectorListItem(
                     .size(dimensionResource(id = dimen.major_200))
             } else {
                 Modifier
-                    .padding(end = 8.dp)
+                    .clickable { onEditConfiguration() }
+                    .padding(8.dp)
                     .size(dimensionResource(id = dimen.major_150))
             }
 
@@ -180,9 +182,10 @@ private fun SelectorListItemPreview() =
         infoLine1 = "Information 1",
         infoLine2 = "Information 2",
         selectionState = SELECTED,
-        isArrowVisible = true,
+        isArrowVisible = false,
         onItemClick = {},
         onClickLabel = null,
         imageContentDescription = null,
-        isCogwheelVisible = false
+        isCogwheelVisible = true,
+        onEditConfiguration = {}
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorScreen.kt
@@ -146,7 +146,8 @@ private fun VariationList(
                     isArrowVisible = false,
                     onClickLabel = stringResource(id = string.product_selector_select_variation_label, variation.title),
                     imageContentDescription = stringResource(string.product_image_content_description),
-                    isCogwheelVisible = false
+                    isCogwheelVisible = false,
+                    onEditConfiguration = {}
                 ) {
                     onVariationClick(variation)
                 }


### PR DESCRIPTION
Part of: #10499 

### Why
This PR implements one of the suggestions from the design team after releasing the new product bundle support.

> After configuring a bundle, tapping the configure icon deselects the bundle and removes the configuration. Can tapping this go back to editing the selected bundle instead?

### Description
With the changes introduced in this PR, it is now possible to edit the configuration of a previously selected product from the product selection screen. When pressing the configuration icon on the product selection screen now, the app will navigate to the configuration screen with the bundle's configuration if the product bundle was selected and has a configuration. You can still deselect a product bundle by pressing elsewhere on a selected bundle product.

### Testing instructions
#### Prerequisites
To test this PR, it is mandatory to have the [Product Bundles](https://woo.com/products/product-bundles/) extension installed and a configurable bundle product.

#### Testing
TC1
1. Open the Order list screen
2. Tap on add new order
3. Tap on Add products
4. Select a configurable bundle product
5. Configure the product and save the configuration
6. Tap on the configuration icon of the configurable bundle product selected
7. Check that the app navigates to the Configuration screen with the right configuration (configuration from step 5)
8. Edit & save the new configuration
9. Tap on select product
10. Check that the product is added to the order with the configuration from step 8

TC2
1. Open the Order list screen
2. Tap on add new order
3. Tap on Add products
4. Select a configurable bundle product
5. Configure the product and save the configuration
6. Tap on select product
7. Check that the product is added to the order
8. Tap on add product (+)
9. Instead of adding a new product, tap on the configuration icon of the configurable bundle product selected
10. Check that the app navigates to the Configuration screen with the right configuration (configuration from step 5)
11. Edit & save the new configuration
12. Tap on select product
13. Check that the product is added to the order with the configuration from step 11

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/512cb367-3d23-4353-bb02-ab9ab6961bdd

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
