### PR TITLE
Bump `navigation.safeargs` to `2.6.0`

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -280,7 +280,8 @@ dependencies {
     implementation "com.github.bumptech.glide:glide:$glideVersion"
     kapt "com.github.bumptech.glide:compiler:$glideVersion"
     implementation "com.github.bumptech.glide:volley-integration:$glideVersion@aar"
-    implementation "com.google.android.play:core:$googlePlayCoreVersion"
+    implementation 'com.google.android.play:app-update-ktx:2.1.0'
+    implementation 'com.google.android.play:review-ktx:2.0.1'
 
     implementation 'com.google.android.gms:play-services-code-scanner:16.0.0-beta3'
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/AppUpgradeActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/AppUpgradeActivity.kt
@@ -206,6 +206,7 @@ abstract class AppUpgradeActivity :
 
     private fun requestAppUpdate(appUpdateInfo: AppUpdateInfo) {
         try {
+            @Suppress("DEPRECATION")
             appUpdateManager.startUpdateFlowForResult(
                 appUpdateInfo,
                 inAppUpdateType,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -10,12 +10,14 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.annotation.IdRes
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -125,7 +127,7 @@ class ProductDetailFragment :
 
     override val activityAppBarStatus: AppBarStatus
         get() {
-            val navigationIcon = if (findNavController().backQueue.any { it.destination.id == R.id.products }) {
+            val navigationIcon = if (findNavController().hasBackStackEntry(R.id.products)) {
                 R.drawable.ic_back_24dp
             } else {
                 R.drawable.ic_gridicons_cross_24dp
@@ -134,6 +136,10 @@ class ProductDetailFragment :
                 navigationIcon = navigationIcon
             )
         }
+
+    private fun NavController.hasBackStackEntry(@IdRes destinationId: Int) = runCatching {
+        getBackStackEntry(destinationId)
+    }.isSuccess
 
     @Inject lateinit var crashLogging: CrashLogging
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ pluginManagement {
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.kotlinVersion = '1.8.21'
     gradle.ext.measureBuildsVersion = '2.0.3'
-    gradle.ext.navigationVersion = '2.5.3'
+    gradle.ext.navigationVersion = '2.6.0'
     gradle.ext.sentryVersion = '3.5.0'
     gradle.ext.violationCommentsVersion = '1.69.0'
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR bumps `androidx.navigation` dependencies to `2.6.0`. It doesn't bump to the newest release, which is `2.7.3`, due to more conflicts with other `androidx` dependencies. This partial update should address: https://github.com/woocommerce/woocommerce-android/security/dependabot/56

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
I'll leave testing instructions to the reviewer, as I'm not entirely certain which areas of the app should be tested.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
