### PR TITLE
[Tablet Orders] Mimic gift section behavior for edit/creation mode the same as on trunk

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 17.2
 -----
 - [*] [Internal] Tracking of "country" and "currency" properties for entry and exit of the payments flows [https://github.com/woocommerce/woocommerce-android/pull/10528]
+- [*] Fixed bug when gift card was not displayed in the "totals" sections on the order creation/editing screens [https://github.com/woocommerce/woocommerce-android/pull/10546]
 
 17.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -386,7 +386,7 @@ data class Order(
                 paymentUrl = "",
                 isEditable = true,
                 selectedGiftCard = "",
-                giftCardDiscountedAmount = BigDecimal(0)
+                giftCardDiscountedAmount = null
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -79,7 +79,6 @@ import com.woocommerce.android.ui.payments.customamounts.CustomAmountsViewModel.
 import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
@@ -585,7 +584,6 @@ class OrderCreateEditFormFragment :
     private fun OrderCreationAdditionalInfoCollectionSectionBinding.bindGiftCardForOrderCreation(
         newOrderData: Order
     ) {
-        if (FeatureFlag.ORDER_GIFT_CARD.isEnabled().not()) return
         if (newOrderData.selectedGiftCard.isNullOrEmpty()) {
             addGiftCardButton.isVisible = viewModel.isGiftCardExtensionEnabled
             addGiftCardButton.setOnClickListener { viewModel.onAddGiftCardButtonClicked() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -128,7 +128,6 @@ import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.Sel
 import com.woocommerce.android.ui.products.selector.variationIds
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.DateUtils
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -699,8 +698,7 @@ class OrderCreateEditViewModel @Inject constructor(
         viewState = viewState.copy(
             isAddGiftCardButtonEnabled = order.hasProducts() &&
                 order.isEditable &&
-                _selectedGiftCard.value.isEmpty() &&
-                FeatureFlag.ORDER_GIFT_CARD.isEnabled()
+                _selectedGiftCard.value.isEmpty()
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -253,14 +253,20 @@ class OrderCreateEditViewModel @Inject constructor(
         }.asLiveData()
 
     val totalsData: LiveData<TotalsSectionsState> =
-        viewStateData.liveData.combineWith(orderDraft) { viewState, order ->
+        viewStateData.liveData.combineWith(
+            _orderDraft.asLiveData(),
+            _selectedGiftCard.asLiveData()
+        ) { viewState, order, selectedGiftCard ->
             totalsHelper.mapToPaymentTotalsState(
-                order = order!!,
+                order = order!!.copy(
+                    selectedGiftCard = selectedGiftCard,
+                    giftCardDiscountedAmount = args.giftCardAmount
+                ),
                 mode = mode,
                 viewState = viewState!!,
                 onShippingClicked = { onShippingButtonClicked() },
                 onCouponsClicked = { onCouponButtonClicked() },
-                onGiftClicked = { onEditGiftCardButtonClicked(order.selectedGiftCard) },
+                onGiftClicked = { onEditGiftCardButtonClicked(selectedGiftCard) },
                 onTaxesLearnMore = { onTaxHelpButtonClicked() },
                 onMainButtonClicked = { onTotalsSectionPrimaryButtonClicked() },
                 onExpandCollapseClicked = { onExpandCollapseTotalsClicked(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -354,7 +354,10 @@ class OrderCreateEditViewModel @Inject constructor(
             is Mode.Edit -> {
                 viewModelScope.launch {
                     orderDetailRepository.getOrderById(mode.orderId)?.let { order ->
-                        _orderDraft.value = order
+                        _orderDraft.value = order.copy(
+                            selectedGiftCard = args.giftCardCode,
+                            giftCardDiscountedAmount = args.giftCardAmount,
+                        )
                         viewState = viewState.copy(
                             isUpdatingOrderDraft = false,
                             showOrderUpdateSnackbar = false,
@@ -1098,11 +1101,10 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     fun onGiftCardSelected(selectedGiftCard: String) {
-        _selectedGiftCard.update { selectedGiftCard }
         _orderDraft.update {
             it.copy(
                 selectedGiftCard = selectedGiftCard,
-                giftCardDiscountedAmount = -(args.giftCardAmount ?: BigDecimal.ZERO)
+                giftCardDiscountedAmount = args.giftCardAmount
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
@@ -150,7 +150,7 @@ class OrderCreateEditTotalsHelper @Inject constructor(
         if (!selectedGiftCard.isNullOrEmpty()) {
             TotalsSectionsState.Line.Button(
                 text = resourceProvider.getString(R.string.order_gift_card),
-                value = bigDecimalFormatter(giftCardDiscountedAmount ?: BigDecimal.ZERO),
+                value = giftCardDiscountedAmount?.let { "-" + bigDecimalFormatter(it) } ?: "",
                 extraValue = selectedGiftCard,
                 enabled = enabled,
                 onClick = onClick,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -95,7 +95,6 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
     private fun showPaymentSubDetails() {
         binding.paymentInfoProductsTotalSection.show()
         binding.paymentInfoDiscountSection.show()
-        binding.paymentInfoGiftCardSection.show()
         binding.paymentInfoFeesSection.show()
         binding.paymentInfoShippingSection.show()
         binding.paymentInfoTaxesSection.show()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -12,7 +12,6 @@ enum class FeatureFlag {
     IAP_FOR_STORE_CREATION,
     BETTER_CUSTOMER_SEARCH_M2,
     ORDER_CREATION_AUTO_TAX_RATE,
-    ORDER_GIFT_CARD,
     BLAZE_I3;
 
     fun isEnabled(context: Context? = null): Boolean {
@@ -20,8 +19,6 @@ enum class FeatureFlag {
             DB_DOWNGRADE -> {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
-
-            ORDER_GIFT_CARD -> true
 
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelperTest.kt
@@ -34,7 +34,7 @@ class OrderCreateEditTotalsHelperTest {
 
     @Test
     @Suppress("LongMethod")
-    fun `given ff enabled and items not empty, when mapToPaymentTotalsState, then full returned`() {
+    fun `given items not empty, when mapToPaymentTotalsState, then full returned`() {
         // GIVEN
         val item = mock<Order.Item> {
             on { total }.thenReturn(BigDecimal(11))
@@ -189,7 +189,7 @@ class OrderCreateEditTotalsHelperTest {
     }
 
     @Test
-    fun `given ff enabled and fee lines not empty, when mapToPaymentTotalsState, then full returned`() {
+    fun `given fee lines not empty, when mapToPaymentTotalsState, then full returned`() {
         // GIVEN
         whenever(resourceProvider.getString(R.string.order_creation_collect_payment_button)).thenReturn(
             "Collect Payment"
@@ -221,7 +221,7 @@ class OrderCreateEditTotalsHelperTest {
     }
 
     @Test
-    fun `given ff enabled and items and fee lines empty, when mapToPaymentTotalsState, then minimised returned`() {
+    fun `given items and fee lines empty, when mapToPaymentTotalsState, then minimised returned`() {
         // GIVEN
         val localOrder = order.copy(
             items = emptyList(),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelperTest.kt
@@ -171,7 +171,7 @@ class OrderCreateEditTotalsHelperTest {
         assertThat((actual.lines[3] as TotalsSectionsState.Line.Button).onClick == onCouponsClicked).isTrue()
 
         assertThat((actual.lines[4] as TotalsSectionsState.Line.Button).text).isEqualTo("Gift Cards")
-        assertThat((actual.lines[4] as TotalsSectionsState.Line.Button).value).isEqualTo("15.00$")
+        assertThat((actual.lines[4] as TotalsSectionsState.Line.Button).value).isEqualTo("-15.00$")
         assertThat((actual.lines[4] as TotalsSectionsState.Line.Button).enabled).isFalse()
         assertThat((actual.lines[4] as TotalsSectionsState.Line.Button).extraValue).isEqualTo("21OFF")
         assertThat((actual.lines[4] as TotalsSectionsState.Line.Button).onClick == onGiftClicked).isTrue()
@@ -251,5 +251,43 @@ class OrderCreateEditTotalsHelperTest {
         // THEN
         assertThat((actual as TotalsSectionsState.Minimised).orderTotal.label).isEqualTo("Order Total")
         assertThat(actual.orderTotal.value).isEqualTo("10.00$")
+    }
+
+    @Test
+    fun `given items not empty and gift amount is null, when mapToPaymentTotalsState, then gift value is empty`() {
+        // GIVEN
+        val item = mock<Order.Item> {
+            on { total }.thenReturn(BigDecimal(11))
+        }
+        val localOrder = order.copy(
+            items = listOf(item),
+            selectedGiftCard = "21OFF",
+            giftCardDiscountedAmount = null,
+        )
+
+        whenever(resourceProvider.getString(R.string.order_gift_card)).thenReturn(
+            "Gift Cards"
+        )
+
+        // WHEN
+        val actual = helper.mapToPaymentTotalsState(
+            localOrder,
+            OrderCreateEditViewModel.Mode.Creation,
+            OrderCreateEditViewModel.ViewState(),
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+        )
+
+        // THEN
+        actual as TotalsSectionsState.Full
+
+        assertThat((actual.lines[1] as TotalsSectionsState.Line.Button).text).isEqualTo("Gift Cards")
+        assertThat((actual.lines[1] as TotalsSectionsState.Line.Button).value).isEqualTo("")
+        assertThat((actual.lines[1] as TotalsSectionsState.Line.Button).enabled).isFalse()
+        assertThat((actual.lines[1] as TotalsSectionsState.Line.Button).extraValue).isEqualTo("21OFF")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10500
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes the bug when the selected card gift information was not shown in the new bottom drawer view 
Also, I removed the forgotten FF set to true with dead code around that

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
* Install https://woo.com/products/gift-cards/
* Marketing -> Gift cards -> Create a gift card product
* Make a purchase of it and send that to some of your emails (check spam)
* in the app: Orders -> Create order -> Add Product -> Add gift card
* Notice that the gift card is displayed in the bottom drawer
* Created order -> Edit order -> Notice that the gift card is displayed in the bottom drawer

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/4923871/761765b0-a8b1-4ae1-a528-64a7dd3137d7


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
