### PR TITLE
Blaze: Edit ad tag line & description suggetions

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.blaze
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.util.TimezoneProvider
+import kotlinx.coroutines.delay
 import org.wordpress.android.fluxc.store.blaze.BlazeCampaignsStore
 import java.util.Date
 import javax.inject.Inject
@@ -21,6 +22,9 @@ class BlazeRepository @Inject constructor(
     }
 
     suspend fun getMostRecentCampaign() = blazeCampaignsStore.getMostRecentBlazeCampaign(selectedSite.get())
+
+    @Suppress("MagicNumber")
+    fun observeLanguages() = blazeCampaignsStore.observeBlazeTargetingLanguages()
 
     fun getCampaignPreviewDetails(productId: Long): CampaignPreview {
         val product = productDetailRepository.getProduct(productId)
@@ -60,8 +64,8 @@ class BlazeRepository @Inject constructor(
     )
 
     data class AiSuggestionForAd(
-        val title: String,
         val tagLine: String,
+        val description: String,
     )
 
     data class Budget(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdScreen.kt
@@ -332,8 +332,6 @@ fun PreviewCampaignEditAdContent() {
     WooThemeWithBackground {
         CampaignEditAdContent(
             viewState = ViewState(
-                tagLine = "From 45.00 USD",
-                description = "Get the latest white t-shirts",
                 adImageUrl = "https://rb.gy/gmjuwb"
             ),
             onTagLineChanged = { },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
@@ -4,6 +4,8 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.ui.blaze.BlazeRepository
+import com.woocommerce.android.ui.blaze.creation.ad.BlazeCampaignCreationEditAdViewModel.ViewState.Suggestion
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -12,12 +14,14 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.mediapicker.api.MediaPickerSetup
 import javax.inject.Inject
 
 @HiltViewModel
 class BlazeCampaignCreationEditAdViewModel @Inject constructor(
+    private val blazeRepository: BlazeRepository,
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
@@ -29,16 +33,50 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
 
     private val _viewState = savedStateHandle.getStateFlow(
         scope = viewModelScope,
-        initialValue = ViewState(navArgs.tagline, navArgs.description, navArgs.adImageUrl)
+        initialValue = ViewState(navArgs.adImageUrl)
     )
     val viewState = _viewState.asLiveData()
 
+    init {
+        loadSuggestions()
+    }
+
+    private fun loadSuggestions() {
+        viewModelScope.launch {
+            blazeRepository.getAdSuggestions(navArgs.productId)?.let { list ->
+                val index = list.indexOfFirst { it.tagLine == navArgs.tagline && it.description == navArgs.description }
+                val suggestions = list.map { Suggestion(it.tagLine, it.description) }
+                if (index != -1) {
+                    _viewState.update {
+                        _viewState.value.copy(
+                            suggestions = suggestions,
+                            suggestionIndex = index
+                        )
+                    }
+                } else {
+                    _viewState.update {
+                        _viewState.value.copy(
+                            suggestions = listOf(Suggestion(navArgs.tagline, navArgs.description)) + suggestions,
+                            suggestionIndex = 0
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     fun onNextSuggestionTapped() {
-        /* TODO */
+        _viewState.update {
+            val index = _viewState.value.suggestionIndex
+            _viewState.value.copy(suggestionIndex = index + 1)
+        }
     }
 
     fun onPreviousSuggestionTapped() {
-        /* TODO */
+        _viewState.update {
+            val index = _viewState.value.suggestionIndex
+            _viewState.value.copy(suggestionIndex = index - 1)
+        }
     }
 
     fun onSaveTapped() {
@@ -71,16 +109,24 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
     }
 
     fun onTagLineChanged(tagLine: String) {
-        _viewState.value = _viewState.value.copy(tagLine = tagLine.take(TAGLINE_MAX_LENGTH))
+        updateSuggestion(Suggestion(tagLine.take(TAGLINE_MAX_LENGTH), _viewState.value.description))
     }
 
     fun onDescriptionChanged(description: String) {
-        _viewState.value = _viewState.value.copy(description = description.take(DESCRIPTION_MAX_LENGTH))
+        updateSuggestion(Suggestion(_viewState.value.tagLine, description.take(TAGLINE_MAX_LENGTH)))
     }
 
     fun onImageChanged(url: String) {
         _viewState.update {
             _viewState.value.copy(adImageUrl = url)
+        }
+    }
+
+    private fun updateSuggestion(suggestion: Suggestion) {
+        _viewState.update {
+            val suggestions = _viewState.value.suggestions.toMutableList()
+            suggestions[_viewState.value.suggestionIndex] = suggestion
+            _viewState.value.copy(suggestions = suggestions)
         }
     }
 
@@ -94,17 +140,29 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
 
     @Parcelize
     data class ViewState(
-        val tagLine: String,
-        val description: String,
         val adImageUrl: String?,
-        val isPreviousSuggestionButtonEnabled: Boolean = false,
-        val isNextSuggestionButtonEnabled: Boolean = true,
+        val suggestions: List<Suggestion> = emptyList(),
+        val suggestionIndex: Int = 0,
         val isMediaPickerDialogVisible: Boolean = false
     ) : Parcelable {
+        val tagLine: String
+            get() = suggestions.getOrNull(suggestionIndex)?.tagLine ?: ""
+        val description: String
+            get() = suggestions.getOrNull(suggestionIndex)?.description ?: ""
         val taglineCharactersRemaining: Int
-            get() = TAGLINE_MAX_LENGTH - tagLine.length
+            get() = TAGLINE_MAX_LENGTH - (suggestions.getOrNull(suggestionIndex)?.tagLine?.length ?: 0)
         val descriptionCharactersRemaining: Int
-            get() = DESCRIPTION_MAX_LENGTH - description.length
+            get() = DESCRIPTION_MAX_LENGTH - (suggestions.getOrNull(suggestionIndex)?.description?.length ?: 0)
+        val isPreviousSuggestionButtonEnabled: Boolean
+            get() = suggestionIndex > 0
+        val isNextSuggestionButtonEnabled: Boolean
+            get() = suggestionIndex < suggestions.size - 1
+
+        @Parcelize
+        data class Suggestion(
+            var tagLine: String,
+            var description: String
+        ) : Parcelable
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
@@ -48,6 +48,7 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
                 is NavigateToEditAdScreen -> findNavController().navigate(
                     BlazeCampaignCreationPreviewFragmentDirections
                         .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignCreationEditAdFragment(
+                            event.productId,
                             event.tagLine,
                             event.description,
                             event.campaignImageUrl

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -119,6 +119,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         viewState.value?.let { campaignPreviewContent ->
             triggerEvent(
                 NavigateToEditAdScreen(
+                    productId = navArgs.productId,
                     tagLine = campaignPreviewContent.adDetails.tagLine,
                     description = campaignPreviewContent.adDetails.description,
                     campaignImageUrl = campaignPreviewContent.adDetails.campaignImageUrl
@@ -139,6 +140,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     }
 
     data class NavigateToEditAdScreen(
+        val productId: Long,
         val tagLine: String,
         val description: String,
         val campaignImageUrl: String?

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -35,9 +34,17 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
 
     init {
         launch {
-            @Suppress("MagicNumber")
-            delay(3000)
-            _viewState.value = _viewState.value?.copy(isLoading = false)
+            val suggestions = blazeRepository.getAdSuggestions(navArgs.productId)
+            _viewState.value?.let {
+                _viewState.value = it.copy(
+                    adDetails = it.adDetails.copy(
+                        tagLine = suggestions.firstOrNull()?.title ?: "",
+                        description = suggestions.firstOrNull()?.description ?: "",
+                        tagLine = suggestions.firstOrNull()?.tagLine ?: "",
+                    )
+                )
+            }
+            _viewState.value = _viewState.value?.copy(adDetails = _, isLoading = false)
         }
     }
 
@@ -50,7 +57,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
             isLoading = isLoading,
             adDetails = AdDetailsUi(
                 productId = productId,
-                description = aiSuggestions.firstOrNull()?.title ?: "",
+                description = aiSuggestions.firstOrNull()?.description ?: "",
                 tagLine = aiSuggestions.firstOrNull()?.tagLine ?: "",
                 campaignImageUrl = campaignImageUrl ?: "",
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -33,17 +33,15 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
 
     init {
         launch {
-            val suggestions = blazeRepository.getAdSuggestions(navArgs.productId)
-            _viewState.value?.let {
-                _viewState.value = it.copy(
-                    adDetails = it.adDetails.copy(
-                        tagLine = suggestions.firstOrNull()?.title ?: "",
-                        description = suggestions.firstOrNull()?.description ?: "",
-                        tagLine = suggestions.firstOrNull()?.tagLine ?: "",
+            blazeRepository.getAdSuggestions(navArgs.productId)?.let { adSuggestions ->
+                _viewState.value = _viewState.value?.copy(
+                    isLoading = false,
+                    adDetails = _viewState.value?.adDetails!!.copy(
+                        description = adSuggestions.firstOrNull()?.description ?: "",
+                        tagLine = adSuggestions.firstOrNull()?.tagLine ?: "",
                     )
                 )
             }
-            _viewState.value = _viewState.value?.copy(adDetails = _, isLoading = false)
         }
     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
@@ -62,6 +62,9 @@
         android:name="com.woocommerce.android.ui.blaze.creation.ad.BlazeCampaignCreationEditAdFragment"
         android:label="BlazeCampaignCreationEditAdFragment" >
         <argument
+            android:name="productId"
+            app:argType="long" />
+        <argument
             android:name="tagline"
             app:argType="string"
             android:defaultValue="" />

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2947-0c336369772d70082143ab140391fea0ddcb41a2'
+    fluxCVersion = 'trunk-bf45b08090e8241eb930e1eef32f935bc6cd0424'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.63.0'
+    fluxCVersion = 'trunk-0c336369772d70082143ab140391fea0ddcb41a2'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-0c336369772d70082143ab140391fea0ddcb41a2'
+    fluxCVersion = '2947-0c336369772d70082143ab140391fea0ddcb41a2'
     glideVersion = '4.13.2'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Part of #10519. Adds AI suggestions to the edit ad screen.

When the Edit ad screen is initially loaded, the 3 suggestions are shown and the user can choose one and save it. If they made changes and they come back to the edit screen, the changed tagline & description is put in the 1st place and the original 3 suggestions follow (see the recording).

[Screen_recording_20240125_121941.webm](https://github.com/woocommerce/woocommerce-android/assets/1522856/5d74b4ac-214a-4940-a57e-e9ff8bccaee5)

**To test:**
1. Start a campaign
2. Select a product
3. Tap on Edit ad button
4. Notice a fake suggestion is loaded
5. Tap on the arrow buttons
6. Notice the suggestions change based on the position
7. Try saving one suggestion
8. Notice the tag line and description are update on the preview screen
9. Go back to the edit screen
10. Change something and Save
11. Notice the changes are reflected on the preview screen
12. Go back to the edit screen
13. Notice the correct tag line and description are shown

**Note:** Please merge the [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2947) and update the hash here before merging.