### PR TITLE
Issue/10526 update ai feedback survey logic

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -126,6 +126,8 @@ object AppPrefs {
         CREATED_STORE_SITE_ID,
         CREATED_STORE_THEME_ID,
         CHA_CHING_SOUND_ISSUE_DIALOG_DISMISSED,
+        TIMES_AI_PRODUCT_CREATION_SURVEY_DISPLAYED,
+        AI_PRODUCT_CREATION_SURVEY_COMPLETED,
     }
 
     /**
@@ -1057,6 +1059,26 @@ object AppPrefs {
         )
         set(value) = setBoolean(
             key = DeletablePrefKey.MY_STORE_BLAZE_VIEW_DISMISSED,
+            value = value
+        )
+
+    var timesAiProductCreationSurveyDisplayed: Int
+        get() = getInt(
+            key = DeletablePrefKey.TIMES_AI_PRODUCT_CREATION_SURVEY_DISPLAYED,
+            default = 0
+        )
+        set(value) = setInt(
+            key = DeletablePrefKey.TIMES_AI_PRODUCT_CREATION_SURVEY_DISPLAYED,
+            value = value
+        )
+
+    var isAiProductCreationSurveyCompleted: Boolean
+        get() = getBoolean(
+            key = DeletablePrefKey.AI_PRODUCT_CREATION_SURVEY_COMPLETED,
+            default = false
+        )
+        set(value) = setBoolean(
+            key = DeletablePrefKey.AI_PRODUCT_CREATION_SURVEY_COMPLETED,
             value = value
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -126,7 +126,6 @@ object AppPrefs {
         CREATED_STORE_SITE_ID,
         CREATED_STORE_THEME_ID,
         CHA_CHING_SOUND_ISSUE_DIALOG_DISMISSED,
-        NUMBER_OF_PRODUCTS_CREATED_WITH_AI,
     }
 
     /**
@@ -288,10 +287,6 @@ object AppPrefs {
     var chaChingSoundIssueDialogDismissed: Boolean
         get() = getBoolean(DeletablePrefKey.CHA_CHING_SOUND_ISSUE_DIALOG_DISMISSED, false)
         set(value) = setBoolean(DeletablePrefKey.CHA_CHING_SOUND_ISSUE_DIALOG_DISMISSED, value)
-
-    var numberOfProductsCreatedUsingAi: Int
-        get() = getInt(DeletablePrefKey.NUMBER_OF_PRODUCTS_CREATED_WITH_AI, 0)
-        set(value) = setInt(DeletablePrefKey.NUMBER_OF_PRODUCTS_CREATED_WITH_AI, value)
 
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -127,7 +127,7 @@ object AppPrefs {
         CREATED_STORE_THEME_ID,
         CHA_CHING_SOUND_ISSUE_DIALOG_DISMISSED,
         TIMES_AI_PRODUCT_CREATION_SURVEY_DISPLAYED,
-        AI_PRODUCT_CREATION_SURVEY_COMPLETED,
+        AI_PRODUCT_CREATION_SURVEY_DISMISSED,
     }
 
     /**
@@ -1072,13 +1072,13 @@ object AppPrefs {
             value = value
         )
 
-    var isAiProductCreationSurveyCompleted: Boolean
+    var isAiProductCreationSurveyDismissed: Boolean
         get() = getBoolean(
-            key = DeletablePrefKey.AI_PRODUCT_CREATION_SURVEY_COMPLETED,
+            key = DeletablePrefKey.AI_PRODUCT_CREATION_SURVEY_DISMISSED,
             default = false
         )
         set(value) = setBoolean(
-            key = DeletablePrefKey.AI_PRODUCT_CREATION_SURVEY_COMPLETED,
+            key = DeletablePrefKey.AI_PRODUCT_CREATION_SURVEY_DISMISSED,
             value = value
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -38,6 +38,10 @@ class AppPrefsWrapper @Inject constructor() {
 
     var chaChingSoundIssueDialogDismissed by AppPrefs::chaChingSoundIssueDialogDismissed
 
+    var timesAiProductCreationSurveyDisplayed by AppPrefs::timesAiProductCreationSurveyDisplayed
+
+    var isAiProductCreationSurveyCompleted by AppPrefs::isAiProductCreationSurveyCompleted
+
     fun getAppInstallationDate() = AppPrefs.installationDate
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -40,7 +40,7 @@ class AppPrefsWrapper @Inject constructor() {
 
     var timesAiProductCreationSurveyDisplayed by AppPrefs::timesAiProductCreationSurveyDisplayed
 
-    var isAiProductCreationSurveyCompleted by AppPrefs::isAiProductCreationSurveyCompleted
+    var isAiProductCreationSurveyDismissed by AppPrefs::isAiProductCreationSurveyDismissed
 
     fun getAppInstallationDate() = AppPrefs.installationDate
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -38,8 +38,6 @@ class AppPrefsWrapper @Inject constructor() {
 
     var chaChingSoundIssueDialogDismissed by AppPrefs::chaChingSoundIssueDialogDismissed
 
-    var numberOfProductsCreatedUsingAi by AppPrefs::numberOfProductsCreatedUsingAi
-
     fun getAppInstallationDate() = AppPrefs.installationDate
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -143,7 +143,6 @@ class ProductDetailViewModel @Inject constructor(
     companion object {
         private const val KEY_PRODUCT_PARAMETERS = "key_product_parameters"
         const val DEFAULT_ADD_NEW_PRODUCT_ID: Long = 0L
-        const val MINUM_NUMBER_OF_AI_CREATED_PRODUCTS_TO_SHOW_SURVEY = 3
     }
 
     private val navArgs: ProductDetailFragmentArgs by savedState.navArgs()
@@ -358,14 +357,11 @@ class ProductDetailViewModel @Inject constructor(
             true -> startAddNewProduct()
             else -> {
                 loadRemoteProduct(navArgs.remoteProductId)
-                if (shouldShowAIProductCreationSurvey())
+                if (navArgs.isAIContent)
                     triggerEventWithDelay(ShowAiProductCreationSurveyBottomSheet, delay = 500)
             }
         }
     }
-
-    private fun shouldShowAIProductCreationSurvey() = navArgs.isAIContent &&
-        appPrefsWrapper.numberOfProductsCreatedUsingAi == MINUM_NUMBER_OF_AI_CREATED_PRODUCTS_TO_SHOW_SURVEY
 
     private fun startAddNewProduct() {
         val defaultProduct = createDefaultProductForAddFlow()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -357,7 +357,7 @@ class ProductDetailViewModel @Inject constructor(
             true -> startAddNewProduct()
             else -> {
                 loadRemoteProduct(navArgs.remoteProductId)
-                if (navArgs.isAIContent)
+                if (navArgs.isAIContent && !appPrefsWrapper.isAiProductCreationSurveyDismissed)
                     triggerEventWithDelay(ShowAiProductCreationSurveyBottomSheet, delay = 500)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AIProductCreationSurveyBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AIProductCreationSurveyBottomSheet.kt
@@ -163,7 +163,8 @@ private fun SurveyBottomSheetContentPreview() {
         SurveyBottomSheetContent(
             timesSurveyWasDisplayed = 0,
             onStartSurveyClick = {},
-            onDismissBottomSheet = {}
+            onDismissBottomSheet = {},
+            onDontShowAgainClicked = {},
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AIProductCreationSurveyBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AIProductCreationSurveyBottomSheet.kt
@@ -68,6 +68,11 @@ class AIProductCreationSurveyBottomSheet : WCBottomSheetDialogFragment() {
                     analyticsTrackerWrapper.track(AnalyticsEvent.PRODUCT_CREATION_AI_SURVEY_SKIP_BUTTON_TAPPED)
                     findNavController().popBackStack()
                 },
+                onDontShowAgainClicked = {
+                    analyticsTrackerWrapper.track(AnalyticsEvent.PRODUCT_CREATION_AI_SURVEY_SKIP_BUTTON_TAPPED)
+                    appPrefs.isAiProductCreationSurveyDismissed = true
+                    findNavController().popBackStack()
+                }
             )
         }
     }
@@ -78,6 +83,7 @@ private fun SurveyBottomSheetContent(
     timesSurveyWasDisplayed: Int,
     onStartSurveyClick: () -> Unit,
     onDismissBottomSheet: () -> Unit,
+    onDontShowAgainClicked: () -> Unit,
 ) {
     Surface(
         shape = RoundedCornerShape(
@@ -132,13 +138,19 @@ private fun SurveyBottomSheetContent(
                 onClick = onStartSurveyClick,
                 text = stringResource(id = R.string.product_creation_survey_button_open)
             )
-            WCOutlinedButton(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = onDismissBottomSheet,
-                text = if (timesSurveyWasDisplayed == 0)
-                    stringResource(id = R.string.product_creation_survey_button_remind_me_later)
-                else stringResource(id = R.string.product_creation_survey_button_dont_show_again)
-            )
+            if (timesSurveyWasDisplayed == 0) {
+                WCOutlinedButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = onDismissBottomSheet,
+                    text = stringResource(id = R.string.product_creation_survey_button_remind_me_later)
+                )
+            } else {
+                WCOutlinedButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = onDontShowAgainClicked,
+                    text = stringResource(id = R.string.product_creation_survey_button_dont_show_again)
+                )
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIViewModel.kt
@@ -117,7 +117,6 @@ class AddProductWithAIViewModel @Inject constructor(
                 AnalyticsTracker.track(AnalyticsEvent.PRODUCT_CREATION_AI_SAVE_AS_DRAFT_FAILED)
             } else {
                 triggerEvent(NavigateToProductDetailScreen(productId))
-                appsPrefsWrapper.numberOfProductsCreatedUsingAi = appsPrefsWrapper.numberOfProductsCreatedUsingAi + 1
                 AnalyticsTracker.track(AnalyticsEvent.PRODUCT_CREATION_AI_SAVE_AS_DRAFT_SUCCESS)
             }
         }

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -41,7 +41,6 @@ Language: ar
     <string name="theme_picker_carousel_info_item_description_settings">يمكنك العثور على قالبك المثالي في متجر قوالب WooCommerce.</string>
     <string name="theme_picker_current_theme_title">القالب الحالي</string>
     <string name="theme_picker_settings_title">تجربة مظهر جديد</string>
-    <string name="product_creation_survey_button_skip">تخطٍّ</string>
     <string name="product_creation_survey_button_open">بدء الاستبيان</string>
     <string name="product_creation_survey_description">لقد استخدمت ميزتنا المدعومة بالذكاء الاصطناعي لإضافة المنتجات مرات عديدة الآن. نرغب في التعرُّف على أفكارك لتحسين الميزة.</string>
     <string name="product_creation_survey_title">إسهاماتك محل تقدير!</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -41,7 +41,6 @@ Language: de
     <string name="theme_picker_carousel_info_item_description_settings">Du kannst dir im WooCommerce-Theme-Shop dein perfektes Theme aussuchen.</string>
     <string name="theme_picker_current_theme_title">Aktuelles Theme</string>
     <string name="theme_picker_settings_title">Teste einen neuen Look</string>
-    <string name="product_creation_survey_button_skip">Überspringen</string>
     <string name="product_creation_survey_button_open">Befragung starten</string>
     <string name="product_creation_survey_description">Du hast unsere KI-unterstützte Funktion verwendet, um Produkte mehrfach hinzuzufügen. Wir würden uns über Feedback freuen, damit wir die Funktion weiter verbessern können.</string>
     <string name="product_creation_survey_title">Deine Meinung ist uns wichtig!</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -41,7 +41,6 @@ Language: es
     <string name="theme_picker_carousel_info_item_description_settings">Puedes buscar el tema perfecto en la tienda de temas de WooCommerce.</string>
     <string name="theme_picker_current_theme_title">Tema actual</string>
     <string name="theme_picker_settings_title">Prueba una nueva imagen.</string>
-    <string name="product_creation_survey_button_skip">Omitir</string>
     <string name="product_creation_survey_button_open">Empieza la encuesta.</string>
     <string name="product_creation_survey_description">Ya has utilizado varias veces nuestra función asistida por IA para añadir productos. Nos encantaría conocer tu opinión para hacerlo aún mejor.</string>
     <string name="product_creation_survey_title">Valoramos tu opinión.</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -41,7 +41,6 @@ Language: fr
     <string name="theme_picker_carousel_info_item_description_settings">Vous trouverez le thème parfait dans la boutique de thèmes WooCommerce.</string>
     <string name="theme_picker_current_theme_title">Thème actuel</string>
     <string name="theme_picker_settings_title">Essayer un nouveau look</string>
-    <string name="product_creation_survey_button_skip">Ignorer</string>
     <string name="product_creation_survey_button_open">Commencer l’enquête</string>
     <string name="product_creation_survey_description">Vous avez utilisé notre fonctionnalité assistée par l’IA pour ajouter des produits à de multiples reprises désormais. Nous aimerions savoir ce que vous en pensez pour l’améliorer.</string>
     <string name="product_creation_survey_title">Nous apprécions vos retours !</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -41,7 +41,6 @@ Language: he_IL
     <string name="theme_picker_carousel_info_item_description_settings">אפשר למצוא את ערכת העיצוב המושלמת בחנות ערכות העיצוב של WooCommerce.</string>
     <string name="theme_picker_current_theme_title">ערכת העיצוב הנוכחית</string>
     <string name="theme_picker_settings_title">לנסות מראה חדש</string>
-    <string name="product_creation_survey_button_skip">לדלג</string>
     <string name="product_creation_survey_button_open">להתחיל לענות על הסקר</string>
     <string name="product_creation_survey_description">כבר השתמשת מספר פעמים באפשרות שנעזרת בבינה מלאכותית כדי להוסיף מוצרים. נשמח לשמוע מה דעתך על האפשרות כדי לשפר אותה.</string>
     <string name="product_creation_survey_title">אנחנו מעריכים את המשוב שלך!</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -41,7 +41,6 @@ Language: id
     <string name="theme_picker_carousel_info_item_description_settings">Temukan tema ideal Anda di Toko Tema WooCommerce.</string>
     <string name="theme_picker_current_theme_title">Tema saat ini</string>
     <string name="theme_picker_settings_title">Coba tampilan baru</string>
-    <string name="product_creation_survey_button_skip">Lewati</string>
     <string name="product_creation_survey_button_open">Mulai Survei</string>
     <string name="product_creation_survey_description">Anda telah menggunakan fitur yang didukung AI untuk menambahkan produk beberapa kali. Sampaikan masukan Anda agar kami bisa meningkatkan fitur.</string>
     <string name="product_creation_survey_title">Kami menghargai masukan Anda!</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -41,7 +41,6 @@ Language: it
     <string name="theme_picker_carousel_info_item_description_settings">Puoi trovare il tema perfetto nel negozio di temi WooCommerce.</string>
     <string name="theme_picker_current_theme_title">Tema corrente</string>
     <string name="theme_picker_settings_title">Prova un nuovo aspetto</string>
-    <string name="product_creation_survey_button_skip">Salta</string>
     <string name="product_creation_survey_button_open">Inizia il sondaggio</string>
     <string name="product_creation_survey_description">Hai usato la nostra funzionalità assistita dall\'intelligenza artificiale per aggiungere prodotti più volte. Ci piacerebbe sapere cosa ne pensi per migliorare ancora di più.</string>
     <string name="product_creation_survey_title">Apprezziamo il tuo contributo!</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -41,7 +41,6 @@ Language: ja_JP
     <string name="theme_picker_carousel_info_item_description_settings">WooCommerce テーマストアでご自身にぴったりなテーマが見つかります。</string>
     <string name="theme_picker_current_theme_title">現在のテーマ</string>
     <string name="theme_picker_settings_title">新しいデザインを試す</string>
-    <string name="product_creation_survey_button_skip">スキップ</string>
     <string name="product_creation_survey_button_open">アンケートをスタート</string>
     <string name="product_creation_survey_description">これまでに AI によるサポート機能を使用して商品を複数回追加しました。 改善を重ねてまいりますので、ぜひご意見をお寄せください。</string>
     <string name="product_creation_survey_title">お待ちしています。</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -41,7 +41,6 @@ Language: ko_KR
     <string name="theme_picker_carousel_info_item_description_settings">우커머스 테마 스토어에서 완벽한 테마를 찾아볼 수 있습니다.</string>
     <string name="theme_picker_current_theme_title">현재 테마</string>
     <string name="theme_picker_settings_title">새 외형 사용하기</string>
-    <string name="product_creation_survey_button_skip">건너뛰기</string>
     <string name="product_creation_survey_button_open">설문 조사 시작</string>
     <string name="product_creation_survey_description">AI 보조 기능을 활용하여 제품을 여러 차례 추가하셨습니다. 개선에 도움이 되도록 의견을 듣고자 합니다.</string>
     <string name="product_creation_survey_title">여러분의 의견을 소중히 생각합니다!</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -41,7 +41,6 @@ Language: nl
     <string name="theme_picker_carousel_info_item_description_settings">Je kan jouw perfecte thema vinden in de WooCommerce Theme Store.</string>
     <string name="theme_picker_current_theme_title">Huidig thema</string>
     <string name="theme_picker_settings_title">Probeer een nieuwe look</string>
-    <string name="product_creation_survey_button_skip">Overslaan</string>
     <string name="product_creation_survey_button_open">Begin het onderzoek</string>
     <string name="product_creation_survey_description">Je hebt onze AI-ondersteunde functie om nu meerdere keren gebruikt om producten toe te voegen. We horen graag je mening om de functie nog beter te kunnen maken.</string>
     <string name="product_creation_survey_title">We waarderen je input!</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -41,7 +41,6 @@ Language: pt_BR
     <string name="theme_picker_carousel_info_item_description_settings">Encontre o tema perfeito na loja de temas do WooCommerce.</string>
     <string name="theme_picker_current_theme_title">Tema atual</string>
     <string name="theme_picker_settings_title">Dê uma repaginada</string>
-    <string name="product_creation_survey_button_skip">Pular</string>
     <string name="product_creation_survey_button_open">Iniciar pesquisa</string>
     <string name="product_creation_survey_description">Você já usou nossa funcionalidade assistida por IA para adicionar produtos várias vezes. Adoraríamos saber sua opinião sobre como podemos deixá-la ainda melhor.</string>
     <string name="product_creation_survey_title">Valorizamos sua opinião!</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -41,7 +41,6 @@ Language: ru
     <string name="theme_picker_carousel_info_item_description_settings">Найдите самую подходящую для вас тему в магазине тем WooCommerce.</string>
     <string name="theme_picker_current_theme_title">Текущая тема</string>
     <string name="theme_picker_settings_title">Попробуйте новый дизайн</string>
-    <string name="product_creation_survey_button_skip">Пропустить</string>
     <string name="product_creation_survey_button_open">Начать опрос</string>
     <string name="product_creation_survey_description">Вы уже несколько раз воспользовались нашей функцией добавления товаров при помощи ИИ. Мы хотели бы узнать ваши впечатления, чтобы сделать её ещё лучше.</string>
     <string name="product_creation_survey_title">Мы высоко ценим ваше мнение!</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -43,7 +43,6 @@ Language: sv_SE
     <string name="theme_picker_carousel_error_placeholder_message_cta">tryck här</string>
     <string name="theme_picker_current_theme_title">Nuvarande tema</string>
     <string name="theme_picker_settings_title">Prova ett nytt utseende</string>
-    <string name="product_creation_survey_button_skip">Hoppa över</string>
     <string name="product_creation_survey_button_open">Börja undersökningen</string>
     <string name="product_creation_survey_title">Vi värdesätter dina åsikter!</string>
     <string name="card_reader_onboarding_contact_us">Behöver du hjälp? &lt;a href=\'\'&gt;Kontakta oss&lt;/a&gt;</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -41,7 +41,6 @@ Language: tr
     <string name="theme_picker_carousel_info_item_description_settings">WooCommerce Tema Mağazasından mükemmel temanızı bulabilirsiniz.</string>
     <string name="theme_picker_current_theme_title">Geçerli tema</string>
     <string name="theme_picker_settings_title">Yeni bir görünüm deneyin</string>
-    <string name="product_creation_survey_button_skip">Atla</string>
     <string name="product_creation_survey_button_open">Anketi Başlat</string>
     <string name="product_creation_survey_description">Birkaç kere ürün eklemek için yapay zeka destekli özelliğimizi kullandınız. Daha da iyi hale getirmek için düşüncelerinizi duymak isteriz.</string>
     <string name="product_creation_survey_title">Fikirlerinize değer veriyoruz!</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -41,7 +41,6 @@ Language: zh_CN
     <string name="theme_picker_carousel_info_item_description_settings">您可以在 WooCommerce 主题商店中找到最适合您的主题。</string>
     <string name="theme_picker_current_theme_title">当前主题</string>
     <string name="theme_picker_settings_title">试用新外观</string>
-    <string name="product_creation_survey_button_skip">跳过</string>
     <string name="product_creation_survey_button_open">开始调查</string>
     <string name="product_creation_survey_description">您已多次使用我们的人工智能辅助功能添加产品。 我们想听听您对这项功能的看法，以便进一步改进。</string>
     <string name="product_creation_survey_title">您的宝贵意见对我们非常重要！</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -41,7 +41,6 @@ Language: zh_TW
     <string name="theme_picker_carousel_info_item_description_settings">歡迎前往 WooCommerce 佈景主題商店，尋找最適合的佈景主題。</string>
     <string name="theme_picker_current_theme_title">目前的佈景主題</string>
     <string name="theme_picker_settings_title">嘗試新的外觀</string>
-    <string name="product_creation_survey_button_skip">略過</string>
     <string name="product_creation_survey_button_open">開始進行調查</string>
     <string name="product_creation_survey_description">你目前已使用 AI 功能多次新增產品。 歡迎與我們分享想法，讓體驗更好。</string>
     <string name="product_creation_survey_title">我們很重視你的意見！</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2043,7 +2043,8 @@
     <string name="product_creation_survey_title">We value your input!</string>
     <string name="product_creation_survey_description">Got a minute? Help us improve our AI-assisted features with your quick feedback.</string>
     <string name="product_creation_survey_button_open">Start the Survey</string>
-    <string name="product_creation_survey_button_skip">Remind me later</string>
+    <string name="product_creation_survey_button_remind_me_later">Remind Me Later</string>
+    <string name="product_creation_survey_button_dont_show_again">Don\’t show it Again</string>
 
     <!--
         Product Add more details Bottom sheet

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2041,9 +2041,9 @@
     <string name="product_filter_explore_plugin">Explore!</string>
     <string name="scan_barcode_to_update_inventory_menu_item_title">Scan barcode to update inventory</string>
     <string name="product_creation_survey_title">We value your input!</string>
-    <string name="product_creation_survey_description">You\'ve used our AI-assisted feature to add products multiple times now. We\'d love to hear your thoughts to make it even better.</string>
+    <string name="product_creation_survey_description">Got a minute? Help us improve our AI-assisted features with your quick feedback.</string>
     <string name="product_creation_survey_button_open">Start the Survey</string>
-    <string name="product_creation_survey_button_skip">Skip</string>
+    <string name="product_creation_survey_button_skip">Remind me later</string>
 
     <!--
         Product Add more details Bottom sheet


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10526
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
⚠️ Don't panic about the amount of file changes; most of them are just small string updates :)

Adds the following changes to the feedback survey bottom sheet we display after the user creates a product using AI: 

1. Show the survey as soon as the user creates a product using AI. Don’t wait for users to create 3 AI products.
2. Remove “You’ve used our AI-assisted feature to add products multiple times now.” text from the confirmation sheet.
3. If the user dismisses the survey confirmation screen, ask again one more time when the user creates the next product using AI. (i.e. Ask two times to attend the survey.)

See the linked issue for extra details. 

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Create 1 product using AI
2. Check the the bottomsheet is displayed after saving the product preview and landing on product detail screen
3. Tap on "Remind me later"
4. Create another product using AI
5. After saving the product check the survey bottom sheet is displayed again. 
6. Tap on "Don't show me again" CTA
7. Create another product using AI and ensure the survey bottom sheet is not displayed again. 



### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

**Test case 1: Bottom sheet shown for the first time**

https://github.com/woocommerce/woocommerce-android/assets/2663464/183ef057-a653-4f05-91f9-c9b55e73d19b

**Test case 2: Bottom sheet shown for the second time**

https://github.com/woocommerce/woocommerce-android/assets/2663464/0b4cd353-531c-4941-b44f-a3890ec0ec72

**Test case 3: Bottom sheet not shown anymore**

https://github.com/woocommerce/woocommerce-android/assets/2663464/b2ed52ff-25f4-44a5-bb3c-ed36108017a4




- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
