### PR TITLE
[Issue 4614] Improve shipping labels validation scrolling

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+
+17.3
+-----
+- [*] [Internal] Enhanced user experience in shipping label creation with automatic scrolling to the first invalid field upon form submission failure [https://github.com/woocommerce/woocommerce-android/pull/10657]
+
 17.1
 -----
 - [*] [Internal] Fixed crash when going to background from the order creation screen [https://github.com/woocommerce/woocommerce-android/pull/10600]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
@@ -68,5 +68,8 @@ sealed class CreateShippingLabelEvent : MultiLiveEvent.Event() {
     data class ShowPrintShippingLabels(val orderId: Long, val labels: List<ShippingLabel>) : CreateShippingLabelEvent()
 
     object ShowWooDiscountBottomSheet : CreateShippingLabelEvent()
-    data class ScrollToFirstErrorField(val viewState: EditShippingLabelAddressViewModel.ViewState) : CreateShippingLabelEvent()
+    data class ScrollToFirstErrorField(
+        val field: EditShippingLabelAddressViewModel.Field,
+        val isStateFieldSpinner: Boolean?
+    ) : CreateShippingLabelEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
@@ -68,6 +68,7 @@ sealed class CreateShippingLabelEvent : MultiLiveEvent.Event() {
     data class ShowPrintShippingLabels(val orderId: Long, val labels: List<ShippingLabel>) : CreateShippingLabelEvent()
 
     object ShowWooDiscountBottomSheet : CreateShippingLabelEvent()
+    object CloseKeyboard : CreateShippingLabelEvent()
     data class ScrollToFirstErrorField(
         val field: EditShippingLabelAddressViewModel.Field,
         val isStateFieldSpinner: Boolean?

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelEvent.kt
@@ -68,4 +68,5 @@ sealed class CreateShippingLabelEvent : MultiLiveEvent.Event() {
     data class ShowPrintShippingLabels(val orderId: Long, val labels: List<ShippingLabel>) : CreateShippingLabelEvent()
 
     object ShowWooDiscountBottomSheet : CreateShippingLabelEvent()
+    data class ScrollToFirstErrorField(val viewState: EditShippingLabelAddressViewModel.ViewState) : CreateShippingLabelEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -64,7 +64,8 @@ class EditShippingLabelAddressFragment :
         const val EDIT_ADDRESS_CLOSED = "key_edit_address_dialog_closed"
     }
 
-    @Inject lateinit var uiMessageResolver: UIMessageResolver
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     private var progressDialog: CustomProgressDialog? = null
 
@@ -146,6 +147,7 @@ class EditShippingLabelAddressFragment :
                 viewModel.onDoneButtonClicked()
                 true
             }
+
             else -> false
         }
     }
@@ -228,33 +230,26 @@ class EditShippingLabelAddressFragment :
         }
     }
 
-    private fun scrollToFirstErrorFieldIfNeeded(
-        viewState: EditShippingLabelAddressViewModel.ViewState,
-        binding: FragmentEditShippingLabelAddressBinding
-    ) {
-        val firstErrorField: Pair<InputField<*>, View>? = listOf(
-            viewState.nameField to binding.name,
-            viewState.companyField to binding.company,
-            viewState.phoneField to binding.phone,
-            viewState.address1Field to binding.address1,
-            viewState.address2Field to binding.address2,
-            viewState.cityField to binding.city,
-            viewState.zipField to binding.zip,
-            viewState.stateField to if (viewState.isStateFieldSpinner == true) binding.stateSpinner else binding.state,
-            viewState.countryField to binding.countrySpinner
-        ).firstOrNull { it.first.error != null }
-
-        firstErrorField?.let { (_, errorView) ->
-            binding.root.clearFocus()
-
-            ActivityUtils.hideKeyboard(requireActivity())
-
-            binding.scrollView.postDelayed({
-                binding.scrollView.smoothScrollTo(0, errorView.top)
-
-                errorView.requestFocus()
-            }, 300)
+    private fun scrollToFirstErrorField(field: EditShippingLabelAddressViewModel.Field, isStateFieldSpinner: Boolean?) {
+        val errorView = when (field) {
+            Field.Name -> binding.name
+            Field.Company -> binding.company
+            Field.Phone -> binding.phone
+            Field.Address1 -> binding.address1
+            Field.Address2 -> binding.address2
+            Field.City -> binding.city
+            Field.Zip -> binding.zip
+            Field.State -> if (isStateFieldSpinner == true) binding.stateSpinner else binding.state
+            Field.Country -> binding.countrySpinner
         }
+
+        binding.root.clearFocus()
+        ActivityUtils.hideKeyboard(requireActivity())
+
+        binding.scrollView.postDelayed({
+            binding.scrollView.smoothScrollTo(0, errorView.top)
+            errorView.requestFocus()
+        }, 300)
     }
 
     @SuppressLint("SetTextI18n")
@@ -273,6 +268,7 @@ class EditShippingLabelAddressFragment :
                         )
                     findNavController().navigateSafely(action)
                 }
