### PR TITLE
Avoid displaying my store expanded toolbar on campaign preview screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -208,7 +208,7 @@ class MainActivity :
             if (f is DialogFragment) return
 
             if (f is BlazeCampaignCreationPreviewFragment) // Context on why this is needed check GH issue #10563
-                animatorHelper.cancelToolBarAnimation()
+                animatorHelper.cancelToolbarAnimation()
 
             when (val appBarStatus = (f as? BaseFragment)?.activityAppBarStatus ?: AppBarStatus.Visible()) {
                 is AppBarStatus.Visible -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -159,7 +159,6 @@ class MainActivity :
 
     @Inject
     lateinit var presenter: MainContract.Presenter
-
     @Inject
     lateinit var loginAnalyticsListener: LoginAnalyticsListener
     @Inject

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -61,6 +61,7 @@ import com.woocommerce.android.ui.appwidgets.WidgetUpdater
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.login.LoginActivity
@@ -158,18 +159,25 @@ class MainActivity :
 
     @Inject
     lateinit var presenter: MainContract.Presenter
+
     @Inject
     lateinit var loginAnalyticsListener: LoginAnalyticsListener
+
     @Inject
     lateinit var selectedSite: SelectedSite
+
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
+
     @Inject
     lateinit var crashLogging: CrashLogging
+
     @Inject
     lateinit var appWidgetUpdaters: WidgetUpdater.StatsWidgetUpdaters
+
     @Inject
     lateinit var trialStatusBarFormatterFactory: TrialStatusBarFormatterFactory
+
     @Inject
     lateinit var startUpgradeFlowFactory: StartUpgradeFlowFactory
     @Inject lateinit var animatorHelper: MainAnimatorHelper
@@ -206,9 +214,12 @@ class MainActivity :
         override fun onFragmentViewCreated(fm: FragmentManager, f: Fragment, v: View, savedInstanceState: Bundle?) {
             if (f is DialogFragment) return
 
+            if (f is BlazeCampaignCreationPreviewFragment) // Context on why this is needed check GH issue #10563
+                animatorHelper.cancelToolBarAnimation()
+
             when (val appBarStatus = (f as? BaseFragment)?.activityAppBarStatus ?: AppBarStatus.Visible()) {
                 is AppBarStatus.Visible -> {
-                    showToolbar(f is TopLevelFragment)
+                    showToolbar(animate = true)
                     // re-expand the AppBar when returning to top level fragment,
                     // collapse it when entering a child fragment
                     if (f is TopLevelFragment) {
@@ -327,6 +338,7 @@ class MainActivity :
             }
         )
     }
+
     override fun hideProgressDialog() {
         progressDialog?.apply {
             if (isShowing) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -162,22 +162,16 @@ class MainActivity :
 
     @Inject
     lateinit var loginAnalyticsListener: LoginAnalyticsListener
-
     @Inject
     lateinit var selectedSite: SelectedSite
-
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
-
     @Inject
     lateinit var crashLogging: CrashLogging
-
     @Inject
     lateinit var appWidgetUpdaters: WidgetUpdater.StatsWidgetUpdaters
-
     @Inject
     lateinit var trialStatusBarFormatterFactory: TrialStatusBarFormatterFactory
-
     @Inject
     lateinit var startUpgradeFlowFactory: StartUpgradeFlowFactory
     @Inject lateinit var animatorHelper: MainAnimatorHelper
@@ -219,7 +213,7 @@ class MainActivity :
 
             when (val appBarStatus = (f as? BaseFragment)?.activityAppBarStatus ?: AppBarStatus.Visible()) {
                 is AppBarStatus.Visible -> {
-                    showToolbar(animate = true)
+                    showToolbar(animate = f is TopLevelFragment)
                     // re-expand the AppBar when returning to top level fragment,
                     // collapse it when entering a child fragment
                     if (f is TopLevelFragment) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainAnimatorHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainAnimatorHelper.kt
@@ -55,7 +55,7 @@ class MainAnimatorHelper @Inject constructor(private val resourceProvider: Resou
         }
     }
 
-    fun cancelToolBarAnimation() {
+    fun cancelToolbarAnimation() {
         toolbarAnimator.cancel()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainAnimatorHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainAnimatorHelper.kt
@@ -55,6 +55,10 @@ class MainAnimatorHelper @Inject constructor(private val resourceProvider: Resou
         }
     }
 
+    fun cancelToolBarAnimation() {
+        toolbarAnimator.cancel()
+    }
+
     private companion object {
         private const val COLLAPSING_ANIMATION_DURATION = 200L
         private const val TOOLBAR_ANIMATION_DURATION = 300L


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes: #10563
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Avoid displaying the expanded toolbar from MyStore fragment when navigating to `BlazeCampaignCreationPreviewFragment` after picking a product from `ProductSelectorFragment`:

https://github.com/woocommerce/woocommerce-android/assets/2663464/11f70a22-a855-49a0-a12d-ba1bfb3b1d46

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Just click `Create Campaign` from the My Store tab (the site must have at least one Blaze campaign created) and check that the campaign preview screen doesn't show two toolbars like in the above video. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/7564e8d7-9c85-457e-b975-3a6082efeb5b

