### PR TITLE
Github Actions job for sending dependencies to GitHub Dependency Graph

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,25 @@
+name: Submit dependencies to GitHub Dependency Graph
+on:
+  push:
+    branches:
+      - trunk
+      - release/*
+      - workflow_dispatch
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - run: cp gradle.properties-example gradle.properties
+      - name: Setup Gradle to generate and submit dependency graphs
+        uses: gradle/gradle-build-action@v2
+        with:
+          dependency-graph: generate-and-submit
+      - name: Generate the dependency graph which will be submitted post-job
+        run: ./gradlew dependencies

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - trunk
       - release/*
-      - workflow_dispatch
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a GitHub Actions job to send Gradle/Maven dependencies to Github Dependency Graph for each push to `trunk` or `release/*` branch.

By sending those dependencies, we allow Dependabot to scan whether dependencies we use are affected by known vulnerabilities.

Soon, those metrics will be available to visualize on Apps Metrics ([link](https://metrics.a8c-ci.services/grafana/d/f2131a73-89a3-48b9-8d3b-ecc1456347ac/dependabot-security-alerts?orgId=1)).

More about this project can be found internally at paaHJt-5Tn-p2

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
This PR can be only verified using the fork: https://github.com/wzieba/woocommerce-android

- Assert that you can see security alerts at https://github.com/wzieba/woocommerce-android/security/dependabot and that some of them are related to `Maven` ecosystem.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->