### PR TITLE
[Tech Debt] Remove exhaustive as this redundant with the fresh kotlin versions

### DIFF
--- a/WooCommerce/src/debug/kotlin/com.woocommerce.android/iapshowcase/purchase/IAPShowcasePurchaseViewModel.kt
+++ b/WooCommerce/src/debug/kotlin/com.woocommerce.android/iapshowcase/purchase/IAPShowcasePurchaseViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.iap.pub.IAPActivityWrapper
 import com.woocommerce.android.iap.pub.PurchaseWPComPlanActions
 import com.woocommerce.android.iap.pub.model.IAPError
@@ -38,7 +37,7 @@ class IAPShowcasePurchaseViewModel(private val iapManager: PurchaseWPComPlanActi
                 when (result) {
                     is WPComPurchaseResult.Success -> _iapEvent.value = "Plan has been successfully purchased"
                     is WPComPurchaseResult.Error -> handleError(result.errorType)
-                }.exhaustive
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/MiscExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/MiscExt.kt
@@ -7,18 +7,6 @@ inline fun <T> T.takeIfNotEqualTo(other: T?, block: (T) -> Unit) {
     if (this != other) block(this)
 }
 
-/**
- * Used to convert when statement into expression. In this case compiler check if all the cases are handled
- *
- * when (sealedClass) {
- *
- *      }.exhaustive
- *
- * https://proandroiddev.com/til-when-is-when-exhaustive-31d69f630a8b
- */
-val Any?.exhaustive
-    get() = Unit
-
 suspend inline fun <T, R> T.runWithContext(
     context: CoroutineContext,
     crossinline block: (T) -> R

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HELP_CON
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE_FLOW
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE_STEP
 import com.woocommerce.android.databinding.ActivityHelpBinding
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.extensions.serializable
 import com.woocommerce.android.extensions.show
@@ -107,7 +106,7 @@ class HelpActivity : AppCompatActivity() {
                         is ShowLoading -> {
                             binding.helpLoading.visibility = View.VISIBLE
                         }
-                    }.exhaustive
+                    }
                 }
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/storecreation/plans/PlansViewModel.kt
@@ -14,7 +14,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STEP_PLAN_PURCHASE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_STEP_WEB_CHECKOUT
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.iap.pub.IAPActivityWrapper
 import com.woocommerce.android.iap.pub.PurchaseWPComPlanActions
 import com.woocommerce.android.iap.pub.model.IAPError
@@ -220,7 +219,7 @@ class PlansViewModel @Inject constructor(
                     when (result) {
                         is WPComPurchaseResult.Success -> onPurchaseSuccess()
                         is WPComPurchaseResult.Error -> onInAppPurchaseError(result)
-                    }.exhaustive
+                    }
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -49,7 +49,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.ActivityMainBinding
 import com.woocommerce.android.extensions.active
 import com.woocommerce.android.extensions.collapse
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.expand
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
@@ -858,7 +857,7 @@ class MainActivity :
                 is UnseenReviews -> binding.bottomNav.showMoreMenuUnseenReviewsBadge(moreMenuBadgeState.count)
                 NewFeature -> binding.bottomNav.showMoreMenuNewFeatureBadge()
                 Hidden -> binding.bottomNav.hideMoreMenuBadge()
-            }.exhaustive
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.REVIEW_OPEN
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.isWooExpressSiteReadyToUse
 import com.woocommerce.android.model.FeatureAnnouncement
 import com.woocommerce.android.model.Notification
@@ -175,7 +174,7 @@ class MainActivityViewModel @Inject constructor(
             ResolveAppLink.Action.DoNothing -> {
                 // no-op
             }
-        }.exhaustive
+        }
     }
 
     private fun handlePostStoreCreationTasks() = launch(dispatchers.io) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
@@ -22,7 +22,6 @@ import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.C
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.StripeM2
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.WisePade3
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateInProgress
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.tools.SelectedSite
@@ -284,7 +283,7 @@ class CardReaderConnectViewModel @Inject constructor(
                     connectionStarted = true
                     viewState.value = provideConnectingState()
                 }
-            }.exhaustive
+            }
         }
     }
 
