### PR TITLE
Blaze: Target device selection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -32,6 +32,11 @@ class BlazeRepository @Inject constructor(
 
     suspend fun fetchLanguages() = blazeCampaignsStore.fetchBlazeTargetingLanguages()
 
+    fun observeDevices() = blazeCampaignsStore.observeBlazeTargetingDevices()
+        .map { it.map { device -> Device(device.id, device.name) } }
+
+    suspend fun fetchDevices() = blazeCampaignsStore.fetchBlazeTargetingDevices()
+
     suspend fun getMostRecentCampaign() = blazeCampaignsStore.getMostRecentBlazeCampaign(selectedSite.get())
 
     suspend fun getAdSuggestions(productId: Long): List<AiSuggestionForAd>? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -100,6 +100,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         launch {
             when (targetType) {
                 LANGUAGE -> selectedLanguages.update { selectedIds }
+                DEVICE -> selectedDevices.update { selectedIds }
                 else -> Unit
             }
         }
@@ -108,6 +109,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     private fun loadData() {
         launch {
             blazeRepository.fetchLanguages()
+            blazeRepository.fetchDevices()
             blazeRepository.getAdSuggestions(navArgs.productId).let { suggestions ->
                 adDetails.update {
                     AdDetails(
@@ -146,7 +148,9 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
                 displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_devices),
                 displayValue = devices.joinToString { it.name }
                     .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
-                onItemSelected = { /* TODO Add device selection */ },
+                onItemSelected = {
+                    triggerEvent(NavigateToTargetSelectionScreen(DEVICE, devices.map { it.id }))
+                },
             ),
             CampaignDetailItemUi(
                 displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_location),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
@@ -45,8 +47,11 @@ private fun TargetSelectionScreen(
                 title = state.title,
                 onNavigationButtonClick = onBackPressed,
                 navigationIcon = Filled.ArrowBack,
-                actionButtonText = stringResource(id = string.save).uppercase(),
-                onActionButtonClick = onSaveTapped
+                actions = {
+                    TextButton(onClick = onSaveTapped, enabled = state.selectedItems.isNotEmpty()) {
+                        Text(stringResource(id = string.save).uppercase())
+                    }
+                }
             )
         },
         modifier = Modifier.background(MaterialTheme.colors.surface)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModel.kt
@@ -71,7 +71,13 @@ class BlazeCampaignTargetSelectionViewModel @Inject constructor(
     }
 
     fun onAllButtonTapped() {
-        selectedIds.update { emptySet() }
+        selectedIds.update {
+            if (it.size == viewState.value?.items?.size) {
+                emptySet()
+            } else {
+                viewState.value?.items?.map { item -> item.id }?.toSet() ?: emptySet()
+            }
+        }
     }
 
     fun onBackPressed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModel.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
@@ -38,7 +37,14 @@ class BlazeCampaignTargetSelectionViewModel @Inject constructor(
                 )
             }
         }
-        else -> flowOf(emptyList())
+        else -> blazeRepository.observeDevices().map { devices ->
+            devices.map { device ->
+                TargetItem(
+                    id = device.id,
+                    value = device.name
+                )
+            }
+        }
     }
 
     private val selectedIds = savedStateHandle.getStateFlow(viewModelScope, navArgs.selectedIds.toSet())
@@ -49,7 +55,7 @@ class BlazeCampaignTargetSelectionViewModel @Inject constructor(
             selectedItems = selectedIds.map { id -> items.first { it.id == id } },
             title = when (navArgs.targetType) {
                 BlazeTargetType.LANGUAGE -> resourceProvider.getString(R.string.blaze_campaign_preview_details_language)
-                else -> ""
+                else -> resourceProvider.getString(R.string.blaze_campaign_preview_details_devices)
             }
         )
     }.asLiveData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/MultiSelectList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/MultiSelectList.kt
@@ -44,7 +44,7 @@ fun <T> MultiSelectList(
         allItemsButton?.let {
             MultiSelectItem(
                 item = it.text,
-                isSelected = selectedItems.isEmpty(),
+                isSelected = selectedItems.size == items.size,
                 onItemToggled = it.onClicked,
                 modifier = Modifier.fillMaxWidth()
             )


### PR DESCRIPTION
Adresses #10629. The PR implements the target device selection in the ad preview screen.

[Screen_recording_20240129_130546.webm](https://github.com/woocommerce/woocommerce-android/assets/1522856/39a852a3-99cb-4a7d-af41-63af80086dae)

**To test:**
1. Start the Blaze campaign creation
2. Select a product
3. Tap on the Devices option
4. Notice a device selection screen opens
5. Select some device
6. Tap on the Save button
7. Notice the selected devices are displayed in the preview 

**Note:** Please merge #10641 before merging this.