### PR TITLE
[UI Test] - Re-enable Create Order test

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
@@ -23,6 +23,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.isNotChecked
 import androidx.test.espresso.matcher.ViewMatchers.withClassName
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -90,6 +91,16 @@ open class Screen {
         private fun isElementDisplayed(element: ViewInteraction): Boolean {
             return try {
                 element.check(matches(isDisplayed()))
+                true
+            } catch (e: Throwable) {
+                false
+            }
+        }
+
+        private fun isElementEnabled(element: Int): Boolean {
+            return try {
+                onView(withId(element))
+                    .check(matches(isEnabled()))
                 true
             } catch (e: Throwable) {
                 false
@@ -305,6 +316,14 @@ open class Screen {
     protected fun pressBack() {
         Espresso.pressBack()
         idleFor(1000) // allow for transitions
+    }
+
+    fun waitForElementToBeEnabled(elementID: Int) {
+        waitForConditionToBeTrue(
+            Supplier<Boolean> {
+                isElementEnabled(elementID)
+            }
+        )
     }
 
     fun waitForElementToBeDisplayed(elementID: Int) {

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/UnifiedOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/UnifiedOrderScreen.kt
@@ -14,12 +14,12 @@ import com.woocommerce.android.R
 import com.woocommerce.android.e2e.helpers.util.NestedScrollViewExtension
 import com.woocommerce.android.e2e.helpers.util.Screen
 import org.hamcrest.CoreMatchers.endsWith
-import org.hamcrest.Matchers
 import org.hamcrest.core.AllOf.allOf
 
 class UnifiedOrderScreen : Screen(R.id.order_creation_root) {
     fun createOrder(): SingleOrderScreen {
-        clickOn(R.id.menu_create)
+        waitForElementToBeEnabled(R.id.menu_create)
+        Espresso.onView(withId(R.id.menu_create)).perform(click())
         return SingleOrderScreen()
     }
 
@@ -60,18 +60,9 @@ class UnifiedOrderScreen : Screen(R.id.order_creation_root) {
         return this
     }
 
-    fun editCustomerNote(note: String): UnifiedOrderScreen {
-        waitForElementToBeDisplayedWithoutFailure(R.id.notes_section)
-        scrollTo(R.id.notes_section)
+    fun addCustomerNote(note: String): UnifiedOrderScreen {
+        Espresso.onView(withText(R.string.order_creation_add_customer_note)).perform(click())
 
-        val editNoteButton = Espresso.onView(
-            Matchers.allOf(
-                isDescendantOfA(withId(R.id.notes_section)),
-                withId(R.id.edit_button)
-            )
-        )
-
-        clickOn(editNoteButton)
         typeTextInto(R.id.customerOrderNote_editor, note)
         clickOn(R.id.menu_done)
         return this

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
@@ -18,7 +18,6 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.json.JSONObject
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -48,11 +47,9 @@ class OrdersUITest : TestBase() {
         TabNavComponent().gotoOrdersScreen()
     }
 
-    @Ignore
     @Test
     fun e2eCreateOrderTest() {
         val note = "Just a placeholder text"
-        val status = "Processing"
         val ordersJSONArray = MocksReader().readOrderToArray()
 
         for (orderJSON in ordersJSONArray.iterator()) {
@@ -63,12 +60,10 @@ class OrdersUITest : TestBase() {
             OrderListScreen()
                 .createFABTap()
                 .assertNewOrderScreen()
-                .updateOrderStatus(status)
+                .addCustomerNote(note)
                 .addProductTap()
                 .assertProductsSelectorScreen(composeTestRule)
                 .selectProduct(composeTestRule, orderData.productName)
-                .editCustomerNote(note)
-                .addShipping()
                 .createOrder()
                 .assertSingleOrderScreenWithProduct(orderData)
                 .goBackToOrdersScreen()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
This PR re-enables the Create Order UI test that was temporarily disabled in https://github.com/woocommerce/woocommerce-android/pull/10035#discussion_r1400483525 because of screen changes and also as a pre-req for better test coverage in project lilypad.

A few changes have been made to the UI test for it to work after the UI changes:
1. Re-ordered add customer note as the first action - there were issues with scrolling on the test, and since we're testing the ability to create notes, this re-order does not reduce test coverage
2. Remove the following steps from the test: `updateOrderStatus` (since the test is creating a new order, this option isn't visible on screen) and `addShipping` (has been replaced by the custom amount field on this particular test because of the mock file used)
3. Created a new helper method, `waitForElementToBeEnabled` to better test conditions when the button is visible but not yet enabled

### Testing instructions
Instrumented tests should be 🟢 in CI and should include previously skipped test [e2eCreateOrderTest](https://console.firebase.google.com/project/api-project-108380595987/testlab/histories/bh.edfd947f2636efe3/matrices/4761090116762822093/details?stepId=bs.222982aaf5517e13&testCaseId=44&query=et.97e288ea18531c8e&deeplink=true)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
