### PR TITLE
Blaze: Ad target languages 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.util.TimezoneProvider
+import kotlinx.coroutines.flow.map
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.persistence.blaze.BlazeCampaignsDao.BlazeAdSuggestionEntity
 import org.wordpress.android.fluxc.store.blaze.BlazeCampaignsStore
@@ -25,6 +26,11 @@ class BlazeRepository @Inject constructor(
         const val CAMPAIGN_MAX_DURATION = 28 // Days
         const val ONE_DAY_IN_MILLIS = 1000 * 60 * 60 * 24
     }
+
+    fun observeLanguages() = blazeCampaignsStore.observeBlazeTargetingLanguages()
+        .map { it.map { language -> Language(language.id, language.name) } }
+
+    suspend fun fetchLanguages() = blazeCampaignsStore.fetchBlazeTargetingLanguages()
 
     suspend fun getMostRecentCampaign() = blazeCampaignsStore.getMostRecentBlazeCampaign(selectedSite.get())
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
@@ -13,6 +13,9 @@ import com.woocommerce.android.ui.blaze.creation.ad.BlazeCampaignCreationEditAdF
 import com.woocommerce.android.ui.blaze.creation.ad.BlazeCampaignCreationEditAdViewModel.EditAdResult
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.NavigateToBudgetScreen
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.NavigateToEditAdScreen
+import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.NavigateToTargetSelectionScreen
+import com.woocommerce.android.ui.blaze.creation.targets.BlazeCampaignTargetSelectionFragment
+import com.woocommerce.android.ui.blaze.creation.targets.BlazeCampaignTargetSelectionViewModel.TargetSelectionResult
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -54,6 +57,13 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
                             event.campaignImageUrl
                         )
                 )
+                is NavigateToTargetSelectionScreen -> findNavController().navigateSafely(
+                    BlazeCampaignCreationPreviewFragmentDirections
+                        .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignTargetSelectionFragment(
+                            event.targetType,
+                            event.selectedIds.toTypedArray()
+                        )
+                )
             }
         }
     }
