### PR TITLE
Bug fix – `Parcel: unable to marshal value WooPlugin`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 17.1
 -----
+- [*] [Internal] Fixed crash when going to background from the order creation screen [https://github.com/woocommerce/woocommerce-android/pull/10600]
 
 17.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/WooPlugin.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/WooPlugin.kt
@@ -1,9 +1,15 @@
 package com.woocommerce.android.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class WooPlugin(
     val isInstalled: Boolean,
     val isActive: Boolean,
     val version: String?
-) {
+) : Parcelable {
+    @IgnoredOnParcel
     val isOperational = isInstalled && isActive
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -216,7 +216,8 @@ class OrderCreateEditViewModel @Inject constructor(
     private val pluginsInformation: MutableStateFlow<Map<String, WooPlugin>> =
         savedState.getStateFlow(
             scope = viewModelScope,
-            initialValue = HashMap()
+            initialValue = HashMap(),
+            key = "plugins_information"
         )
     val isGiftCardExtensionEnabled
         get() = pluginsInformation.value[WOO_GIFT_CARDS.pluginName]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10596
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The app crashes when going to background in the Order Creation screen.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
#### Reproduce the crash
1. Checkout `trunk`
2. Make sure the store has the [Gift Cards](https://woocommerce.com/products/gift-cards/) extension/plugin activated
3. Create a new order and move the app to the background (e.g. click home button)
4. Observe the crash – WooPlugin is not `Parcelable`

#### Verify the fix
1. Checkout this PR's branch
2. Follow above steps and verify there's no crash

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
