### PR TITLE
Fix for NotificationMessageHandler Concurrent Modification Exception

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationsProcessingService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationsProcessingService.kt
@@ -68,9 +68,8 @@ class NotificationsProcessingService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        // Offload to a separate thread.
         actionProcessor = ActionProcessor(intent, startId)
-        Thread { actionProcessor.process() }.start()
+        actionProcessor.process()
 
         return START_NOT_STICKY
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -259,19 +259,18 @@ class NotificationMessageHandler @Inject constructor(
 
     @Synchronized
     fun removeNotificationByNotificationIdFromSystemsBar(localPushId: Int) {
-        val keysToRemove = mutableListOf<Int>()
-
-        ACTIVE_NOTIFICATIONS_MAP.forEach { (key, _) ->
-            if (key == localPushId) {
-                keysToRemove.add(key)
+        val keptNotifs = HashMap<Int, Notification>()
+        ACTIVE_NOTIFICATIONS_MAP.asSequence()
+            .forEach { row ->
+                if (row.key == localPushId) {
+                    notificationBuilder.cancelNotification(row.key)
+                } else {
+                    keptNotifs[row.key] = row.value
+                }
             }
-        }
 
-        keysToRemove.forEach { key ->
-            notificationBuilder.cancelNotification(key)
-            ACTIVE_NOTIFICATIONS_MAP.remove(key)
-        }
-
+        clearNotifications()
+        ACTIVE_NOTIFICATIONS_MAP.putAll(keptNotifs)
         updateNotificationsState()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -58,12 +58,10 @@ class NotificationMessageHandler @Inject constructor(
         private val ACTIVE_NOTIFICATIONS_MAP = mutableMapOf<Int, Notification>()
     }
 
-    @Synchronized
     fun onPushNotificationDismissed(notificationId: Int) {
         removeNotificationByNotificationIdFromSystemsBar(notificationId)
     }
 
-    @Synchronized
     fun onLocalNotificationDismissed(notificationId: Int, notificationType: String) {
         removeNotificationByNotificationIdFromSystemsBar(notificationId)
         AnalyticsTracker.track(
@@ -240,7 +238,6 @@ class NotificationMessageHandler @Inject constructor(
         notificationBuilder.cancelAllNotifications()
     }
 
-    @Synchronized
     fun removeNotificationByRemoteIdFromSystemsBar(remoteNoteId: Long) {
         val keptNotifs = HashMap<Int, Notification>()
         ACTIVE_NOTIFICATIONS_MAP.asSequence()
@@ -257,7 +254,6 @@ class NotificationMessageHandler @Inject constructor(
         updateNotificationsState()
     }
 
-    @Synchronized
     fun removeNotificationByNotificationIdFromSystemsBar(localPushId: Int) {
         val keptNotifs = HashMap<Int, Notification>()
         ACTIVE_NOTIFICATIONS_MAP.asSequence()
@@ -274,7 +270,6 @@ class NotificationMessageHandler @Inject constructor(
         updateNotificationsState()
     }
 
-    @Synchronized
     fun removeNotificationsOfTypeFromSystemsBar(type: NotificationChannelType, remoteSiteId: Long) {
         val keptNotifs = HashMap<Int, Notification>()
         // Using a copy of the map to avoid concurrency problems

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -259,18 +259,19 @@ class NotificationMessageHandler @Inject constructor(
 
     @Synchronized
     fun removeNotificationByNotificationIdFromSystemsBar(localPushId: Int) {
-        val keptNotifs = HashMap<Int, Notification>()
-        ACTIVE_NOTIFICATIONS_MAP.asSequence()
-            .forEach { row ->
-                if (row.key == localPushId) {
-                    notificationBuilder.cancelNotification(row.key)
-                } else {
-                    keptNotifs[row.key] = row.value
-                }
-            }
+        val keysToRemove = mutableListOf<Int>()
 
-        clearNotifications()
-        ACTIVE_NOTIFICATIONS_MAP.putAll(keptNotifs)
+        ACTIVE_NOTIFICATIONS_MAP.forEach { (key, _) ->
+            if (key == localPushId) {
+                keysToRemove.add(key)
+            }
+        }
+
+        keysToRemove.forEach { key ->
+            notificationBuilder.cancelNotification(key)
+            ACTIVE_NOTIFICATIONS_MAP.remove(key)
+        }
+
         updateNotificationsState()
     }
 

--- a/WooCommerce/src/main/res/layout/view_expandable_notice_card.xml
+++ b/WooCommerce/src/main/res/layout/view_expandable_notice_card.xml
@@ -24,47 +24,58 @@
             tools:textOff="@string/product_wip_title"
             tools:textOn="@string/product_wip_title_m5" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/notice_message"
-            style="@style/Woo.Card.Body"
-            android:layout_width="0dp"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/notice_morePanel"
+            android:layout_width="@dimen/minor_00"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/minor_00"
-            android:layout_marginEnd="@dimen/major_300"
-            android:gravity="start"
-            app:layout_constraintBottom_toTopOf="@+id/btn_mainAction"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toEndOf="@+id/guideline7"
             app:layout_constraintTop_toBottomOf="@+id/notice_viewMore"
-            tools:text="@string/error_chooser_photo" />
+            tools:visibility="visible">
 
-        <!-- PRIMARY button -->
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/btn_secondaryAction"
-            style="@style/Woo.Card.Button"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/btn_mainAction"
-            app:layout_constraintTop_toBottomOf="@+id/notice_message"
-            tools:text="@string/support_contact" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/notice_message"
+                style="@style/Woo.Card.Body"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/minor_00"
+                android:layout_marginEnd="@dimen/major_300"
+                android:gravity="start"
+                app:layout_constraintBottom_toTopOf="@+id/btn_mainAction"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="@string/error_chooser_photo" />
 
-        <!-- SECONDARY button -->
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/btn_mainAction"
-            style="@style/Woo.Card.Button"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/minor_00"
-            android:layout_marginEnd="8dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/btn_secondaryAction"
-            app:layout_constraintStart_toEndOf="@+id/guideline7"
-            app:layout_constraintTop_toBottomOf="@+id/notice_message"
-            tools:text="@string/error_troubleshooting" />
+            <!-- PRIMARY button -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_secondaryAction"
+                style="@style/Woo.Card.Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                tools:text="@string/support_contact"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/notice_message" />
+
+            <!-- SECONDARY button -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_mainAction"
+                style="@style/Woo.Card.Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginEnd="@dimen/minor_100"
+                tools:text="@string/error_troubleshooting"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/btn_secondaryAction"
+                app:layout_constraintTop_toBottomOf="@+id/notice_message" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/guideline7"
@@ -75,3 +86,4 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </merge>
+

--- a/WooCommerce/src/main/res/layout/view_expandable_notice_card.xml
+++ b/WooCommerce/src/main/res/layout/view_expandable_notice_card.xml
@@ -24,58 +24,47 @@
             tools:textOff="@string/product_wip_title"
             tools:textOn="@string/product_wip_title_m5" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/notice_morePanel"
-            android:layout_width="@dimen/minor_00"
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/notice_message"
+            style="@style/Woo.Card.Body"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:layout_marginStart="@dimen/minor_00"
+            android:layout_marginEnd="@dimen/major_300"
+            android:gravity="start"
+            app:layout_constraintBottom_toTopOf="@+id/btn_mainAction"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toEndOf="@+id/guideline7"
             app:layout_constraintTop_toBottomOf="@+id/notice_viewMore"
-            tools:visibility="visible">
+            tools:text="@string/error_chooser_photo" />
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/notice_message"
-                style="@style/Woo.Card.Body"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/minor_00"
-                android:layout_marginEnd="@dimen/major_300"
-                android:gravity="start"
-                app:layout_constraintBottom_toTopOf="@+id/btn_mainAction"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="@string/error_chooser_photo" />
+        <!-- PRIMARY button -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_secondaryAction"
+            style="@style/Woo.Card.Button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/btn_mainAction"
+            app:layout_constraintTop_toBottomOf="@+id/notice_message"
+            tools:text="@string/support_contact" />
 
-            <!-- PRIMARY button -->
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btn_secondaryAction"
-                style="@style/Woo.Card.Button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                tools:text="@string/support_contact"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/notice_message" />
-
-            <!-- SECONDARY button -->
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btn_mainAction"
-                style="@style/Woo.Card.Button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginEnd="@dimen/minor_100"
-                tools:text="@string/error_troubleshooting"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@+id/btn_secondaryAction"
-                app:layout_constraintTop_toBottomOf="@+id/notice_message" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        <!-- SECONDARY button -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_mainAction"
+            style="@style/Woo.Card.Button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/minor_00"
+            android:layout_marginEnd="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/btn_secondaryAction"
+            app:layout_constraintStart_toEndOf="@+id/guideline7"
+            app:layout_constraintTop_toBottomOf="@+id/notice_message"
+            tools:text="@string/error_troubleshooting" />
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/guideline7"
@@ -86,4 +75,3 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </merge>
-


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10529
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
### Optimization of Notification Processing:
In this PR, we have refined the handling of notification actions within the `NotificationsProcessingService` by directly invoking `actionProcessor.process()` on the service's main thread. This approach replaces the previous method of spawning a new thread for each action, specifically `Thread { actionProcessor.process() }.start()`, which was identified as a source of concurrency issues due to simultaneous modifications of shared notification state. This modification presumes that the actions triggered by process() are swift and non-blocking, ensuring the service's performance remains stable. 

### Simplification of Synchronization:
Given the shift to main-thread execution, we propose removing the `@Synchronized` annotation from methods within `NotificationMessageHandler`, This adjustment is underpinned by the observation that these methods are exclusively invoked by the `ActionProcessor`, now operating on the main thread, which negates the need for synchronization mechanisms initially put in place to manage concurrent access risks.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Send remote push notifications to the device or send push notifications to the store that would trigger the behavior in app. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

