### PR TITLE
 ClassCastException when getting visitor stats

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2943-7139ed61df4e3cac2997c3b8f34ab624a41d1d45'
+    fluxCVersion = 'trunk-c78d940ebc2d79315bcbfbcccea400da26e0bf1d'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.60.0'
+    fluxCVersion = '2943-7139ed61df4e3cac2997c3b8f34ab624a41d1d45'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Closes: #10515

### Description
This PR simply updates the version of FluxC to use a new one that fixes a ClassCastException when getting visitor statistics.

FluxC PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2943

> This PR fixes a ClassCastException when getting visitor stats.
It seems that some plugins can change the visitor result type, and when this type is not Number, the application crashes. With the changes introduced in this PR, the application will be more resilient and will try to recover from the error.

### Testing instructions
Check that MyStore stats and Analytics Hub keep working as expected. Failure paths should be covered by unit tests on the FluxC PR.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
