### PR TITLE
Issue/10551 campaig preview loading

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.media
 import android.content.Context
 import android.net.Uri
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.media.MediaFilesRepository.UploadResult.UploadFailure
 import com.woocommerce.android.media.MediaFilesRepository.UploadResult.UploadSuccess
 import com.woocommerce.android.tools.SelectedSite
@@ -145,7 +146,7 @@ class MediaFilesRepository @Inject constructor(
 
                 event.completed -> {
                     val media = event.media
-                    val channelResult = if (media != null && media.url.isNotBlank()) {
+                    val channelResult = if (media != null && media.url.isNotNullOrEmpty()) {
                         WooLog.i(T.MEDIA, "MediaFilesRepository > uploaded media ${media.id}")
                         producerScope.trySendBlocking(
                             UploadSuccess(media)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.blaze.creation.preview
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -43,6 +45,7 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.CampaignPreviewUiState.CampaignDetailItem
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.CampaignPreviewUiState.CampaignPreviewContent
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.CampaignPreviewUiState.Loading
+import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
@@ -64,7 +67,12 @@ fun BlazeCampaignCreationPreviewScreen(viewModel: BlazeCampaignCreationPreviewVi
                 modifier = Modifier.background(MaterialTheme.colors.surface)
             ) { paddingValues ->
                 when (previewState) {
-                    is Loading -> LoadingPreview()
+                    is Loading -> CampaignLoadingPreview(
+                        modifier = Modifier
+                            .padding(paddingValues)
+                            .background(color = MaterialTheme.colors.surface)
+                    )
+
                     is CampaignPreviewContent -> CampaignPreviewContent(
                         state = previewState,
                         modifier = Modifier
@@ -78,8 +86,88 @@ fun BlazeCampaignCreationPreviewScreen(viewModel: BlazeCampaignCreationPreviewVi
 }
 
 @Composable
-fun LoadingPreview() {
-    TODO("Not yet implemented")
+private fun CampaignLoadingPreview(modifier: Modifier = Modifier) {
+    @Composable
+    fun CampaignHeaderSkeletons() {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(color = colorResource(id = R.color.blaze_campaign_preview_header_background)),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Card(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+                shape = RoundedCornerShape(8.dp)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    SkeletonView(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(276.dp)
+                    )
+                    SkeletonView(
+                        modifier = Modifier
+                            .width(120.dp)
+                            .height(8.dp)
+                    )
+                    Row(verticalAlignment = Alignment.Bottom) {
+                        SkeletonView(
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(24.dp))
+                        SkeletonView(
+                            modifier = Modifier
+                                .width(80.dp)
+                                .height(24.dp)
+                        )
+                    }
+                }
+            }
+            WCTextButton(
+                modifier = Modifier.padding(bottom = 8.dp),
+                onClick = { /* No action expected for disabled button */ },
+                enabled = false,
+            ) {
+                Text(stringResource(id = R.string.blaze_campaign_preview_edit_ad_button))
+            }
+        }
+    }
+
+    @Composable
+    fun CampaignDetailSkeletons() {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                modifier = Modifier.padding(bottom = 8.dp),
+                text = stringResource(id = R.string.blaze_campaign_preview_details_section_title),
+                style = MaterialTheme.typography.body2
+            )
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .fillMaxWidth(),
+    ) {
+        CampaignHeaderSkeletons()
+        CampaignDetailSkeletons()
+    }
 }
 
 @Composable
@@ -319,4 +407,10 @@ fun CampaignScreenPreview() {
             maxLinesValue = 1,
         )
     )
+}
+
+@LightDarkThemePreviews
+@Composable
+fun CampaignLoadingScreenPreview() {
+    CampaignLoadingScreenPreview()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
@@ -42,6 +42,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.woocommerce.android.R
 import com.woocommerce.android.R.string
+import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.CampaignPreviewUiState
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.CampaignPreviewUiState.CampaignDetailItem
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.CampaignPreviewUiState.CampaignPreviewContent
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.CampaignPreviewUiState.Loading
@@ -50,43 +51,55 @@ import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
-import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 fun BlazeCampaignCreationPreviewScreen(viewModel: BlazeCampaignCreationPreviewViewModel) {
     viewModel.viewState.observeAsState().value?.let { previewState ->
-        WooThemeWithBackground {
-            Scaffold(
-                topBar = {
-                    Toolbar(
-                        title = stringResource(id = R.string.blaze_campaign_screen_fragment_title),
-                        onNavigationButtonClick = { /*TODO*/ },
-                        navigationIcon = Filled.ArrowBack
-                    )
-                },
-                modifier = Modifier.background(MaterialTheme.colors.surface)
-            ) { paddingValues ->
-                when (previewState) {
-                    is Loading -> CampaignLoadingPreview(
-                        modifier = Modifier
-                            .padding(paddingValues)
-                            .background(color = MaterialTheme.colors.surface)
-                    )
+        BlazeCampaignCreationPreviewScreen(previewState)
+    }
+}
 
-                    is CampaignPreviewContent -> CampaignPreviewContent(
-                        state = previewState,
-                        modifier = Modifier
-                            .padding(paddingValues)
-                            .background(color = MaterialTheme.colors.surface)
-                    )
-                }
+@Composable
+private fun BlazeCampaignCreationPreviewScreen(previewState: CampaignPreviewUiState) {
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = stringResource(id = R.string.blaze_campaign_screen_fragment_title),
+                onNavigationButtonClick = { /*TODO*/ },
+                navigationIcon = Filled.ArrowBack
+            )
+        },
+        modifier = Modifier.background(MaterialTheme.colors.surface)
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .fillMaxSize()
+                .padding(paddingValues)
+                .background(color = MaterialTheme.colors.surface)
+        ) {
+            when (previewState) {
+                is Loading -> CampaignPreviewLoading()
+                is CampaignPreviewContent -> CampaignPreviewContent(state = previewState)
             }
+
+            Spacer(modifier = Modifier.height(16.dp))
+            Divider()
+            WCColoredButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .padding(bottom = 8.dp),
+                text = stringResource(id = R.string.blaze_campaign_preview_details_confirm_details_button),
+                onClick = { /*TODO*/ },
+                enabled = previewState !is Loading
+            )
         }
     }
 }
 
 @Composable
-private fun CampaignLoadingPreview(modifier: Modifier = Modifier) {
+private fun CampaignPreviewLoading(modifier: Modifier = Modifier) {
     @Composable
     fun CampaignHeaderSkeletons() {
         Column(
@@ -160,11 +173,7 @@ private fun CampaignLoadingPreview(modifier: Modifier = Modifier) {
         }
     }
 
-    Column(
-        modifier = modifier
-            .verticalScroll(rememberScrollState())
-            .fillMaxWidth(),
-    ) {
+    Column(modifier = modifier.fillMaxWidth()) {
         CampaignHeaderSkeletons()
         CampaignDetailSkeletons()
     }
@@ -175,11 +184,7 @@ fun CampaignPreviewContent(
     state: CampaignPreviewContent,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-            .verticalScroll(rememberScrollState())
-            .fillMaxSize()
-    ) {
+    Column(modifier = modifier.fillMaxWidth()) {
         CampaignHeader(
             state = state,
             modifier = Modifier
@@ -193,16 +198,6 @@ fun CampaignPreviewContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp)
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Divider()
-        WCColoredButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-                .padding(bottom = 8.dp),
-            text = stringResource(id = R.string.blaze_campaign_preview_details_confirm_details_button),
-            onClick = { /*TODO*/ },
         )
     }
 }
@@ -374,37 +369,39 @@ private fun CampaignPropertyItem(
 @LightDarkThemePreviews
 @Composable
 fun CampaignScreenPreview() {
-    CampaignPreviewContent(
-        productId = 123,
-        title = "Get the latest white t-shirts",
-        tagLine = "From 45.00 USD",
-        campaignImageUrl = "https://rb.gy/gmjuwb",
-        budget = CampaignDetailItem(
-            displayTitle = stringResource(R.string.blaze_campaign_preview_details_budget),
-            displayValue = "140 USD, 7 days from Jan 14",
-        ),
-        audienceDetails = listOf(
-            CampaignDetailItem(
-                displayTitle = stringResource(string.blaze_campaign_preview_details_language),
-                displayValue = "English, Spanish",
+    BlazeCampaignCreationPreviewScreen(
+        CampaignPreviewContent(
+            productId = 123,
+            title = "Get the latest white t-shirts",
+            tagLine = "From 45.00 USD",
+            campaignImageUrl = "https://rb.gy/gmjuwb",
+            budget = CampaignDetailItem(
+                displayTitle = stringResource(R.string.blaze_campaign_preview_details_budget),
+                displayValue = "140 USD, 7 days from Jan 14",
             ),
-            CampaignDetailItem(
-                displayTitle = stringResource(string.blaze_campaign_preview_details_devices),
-                displayValue = "USA, Poland, Japan",
+            audienceDetails = listOf(
+                CampaignDetailItem(
+                    displayTitle = stringResource(string.blaze_campaign_preview_details_language),
+                    displayValue = "English, Spanish",
+                ),
+                CampaignDetailItem(
+                    displayTitle = stringResource(string.blaze_campaign_preview_details_devices),
+                    displayValue = "USA, Poland, Japan",
+                ),
+                CampaignDetailItem(
+                    displayTitle = stringResource(string.blaze_campaign_preview_details_location),
+                    displayValue = "Samsung, Apple, Xiaomi",
+                ),
+                CampaignDetailItem(
+                    displayTitle = stringResource(string.blaze_campaign_preview_details_interests),
+                    displayValue = "Fashion, Clothing, T-shirts",
+                ),
             ),
-            CampaignDetailItem(
-                displayTitle = stringResource(string.blaze_campaign_preview_details_location),
-                displayValue = "Samsung, Apple, Xiaomi",
-            ),
-            CampaignDetailItem(
-                displayTitle = stringResource(string.blaze_campaign_preview_details_interests),
-                displayValue = "Fashion, Clothing, T-shirts",
-            ),
-        ),
-        destinationUrl = CampaignDetailItem(
-            displayTitle = "Destination URL",
-            displayValue = "https://www.myer.com.au/p/white-t-shirt-797334760-797334760",
-            maxLinesValue = 1,
+            destinationUrl = CampaignDetailItem(
+                displayTitle = "Destination URL",
+                displayValue = "https://www.myer.com.au/p/white-t-shirt-797334760-797334760",
+                maxLinesValue = 1,
+            )
         )
     )
 }
@@ -412,5 +409,5 @@ fun CampaignScreenPreview() {
 @LightDarkThemePreviews
 @Composable
 fun CampaignLoadingScreenPreview() {
-    CampaignLoadingScreenPreview()
+    CampaignPreviewLoading()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
@@ -99,83 +99,61 @@ private fun BlazeCampaignCreationPreviewScreen(previewState: CampaignPreviewUiSt
 }
 
 @Composable
-private fun CampaignPreviewLoading(modifier: Modifier = Modifier) {
-    @Composable
-    fun CampaignHeaderSkeletons() {
-        Column(
+private fun CampaignPreviewLoading(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(color = colorResource(id = R.color.blaze_campaign_preview_header_background)),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Card(
             modifier = Modifier
-                .fillMaxWidth()
                 .padding(16.dp)
-                .clip(RoundedCornerShape(8.dp))
-                .background(color = colorResource(id = R.color.blaze_campaign_preview_header_background)),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .fillMaxWidth(),
+            shape = RoundedCornerShape(8.dp)
         ) {
-            Card(
+            Column(
                 modifier = Modifier
-                    .padding(16.dp)
-                    .fillMaxWidth(),
-                shape = RoundedCornerShape(8.dp)
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                Column(
+                SkeletonView(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp)
-                ) {
+                        .height(276.dp)
+                )
+                SkeletonView(
+                    modifier = Modifier
+                        .width(120.dp)
+                        .height(8.dp)
+                )
+                Row(verticalAlignment = Alignment.Bottom) {
                     SkeletonView(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .height(276.dp)
+                            .weight(1f)
+                            .height(16.dp)
                     )
+                    Spacer(modifier = Modifier.width(24.dp))
                     SkeletonView(
                         modifier = Modifier
-                            .width(120.dp)
-                            .height(8.dp)
+                            .width(80.dp)
+                            .height(24.dp)
                     )
-                    Row(verticalAlignment = Alignment.Bottom) {
-                        SkeletonView(
-                            modifier = Modifier
-                                .weight(1f)
-                                .height(16.dp)
-                        )
-                        Spacer(modifier = Modifier.width(24.dp))
-                        SkeletonView(
-                            modifier = Modifier
-                                .width(80.dp)
-                                .height(24.dp)
-                        )
-                    }
                 }
             }
-            WCTextButton(
-                modifier = Modifier.padding(bottom = 8.dp),
-                onClick = { /* No action expected for disabled button */ },
-                enabled = false,
-            ) {
-                Text(stringResource(id = R.string.blaze_campaign_preview_edit_ad_button))
-            }
         }
-    }
-
-    @Composable
-    fun CampaignDetailSkeletons() {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+        WCTextButton(
+            modifier = Modifier.padding(bottom = 8.dp),
+            onClick = { /* No action expected for disabled button */ },
+            enabled = false,
         ) {
-            Text(
-                modifier = Modifier.padding(bottom = 8.dp),
-                text = stringResource(id = R.string.blaze_campaign_preview_details_section_title),
-                style = MaterialTheme.typography.body2
-            )
+            Text(stringResource(id = R.string.blaze_campaign_preview_edit_ad_button))
         }
-    }
-
-    Column(modifier = modifier.fillMaxWidth()) {
-        CampaignHeaderSkeletons()
-        CampaignDetailSkeletons()
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -27,6 +27,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
 
     init {
         launch {
+            @Suppress("MagicNumber")
             delay(5000)
             val product = productDetailRepository.getProduct(navArgs.productId)
             _viewState.value = CampaignPreviewUiState.CampaignPreviewContent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -26,6 +27,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
 
     init {
         launch {
+            delay(10000)
             val product = productDetailRepository.getProduct(navArgs.productId)
             _viewState.value = CampaignPreviewUiState.CampaignPreviewContent(
                 productId = product?.remoteId ?: -1,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -27,7 +27,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
 
     init {
         launch {
-            delay(10000)
+            delay(5000)
             val product = productDetailRepository.getProduct(navArgs.productId)
             _viewState.value = CampaignPreviewUiState.CampaignPreviewContent(
                 productId = product?.remoteId ?: -1,
@@ -68,6 +68,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     sealed interface CampaignPreviewUiState {
         object Loading : CampaignPreviewUiState
         data class CampaignPreviewContent(
+            val isLoading: Boolean = false,
             val productId: Long,
             val title: String,
             val tagLine: String,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10551 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We don't have an official design for the loading part, but we agreed on replicating the shimmering/skeleton effect while we fetch the AI suggestion for the Blaze campaign. 
This PR adds the loading UI for the header part. Note that the details section is not shown yet. I'll do a refactor in a subsequent PR I'm working on to show the preview details section right away below the loading header section. 

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
- Click on "Create campaign" from any of the Blaze CTAs
- Check the shimmering effect is correct in light and dark mode

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/207374fd-23f4-43da-b893-da2f3251394a