### PR TITLE
[Backend Receipts] Loading indicator when receipt is fetching on the order details screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -437,7 +437,7 @@ class OrderDetailFragment :
     private fun showOrderDetail(
         order: Order,
         isPaymentCollectableWithCardReader: Boolean,
-        isReceiptButtonsVisible: Boolean
+        receiptButtonStatus: OrderDetailViewState.ReceiptButtonStatus
     ) {
         binding.orderDetailOrderStatus.updateOrder(order)
         binding.orderDetailShippingMethodNotice.isVisible = order.hasMultipleShippingLines
@@ -449,7 +449,7 @@ class OrderDetailFragment :
         binding.orderDetailPaymentInfo.updatePaymentInfo(
             order = order,
             isPaymentCollectableWithCardReader = isPaymentCollectableWithCardReader,
-            isReceiptAvailable = isReceiptButtonsVisible,
+            receiptButtonStatus = receiptButtonStatus,
             formatCurrencyForDisplay = currencyFormatter.buildBigDecimalFormatter(order.currency),
             onIssueRefundClickListener = { viewModel.onIssueOrderRefundClicked() },
             onSeeReceiptClickListener = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -254,7 +254,7 @@ class OrderDetailFragment :
     private fun setupObservers(viewModel: OrderDetailViewModel) {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.orderInfo?.takeIfNotEqualTo(old?.orderInfo) {
-                showOrderDetail(it.order!!, it.isPaymentCollectableWithCardReader, it.isReceiptButtonsVisible)
+                showOrderDetail(it.order!!, it.isPaymentCollectableWithCardReader, it.receiptButtonStatus)
                 requireActivity().invalidateOptionsMenu()
             }
             new.orderStatus?.takeIfNotEqualTo(old?.orderStatus) { showOrderStatus(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -49,6 +49,7 @@ import com.woocommerce.android.ui.orders.OrderStatusUpdateSource
 import com.woocommerce.android.ui.orders.details.customfields.CustomOrderFieldsHelper
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentCollectibilityChecker
+import com.woocommerce.android.ui.payments.receipt.PaymentReceiptHelper
 import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.ui.products.addons.AddonRepository
@@ -91,7 +92,8 @@ class OrderDetailViewModel @Inject constructor(
     private val getOrderSubscriptions: GetOrderSubscriptions,
     private val giftCardRepository: GiftCardRepository,
     private val orderProductMapper: OrderProductMapper,
-    private val productDetailRepository: ProductDetailRepository
+    private val productDetailRepository: ProductDetailRepository,
+    private val paymentReceiptHelper: PaymentReceiptHelper,
 ) : ScopedViewModel(savedState), OnProductFetchedListener {
     private val navArgs: OrderDetailFragmentArgs by savedState.navArgs()
 
@@ -343,10 +345,15 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun onSeeReceiptClicked() {
-        tracker.trackReceiptViewTapped(order.id, order.status)
-        loadReceiptUrl()?.let {
-            triggerEvent(PreviewReceipt(order.billingAddress.email, it, order.id))
-        } ?: WooLog.e(T.ORDERS, "ReceiptUrl is null, but SeeReceipt button is visible")
+        launch {
+            tracker.trackReceiptViewTapped(order.id, order.status)
+            val receiptResult = paymentReceiptHelper.getReceiptUrl(order.id)
+            if (receiptResult.isSuccess) {
+                triggerEvent(PreviewReceipt(order.billingAddress.email, receiptResult.getOrThrow(), order.id))
+            } else {
+                triggerEvent(ShowSnackbar(string.receipt_fetching_error))
+            }
+        }
     }
 
     fun onPrintingInstructionsClicked() {
@@ -370,12 +377,6 @@ class OrderDetailViewModel @Inject constructor(
     fun onOrderEditFailed(@StringRes message: Int) {
         reloadOrderDetails()
         triggerEvent(ShowSnackbar(message))
-    }
-
-    private fun loadReceiptUrl(): String? {
-        return selectedSite.getIfExists()?.let {
-            appPrefs.getReceiptUrl(it.id, it.siteId, it.selfHostedSiteId, order.id)
-        }
     }
 
     fun onViewRefundedProductsClicked() {
@@ -580,7 +581,11 @@ class OrderDetailViewModel @Inject constructor(
             orderInfo = OrderDetailViewState.OrderInfo(
                 order = order,
                 isPaymentCollectableWithCardReader = isPaymentCollectable,
-                receiptButtonStatus = !loadReceiptUrl().isNullOrEmpty()
+                receiptButtonStatus = if (paymentReceiptHelper.isReceiptAvailable(order.id) && order.isOrderPaid) {
+                    OrderDetailViewState.ReceiptButtonStatus.Visible
+                } else {
+                    OrderDetailViewState.ReceiptButtonStatus.Hidden
+                }
             ),
             orderStatus = orderStatus,
             toolbarTitle = resourceProvider.getString(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -103,9 +103,13 @@ class OrderDetailViewModel @Inject constructor(
         get() = requireNotNull(viewState.orderInfo?.order)
         set(value) {
             viewState = viewState.copy(
-                orderInfo = OrderDetailViewState.OrderInfo(
+                orderInfo = viewState.orderInfo?.copy(
+                    order = value,
+                    isPaymentCollectableWithCardReader = viewState.orderInfo?.isPaymentCollectableWithCardReader
+                        ?: false
+                ) ?: OrderDetailViewState.OrderInfo(
                     value,
-                    viewState.orderInfo?.isPaymentCollectableWithCardReader ?: false
+                    isPaymentCollectableWithCardReader = false
                 )
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -347,7 +347,21 @@ class OrderDetailViewModel @Inject constructor(
     fun onSeeReceiptClicked() {
         launch {
             tracker.trackReceiptViewTapped(order.id, order.status)
+
+            viewState = viewState.copy(
+                orderInfo = viewState.orderInfo?.copy(
+                    receiptButtonStatus = OrderDetailViewState.ReceiptButtonStatus.Loading
+                )
+            )
+
             val receiptResult = paymentReceiptHelper.getReceiptUrl(order.id)
+
+            viewState = viewState.copy(
+                orderInfo = viewState.orderInfo?.copy(
+                    receiptButtonStatus = OrderDetailViewState.ReceiptButtonStatus.Visible
+                )
+            )
+
             if (receiptResult.isSuccess) {
                 triggerEvent(PreviewReceipt(order.billingAddress.email, receiptResult.getOrThrow(), order.id))
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewState.kt
@@ -33,6 +33,10 @@ data class OrderDetailViewState(
     data class OrderInfo(
         val order: Order? = null,
         val isPaymentCollectableWithCardReader: Boolean = false,
-        val isReceiptButtonsVisible: Boolean = false
+        val receiptButtonStatus: ReceiptButtonStatus = ReceiptButtonStatus.Hidden,
     ) : Parcelable
+
+    enum class ReceiptButtonStatus {
+        Loading, Hidden, Visible
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -198,10 +198,16 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
     ) {
         when (receiptButtonStatus) {
             OrderDetailViewState.ReceiptButtonStatus.Loading -> {
-
+                binding.paymentInfoSeeReceiptButton.visibility = VISIBLE
+                binding.paymentInfoSeeReceiptButton.isEnabled = false
+                binding.paymentInfoSeeReceiptButtonProgressBar.visibility = VISIBLE
             }
-            OrderDetailViewState.ReceiptButtonStatus.Hidden -> binding.paymentInfoSeeReceiptButton.visibility = GONE
+            OrderDetailViewState.ReceiptButtonStatus.Hidden -> {
+                binding.paymentInfoSeeReceiptButton.visibility = GONE
+                binding.paymentInfoSeeReceiptButtonProgressBar.visibility = GONE
+            }
             OrderDetailViewState.ReceiptButtonStatus.Visible -> {
+                binding.paymentInfoSeeReceiptButtonProgressBar.visibility = GONE
                 binding.paymentInfoSeeReceiptButton.visibility = VISIBLE
                 binding.paymentInfoSeeReceiptButton.setOnClickListener(
                     onSeeReceiptClickListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailPaymentInfoView.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.GiftCardSummary
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
+import com.woocommerce.android.ui.orders.details.OrderDetailViewState
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailRefundsAdapter
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailRefundsLineBuilder
 import dagger.hilt.android.AndroidEntryPoint
@@ -36,7 +37,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
     @Suppress("LongParameterList")
     fun updatePaymentInfo(
         order: Order,
-        isReceiptAvailable: Boolean,
+        receiptButtonStatus: OrderDetailViewState.ReceiptButtonStatus,
         isPaymentCollectableWithCardReader: Boolean,
         formatCurrencyForDisplay: (BigDecimal) -> String,
         onSeeReceiptClickListener: (view: View) -> Unit,
@@ -88,7 +89,7 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
         updateFeesSection(order, formatCurrencyForDisplay)
         updateRefundSection(order, formatCurrencyForDisplay, onIssueRefundClickListener)
         updateCollectPaymentSection(order, onCollectPaymentClickListener)
-        updateSeeReceiptSection(isReceiptAvailable, onSeeReceiptClickListener)
+        updateSeeReceiptSection(receiptButtonStatus, onSeeReceiptClickListener)
         updatePrintingInstructionSection(isPaymentCollectableWithCardReader, onPrintingInstructionsClickListener)
     }
 
@@ -192,16 +193,20 @@ class OrderDetailPaymentInfoView @JvmOverloads constructor(
     }
 
     private fun updateSeeReceiptSection(
-        isReceiptAvailable: Boolean,
+        receiptButtonStatus: OrderDetailViewState.ReceiptButtonStatus,
         onSeeReceiptClickListener: (view: View) -> Unit
     ) {
-        if (isReceiptAvailable) {
-            binding.paymentInfoSeeReceiptButton.visibility = VISIBLE
-            binding.paymentInfoSeeReceiptButton.setOnClickListener(
-                onSeeReceiptClickListener
-            )
-        } else {
-            binding.paymentInfoSeeReceiptButton.visibility = GONE
+        when (receiptButtonStatus) {
+            OrderDetailViewState.ReceiptButtonStatus.Loading -> {
+
+            }
+            OrderDetailViewState.ReceiptButtonStatus.Hidden -> binding.paymentInfoSeeReceiptButton.visibility = GONE
+            OrderDetailViewState.ReceiptButtonStatus.Visible -> {
+                binding.paymentInfoSeeReceiptButton.visibility = VISIBLE
+                binding.paymentInfoSeeReceiptButton.setOnClickListener(
+                    onSeeReceiptClickListener
+                )
+            }
         }
     }
 

--- a/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
@@ -388,7 +388,7 @@
                     android:paddingEnd="@dimen/major_100"
                     android:text="@string/orderdetail_see_receipt_button"
                     android:textAllCaps="false"
-                    app:layout_constraintEnd_toStartOf="@id/paymentInfo_seeReceiptButton_progressBar"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 

--- a/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -370,65 +370,69 @@
                         tools:text="$34.00"/>
                 </LinearLayout>
             </LinearLayout>
+
+            <!-- Refund button & In-Person Payments section -->
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <!-- See Receipt button -->
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/paymentInfo_seeReceiptButton"
+                    style="@style/Woo.Button.TextButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:paddingStart="@dimen/major_100"
+                    android:paddingEnd="@dimen/major_100"
+                    android:gravity="start"
+                    android:text="@string/orderdetail_see_receipt_button"
+                    android:textAllCaps="false"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    android:layout_marginTop="@dimen/minor_100" />
+
+                <!-- Accept Card Present Payment button -->
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/paymentInfo_collectCardPresentPaymentButton"
+                    style="@style/Woo.Button.Colored"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/orderdetail_collect_payment_button"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/paymentInfo_seeReceiptButton"
+                    android:layout_marginTop="@dimen/minor_100" />
+
+                <!-- Refund button -->
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/paymentInfo_issueRefundButton"
+                    style="@style/Woo.Button.Outlined"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/orderdetail_issue_refund_button"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/paymentInfo_collectCardPresentPaymentButton"
+                    android:layout_marginTop="@dimen/minor_100" />
+
+                <!-- Show Printing Instructions button -->
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/paymentInfo_printingInstructions"
+                    style="@style/Woo.TextView.Caption"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:drawableStart="@drawable/ic_deprecated_info_outline_24dp"
+                    android:drawablePadding="@dimen/major_100"
+                    android:background="?attr/selectableItemBackground"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/paymentInfo_issueRefundButton"
+                    android:layout_marginTop="@dimen/major_100" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
         </LinearLayout>
 
-        <!-- Refund button & In-Person Payments section -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <!-- See Receipt button -->
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/paymentInfo_seeReceiptButton"
-                style="@style/Woo.Button.TextButton"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_gravity="end|center_vertical"
-                android:layout_marginTop="@dimen/minor_100"
-                android:gravity="start|center_vertical"
-                android:paddingStart="@dimen/major_100"
-                android:paddingEnd="@dimen/major_100"
-                android:text="@string/orderdetail_see_receipt_button"
-                android:textAllCaps="false" />
-
-            <!-- Accept Card Present Payment button -->
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/paymentInfo_collectCardPresentPaymentButton"
-                style="@style/Woo.Button.Colored"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:layout_marginTop="@dimen/minor_100"
-                android:layout_gravity="end|center_vertical"
-                android:text="@string/orderdetail_collect_payment_button"/>
-
-            <!-- Refund button -->
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/paymentInfo_issueRefundButton"
-                style="@style/Woo.Button.Outlined"
-                android:layout_width="match_parent"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:layout_height="wrap_content"
-                android:layout_gravity="end|center_vertical"
-                android:text="@string/orderdetail_issue_refund_button"/>
-
-            <!-- Show Printing Instructions button -->
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/paymentInfo_printingInstructions"
-                android:gravity="center_vertical"
-                style="@style/Woo.TextView.Caption"
-                android:layout_width="match_parent"
-                android:textColor="@color/color_on_surface_medium"
-                android:layout_marginVertical="@dimen/major_100"
-                android:layout_height="wrap_content"
-                android:drawableStart="@drawable/ic_deprecated_info_outline_24dp"
-                android:drawablePadding="@dimen/major_100"
-                android:background="?attr/selectableItemBackground"
-                android:layout_marginEnd="@dimen/major_100"
-                android:text="@string/orderdetail_printing_instructions_button"/>
-        </LinearLayout>
     </LinearLayout>
 </merge>

--- a/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_payment_info.xml
@@ -382,15 +382,24 @@
                     style="@style/Woo.Button.TextButton"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/minor_100"
+                    android:gravity="start|center_vertical"
                     android:paddingStart="@dimen/major_100"
                     android:paddingEnd="@dimen/major_100"
-                    android:gravity="start"
                     android:text="@string/orderdetail_see_receipt_button"
                     android:textAllCaps="false"
+                    app:layout_constraintEnd_toStartOf="@id/paymentInfo_seeReceiptButton_progressBar"
                     app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <ProgressBar
+                    android:id="@+id/paymentInfo_seeReceiptButton_progressBar"
+                    android:layout_width="@dimen/major_100"
+                    android:layout_height="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
+                    app:layout_constraintBottom_toBottomOf="@id/paymentInfo_seeReceiptButton"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    android:layout_marginTop="@dimen/minor_100" />
+                    app:layout_constraintTop_toTopOf="@id/paymentInfo_seeReceiptButton" />
 
                 <!-- Accept Card Present Payment button -->
                 <com.google.android.material.button.MaterialButton
@@ -398,11 +407,13 @@
                     style="@style/Woo.Button.Colored"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/minor_100"
+                    android:layout_marginEnd="@dimen/major_100"
                     android:text="@string/orderdetail_collect_payment_button"
-                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/paymentInfo_seeReceiptButton"
-                    android:layout_marginTop="@dimen/minor_100" />
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/paymentInfo_seeReceiptButton" />
 
                 <!-- Refund button -->
                 <com.google.android.material.button.MaterialButton
@@ -410,11 +421,12 @@
                     style="@style/Woo.Button.Outlined"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
                     android:text="@string/orderdetail_issue_refund_button"
-                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/paymentInfo_collectCardPresentPaymentButton"
-                    android:layout_marginTop="@dimen/minor_100" />
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/paymentInfo_collectCardPresentPaymentButton" />
 
                 <!-- Show Printing Instructions button -->
                 <com.google.android.material.textview.MaterialTextView
@@ -422,14 +434,16 @@
                     style="@style/Woo.TextView.Caption"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_marginVertical="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:background="?attr/selectableItemBackground"
                     android:drawableStart="@drawable/ic_deprecated_info_outline_24dp"
                     android:drawablePadding="@dimen/major_100"
-                    android:background="?attr/selectableItemBackground"
-                    app:layout_constraintStart_toStartOf="parent"
+                    android:gravity="center_vertical"
+                    android:text="@string/orderdetail_printing_instructions_button"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/paymentInfo_issueRefundButton"
-                    android:layout_marginTop="@dimen/major_100" />
-
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/paymentInfo_issueRefundButton" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
         </LinearLayout>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.ui.products.addons.AddonRepository
 import com.woocommerce.android.util.ContinuationWrapper
+import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUndoSnackbar
@@ -326,7 +327,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given receipt is available and order is paid, when view model started, then state with receipt isReceiptButtonsVisible true emitted`() =
+    fun `given receipt is available and order is paid, when view model started, then state with receipt is visible emitted`() =
         testBlocking {
             // GIVEN
             whenever(paymentReceiptHelper.isReceiptAvailable(any())).thenReturn(true)
@@ -350,11 +351,13 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             viewModel.start()
 
             // THEN
-            assertThat(detailViewState!!.orderInfo!!.isReceiptButtonsVisible).isTrue()
+            assertThat(detailViewState!!.orderInfo!!.receiptButtonStatus).isEqualTo(
+                OrderDetailViewState.ReceiptButtonStatus.Visible
+            )
         }
 
     @Test
-    fun `given receipt is available and order not paid, when view model started, then state with receipt isReceiptButtonsVisible false emitted`() =
+    fun `given receipt is available and order not paid, when view model started, then state with receipt is hidden emitted`() =
         testBlocking {
             // GIVEN
             whenever(paymentReceiptHelper.isReceiptAvailable(any())).thenReturn(true)
@@ -378,11 +381,13 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             viewModel.start()
 
             // THEN
-            assertThat(detailViewState!!.orderInfo!!.isReceiptButtonsVisible).isFalse()
+            assertThat(detailViewState!!.orderInfo!!.receiptButtonStatus).isEqualTo(
+                OrderDetailViewState.ReceiptButtonStatus.Hidden
+            )
         }
 
     @Test
-    fun `given receipt is not available, when view model started, then state with receipt isReceiptButtonsVisible false emitted`() =
+    fun `given receipt is not available, when view model started, then state with receipt is hidden emitted`() =
         testBlocking {
             // GIVEN
             whenever(paymentReceiptHelper.isReceiptAvailable(any())).thenReturn(false)
@@ -402,7 +407,9 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             viewModel.start()
 
             // THEN
-            assertThat(detailViewState!!.orderInfo!!.isReceiptButtonsVisible).isFalse()
+            assertThat(detailViewState!!.orderInfo!!.receiptButtonStatus).isEqualTo(
+                OrderDetailViewState.ReceiptButtonStatus.Hidden
+            )
         }
 
     @Test
@@ -1273,6 +1280,32 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             assertThat((viewModel.event.value as PreviewReceipt).orderId).isEqualTo(order.id)
             assertThat((viewModel.event.value as PreviewReceipt).receiptUrl).isEqualTo(receiptUrl)
             assertThat((viewModel.event.value as PreviewReceipt).billingEmail).isEqualTo(order.billingAddress.email)
+        }
+
+    @Test
+    fun `when onSeeReceiptClicked clicked, then loading receipt status emitted`() =
+        testBlocking {
+            // GIVEN
+            whenever(orderDetailRepository.getOrderById(any())).thenReturn(order)
+            whenever(orderDetailRepository.fetchOrderNotes(any())).thenReturn(false)
+            whenever(addonsRepository.containsAddonsFrom(any())).thenReturn(false)
+            val receiptUrl = "https://example.com"
+            whenever(paymentReceiptHelper.getReceiptUrl(order.id)).thenReturn(Result.success(receiptUrl))
+
+            // WHEN
+            viewModel.start()
+
+            val states = viewModel.viewStateData.liveData.captureValues()
+
+            viewModel.onSeeReceiptClicked()
+
+            // THEN
+            assertThat((states.last()).orderInfo!!.receiptButtonStatus).isEqualTo(
+                OrderDetailViewState.ReceiptButtonStatus.Visible
+            )
+            assertThat((states[states.size - 2]).orderInfo!!.receiptButtonStatus).isEqualTo(
+                OrderDetailViewState.ReceiptButtonStatus.Loading
+            )
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10634
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Add loading indicator to the order details screen next to "see receipt" button

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
* Use both backend generated receipts test store and the one with released WC core version
* Open paid order 
* Click on "see receipt"
* Notice loading indicator

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/15c1dd3e-29ae-4c5c-a795-6ed770570938



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