+
                 is ShowCountrySelector -> {
                     val action = EditShippingLabelAddressFragmentDirections.actionSearchFilterFragment(
                         items = event.locations.map {
@@ -287,6 +283,7 @@ class EditShippingLabelAddressFragment :
                     )
                     findNavController().navigateSafely(action)
                 }
+
                 is ShowStateSelector -> {
                     val action = EditShippingLabelAddressFragmentDirections.actionSearchFilterFragment(
                         items = event.locations.map {
@@ -301,9 +298,13 @@ class EditShippingLabelAddressFragment :
                     )
                     findNavController().navigateSafely(action)
                 }
+
                 is OpenMapWithAddress -> launchMapsWithAddress(event.address)
                 is DialPhoneNumber -> dialPhoneNumber(requireContext(), event.phoneNumber)
-                is CreateShippingLabelEvent.ScrollToFirstErrorField -> scrollToFirstErrorFieldIfNeeded(event.viewState, binding)
+                is CreateShippingLabelEvent.ScrollToFirstErrorField -> scrollToFirstErrorField(
+                    event.field,
+                    event.isStateFieldSpinner
+                )
 
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import android.annotation.SuppressLint
 import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -9,7 +10,9 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import android.widget.Button
+import android.widget.EditText
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -62,6 +65,7 @@ class EditShippingLabelAddressFragment :
         const val SELECT_STATE_REQUEST = "select_state_request"
         const val EDIT_ADDRESS_RESULT = "key_edit_address_dialog_result"
         const val EDIT_ADDRESS_CLOSED = "key_edit_address_dialog_closed"
+        const val ERROR_SCROLL_DELAY = 300L
     }
 
     @Inject
@@ -244,7 +248,10 @@ class EditShippingLabelAddressFragment :
         }
 
         if (!isViewVisibleInScrollView(binding.scrollView, errorView)) {
-            binding.scrollView.smoothScrollTo(0, errorView.top)
+            binding.scrollView.postDelayed({
+                binding.scrollView.smoothScrollTo(0, errorView.top)
+                errorView.requestFocus()
+            }, ERROR_SCROLL_DELAY)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -248,7 +248,7 @@ class EditShippingLabelAddressFragment :
         if (!isViewVisibleInScrollView(binding.scrollView, errorView)) {
             binding.scrollView.postDelayed({
                 binding.scrollView.smoothScrollTo(0, errorView.top)
-                errorView.editText?.requestFocusFromTouch()
+                errorView.editText?.requestFocus()
             }, ERROR_SCROLL_DELAY)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -34,6 +34,8 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingL
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowCountrySelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowStateSelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ScrollToFirstErrorField
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.CloseKeyboard
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelAddressViewModel.Field
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_ACCEPTED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_TO_BE_EDITED
@@ -300,11 +302,11 @@ class EditShippingLabelAddressFragment :
 
                 is OpenMapWithAddress -> launchMapsWithAddress(event.address)
                 is DialPhoneNumber -> dialPhoneNumber(requireContext(), event.phoneNumber)
-                is CreateShippingLabelEvent.ScrollToFirstErrorField -> scrollToFirstErrorField(
+                is ScrollToFirstErrorField -> scrollToFirstErrorField(
                     event.field,
                     event.isStateFieldSpinner
                 )
-                CreateShippingLabelEvent.CloseKeyboard -> {
+                CloseKeyboard -> {
                     activity?.let { ActivityUtils.hideKeyboard(it) }
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -29,13 +29,13 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.common.InputField
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.CloseKeyboard
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.DialPhoneNumber
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.OpenMapWithAddress
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ScrollToFirstErrorField
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowCountrySelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowStateSelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
-import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ScrollToFirstErrorField
-import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.CloseKeyboard
 import com.woocommerce.android.ui.orders.shippinglabels.creation.EditShippingLabelAddressViewModel.Field
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_ACCEPTED
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressSuggestionFragment.Companion.SELECTED_ADDRESS_TO_BE_EDITED

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -230,7 +230,7 @@ class EditShippingLabelAddressFragment :
         }
     }
 
-    private fun scrollToFirstErrorField(field: EditShippingLabelAddressViewModel.Field, isStateFieldSpinner: Boolean?) {
+    private fun scrollToFirstErrorField(field: Field, isStateFieldSpinner: Boolean?) {
         val errorView = when (field) {
             Field.Name -> binding.name
             Field.Company -> binding.company
@@ -243,13 +243,9 @@ class EditShippingLabelAddressFragment :
             Field.Country -> binding.countrySpinner
         }
 
-        binding.root.clearFocus()
-        ActivityUtils.hideKeyboard(requireActivity())
-
-        binding.scrollView.postDelayed({
+        if (!isViewVisibleInScrollView(binding.scrollView, errorView)) {
             binding.scrollView.smoothScrollTo(0, errorView.top)
-            errorView.requestFocus()
-        }, 300)
+        }
     }
 
     @SuppressLint("SetTextI18n")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -240,10 +240,13 @@ class EditShippingLabelAddressFragment :
 
         firstErrorField?.let { (_, view) ->
             if (!isViewVisibleInScrollView(binding.scrollView, view)) {
+                binding.root.clearFocus()
+
                 ActivityUtils.hideKeyboard(requireActivity())
 
                 binding.scrollView.post {
                     binding.scrollView.smoothScrollTo(0, view.top)
+                    view.requestFocus()
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -144,7 +144,6 @@ class EditShippingLabelAddressFragment :
     override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
-                ActivityUtils.hideKeyboard(activity)
                 viewModel.onDoneButtonClicked()
                 true
             }
@@ -247,7 +246,7 @@ class EditShippingLabelAddressFragment :
         if (!isViewVisibleInScrollView(binding.scrollView, errorView)) {
             binding.scrollView.postDelayed({
                 binding.scrollView.smoothScrollTo(0, errorView.top)
-                errorView.requestFocus()
+                errorView.editText?.requestFocusFromTouch()
             }, ERROR_SCROLL_DELAY)
         }
     }
@@ -305,6 +304,9 @@ class EditShippingLabelAddressFragment :
                     event.field,
                     event.isStateFieldSpinner
                 )
+                CreateShippingLabelEvent.CloseKeyboard -> {
+                    activity?.let { ActivityUtils.hideKeyboard(it) }
+                }
 
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import android.annotation.SuppressLint
 import android.content.ActivityNotFoundException
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -10,9 +9,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import android.view.inputmethod.InputMethodManager
 import android.widget.Button
-import android.widget.EditText
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAd
 import com.woocommerce.android.ui.searchfilter.SearchFilterItem
 import com.woocommerce.android.util.ActivityUtils.dialPhoneNumber
 import com.woocommerce.android.util.UiHelpers
+import com.woocommerce.android.util.isViewVisibleInScrollView
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -215,6 +216,35 @@ class EditShippingLabelAddressFragment :
             }
             new.isContactCustomerButtonVisible.takeIfNotEqualTo(old?.isContactCustomerButtonVisible) { isVisible ->
                 binding.contactCustomerButton.isVisible = isVisible
+            }
+
+            scrollToFirstErrorFieldIfNeeded(new, binding)
+        }
+    }
+
+    private fun scrollToFirstErrorFieldIfNeeded(
+        viewState: EditShippingLabelAddressViewModel.ViewState,
+        binding: FragmentEditShippingLabelAddressBinding
+    ) {
+        val firstErrorField: Pair<InputField<*>, View>? = listOf<Pair<InputField<*>, View>>(
+            viewState.nameField to binding.name,
+            viewState.companyField to binding.company,
+            viewState.phoneField to binding.phone,
+            viewState.address1Field to binding.address1,
+            viewState.address2Field to binding.address2,
+            viewState.cityField to binding.city,
+            viewState.zipField to binding.zip,
+            viewState.stateField to if (viewState.isStateFieldSpinner == true) binding.stateSpinner else binding.state,
+            viewState.countryField to binding.countrySpinner
+        ).firstOrNull { it.first.error != null }
+
+        firstErrorField?.let { (_, view) ->
+            if (!isViewVisibleInScrollView(binding.scrollView, view)) {
+                ActivityUtils.hideKeyboard(requireActivity())
+
+                binding.scrollView.post {
+                    binding.scrollView.smoothScrollTo(0, view.top)
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -116,6 +116,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
                 viewState = viewState.copy(isValidationProgressDialogVisible = false)
             }
         } else {
+            triggerEvent(ShowSnackbar(R.string.shipping_label_address_data_invalid_snackbar_message))
             triggerScrollToFirstErrorFieldEvent()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -115,8 +115,27 @@ class EditShippingLabelAddressViewModel @Inject constructor(
                 handleValidationResult(address, result)
                 viewState = viewState.copy(isValidationProgressDialogVisible = false)
             }
-        }else {
-            triggerEvent(CreateShippingLabelEvent.ScrollToFirstErrorField(viewState))
+        } else {
+            triggerScrollToFirstErrorFieldEvent()
+        }
+    }
+
+    private fun triggerScrollToFirstErrorFieldEvent() {
+        val firstErrorField = when {
+            viewState.nameField.error != null -> Field.Name
+            viewState.companyField.error != null -> Field.Company
+            viewState.phoneField.error != null -> Field.Phone
+            viewState.address1Field.error != null -> Field.Address1
+            viewState.address2Field.error != null -> Field.Address2
+            viewState.cityField.error != null -> Field.City
+            viewState.zipField.error != null -> Field.Zip
+            viewState.stateField.error != null -> Field.State
+            viewState.countryField.error != null -> Field.Country
+            else -> null
+        }
+
+        firstErrorField?.let {
+            triggerEvent(CreateShippingLabelEvent.ScrollToFirstErrorField(it, viewState.isStateFieldSpinner))
         }
     }
 
@@ -149,6 +168,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
             ValidationResult.Valid -> {
                 exitWithAddress(address)
             }
+
             is ValidationResult.Invalid -> {
                 val validationErrorMessage = getAddressErrorStringRes(result.message)
                 viewState = viewState.copy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -121,22 +121,14 @@ class EditShippingLabelAddressViewModel @Inject constructor(
     }
 
     private fun triggerScrollToFirstErrorFieldEvent() {
-        val firstErrorField = when {
-            viewState.nameField.error != null -> Field.Name
-            viewState.companyField.error != null -> Field.Company
-            viewState.phoneField.error != null -> Field.Phone
-            viewState.address1Field.error != null -> Field.Address1
-            viewState.address2Field.error != null -> Field.Address2
-            viewState.cityField.error != null -> Field.City
-            viewState.zipField.error != null -> Field.Zip
-            viewState.stateField.error != null -> Field.State
-            viewState.countryField.error != null -> Field.Country
-            else -> null
-        }
-
+        val firstErrorField = viewState.findFirstErrorField()
         firstErrorField?.let {
             triggerEvent(CreateShippingLabelEvent.ScrollToFirstErrorField(it, viewState.isStateFieldSpinner))
         }
+    }
+
+    private fun ViewState.findFirstErrorField(): Field? {
+        return Field.values().firstOrNull { this[it].error != null }
     }
 
     private fun loadCountriesAndStates() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingL
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowCountrySelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowStateSelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.CloseKeyboard
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.DESTINATION
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN
@@ -102,7 +103,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         viewState = viewState.validateAllFields()
         val address = viewState.getAddress()
         if (viewState.areAllRequiredFieldsValid) {
-            triggerEvent(CreateShippingLabelEvent.CloseKeyboard)
+            triggerEvent(CloseKeyboard)
             launch {
                 viewState = viewState.copy(
                     isValidationProgressDialogVisible = true,
@@ -225,7 +226,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         // Validate fields locally
         viewState = viewState.validateAllFields()
         if (viewState.areAllRequiredFieldsValid) {
-            triggerEvent(CreateShippingLabelEvent.CloseKeyboard)
+            triggerEvent(CloseKeyboard)
             exitWithAddress(viewState.getAddress())
         } else {
             triggerEvent(ShowSnackbar(R.string.shipping_label_address_data_invalid_snackbar_message))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -115,6 +115,8 @@ class EditShippingLabelAddressViewModel @Inject constructor(
                 handleValidationResult(address, result)
                 viewState = viewState.copy(isValidationProgressDialogVisible = false)
             }
+        }else {
+            triggerEvent(CreateShippingLabelEvent.ScrollToFirstErrorField(viewState))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -102,6 +102,7 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         viewState = viewState.validateAllFields()
         val address = viewState.getAddress()
         if (viewState.areAllRequiredFieldsValid) {
+            triggerEvent(CreateShippingLabelEvent.CloseKeyboard)
             launch {
                 viewState = viewState.copy(
                     isValidationProgressDialogVisible = true,
@@ -224,9 +225,11 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         // Validate fields locally
         viewState = viewState.validateAllFields()
         if (viewState.areAllRequiredFieldsValid) {
+            triggerEvent(CreateShippingLabelEvent.CloseKeyboard)
             exitWithAddress(viewState.getAddress())
         } else {
             triggerEvent(ShowSnackbar(R.string.shipping_label_address_data_invalid_snackbar_message))
+            triggerScrollToFirstErrorFieldEvent()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -17,12 +17,12 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.InputField
 import com.woocommerce.android.ui.common.OptionalField
 import com.woocommerce.android.ui.common.RequiredField
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.CloseKeyboard
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.DialPhoneNumber
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.OpenMapWithAddress
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowCountrySelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowStateSelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
-import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.CloseKeyboard
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.DESTINATION
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelAddressValidator.AddressType.ORIGIN

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -76,7 +76,9 @@ class EditShippingLabelAddressViewModel @Inject constructor(
             val fullCountriesList = dataStore.getCountries()
             val supportedCountries = if (arguments.addressType == ORIGIN) {
                 fullCountriesList.filter { ACCEPTED_USPS_ORIGIN_COUNTRIES.contains(it.code) }
-            } else fullCountriesList
+            } else {
+                fullCountriesList
+            }
             return supportedCountries.map { it.toAppModel() }
         }
 
@@ -169,8 +171,11 @@ class EditShippingLabelAddressViewModel @Inject constructor(
                 viewState = viewState.copy(
                     address1Field = viewState.address1Field.copy(validationError = validationErrorMessage).validate(),
                     bannerMessage = resourceProvider.getString(
-                        if (arguments.addressType == ORIGIN) R.string.shipping_label_edit_origin_address_error_warning
-                        else R.string.shipping_label_edit_address_error_warning
+                        if (arguments.addressType == ORIGIN) {
+                            R.string.shipping_label_edit_origin_address_error_warning
+                        } else {
+                            R.string.shipping_label_edit_address_error_warning
+                        }
                     )
                 )
             }
@@ -456,8 +461,11 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         val companyContent: String
     ) : InputField<NameField>(content) {
         override fun validateInternal(): UiString? {
-            return if (content.isNotBlank() || companyContent.isNotBlank()) null
-            else UiStringRes(R.string.error_required_field)
+            return if (content.isNotBlank() || companyContent.isNotBlank()) {
+                null
+            } else {
+                UiStringRes(R.string.error_required_field)
+            }
         }
     }
 
@@ -482,8 +490,9 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         val addressType: AddressType
     ) : InputField<PhoneField>(content) {
         override fun validateInternal(): UiString? {
-            return if (content.isValidPhoneNumber(addressType, isCustomsFormRequired)) null
-            else {
+            return if (content.isValidPhoneNumber(addressType, isCustomsFormRequired)) {
+                null
+            } else {
                 when {
                     content.isBlank() -> UiStringRes(R.string.shipping_label_address_phone_required)
                     addressType == ORIGIN ->
@@ -504,8 +513,11 @@ class EditShippingLabelAddressViewModel @Inject constructor(
         val isRequired: Boolean = false
     ) : InputField<LocationField>(location.name) {
         override fun validateInternal(): UiString? {
-            return if (isRequired && content.isBlank()) UiStringRes(R.string.error_required_field)
-            else null
+            return if (isRequired && content.isBlank()) {
+                UiStringRes(R.string.error_required_field)
+            } else {
+                null
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ViewUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ViewUtils.kt
@@ -1,6 +1,9 @@
 package com.woocommerce.android.util
 
 import android.content.Context
+import android.graphics.Rect
+import android.view.View
+import android.widget.ScrollView
 
 /**
  * Converts a pixel to a density pixel to match the density of
@@ -9,4 +12,12 @@ import android.content.Context
 fun getDensityPixel(context: Context, dps: Int): Int {
     val scale = context.resources.displayMetrics.density
     return (dps * scale + 0.5f).toInt()
+}
+
+fun isViewVisibleInScrollView(scrollView: ScrollView, targetView: View): Boolean {
+    val scrollBounds = Rect()
+    scrollView.getDrawingRect(scrollBounds)
+    val top = targetView.y + scrollView.y
+    val bottom = top + targetView.height
+    return scrollBounds.top < top && scrollBounds.bottom > bottom
 }

--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
@@ -2,6 +2,7 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/scrollView"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
@@ -412,4 +412,51 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
 
         assertThat(event).isNotInstanceOf(CreateShippingLabelEvent.ScrollToFirstErrorField::class.java)
     }
+
+    @Test
+    fun `given all fields are valid, when onDoneButtonClicked, then CloseKeyboard event is triggered`() = testBlocking {
+
+        var event: Event? = null
+        viewModel.event.observeForever { event = it }
+
+        viewModel.onDoneButtonClicked()
+
+        assertThat(event).isEqualTo(CreateShippingLabelEvent.CloseKeyboard)
+    }
+
+    @Test
+    fun `given all fields are valid, when onUseAddressAsIsButtonClicked, then CloseKeyboard event is triggered`() = testBlocking {
+        val events = mutableListOf<Event>()
+        viewModel.event.observeForever { events.add(it) }
+
+        viewModel.onUseAddressAsIsButtonClicked()
+
+        assertThat(events).contains(CreateShippingLabelEvent.CloseKeyboard)
+    }
+
+    @Test
+    fun `given fields are invalid, when onDoneButtonClicked, then CloseKeyboard event is not triggered`() = testBlocking {
+        viewModel.onFieldEdited(Field.Name, "")
+        viewModel.onFieldEdited(Field.Company, "")
+
+        var event: Event? = null
+        viewModel.event.observeForever { event = it }
+
+        viewModel.onDoneButtonClicked()
+
+        assertThat(event).isNotEqualTo(CreateShippingLabelEvent.CloseKeyboard)
+    }
+
+    @Test
+    fun `given fields are invalid, when onUseAddressAsIsButtonClicked, then CloseKeyboard event is not triggered`() = testBlocking {
+        viewModel.onFieldEdited(Field.Name, "")
+        viewModel.onFieldEdited(Field.Company, "")
+
+        var event: Event? = null
+        viewModel.event.observeForever { event = it }
+
+        viewModel.onUseAddressAsIsButtonClicked()
+
+        assertThat(event).isNotEqualTo(CreateShippingLabelEvent.CloseKeyboard)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
@@ -381,7 +381,6 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
             assertThat(viewState.areAllRequiredFieldsValid).isTrue()
         }
 
-
     @Test
     fun `when validation fails for a set of fields, ScrollToFirstErrorField event is triggered with correct field`() = testBlocking {
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
@@ -380,4 +380,37 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
             val viewState = viewModel.viewStateData.liveData.value!!
             assertThat(viewState.areAllRequiredFieldsValid).isTrue()
         }
+
+
+    @Test
+    fun `when validation fails for a set of fields, ScrollToFirstErrorField event is triggered with correct field`() = testBlocking {
+
+        viewModel.onFieldEdited(Field.Name, "")
+        viewModel.onFieldEdited(Field.Company, "")
+
+        var event: Event? = null
+        viewModel.event.observeForever { event = it }
+
+        viewModel.onDoneButtonClicked()
+
+        verify(addressValidator, never()).validateAddress(any(), any(), any())
+
+        assertThat(event).isInstanceOf(CreateShippingLabelEvent.ScrollToFirstErrorField::class.java)
+        if (event is CreateShippingLabelEvent.ScrollToFirstErrorField) {
+            assertThat((event as CreateShippingLabelEvent.ScrollToFirstErrorField).field).isEqualTo(Field.Name)
+        }
+    }
+
+    @Test
+    fun `when all fields are valid, ScrollToFirstErrorField event is not triggered`() = testBlocking {
+
+        var event: Event? = null
+        viewModel.event.observeForever { event = it }
+
+        viewModel.onDoneButtonClicked()
+
+        verify(addressValidator, atLeastOnce()).validateAddress(any(), any(), any())
+
+        assertThat(event).isNotInstanceOf(CreateShippingLabelEvent.ScrollToFirstErrorField::class.java)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
@@ -384,40 +384,39 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given validation fails for a set of fields, when on done clicked, then ScrollToFirstErrorField event is triggered with correct field`() = testBlocking {
+    fun `given validation fails for a set of fields, when on done clicked, then ScrollToFirstErrorField event is triggered with correct field`() =
+        testBlocking {
+            viewModel.onFieldEdited(Field.Name, "")
+            viewModel.onFieldEdited(Field.Company, "")
 
-        viewModel.onFieldEdited(Field.Name, "")
-        viewModel.onFieldEdited(Field.Company, "")
+            var event: Event? = null
+            viewModel.event.observeForever { event = it }
 
-        var event: Event? = null
-        viewModel.event.observeForever { event = it }
+            viewModel.onDoneButtonClicked()
 
-        viewModel.onDoneButtonClicked()
+            verify(addressValidator, never()).validateAddress(any(), any(), any())
 
-        verify(addressValidator, never()).validateAddress(any(), any(), any())
-
-        assertThat(event).isInstanceOf(ScrollToFirstErrorField::class.java)
-        if (event is ScrollToFirstErrorField) {
-            assertThat((event as ScrollToFirstErrorField).field).isEqualTo(Field.Name)
+            assertThat(event).isInstanceOf(ScrollToFirstErrorField::class.java)
+            if (event is ScrollToFirstErrorField) {
+                assertThat((event as ScrollToFirstErrorField).field).isEqualTo(Field.Name)
+            }
         }
-    }
 
     @Test
-    fun `given all fields are valid, when on done clicked, then ScrollToFirstErrorField event is not triggered`() = testBlocking {
+    fun `given all fields are valid, when on done clicked, then ScrollToFirstErrorField event is not triggered`() =
+        testBlocking {
+            var event: Event? = null
+            viewModel.event.observeForever { event = it }
 
-        var event: Event? = null
-        viewModel.event.observeForever { event = it }
+            viewModel.onDoneButtonClicked()
 
-        viewModel.onDoneButtonClicked()
+            verify(addressValidator, atLeastOnce()).validateAddress(any(), any(), any())
 
-        verify(addressValidator, atLeastOnce()).validateAddress(any(), any(), any())
-
-        assertThat(event).isNotInstanceOf(ScrollToFirstErrorField::class.java)
-    }
+            assertThat(event).isNotInstanceOf(ScrollToFirstErrorField::class.java)
+        }
 
     @Test
     fun `given all fields are valid, when onDoneButtonClicked, then CloseKeyboard event is triggered`() = testBlocking {
-
         var event: Event? = null
         viewModel.event.observeForever { event = it }
 
@@ -427,38 +426,41 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given all fields are valid, when onUseAddressAsIsButtonClicked, then CloseKeyboard event is triggered`() = testBlocking {
-        val events = mutableListOf<Event>()
-        viewModel.event.observeForever { events.add(it) }
+    fun `given all fields are valid, when onUseAddressAsIsButtonClicked, then CloseKeyboard event is triggered`() =
+        testBlocking {
+            val events = mutableListOf<Event>()
+            viewModel.event.observeForever { events.add(it) }
 
-        viewModel.onUseAddressAsIsButtonClicked()
+            viewModel.onUseAddressAsIsButtonClicked()
 
-        assertThat(events).contains(CloseKeyboard)
-    }
-
-    @Test
-    fun `given fields are invalid, when onDoneButtonClicked, then CloseKeyboard event is not triggered`() = testBlocking {
-        viewModel.onFieldEdited(Field.Name, "")
-        viewModel.onFieldEdited(Field.Company, "")
-
-        var event: Event? = null
-        viewModel.event.observeForever { event = it }
-
-        viewModel.onDoneButtonClicked()
-
-        assertThat(event).isNotEqualTo(CloseKeyboard)
-    }
+            assertThat(events).contains(CloseKeyboard)
+        }
 
     @Test
-    fun `given fields are invalid, when onUseAddressAsIsButtonClicked, then CloseKeyboard event is not triggered`() = testBlocking {
-        viewModel.onFieldEdited(Field.Name, "")
-        viewModel.onFieldEdited(Field.Company, "")
+    fun `given fields are invalid, when onDoneButtonClicked, then CloseKeyboard event is not triggered`() =
+        testBlocking {
+            viewModel.onFieldEdited(Field.Name, "")
+            viewModel.onFieldEdited(Field.Company, "")
 
-        var event: Event? = null
-        viewModel.event.observeForever { event = it }
+            var event: Event? = null
+            viewModel.event.observeForever { event = it }
 
-        viewModel.onUseAddressAsIsButtonClicked()
+            viewModel.onDoneButtonClicked()
 
-        assertThat(event).isNotEqualTo(CloseKeyboard)
-    }
+            assertThat(event).isNotEqualTo(CloseKeyboard)
+        }
+
+    @Test
+    fun `given fields are invalid, when onUseAddressAsIsButtonClicked, then CloseKeyboard event is not triggered`() =
+        testBlocking {
+            viewModel.onFieldEdited(Field.Name, "")
+            viewModel.onFieldEdited(Field.Company, "")
+
+            var event: Event? = null
+            viewModel.event.observeForever { event = it }
+
+            viewModel.onUseAddressAsIsButtonClicked()
+
+            assertThat(event).isNotEqualTo(CloseKeyboard)
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
@@ -7,6 +7,8 @@ import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.DialPhoneNumber
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.OpenMapWithAddress
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ScrollToFirstErrorField
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.CloseKeyboard
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowCountrySelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowStateSelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress
@@ -394,9 +396,9 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
 
         verify(addressValidator, never()).validateAddress(any(), any(), any())
 
-        assertThat(event).isInstanceOf(CreateShippingLabelEvent.ScrollToFirstErrorField::class.java)
-        if (event is CreateShippingLabelEvent.ScrollToFirstErrorField) {
-            assertThat((event as CreateShippingLabelEvent.ScrollToFirstErrorField).field).isEqualTo(Field.Name)
+        assertThat(event).isInstanceOf(ScrollToFirstErrorField::class.java)
+        if (event is ScrollToFirstErrorField) {
+            assertThat((event as ScrollToFirstErrorField).field).isEqualTo(Field.Name)
         }
     }
 
@@ -410,7 +412,7 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
 
         verify(addressValidator, atLeastOnce()).validateAddress(any(), any(), any())
 
-        assertThat(event).isNotInstanceOf(CreateShippingLabelEvent.ScrollToFirstErrorField::class.java)
+        assertThat(event).isNotInstanceOf(ScrollToFirstErrorField::class.java)
     }
 
     @Test
@@ -421,7 +423,7 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
 
         viewModel.onDoneButtonClicked()
 
-        assertThat(event).isEqualTo(CreateShippingLabelEvent.CloseKeyboard)
+        assertThat(event).isEqualTo(CloseKeyboard)
     }
 
     @Test
@@ -431,7 +433,7 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
 
         viewModel.onUseAddressAsIsButtonClicked()
 
-        assertThat(events).contains(CreateShippingLabelEvent.CloseKeyboard)
+        assertThat(events).contains(CloseKeyboard)
     }
 
     @Test
@@ -444,7 +446,7 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
 
         viewModel.onDoneButtonClicked()
 
-        assertThat(event).isNotEqualTo(CreateShippingLabelEvent.CloseKeyboard)
+        assertThat(event).isNotEqualTo(CloseKeyboard)
     }
 
     @Test
@@ -457,6 +459,6 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
 
         viewModel.onUseAddressAsIsButtonClicked()
 
-        assertThat(event).isNotEqualTo(CreateShippingLabelEvent.CloseKeyboard)
+        assertThat(event).isNotEqualTo(CloseKeyboard)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
@@ -5,10 +5,10 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.CloseKeyboard
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.DialPhoneNumber
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.OpenMapWithAddress
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ScrollToFirstErrorField
-import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.CloseKeyboard
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowCountrySelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowStateSelector
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowSuggestedAddress

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModelTest.kt
@@ -382,7 +382,7 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when validation fails for a set of fields, ScrollToFirstErrorField event is triggered with correct field`() = testBlocking {
+    fun `given validation fails for a set of fields, when on done clicked, then ScrollToFirstErrorField event is triggered with correct field`() = testBlocking {
 
         viewModel.onFieldEdited(Field.Name, "")
         viewModel.onFieldEdited(Field.Company, "")
@@ -401,7 +401,7 @@ class EditShippingLabelAddressViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when all fields are valid, ScrollToFirstErrorField event is not triggered`() = testBlocking {
+    fun `given all fields are valid, when on done clicked, then ScrollToFirstErrorField event is not triggered`() = testBlocking {
 
         var event: Event? = null
         viewModel.event.observeForever { event = it }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4614
<!-- Id number of the GitHub issue this PR addresses. -->

### Description

This pull request introduces a new feature to the address form in the shipping label creation workflow. The primary goal is to enhance the user experience by automatically scrolling to the first field that fails validation when the user attempts to submit the form with invalid data.

**Key Changes:**

1. Scrolling Logic: Added logic to `EditShippingLabelAddressViewModel` to determine the first field with a validation error. When the user clicks the "Done" button, and if any field validation fails, the form will now scroll to the first invalid field, making it easier for the user to identify and correct the error.

2. Event Triggering: Modified the `onDoneButtonClicked` method to trigger a `ScrollToFirstErrorField` event if there are any validation errors. This event includes the field that needs attention and a flag indicating whether the state field should be displayed as a spinner.

4. ViewModel Testing: Expanded the `EditShippingLabelAddressViewModelTest` suite to include tests for the new scrolling functionality. These tests verify that the correct events are triggered based on the form's validation state and that the form behaves as expected under various scenarios.

### Testing instructions
1. Create an order eligible for shipping label creation.
2. Open the order in the app.
3. Click on "Create shipping label"
4. Ensure that you remove the data from a few required fields like name, company, address. 
5. Click done and notice the app scrolls to the first error field. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<kbd><video src="https://github.com/woocommerce/woocommerce-android/assets/1509205/ed19c45e-d790-4f12-98cc-7f7d97a87825" width="320"></kbd>


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
