### PR TITLE
[Issue 4156] Disable Pull-to-Refresh During Product Search

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -417,6 +417,9 @@ class ProductListFragment :
                     one = R.string.product_selection_count_single
                 )
             }
+            new.isSearchActive?.takeIfNotEqualTo(old?.isSearchActive) { isSearchActive ->
+                binding.productsRefreshLayout.isEnabled = !isSearchActive
+            }
         }
 
         viewModel.productList.observe(viewLifecycleOwner) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4156
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR addresses an issue in the app where the pull-to-refresh spinner would get stuck on the screen after performing a search in the Products section. The problem occurred when the user initiated a pull-to-refresh while the search was active and then pressed the back button, causing the spinner to remain indefinitely until navigating away from the Products screen.

### Testing instructions
1. Go to the Products section in the app.
2. Tap the search icon to activate the search functionality.
3. Attempt to pull down to refresh; the refresh action should be disabled.
4. Tap the back button to exit the search; the spinner should not appear.



<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/1509205/ff48f2dc-38a5-4432-a028-ecf960e8c454





- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
