### PR TITLE
Blaze: Preview screen state management

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
@@ -3,6 +3,29 @@ package com.woocommerce.android.extensions
 import kotlinx.coroutines.flow.Flow
 
 @Suppress("LongParameterList")
+inline fun <T1, T2, T3, T4, T5, T6, R> combine(
+    flow: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+    flow4: Flow<T4>,
+    flow5: Flow<T5>,
+    flow6: Flow<T6>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6) -> R
+): Flow<R> {
+    return kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6) { args: Array<*> ->
+        @Suppress("UNCHECKED_CAST", "MagicNumber")
+        transform(
+            args[0] as T1,
+            args[1] as T2,
+            args[2] as T3,
+            args[3] as T4,
+            args[4] as T5,
+            args[5] as T6,
+        )
+    }
+}
+
+@Suppress("LongParameterList")
 inline fun <T1, T2, T3, T4, T5, T6, T7, R> combine(
     flow: Flow<T1>,
     flow2: Flow<T2>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -1,8 +1,10 @@
 package com.woocommerce.android.ui.blaze
 
+import android.os.Parcelable
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.util.TimezoneProvider
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.persistence.blaze.BlazeCampaignsDao.BlazeAdSuggestionEntity
 import org.wordpress.android.fluxc.store.blaze.BlazeCampaignsStore
 import java.util.Date
@@ -43,18 +45,6 @@ class BlazeRepository @Inject constructor(
         val product = productDetailRepository.getProduct(productId)
         return CampaignPreview(
             productId = productId,
-            aiSuggestions = listOf(),
-            budget = Budget(
-                totalBudget = DEFAULT_CAMPAIGN_TOTAL_BUDGET,
-                spentBudget = 0f,
-                currencyCode = BLAZE_DEFAULT_CURRENCY_CODE,
-                durationInDays = DEFAULT_CAMPAIGN_DURATION,
-                startDate = Date().apply { time += ONE_DAY_IN_MILLIS }, // By default start tomorrow
-            ),
-            languages = listOf(),
-            devices = listOf(),
-            locations = listOf(),
-            interests = listOf(),
             userTimeZone = timezoneProvider.deviceTimezone.displayName,
             targetUrl = product?.permalink ?: "",
             urlParams = null,
@@ -62,50 +52,51 @@ class BlazeRepository @Inject constructor(
         )
     }
 
+    @Parcelize
     data class CampaignPreview(
         val productId: Long,
-        val aiSuggestions: List<AiSuggestionForAd>,
-        val budget: Budget,
-        val languages: List<Language>,
-        val devices: List<Device>,
-        val locations: List<Location>,
-        val interests: List<Interest>,
         val userTimeZone: String,
         val targetUrl: String,
         val urlParams: Pair<String, String>?,
         val campaignImageUrl: String?,
-    )
+    ) : Parcelable
 
+    @Parcelize
     data class AiSuggestionForAd(
         val tagLine: String,
         val description: String,
-    )
+    ) : Parcelable
 
+    @Parcelize
     data class Budget(
         val totalBudget: Float,
         val spentBudget: Float,
         val currencyCode: String,
         val durationInDays: Int,
         val startDate: Date,
-    )
+    ) : Parcelable
 
+    @Parcelize
     data class Location(
         val id: String,
         val name: String,
-    )
+    ) : Parcelable
 
+    @Parcelize
     data class Language(
         val code: String,
         val name: String,
-    )
+    ) : Parcelable
 
+    @Parcelize
     data class Device(
         val id: String,
         val name: String,
-    )
+    ) : Parcelable
 
