### PR TITLE
Crash: Media URL null returned by the API

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -146,7 +146,7 @@ class MediaFilesRepository @Inject constructor(
 
                 event.completed -> {
                     val media = event.media
-                    val channelResult = if (media != null && media.url.isNotNullOrEmpty() && media.url.isNotBlank()) {
+                    val channelResult = if (media != null && media.url.isNotNullOrEmpty()) {
                         WooLog.i(T.MEDIA, "MediaFilesRepository > uploaded media ${media.id}")
                         producerScope.trySendBlocking(
                             UploadSuccess(media)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.media
 import android.content.Context
 import android.net.Uri
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.media.MediaFilesRepository.UploadResult.UploadFailure
 import com.woocommerce.android.media.MediaFilesRepository.UploadResult.UploadSuccess
 import com.woocommerce.android.tools.SelectedSite
@@ -145,7 +146,7 @@ class MediaFilesRepository @Inject constructor(
 
                 event.completed -> {
                     val media = event.media
-                    val channelResult = if (media != null && media.url.isNotBlank()) {
+                    val channelResult = if (media != null && media.url.isNotNullOrEmpty() && media.url.isNotBlank()) {
                         WooLog.i(T.MEDIA, "MediaFilesRepository > uploaded media ${media.id}")
                         producerScope.trySendBlocking(
                             UploadSuccess(media)


### PR DESCRIPTION
Fixes #10264. The WCAndroid client works with the wrong assumption that the `MediaModel.url` cannot be null. This PR handles that case.

**To test:**
There's nothing to test since it's difficult to reproduce the scenario.