@@ -332,7 +331,7 @@ class CardReaderConnectViewModel @Inject constructor(
             CardReaderUpdateViewModel.UpdateResult.SUCCESS -> {
                 // noop
             }
-        }.exhaustive
+        }
     }
 
     private fun onReadersFound(discoveryEvent: ReadersFound) {
@@ -426,7 +425,7 @@ class CardReaderConnectViewModel @Inject constructor(
                     is CardReaderLocationRepository.LocationIdFetchingResult.Error -> {
                         handleLocationFetchingError(result)
                     }
-                }.exhaustive
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailFragment.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.R.color
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentCardReaderDetailBinding
 import com.woocommerce.android.extensions.copyToClipboard
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.expandHitArea
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
@@ -151,7 +150,7 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                 }
                 Loading -> {
                 }
-            }.exhaustive
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModel.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.cardreader.connection.ReaderType
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus.StatusChanged
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
@@ -87,7 +86,7 @@ class CardReaderDetailViewModel @Inject constructor(
                         )
                         handleNotConnectedState()
                     }
-                }.exhaustive
+                }
             }
         }
     }
@@ -126,7 +125,7 @@ class CardReaderDetailViewModel @Inject constructor(
                 triggerEvent(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_success))
             }
             FAILED -> triggerEvent(Event.ShowSnackbar(R.string.card_reader_detail_connected_update_failed))
-        }.exhaustive
+        }
     }
 
     private fun handleNotConnectedState() {
@@ -230,7 +229,7 @@ class CardReaderDetailViewModel @Inject constructor(
         when (updateStatus) {
             SoftwareUpdateAvailability.Available -> showConnectedState(readerStatus, updateAvailable = true)
             SoftwareUpdateAvailability.NotAvailable -> showConnectedState(readerStatus)
-        }.exhaustive
+        }
     }
 
     private fun handleBatteryStatusChange(newStatus: CardReaderBatteryStatus) {
@@ -239,7 +238,7 @@ class CardReaderDetailViewModel @Inject constructor(
                 updateBatteryLevelOnConnectedState(newStatus.batteryLevel)
             }
             else -> {}
-        }.exhaustive
+        }
     }
 
     private fun clearLastKnowReader() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -23,7 +23,6 @@ import com.woocommerce.android.databinding.FragmentCardReaderOnboardingSelectPay
 import com.woocommerce.android.databinding.FragmentCardReaderOnboardingStripeBinding
 import com.woocommerce.android.databinding.FragmentCardReaderOnboardingUnsupportedBinding
 import com.woocommerce.android.databinding.FragmentCardReaderOnboardingWcpayBinding
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.startHelpActivity
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.base.BaseFragment
@@ -136,7 +135,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                 showPaymentPluginSelectionState(layout, state)
             is CardReaderOnboardingViewState.CashOnDeliveryDisabledState ->
                 showCashOnDeliveryDisabledState(layout, state)
-        }.exhaustive
+        }
     }
 
     private fun showCashOnDeliveryDisabledState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.formatToMMMMdd
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.SelectedSite
@@ -93,7 +92,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
         when (val onboardingParam = arguments.cardReaderOnboardingParam) {
             is Check -> refreshState(onboardingParam.pluginType)
             is Failed -> showOnboardingState(onboardingParam.onboardingState)
-        }.exhaustive
+        }
     }
 
     private fun refreshState(pluginType: PluginType? = null) {
@@ -280,7 +279,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
                     onLearnMoreActionClicked = ::onLearnMoreClicked,
                     onContactSupportActionClicked = ::onContactSupportClicked
                 )
-        }.exhaustive
+        }
     }
 
     private fun onSkipCashOnDeliveryClicked(
@@ -439,7 +438,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
                     CardReaderOnboardingEvent.ContinueToConnection(params, requireNotNull(arguments.cardReaderType))
                 )
             }
-        }.exhaustive
+        }
     }
 
     private fun convertCountryCodeToCountry(countryCode: String?) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -47,7 +47,6 @@ import com.woocommerce.android.cardreader.payments.PaymentInfo
 import com.woocommerce.android.cardreader.payments.RefundConfig
 import com.woocommerce.android.cardreader.payments.RefundParams
 import com.woocommerce.android.cardreader.payments.StatementDescriptor
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
@@ -200,7 +199,7 @@ class CardReaderPaymentViewModel
 
                 is BluetoothCardReaderMessages.CardReaderNoMessage -> { /* no-op*/
                 }
-            }.exhaustive
+            }
         }
     }
 
