### PR TITLE
Adjust GitHub workflow reference to use Dangermattic's main branch

### DIFF
--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   dangermattic:
-    uses: Automattic/dangermattic/.github/workflows/reusable-run-danger.yml@iangmaia/danger-on-gha
+    uses: Automattic/dangermattic/.github/workflows/reusable-run-danger.yml@trunk
     secrets:
       github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

Following up on https://github.com/woocommerce/woocommerce-android/pull/10483 (it was merged by mistake before adjusting the branch reference), this PR now adjusts the GitHub workflow reference to use Dangermattic's main branch.

### Testing instructions
Just make sure CI is 🟢