@@ -61,6 +71,9 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
     private fun handleResults() {
         handleResult<EditAdResult>(BlazeCampaignCreationEditAdFragment.EDIT_AD_RESULT) {
             viewModel.onAdUpdated(it.tagline, it.description, it.campaignImageUrl)
+        }
+        handleResult<TargetSelectionResult>(BlazeCampaignTargetSelectionFragment.BLAZE_TARGET_SELECTION_RESULT) {
+            viewModel.onTargetSelectionUpdated(it.targetType, it.selectedIds)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.ui.blaze.BlazeRepository.Location
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.AdDetailsUi.AdDetails
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.AdDetailsUi.Loading
 import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType
-import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType.DEVICE
 import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType.LANGUAGE
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R.string
-import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.extensions.formatToMMMdd
 import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.ui.blaze.BlazeRepository.Budget
@@ -25,6 +24,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -45,19 +45,13 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     private val budget = savedStateHandle.getStateFlow(viewModelScope, getDefaultBudget())
     private val languages = blazeRepository.observeLanguages()
     private val selectedLanguages = savedStateHandle.getStateFlow<List<String>>(viewModelScope, emptyList())
-    private val selectedDevices = savedStateHandle.getStateFlow<List<String>>(viewModelScope, emptyList())
-    private val selectedInterests = savedStateHandle.getStateFlow<List<String>>(viewModelScope, emptyList())
-    private val selectedLocations = savedStateHandle.getStateFlow<List<String>>(viewModelScope, emptyList())
 
     val viewState = combine(
         adDetails,
         budget,
         languages,
-        selectedLanguages,
-        selectedDevices,
-        selectedInterests,
-        selectedLocations
-    ) { adDetails, budget, languages, selectedLanguages, selectedDevices, selectedInterests, selectedLocations ->
+        selectedLanguages
+    ) { adDetails, budget, languages, selectedLanguages ->
         CampaignPreviewUiState(
             adDetails = adDetails,
             campaignDetails = campaign.toCampaignDetailsUi(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionFragment.kt
@@ -6,14 +6,20 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class BlazeCampaignTargetSelectionFragment : BaseFragment() {
+    companion object {
+        const val BLAZE_TARGET_SELECTION_RESULT = "blaze_target_selection_result"
+    }
+
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
@@ -21,6 +27,7 @@ class BlazeCampaignTargetSelectionFragment : BaseFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {
+            BlazeCampaignTargetSelectionScreen(viewModel)
         }
     }
 
@@ -33,6 +40,7 @@ class BlazeCampaignTargetSelectionFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
+                is ExitWithResult<*> -> navigateBackWithResult(BLAZE_TARGET_SELECTION_RESULT, event.data)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionFragment.kt
@@ -1,0 +1,39 @@
+package com.woocommerce.android.ui.blaze.creation.targets
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class BlazeCampaignTargetSelectionFragment : BaseFragment() {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    val viewModel: BlazeCampaignTargetSelectionViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return composeView {
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionScreen.kt
@@ -67,7 +67,6 @@ private fun TargetSelectionScreen(
     }
 }
 
-
 @LightDarkThemePreviews
 @Composable
 fun PreviewTargetSelectionScreen() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionScreen.kt
@@ -1,7 +1,100 @@
 package com.woocommerce.android.ui.blaze.creation.targets
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.icons.Icons.Filled
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.R.string
+import com.woocommerce.android.ui.blaze.creation.targets.BlazeCampaignTargetSelectionViewModel.TargetItem
+import com.woocommerce.android.ui.blaze.creation.targets.BlazeCampaignTargetSelectionViewModel.ViewState
+import com.woocommerce.android.ui.compose.component.MultiSelectAllItemsButton
+import com.woocommerce.android.ui.compose.component.MultiSelectList
+import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 
 @Composable
 fun BlazeCampaignTargetSelectionScreen(viewModel: BlazeCampaignTargetSelectionViewModel) {
+    viewModel.viewState.observeAsState().value?.let { state ->
+        TargetSelectionScreen(
+            state = state,
+            onBackPressed = viewModel::onBackPressed,
+            onSaveTapped = viewModel::onSaveTapped,
+            onItemTapped = viewModel::onItemTapped,
+            onAllButtonTapped = viewModel::onAllButtonTapped
+        )
+    }
+}
+
+@Composable
+private fun TargetSelectionScreen(
+    state: ViewState,
+    onBackPressed: () -> Unit,
+    onSaveTapped: () -> Unit,
+    onItemTapped: (TargetItem) -> Unit,
+    onAllButtonTapped: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = state.title,
+                onNavigationButtonClick = onBackPressed,
+                navigationIcon = Filled.ArrowBack,
+                actionButtonText = stringResource(id = string.save).uppercase(),
+                onActionButtonClick = onSaveTapped
+            )
+        },
+        modifier = Modifier.background(MaterialTheme.colors.surface)
+    ) { paddingValues ->
+        MultiSelectList(
+            items = state.items,
+            selectedItems = state.selectedItems,
+            itemFormatter = { value },
+            onItemToggled = onItemTapped,
+            allItemsButton = MultiSelectAllItemsButton(
+                text = stringResource(id = string.blaze_campaign_preview_target_default_value),
+                onClicked = onAllButtonTapped
+            ),
+            modifier = Modifier
+                .background(MaterialTheme.colors.surface)
+                .padding(paddingValues)
+        )
+    }
+}
+
+
+@LightDarkThemePreviews
+@Composable
+fun PreviewTargetSelectionScreen() {
+    TargetSelectionScreen(
+        state = ViewState(
+            items = listOf(
+                TargetItem("1", "Item 1"),
+                TargetItem("2", "Item 2"),
+                TargetItem("3", "Item 3"),
+                TargetItem("4", "Item 4"),
+                TargetItem("5", "Item 5"),
+                TargetItem("6", "Item 6"),
+                TargetItem("7", "Item 7"),
+                TargetItem("8", "Item 8"),
+                TargetItem("9", "Item 9")
+            ),
+            selectedItems = listOf(
+                TargetItem("4", "Item 4"),
+                TargetItem("5", "Item 5"),
+                TargetItem("8", "Item 8"),
+                TargetItem("9", "Item 9")
+            ),
+            title = "Title"
+        ),
+        onBackPressed = { /*TODO*/ },
+        onSaveTapped = { /*TODO*/ },
+        onItemTapped = {},
+        onAllButtonTapped = {}
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionScreen.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.ui.blaze.creation.targets
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun BlazeCampaignTargetSelectionScreen(viewModel: BlazeCampaignTargetSelectionViewModel) {
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModel.kt
@@ -1,23 +1,100 @@
 package com.woocommerce.android.ui.blaze.creation.targets
 
+import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.ui.products.ProductListRepository
-import com.woocommerce.android.ui.products.ProductStatus
-import com.woocommerce.android.util.CoroutineDispatchers
-import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.viewmodel.MultiLiveEvent
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
-import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
 class BlazeCampaignTargetSelectionViewModel @Inject constructor(
+    private val resourceProvider: ResourceProvider,
+    blazeRepository: BlazeRepository,
     savedStateHandle: SavedStateHandle,
 ) : ScopedViewModel(savedStateHandle) {
+    private val navArgs: BlazeCampaignTargetSelectionFragmentArgs by savedStateHandle.navArgs()
+
+    private val items: Flow<List<TargetItem>> = when (navArgs.targetType) {
+        BlazeTargetType.LANGUAGE -> blazeRepository.observeLanguages().map { languages ->
+            languages.map { language ->
+                TargetItem(
+                    id = language.code,
+                    value = language.name
+                )
+            }
+        }
+        else -> flowOf(emptyList())
+    }
+
+    private val selectedIds = savedStateHandle.getStateFlow(viewModelScope, navArgs.selectedIds.toSet())
+
+    val viewState = combine(items, selectedIds) { items, selectedIds ->
+        ViewState(
+            items = items,
+            selectedItems = selectedIds.map { id -> items.first { it.id == id } },
+            title = when (navArgs.targetType) {
+                BlazeTargetType.LANGUAGE -> resourceProvider.getString(R.string.blaze_campaign_preview_details_language)
+                else -> ""
+            }
+        )
+    }.asLiveData()
+
+    fun onItemTapped(item: TargetItem) {
+        selectedIds.update { selectedIds ->
+            if (selectedIds.contains(item.id)) {
+                selectedIds - item.id
+            } else {
+                selectedIds + item.id
+            }
+        }
+    }
+
+    fun onAllButtonTapped() {
+        selectedIds.update { emptySet() }
+    }
+
+    fun onBackPressed() {
+        triggerEvent(Exit)
+    }
+
+    fun onSaveTapped() {
+        // Empty selection set means all items are selected
+        val result = if (selectedIds.value.size == viewState.value?.items?.size)
+            emptyList()
+        else
+            selectedIds.value.toList()
+        triggerEvent(ExitWithResult(TargetSelectionResult(navArgs.targetType, result)))
+    }
+
+    data class TargetItem(
+        val id: String,
+        val value: String,
+    )
+
+    data class ViewState(
+        val items: List<TargetItem>,
+        val selectedItems: List<TargetItem>,
+        val title: String
+    )
+
+    @Parcelize
+    data class TargetSelectionResult(
+        val targetType: BlazeTargetType,
+        val selectedIds: List<String>
+    ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModel.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.ui.blaze.creation.targets
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.ui.products.ProductListRepository
+import com.woocommerce.android.ui.products.ProductStatus
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
+import javax.inject.Inject
+
+@HiltViewModel
+class BlazeCampaignTargetSelectionViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : ScopedViewModel(savedStateHandle) {
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModel.kt
@@ -14,10 +14,10 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeTargetType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeTargetType.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.blaze.creation.targets
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+enum class BlazeTargetType : Parcelable {
+    LANGUAGE,
+    DEVICE,
+    INTEREST,
+    LOCATION
+}

--- a/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
@@ -56,6 +56,9 @@
         <action
             android:id="@+id/action_blazeCampaignCreationPreviewFragment_to_blazeCampaignBudgetFragment"
             app:destination="@id/blazeCampaignBudgetFragment" />
+        <action
+            android:id="@+id/action_blazeCampaignCreationPreviewFragment_to_blazeCampaignTargetSelectionFragment"
+            app:destination="@id/blazeCampaignTargetSelectionFragment" />
     </fragment>
     <fragment
         android:id="@+id/blazeCampaignCreationEditAdFragment"
@@ -82,4 +85,15 @@
         android:id="@+id/blazeCampaignBudgetFragment"
         android:name="com.woocommerce.android.ui.blaze.creation.budget.BlazeCampaignBudgetFragment"
         android:label="BlazeCampaignBudgetFragment" />
+    <fragment
+        android:id="@+id/blazeCampaignTargetSelectionFragment"
+        android:name="com.woocommerce.android.ui.blaze.creation.targets.BlazeCampaignTargetSelectionFragment"
+        android:label="BlazeCampaignTargetSelectionFragment" >
+        <argument
+            android:name="targetType"
+            app:argType="com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType" />
+        <argument
+            android:name="selectedIds"
+            app:argType="string[]" />
+    </fragment>
 </navigation>


### PR DESCRIPTION
Adresses #10589. The PR implements the target language selection in the ad preview screen.

[Screen_recording_20240127_150953.webm](https://github.com/woocommerce/woocommerce-android/assets/1522856/cf81ade8-9d91-4cd3-87b6-9ec4fc3cc65f)

**To test:**
1. Start the Blaze campaign creation
2. Select a product
3. Tap on the Languages option
4. Notice a language selection screen opens
5. Select some languages
6. Tap on the Save button
7. Notice the selected languages are displayed in the preview 

**Note:** Please merge #10638 before merging this.