@@ -375,7 +374,7 @@ class CardReaderPaymentViewModel
                 tracker.trackPaymentFailed(paymentStatus.errorMessage, paymentStatus.type)
                 emitFailedPaymentState(orderId, billingEmail, paymentStatus, amountLabel)
             }
-        }.exhaustive
+        }
     }
 
     private suspend fun refundPaymentFlow(
@@ -451,7 +450,7 @@ class CardReaderPaymentViewModel
                     refundStatus
                 )
             }
-        }.exhaustive
+        }
     }
 
     private fun onPaymentCompleted(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerDialogFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.ui.payments.PaymentsBaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -68,7 +67,7 @@ class CardReaderStatusCheckerDialogFragment : PaymentsBaseDialogFragment(R.layou
                         )
                 }
                 else -> event.isHandled = false
-            }.exhaustive
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModel.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
 import com.woocommerce.android.cardreader.connection.ReaderType
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.ui.payments.cardreader.CardReaderTracker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
@@ -70,7 +69,7 @@ class CardReaderStatusCheckerViewModel
                     handleOnboardingStatus(param)
                 }
             }
-        }.exhaustive
+        }
     }
 
     private suspend fun handleNotSelectedReaderTypeConnected(param: CardReaderFlowParam) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/update/CardReaderUpdateViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/update/CardReaderUpdateViewModel.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.Success
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus.Unknown
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatusErrorType
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
@@ -94,7 +93,7 @@ class CardReaderUpdateViewModel @Inject constructor(
                 }
                 Success -> onUpdateSucceeded()
                 Unknown -> onUpdateStatusUnknown()
-            }.exhaustive
+            }
         }
     }
 
@@ -120,7 +119,7 @@ class CardReaderUpdateViewModel @Inject constructor(
                     ),
                 )
             else -> finishFlow(FAILED)
-        }.exhaustive
+        }
     }
 
     private fun finishFlow(result: UpdateResult) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewModel.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.tools.SelectedSite
@@ -128,7 +127,7 @@ class PaymentsHubViewModel @Inject constructor(
             SoftwareUpdateAvailability.NotAvailable -> {
                 // no op
             }
-        }.exhaustive
+        }
     }
 
     private val initialState
@@ -508,7 +507,7 @@ class PaymentsHubViewModel @Inject constructor(
             is PaymentOrRefund -> {
                 // no-op
             }
-        }.exhaustive
+        }
     }
 
     private fun handlePositiveButtonClickTTPUnavailable(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -17,7 +17,6 @@ import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentSelectPaymentMethodBinding
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.handleDialogNotice
 import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.navigateSafely
@@ -74,7 +73,7 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
             when (state) {
                 Loading -> renderLoadingState(binding)
                 is Success -> renderSuccessfulState(binding, state)
-            }.exhaustive
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_COLLECT_LINK
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.internal.payments.PaymentUtils
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
@@ -118,7 +117,7 @@ class SelectPaymentMethodViewModel @Inject constructor(
                     is Refund -> triggerEvent(NavigateToCardReaderRefundFlow(param, EXTERNAL))
                 }
             }
-        }.exhaustive
+        }
     }
 
     private suspend fun showPaymentState() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.adminUrlOrDefault
 import com.woocommerce.android.extensions.calculateTotals
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.isCashPayment
 import com.woocommerce.android.extensions.isEqualTo
 import com.woocommerce.android.extensions.joinToString
@@ -818,7 +817,7 @@ class IssueRefundViewModel @Inject constructor(
                     cardType = PaymentMethodType.CARD_PRESENT
                     updateRefundSummaryState(refundMethod, isMethodDescriptionVisible = false)
                 }
-            }.exhaustive
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/searchfilter/SearchFilterFragment.kt
@@ -10,7 +10,6 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentSearchFilterBinding
-import com.woocommerce.android.extensions.exhaustive
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.show
@@ -94,7 +93,7 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
                         hideSearchList()
                         showEmptyView(viewState.searchQuery)
                     }
-                }.exhaustive
+                }
             }
         )
     }
@@ -107,7 +106,7 @@ class SearchFilterFragment : BaseFragment(R.layout.fragment_search_filter) {
                     is ItemSelected -> {
                         navigateBackWithResult(event.requestKey, event.selectedItemValue)
                     }
-                }.exhaustive
+                }
             }
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10541
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Since some time all `when` require to be `exhaustive` so the property we used before for this matter not needed. The PR reviews them

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Look at the changes


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
