### PR TITLE
Blaze: Target interest selection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
@@ -3,29 +3,6 @@ package com.woocommerce.android.extensions
 import kotlinx.coroutines.flow.Flow
 
 @Suppress("LongParameterList")
-inline fun <T1, T2, T3, T4, T5, T6, R> combine(
-    flow: Flow<T1>,
-    flow2: Flow<T2>,
-    flow3: Flow<T3>,
-    flow4: Flow<T4>,
-    flow5: Flow<T5>,
-    flow6: Flow<T6>,
-    crossinline transform: suspend (T1, T2, T3, T4, T5, T6) -> R
-): Flow<R> {
-    return kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6) { args: Array<*> ->
-        @Suppress("UNCHECKED_CAST", "MagicNumber")
-        transform(
-            args[0] as T1,
-            args[1] as T2,
-            args[2] as T3,
-            args[3] as T4,
-            args[4] as T5,
-            args[5] as T6,
-        )
-    }
-}
-
-@Suppress("LongParameterList")
 inline fun <T1, T2, T3, T4, T5, T6, T7, R> combine(
     flow: Flow<T1>,
     flow2: Flow<T2>,
@@ -46,6 +23,33 @@ inline fun <T1, T2, T3, T4, T5, T6, T7, R> combine(
             args[4] as T5,
             args[5] as T6,
             args[6] as T7,
+        )
+    }
+}
+
+@Suppress("LongParameterList")
+inline fun <T1, T2, T3, T4, T5, T6, T7, T8, R> combine(
+    flow: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+    flow4: Flow<T4>,
+    flow5: Flow<T5>,
+    flow6: Flow<T6>,
+    flow7: Flow<T7>,
+    flow8: Flow<T8>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8) -> R
+): Flow<R> {
+    return kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6, flow7, flow8) { args: Array<*> ->
+        @Suppress("UNCHECKED_CAST", "MagicNumber")
+        transform(
+            args[0] as T1,
+            args[1] as T2,
+            args[2] as T3,
+            args[3] as T4,
+            args[4] as T5,
+            args[5] as T6,
+            args[6] as T7,
+            args[7] as T8,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -35,7 +35,12 @@ class BlazeRepository @Inject constructor(
     fun observeDevices() = blazeCampaignsStore.observeBlazeTargetingDevices()
         .map { it.map { device -> Device(device.id, device.name) } }
 
-    suspend fun fetchDevices() = blazeCampaignsStore.fetchBlazeTargetingDevices()
+    suspend fun fetchDevices() = blazeCampaignsStore.fetchBlazeTargetingTopics()
+
+    fun observeInterests() = blazeCampaignsStore.observeBlazeTargetingTopics()
+        .map { it.map { interest -> Interest(interest.id, interest.description) } }
+
+    suspend fun fetchInterests() = blazeCampaignsStore.fetchBlazeTargetingTopics()
 
     suspend fun getMostRecentCampaign() = blazeCampaignsStore.getMostRecentBlazeCampaign(selectedSite.get())
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPr
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.AdDetailsUi.Loading
 import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType
 import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType.DEVICE
+import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType.INTEREST
 import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType.LANGUAGE
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -58,22 +59,29 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         initialValue = emptyList(),
         key = "selectedDevices"
     )
+    private val selectedInterests = savedStateHandle.getStateFlow<List<String>>(
+        scope = viewModelScope,
+        initialValue = emptyList(),
+        key = "selectedInterests"
+    )
 
     val viewState = combine(
         adDetails,
         budget,
         languages,
         devices,
+        interests,
         selectedLanguages,
-        selectedDevices
-    ) { adDetails, budget, languages, devices, selectedLanguages, selectedDevices ->
+        selectedDevices,
+        selectedInterests
+    ) { adDetails, budget, languages, devices, interests, selectedLanguages, selectedDevices, selectedInterests ->
         CampaignPreviewUiState(
             adDetails = adDetails,
             campaignDetails = campaign.toCampaignDetailsUi(
                 budget,
                 languages.filter { it.code in selectedLanguages },
                 devices.filter { it.id in selectedDevices },
-                emptyList(),
+                interests.filter { it.id in selectedInterests },
                 emptyList()
             )
         )
@@ -116,6 +124,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
             when (targetType) {
                 LANGUAGE -> selectedLanguages.update { selectedIds }
                 DEVICE -> selectedDevices.update { selectedIds }
+                INTEREST -> selectedInterests.update { selectedIds }
                 else -> Unit
             }
         }
@@ -179,7 +188,9 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
                 displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_interests),
                 displayValue = interests.joinToString { it.description }
                     .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
-                onItemSelected = { /* TODO Add interests selection */ },
+                onItemSelected = {
+                    triggerEvent(NavigateToTargetSelectionScreen(INTEREST, interests.map { it.id }))
+                },
             ),
         ),
         destinationUrl = CampaignDetailItemUi(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -47,6 +47,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
 
     private val languages = blazeRepository.observeLanguages()
     private val devices = blazeRepository.observeDevices()
+    private val interests = blazeRepository.observeInterests()
     private val selectedLanguages = savedStateHandle.getStateFlow<List<String>>(
         scope = viewModelScope,
         initialValue = emptyList(),
@@ -124,6 +125,8 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         launch {
             blazeRepository.fetchLanguages()
             blazeRepository.fetchDevices()
+            blazeRepository.fetchInterests()
+
             blazeRepository.getAdSuggestions(navArgs.productId).let { suggestions ->
                 adDetails.update {
                     AdDetails(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModel.kt
@@ -37,11 +37,19 @@ class BlazeCampaignTargetSelectionViewModel @Inject constructor(
                 )
             }
         }
-        else -> blazeRepository.observeDevices().map { devices ->
+        BlazeTargetType.DEVICE -> blazeRepository.observeDevices().map { devices ->
             devices.map { device ->
                 TargetItem(
                     id = device.id,
                     value = device.name
+                )
+            }
+        }
+        else -> blazeRepository.observeInterests().map { interests ->
+            interests.map { interest ->
+                TargetItem(
+                    id = interest.id,
+                    value = interest.description
                 )
             }
         }
@@ -55,7 +63,8 @@ class BlazeCampaignTargetSelectionViewModel @Inject constructor(
             selectedItems = selectedIds.map { id -> items.first { it.id == id } },
             title = when (navArgs.targetType) {
                 BlazeTargetType.LANGUAGE -> resourceProvider.getString(R.string.blaze_campaign_preview_details_language)
-                else -> resourceProvider.getString(R.string.blaze_campaign_preview_details_devices)
+                BlazeTargetType.INTEREST -> resourceProvider.getString(R.string.blaze_campaign_preview_details_devices)
+                else -> resourceProvider.getString(R.string.blaze_campaign_preview_details_interests)
             }
         )
     }.asLiveData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModel.kt
@@ -63,7 +63,7 @@ class BlazeCampaignTargetSelectionViewModel @Inject constructor(
             selectedItems = selectedIds.map { id -> items.first { it.id == id } },
             title = when (navArgs.targetType) {
                 BlazeTargetType.LANGUAGE -> resourceProvider.getString(R.string.blaze_campaign_preview_details_language)
-                BlazeTargetType.INTEREST -> resourceProvider.getString(R.string.blaze_campaign_preview_details_devices)
+                BlazeTargetType.DEVICE -> resourceProvider.getString(R.string.blaze_campaign_preview_details_devices)
                 else -> resourceProvider.getString(R.string.blaze_campaign_preview_details_interests)
             }
         )


### PR DESCRIPTION
Adresses #10631. The PR implements the target interest selection in the ad preview screen.

[Screen_recording_20240129_133622.webm](https://github.com/woocommerce/woocommerce-android/assets/1522856/4915445d-a60f-4a8f-a816-d5f492018f42)

**To test:**
1. Start the Blaze campaign creation
2. Select a product
3. Tap on the Interests option
4. Notice a interest selection screen opens
5. Select some interests
6. Tap on the Save button
7. Notice the selected interests are displayed in the preview 

**Note:** Please merge #10644 before merging this.