### PR TITLE
[Custom Amounts]  Current Percentage ArithmeticException Fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
@@ -41,9 +41,9 @@ class CustomAmountsViewModel @Inject constructor(
         get() {
             val orderTotal = BigDecimal(args.orderTotal ?: "0")
             return if (orderTotal > BigDecimal.ZERO) {
-                (viewState.customAmountUIModel.currentPrice
-                    .divide(orderTotal, 2, RoundingMode.HALF_UP))
-                    .multiply(BigDecimal(PERCENTAGE_SCALE_FACTOR))
+                (viewState.customAmountUIModel.currentPrice.divide(orderTotal, 2, RoundingMode.HALF_UP)).multiply(
+                    BigDecimal(PERCENTAGE_SCALE_FACTOR)
+                )
             } else {
                 BigDecimal.ZERO
             }
@@ -118,6 +118,7 @@ class CustomAmountsViewModel @Inject constructor(
                     CustomAmountType.FIXED_CUSTOM_AMOUNT -> {
                         currentPrice = amount
                     }
+
                     CustomAmountType.PERCENTAGE_CUSTOM_AMOUNT -> {
                         currentPercentage = (amount.divide(orderTotalValue, 2, RoundingMode.HALF_UP))
                             .multiply(BigDecimal(PERCENTAGE_SCALE_FACTOR))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragmentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragmentViewModelTest.kt
@@ -85,7 +85,17 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when percentage is not zero, then done button is enabled`() {
+    fun `when percentage is not zero and order total is not zero, then done button is enabled`() {
+        val args = CustomAmountsFragmentArgs(
+            customAmountUIModel = CustomAmountUIModel(
+                id = 0L,
+                amount = BigDecimal.TEN,
+                name = "",
+                type = PERCENTAGE_CUSTOM_AMOUNT
+            ),
+            orderTotal = "100"
+        )
+        viewModel = CustomAmountsViewModel(args.toSavedStateHandle(), tracker)
         viewModel.currentPercentage = BigDecimal.TEN
 
         assertTrue(viewModel.viewState.isDoneButtonEnabled)
@@ -193,5 +203,40 @@ class CustomAmountsFragmentViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `when order total is zero, then current percentage is zero`() {
+        viewModel = CustomAmountsViewModel(
+            CustomAmountsFragmentArgs(
+                customAmountUIModel = CustomAmountUIModel(
+                    id = 0L,
+                    amount = BigDecimal.TEN,
+                    name = "",
+                    type = PERCENTAGE_CUSTOM_AMOUNT
+                ),
+                orderTotal = "0"
+            ).toSavedStateHandle(),
+            tracker
+        )
+
+        assertThat(viewModel.currentPercentage).isEqualTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `when order total is null, then current percentage is zero`() {
+        viewModel = CustomAmountsViewModel(
+            CustomAmountsFragmentArgs(
+                customAmountUIModel = CustomAmountUIModel(
+                    id = 0L,
+                    amount = BigDecimal.TEN,
+                    name = "",
+                    type = PERCENTAGE_CUSTOM_AMOUNT
+                ),
+                orderTotal = null
+            ).toSavedStateHandle(),
+            tracker
+        )
+
+        assertThat(viewModel.currentPercentage).isEqualTo(BigDecimal.ZERO)
+    }
     //endregion
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10597
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The error encountered was an `ArithmeticException`: divide by zero, which occurred when attempting to calculate the `currentPercentage` in the `CustomAmountsViewModel` class. This exception is thrown when a division operation is performed with a denominator of zero.

I was able to reproduce the error by creating a product with a price of $0 and then attempting to modify the percentage based custom amount.

The root cause of the error was that the code did not account for the possibility that `args.orderTotal` could be zero or null. When `args.orderTotal` is zero, dividing by it directly will result in a divide by zero error.

To resolve this issue, I introduced checks to ensure that `args.orderTotal` is greater than zero before proceeding with the division. If `args.orderTotal` is zero or null (which is coerced to "0" and then to BigDecimal.ZERO), the `currentPercentage` getter now returns `BigDecimal.ZERO`, and the setter avoids performing any division. 

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

1. For testing I utilized this PR https://github.com/woocommerce/woocommerce-android/pull/10298 
The main focus should be on testing percentage based custom amount.

2. Ensure unit tests pass.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
