### PR TITLE
Avoid null pointer exception when creating new stores

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
@@ -83,6 +83,12 @@ class StoreInstallationViewModel @Inject constructor(
     init {
         if (!savedStateHandle.contains(STORE_DATA_KEY)) {
             storeData = newStore.data
+            if (storeData.siteId == null) {
+                storeData.copy(siteId = appPrefsWrapper.createdStoreSiteId)
+            }
+            if (storeData.siteId == null) {
+                throw IllegalStateException("Store data must contain site id during store creation")
+            }
         }
 
         analyticsTrackerWrapper.track(
@@ -102,7 +108,7 @@ class StoreInstallationViewModel @Inject constructor(
 
                 val properties = mapOf(
                     AnalyticsTracker.KEY_SOURCE to appPrefsWrapper.getStoreCreationSource(),
-                    AnalyticsTracker.KEY_URL to storeData.domain!!,
+                    AnalyticsTracker.KEY_URL to storeData.domain,
                     AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_NATIVE,
                     AnalyticsTracker.KEY_IS_FREE_TRIAL to true
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/installation/StoreInstallationViewModel.kt
@@ -84,11 +84,9 @@ class StoreInstallationViewModel @Inject constructor(
         if (!savedStateHandle.contains(STORE_DATA_KEY)) {
             storeData = newStore.data
             if (storeData.siteId == null) {
-                storeData.copy(siteId = appPrefsWrapper.createdStoreSiteId)
+                storeData = storeData.copy(siteId = appPrefsWrapper.createdStoreSiteId)
             }
-            if (storeData.siteId == null) {
-                throw IllegalStateException("Store data must contain site id during store creation")
-            }
+            check(storeData.siteId != null) { "Store data must contain site id during store creation" }
         }
 
         analyticsTrackerWrapper.track(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes crash: #10525
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Avoid null pointer exceptions during store creation when the Android system process death happens for the app. 

Crash in action: 

https://github.com/woocommerce/woocommerce-android/assets/2663464/83f032e4-0c89-4c97-8d89-2770342bc26e

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Trigger store creation flow from site picker. 
2. Click on "Try for free"
3. Navigate to country picker step for example and send the app to the background
4. Run this from terminal `adb shell am kill com.woocommerce.android.dev ` while the app is in background
5. Wait for about 5 seconds
6. Open the app and continue the store creation flow to the last step where the progress bar is shown. The app should not crash anymore after theme picker step (like in the screen recording above).

### Fixed
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/2663464/c99aa02b-8165-4936-b3f7-61e0e85d1308


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
