### PR TITLE
Replace org.wordpress.utils.GravatarUtils by com.gravatar.GravatarUtils

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -54,6 +54,7 @@ repositories {
             includeGroup "org.wordpress.mediapicker"
             includeGroup "com.automattic"
             includeGroup "com.automattic.tracks"
+            includeGroup "com.gravatar"
         }
     }
     maven {
@@ -273,6 +274,8 @@ dependencies {
         exclude group: "com.android.support"
         exclude group: "org.wordpress", module: "utils"
     }
+
+    implementation("com.gravatar:gravatar:$gravatarVersion")
 
     implementation project(":libs:cardreader")
     debugImplementation project(":libs:iap")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationMagicLinkRequestViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationMagicLinkRequestViewModel.kt
@@ -5,6 +5,10 @@ import androidx.core.util.PatternsCompat
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.gravatar.AvatarQueryOptions
+import com.gravatar.AvatarUrl
+import com.gravatar.DefaultAvatarOption
+import com.gravatar.types.Email
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.JETPACK_SETUP_LOGIN_FLOW
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -23,7 +27,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
-import org.wordpress.android.util.GravatarUtils
 import javax.inject.Inject
 
 @HiltViewModel
@@ -124,7 +127,10 @@ class JetpackActivationMagicLinkRequestViewModel @Inject constructor(
 
     private fun avatarUrlFromEmail(email: String): String {
         val avatarSize = resourceProvider.getDimensionPixelSize(R.dimen.image_minor_100)
-        return GravatarUtils.gravatarFromEmail(email, avatarSize, GravatarUtils.DefaultImage.STATUS_404)
+        return AvatarUrl(
+            Email(email),
+            AvatarQueryOptions(preferredSize = avatarSize, defaultAvatarOption = DefaultAvatarOption.Status404)
+        ).toString()
     }
 
     private fun String.isAnEmail() = PatternsCompat.EMAIL_ADDRESS.matcher(this).matches()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPasswordViewModel.kt
@@ -3,6 +3,10 @@ package com.woocommerce.android.ui.login.jetpack.wpcom
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.gravatar.AvatarQueryOptions
+import com.gravatar.AvatarUrl
+import com.gravatar.DefaultAvatarOption
+import com.gravatar.types.Email
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.JETPACK_SETUP_LOGIN_FLOW
@@ -27,7 +31,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationError
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType
-import org.wordpress.android.util.GravatarUtils
 import javax.inject.Inject
 
 @HiltViewModel
@@ -161,7 +164,10 @@ class JetpackActivationWPComPasswordViewModel @Inject constructor(
 
     private fun avatarUrlFromEmail(email: String): String {
         val avatarSize = resourceProvider.getDimensionPixelSize(R.dimen.image_minor_100)
-        return GravatarUtils.gravatarFromEmail(email, avatarSize, GravatarUtils.DefaultImage.STATUS_404)
+        return AvatarUrl(
+            Email(email),
+            AvatarQueryOptions(preferredSize = avatarSize, defaultAvatarOption = DefaultAvatarOption.Status404)
+        ).toString()
     }
 
     data class ViewState(

--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ ext {
     hiltJetpackVersion = '1.1.0'
     wordPressUtilsVersion = '3.5.0'
     mediapickerVersion = '0.3.0'
-    wordPressLoginVersion = '1.13.0'
+    wordPressLoginVersion = '1.15.0'
     aboutAutomatticVersion = '0.0.6'
     automatticTracksVersion = '4.0.2'
     workManagerVersion = '2.7.1'
@@ -127,6 +127,7 @@ ext {
     androidxCameraVersion = '1.2.3'
     guavaVersion = '33.1.0-android'
     protobufVersion = '3.25.3'
+    gravatarVersion = '0.2.0'
 
     // Apache
     commonsText = '1.10.0'


### PR DESCRIPTION
Replace `org.wordpress.utils.GravatarUtils` by `com.gravatar`.

### Description

We're removing gravatar related code from WPUtils. We recently released a [Gravatar library](https://github.com/Automattic/Gravatar-SDK-Android) and did the according changes in WCAndroid to prepare for code removal in the next WPUtils release.


### Testing instructions

Build / run, then test impacted screens. I need help for this part, I don't know what's the flow to get to these screens in the app (`JetpackActivationWPComPasswordViewModel`).

### Images/gif

There shouldn't be any visual changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

Note: there is no "[Internal]" label, I picked `type: task` instead.