+    @Parcelize
     data class Interest(
         val id: String,
         val description: String,
-    )
+    ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.blaze.BlazeRepository
-import com.woocommerce.android.ui.blaze.creation.ad.BlazeCampaignCreationEditAdViewModel.ViewState.Suggestion
+import com.woocommerce.android.ui.blaze.BlazeRepository.AiSuggestionForAd
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -45,7 +45,7 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
         viewModelScope.launch {
             blazeRepository.getAdSuggestions(navArgs.productId)?.let { list ->
                 val index = list.indexOfFirst { it.tagLine == navArgs.tagline && it.description == navArgs.description }
-                val suggestions = list.map { Suggestion(it.tagLine, it.description) }
+                val suggestions = list.map { AiSuggestionForAd(it.tagLine, it.description) }
                 if (index != -1) {
                     _viewState.update {
                         _viewState.value.copy(
@@ -56,7 +56,7 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
                 } else {
                     _viewState.update {
                         _viewState.value.copy(
-                            suggestions = listOf(Suggestion(navArgs.tagline, navArgs.description)) + suggestions,
+                            suggestions = listOf(AiSuggestionForAd(navArgs.tagline, navArgs.description)) + suggestions,
                             suggestionIndex = 0
                         )
                     }
@@ -109,11 +109,11 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
     }
 
     fun onTagLineChanged(tagLine: String) {
-        updateSuggestion(Suggestion(tagLine.take(TAGLINE_MAX_LENGTH), _viewState.value.description))
+        updateSuggestion(AiSuggestionForAd(tagLine.take(TAGLINE_MAX_LENGTH), _viewState.value.description))
     }
 
     fun onDescriptionChanged(description: String) {
-        updateSuggestion(Suggestion(_viewState.value.tagLine, description.take(TAGLINE_MAX_LENGTH)))
+        updateSuggestion(AiSuggestionForAd(_viewState.value.tagLine, description.take(TAGLINE_MAX_LENGTH)))
     }
 
     fun onImageChanged(url: String) {
@@ -122,7 +122,7 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
         }
     }
 
-    private fun updateSuggestion(suggestion: Suggestion) {
+    private fun updateSuggestion(suggestion: AiSuggestionForAd) {
         _viewState.update {
             val suggestions = _viewState.value.suggestions.toMutableList()
             suggestions[_viewState.value.suggestionIndex] = suggestion
@@ -141,7 +141,7 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
     @Parcelize
     data class ViewState(
         val adImageUrl: String?,
-        val suggestions: List<Suggestion> = emptyList(),
+        val suggestions: List<AiSuggestionForAd> = emptyList(),
         val suggestionIndex: Int = 0,
         val isMediaPickerDialogVisible: Boolean = false
     ) : Parcelable {
@@ -157,12 +157,6 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
             get() = suggestionIndex > 0
         val isNextSuggestionButtonEnabled: Boolean
             get() = suggestionIndex < suggestions.size - 1
-
-        @Parcelize
-        data class Suggestion(
-            var tagLine: String,
-            var description: String
-        ) : Parcelable
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
@@ -45,7 +45,7 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
                     BlazeCampaignCreationPreviewFragmentDirections
                         .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignBudgetFragment()
                 )
-                is NavigateToEditAdScreen -> findNavController().navigate(
+                is NavigateToEditAdScreen -> findNavController().navigateSafely(
                     BlazeCampaignCreationPreviewFragmentDirections
                         .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignCreationEditAdFragment(
                             event.productId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
@@ -42,7 +42,8 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.AdDetailsUi
+import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.AdDetailsUi.AdDetails
+import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.AdDetailsUi.Loading
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.CampaignDetailItemUi
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.CampaignDetailsUi
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.CampaignPreviewUiState
@@ -87,10 +88,10 @@ private fun BlazeCampaignCreationPreviewScreen(
                 .background(color = MaterialTheme.colors.surface)
         ) {
 
-            when {
-                previewState.isLoading -> AdDetailsLoading()
+            when (previewState.adDetails) {
+                is Loading -> AdDetailsLoading()
                 else -> AdDetailsHeader(
-                    state = previewState,
+                    previewState.adDetails as AdDetails,
                     onEditAdClicked = onEditAdClicked
                 )
             }
@@ -110,7 +111,7 @@ private fun BlazeCampaignCreationPreviewScreen(
                     .padding(bottom = 8.dp),
                 text = stringResource(id = R.string.blaze_campaign_preview_details_confirm_details_button),
                 onClick = { /*TODO*/ },
-                enabled = !previewState.isLoading
+                enabled = previewState.adDetails != Loading
             )
         }
     }
@@ -177,12 +178,12 @@ private fun AdDetailsLoading(
 
 @Composable
 fun AdDetailsHeader(
-    state: CampaignPreviewUiState,
+    adDetails: AdDetails,
     onEditAdClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     CampaignHeader(
-        adDetails = state.adDetails,
+        adDetails = adDetails,
         onEditAdClicked = onEditAdClicked,
         modifier = modifier
             .fillMaxWidth()
@@ -194,7 +195,7 @@ fun AdDetailsHeader(
 
 @Composable
 fun CampaignHeader(
-    adDetails: AdDetailsUi,
+    adDetails: AdDetails,
     onEditAdClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -366,8 +367,7 @@ private fun CampaignPropertyItem(
 fun CampaignScreenPreview() {
     BlazeCampaignCreationPreviewScreen(
         CampaignPreviewUiState(
-            isLoading = false,
-            adDetails = AdDetailsUi(
+            adDetails = AdDetails(
                 productId = 123,
                 description = "Get the latest white t-shirts",
                 tagLine = "From 45.00 USD",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -1,68 +1,119 @@
 package com.woocommerce.android.ui.blaze.creation.preview
 
-import androidx.lifecycle.MutableLiveData
+import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R.string
+import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.extensions.formatToMMMdd
 import com.woocommerce.android.ui.blaze.BlazeRepository
+import com.woocommerce.android.ui.blaze.BlazeRepository.Budget
 import com.woocommerce.android.ui.blaze.BlazeRepository.CampaignPreview
+import com.woocommerce.android.ui.blaze.BlazeRepository.Device
+import com.woocommerce.android.ui.blaze.BlazeRepository.Interest
+import com.woocommerce.android.ui.blaze.BlazeRepository.Language
+import com.woocommerce.android.ui.blaze.BlazeRepository.Location
+import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.AdDetailsUi.AdDetails
+import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.AdDetailsUi.Loading
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
+import java.util.Date
 import javax.inject.Inject
 
 @HiltViewModel
 class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    blazeRepository: BlazeRepository,
+    private val blazeRepository: BlazeRepository,
     private val resourceProvider: ResourceProvider,
     private val currencyFormatter: CurrencyFormatter
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: BlazeCampaignCreationPreviewFragmentArgs by savedStateHandle.navArgs()
+    private val campaign = blazeRepository.getCampaignPreviewDetails(navArgs.productId)
 
-    private val _viewState = MutableLiveData(
-        blazeRepository
-            .getCampaignPreviewDetails(navArgs.productId)
-            .toCampaignPreviewUiState(isLoading = true)
-    )
-    val viewState = _viewState
+    private val adDetails = savedStateHandle.getStateFlow<AdDetailsUi>(viewModelScope, Loading)
+    private val budget = savedStateHandle.getStateFlow(viewModelScope, getDefaultBudget())
+    private val selectedLanguages = savedStateHandle.getStateFlow<List<Language>>(viewModelScope, emptyList())
+    private val selectedDevices = savedStateHandle.getStateFlow<List<Device>>(viewModelScope, emptyList())
+    private val selectedInterests = savedStateHandle.getStateFlow<List<Interest>>(viewModelScope, emptyList())
+    private val selectedLocations = savedStateHandle.getStateFlow<List<Location>>(viewModelScope, emptyList())
+
+    val viewState = combine(
+        adDetails,
+        budget,
+        selectedLanguages,
+        selectedDevices,
+        selectedInterests,
+        selectedLocations
+    ) { adDetails, budget, languages, devices, interests, locations ->
+        CampaignPreviewUiState(
+            adDetails = adDetails,
+            campaignDetails = campaign.toCampaignDetailsUi(budget, languages, devices, locations, interests)
+        )
+    }.asLiveData()
 
     init {
-        launch {
-            blazeRepository.getAdSuggestions(navArgs.productId)?.let { adSuggestions ->
-                _viewState.value = _viewState.value?.copy(
-                    isLoading = false,
-                    adDetails = _viewState.value?.adDetails!!.copy(
-                        description = adSuggestions.firstOrNull()?.description ?: "",
-                        tagLine = adSuggestions.firstOrNull()?.tagLine ?: "",
-                    )
-                )
-            }
-        }
+        loadSuggestions()
     }
 
     fun onBackPressed() {
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
-    private fun CampaignPreview.toCampaignPreviewUiState(isLoading: Boolean = false) =
-        CampaignPreviewUiState(
-            isLoading = isLoading,
-            adDetails = AdDetailsUi(
-                productId = productId,
-                description = aiSuggestions.firstOrNull()?.description ?: "",
-                tagLine = aiSuggestions.firstOrNull()?.tagLine ?: "",
-                campaignImageUrl = campaignImageUrl ?: "",
-            ),
-            campaignDetails = toCampaignDetailsUi()
-        )
+    fun onEditAdClicked() {
+        (adDetails.value as? AdDetails)?.let {
+            triggerEvent(
+                NavigateToEditAdScreen(
+                    productId = navArgs.productId,
+                    tagLine = it.tagLine,
+                    description = it.description,
+                    campaignImageUrl = it.campaignImageUrl
+                )
+            )
+        }
+    }
 
-    private fun CampaignPreview.toCampaignDetailsUi() =
-        CampaignDetailsUi(
+    fun onAdUpdated(tagline: String, description: String, campaignImageUrl: String?) {
+        adDetails.update {
+            AdDetails(
+                productId = navArgs.productId,
+                description = description,
+                tagLine = tagline,
+                campaignImageUrl = campaignImageUrl
+            )
+        }
+    }
+
+    private fun loadSuggestions() {
+        launch {
+            blazeRepository.getAdSuggestions(navArgs.productId).let { suggestions ->
+                adDetails.update {
+                    AdDetails(
+                        productId = navArgs.productId,
+                        description = suggestions?.firstOrNull()?.description ?: "",
+                        tagLine = suggestions?.firstOrNull()?.tagLine ?: "",
+                        campaignImageUrl = campaign.campaignImageUrl
+                    )
+                }
+            }
+        }
+    }
+
+    private fun CampaignPreview.toCampaignDetailsUi(
+        budget: Budget,
+        languages: List<Language>,
+        devices: List<Device>,
+        locations: List<Location>,
+        interests: List<Interest>
+    ) = CampaignDetailsUi(
             budget = CampaignDetailItemUi(
                 displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_budget),
                 displayValue = budget.toDisplayValue(),
@@ -77,13 +128,13 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
                 ),
                 CampaignDetailItemUi(
                     displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_devices),
-                    displayValue = locations.joinToString { it.name }
+                    displayValue = devices.joinToString { it.name }
                         .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
                     onItemSelected = { /* TODO Add devices selection */ },
                 ),
                 CampaignDetailItemUi(
                     displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_location),
-                    displayValue = devices.joinToString { it.name }
+                    displayValue = locations.joinToString { it.name }
                         .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
                     onItemSelected = { /* TODO Add location selection */ },
                 ),
@@ -102,7 +153,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
             )
         )
 
-    private fun BlazeRepository.Budget.toDisplayValue(): String {
+    private fun Budget.toDisplayValue(): String {
         val totalBudgetWithCurrency = currencyFormatter.formatCurrency(
             totalBudget.toBigDecimal(),
             currencyCode
@@ -115,29 +166,13 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         return "$totalBudgetWithCurrency,  $duration"
     }
 
-    fun onEditAdClicked() {
-        viewState.value?.let { campaignPreviewContent ->
-            triggerEvent(
-                NavigateToEditAdScreen(
-                    productId = navArgs.productId,
-                    tagLine = campaignPreviewContent.adDetails.tagLine,
-                    description = campaignPreviewContent.adDetails.description,
-                    campaignImageUrl = campaignPreviewContent.adDetails.campaignImageUrl
-                )
-            )
-        }
-    }
-
-    fun onAdUpdated(tagline: String, description: String, campaignImageUrl: String?) {
-        _viewState.value = viewState.value?.copy(
-            adDetails = AdDetailsUi(
-                productId = navArgs.productId,
-                description = description,
-                tagLine = tagline,
-                campaignImageUrl = campaignImageUrl
-            )
-        )
-    }
+    private fun getDefaultBudget() = Budget(
+        totalBudget = BlazeRepository.DEFAULT_CAMPAIGN_TOTAL_BUDGET,
+        spentBudget = 0f,
+        currencyCode = BlazeRepository.BLAZE_DEFAULT_CURRENCY_CODE,
+        durationInDays = BlazeRepository.DEFAULT_CAMPAIGN_DURATION,
+        startDate = Date().apply { time += BlazeRepository.ONE_DAY_IN_MILLIS }, // By default start tomorrow
+    )
 
     data class NavigateToEditAdScreen(
         val productId: Long,
@@ -147,17 +182,22 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     ) : MultiLiveEvent.Event()
 
     data class CampaignPreviewUiState(
-        val isLoading: Boolean = false,
         val adDetails: AdDetailsUi,
         val campaignDetails: CampaignDetailsUi,
     )
 
-    data class AdDetailsUi(
-        val productId: Long,
-        val description: String,
-        val tagLine: String,
-        val campaignImageUrl: String?,
-    )
+    sealed interface AdDetailsUi : Parcelable {
+        @Parcelize
+        object Loading : AdDetailsUi
+
+        @Parcelize
+        data class AdDetails(
+            val productId: Long,
+            val description: String,
+            val tagLine: String,
+            val campaignImageUrl: String?,
+        ) : AdDetailsUi
+    }
 
     data class CampaignDetailsUi(
         val budget: CampaignDetailItemUi,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -114,44 +114,44 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         locations: List<Location>,
         interests: List<Interest>
     ) = CampaignDetailsUi(
-            budget = CampaignDetailItemUi(
-                displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_budget),
-                displayValue = budget.toDisplayValue(),
-                onItemSelected = { triggerEvent(NavigateToBudgetScreen) },
+        budget = CampaignDetailItemUi(
+            displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_budget),
+            displayValue = budget.toDisplayValue(),
+            onItemSelected = { triggerEvent(NavigateToBudgetScreen) },
+        ),
+        targetDetails = listOf(
+            CampaignDetailItemUi(
+                displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_language),
+                displayValue = languages.joinToString { it.name }
+                    .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
+                onItemSelected = { /* TODO Add language selection */ },
             ),
-            targetDetails = listOf(
-                CampaignDetailItemUi(
-                    displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_language),
-                    displayValue = languages.joinToString { it.name }
-                        .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
-                    onItemSelected = { /* TODO Add language selection */ },
-                ),
-                CampaignDetailItemUi(
-                    displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_devices),
-                    displayValue = devices.joinToString { it.name }
-                        .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
-                    onItemSelected = { /* TODO Add devices selection */ },
-                ),
-                CampaignDetailItemUi(
-                    displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_location),
-                    displayValue = locations.joinToString { it.name }
-                        .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
-                    onItemSelected = { /* TODO Add location selection */ },
-                ),
-                CampaignDetailItemUi(
-                    displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_interests),
-                    displayValue = interests.joinToString { it.description }
-                        .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
-                    onItemSelected = { /* TODO Add interests selection */ },
-                ),
+            CampaignDetailItemUi(
+                displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_devices),
+                displayValue = devices.joinToString { it.name }
+                    .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
+                onItemSelected = { /* TODO Add devices selection */ },
             ),
-            destinationUrl = CampaignDetailItemUi(
-                displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_destination_url),
-                displayValue = targetUrl,
-                onItemSelected = { /* TODO Add destination url selection */ },
-                maxLinesValue = 1,
-            )
+            CampaignDetailItemUi(
+                displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_location),
+                displayValue = locations.joinToString { it.name }
+                    .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
+                onItemSelected = { /* TODO Add location selection */ },
+            ),
+            CampaignDetailItemUi(
+                displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_interests),
+                displayValue = interests.joinToString { it.description }
+                    .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
+                onItemSelected = { /* TODO Add interests selection */ },
+            ),
+        ),
+        destinationUrl = CampaignDetailItemUi(
+            displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_destination_url),
+            displayValue = targetUrl,
+            onItemSelected = { /* TODO Add destination url selection */ },
+            maxLinesValue = 1,
         )
+    )
 
     private fun Budget.toDisplayValue(): String {
         val totalBudgetWithCurrency = currencyFormatter.formatCurrency(


### PR DESCRIPTION
This PR refactors the `BlazeCampaignCreationPreviewViewModel` view state management using `Flows`. Updating the single ViewState `LiveData` class was becoming very messy when dealing with Blaze target selections and this change will simplify the updates.

**To test:**
Just smoke test the Blaze campaign Preview and Edit ad screens to make sure everything works as before.