### PR TITLE
[Backend Receipts] Add tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -452,6 +452,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     RECEIPT_PRINT_CANCELED,
     RECEIPT_PRINT_SUCCESS,
     RECEIPT_VIEW_TAPPED,
+    RECEIPT_URL_FETCHING_FAILS,
 
     // -- Top-level navigation
     MAIN_MENU_SETTINGS_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailTracker.kt
@@ -4,11 +4,13 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import org.wordpress.android.fluxc.store.WCOrderStore
 import javax.inject.Inject
 
 class OrderDetailTracker @Inject constructor(
-    private val trackerWrapper: AnalyticsTrackerWrapper
+    private val trackerWrapper: AnalyticsTrackerWrapper,
+    private val paymentsFlowTracker: PaymentsFlowTracker,
 ) {
     fun trackCustomFieldsTapped() {
         trackerWrapper.track(AnalyticsEvent.ORDER_VIEW_CUSTOM_FIELDS_TAPPED)
@@ -24,9 +26,8 @@ class OrderDetailTracker @Inject constructor(
         )
     }
 
-    fun trackReceiptViewTapped(orderId: Long, orderStatus: Order.Status) {
-        trackerWrapper.track(
-            AnalyticsEvent.RECEIPT_VIEW_TAPPED,
+    suspend fun trackReceiptViewTapped(orderId: Long, orderStatus: Order.Status) {
+        paymentsFlowTracker.trackReceiptViewTapped(
             mapOf(
                 AnalyticsTracker.KEY_ORDER_ID to orderId,
                 AnalyticsTracker.KEY_STATUS to orderStatus

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -351,6 +351,9 @@ class OrderDetailViewModel @Inject constructor(
             if (receiptResult.isSuccess) {
                 triggerEvent(PreviewReceipt(order.billingAddress.email, receiptResult.getOrThrow(), order.id))
             } else {
+                paymentsFlowTracker.trackReceiptUrlFetchingFails(
+                    errorDescription = receiptResult.exceptionOrNull()?.message ?: "Unknown error",
+                )
                 triggerEvent(ShowSnackbar(string.receipt_fetching_error))
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -759,10 +759,12 @@ class CardReaderPaymentViewModel
     fun onPrintResult(result: PrintJobResult) {
         showPaymentSuccessfulState()
 
-        when (result) {
-            CANCELLED -> tracker.trackPrintReceiptCancelled()
-            FAILED -> tracker.trackPrintReceiptFailed()
-            STARTED -> tracker.trackPrintReceiptSucceeded()
+        launch {
+            when (result) {
+                CANCELLED -> tracker.trackPrintReceiptCancelled()
+                FAILED -> tracker.trackPrintReceiptFailed()
+                STARTED -> tracker.trackPrintReceiptSucceeded()
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -756,11 +756,6 @@ class CardReaderPaymentViewModel
         }
     }
 
-    fun onEmailActivityNotFound() {
-        tracker.trackEmailReceiptFailed()
-        triggerEvent(ShowSnackbarInDialog(R.string.card_reader_payment_receipt_app_to_share_not_found))
-    }
-
     fun onPrintResult(result: PrintJobResult) {
         showPaymentSuccessfulState()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentViewModel.kt
@@ -718,6 +718,9 @@ class CardReaderPaymentViewModel
                     )
                 )
             } else {
+                tracker.trackReceiptUrlFetchingFails(
+                    errorDescription = receiptResult.exceptionOrNull()?.message ?: "Unknown error",
+                )
                 triggerEvent(ShowSnackbar(R.string.receipt_fetching_error))
             }
         }
@@ -749,6 +752,9 @@ class CardReaderPaymentViewModel
                     }
                 }
             } else {
+                tracker.trackReceiptUrlFetchingFails(
+                    errorDescription = receiptResult.exceptionOrNull()?.message ?: "Unknown error",
+                )
                 triggerEvent(ShowSnackbar(R.string.receipt_fetching_error))
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptHelper.kt
@@ -77,7 +77,7 @@ class PaymentReceiptHelper @Inject constructor(
         }
     }
 
-    private suspend fun isWCCanGenerateReceipts(): Boolean {
+    suspend fun isWCCanGenerateReceipts(): Boolean {
         val currentWooCoreVersion = getWoocommerceCorePluginVersion()
 
         return currentWooCoreVersion.semverCompareTo(WC_CAN_GENERATE_RECEIPTS_VERSION) >= 0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
@@ -421,28 +421,53 @@ class PaymentsFlowTracker @Inject constructor(
         )
     }
 
-    fun trackPrintReceiptTapped() {
-        track(RECEIPT_PRINT_TAPPED)
+    suspend fun trackPrintReceiptTapped() {
+        track(
+            RECEIPT_PRINT_TAPPED,
+            properties = mutableMapOf(getReceiptSource())
+        )
     }
 
-    fun trackEmailReceiptTapped() {
-        track(RECEIPT_EMAIL_TAPPED)
+    suspend fun trackEmailReceiptTapped() {
+        track(
+            RECEIPT_EMAIL_TAPPED,
+            properties = mutableMapOf(getReceiptSource())
+        )
     }
 
-    fun trackEmailReceiptFailed() {
-        track(RECEIPT_EMAIL_FAILED)
+    suspend fun trackEmailReceiptFailed() {
+        track(
+            RECEIPT_EMAIL_FAILED,
+            properties = mutableMapOf(getReceiptSource())
+        )
     }
 
-    fun trackPrintReceiptCancelled() {
-        track(RECEIPT_PRINT_CANCELED)
+    suspend fun trackPrintReceiptCancelled() {
+        track(
+            RECEIPT_PRINT_CANCELED,
+            properties = mutableMapOf(getReceiptSource())
+        )
     }
 
-    fun trackPrintReceiptFailed() {
-        track(RECEIPT_PRINT_FAILED)
+    suspend fun trackPrintReceiptFailed() {
+        track(
+            RECEIPT_PRINT_FAILED,
+            properties = mutableMapOf(getReceiptSource())
+        )
     }
 
-    fun trackPrintReceiptSucceeded() {
-        track(RECEIPT_PRINT_SUCCESS)
+    suspend fun trackPrintReceiptSucceeded() {
+        track(
+            RECEIPT_PRINT_SUCCESS,
+            properties = mutableMapOf(getReceiptSource())
+        )
+    }
+
+    suspend fun trackReceiptViewTapped() {
+        track(
+            AnalyticsEvent.RECEIPT_VIEW_TAPPED,
+            properties = mutableMapOf(getReceiptSource())
+        )
     }
 
     fun trackPaymentCancelled(currentPaymentState: String?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
@@ -162,9 +162,9 @@ class PaymentsFlowTracker @Inject constructor(
 
     private suspend fun getReceiptSource(): Pair<String, String> =
         if (paymentReceiptHelper.isWCCanGenerateReceipts()) {
-            "source" to "backend"
+            AnalyticsTracker.KEY_SOURCE to "backend"
         } else {
-            "source" to "local"
+            AnalyticsTracker.KEY_SOURCE to "local"
         }
 
     @Suppress("ComplexMethod")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
@@ -469,15 +469,11 @@ class PaymentsFlowTracker @Inject constructor(
         )
     }
 
-    suspend fun trackReceiptUrlFetchingFails(
-        errorDescription: String,
-        errorType: String,
-    ) {
+    suspend fun trackReceiptUrlFetchingFails(errorDescription: String) {
         track(
             RECEIPT_URL_FETCHING_FAILS,
             properties = mutableMapOf(getReceiptSource()),
             errorDescription = errorDescription,
-            errorType = errorType,
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
@@ -456,10 +456,14 @@ class PaymentsFlowTracker @Inject constructor(
         )
     }
 
-    suspend fun trackReceiptViewTapped() {
+    suspend fun trackReceiptViewTapped(properties: Map<String, Any>) {
         track(
             AnalyticsEvent.RECEIPT_VIEW_TAPPED,
-            properties = mutableMapOf(getReceiptSource())
+            properties = properties.toMutableMap().also {
+                it.putAll(
+                    mapOf(getReceiptSource())
+                )
+            }
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
@@ -53,6 +53,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_PRINT_CANCELED
 import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_PRINT_FAILED
 import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_PRINT_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_PRINT_TAPPED
+import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_URL_FETCHING_FAILS
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_CASH_ON_DELIVERY_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_DESC
@@ -464,6 +465,18 @@ class PaymentsFlowTracker @Inject constructor(
                     mapOf(getReceiptSource())
                 )
             }
+        )
+    }
+
+    suspend fun trackReceiptUrlFetchingFails(
+        errorDescription: String,
+        errorType: String,
+    ) {
+        track(
+            RECEIPT_URL_FETCHING_FAILS,
+            properties = mutableMapOf(getReceiptSource()),
+            errorDescription = errorDescription,
+            errorType = errorType,
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
@@ -435,13 +435,6 @@ class PaymentsFlowTracker @Inject constructor(
         )
     }
 
-    suspend fun trackEmailReceiptFailed() {
-        track(
-            RECEIPT_EMAIL_FAILED,
-            properties = mutableMapOf(getReceiptSource())
-        )
-    }
-
     suspend fun trackPrintReceiptCancelled() {
         track(
             RECEIPT_PRINT_CANCELED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
@@ -54,6 +54,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_PRINT_FAILED
 import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_PRINT_SUCCESS
 import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_PRINT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_URL_FETCHING_FAILS
+import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_VIEW_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_CASH_ON_DELIVERY_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR_DESC
@@ -459,7 +460,7 @@ class PaymentsFlowTracker @Inject constructor(
 
     suspend fun trackReceiptViewTapped(properties: Map<String, Any>) {
         track(
-            AnalyticsEvent.RECEIPT_VIEW_TAPPED,
+            RECEIPT_VIEW_TAPPED,
             properties = properties.toMutableMap().also {
                 it.putAll(
                     mapOf(getReceiptSource())
@@ -635,6 +636,7 @@ class PaymentsFlowTracker @Inject constructor(
                     properties = mutableMapOf(getReceiptSource())
                 )
             }
+
             is PaymentReceiptShare.ReceiptShareResult.Error.FileDownload -> {
                 track(
                     RECEIPT_EMAIL_FAILED,
@@ -643,6 +645,7 @@ class PaymentsFlowTracker @Inject constructor(
                     properties = mutableMapOf(getReceiptSource())
                 )
             }
+
             is PaymentReceiptShare.ReceiptShareResult.Error.Sharing -> {
                 track(
                     RECEIPT_EMAIL_FAILED,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -1243,7 +1243,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             whenever(orderDetailRepository.fetchOrderNotes(any())).thenReturn(false)
             whenever(addonsRepository.containsAddonsFrom(any())).thenReturn(false)
 
-            whenever(paymentReceiptHelper.getReceiptUrl(order.id)).thenReturn(Result.failure(Exception("")))
+            val errorMessage = "error"
+            whenever(paymentReceiptHelper.getReceiptUrl(order.id)).thenReturn(Result.failure(Exception(errorMessage)))
 
             // WHEN
             viewModel.start()
@@ -1252,6 +1253,9 @@ class OrderDetailViewModelTest : BaseUnitTest() {
 
             // THEN
             assertThat((viewModel.event.value as ShowSnackbar).message).isEqualTo(string.receipt_fetching_error)
+            verify(paymentsFlowTracker).trackReceiptUrlFetchingFails(
+                errorDescription = errorMessage
+            )
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
@@ -2337,21 +2337,21 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when OS accepts the print request, then print success event tracked`() {
+    fun `when OS accepts the print request, then print success event tracked`() = testBlocking {
         viewModel.onPrintResult(STARTED)
 
         verify(tracker).trackPrintReceiptSucceeded()
     }
 
     @Test
-    fun `when OS refuses the print request, then print failed event tracked`() {
+    fun `when OS refuses the print request, then print failed event tracked`() = testBlocking {
         viewModel.onPrintResult(FAILED)
 
         verify(tracker).trackPrintReceiptFailed()
     }
 
     @Test
-    fun `when manually cancels the print request, then print cancelled event tracked`() {
+    fun `when manually cancels the print request, then print cancelled event tracked`() = testBlocking {
         viewModel.onPrintResult(CANCELLED)
 
         verify(tracker).trackPrintReceiptCancelled()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
@@ -2569,14 +2569,6 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when email activity not found, then event tracked`() =
-        testBlocking {
-            viewModel.onEmailActivityNotFound()
-
-            verify(tracker).trackEmailReceiptFailed()
-        }
-
-    @Test
     fun `given user presses back button, when re-fetching order, then ReFetchingOrderState shown`() =
         testBlocking {
             simulateFetchOrderJobState(inProgress = true)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/receipt/preview/ReceiptPreviewViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/receipt/preview/ReceiptPreviewViewModelTest.kt
@@ -2,12 +2,6 @@ package com.woocommerce.android.ui.payments.receipt.preview
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
-import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_EMAIL_TAPPED
-import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_PRINT_CANCELED
-import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_PRINT_FAILED
-import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_PRINT_SUCCESS
-import com.woocommerce.android.analytics.AnalyticsEvent.RECEIPT_PRINT_TAPPED
-import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.payments.receipt.PaymentReceiptShare
 import com.woocommerce.android.ui.payments.receipt.preview.ReceiptPreviewViewModel.ReceiptPreviewViewState.Content
 import com.woocommerce.android.ui.payments.receipt.preview.ReceiptPreviewViewModel.ReceiptPreviewViewState.Loading
@@ -29,7 +23,6 @@ import org.mockito.kotlin.whenever
 class ReceiptPreviewViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: ReceiptPreviewViewModel
 
-    private val tracker: AnalyticsTrackerWrapper = mock()
     private val paymentsFlowTracker: PaymentsFlowTracker = mock()
     private val paymentReceiptShare: PaymentReceiptShare = mock()
 
@@ -41,7 +34,7 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        viewModel = ReceiptPreviewViewModel(savedState, tracker, paymentsFlowTracker, paymentReceiptShare)
+        viewModel = ReceiptPreviewViewModel(savedState, paymentsFlowTracker, paymentReceiptShare)
     }
 
     @Test
@@ -77,7 +70,7 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
         testBlocking {
             viewModel.onShareClicked()
 
-            verify(tracker).track(RECEIPT_EMAIL_TAPPED)
+            verify(paymentsFlowTracker).trackEmailReceiptTapped()
         }
 
     @Test
@@ -167,7 +160,7 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
         testBlocking {
             viewModel.onPrintClicked()
 
-            verify(tracker).track(RECEIPT_PRINT_TAPPED)
+            verify(paymentsFlowTracker).trackPrintReceiptTapped()
         }
 
     @Test
@@ -175,7 +168,7 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
         testBlocking {
             viewModel.onPrintResult(FAILED)
 
-            verify(tracker).track(RECEIPT_PRINT_FAILED)
+            verify(paymentsFlowTracker).trackPrintReceiptFailed()
         }
 
     @Test
@@ -183,7 +176,7 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
         testBlocking {
             viewModel.onPrintResult(CANCELLED)
 
-            verify(tracker).track(RECEIPT_PRINT_CANCELED)
+            verify(paymentsFlowTracker).trackPrintReceiptCancelled()
         }
 
     @Test
@@ -191,6 +184,6 @@ class ReceiptPreviewViewModelTest : BaseUnitTest() {
         testBlocking {
             viewModel.onPrintResult(STARTED)
 
-            verify(tracker).track(RECEIPT_PRINT_SUCCESS)
+            verify(paymentsFlowTracker).trackPrintReceiptSucceeded()
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTrackerTest.kt
@@ -42,6 +42,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.STRI
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.WOOCOMMERCE_PAYMENTS
 import com.woocommerce.android.ui.payments.hub.PaymentsHubViewModel.CashOnDeliverySource.ONBOARDING
 import com.woocommerce.android.ui.payments.hub.PaymentsHubViewModel.CashOnDeliverySource.PAYMENTS_HUB
+import com.woocommerce.android.ui.payments.receipt.PaymentReceiptHelper
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -93,11 +94,14 @@ class PaymentsFlowTrackerTest : BaseUnitTest() {
         )
     }
 
+    private val paymentReceiptHelper: PaymentReceiptHelper = mock()
+
     private val paymentsFlowTracker = PaymentsFlowTracker(
         trackerWrapper,
         appPrefsWrapper,
         selectedSite,
-        cardReaderTrackingInfoProvider
+        cardReaderTrackingInfoProvider,
+        paymentReceiptHelper,
     )
 
     @Test
@@ -1047,21 +1051,21 @@ class PaymentsFlowTrackerTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when OS accepts the print request, then RECEIPT_PRINT_SUCCESS tracked`() {
+    fun `when OS accepts the print request, then RECEIPT_PRINT_SUCCESS tracked`() = testBlocking {
         paymentsFlowTracker.trackPrintReceiptSucceeded()
 
         verify(trackerWrapper).track(eq(RECEIPT_PRINT_SUCCESS), any())
     }
 
     @Test
-    fun `when OS refuses the print request, then RECEIPT_PRINT_FAILED tracked`() {
+    fun `when OS refuses the print request, then RECEIPT_PRINT_FAILED tracked`() = testBlocking {
         paymentsFlowTracker.trackPrintReceiptFailed()
 
         verify(trackerWrapper).track(eq(RECEIPT_PRINT_FAILED), any())
     }
 
     @Test
-    fun `when manually cancels the print request, then RECEIPT_PRINT_CANCELED tracked`() {
+    fun `when manually cancels the print request, then RECEIPT_PRINT_CANCELED tracked`() = testBlocking {
         paymentsFlowTracker.trackPrintReceiptCancelled()
 
         verify(trackerWrapper).track(eq(RECEIPT_PRINT_CANCELED), any())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10633
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
pfoUAQ-cg-p2

The PR adds the following changes in the tracking
To all events:
```
RECEIPT_PRINT_TAPPED
RECEIPT_EMAIL_TAPPED
RECEIPT_EMAIL_FAILED
RECEIPT_PRINT_FAILED
RECEIPT_PRINT_CANCELED
RECEIPT_PRINT_SUCCESS
RECEIPT_VIEW_TAPPED
RECEIPT_URL_FETCHING_FAILS
```

Add to all receipt_* events property: `source` : `backend` or `local` so we can figure out what flow is used

And `RECEIPT_URL_FETCHING_FAILS` event when fetching of a receipt fails

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
* Go through receipts flows on the test site with WC that can generate and with older version
* Use logcat with "track" filter
* Notice the events mentioned above

For instance:
```
Tracked: receipt_view_tapped, Properties: {"order_id":1386,"status":null,"source":"backend","plugin_slug":"woocommerce-payments","country":"US","blog_id":0,"is_wpcom_store":false,"was_ecommerce_trial":null,"plan_product_slug":null,"store_id":"e337f176-b394-4849-a43b-128ab1538836","is_debug":true,"site_url":"https:\/\/very-child-traveler.jurassic.ninja"}

Tracked: receipt_url_fetching_fails, Properties: {"source":"backend","plugin_slug":"woocommerce-payments","country":"US","blog_id":0,"is_wpcom_store":false,"was_ecommerce_trial":null,"plan_product_slug":null,"store_id":"e337f176-b394-4849-a43b-128ab1538836","is_debug":true,"site_url":"https:\/\/very-child-traveler.jurassic.ninja"}

Tracked: receipt_print_tapped, Properties: {"source":"backend","plugin_slug":"woocommerce-payments","country":"US","currency":"USD","payment_method_type":"card","card_reader_model":"CHIPPER_2X","card_reader_battery_level":"85 %","blog_id":0,"is_wpcom_store":false,"was_ecommerce_trial":null,"plan_product_slug":null,"store_id":"e337f176-b394-4849-a43b-128ab1538836","is_debug":true,"site_url":"https:\/\/very-child-traveler.jurassic.ninja"}

Tracked: receipt_print_canceled, Properties: {"source":"backend","plugin_slug":"woocommerce-payments","country":"US","currency":"USD","payment_method_type":"card","card_reader_model":"CHIPPER_2X","card_reader_battery_level":"85 %","blog_id":0,"is_wpcom_store":false,"was_ecommerce_trial":null,"plan_product_slug":null,"store_id":"e337f176-b394-4849-a43b-128ab1538836","is_debug":true,"site_url":"https:\/\/very-child-traveler.jurassic.ninja"}

Tracked: receipt_email_tapped, Properties: {"source":"backend","plugin_slug":"woocommerce-payments","country":"US","currency":"USD","payment_method_type":"card","card_reader_model":"CHIPPER_2X","card_reader_battery_level":"85 %","blog_id":0,"is_wpcom_store":false,"was_ecommerce_trial":null,"plan_product_slug":null,"store_id":"e337f176-b394-4849-a43b-128ab1538836","is_debug":true,"site_url":"https:\/\/very-child-traveler.jurassic.ninja"}

Tracked: receipt_url_fetching_fails, Properties: {"source":"backend","plugin_slug":"woocommerce-payments","country":"US","currency":"USD","payment_method_type":"card","card_reader_model":"CHIPPER_2X","card_reader_battery_level":"85 %","blog_id":0,"is_wpcom_store":false,"was_ecommerce_trial":null,"plan_product_slug":null,"store_id":"e337f176-b394-4849-a43b-128ab1538836","is_debug":true,"site_url":"https:\/\/very-child-traveler.jurassic.ninja"}
```

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->