### PR TITLE
Handle null or empty dates

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateUtils.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.util.WooLog.T.UTILS
 import org.apache.commons.lang3.time.DateUtils
 import org.wordpress.android.fluxc.utils.SiteUtils
 import java.text.DateFormatSymbols
-import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -373,6 +372,7 @@ class DateUtils @Inject constructor(
         }
 
     fun getDateUsingSiteTimeZone(isoStringDate: String): Date? {
+        if (isoStringDate.isEmpty()) return null
         val iso8601DateString = iso8601OnSiteTimeZoneFromIso8601UTC(isoStringDate)
         return getDateFromFullDateString(iso8601DateString)
     }
@@ -397,6 +397,7 @@ class DateUtils @Inject constructor(
             null
         }
     }
+    @Suppress("SwallowedException")
     private fun iso8601OnSiteTimeZoneFromIso8601UTC(iso8601date: String): String {
         return try {
             val site = selectedSite.getOrNull() ?: return iso8601date
@@ -411,7 +412,7 @@ class DateUtils @Inject constructor(
 
             // Format the result as a string
             zonedDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
-        } catch (e: ParseException) {
+        } catch (e: Exception) {
             iso8601date
         }
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -794,9 +794,7 @@ platform :android do
     )
 
     UI.important('Pushing changes to remote')
-    unless is_ci || UI.confirm('Do you want to continue?')
-      UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.")
-    end
+    UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless is_ci || UI.confirm('Do you want to continue?')
 
     push_to_git_remote(tags: false)
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1325,7 +1325,7 @@ end
 # -----------------------------------------------------------------------------------
 def create_release_management_pull_request(base_branch:, title:)
   create_pull_request(
-    api_token: get_required_env('GITHUB_TOKEN'),
+    api_token: ENV.fetch('GITHUB_TOKEN', nil),
     repo: GITHUB_REPO,
     title: title,
     head: Fastlane::Helper::GitHelper.current_git_branch,


### PR DESCRIPTION
Closes: #10565 

### Description
This PR fixes a `DateTimeParseException`  peaMlT-oI-p2 when the order list screen tries to parse an order where the creation date is null or empty. I fixed the crash by returning `null` when the date to parse is empty and swallowing all kinds of exceptions when the date is not in the expected format.

### Testing instructions
TC1
1. Check that the order lists keep working as expected in a normal scenario

TC2
2. Apply the patch below and check that the app keeps working even when the date created field is not a valid date
<details>
  <summary>Patch</summary>

```
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt	(revision 90910eed8a6090bda113f797cd5101974cf52cd8)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt	(date 1705681450320)
@@ -179,8 +179,9 @@
     }
 
     private fun getFormattedDateWithSiteTimeZone(dateCreated: String): String? {
+        dateCreated.length
         val currentSiteDate = dateUtils.getCurrentDateInSiteTimeZone() ?: Date()
-        val siteDate = dateUtils.getDateUsingSiteTimeZone(dateCreated) ?: Date()
+        val siteDate = dateUtils.getDateUsingSiteTimeZone("this is not a date") ?: Date()
         val iso8601DateString = dateUtils.getYearMonthDayStringFromDate(siteDate)
 
         return if (DateTimeUtils.isSameYear(currentSiteDate, siteDate)) {

```
</details>
 
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->