### PR TITLE
Remove shared toolbar and add fragment specific toolbar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -896,9 +896,13 @@ class MainActivity :
         }
     }
 
-    private fun navigateToWebView(event: ViewUrlInWebView) {
+    fun navigateToWebView(event: ViewUrlInWebView) {
         navController.navigate(
-            NavGraphMainDirections.actionGlobalWPComWebViewFragment(urlToLoad = event.url)
+            NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+                urlToLoad = event.url,
+                urlsToTriggerExit = event.urlsToTriggerExit,
+                title = event.title
+            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -61,6 +61,7 @@ import com.woocommerce.android.ui.appwidgets.WidgetUpdater
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.common.InfoScreenFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.login.LoginActivity
@@ -904,6 +905,25 @@ class MainActivity :
                 title = event.title
             )
         )
+    }
+
+    fun navigateToGlobalInfoScreenFragment(
+        screenTitle: Int,
+        heading: Int,
+        message: Int,
+        linkTitle: Int,
+        imageResource: Int,
+        linkAction: InfoScreenFragment.InfoScreenLinkAction
+    ) {
+        val action = NavGraphMainDirections.actionGlobalInfoScreenFragment(
+            screenTitle = screenTitle,
+            heading = heading,
+            message = message,
+            linkTitle = linkTitle,
+            imageResource = imageResource,
+            linkAction = linkAction
+        )
+        navController.navigate(action)
     }
 
     private fun showOrderDetail(event: ViewOrderDetail) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -907,6 +907,7 @@ class MainActivity :
         )
     }
 
+    @Suppress("LongParameterList")
     fun navigateToGlobalInfoScreenFragment(
         screenTitle: Int,
         heading: Int,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -398,7 +398,11 @@ class MainActivityViewModel @Inject constructor(
     object ViewPayments : Event()
     object ViewTapToPay : Event()
     object RequestNotificationsPermission : Event()
-    data class ViewUrlInWebView(val url: String) : Event()
+    data class ViewUrlInWebView(
+        val url: String,
+        val urlsToTriggerExit: Array<String>? = null,
+        val title: String? = null,
+    ) : Event()
     object ShortcutOpenPayments : Event()
     object ShortcutOpenOrderCreation : Event()
     data class ViewStorePlanUpgrade(val source: PlanUpgradeStartSource) : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -2,10 +2,10 @@ package com.woocommerce.android.ui.orders
 
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.common.InfoScreenFragment.InfoScreenLinkAction.LearnMoreAboutShippingLabels
+import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AIThankYouNote
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderNote
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.AddOrderShipmentTracking
@@ -115,7 +115,7 @@ class OrderNavigator @Inject constructor() {
                 fragment.findNavController().navigateSafely(action)
             }
             is ViewCreateShippingLabelInfo -> {
-                val action = NavGraphMainDirections.actionGlobalInfoScreenFragment(
+                (fragment.activity as? MainActivity)?.navigateToGlobalInfoScreenFragment(
                     screenTitle = R.string.shipping_label_more_information_title,
                     heading = R.string.shipping_label_more_information_heading,
                     message = R.string.shipping_label_more_information_message,
@@ -123,7 +123,6 @@ class OrderNavigator @Inject constructor() {
                     imageResource = R.drawable.img_print_with_phone,
                     linkAction = LearnMoreAboutShippingLabels
                 )
-                fragment.findNavController().navigateSafely(action)
             }
             is ViewShippingLabelFormatOptions -> {
                 val action = PrintShippingLabelFragmentDirections

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt
@@ -50,7 +50,7 @@ object OrderCreateEditNavigator {
 
             is ShowCreatedOrder ->
                 OrderCreateEditFormFragmentDirections
-                    .actionOrderCreationFragmentToOrderDetailFragment(target.orderId, target.startPaymentFlow)
+                    .actionOrderCreationFragmentToOrderListFragment(target.orderId)
 
             is EditShipping ->
                 OrderCreateEditFormFragmentDirections

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.extensions.isTablet
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
@@ -268,6 +269,9 @@ class OrderDetailFragment :
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
             new.orderInfo?.takeIfNotEqualTo(old?.orderInfo) {
                 showOrderDetail(it.order!!, it.isPaymentCollectableWithCardReader, it.isReceiptButtonsVisible)
+                if (isTablet()) {
+                    orderEditingViewModel.setOrderId(it.order.id)
+                }
                 onPrepareMenu(binding.toolbar.menu)
             }
             new.orderStatus?.takeIfNotEqualTo(old?.orderStatus) { showOrderStatus(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.orders.details
 import android.graphics.Color
 import android.os.Bundle
 import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.compose.foundation.layout.Column
@@ -13,7 +12,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
-import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -90,8 +88,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class OrderDetailFragment :
     BaseFragment(R.layout.fragment_order_detail),
-    OrderProductActionListener
-{
+    OrderProductActionListener {
     companion object {
         val TAG: String = OrderDetailFragment::class.java.simpleName
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.livedata.observeAsState
@@ -201,7 +202,14 @@ class OrderDetailFragment :
 
     private fun setupToolbarMenu(menu: Menu) {
         onPrepareMenu(menu)
-        binding.toolbar.navigationIcon = null
+        if (isTablet()) {
+            binding.toolbar.navigationIcon = null
+        } else {
+            binding.toolbar.navigationIcon = AppCompatResources.getDrawable(requireActivity(), R.drawable.ic_back_24dp)
+            binding.toolbar.setNavigationOnClickListener {
+                findNavController().navigateUp()
+            }
+        }
         val menuEditOrder = menu.findItem(R.id.menu_edit_order)
         menuEditOrder.isVisible = true
     }
@@ -290,7 +298,10 @@ class OrderDetailFragment :
             new.isProductListVisible?.takeIfNotEqualTo(old?.isProductListVisible) {
                 binding.orderDetailProductList.isVisible = it
             }
-            new.toolbarTitle?.takeIfNotEqualTo(old?.toolbarTitle) { screenTitle = it }
+            new.toolbarTitle?.takeIfNotEqualTo(old?.toolbarTitle) {
+                screenTitle = it
+                binding.toolbar.title = it
+            }
             new.isOrderDetailSkeletonShown?.takeIfNotEqualTo(old?.isOrderDetailSkeletonShown) { showSkeleton(it) }
             new.isShipmentTrackingAvailable?.takeIfNotEqualTo(old?.isShipmentTrackingAvailable) {
                 showAddShipmentTracking(it)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -175,12 +175,18 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     fun start() {
-        launch {
-            orderDetailRepository.getOrderById(navArgs.orderId)?.let {
-                order = it
-                displayOrderDetails()
-                fetchOrder(showSkeleton = false)
-            } ?: fetchOrder(showSkeleton = true)
+        if (navArgs.orderId != -1L) {
+            launch {
+                orderDetailRepository.getOrderById(navArgs.orderId)?.let {
+                    order = it
+                    displayOrderDetails()
+                    fetchOrder(showSkeleton = false)
+                } ?: fetchOrder(showSkeleton = true)
+            }
+        } else {
+            viewState = viewState.copy(
+                isOrderDetailSkeletonShown = true
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -56,6 +56,7 @@ import com.woocommerce.android.ui.shipping.InstallWCShippingViewModel
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import com.woocommerce.android.viewmodel.LiveDataDelegate
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUndoSnackbar
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -260,6 +261,10 @@ class OrderDetailViewModel @Inject constructor(
      */
     fun onCustomFieldClicked(context: Context, value: String) {
         CustomOrderFieldsHelper.handleMetadataValue(context, value)
+    }
+
+    fun onBackPressed() {
+        triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
     fun getOrderMetadata(): List<OrderMetaDataEntity> = runBlocking {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/customfields/CustomOrderFieldsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/customfields/CustomOrderFieldsFragment.kt
@@ -7,11 +7,13 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
 import com.woocommerce.android.ui.orders.details.customfields.CustomOrderFieldsHelper.CustomOrderFieldClickListener
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -29,6 +31,15 @@ class CustomOrderFieldsFragment : BaseFragment(), CustomOrderFieldClickListener 
                 WooThemeWithBackground {
                     CustomOrderFieldsScreen(viewModel, this@CustomOrderFieldsFragment)
                 }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.event.observe(viewLifecycleOwner) {
+            when (it) {
+                MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/customfields/CustomOrderFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/customfields/CustomOrderFieldsScreen.kt
@@ -5,9 +5,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -17,6 +19,8 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -24,10 +28,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight.Companion.W700
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.details.OrderDetailViewModel
 import com.woocommerce.android.ui.orders.details.customfields.CustomOrderFieldsHelper.CustomOrderFieldClickListener
@@ -41,27 +48,44 @@ private var clickListener: CustomOrderFieldClickListener? = null
 fun CustomOrderFieldsScreen(viewModel: OrderDetailViewModel, listener: CustomOrderFieldClickListener? = null) {
     clickListener = listener
     CustomFieldsScreen(
-        viewModel.getOrderMetadata()
+        viewModel.getOrderMetadata(),
+        viewModel::onBackPressed
     )
 }
 
 @Composable
-fun CustomFieldsScreen(metadataList: List<OrderMetaDataEntity>) {
-    val listState = rememberLazyListState()
-    LazyColumn(
-        state = listState,
-        modifier = Modifier.background(color = MaterialTheme.colors.surface)
+fun CustomFieldsScreen(
+    metadataList: List<OrderMetaDataEntity>,
+    onBackPressed: () -> Unit
+) {
+    Box(
+        modifier = Modifier.height(600.dp)
     ) {
-        itemsIndexed(
-            items = metadataList,
-            key = { _, metadata -> metadata.id }
-        ) { _, metadata ->
-            CustomFieldListItem(metadata)
-            Divider(
-                modifier = Modifier.offset(x = dimensionResource(id = R.dimen.major_100)),
-                color = colorResource(id = R.color.divider_color),
-                thickness = dimensionResource(id = R.dimen.minor_10)
+        Column {
+            Toolbar(
+                title = stringResource(id = R.string.orderdetail_custom_fields),
+                navigationIcon = Icons.Filled.ArrowBack,
+                onNavigationButtonClick = {
+                    onBackPressed()
+                }
             )
+            val listState = rememberLazyListState()
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.background(color = MaterialTheme.colors.surface)
+            ) {
+                itemsIndexed(
+                    items = metadataList,
+                    key = { _, metadata -> metadata.id }
+                ) { _, metadata ->
+                    CustomFieldListItem(metadata)
+                    Divider(
+                        modifier = Modifier.offset(x = dimensionResource(id = R.dimen.major_100)),
+                        color = colorResource(id = R.color.divider_color),
+                        thickness = dimensionResource(id = R.dimen.minor_10)
+                    )
+                }
+            }
         }
     }
 }
@@ -178,7 +202,8 @@ private fun CustomFieldsPreview() {
                     key = "phone key",
                     value = "tel://1234567890"
                 )
-            )
+            ),
+            onBackPressed = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
@@ -22,7 +22,7 @@ import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
-abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener, MenuProvider {
+abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener {
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
 
@@ -81,18 +81,11 @@ abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener, MenuP
     @CallSuper
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
         setupObservers()
     }
 
     @CallSuper
-    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_done, menu)
-        doneMenuItem = menu.findItem(R.id.menu_done)
-    }
-
-    @CallSuper
-    override fun onPrepareMenu(menu: Menu) {
+    fun onPrepareMenu() {
         updateDoneMenuItem()
     }
 
@@ -111,7 +104,7 @@ abstract class BaseOrderEditingFragment : BaseFragment, BackPressListener, MenuP
     }
 
     @CallSuper
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
+    fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
                 if (saveChanges()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/BaseOrderEditingFragment.kt
@@ -3,13 +3,10 @@ package com.woocommerce.android.ui.orders.details.editing
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
-import androidx.core.view.MenuProvider
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/CustomerOrderNoteEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/CustomerOrderNoteEditingFragment.kt
@@ -54,7 +54,10 @@ class CustomerOrderNoteEditingFragment :
     }
 
     private fun setupToolbarMenu() {
-        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(requireActivity(), R.drawable.ic_gridicons_cross_24dp)
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_gridicons_cross_24dp
+        )
         binding.toolbar.setNavigationOnClickListener {
             navigateUp()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/CustomerOrderNoteEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/CustomerOrderNoteEditingFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.details.editing
 
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.content.res.AppCompatResources
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentOrderCreateEditCustomerNoteBinding
@@ -22,14 +23,15 @@ class CustomerOrderNoteEditingFragment :
     override val analyticsValue: String = AnalyticsTracker.ORDER_EDIT_CUSTOMER_NOTE
 
     override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Visible(
-            navigationIcon = R.drawable.ic_gridicons_cross_24dp
-        )
+        get() = AppBarStatus.Hidden
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         _binding = FragmentOrderCreateEditCustomerNoteBinding.bind(view)
+
+        setupToolbar()
+        onPrepareMenu()
 
         if (savedInstanceState == null) {
             binding.customerOrderNoteEditor.setText(sharedViewModel.order.customerNote)
@@ -38,6 +40,24 @@ class CustomerOrderNoteEditingFragment :
         }
 
         binding.customerOrderNoteEditor.addTextChangedListener(textWatcher)
+    }
+
+    private fun setupToolbar() {
+        binding.toolbar.title = requireActivity().getString(R.string.orderdetail_customer_provided_note)
+        binding.toolbar.setOnMenuItemClickListener { menuItem ->
+            onMenuItemSelected(menuItem)
+        }
+        // Set up the toolbar menu
+        binding.toolbar.inflateMenu(R.menu.menu_done)
+        doneMenuItem = binding.toolbar.menu.findItem(R.id.menu_done)
+        setupToolbarMenu()
+    }
+
+    private fun setupToolbarMenu() {
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(requireActivity(), R.drawable.ic_gridicons_cross_24dp)
+        binding.toolbar.setNavigationOnClickListener {
+            navigateUp()
+        }
     }
 
     override fun onDestroyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -43,13 +43,23 @@ class OrderEditingViewModel @Inject constructor(
     private var viewState by viewStateData
 
     lateinit var order: Order
+    private var orderId: Long = -1L
 
     fun start() {
         runBlocking {
-            order = requireNotNull(orderDetailRepository.getOrderById(navArgs.orderId)) {
-                "Order ${navArgs.orderId} not found in the database."
+            val orderId = if (orderId == -1L) {
+                navArgs.orderId
+            } else {
+                orderId
+            }
+            order = requireNotNull(orderDetailRepository.getOrderById(orderId)) {
+                "Order $orderId not found in the database."
             }
         }
+    }
+
+    fun setOrderId(orderId: Long) {
+        this.orderId = orderId
     }
 
     private fun checkConnectionAndResetState(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -60,6 +60,7 @@ abstract class BaseAddressEditingFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentBaseEditAddressBinding.bind(view)
+        setupToolbar()
         replicateAddressSwitch = SwitchMaterial(requireContext())
         _binding?.form?.root?.addView(replicateAddressSwitch)
         replicateAddressSwitch.apply {
@@ -73,6 +74,7 @@ abstract class BaseAddressEditingFragment :
         replicateAddressSwitch.setOnCheckedChangeListener { _, isChecked ->
             sharedViewModel.onReplicateAddressSwitchChanged(isChecked)
         }
+        onPrepareMenu()
         bindTextWatchers()
 
         binding.form.countrySpinner.setClickListener {
@@ -90,6 +92,22 @@ abstract class BaseAddressEditingFragment :
         setupObservers()
         setupResultHandlers()
         onViewBound(binding)
+    }
+
+    private fun setupToolbar() {
+        binding.toolbar.setOnMenuItemClickListener { menuItem ->
+            onMenuItemSelected(menuItem)
+        }
+        // Set up the toolbar menu
+        binding.toolbar.inflateMenu(R.menu.menu_done)
+        doneMenuItem = binding.toolbar.menu.findItem(R.id.menu_done)
+        setupToolbarMenu()
+    }
+
+    private fun setupToolbarMenu() {
+        binding.toolbar.setNavigationOnClickListener {
+            navigateUp()
+        }
     }
 
     override fun hasChanges() =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -43,7 +43,7 @@ abstract class BaseAddressEditingFragment :
     abstract fun onViewBound(binding: FragmentBaseEditAddressBinding)
 
     private var _binding: FragmentBaseEditAddressBinding? = null
-    private val binding get() = _binding!!
+    protected val binding get() = _binding!!
 
     protected lateinit var replicateAddressSwitch: SwitchMaterial
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.orders.details.editing.address
 
+import android.os.Bundle
+import android.view.View
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentBaseEditAddressBinding
@@ -26,5 +28,10 @@ class BillingAddressEditingFragment : BaseAddressEditingFragment() {
     override fun onViewBound(binding: FragmentBaseEditAddressBinding) {
         binding.form.addressSectionHeader.text = getString(R.string.order_detail_billing_address_section)
         replicateAddressSwitch.text = getString(R.string.order_detail_use_as_shipping_address)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.toolbar.title = getString(R.string.order_detail_billing_address_section)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.details.editing.address
 
+import android.os.Bundle
 import android.view.View
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -11,9 +12,7 @@ class ShippingAddressEditingFragment : BaseAddressEditingFragment() {
     override val analyticsValue: String = AnalyticsTracker.ORDER_EDIT_SHIPPING_ADDRESS
 
     override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Visible(
-            navigationIcon = R.drawable.ic_gridicons_cross_24dp
-        )
+        get() = AppBarStatus.Hidden
 
     override val storedAddress: Address
         get() = sharedViewModel.order.shippingAddress

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.details.editing.address
 
+import android.os.Bundle
 import android.view.View
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -26,5 +27,10 @@ class ShippingAddressEditingFragment : BaseAddressEditingFragment() {
         binding.form.email.visibility = View.GONE
         binding.form.addressSectionHeader.text = getString(R.string.order_detail_shipping_address_section)
         replicateAddressSwitch.text = getString(R.string.order_detail_use_as_billing_address)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.toolbar.title = getString(R.string.order_detail_shipping_address_section)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.details.editing.address
 
-import android.os.Bundle
 import android.view.View
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -136,6 +136,15 @@ class OrderListAdapter(
         }
     }
 
+    fun openOrder(orderId: Long) {
+        listener.openOrderDetail(
+            orderId = orderId,
+            allOrderIds = allOrderIds,
+            orderStatus = "",
+            sharedView = null,
+        )
+    }
+
     private inner class OrderItemUIViewHolder(val viewBinding: OrderListItemBinding) :
         RecyclerView.ViewHolder(viewBinding.root), SwipeToComplete.SwipeAbleViewHolder {
         private var isNotCompleted = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -196,9 +196,6 @@ class OrderListFragment :
         initObservers()
         initializeResultHandlers()
         displayTwoPaneLayoutIfTablet()
-        if (isSearching) {
-            searchHandler.postDelayed({ searchView?.setQuery(searchQuery, true) }, 100)
-        }
         binding.orderFiltersCard.setClickListener { viewModel.onFiltersButtonTapped() }
         initCreateOrderFAB(binding.createOrderButton)
         initSwipeBehaviour()
@@ -312,7 +309,6 @@ class OrderListFragment :
     private fun refreshOptionsMenu() {
         if (!isChildFragmentShowing() && isSearching) {
             val savedSearchQuery = searchQuery
-            searchMenuItem?.expandActionView()
             enableSearchListeners()
             searchQuery = savedSearchQuery
             searchView?.setQuery(searchQuery, false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -71,13 +71,13 @@ import javax.inject.Inject
 import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 
 @AndroidEntryPoint
+@Suppress("LargeClass")
 class OrderListFragment :
     TopLevelFragment(R.layout.fragment_order_list),
     OnQueryTextListener,
     OnActionExpandListener,
     OrderListListener,
-    SwipeToComplete.OnSwipeListener
-{
+    SwipeToComplete.OnSwipeListener {
     companion object {
         const val TAG: String = "OrderListFragment"
         const val STATE_KEY_SEARCH_QUERY = "search-query"
@@ -242,7 +242,7 @@ class OrderListFragment :
         searchHandler.postDelayed({
             binding.orderListView.clearAdapterData()
         }, 100)
-        return true  // Return true to expand the action view
+        return true // Return true to expand the action view
     }
 
     private fun handleSearchViewCollapse(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
@@ -84,7 +84,9 @@ class OrderListView @JvmOverloads constructor(
      * clear order list adapter data
      */
     fun clearAdapterData() {
-        ordersAdapter.submitList(null)
+        if (::ordersAdapter.isInitialized) {
+            ordersAdapter.submitList(null)
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListView.kt
@@ -64,6 +64,10 @@ class OrderListView @JvmOverloads constructor(
         ordersAdapter.openFirstOrder()
     }
 
+    fun openOrder(orderId: Long) {
+        ordersAdapter.openOrder(orderId)
+    }
+
     /**
      * Submit new paged list data to the adapter
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -153,6 +153,8 @@ class OrderListViewModel @Inject constructor(
     private val _isEmpty = MediatorLiveData<Boolean>()
     val isEmpty: LiveData<Boolean> = _isEmpty
 
+    val orderId: LiveData<Long> = savedState.getLiveData<Long>("orderId")
+
     private val _emptyViewType: ThrottleLiveData<EmptyViewType?> by lazy {
         ThrottleLiveData(
             offset = EMPTY_VIEW_THROTTLE,
@@ -588,6 +590,10 @@ class OrderListViewModel @Inject constructor(
             }
         }
         triggerEvent(OrderListEvent.NotifyOrderSelectionChanged)
+    }
+
+    fun clearOrderId() {
+        savedState["orderId"] = -1L
     }
 
     fun onSwipeStatusUpdate(gestureSource: OrderStatusUpdateSource.SwipeToCompleteGesture) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SelectedOrderTrackerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/SelectedOrderTrackerViewModel.kt
@@ -25,7 +25,14 @@ class SelectedOrderTrackerViewModel @Inject constructor(
     private val _selectedOrderId = MutableLiveData<Long>()
     val selectedOrderId: LiveData<Long> = _selectedOrderId
 
+    private val _refreshOrders = MutableLiveData<Unit>()
+    val refreshOrders: LiveData<Unit> = _refreshOrders
+
     fun selectOrder(orderId: Long) {
         _selectedOrderId.value = orderId
+    }
+
+    fun refreshOrders() {
+        _refreshOrders.value = Unit
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
@@ -2,10 +2,8 @@ package com.woocommerce.android.ui.orders.notes
 
 import android.os.Bundle
 import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.viewModels

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteFragment.kt
@@ -31,7 +31,7 @@ import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class AddOrderNoteFragment : BaseFragment(R.layout.fragment_add_order_note), BackPressListener, MenuProvider {
+class AddOrderNoteFragment : BaseFragment(R.layout.fragment_add_order_note), BackPressListener {
     companion object {
         const val TAG = "AddOrderNoteFragment"
         const val KEY_ADD_NOTE_RESULT = "key_add_note_result"
@@ -46,16 +46,13 @@ class AddOrderNoteFragment : BaseFragment(R.layout.fragment_add_order_note), Bac
     private var addMenuItem: MenuItem? = null
 
     override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Visible(
-            navigationIcon = R.drawable.ic_gridicons_cross_24dp
-        )
+        get() = AppBarStatus.Hidden
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
-
         val binding = FragmentAddOrderNoteBinding.bind(view)
+        setupToolbar(binding)
         initUi(binding)
         setupObservers(binding)
 
@@ -63,6 +60,24 @@ class AddOrderNoteFragment : BaseFragment(R.layout.fragment_add_order_note), Bac
             binding.addNoteEditor.requestFocus()
             ActivityUtils.showKeyboard(binding.addNoteEditor)
         }
+    }
+
+    private fun setupToolbar(binding: FragmentAddOrderNoteBinding) {
+        binding.toolbar.title = viewModel.screenTitle
+        binding.toolbar.setOnMenuItemClickListener { menuItem ->
+            onMenuItemSelected(menuItem)
+        }
+        // Set up the toolbar menu
+        binding.toolbar.inflateMenu(R.menu.menu_add)
+        binding.toolbar.setNavigationOnClickListener {
+            viewModel.onBackPressed()
+        }
+        setupToolbarMenu(binding.toolbar.menu)
+    }
+
+    private fun setupToolbarMenu(menu: Menu) {
+        addMenuItem = menu.findItem(R.id.menu_add)
+        addMenuItem!!.isVisible = viewModel.shouldShowAddButton
     }
 
     override fun getFragmentTitle() = viewModel.screenTitle
@@ -80,14 +95,7 @@ class AddOrderNoteFragment : BaseFragment(R.layout.fragment_add_order_note), Bac
         }
     }
 
-    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
-        menu.clear()
-        inflater.inflate(R.menu.menu_add, menu)
-        addMenuItem = menu.findItem(R.id.menu_add)
-        addMenuItem!!.isVisible = viewModel.shouldShowAddButton
-    }
-
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
+    fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_add -> {
                 AnalyticsTracker.track(ADD_ORDER_NOTE_ADD_BUTTON_TAPPED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/LabelFormatOptionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/LabelFormatOptionsFragment.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentLabelFormatOptionsBinding
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.main.AppBarStatus
-import com.woocommerce.android.ui.main.MainActivity
 
 class LabelFormatOptionsFragment : BaseFragment(R.layout.fragment_label_format_options) {
     override val activityAppBarStatus: AppBarStatus

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/LabelFormatOptionsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/LabelFormatOptionsFragment.kt
@@ -1,15 +1,36 @@
 package com.woocommerce.android.ui.orders.shippinglabels
 
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentLabelFormatOptionsBinding
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.main.MainActivity
 
 class LabelFormatOptionsFragment : BaseFragment(R.layout.fragment_label_format_options) {
     override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Visible(
-            navigationIcon = R.drawable.ic_gridicons_cross_24dp
+        get() = AppBarStatus.Hidden
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val binding = FragmentLabelFormatOptionsBinding.bind(view)
+        setupToolbar(binding)
+    }
+
+    private fun setupToolbar(binding: FragmentLabelFormatOptionsBinding) {
+        binding.toolbar.title = getString(R.string.print_shipping_label_format_options_title)
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_gridicons_cross_24dp
         )
+        binding.toolbar.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
+    }
 
     override fun onResume() {
         super.onResume()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormFragment.kt
@@ -5,6 +5,7 @@ import android.os.Environment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -20,6 +21,7 @@ import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.PrintCustomsFormAdapter.PrintCustomsFormViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.PrintShippingLabelCustomsFormViewModel.PrintCustomsForm
@@ -42,6 +44,8 @@ class PrintShippingLabelCustomsFormFragment :
 
     private val invoicesAdapter by lazy { PrintCustomsFormAdapter(viewModel::onInvoicePrintButtonClicked) }
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
     override fun getFragmentTitle(): String = getString(R.string.shipping_label_print_customs_form_screen_title)
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -53,8 +57,20 @@ class PrintShippingLabelCustomsFormFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentPrintLabelCustomsFormBinding.bind(view)
+        setupToolbar(binding)
         setupObservers(binding)
         setupView(binding)
+    }
+
+    private fun setupToolbar(binding: FragmentPrintLabelCustomsFormBinding) {
+        binding.toolbar.title = getString(R.string.shipping_label_print_customs_form_screen_title)
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            onRequestAllowBackPress()
+        }
     }
 
     private fun setupObservers(binding: FragmentPrintLabelCustomsFormBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormFragment.kt
@@ -26,7 +26,9 @@ import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.PrintCustomsFormAdapter.PrintCustomsFormViewHolder
 import com.woocommerce.android.ui.orders.shippinglabels.PrintShippingLabelCustomsFormViewModel.PrintCustomsForm
 import com.woocommerce.android.util.ActivityUtils
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.*
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.CustomProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelFragment.kt
@@ -6,14 +6,18 @@ import android.view.View
 import androidx.annotation.StringRes
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentPrintShippingLabelBinding
 import com.woocommerce.android.extensions.handleDialogResult
+import com.woocommerce.android.extensions.isTablet
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.OrderNavigationTarget
 import com.woocommerce.android.ui.orders.OrderNavigator
@@ -39,6 +43,9 @@ class PrintShippingLabelFragment : BaseFragment(R.layout.fragment_print_shipping
 
     private var progressDialog: CustomProgressDialog? = null
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     override fun getFragmentTitle(): String {
         return getString(viewModel.screenTitle)
     }
@@ -47,10 +54,21 @@ class PrintShippingLabelFragment : BaseFragment(R.layout.fragment_print_shipping
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentPrintShippingLabelBinding.bind(view)
+        setupToolbar(binding)
 
         initUi(binding)
         setupObservers(viewModel, binding)
         setupResultHandlers(viewModel)
+    }
+
+    private fun setupToolbar(binding: FragmentPrintShippingLabelBinding) {
+        binding.toolbar.title = getString(viewModel.screenTitle)
+        binding.toolbar.setNavigationOnClickListener {
+            when {
+                isTablet() && onRequestAllowBackPress() -> findNavController().navigateUp()
+                else -> (activity as? MainActivity)?.onBackPressed()
+            }
+        }
     }
 
     private fun initUi(binding: FragmentPrintShippingLabelBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelInfoFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelInfoFragment.kt
@@ -2,7 +2,9 @@ package com.woocommerce.android.ui.orders.shippinglabels
 
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.text.HtmlCompat
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentPrintShippingLabelInfoBinding
@@ -11,13 +13,12 @@ import com.woocommerce.android.ui.main.AppBarStatus
 
 class PrintShippingLabelInfoFragment : BaseFragment(R.layout.fragment_print_shipping_label_info) {
     override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Visible(
-            navigationIcon = R.drawable.ic_gridicons_cross_24dp
-        )
+        get() = AppBarStatus.Hidden
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentPrintShippingLabelInfoBinding.bind(view)
+        setupToolbar(binding)
         binding.printShippingLabelInfoStep1.text =
             HtmlCompat.fromHtml(getString(R.string.print_shipping_label_info_step_1), HtmlCompat.FROM_HTML_MODE_LEGACY)
         binding.printShippingLabelInfoStep2.text =
@@ -28,6 +29,17 @@ class PrintShippingLabelInfoFragment : BaseFragment(R.layout.fragment_print_ship
             HtmlCompat.fromHtml(getString(R.string.print_shipping_label_info_step_4), HtmlCompat.FROM_HTML_MODE_LEGACY)
         binding.printShippingLabelInfoStep5.text =
             HtmlCompat.fromHtml(getString(R.string.print_shipping_label_info_step_5), HtmlCompat.FROM_HTML_MODE_LEGACY)
+    }
+
+    private fun setupToolbar(binding: FragmentPrintShippingLabelInfoBinding) {
+        binding.toolbar.title = getString(R.string.print_shipping_label_info_title)
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_gridicons_cross_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
     }
 
     override fun onResume() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundFragment.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.shippinglabels
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -15,6 +16,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ShippingLabel
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -33,6 +35,9 @@ class ShippingLabelRefundFragment : BaseFragment(R.layout.fragment_shipping_labe
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var currencyFormatter: CurrencyFormatter
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
@@ -41,7 +46,19 @@ class ShippingLabelRefundFragment : BaseFragment(R.layout.fragment_shipping_labe
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentShippingLabelRefundBinding.bind(view)
+        setupToolbar(binding)
         setupObservers(binding)
+    }
+
+    private fun setupToolbar(binding: FragmentShippingLabelRefundBinding) {
+        binding.toolbar.title = getString(R.string.orderdetail_shipping_label_request_refund)
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            onRequestAllowBackPress()
+        }
     }
 
     private fun setupObservers(binding: FragmentShippingLabelRefundBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import androidx.annotation.StringRes
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -28,6 +29,7 @@ import com.woocommerce.android.model.getTitle
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.dialog.WooDialog
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowAddressEditor
 import com.woocommerce.android.ui.orders.shippinglabels.creation.CreateShippingLabelEvent.ShowCustomsForm
@@ -87,15 +89,30 @@ class CreateShippingLabelFragment : BaseFragment(R.layout.fragment_create_shippi
 
     private val skeletonView: SkeletonView = SkeletonView()
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     override fun getFragmentTitle() = getString(R.string.shipping_label_create_title)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentCreateShippingLabelBinding.bind(view)
+        setupToolbar(binding)
 
         initializeViewModel(binding)
         initializeViews(binding)
+    }
+
+    private fun setupToolbar(binding: FragmentCreateShippingLabelBinding) {
+        binding.toolbar.title = getString(R.string.shipping_label_create_title)
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            onRequestAllowBackPress()
+        }
     }
 
     override fun onStop() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -10,6 +10,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.widget.Button
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -54,8 +55,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class EditShippingLabelAddressFragment :
     BaseFragment(R.layout.fragment_edit_shipping_label_address),
-    BackPressListener,
-    MenuProvider {
+    BackPressListener {
     companion object {
         const val SELECT_COUNTRY_REQUEST = "select_country_request"
         const val SELECT_STATE_REQUEST = "select_state_request"
@@ -95,12 +95,25 @@ class EditShippingLabelAddressFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
-
         val binding = FragmentEditShippingLabelAddressBinding.bind(view)
+        setupToolbar(binding)
 
         initializeViewModel(binding)
         initializeViews(binding)
+    }
+
+    private fun setupToolbar(binding: FragmentEditShippingLabelAddressBinding) {
+        binding.toolbar.setOnMenuItemClickListener { menuItem ->
+            onMenuItemSelected(menuItem)
+        }
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            onRequestAllowBackPress()
+        }
+        binding.toolbar.inflateMenu(R.menu.menu_done)
     }
 
     private fun initializeViewModel(binding: FragmentEditShippingLabelAddressBinding) {
@@ -126,11 +139,7 @@ class EditShippingLabelAddressFragment :
 
     override fun getFragmentTitle() = screenTitle
 
-    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_done, menu)
-    }
-
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
+    fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
                 ActivityUtils.hideKeyboard(activity)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressFragment.kt
@@ -5,13 +5,10 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.widget.Button
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -5,6 +5,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -40,8 +41,7 @@ typealias OnHazmatCategorySelected = (ShippingLabelHazmatCategory) -> Unit
 @AndroidEntryPoint
 class EditShippingLabelPackagesFragment :
     BaseFragment(R.layout.fragment_edit_shipping_label_packages),
-    BackPressListener,
-    MenuProvider {
+    BackPressListener {
     companion object {
         const val EDIT_PACKAGES_CLOSED = "edit_packages_closed"
         const val EDIT_PACKAGES_RESULT = "edit_packages_result"
@@ -70,13 +70,7 @@ class EditShippingLabelPackagesFragment :
 
     override fun getFragmentTitle() = getString(R.string.orderdetail_shipping_label_item_package_info)
 
-    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_done, menu)
-        doneMenuItem = menu.findItem(R.id.menu_done)
-        doneMenuItem.isVisible = viewModel.viewStateData.liveData.value?.isDataValid ?: false
-    }
-
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
+    fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
                 viewModel.onDoneButtonClicked()
@@ -91,9 +85,8 @@ class EditShippingLabelPackagesFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
-
         val binding = FragmentEditShippingLabelPackagesBinding.bind(view)
+        setupToolbar(binding)
         with(binding.packagesList) {
             layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
             adapter = packagesAdapter
@@ -105,6 +98,23 @@ class EditShippingLabelPackagesFragment :
 
         setupObservers(binding)
         setupResultHandlers()
+    }
+
+    private fun setupToolbar(binding: FragmentEditShippingLabelPackagesBinding) {
+        binding.toolbar.title = getString(R.string.orderdetail_shipping_label_item_package_info)
+        binding.toolbar.setOnMenuItemClickListener { menuItem ->
+            onMenuItemSelected(menuItem)
+        }
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            onRequestAllowBackPress()
+        }
+        binding.toolbar.inflateMenu(R.menu.menu_done)
+        doneMenuItem = binding.toolbar.menu.findItem(R.id.menu_done)
+        doneMenuItem.isVisible = viewModel.viewStateData.liveData.value?.isDataValid ?: false
     }
 
     private fun setupResultHandlers() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesFragment.kt
@@ -1,12 +1,9 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DefaultItemAnimator

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -1,24 +1,18 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.AppUrls
-import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentEditShippingLabelPaymentBinding
 import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.navigateBackWithNotice
 import com.woocommerce.android.extensions.navigateBackWithResult
-import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -200,20 +200,13 @@ class EditShippingLabelPaymentFragment :
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is AddPaymentMethod -> {
-                    (activity as? MainActivity)?.navigateToWebViewNew(
-                        MainActivityViewModel.ViewUrlInWebViewNew(
+                    (activity as? MainActivity)?.navigateToWebView(
+                        MainActivityViewModel.ViewUrlInWebView(
                             AppUrls.WPCOM_ADD_PAYMENT_METHOD,
                             urlsToTriggerExit = arrayOf(FETCH_PAYMENT_METHOD_URL_PATH),
                             title = getFragmentTitle()
                         )
                     )
-//                    findNavController().navigate(
-//                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(
-//                            urlToLoad = AppUrls.WPCOM_ADD_PAYMENT_METHOD,
-//                            urlsToTriggerExit = arrayOf(FETCH_PAYMENT_METHOD_URL_PATH),
-//                            title = getFragmentTitle()
-//                        )
-//                    )
                 }
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ExitWithResult<*> -> navigateBackWithResult(EDIT_PAYMENTS_RESULT, event.data)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesFragment.kt
@@ -2,12 +2,9 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import android.annotation.SuppressLint
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DefaultItemAnimator

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesFragment.kt
@@ -6,6 +6,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -34,8 +35,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class ShippingCarrierRatesFragment :
     BaseFragment(R.layout.fragment_shipping_carrier_rates),
-    BackPressListener,
-    MenuProvider {
+    BackPressListener {
     companion object {
         const val SHIPPING_CARRIERS_CLOSED = "shipping_carriers_closed"
         const val SHIPPING_CARRIERS_RESULT = "shipping_carriers_result"
@@ -73,13 +73,27 @@ class ShippingCarrierRatesFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
-
         _binding = FragmentShippingCarrierRatesBinding.bind(view)
-
+        setupToolbar()
         initializeViewModel()
         initializeViews()
+    }
+
+    private fun setupToolbar() {
+        binding.toolbar.title = getString(R.string.shipping_label_shipping_carriers_title)
+        binding.toolbar.setOnMenuItemClickListener { menuItem ->
+            onMenuItemSelected(menuItem)
+        }
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            onRequestAllowBackPress()
+        }
+        binding.toolbar.inflateMenu(R.menu.menu_done)
+        doneMenuItem = binding.toolbar.menu.findItem(R.id.menu_done)
+        doneMenuItem?.isVisible = viewModel.viewStateData.liveData.value?.isDoneButtonVisible ?: false
     }
 
     private fun initializeViewModel() {
@@ -101,13 +115,7 @@ class ShippingCarrierRatesFragment :
 
     override fun getFragmentTitle() = getString(R.string.shipping_label_shipping_carriers_title)
 
-    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_done, menu)
-        doneMenuItem = menu.findItem(R.id.menu_done)
-        doneMenuItem?.isVisible = viewModel.viewStateData.liveData.value?.isDoneButtonVisible ?: false
-    }
-
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
+    private fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
                 ActivityUtils.hideKeyboard(activity)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -1,12 +1,9 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DefaultItemAnimator

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsFragment.kt
@@ -5,6 +5,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -30,8 +31,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class ShippingCustomsFragment :
     BaseFragment(R.layout.fragment_shipping_customs),
-    BackPressListener,
-    MenuProvider {
+    BackPressListener {
     companion object {
         const val EDIT_CUSTOMS_CLOSED = "edit_customs_closed"
         const val EDIT_CUSTOMS_RESULT = "edit_customs_result"
@@ -51,13 +51,7 @@ class ShippingCustomsFragment :
         )
     }
 
-    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_done, menu)
-        doneMenuItem = menu.findItem(R.id.menu_done)
-        doneMenuItem.isVisible = viewModel.viewStateData.liveData.value?.canSubmitForm ?: false
-    }
-
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
+    private fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
                 viewModel.onDoneButtonClicked()
@@ -72,9 +66,8 @@ class ShippingCustomsFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
-
         val binding = FragmentShippingCustomsBinding.bind(view)
+        setupToolbar(binding)
         binding.packagesList.apply {
             this.adapter = customsAdapter
             layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
@@ -94,6 +87,23 @@ class ShippingCustomsFragment :
         }
 
         setupObservers(binding)
+    }
+
+    private fun setupToolbar(binding: FragmentShippingCustomsBinding) {
+        binding.toolbar.title = getString(R.string.shipping_label_create_customs)
+        binding.toolbar.setOnMenuItemClickListener { menuItem ->
+            onMenuItemSelected(menuItem)
+        }
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            onRequestAllowBackPress()
+        }
+        binding.toolbar.inflateMenu(R.menu.menu_done)
+        doneMenuItem = binding.toolbar.menu.findItem(R.id.menu_done)
+        doneMenuItem.isVisible = viewModel.viewStateData.liveData.value?.canSubmitForm ?: false
     }
 
     private fun setupObservers(binding: FragmentShippingCustomsBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionFragment.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -63,9 +64,20 @@ class ShippingLabelAddressSuggestionFragment :
         super.onViewCreated(view, savedInstanceState)
 
         _binding = FragmentShippingLabelAddressSuggestionBinding.bind(view)
-
+        setupToolbar()
         initializeViewModel()
         initializeViews()
+    }
+
+    private fun setupToolbar() {
+//        binding.toolbar.title = getString(screenTitle)
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            onRequestAllowBackPress()
+        }
     }
 
     private fun initializeViewModel() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageFragment.kt
@@ -1,13 +1,10 @@
 package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.annotation.StringRes
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageFragment.kt
@@ -6,14 +6,17 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.annotation.StringRes
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentShippingLabelCreateCustomPackageBinding
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.CustomPackageType
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreateCustomPackageViewModel.InputName
 import com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreateCustomPackageViewModel.PackageSuccessfullyMadeEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -24,7 +27,7 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class ShippingLabelCreateCustomPackageFragment :
-    BaseFragment(R.layout.fragment_shipping_label_create_custom_package), MenuProvider {
+    BaseFragment(R.layout.fragment_shipping_label_create_custom_package) {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
     private var progressDialog: CustomProgressDialog? = null
@@ -36,18 +39,32 @@ class ShippingLabelCreateCustomPackageFragment :
 
     private val viewModel: ShippingLabelCreateCustomPackageViewModel by viewModels()
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentShippingLabelCreateCustomPackageBinding.bind(view)
-
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
+        setupToolbar()
 
         initializeInputFields()
         setupObservers()
     }
 
-    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_done, menu)
+    private fun setupToolbar() {
+        binding.toolbar.title = getString(R.string.shipping_label_package_selector_title)
+        binding.toolbar.setOnMenuItemClickListener { menuItem ->
+            onMenuItemSelected(menuItem)
+        }
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
+        binding.toolbar.inflateMenu(R.menu.menu_done)
+        binding.toolbar.menu.findItem(R.id.menu_done)
     }
 
     private fun initializeInputFields() {
@@ -157,7 +174,7 @@ class ShippingLabelCreateCustomPackageFragment :
         progressDialog = null
     }
 
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
+    private fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
                 ActivityUtils.hideKeyboard(activity)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreatePackageFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreatePackageFragment.kt
@@ -2,7 +2,9 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
@@ -26,6 +28,7 @@ class ShippingLabelCreatePackageFragment : BaseFragment(R.layout.fragment_shippi
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentShippingLabelCreatePackageBinding.bind(view)
+        setupToolbar(binding)
         val tabLayout = binding.createPackageTabLayout
         val viewPager = binding.createPackagePager
 
@@ -34,6 +37,17 @@ class ShippingLabelCreatePackageFragment : BaseFragment(R.layout.fragment_shippi
 
         initializeTabs(tabLayout, viewPager)
         setupObservers(viewModel)
+    }
+
+    private fun setupToolbar(binding: FragmentShippingLabelCreatePackageBinding) {
+        binding.toolbar.title = getString(R.string.shipping_label_create_package_title)
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
     }
 
     private fun initializeTabs(tabLayout: TabLayout, viewPager: ViewPager2) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.shippinglabels.creation
 
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -39,7 +40,7 @@ class ShippingPackageSelectorFragment : BaseFragment(R.layout.fragment_shipping_
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentShippingPackagesSelectorBinding.bind(view)
-
+        setupToolbar(binding)
         with(binding.packagesList) {
             layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
             adapter = packagesAdapter
@@ -49,6 +50,17 @@ class ShippingPackageSelectorFragment : BaseFragment(R.layout.fragment_shipping_
             viewModel.onCreateNewPackageButtonClicked()
         }
         setupObservers(binding)
+    }
+
+    private fun setupToolbar(binding: FragmentShippingPackagesSelectorBinding) {
+        binding.toolbar.title = getString(R.string.shipping_label_package_selector_title)
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
     }
 
     private fun setupObservers(binding: FragmentShippingPackagesSelectorBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -6,6 +6,7 @@ import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import androidx.annotation.DrawableRes
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.getColor
 import androidx.core.view.get
@@ -27,6 +28,7 @@ import com.woocommerce.android.extensions.startHelpActivity
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UiHelpers
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -43,10 +45,25 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
 
     val viewModel: CardReaderOnboardingViewModel by viewModels()
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentCardReaderOnboardingBinding.bind(view)
+        setupToolbar(binding)
         initObservers(binding)
+    }
+
+    private fun setupToolbar(binding: FragmentCardReaderOnboardingBinding) {
+        binding.toolbar.title = resources.getString(R.string.card_reader_onboarding_title)
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
     }
 
     private fun initObservers(binding: FragmentCardReaderOnboardingBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
@@ -80,6 +80,7 @@ class CardReaderPaymentDialogFragment : PaymentsBaseDialogFragment(R.layout.card
         viewModel.start()
     }
 
+    @Suppress("LongMethod")
     private fun initObservers(binding: CardReaderPaymentDialogBinding) {
         viewModel.event.observe(
             viewLifecycleOwner

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
@@ -13,6 +13,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.ComponentDialog
 import androidx.activity.addCallback
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.BaseTransientBottomBar
@@ -26,6 +27,7 @@ import com.woocommerce.android.model.UiString
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.requests.SupportRequestFormActivity
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.orders.list.SelectedOrderTrackerViewModel
 import com.woocommerce.android.ui.payments.PaymentsBaseDialogFragment
 import com.woocommerce.android.ui.payments.cardreader.payment.ViewState.BuiltInReaderPaymentSuccessfulReceiptSentAutomaticallyState
 import com.woocommerce.android.ui.payments.cardreader.payment.ViewState.BuiltInReaderPaymentSuccessfulState
@@ -46,6 +48,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class CardReaderPaymentDialogFragment : PaymentsBaseDialogFragment(R.layout.card_reader_payment_dialog) {
     val viewModel: CardReaderPaymentViewModel by viewModels()
+    private val selectedOrderTrackerViewModel: SelectedOrderTrackerViewModel by activityViewModels()
 
     @Inject
     lateinit var printHtmlHelper: PrintHtmlHelper
@@ -87,13 +90,19 @@ class CardReaderPaymentDialogFragment : PaymentsBaseDialogFragment(R.layout.card
                     event.receiptUrl,
                     event.documentName
                 )
-                InteracRefundSuccessful -> navigateBackWithNotice(KEY_INTERAC_SUCCESS)
+                InteracRefundSuccessful -> {
+                    navigateBackWithNotice(KEY_INTERAC_SUCCESS)
+                    selectedOrderTrackerViewModel.refreshOrders()
+                }
                 is SendReceipt -> composeEmail(event.address, event.subject, event.content)
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ShowSnackbarInDialog -> Snackbar.make(
                     requireView(), event.message, BaseTransientBottomBar.LENGTH_LONG
                 ).show()
-                is PlayChaChing -> playChaChing()
+                is PlayChaChing -> {
+                    playChaChing()
+                    selectedOrderTrackerViewModel.refreshOrders()
+                }
                 is ContactSupport -> openSupportRequestScreen()
                 is EnableNfc -> openEnableNfcScreen()
                 is PurchaseCardReader -> openPurchaseCardReaderScreen(event.url)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubFragment.kt
@@ -5,6 +5,7 @@ import android.text.method.LinkMovementMethod
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isInvisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.viewModels
@@ -21,6 +22,7 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.feedback.SurveyType
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingParams
 import com.woocommerce.android.ui.payments.hub.PaymentsHubViewModel.PaymentsHubEvents.NavigateToTapTooPaySummaryScreen
@@ -41,6 +43,9 @@ class PaymentsHubFragment : BaseFragment(R.layout.fragment_payments_hub) {
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     override fun getFragmentTitle() = resources.getString(R.string.payments_hub_title)
     val viewModel: PaymentsHubViewModel by viewModels()
 
@@ -48,10 +53,21 @@ class PaymentsHubFragment : BaseFragment(R.layout.fragment_payments_hub) {
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentPaymentsHubBinding.bind(view)
-
+        setupToolbar(binding)
         initViews(binding)
         observeEvents()
         observeViewState(binding)
+    }
+
+    private fun setupToolbar(binding: FragmentPaymentsHubBinding) {
+        binding.toolbar.title = resources.getString(R.string.payments_hub_title)
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
     }
 
     private fun initViews(binding: FragmentPaymentsHubBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -22,6 +23,7 @@ import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.dialog.WooDialog
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectDialogFragment
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentDialogFragment
@@ -47,14 +49,27 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
     private var _binding: FragmentSelectPaymentMethodBinding? = null
     private val binding get() = _binding!!
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentSelectPaymentMethodBinding.inflate(inflater, container, false)
-
+        setupToolbar()
         return binding.root
+    }
+
+    private fun setupToolbar() {
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -92,7 +107,7 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
         binding.tvSelectPaymentTitle.isVisible = true
         binding.pbLoading.isVisible = false
 
-        requireActivity().title = getString(R.string.simple_payments_take_payment_button, state.orderTotal)
+        binding.toolbar.title = getString(R.string.simple_payments_take_payment_button, state.orderTotal)
 
         binding.container.removeAllViews()
         state.rows.forEach { row ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundFragment.kt
@@ -7,12 +7,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentIssueRefundBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
@@ -30,16 +32,18 @@ import javax.inject.Inject
 class IssueRefundFragment : BaseFragment() {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 
+    private var _binding: FragmentIssueRefundBinding? = null
+    private val binding get() = _binding!!
+
     private val viewModel: IssueRefundViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_refunds)
 
     override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Visible(
-            navigationIcon = R.drawable.ic_gridicons_cross_24dp
-        )
+        get() = AppBarStatus.Hidden
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreate(savedInstanceState)
-        return inflater.inflate(R.layout.fragment_issue_refund, container, false)
+        _binding = FragmentIssueRefundBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onResume() {
@@ -55,9 +59,20 @@ class IssueRefundFragment : BaseFragment() {
             .replace(R.id.issueRefund_frame, RefundByItemsFragment())
             .commit()
 
+        setupToolbar()
         // TODO: Temporary; it will be used again in a future release - do not remove
 //        initializeViews(viewModel)
         setupObservers(viewModel)
+    }
+
+    private fun setupToolbar() {
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
     }
 
     // TODO: Temporary; it will be used again in a future release - do not remove
@@ -76,7 +91,9 @@ class IssueRefundFragment : BaseFragment() {
 
     private fun setupObservers(viewModel: IssueRefundViewModel) {
         viewModel.commonStateLiveData.observe(viewLifecycleOwner) { old, new ->
-            new.screenTitle?.takeIfNotEqualTo(old?.screenTitle) { requireActivity().title = it }
+            new.screenTitle?.takeIfNotEqualTo(old?.screenTitle) {
+                binding.toolbar.title = it
+            }
 
             // As the tabs are hidden, this logic is not used for now
 //            if (new.refundType == AMOUNT) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundByItemsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundByItemsFragment.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.IssueRefundEvent.OpenUrl
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.IssueRefundEvent.ShowNumberPicker
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.IssueRefundEvent.ShowRefundAmountDialog
@@ -56,6 +57,8 @@ class RefundByItemsFragment :
 
     private val viewModel: IssueRefundViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_refunds)
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryFragment.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.payments.refunds
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.widget.doOnTextChanged
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
@@ -16,6 +17,7 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.IssueRefundEvent.ShowRefundConfirmation
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -38,6 +40,9 @@ class RefundSummaryFragment : BaseFragment(R.layout.fragment_refund_summary), Ba
     private var _binding: FragmentRefundSummaryBinding? = null
     private val binding get() = _binding!!
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
@@ -47,9 +52,19 @@ class RefundSummaryFragment : BaseFragment(R.layout.fragment_refund_summary), Ba
         super.onViewCreated(view, savedInstanceState)
 
         _binding = FragmentRefundSummaryBinding.bind(view)
-
+        setupToolbar()
         initializeViews()
         setupObservers()
+    }
+
+    private fun setupToolbar() {
+        binding.toolbar.navigationIcon = AppCompatResources.getDrawable(
+            requireActivity(),
+            R.drawable.ic_back_24dp
+        )
+        binding.toolbar.setNavigationOnClickListener {
+            onRequestAllowBackPress()
+        }
     }
 
     override fun onDestroyView() {
@@ -87,6 +102,9 @@ class RefundSummaryFragment : BaseFragment(R.layout.fragment_refund_summary), Ba
             }
             new.refundAmount?.takeIfNotEqualTo(old?.refundAmount) {
                 binding.refundSummaryRefundAmount.text = it
+                binding.toolbar.title = resources.getString(
+                    R.string.order_refunds_title_with_amount, it
+                )
             }
             new.previouslyRefunded?.takeIfNotEqualTo(old?.previouslyRefunded) {
                 binding.refundSummaryPreviouslyRefunded.text = it

--- a/WooCommerce/src/main/res/layout/fragment_add_order_note.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_order_note.xml
@@ -8,6 +8,17 @@
     android:orientation="vertical"
     tools:context="com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        app:layout_collapseMode="pin"
+        style="@style/Widget.Woo.Toolbar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name"/>
+
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/addNote_editContainer"
         style="@style/Woo.Card"

--- a/WooCommerce/src/main/res/layout/fragment_add_order_note.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_order_note.xml
@@ -12,6 +12,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
         app:layout_collapseMode="pin"
         style="@style/Widget.Woo.Toolbar"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
@@ -1,32 +1,50 @@
-<?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical">
 
-    <ScrollView
-        android:id="@+id/edit_address_scroll"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        app:layout_collapseMode="pin"
+        style="@style/Widget.Woo.Toolbar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name"/>
+
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <include
-            android:id="@+id/form"
-            layout="@layout/layout_address_form" />
+        <ScrollView
+            android:id="@+id/edit_address_scroll"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-    </ScrollView>
+            <include
+                android:id="@+id/form"
+                layout="@layout/layout_address_form" />
 
-    <FrameLayout
-        android:id="@+id/progressBar"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/grey_c_30"
-        android:clickable="true"
-        android:focusable="true">
+        </ScrollView>
 
-        <ProgressBar
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center" />
+        <FrameLayout
+            android:id="@+id/progressBar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/grey_c_30"
+            android:clickable="true"
+            android:focusable="true">
+
+            <ProgressBar
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center" />
+
+        </FrameLayout>
 
     </FrameLayout>
-
-</FrameLayout>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_base_edit_address.xml
@@ -9,6 +9,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
         app:layout_collapseMode="pin"
         style="@style/Widget.Woo.Toolbar"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding.xml
@@ -12,7 +12,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/toolbar_height"
-        android:elevation="@dimen/minor_50"
+        android:elevation="@dimen/appbar_elevation"
         app:layout_collapseMode="pin"
         style="@style/Widget.Woo.Toolbar"
         tools:title="@string/app_name"/>

--- a/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding.xml
+++ b/WooCommerce/src/main/res/layout/fragment_card_reader_onboarding.xml
@@ -3,10 +3,24 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     tools:context="com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingFragment">
 
-    <View style="@style/Woo.Divider" />
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        style="@style/Widget.Woo.Toolbar"
+        tools:title="@string/app_name"/>
+
+    <View
+        android:id="@+id/app_bar_divider"
+        android:layout_gravity="bottom"
+        style="@style/Woo.Divider" />
 
     <ScrollView
         android:id="@+id/container"

--- a/WooCommerce/src/main/res/layout/fragment_create_shipping_label.xml
+++ b/WooCommerce/src/main/res/layout/fragment_create_shipping_label.xml
@@ -1,112 +1,136 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/snack_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fillViewport="true">
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
 
-        <com.woocommerce.android.widgets.WCEmptyView
-            android:id="@+id/error_view"
+    <View
+        android:id="@+id/app_bar_divider"
+        style="@style/Woo.Divider"
+        android:layout_gravity="bottom" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <com.woocommerce.android.ui.orders.shippinglabels.creation.banner.ShippingNoticeCard
-            android:id="@+id/shipping_notice_banner"
-            style="@style/Woo.Card"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:visibility="gone"/>
-
-        <com.woocommerce.android.widgets.WCElevatedLinearLayout
-            android:id="@+id/steps_layout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/major_100"
             android:orientation="vertical">
 
-            <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
-                android:id="@+id/originStep"
+            <com.woocommerce.android.widgets.WCEmptyView
+                android:id="@+id/error_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:caption="@string/orderdetail_shipping_label_item_shipfrom"
-                app:icon="@drawable/ic_gridicons_shipping"
-                tools:continue_button_visible="false"
-                tools:details="Some address\nSecond line\nThird"
-                tools:edit_button_visible="true"
-                tools:enabled="true" />
+                android:layout_gravity="center"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-            <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
-                android:id="@+id/shippingStep"
+            <com.woocommerce.android.ui.orders.shippinglabels.creation.banner.ShippingNoticeCard
+                android:id="@+id/shipping_notice_banner"
+                style="@style/Woo.Card"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:caption="@string/orderdetail_shipping_label_item_shipto"
-                app:icon="@drawable/ic_gridicons_house"
-                tools:continue_button_visible="true"
-                tools:details="Some address\nSecond line\nThird"
-                tools:edit_button_visible="false"
-                tools:enabled="true" />
+                android:visibility="gone" />
 
-            <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
-                android:id="@+id/packagingStep"
+            <com.woocommerce.android.widgets.WCElevatedLinearLayout
+                android:id="@+id/steps_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:caption="@string/shipping_label_create_packaging_details"
-                app:details="@string/shipping_label_create_packaging_details_description"
-                app:icon="@drawable/ic_product"
-                tools:continue_button_visible="false"
-                tools:edit_button_visible="false"
-                tools:enabled="false" />
+                android:layout_marginBottom="@dimen/major_100"
+                android:orientation="vertical">
 
-            <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
-                android:id="@+id/customsStep"
+                <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
+                    android:id="@+id/originStep"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:caption="@string/orderdetail_shipping_label_item_shipfrom"
+                    app:icon="@drawable/ic_gridicons_shipping"
+                    tools:continue_button_visible="false"
+                    tools:details="Some address\nSecond line\nThird"
+                    tools:edit_button_visible="true"
+                    tools:enabled="true" />
+
+                <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
+                    android:id="@+id/shippingStep"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:caption="@string/orderdetail_shipping_label_item_shipto"
+                    app:icon="@drawable/ic_gridicons_house"
+                    tools:continue_button_visible="true"
+                    tools:details="Some address\nSecond line\nThird"
+                    tools:edit_button_visible="false"
+                    tools:enabled="true" />
+
+                <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
+                    android:id="@+id/packagingStep"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:caption="@string/shipping_label_create_packaging_details"
+                    app:details="@string/shipping_label_create_packaging_details_description"
+                    app:icon="@drawable/ic_product"
+                    tools:continue_button_visible="false"
+                    tools:edit_button_visible="false"
+                    tools:enabled="false" />
+
+                <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
+                    android:id="@+id/customsStep"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:caption="@string/shipping_label_create_customs"
+                    app:details="@string/shipping_label_create_customs_description"
+                    app:icon="@drawable/ic_gridicons_globe"
+                    tools:continue_button_visible="false"
+                    tools:edit_button_visible="false"
+                    tools:enabled="false" />
+
+                <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
+                    android:id="@+id/carrierStep"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:caption="@string/orderdetail_shipping_label_item_carrier"
+                    app:details="@string/shipping_label_create_carrier_description"
+                    app:icon="@drawable/ic_gridicons_money"
+                    tools:continue_button_visible="false"
+                    tools:edit_button_visible="false"
+                    tools:enabled="false" />
+
+                <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
+                    android:id="@+id/paymentStep"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:caption="@string/orderdetail_shipping_label_item_payment"
+                    app:details="@string/shipping_label_create_payment_description"
+                    app:divider_visible="false"
+                    app:icon="@drawable/ic_gridicons_credit_card"
+                    tools:continue_button_visible="false"
+                    tools:edit_button_visible="false"
+                    tools:enabled="false" />
+            </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+
+            <include
+                android:id="@+id/order_summary_layout"
+                layout="@layout/view_shipping_label_order_summary"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:caption="@string/shipping_label_create_customs"
-                app:details="@string/shipping_label_create_customs_description"
-                app:icon="@drawable/ic_gridicons_globe"
-                tools:continue_button_visible="false"
-                tools:edit_button_visible="false"
-                tools:enabled="false" />
-
-            <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
-                android:id="@+id/carrierStep"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:caption="@string/orderdetail_shipping_label_item_carrier"
-                app:details="@string/shipping_label_create_carrier_description"
-                app:icon="@drawable/ic_gridicons_money"
-                tools:continue_button_visible="false"
-                tools:edit_button_visible="false"
-                tools:enabled="false" />
-
-            <com.woocommerce.android.ui.orders.shippinglabels.creation.ShippingLabelCreationStepView
-                android:id="@+id/paymentStep"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:caption="@string/orderdetail_shipping_label_item_payment"
-                app:details="@string/shipping_label_create_payment_description"
-                app:divider_visible="false"
-                app:icon="@drawable/ic_gridicons_credit_card"
-                tools:continue_button_visible="false"
-                tools:edit_button_visible="false"
-                tools:enabled="false" />
-        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
-
-        <include
-            android:id="@+id/order_summary_layout"
-            layout="@layout/view_shipping_label_order_summary"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/major_100" />
-    </LinearLayout>
-</ScrollView>
+                android:layout_marginBottom="@dimen/major_100" />
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_address.xml
@@ -1,206 +1,230 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/snack_root"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <com.woocommerce.android.widgets.WCElevatedLinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/minor_100"
-        android:orientation="vertical">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/errorBanner"
+    <View
+        android:id="@+id/app_bar_divider"
+        style="@style/Woo.Divider"
+        android:layout_gravity="bottom" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.woocommerce.android.widgets.WCElevatedLinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:animateLayoutChanges="true"
-            android:background="@color/warning_banner_background_color"
-            android:clickable="true"
-            android:focusable="true"
-            android:visibility="gone"
-            tools:visibility="visible">
+            android:layout_marginBottom="@dimen/minor_100"
+            android:orientation="vertical">
 
-            <ImageView
-                android:id="@+id/errorBannerIcon"
-                android:layout_width="wrap_content"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/errorBanner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:animateLayoutChanges="true"
+                android:background="@color/warning_banner_background_color"
+                android:clickable="true"
+                android:focusable="true"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <ImageView
+                    android:id="@+id/errorBannerIcon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:contentDescription="@string/shipping_label_edit_address_validation_error"
+                    android:src="@drawable/ic_tintable_info_outline_24dp"
+                    app:layout_constraintBottom_toTopOf="@id/errorBannerDivider"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/errorBannerMessage"
+                    app:layout_constraintVertical_bias="0.0"
+                    app:tint="@color/warning_banner_foreground_color"
+                    tools:visibility="visible" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/contactCustomerButton"
+                    style="@style/Woo.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/shipping_label_validation_contact_customer"
+                    android:textColor="@color/color_on_surface_high"
+                    app:layout_constraintBottom_toTopOf="@id/errorBannerDivider"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/errorBannerMessage" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/errorBannerMessage"
+                    style="@style/Woo.TextView.Warning"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_200"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:text="@string/shipping_label_edit_address_error_warning"
+                    app:layout_constraintBottom_toTopOf="@id/openMapButton"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/errorBannerIcon"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:visibility="visible" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/openMapButton"
+                    style="@style/Woo.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/shipping_label_validation_view_map"
+                    android:textColor="@color/color_on_surface_high"
+                    app:layout_constraintBottom_toTopOf="@id/errorBannerDivider"
+                    app:layout_constraintEnd_toStartOf="@id/contactCustomerButton"
+                    app:layout_constraintTop_toBottomOf="@id/errorBannerMessage" />
+
+                <View
+                    android:id="@+id/errorBannerDivider"
+                    style="@style/Woo.Divider.Warning"
+                    android:layout_width="@dimen/minor_00"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_100"
+                android:hint="@string/shipping_label_edit_address_name"
+                android:inputType="text"
+                android:nextFocusForward="@id/company"
+                app:errorEnabled="true" />
+
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/company"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:hint="@string/shipping_label_edit_address_company"
+                android:inputType="text"
+                android:nextFocusForward="@+id/phone"
+                app:errorEnabled="true" />
+
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/phone"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:hint="@string/shipping_label_edit_address_phone"
+                android:inputType="text"
+                android:nextFocusForward="@+id/address1"
+                app:errorEnabled="true" />
+
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/address1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:hint="@string/shipping_label_edit_address_line1"
+                android:inputType="text"
+                android:nextFocusForward="@+id/address2"
+                app:errorEnabled="true" />
+
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/address2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:hint="@string/shipping_label_edit_address_line2"
+                android:inputType="text"
+                android:nextFocusForward="@+id/city"
+                app:errorEnabled="true" />
+
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/city"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:hint="@string/shipping_label_edit_address_city"
+                android:inputType="text"
+                android:nextFocusForward="@+id/state"
+                app:errorEnabled="true" />
+
+            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                android:id="@+id/countrySpinner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/minor_00"
+                android:layout_marginEnd="@dimen/major_100"
+                android:layout_marginBottom="@dimen/major_100"
+                android:hint="@string/shipping_label_edit_address_country"
+                android:inputType="text"
+                android:nextFocusForward="@+id/useAddressAsIsButton"
+                android:textAppearance="@style/TextAppearance.Woo.Caption" />
+
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/state"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:hint="@string/shipping_label_edit_address_state"
+                android:inputType="text"
+                android:nextFocusForward="@+id/zip"
+                app:errorEnabled="true" />
+
+            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                android:id="@+id/stateSpinner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/minor_00"
+                android:layout_marginEnd="@dimen/major_100"
+                android:layout_marginBottom="@dimen/major_100"
+                android:hint="@string/shipping_label_edit_address_state"
+                android:inputType="text"
+                android:nextFocusForward="@+id/zip"
+                android:textAppearance="@style/TextAppearance.Woo.Caption" />
+
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/zip"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:hint="@string/shipping_label_edit_address_zip"
+                android:inputType="text"
+                android:nextFocusForward="@+id/countrySpinner"
+                app:errorEnabled="true" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/useAddressAsIsButton"
+                style="@style/Woo.Button.Outlined"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_marginEnd="@dimen/major_100"
-                android:contentDescription="@string/shipping_label_edit_address_validation_error"
-                android:src="@drawable/ic_tintable_info_outline_24dp"
-                app:layout_constraintBottom_toTopOf="@id/errorBannerDivider"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/errorBannerMessage"
-                app:layout_constraintVertical_bias="0.0"
-                app:tint="@color/warning_banner_foreground_color"
-                tools:visibility="visible" />
+                android:layout_marginBottom="@dimen/major_100"
+                android:text="@string/shipping_label_edit_address_use_address_as_is"
+                app:layout_goneMarginBottom="@dimen/major_100" />
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/contactCustomerButton"
-                style="@style/Woo.Button.TextButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/shipping_label_validation_contact_customer"
-                android:textColor="@color/color_on_surface_high"
-                app:layout_constraintBottom_toTopOf="@id/errorBannerDivider"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/errorBannerMessage" />
+        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/errorBannerMessage"
-                style="@style/Woo.TextView.Warning"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_200"
-                android:layout_marginTop="@dimen/major_100"
-                android:text="@string/shipping_label_edit_address_error_warning"
-                app:layout_constraintBottom_toTopOf="@id/openMapButton"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/errorBannerIcon"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:visibility="visible" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/openMapButton"
-                style="@style/Woo.Button.TextButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/shipping_label_validation_view_map"
-                android:textColor="@color/color_on_surface_high"
-                app:layout_constraintBottom_toTopOf="@id/errorBannerDivider"
-                app:layout_constraintEnd_toStartOf="@id/contactCustomerButton"
-                app:layout_constraintTop_toBottomOf="@id/errorBannerMessage" />
-
-            <View
-                android:id="@+id/errorBannerDivider"
-                style="@style/Woo.Divider.Warning"
-                android:layout_width="@dimen/minor_00"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/name"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_100"
-            android:hint="@string/shipping_label_edit_address_name"
-            android:inputType="text"
-            android:nextFocusForward="@id/company"
-            app:errorEnabled="true" />
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/company"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/major_100"
-            android:hint="@string/shipping_label_edit_address_company"
-            android:inputType="text"
-            android:nextFocusForward="@+id/phone"
-            app:errorEnabled="true" />
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/phone"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/major_100"
-            android:hint="@string/shipping_label_edit_address_phone"
-            android:inputType="text"
-            android:nextFocusForward="@+id/address1"
-            app:errorEnabled="true" />
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/address1"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/major_100"
-            android:hint="@string/shipping_label_edit_address_line1"
-            android:inputType="text"
-            android:nextFocusForward="@+id/address2"
-            app:errorEnabled="true" />
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/address2"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/major_100"
-            android:hint="@string/shipping_label_edit_address_line2"
-            android:inputType="text"
-            android:nextFocusForward="@+id/city"
-            app:errorEnabled="true" />
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/city"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/shipping_label_edit_address_city"
-            android:layout_marginHorizontal="@dimen/major_100"
-            android:inputType="text"
-            android:nextFocusForward="@+id/state"
-            app:errorEnabled="true"/>
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-            android:id="@+id/countrySpinner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/minor_00"
-            android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_100"
-            android:hint="@string/shipping_label_edit_address_country"
-            android:inputType="text"
-            android:nextFocusForward="@+id/useAddressAsIsButton"
-            android:textAppearance="@style/TextAppearance.Woo.Caption" />
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/state"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/shipping_label_edit_address_state"
-            android:layout_marginHorizontal="@dimen/major_100"
-            android:inputType="text"
-            android:nextFocusForward="@+id/zip"
-            app:errorEnabled="true"/>
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-            android:id="@+id/stateSpinner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/minor_00"
-            android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_100"
-            android:hint="@string/shipping_label_edit_address_state"
-            android:inputType="text"
-            android:nextFocusForward="@+id/zip"
-            android:textAppearance="@style/TextAppearance.Woo.Caption" />
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/zip"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/major_100"
-            android:inputType="text"
-            android:hint="@string/shipping_label_edit_address_zip"
-            android:nextFocusForward="@+id/countrySpinner"
-            app:errorEnabled="true"/>
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/useAddressAsIsButton"
-            style="@style/Woo.Button.Outlined"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_100"
-            android:text="@string/shipping_label_edit_address_use_address_as_is"
-            app:layout_goneMarginBottom="@dimen/major_100" />
-
-    </com.woocommerce.android.widgets.WCElevatedLinearLayout>
-
-</ScrollView>
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_packages.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_packages.xml
@@ -2,7 +2,26 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
+
+    <View
+        android:id="@+id/app_bar_divider"
+        style="@style/Woo.Divider"
+        android:layout_gravity="bottom" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/packages_list"

--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_payment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_payment.xml
@@ -1,110 +1,133 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <ScrollView
-        android:id="@+id/content_layout"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
+
+    <View
+        android:id="@+id/app_bar_divider"
+        style="@style/Woo.Divider"
+        android:layout_gravity="bottom" />
+
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <com.woocommerce.android.widgets.WCElevatedLinearLayout
+        <ScrollView
+            android:id="@+id/content_layout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:layout_height="match_parent">
 
-            <com.woocommerce.android.widgets.WCWarningBanner
-                android:id="@+id/edit_warning_banner"
+            <com.woocommerce.android.widgets.WCElevatedLinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:visibility="gone"
-                tools:text="@string/shipping_label_payments_cant_edit_warning"
-                tools:visibility="visible" />
+                android:orientation="vertical">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/payment_methods_section_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_75"
-                android:layout_marginEnd="@dimen/major_100"
-                android:text="@string/shipping_label_payments_selected_payment_method"
-                android:textAppearance="?attr/textAppearanceSubtitle1"
-                app:layout_constrainedWidth="true" />
+                <com.woocommerce.android.widgets.WCWarningBanner
+                    android:id="@+id/edit_warning_banner"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone"
+                    tools:text="@string/shipping_label_payments_cant_edit_warning"
+                    tools:visibility="visible" />
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/payment_methods_list"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/major_100"
-                tools:itemCount="2"
-                tools:listitem="@layout/shipping_label_payment_method_list_item" />
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/payment_methods_section_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_75"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:text="@string/shipping_label_payments_selected_payment_method"
+                    android:textAppearance="?attr/textAppearanceSubtitle1"
+                    app:layout_constrainedWidth="true" />
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/add_first_payment_method_button"
-                style="@style/Woo.Button.Outlined"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:layout_marginBottom="@dimen/major_100"
-                android:text="@string/shipping_label_payments_add_first_credit_card"
-                app:icon="@drawable/ic_external"
-                app:iconGravity="textEnd"
-                app:iconPadding="@dimen/minor_100"
-                android:visibility="gone"/>
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/payment_methods_list"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/major_100"
+                    tools:itemCount="2"
+                    tools:listitem="@layout/shipping_label_payment_method_list_item" />
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/payments_info"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:breakStrategy="simple"
-                android:textAppearance="?attr/textAppearanceCaption"
-                tools:ignore="UnusedAttribute"
-                tools:text="Credit cards are retrieved from the following WordPress.com account: username user@email.com" />
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/add_first_payment_method_button"
+                    style="@style/Woo.Button.Outlined"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:layout_marginBottom="@dimen/major_100"
+                    android:text="@string/shipping_label_payments_add_first_credit_card"
+                    android:visibility="gone"
+                    app:icon="@drawable/ic_external"
+                    app:iconGravity="textEnd"
+                    app:iconPadding="@dimen/minor_100" />
 
-            <com.google.android.material.checkbox.MaterialCheckBox
-                android:id="@+id/email_receipts_checkbox"
-                style="@style/Woo.CheckBox"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_150"
-                android:layout_marginEnd="@dimen/major_100"
-                android:layout_marginBottom="@dimen/major_150"
-                android:gravity="top"
-                android:paddingStart="@dimen/minor_100"
-                android:textAppearance="?attr/textAppearanceSubtitle1"
-                tools:ignore="RtlSymmetry"
-                tools:text="Email the label purchase receipts to username (username) at user@email.com" />
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/payments_info"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:breakStrategy="simple"
+                    android:textAppearance="?attr/textAppearanceCaption"
+                    tools:ignore="UnusedAttribute"
+                    tools:text="Credit cards are retrieved from the following WordPress.com account: username user@email.com" />
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/add_payment_method_button"
-                style="@style/Woo.Button.Outlined"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:layout_marginBottom="@dimen/major_100"
-                android:text="@string/shipping_label_payments_add_credit_card"
-                app:icon="@drawable/ic_external"
-                app:iconGravity="textEnd"
-                app:iconPadding="@dimen/minor_100" />
+                <com.google.android.material.checkbox.MaterialCheckBox
+                    android:id="@+id/email_receipts_checkbox"
+                    style="@style/Woo.CheckBox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_150"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:layout_marginBottom="@dimen/major_150"
+                    android:gravity="top"
+                    android:paddingStart="@dimen/minor_100"
+                    android:textAppearance="?attr/textAppearanceSubtitle1"
+                    tools:ignore="RtlSymmetry"
+                    tools:text="Email the label purchase receipts to username (username) at user@email.com" />
 
-        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/add_payment_method_button"
+                    style="@style/Woo.Button.Outlined"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:layout_marginBottom="@dimen/major_100"
+                    android:text="@string/shipping_label_payments_add_credit_card"
+                    app:icon="@drawable/ic_external"
+                    app:iconGravity="textEnd"
+                    app:iconPadding="@dimen/minor_100" />
 
-    </ScrollView>
+            </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 
-    <com.woocommerce.android.widgets.WCEmptyView
-        android:id="@+id/error_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone"/>
-</FrameLayout>
+        </ScrollView>
+
+        <com.woocommerce.android.widgets.WCEmptyView
+            android:id="@+id/error_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone" />
+    </FrameLayout>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_payment.xml
+++ b/WooCommerce/src/main/res/layout/fragment_edit_shipping_label_payment.xml
@@ -11,7 +11,7 @@
         style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/toolbar_height"
-        android:elevation="@dimen/minor_50"
+        android:elevation="@dimen/appbar_elevation"
         app:layout_collapseMode="pin"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_issue_refund.xml
+++ b/WooCommerce/src/main/res/layout/fragment_issue_refund.xml
@@ -1,29 +1,53 @@
-<FrameLayout
-    android:id="@+id/issueRefund_frame"
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" />
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-<!-- TODO: Temporary; it will be used again in a future release - do not remove -->
-<!--<LinearLayout-->
-<!--    xmlns:android="http://schemas.android.com/apk/res/android"-->
-<!--    xmlns:tools="http://schemas.android.com/tools"-->
-<!--    xmlns:app="http://schemas.android.com/apk/res-auto"-->
-<!--    android:layout_width="match_parent"-->
-<!--    android:layout_height="match_parent"-->
-<!--    android:orientation="vertical"-->
-<!--    android:background="@color/default_window_background">-->
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        app:layout_collapseMode="pin"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
 
-<!--    <com.google.android.material.tabs.TabLayout-->
-<!--        android:id="@+id/issueRefund_tabLayout"-->
-<!--        style="@style/Woo.Refunds.TabLayout"-->
-<!--        app:tabMode="fixed"-->
-<!--        android:layout_width="match_parent"-->
-<!--        android:layout_height="wrap_content" />-->
+    <View
+        android:id="@+id/app_bar_divider"
+        style="@style/Woo.Divider"
+        android:layout_gravity="bottom" />
 
-<!--    <androidx.viewpager.widget.ViewPager-->
-<!--        android:id="@+id/issueRefund_viewPager"-->
-<!--        android:layout_width="match_parent"-->
-<!--        android:layout_height="match_parent" />-->
+    <FrameLayout
+        android:id="@+id/issueRefund_frame"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</LinearLayout>
 
-<!--</LinearLayout>-->
+    <!-- TODO: Temporary; it will be used again in a future release - do not remove -->
+    <!--<LinearLayout-->
+    <!--    xmlns:android="http://schemas.android.com/apk/res/android"-->
+    <!--    xmlns:tools="http://schemas.android.com/tools"-->
+    <!--    xmlns:app="http://schemas.android.com/apk/res-auto"-->
+    <!--    android:layout_width="match_parent"-->
+    <!--    android:layout_height="match_parent"-->
+    <!--    android:orientation="vertical"-->
+    <!--    android:background="@color/default_window_background">-->
+
+    <!--    <com.google.android.material.tabs.TabLayout-->
+    <!--        android:id="@+id/issueRefund_tabLayout"-->
+    <!--        style="@style/Woo.Refunds.TabLayout"-->
+    <!--        app:tabMode="fixed"-->
+    <!--        android:layout_width="match_parent"-->
+    <!--        android:layout_height="wrap_content" />-->
+
+    <!--    <androidx.viewpager.widget.ViewPager-->
+    <!--        android:id="@+id/issueRefund_viewPager"-->
+    <!--        android:layout_width="match_parent"-->
+    <!--        android:layout_height="match_parent" />-->
+
+    <!--</LinearLayout>-->

--- a/WooCommerce/src/main/res/layout/fragment_label_format_options.xml
+++ b/WooCommerce/src/main/res/layout/fragment_label_format_options.xml
@@ -11,7 +11,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/toolbar_height"
-        android:elevation="@dimen/minor_50"
+        android:elevation="@dimen/appbar_elevation"
         app:layout_collapseMode="pin"
         style="@style/Widget.Woo.Toolbar"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_label_format_options.xml
+++ b/WooCommerce/src/main/res/layout/fragment_label_format_options.xml
@@ -1,107 +1,131 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/snack_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/colorSurface">
+    android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        style="@style/Widget.Woo.Toolbar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name"/>
 
-        <androidx.constraintlayout.helper.widget.Flow
+    <View
+        android:id="@+id/app_bar_divider"
+        android:layout_gravity="bottom"
+        style="@style/Woo.Divider" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/colorSurface">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:constraint_referenced_ids="labelFormatOption_legalView,labelFormatOption_letterView,labelFormatOption_labelView"
-            app:flow_horizontalAlign="start"
-            app:flow_horizontalGap="@dimen/major_75"
-            app:flow_horizontalStyle="spread_inside"
-            app:flow_verticalAlign="top"
-            app:flow_verticalGap="@dimen/major_100"
-            app:flow_wrapMode="chain"
-            app:flow_verticalBias="0"
-            app:flow_horizontalBias="0"/>
+            android:layout_height="wrap_content">
 
-        <LinearLayout
-            android:id="@+id/labelFormatOption_legalView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            tools:ignore="MissingConstraints">
+            <androidx.constraintlayout.helper.widget.Flow
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:constraint_referenced_ids="labelFormatOption_legalView,labelFormatOption_letterView,labelFormatOption_labelView"
+                app:flow_horizontalAlign="start"
+                app:flow_horizontalBias="0"
+                app:flow_horizontalGap="@dimen/major_75"
+                app:flow_horizontalStyle="spread_inside"
+                app:flow_verticalAlign="top"
+                app:flow_verticalBias="0"
+                app:flow_verticalGap="@dimen/major_100"
+                app:flow_wrapMode="chain" />
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/labelFormatOption_legalTxt"
-                style="@style/Woo.TextView.Subtitle1"
+            <LinearLayout
+                android:id="@+id/labelFormatOption_legalView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/major_200"
-                android:text="@string/shipping_label_paper_size_legal" />
+                android:orientation="vertical"
+                tools:ignore="MissingConstraints">
 
-            <ImageView
-                android:id="@+id/labelFormatOption_legal"
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/labelFormatOption_legalTxt"
+                    style="@style/Woo.TextView.Subtitle1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/major_200"
+                    android:text="@string/shipping_label_paper_size_legal" />
+
+                <ImageView
+                    android:id="@+id/labelFormatOption_legal"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:importantForAccessibility="no"
+                    android:src="@drawable/img_label_option_legal" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/labelFormatOption_letterView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_100"
-                android:importantForAccessibility="no"
-                android:src="@drawable/img_label_option_legal" />
-        </LinearLayout>
+                android:orientation="vertical"
+                tools:ignore="MissingConstraints">
 
-        <LinearLayout
-            android:id="@+id/labelFormatOption_letterView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            tools:ignore="MissingConstraints">
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/labelFormatOption_letterTxt"
+                    style="@style/Woo.TextView.Subtitle1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/major_200"
+                    android:text="@string/shipping_label_paper_size_letter" />
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/labelFormatOption_letterTxt"
-                style="@style/Woo.TextView.Subtitle1"
-                android:layout_marginTop="@dimen/major_200"
+                <ImageView
+                    android:id="@+id/labelFormatOption_letter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_200"
+                    android:importantForAccessibility="no"
+                    android:src="@drawable/img_label_option_letter" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/labelFormatOption_labelView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/shipping_label_paper_size_letter" />
+                android:orientation="vertical"
+                tools:ignore="MissingConstraints">
 
-            <ImageView
-                android:id="@+id/labelFormatOption_letter"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_200"
-                android:importantForAccessibility="no"
-                android:src="@drawable/img_label_option_letter" />
-        </LinearLayout>
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/labelFormatOption_labelTxt"
+                    style="@style/Woo.TextView.Subtitle1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/major_200"
+                    android:text="@string/shipping_label_paper_size_label"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/labelFormatOption_letter" />
 
-        <LinearLayout
-            android:id="@+id/labelFormatOption_labelView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            tools:ignore="MissingConstraints">
+                <ImageView
+                    android:id="@+id/labelFormatOption_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_200"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_200"
+                    android:layout_marginBottom="@dimen/major_100"
+                    android:importantForAccessibility="no"
+                    android:src="@drawable/img_label_option_label" />
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/labelFormatOption_labelTxt"
-                style="@style/Woo.TextView.Subtitle1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/major_200"
-                android:text="@string/shipping_label_paper_size_label"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/labelFormatOption_letter" />
+            </LinearLayout>
 
-            <ImageView
-                android:id="@+id/labelFormatOption_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/major_100"
-                android:layout_marginStart="@dimen/major_200"
-                android:layout_marginEnd="@dimen/major_200"
-                android:layout_marginBottom="@dimen/major_100"
-                android:importantForAccessibility="no"
-                android:src="@drawable/img_label_option_label" />
-
-        </LinearLayout>
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_order_create_edit_customer_note.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_create_edit_customer_note.xml
@@ -1,20 +1,41 @@
-<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/snack_root"
-    style="@style/Woo.Card"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context="com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <EditText
-        android:id="@+id/customerOrderNote_editor"
-        style="@style/Woo.EditText"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="top|start"
-        android:hint="@string/orderdetail_customer_note_hint"
-        android:importantForAutofill="no"
-        android:inputType="textAutoComplete|textMultiLine|textCapSentences"
-        tools:text="This is a customer order note." />
-</com.google.android.material.card.MaterialCardView>
+        android:layout_height="@dimen/toolbar_height"
+        app:layout_collapseMode="pin"
+        style="@style/Widget.Woo.Toolbar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name"/>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/snack_root"
+        style="@style/Woo.Card"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:context="com.woocommerce.android.ui.orders.notes.AddOrderNoteFragment">
+
+        <EditText
+            android:id="@+id/customerOrderNote_editor"
+            style="@style/Woo.EditText"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="top|start"
+            android:hint="@string/orderdetail_customer_note_hint"
+            android:importantForAutofill="no"
+            android:inputType="textAutoComplete|textMultiLine|textCapSentences"
+            tools:text="This is a customer order note." />
+    </com.google.android.material.card.MaterialCardView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_order_create_edit_customer_note.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_create_edit_customer_note.xml
@@ -8,6 +8,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
         app:layout_collapseMode="pin"
         style="@style/Widget.Woo.Toolbar"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -17,6 +17,7 @@
             style="@style/Widget.Woo.Toolbar"
             android:layout_width="match_parent"
             android:layout_height="@dimen/toolbar_height"
+            android:elevation="@dimen/appbar_elevation"
             app:layout_collapseMode="pin"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -1,170 +1,192 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/orderRefreshLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.woocommerce.android.ui.orders.details.OrderDetailFragment">
 
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/scrollView"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-        <!-- The FrameLayout is needed to display the skeleton view dynamically -->
-        <FrameLayout
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            style="@style/Widget.Woo.Toolbar"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="@dimen/toolbar_height"
+            app:layout_collapseMode="pin"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:title="@string/app_name" />
 
-            <LinearLayout
-                android:id="@+id/orderDetail_container"
+        <View
+            android:id="@+id/app_bar_divider"
+            android:layout_gravity="bottom"
+            style="@style/Woo.Divider" />
+
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/scrollView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <!-- The FrameLayout is needed to display the skeleton view dynamically -->
+            <FrameLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                tools:ignore="UselessParent">
+                android:layout_height="wrap_content">
 
-                <!-- Shipping Labels work in progress notice card -->
-                <com.woocommerce.android.ui.products.FeatureWIPNoticeCard
-                    android:id="@+id/orderDetail_shippingLabelsWipCard"
-                    style="@style/Woo.Card.Expandable"
+                <LinearLayout
+                    android:id="@+id/orderDetail_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
+                    android:orientation="vertical"
+                    tools:ignore="UselessParent">
 
-                <!-- Order Status -->
-                <com.woocommerce.android.ui.orders.details.views.OrderDetailOrderStatusView
-                    android:id="@+id/orderDetail_orderStatus"
-                    style="@style/Woo.Card.WithoutPadding"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
+                    <!-- Shipping Labels work in progress notice card -->
+                    <com.woocommerce.android.ui.products.FeatureWIPNoticeCard
+                        android:id="@+id/orderDetail_shippingLabelsWipCard"
+                        style="@style/Woo.Card.Expandable"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone"
+                        tools:visibility="visible" />
 
-                <!-- Order Details AI -->
-                <com.woocommerce.android.ui.orders.details.views.OrderDetailAICard
-                    android:id="@+id/orderDetailsAICard"
-                    style="@style/Woo.Card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
+                    <!-- Order Status -->
+                    <com.woocommerce.android.ui.orders.details.views.OrderDetailOrderStatusView
+                        android:id="@+id/orderDetail_orderStatus"
+                        style="@style/Woo.Card.WithoutPadding"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
 
-                <!-- Order Shipping method warning card -->
-                <com.woocommerce.android.ui.orders.OrderDetailShippingMethodNoticeCard
-                    android:id="@+id/orderDetail_shippingMethodNotice"
-                    style="@style/Woo.Card.WithoutPadding"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
+                    <!-- Order Details AI -->
+                    <com.woocommerce.android.ui.orders.details.views.OrderDetailAICard
+                        android:id="@+id/orderDetailsAICard"
+                        style="@style/Woo.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone"
+                        tools:visibility="visible" />
 
-                <!-- Product List -->
-                <com.woocommerce.android.ui.orders.details.views.OrderDetailProductListView
-                    android:id="@+id/orderDetail_productList"
-                    style="@style/Woo.Card.WithoutPadding"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:clipToPadding="false"
-                    android:contentDescription="@string/products"
-                    android:visibility="gone"
-                    tools:visibility="visible"
-                    app:contentPaddingTop="@dimen/minor_00"/>
+                    <!-- Order Shipping method warning card -->
+                    <com.woocommerce.android.ui.orders.OrderDetailShippingMethodNoticeCard
+                        android:id="@+id/orderDetail_shippingMethodNotice"
+                        style="@style/Woo.Card.WithoutPadding"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone"
+                        tools:visibility="visible" />
 
-                <!-- Custom Amounts List -->
-                <androidx.compose.ui.platform.ComposeView
-                    android:id="@+id/orderDetail_customAmount"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:clipToPadding="false"
-                    android:contentDescription="@string/custom_amounts"/>
+                    <!-- Product List -->
+                    <com.woocommerce.android.ui.orders.details.views.OrderDetailProductListView
+                        android:id="@+id/orderDetail_productList"
+                        style="@style/Woo.Card.WithoutPadding"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:clipToPadding="false"
+                        android:contentDescription="@string/products"
+                        android:visibility="gone"
+                        app:contentPaddingTop="@dimen/minor_00"
+                        tools:visibility="visible" />
 
-                <!-- Custom fields button -->
-                <com.woocommerce.android.ui.orders.details.views.OrderDetailCustomFieldsCard
-                    android:id="@+id/customFieldsCard"
-                    style="@style/Woo.Card.WithoutPadding"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
+                    <!-- Custom Amounts List -->
+                    <androidx.compose.ui.platform.ComposeView
+                        android:id="@+id/orderDetail_customAmount"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:clipToPadding="false"
+                        android:contentDescription="@string/custom_amounts" />
 
-                <!-- Refunds Info -->
-                <com.woocommerce.android.ui.orders.details.views.OrderDetailRefundsView
-                    android:id="@+id/orderDetail_refundsInfo"
-                    style="@style/Woo.Card.WithoutPadding"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:clipToPadding="false"
-                    android:contentDescription="@string/refunds"
-                    android:visibility="gone" />
+                    <!-- Custom fields button -->
+                    <com.woocommerce.android.ui.orders.details.views.OrderDetailCustomFieldsCard
+                        android:id="@+id/customFieldsCard"
+                        style="@style/Woo.Card.WithoutPadding"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone"
+                        tools:visibility="visible" />
 
-                <!-- Install WC shipping plugin banner -->
-                <com.woocommerce.android.ui.orders.details.views.OrderDetailInstallWcShippingBanner
-                    android:id="@+id/orderDetail_installWcShippingBanner"
-                    style="@style/Woo.Card.WithoutPadding"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/minor_100"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
+                    <!-- Refunds Info -->
+                    <com.woocommerce.android.ui.orders.details.views.OrderDetailRefundsView
+                        android:id="@+id/orderDetail_refundsInfo"
+                        style="@style/Woo.Card.WithoutPadding"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:clipToPadding="false"
+                        android:contentDescription="@string/refunds"
+                        android:visibility="gone" />
 
-                <!-- Shipping Labels List -->
-                <com.woocommerce.android.ui.orders.details.views.OrderDetailShippingLabelsView
-                    android:id="@+id/orderDetail_shippingLabelList"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:clipToPadding="false"
-                    android:contentDescription="@string/shipping_labels"
-                    android:visibility="gone" />
+                    <!-- Install WC shipping plugin banner -->
+                    <com.woocommerce.android.ui.orders.details.views.OrderDetailInstallWcShippingBanner
+                        android:id="@+id/orderDetail_installWcShippingBanner"
+                        style="@style/Woo.Card.WithoutPadding"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/minor_100"
+                        android:visibility="gone"
+                        tools:visibility="visible" />
 
-                <!-- Payments -->
-                <com.woocommerce.android.ui.orders.details.views.OrderDetailPaymentInfoView
-                    android:id="@+id/orderDetail_paymentInfo"
-                    style="@style/Woo.Card.WithoutPadding"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:animateLayoutChanges="true"
-                    android:focusable="true"
-                    app:contentPaddingTop="@dimen/minor_00"/>
+                    <!-- Shipping Labels List -->
+                    <com.woocommerce.android.ui.orders.details.views.OrderDetailShippingLabelsView
+                        android:id="@+id/orderDetail_shippingLabelList"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:clipToPadding="false"
+                        android:contentDescription="@string/shipping_labels"
+                        android:visibility="gone" />
 
-                <!-- Customer Info -->
-                <com.woocommerce.android.ui.orders.details.views.OrderDetailCustomerInfoView
-                    android:id="@+id/orderDetail_customerInfo"
-                    style="@style/Woo.Card.WithoutPadding"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
+                    <!-- Payments -->
+                    <com.woocommerce.android.ui.orders.details.views.OrderDetailPaymentInfoView
+                        android:id="@+id/orderDetail_paymentInfo"
+                        style="@style/Woo.Card.WithoutPadding"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:animateLayoutChanges="true"
+                        android:focusable="true"
+                        app:contentPaddingTop="@dimen/minor_00" />
 
-                <com.woocommerce.android.ui.orders.details.views.OrderDetailSubscriptionListView
-                    android:id="@+id/orderDetail_subscriptionList"
-                    style="@style/Woo.Card.WithoutPadding"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"/>
+                    <!-- Customer Info -->
+                    <com.woocommerce.android.ui.orders.details.views.OrderDetailCustomerInfoView
+                        android:id="@+id/orderDetail_customerInfo"
+                        style="@style/Woo.Card.WithoutPadding"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
 
-                <com.woocommerce.android.ui.orders.details.views.OrderDetailGiftCardListView
-                    android:id="@+id/orderDetail_giftCardList"
-                    style="@style/Woo.Card.WithoutPadding"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"/>
+                    <com.woocommerce.android.ui.orders.details.views.OrderDetailSubscriptionListView
+                        android:id="@+id/orderDetail_subscriptionList"
+                        style="@style/Woo.Card.WithoutPadding"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone" />
 
-                <!-- Shipment Tracking -->
-                <com.woocommerce.android.ui.orders.details.views.OrderDetailShipmentTrackingListView
-                    android:id="@+id/orderDetail_shipmentList"
-                    style="@style/Woo.Card.WithoutPadding"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:clipToPadding="false"
-                    android:contentDescription="@string/order_shipment_tracking_section_cd"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
+                    <com.woocommerce.android.ui.orders.details.views.OrderDetailGiftCardListView
+                        android:id="@+id/orderDetail_giftCardList"
+                        style="@style/Woo.Card.WithoutPadding"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone" />
 
-                <!-- Order Notes -->
-                <com.woocommerce.android.ui.orders.details.views.OrderDetailOrderNotesView
-                    android:id="@+id/orderDetail_noteList"
-                    style="@style/Woo.Card.WithoutPadding"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-            </LinearLayout>
-        </FrameLayout>
-    </androidx.core.widget.NestedScrollView>
+                    <!-- Shipment Tracking -->
+                    <com.woocommerce.android.ui.orders.details.views.OrderDetailShipmentTrackingListView
+                        android:id="@+id/orderDetail_shipmentList"
+                        style="@style/Woo.Card.WithoutPadding"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:clipToPadding="false"
+                        android:contentDescription="@string/order_shipment_tracking_section_cd"
+                        android:visibility="gone"
+                        tools:visibility="visible" />
+
+                    <!-- Order Notes -->
+                    <com.woocommerce.android.ui.orders.details.views.OrderDetailOrderNotesView
+                        android:id="@+id/orderDetail_noteList"
+                        style="@style/Woo.Card.WithoutPadding"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
+                </LinearLayout>
+            </FrameLayout>
+        </androidx.core.widget.NestedScrollView>
+    </LinearLayout>
 </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>

--- a/WooCommerce/src/main/res/layout/fragment_payments_hub.xml
+++ b/WooCommerce/src/main/res/layout/fragment_payments_hub.xml
@@ -9,7 +9,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/toolbar_height"
-        android:elevation="@dimen/minor_50"
+        android:elevation="@dimen/appbar_elevation"
         app:layout_collapseMode="pin"
         style="@style/Widget.Woo.Toolbar"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_payments_hub.xml
+++ b/WooCommerce/src/main/res/layout/fragment_payments_hub.xml
@@ -5,6 +5,25 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        style="@style/Widget.Woo.Toolbar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name"/>
+
+    <View
+        android:id="@+id/app_bar_divider"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        style="@style/Woo.Divider" />
+
     <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/paymentsHubLoading"
         android:layout_width="match_parent"
@@ -12,7 +31,7 @@
         android:indeterminate="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/app_bar_divider" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/paymentsHubRv"

--- a/WooCommerce/src/main/res/layout/fragment_print_label_customs_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_print_label_customs_form.xml
@@ -1,73 +1,99 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/snack_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fillViewport="true">
+    android:orientation="vertical">
 
-    <com.woocommerce.android.widgets.WCElevatedLinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_horizontal"
-        android:orientation="vertical">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        style="@style/Widget.Woo.Toolbar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name"/>
 
-        <com.google.android.material.textview.MaterialTextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
-            android:text="@string/shipping_label_customs_form"
-            android:textAppearance="?attr/textAppearanceBody1"
-            android:textColor="@color/color_on_surface_high" />
+    <View
+        android:id="@+id/app_bar_divider"
+        android:layout_gravity="bottom"
+        style="@style/Woo.Divider" />
 
-        <androidx.appcompat.widget.AppCompatImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_200"
-            app:srcCompat="@drawable/img_print_with_phone" />
+    <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
 
-        <com.google.android.material.textview.MaterialTextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/major_200"
-            android:layout_marginTop="@dimen/major_200"
-            android:gravity="center"
-            android:text="@string/shipping_label_print_customs_explanation"
-            android:textAppearance="?attr/textAppearanceBody2"
-            android:textColor="@color/color_on_surface_high" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/invoices_list"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_marginTop="@dimen/major_200"
-            android:layout_weight="1"
-            tools:itemCount="2"
-            tools:listitem="@layout/print_customs_form_list_item" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/print_button"
-            style="@style/Woo.Button.Colored"
+        <com.woocommerce.android.widgets.WCElevatedLinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_200"
-            android:text="@string/shipping_label_print_customs_form"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_paperSize" />
+            android:gravity="center_horizontal"
+            android:orientation="vertical">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/save_for_later_button"
-            style="@style/Woo.Button.Outlined"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_100"
-            android:text="@string/shipping_label_print_save_for_later"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_paperSize" />
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_100"
+                android:text="@string/shipping_label_customs_form"
+                android:textAppearance="?attr/textAppearanceBody1"
+                android:textColor="@color/color_on_surface_high" />
 
-    </com.woocommerce.android.widgets.WCElevatedLinearLayout>
-</ScrollView>
+            <androidx.appcompat.widget.AppCompatImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_200"
+                app:srcCompat="@drawable/img_print_with_phone" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_200"
+                android:layout_marginTop="@dimen/major_200"
+                android:gravity="center"
+                android:text="@string/shipping_label_print_customs_explanation"
+                android:textAppearance="?attr/textAppearanceBody2"
+                android:textColor="@color/color_on_surface_high" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/invoices_list"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginTop="@dimen/major_200"
+                android:layout_weight="1"
+                tools:itemCount="2"
+                tools:listitem="@layout/print_customs_form_list_item" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/print_button"
+                style="@style/Woo.Button.Colored"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_200"
+                android:text="@string/shipping_label_print_customs_form"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_paperSize" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/save_for_later_button"
+                style="@style/Woo.Button.Outlined"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/major_100"
+                android:layout_marginBottom="@dimen/major_100"
+                android:text="@string/shipping_label_print_save_for_later"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_paperSize" />
+
+        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_print_shipping_label.xml
+++ b/WooCommerce/src/main/res/layout/fragment_print_shipping_label.xml
@@ -1,202 +1,226 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/snack_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fillViewport="true">
+    android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="?attr/colorSurface">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        style="@style/Widget.Woo.Toolbar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name"/>
 
-        <com.woocommerce.android.widgets.WCWarningBanner
-            android:id="@+id/expiration_warning_banner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="parent"
-            app:message="@string/shipping_label_reprint_expired_message"
-            android:visibility="gone"/>
+    <View
+        android:id="@+id/app_bar_divider"
+        android:layout_gravity="bottom"
+        style="@style/Woo.Divider" />
 
-        <androidx.constraintlayout.widget.Group
-            android:id="@+id/reprint_group"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:visibility="gone"
-            app:constraint_referenced_ids="shippingLabelPrint_errorMessage, shippingLabelPrint_disclaimerIcon, shippingLabelPrint_disclaimer" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/shippingLabelPrint_errorMessage"
-            style="@style/Woo.Card.Title"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:paddingBottom="@dimen/major_100"
-            android:text="@string/shipping_label_print_error_message"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/expiration_warning_banner" />
-
-        <ImageView
-            android:id="@+id/shippingLabelPrint_disclaimerIcon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/minor_25"
-            android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_100"
-            android:contentDescription="@string/shipping_label_print_disclaimer"
-            android:src="@drawable/ic_deprecated_info_outline_24dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_errorMessage" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/shippingLabelPrint_disclaimer"
-            style="@style/Woo.ListItem.Body"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:paddingBottom="@dimen/major_75"
-            android:text="@string/shipping_label_print_disclaimer"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/shippingLabelPrint_disclaimerIcon"
-            app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_errorMessage" />
-
-        <androidx.constraintlayout.widget.Group
-            android:id="@+id/purchase_group"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:visibility="visible"
-            app:constraint_referenced_ids="label_purchased, label_purchased_img,save_for_later_button" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/label_purchased"
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:text="@string/shipping_label_print_purchase_success"
-            android:textAppearance="?attr/textAppearanceBody1"
-            android:textColor="@color/color_on_surface_high"
-            android:layout_marginTop="@dimen/major_100"
-            app:layout_constrainedWidth="true"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/expiration_warning_banner" />
-
-        <androidx.appcompat.widget.AppCompatImageView
-            android:id="@+id/label_purchased_img"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constrainedWidth="true"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/label_purchased"
-            app:srcCompat="@drawable/img_label_purchased" />
-
-        <androidx.constraintlayout.widget.Barrier
-            android:id="@+id/top_part_barrier"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:barrierDirection="bottom"
-            app:constraint_referenced_ids="label_purchased_img,shippingLabelPrint_disclaimer" />
-
-        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-            android:id="@+id/shippingLabelPrint_paperSize"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/major_100"
-            android:hint="@string/shipping_label_paper_size"
-            android:text="@string/shipping_label_paper_size_legal"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/top_part_barrier" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/shippingLabelPrint_btn"
-            style="@style/Woo.Button.Colored"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/major_100"
-            android:text="@string/shipping_label_print_button"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_paperSize" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/save_for_later_button"
-            style="@style/Woo.Button.Outlined"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/shipping_label_print_save_for_later"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/shippingLabelPrint_btn" />
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/shippingLabelPrint_pageOptionsView"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="?attr/selectableItemBackground"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/save_for_later_button">
+            android:background="?attr/colorSurface">
 
-            <ImageView
-                android:id="@+id/shippingLabelPrint_pagesIcon"
-                android:layout_width="wrap_content"
+            <com.woocommerce.android.widgets.WCWarningBanner
+                android:id="@+id/expiration_warning_banner"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="@dimen/major_100"
-                android:contentDescription="@string/shipping_label_paper_size_options_info"
-                android:src="@drawable/ic_gridicons_pages"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                android:visibility="gone"
+                app:layout_constraintTop_toTopOf="parent"
+                app:message="@string/shipping_label_reprint_expired_message" />
+
+            <androidx.constraintlayout.widget.Group
+                android:id="@+id/reprint_group"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:visibility="gone"
+                app:constraint_referenced_ids="shippingLabelPrint_errorMessage, shippingLabelPrint_disclaimerIcon, shippingLabelPrint_disclaimer" />
 
             <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/shippingLabelPrint_pagesInfo"
-                style="@style/Woo.ListItem.Body"
+                android:id="@+id/shippingLabelPrint_errorMessage"
+                style="@style/Woo.Card.Title"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:text="@string/shipping_label_paper_size_options_info"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toEndOf="@id/shippingLabelPrint_pagesIcon"
+                android:paddingBottom="@dimen/major_100"
+                android:text="@string/shipping_label_print_error_message"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/shippingLabelPrint_infoView"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:background="?attr/selectableItemBackground"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_pageOptionsView"
-            app:layout_constraintVertical_bias="0">
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/expiration_warning_banner" />
 
             <ImageView
-                android:id="@+id/shippingLabelPrint_infoIcon"
+                android:id="@+id/shippingLabelPrint_disclaimerIcon"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_margin="@dimen/major_100"
-                android:contentDescription="@string/shipping_label_print_info"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/minor_25"
+                android:layout_marginEnd="@dimen/major_100"
+                android:layout_marginBottom="@dimen/major_100"
+                android:contentDescription="@string/shipping_label_print_disclaimer"
                 android:src="@drawable/ic_deprecated_info_outline_24dp"
-                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_errorMessage" />
 
             <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/shippingLabelPrint_info"
+                android:id="@+id/shippingLabelPrint_disclaimer"
                 style="@style/Woo.ListItem.Body"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:text="@string/shipping_label_print_info"
+                android:paddingBottom="@dimen/major_75"
+                android:text="@string/shipping_label_print_disclaimer"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/shippingLabelPrint_disclaimerIcon"
+                app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_errorMessage" />
+
+            <androidx.constraintlayout.widget.Group
+                android:id="@+id/purchase_group"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:visibility="visible"
+                app:constraint_referenced_ids="label_purchased, label_purchased_img,save_for_later_button" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/label_purchased"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_marginTop="@dimen/major_100"
+                android:text="@string/shipping_label_print_purchase_success"
+                android:textAppearance="?attr/textAppearanceBody1"
+                android:textColor="@color/color_on_surface_high"
+                app:layout_constrainedWidth="true"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/expiration_warning_banner" />
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/label_purchased_img"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constrainedWidth="true"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/label_purchased"
+                app:srcCompat="@drawable/img_label_purchased" />
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/top_part_barrier"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="label_purchased_img,shippingLabelPrint_disclaimer" />
+
+            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                android:id="@+id/shippingLabelPrint_paperSize"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/major_100"
+                android:hint="@string/shipping_label_paper_size"
+                android:text="@string/shipping_label_paper_size_legal"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/top_part_barrier" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/shippingLabelPrint_btn"
+                style="@style/Woo.Button.Colored"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/major_100"
+                android:text="@string/shipping_label_print_button"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_paperSize" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/save_for_later_button"
+                style="@style/Woo.Button.Outlined"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:text="@string/shipping_label_print_save_for_later"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/shippingLabelPrint_btn" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/shippingLabelPrint_pageOptionsView"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/save_for_later_button">
+
+                <ImageView
+                    android:id="@+id/shippingLabelPrint_pagesIcon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="@dimen/major_100"
+                    android:contentDescription="@string/shipping_label_paper_size_options_info"
+                    android:src="@drawable/ic_gridicons_pages"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/shippingLabelPrint_pagesInfo"
+                    style="@style/Woo.ListItem.Body"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/shipping_label_paper_size_options_info"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/shippingLabelPrint_pagesIcon"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/shippingLabelPrint_infoView"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/shippingLabelPrint_infoIcon"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/shippingLabelPrint_pageOptionsView"
+                app:layout_constraintVertical_bias="0">
 
+                <ImageView
+                    android:id="@+id/shippingLabelPrint_infoIcon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="@dimen/major_100"
+                    android:contentDescription="@string/shipping_label_print_info"
+                    android:src="@drawable/ic_deprecated_info_outline_24dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/shippingLabelPrint_info"
+                    style="@style/Woo.ListItem.Body"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/shipping_label_print_info"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/shippingLabelPrint_infoIcon"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_print_shipping_label_info.xml
+++ b/WooCommerce/src/main/res/layout/fragment_print_shipping_label_info.xml
@@ -1,156 +1,182 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/snack_root"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/major_100"
-        android:background="@color/color_surface">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        style="@style/Widget.Woo.Toolbar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name"/>
 
-        <ImageView
-            android:id="@+id/imageView"
-            android:layout_width="wrap_content"
+    <View
+        android:id="@+id/app_bar_divider"
+        android:layout_gravity="bottom"
+        style="@style/Woo.Divider" />
+
+    <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_200"
-            android:importantForAccessibility="no"
-            android:src="@drawable/img_print_with_phone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="1.0" />
+            android:background="@color/color_surface"
+            android:paddingBottom="@dimen/major_100">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/printShippingLabelInfo_stepCount1"
-            style="@style/Woo.Button.Colored.Circle"
-            android:layout_width="@dimen/image_minor_100"
-            android:layout_height="@dimen/image_minor_100"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_200"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_count_1"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/imageView"
-            app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
+            <ImageView
+                android:id="@+id/imageView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_200"
+                android:importantForAccessibility="no"
+                android:src="@drawable/img_print_with_phone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_bias="1.0" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/printShippingLabelInfo_step1"
-            style="@style/Woo.TextView.Subtitle1"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_200"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_1"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/printShippingLabelInfo_stepCount1"
-            app:layout_constraintTop_toBottomOf="@+id/imageView" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/printShippingLabelInfo_stepCount1"
+                style="@style/Woo.Button.Colored.Circle"
+                android:layout_width="@dimen/image_minor_100"
+                android:layout_height="@dimen/image_minor_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_200"
+                android:layout_marginEnd="@dimen/major_100"
+                android:text="@string/print_shipping_label_info_step_count_1"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/imageView"
+                app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/printShippingLabelInfo_stepCount2"
-            style="@style/Woo.Button.Colored.Circle"
-            android:layout_width="@dimen/image_minor_100"
-            android:layout_height="@dimen/image_minor_100"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_200"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_count_2"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step1"
-            app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/printShippingLabelInfo_step1"
+                style="@style/Woo.TextView.Subtitle1"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_200"
+                android:layout_marginEnd="@dimen/major_100"
+                android:text="@string/print_shipping_label_info_step_1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/printShippingLabelInfo_stepCount1"
+                app:layout_constraintTop_toBottomOf="@+id/imageView" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/printShippingLabelInfo_step2"
-            style="@style/Woo.TextView.Subtitle1"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_200"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_2"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/printShippingLabelInfo_stepCount1"
-            app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step1" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/printShippingLabelInfo_stepCount2"
+                style="@style/Woo.Button.Colored.Circle"
+                android:layout_width="@dimen/image_minor_100"
+                android:layout_height="@dimen/image_minor_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_200"
+                android:layout_marginEnd="@dimen/major_100"
+                android:text="@string/print_shipping_label_info_step_count_2"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step1"
+                app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/printShippingLabelInfo_stepCount3"
-            style="@style/Woo.Button.Colored.Circle"
-            android:layout_width="@dimen/image_minor_100"
-            android:layout_height="@dimen/image_minor_100"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_200"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_count_3"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step2"
-            app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/printShippingLabelInfo_step2"
+                style="@style/Woo.TextView.Subtitle1"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_200"
+                android:layout_marginEnd="@dimen/major_100"
+                android:text="@string/print_shipping_label_info_step_2"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/printShippingLabelInfo_stepCount1"
+                app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step1" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/printShippingLabelInfo_step3"
-            style="@style/Woo.TextView.Subtitle1"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_200"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_3"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/printShippingLabelInfo_stepCount3"
-            app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step2" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/printShippingLabelInfo_stepCount3"
+                style="@style/Woo.Button.Colored.Circle"
+                android:layout_width="@dimen/image_minor_100"
+                android:layout_height="@dimen/image_minor_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_200"
+                android:layout_marginEnd="@dimen/major_100"
+                android:text="@string/print_shipping_label_info_step_count_3"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step2"
+                app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/printShippingLabelInfo_stepCount4"
-            style="@style/Woo.Button.Colored.Circle"
-            android:layout_width="@dimen/image_minor_100"
-            android:layout_height="@dimen/image_minor_100"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_200"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_count_4"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step3"
-            app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/printShippingLabelInfo_step3"
+                style="@style/Woo.TextView.Subtitle1"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_200"
+                android:layout_marginEnd="@dimen/major_100"
+                android:text="@string/print_shipping_label_info_step_3"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/printShippingLabelInfo_stepCount3"
+                app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step2" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/printShippingLabelInfo_step4"
-            style="@style/Woo.TextView.Subtitle1"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_200"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_4"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/printShippingLabelInfo_stepCount4"
-            app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step3" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/printShippingLabelInfo_stepCount4"
+                style="@style/Woo.Button.Colored.Circle"
+                android:layout_width="@dimen/image_minor_100"
+                android:layout_height="@dimen/image_minor_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_200"
+                android:layout_marginEnd="@dimen/major_100"
+                android:text="@string/print_shipping_label_info_step_count_4"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step3"
+                app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/printShippingLabelInfo_stepCount5"
-            style="@style/Woo.Button.Colored.Circle"
-            android:layout_width="@dimen/image_minor_100"
-            android:layout_height="@dimen/image_minor_100"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_200"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_count_5"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step4"
-            app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/printShippingLabelInfo_step4"
+                style="@style/Woo.TextView.Subtitle1"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_200"
+                android:layout_marginEnd="@dimen/major_100"
+                android:text="@string/print_shipping_label_info_step_4"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/printShippingLabelInfo_stepCount4"
+                app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step3" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/printShippingLabelInfo_step5"
-            style="@style/Woo.TextView.Subtitle1"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_200"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/print_shipping_label_info_step_5"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/printShippingLabelInfo_stepCount5"
-            app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step4" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/printShippingLabelInfo_stepCount5"
+                style="@style/Woo.Button.Colored.Circle"
+                android:layout_width="@dimen/image_minor_100"
+                android:layout_height="@dimen/image_minor_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_200"
+                android:layout_marginEnd="@dimen/major_100"
+                android:text="@string/print_shipping_label_info_step_count_5"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step4"
+                app:shapeAppearanceOverlay="@style/Woo.Button.Colored.Circle" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/printShippingLabelInfo_step5"
+                style="@style/Woo.TextView.Subtitle1"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_200"
+                android:layout_marginEnd="@dimen/major_100"
+                android:text="@string/print_shipping_label_info_step_5"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/printShippingLabelInfo_stepCount5"
+                app:layout_constraintTop_toBottomOf="@+id/printShippingLabelInfo_step4" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_refund_summary.xml
+++ b/WooCommerce/src/main/res/layout/fragment_refund_summary.xml
@@ -13,6 +13,23 @@
         android:orientation="vertical"
         tools:context="com.woocommerce.android.ui.payments.refunds.RefundByAmountFragment">
 
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            style="@style/Widget.Woo.Toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/toolbar_height"
+            android:elevation="@dimen/appbar_elevation"
+            app:layout_collapseMode="pin"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:title="@string/app_name" />
+
+        <View
+            android:id="@+id/app_bar_divider"
+            style="@style/Woo.Divider"
+            android:layout_gravity="bottom" />
+
         <com.google.android.material.card.MaterialCardView
             style="@style/Woo.Card"
             android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/fragment_select_payment_method.xml
+++ b/WooCommerce/src/main/res/layout/fragment_select_payment_method.xml
@@ -1,56 +1,81 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/snack_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fillViewport="true">
+    android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:animateLayoutChanges="true">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/tvSelectPaymentTitle"
-            style="@style/TextAppearance.Woo.Subtitle2"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:background="@color/default_window_background"
-            android:padding="@dimen/major_100"
-            android:text="@string/simple_payments_choose_method"
-            android:textAllCaps="true"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+    <View
+        android:id="@+id/app_bar_divider"
+        style="@style/Woo.Divider"
+        android:layout_gravity="bottom" />
 
-        <LinearLayout
-            android:id="@+id/container"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:background="@color/color_surface"
-            android:orientation="vertical"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tvSelectPaymentTitle" />
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
 
-        <include
-            android:id="@+id/learn_more_ipp_payment_methods_tv"
-            layout="@layout/card_reader_learn_more_section"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/container" />
+            android:animateLayoutChanges="true">
 
-        <ProgressBar
-            android:id="@+id/pbLoading"
-            style="?android:attr/progressBarStyleLarge"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/tvSelectPaymentTitle"
+                style="@style/TextAppearance.Woo.Subtitle2"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:background="@color/default_window_background"
+                android:padding="@dimen/major_100"
+                android:text="@string/simple_payments_choose_method"
+                android:textAllCaps="true"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>
+            <LinearLayout
+                android:id="@+id/container"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:background="@color/color_surface"
+                android:orientation="vertical"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tvSelectPaymentTitle" />
+
+            <include
+                android:id="@+id/learn_more_ipp_payment_methods_tv"
+                layout="@layout/card_reader_learn_more_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/container" />
+
+            <ProgressBar
+                android:id="@+id/pbLoading"
+                style="?android:attr/progressBarStyleLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_select_payment_method.xml
+++ b/WooCommerce/src/main/res/layout/fragment_select_payment_method.xml
@@ -12,7 +12,7 @@
         style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/toolbar_height"
-        android:elevation="@dimen/minor_50"
+        android:elevation="@dimen/appbar_elevation"
         app:layout_collapseMode="pin"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_shipping_carrier_rates.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_carrier_rates.xml
@@ -11,7 +11,7 @@
         style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/toolbar_height"
-        android:elevation="@dimen/minor_50"
+        android:elevation="@dimen/appbar_elevation"
         app:layout_collapseMode="pin"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_shipping_carrier_rates.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_carrier_rates.xml
@@ -1,88 +1,110 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.woocommerce.android.widgets.WCElevatedConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:layout_marginBottom="@dimen/minor_100">
+    android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/infoBanner"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:background="@color/info_banner_background_color"
-        android:animateLayoutChanges="true"
-        android:clickable="true"
-        android:focusable="true"
-        tools:visibility="visible">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
 
-        <ImageView
-            android:id="@+id/infoBannerIcon"
-            android:layout_width="wrap_content"
+    <View
+        android:id="@+id/app_bar_divider"
+        style="@style/Woo.Divider"
+        android:layout_gravity="bottom" />
+
+    <com.woocommerce.android.widgets.WCElevatedConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="@dimen/minor_100"
+        android:orientation="vertical">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/infoBanner"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:contentDescription="@string/shipping_label_edit_address_validation_error"
-            android:src="@drawable/ic_tintable_info_outline_24dp"
-            app:layout_constraintBottom_toTopOf="@id/infoBannerDivider"
+            android:animateLayoutChanges="true"
+            android:background="@color/info_banner_background_color"
+            android:clickable="true"
+            android:focusable="true"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <ImageView
+                android:id="@+id/infoBannerIcon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:contentDescription="@string/shipping_label_edit_address_validation_error"
+                android:src="@drawable/ic_tintable_info_outline_24dp"
+                app:layout_constraintBottom_toTopOf="@id/infoBannerDivider"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@id/infoBannerMessage"
+                app:layout_constraintVertical_bias="0.0"
+                app:tint="@color/info_banner_foreground_color"
+                tools:visibility="visible" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/infoBannerMessage"
+                style="@style/Woo.TextView.Warning"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_200"
+                android:layout_marginTop="@dimen/major_125"
+                android:layout_marginBottom="@dimen/major_125"
+                android:textColor="@color/color_on_surface_medium"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/infoBannerIcon"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="Customer paid $6 flat fee"
+                tools:visibility="visible" />
+
+            <View
+                android:id="@+id/infoBannerDivider"
+                style="@style/Woo.Divider.Info"
+                android:layout_width="@dimen/minor_00"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/carrierRates"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="?attr/colorSurface"
+            android:scrollbars="vertical"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/infoBannerMessage"
-            app:layout_constraintVertical_bias="0.0"
-            app:tint="@color/info_banner_foreground_color"
+            app:layout_constraintTop_toBottomOf="@+id/infoBanner"
+            tools:itemCount="5"
+            tools:listitem="@layout/shipping_rate_list_item"
             tools:visibility="visible" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/infoBannerMessage"
-            style="@style/Woo.TextView.Warning"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_200"
-            android:layout_marginTop="@dimen/major_125"
-            android:layout_marginBottom="@dimen/major_125"
-            tools:text="Customer paid $6 flat fee"
-            android:textColor="@color/color_on_surface_medium"
+        <com.woocommerce.android.widgets.WCEmptyView
+            android:id="@+id/emptyView"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/infoBannerIcon"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/infoBanner"
             tools:visibility="visible" />
 
-        <View
-            android:id="@+id/infoBannerDivider"
-            style="@style/Woo.Divider.Info"
-            android:layout_width="@dimen/minor_00"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/carrierRates"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:background="?attr/colorSurface"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/infoBanner"
-        android:scrollbars="vertical"
-        tools:itemCount="5"
-        tools:listitem="@layout/shipping_rate_list_item"
-        tools:visibility="visible" />
-
-    <com.woocommerce.android.widgets.WCEmptyView
-        android:id="@+id/emptyView"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/infoBanner"
-        tools:visibility="visible" />
-
-</com.woocommerce.android.widgets.WCElevatedConstraintLayout>
+    </com.woocommerce.android.widgets.WCElevatedConstraintLayout>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_shipping_customs.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_customs.xml
@@ -1,34 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <androidx.appcompat.widget.LinearLayoutCompat
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
 
-        <com.woocommerce.android.ui.orders.shippinglabels.creation.banner.ShippingNoticeCard
-            android:id="@+id/shipping_notice_banner"
-            style="@style/Woo.Card"
+    <View
+        android:id="@+id/app_bar_divider"
+        style="@style/Woo.Divider"
+        android:layout_gravity="bottom" />
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.appcompat.widget.LinearLayoutCompat
             android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <com.woocommerce.android.ui.orders.shippinglabels.creation.banner.ShippingNoticeCard
+                android:id="@+id/shipping_notice_banner"
+                style="@style/Woo.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/packages_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                tools:itemCount="2"
+                tools:listitem="@layout/shipping_customs_list_item" />
+
+        </androidx.appcompat.widget.LinearLayoutCompat>
+
+        <ProgressBar
+            android:id="@+id/progress_view"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:visibility="gone"/>
+            android:layout_gravity="center" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/packages_list"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            tools:itemCount="2"
-            tools:listitem="@layout/shipping_customs_list_item" />
-
-    </androidx.appcompat.widget.LinearLayoutCompat>
-
-    <ProgressBar
-        android:id="@+id/progress_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center" />
-
-</FrameLayout>
+    </FrameLayout>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_shipping_customs.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_customs.xml
@@ -11,7 +11,7 @@
         style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/toolbar_height"
-        android:elevation="@dimen/minor_50"
+        android:elevation="@dimen/appbar_elevation"
         app:layout_collapseMode="pin"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_shipping_label_address_suggestion.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_label_address_suggestion.xml
@@ -12,7 +12,7 @@
         style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/toolbar_height"
-        android:elevation="@dimen/minor_50"
+        android:elevation="@dimen/appbar_elevation"
         app:layout_collapseMode="pin"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_shipping_label_address_suggestion.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_label_address_suggestion.xml
@@ -1,153 +1,176 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:fillViewport="true">
+    android:id="@+id/snack_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <com.woocommerce.android.widgets.WCElevatedConstraintLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:layout_marginBottom="@dimen/minor_100">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/suggestionBanner"
+    <View
+        android:id="@+id/app_bar_divider"
+        style="@style/Woo.Divider"
+        android:layout_gravity="bottom" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
+
+        <com.woocommerce.android.widgets.WCElevatedConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/warning_banner_background_color"
-            android:animateLayoutChanges="true"
-            app:layout_constraintTop_toTopOf="parent"
-            android:clickable="true"
-            android:focusable="true"
-            tools:visibility="visible">
+            android:layout_marginBottom="@dimen/minor_100"
+            android:orientation="vertical">
 
-            <ImageView
-                android:id="@+id/suggestionBannerIcon"
-                android:layout_width="wrap_content"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/suggestionBanner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:animateLayoutChanges="true"
+                android:background="@color/warning_banner_background_color"
+                android:clickable="true"
+                android:focusable="true"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:visibility="visible">
+
+                <ImageView
+                    android:id="@+id/suggestionBannerIcon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:contentDescription="@string/shipping_label_edit_address_validation_error"
+                    android:src="@drawable/ic_tintable_info_outline_24dp"
+                    app:layout_constraintBottom_toTopOf="@id/bannerDivider"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/suggestionBannerMessage"
+                    app:layout_constraintVertical_bias="0.0"
+                    app:tint="@color/warning_banner_foreground_color"
+                    tools:visibility="visible" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/suggestionBannerMessage"
+                    style="@style/Woo.TextView.Warning"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_200"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:layout_marginBottom="@dimen/major_100"
+                    android:text="@string/shipping_label_address_suggestion_banner"
+                    app:layout_constraintBottom_toBottomOf="@id/bannerDivider"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/suggestionBannerIcon"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:visibility="visible" />
+
+                <View
+                    android:id="@+id/bannerDivider"
+                    style="@style/Woo.Divider.Warning"
+                    android:layout_width="@dimen/minor_00"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <RadioGroup
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_75"
+                android:layout_marginBottom="@dimen/major_100"
+                app:layout_constraintBottom_toTopOf="@id/useSuggestedAddressButton"
+                app:layout_constraintTop_toBottomOf="@id/suggestionBanner"
+                app:layout_constraintVertical_bias="0">
+
+                <RadioButton
+                    android:id="@+id/enteredAddressOption"
+                    style="@style/Woo.RadioButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/minor_75"
+                    android:paddingStart="@dimen/major_175"
+                    android:paddingEnd="@dimen/major_150"
+                    android:text="@string/shipping_label_address_suggestion_entered_address" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/enteredAddressText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_350"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:lineSpacingExtra="@dimen/minor_50"
+                    tools:text="Carolle bruce 123 Main St\nSan Francisco CA, 78117\nUSA" />
+
+                <View
+                    android:id="@+id/divider"
+                    style="@style/Woo.Divider"
+                    android:layout_marginStart="@dimen/major_350"
+                    android:layout_marginTop="@dimen/major_100"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/editText" />
+
+                <RadioButton
+                    android:id="@+id/suggestedAddressOption"
+                    style="@style/Woo.RadioButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/minor_50"
+                    android:checked="true"
+                    android:paddingStart="@dimen/major_175"
+                    android:paddingEnd="@dimen/major_150"
+                    android:text="@string/shipping_label_address_suggestion_suggested_address" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/suggestedAddressText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_350"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:lineSpacingExtra="@dimen/minor_50"
+                    tools:text="Carolle bruce 123 Main St\nSan Francisco CA, 78117\nUSA" />
+
+            </RadioGroup>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/useSuggestedAddressButton"
+                style="@style/Woo.Button.Colored"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/major_100"
                 android:layout_marginEnd="@dimen/major_100"
-                android:contentDescription="@string/shipping_label_edit_address_validation_error"
-                android:src="@drawable/ic_tintable_info_outline_24dp"
-                app:layout_constraintBottom_toTopOf="@id/bannerDivider"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/suggestionBannerMessage"
-                app:layout_constraintVertical_bias="0.0"
-                app:tint="@color/warning_banner_foreground_color"
-                tools:visibility="visible" />
+                android:text="@string/shipping_label_address_suggestion_use_selected_address"
+                app:layout_constraintBottom_toTopOf="@id/editAddressButton" />
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/suggestionBannerMessage"
-                style="@style/Woo.TextView.Warning"
-                android:layout_width="0dp"
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/editAddressButton"
+                style="@style/Woo.Button.Outlined"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_200"
-                android:layout_marginTop="@dimen/major_100"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
                 android:layout_marginBottom="@dimen/major_100"
-                android:text="@string/shipping_label_address_suggestion_banner"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/suggestionBannerIcon"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="@id/bannerDivider"
-                tools:visibility="visible" />
+                android:text="@string/shipping_label_address_suggestion_edit_selected_address"
+                app:layout_constraintBottom_toBottomOf="parent" />
 
-            <View
-                android:id="@+id/bannerDivider"
-                style="@style/Woo.Divider.Warning"
-                android:layout_width="@dimen/minor_00"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <RadioGroup
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@id/suggestionBanner"
-            app:layout_constraintBottom_toTopOf="@id/useSuggestedAddressButton"
-            app:layout_constraintVertical_bias="0"
-            android:layout_marginStart="@dimen/major_75"
-            android:layout_marginBottom="@dimen/major_100">
-
-            <RadioButton
-                android:id="@+id/enteredAddressOption"
-                style="@style/Woo.RadioButton"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/minor_75"
-                android:paddingStart="@dimen/major_175"
-                android:paddingEnd="@dimen/major_150"
-                android:text="@string/shipping_label_address_suggestion_entered_address" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/enteredAddressText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_350"
-                android:lineSpacingExtra="@dimen/minor_50"
-                android:clickable="true"
-                android:focusable="true"
-                android:background="?attr/selectableItemBackground"
-                tools:text="Carolle bruce 123 Main St\nSan Francisco CA, 78117\nUSA" />
-
-            <View
-                android:id="@+id/divider"
-                style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_350"
-                android:layout_marginTop="@dimen/major_100"
-                app:layout_constraintTop_toBottomOf="@id/editText"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"/>
-
-            <RadioButton
-                android:id="@+id/suggestedAddressOption"
-                style="@style/Woo.RadioButton"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/minor_50"
-                android:paddingStart="@dimen/major_175"
-                android:paddingEnd="@dimen/major_150"
-                android:checked="true"
-                android:text="@string/shipping_label_address_suggestion_suggested_address" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/suggestedAddressText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_350"
-                android:lineSpacingExtra="@dimen/minor_50"
-                android:clickable="true"
-                android:focusable="true"
-                android:background="?attr/selectableItemBackground"
-                tools:text="Carolle bruce 123 Main St\nSan Francisco CA, 78117\nUSA" />
-
-        </RadioGroup>
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/useSuggestedAddressButton"
-            style="@style/Woo.Button.Colored"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
-            app:layout_constraintBottom_toTopOf="@id/editAddressButton"
-            android:text="@string/shipping_label_address_suggestion_use_selected_address" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/editAddressButton"
-            style="@style/Woo.Button.Outlined"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_100"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:text="@string/shipping_label_address_suggestion_edit_selected_address" />
-
-    </com.woocommerce.android.widgets.WCElevatedConstraintLayout>
-</ScrollView>
+        </com.woocommerce.android.widgets.WCElevatedConstraintLayout>
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_shipping_label_create_custom_package.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_label_create_custom_package.xml
@@ -1,104 +1,128 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <com.woocommerce.android.widgets.WCElevatedConstraintLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/minor_100">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/custom_package_form_info"
+    <View
+        android:id="@+id/app_bar_divider"
+        style="@style/Woo.Divider"
+        android:layout_gravity="bottom" />
+
+    <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.woocommerce.android.widgets.WCElevatedConstraintLayout xmlns:app="http://schemas.android.com/apk/res-auto"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_75"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/shipping_label_create_package_field_info"
-            android:textAppearance="@style/TextAppearance.Woo.Body1"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:paddingBottom="@dimen/minor_100">
 
-        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-            android:id="@+id/type_spinner"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_75"
-            android:layout_marginEnd="@dimen/major_100"
-            android:hint="@string/shipping_label_create_custom_package_field_type"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/custom_package_form_info" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/custom_package_form_info"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_75"
+                android:layout_marginEnd="@dimen/major_100"
+                android:text="@string/shipping_label_create_package_field_info"
+                android:textAppearance="@style/TextAppearance.Woo.Body1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/name"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_175"
-            android:layout_marginEnd="@dimen/major_100"
-            android:hint="@string/shipping_label_create_custom_package_field_name"
-            android:inputType="text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/type_spinner" />
+            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                android:id="@+id/type_spinner"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_75"
+                android:layout_marginEnd="@dimen/major_100"
+                android:hint="@string/shipping_label_create_custom_package_field_type"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/custom_package_form_info" />
 
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/length"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_175"
-            android:layout_marginEnd="@dimen/major_100"
-            android:hint="@string/shipping_label_create_custom_package_field_length"
-            android:inputType="numberDecimal"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/name" />
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_175"
+                android:layout_marginEnd="@dimen/major_100"
+                android:hint="@string/shipping_label_create_custom_package_field_name"
+                android:inputType="text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/type_spinner" />
 
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/width"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_175"
-            android:layout_marginEnd="@dimen/major_100"
-            android:hint="@string/shipping_label_create_custom_package_field_width"
-            android:inputType="numberDecimal"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/length" />
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/length"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_175"
+                android:layout_marginEnd="@dimen/major_100"
+                android:hint="@string/shipping_label_create_custom_package_field_length"
+                android:inputType="numberDecimal"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/name" />
 
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/height"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_175"
-            android:layout_marginEnd="@dimen/major_100"
-            android:hint="@string/shipping_label_create_custom_package_field_height"
-            android:inputType="numberDecimal"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/width" />
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/width"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_175"
+                android:layout_marginEnd="@dimen/major_100"
+                android:hint="@string/shipping_label_create_custom_package_field_width"
+                android:inputType="numberDecimal"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/length" />
 
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/weight"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_175"
-            android:layout_marginEnd="@dimen/major_100"
-            android:hint="@string/shipping_label_create_custom_package_field_empty_weight"
-            android:inputType="numberDecimal"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/height"
-            app:helperText="@string/shipping_label_create_custom_package_field_empty_weight_helper"
-            />
-    </com.woocommerce.android.widgets.WCElevatedConstraintLayout>
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/height"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_175"
+                android:layout_marginEnd="@dimen/major_100"
+                android:hint="@string/shipping_label_create_custom_package_field_height"
+                android:inputType="numberDecimal"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/width" />
 
-</ScrollView>
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/weight"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_175"
+                android:layout_marginEnd="@dimen/major_100"
+                android:hint="@string/shipping_label_create_custom_package_field_empty_weight"
+                android:inputType="numberDecimal"
+                app:helperText="@string/shipping_label_create_custom_package_field_empty_weight_helper"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/height" />
+        </com.woocommerce.android.widgets.WCElevatedConstraintLayout>
+
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_shipping_label_create_custom_package.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_label_create_custom_package.xml
@@ -11,7 +11,7 @@
         style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/toolbar_height"
-        android:elevation="@dimen/minor_50"
+        android:elevation="@dimen/appbar_elevation"
         app:layout_collapseMode="pin"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_shipping_label_create_package.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_label_create_package.xml
@@ -2,7 +2,26 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        style="@style/Widget.Woo.Toolbar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name"/>
+
+    <View
+        android:id="@+id/app_bar_divider"
+        android:layout_gravity="bottom"
+        style="@style/Woo.Divider" />
 
     <com.google.android.material.tabs.TabLayout
         android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/fragment_shipping_label_create_package.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_label_create_package.xml
@@ -10,7 +10,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/toolbar_height"
-        android:elevation="@dimen/minor_50"
+        android:elevation="@dimen/appbar_elevation"
         app:layout_collapseMode="pin"
         style="@style/Widget.Woo.Toolbar"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_shipping_label_refund.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_label_refund.xml
@@ -6,12 +6,32 @@
     android:layout_height="match_parent"
     android:background="?attr/colorSurface">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        style="@style/Widget.Woo.Toolbar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name"/>
+
+    <View
+        android:id="@+id/app_bar_divider"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        style="@style/Woo.Divider" />
+
+
     <com.woocommerce.android.widgets.WCWarningBanner
         android:id="@+id/expiration_warning_banner"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:visibility="visible"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/app_bar_divider"
         app:message="@string/shipping_label_refund_expired" />
 
     <com.google.android.material.textview.MaterialTextView

--- a/WooCommerce/src/main/res/layout/fragment_shipping_packages_selector.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_packages_selector.xml
@@ -14,13 +14,32 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/minor_50"
+        app:layout_collapseMode="pin"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
+
+    <View
+        android:id="@+id/app_bar_divider"
+        style="@style/Woo.Divider"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/packages_list"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/app_bar_divider"
         app:layout_constraintBottom_toTopOf="@id/packages_createNewContainer"
         app:layout_constraintVertical_bias="0.0"
         tools:itemCount="5"

--- a/WooCommerce/src/main/res/layout/fragment_shipping_packages_selector.xml
+++ b/WooCommerce/src/main/res/layout/fragment_shipping_packages_selector.xml
@@ -19,7 +19,7 @@
         style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/toolbar_height"
-        android:elevation="@dimen/minor_50"
+        android:elevation="@dimen/appbar_elevation"
         app:layout_collapseMode="pin"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -93,6 +93,10 @@
         android:name="com.woocommerce.android.ui.orders.list.OrderListFragment"
         android:label="fragment_order_list"
         tools:layout="@layout/fragment_order_list">
+        <argument
+            android:name="orderId"
+            app:argType="long"
+            android:defaultValue="-1L"/>
         <action
             android:id="@+id/action_orderListFragment_to_orderDetailFragment"
             app:destination="@id/nav_graph_orders">

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -55,6 +55,16 @@
             android:id="@+id/action_orderCreationFragment_to_customerListFragment"
             app:destination="@id/customerListFragment" />
         <action
+            android:id="@+id/action_orderCreationFragment_to_orderListFragment"
+            app:destination="@id/orders"
+            app:enterAnim="@anim/default_enter_anim"
+            app:exitAnim="@anim/default_exit_anim">
+        <argument
+            android:name="orderId"
+            app:argType="long"
+            android:defaultValue="-1L"/>
+        </action>
+        <action
             android:id="@+id/action_orderCreationFragment_to_orderDetailFragment"
             app:destination="@id/nav_graph_orders"
             app:enterAnim="@anim/default_enter_anim"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -7,6 +7,7 @@
 
     <include app:graph="@navigation/nav_graph_payment_flow" />
     <include app:graph="@navigation/nav_graph_refunds" />
+    <include app:graph="@navigation/nav_graph_order_creations" />
 
     <dialog
         android:id="@+id/itemSelectorDialog"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10570 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR introduces individual toolbars for each fragment, replacing the shared toolbar previously used with `MainActivity`. This modification is essential to accommodate screens within a two-pane layout, ensuring that each screen maintains its distinct toolbar despite sharing a common parent.

Following fragments have been modified to contain its own toolbar
1. OrderListFragment
2. OrderDetailFragment
3. CustomerOrderNoteEditingFragment
4. AddOrderNoteFragment
5. PrintShippingLabelFragment
6. LabelFormatOptionsFragment
7. PrintShippingLabelInfoFragment
8. PrintShippingLabelCustomsFormFragment
9. ShippingLabelRefundFragment
10. CreateShippingLabelFragment
11. EditShippingLabelAddressFragment
12. EditShippingLabelPackagesFragment
13. EditShippingLabelPaymentFragment
14. ShippingCarrierRatesFragment
15. ShippingCustomsFragment
16. ShippingLabelAddressSuggestionFragment
17. ShippingLabelCreateCustomPackageFragment
18. ShippingLabelCreatePackageFragment
19. ShippingPackageSelectorFragment
20. SelectPaymentMethodFragment
21. PaymentsHubFragment
22. CardReaderOnboardingFragment

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Please navigate through all the specified screens from the Order Detail screen in a two-pane layout, verifying the accuracy and functionality of each screen's toolbar and its action items. Additionally, confirm that the toolbars and their action items function identically on mobile phones, maintaining consistency across different device types.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/1331230/cb2e0669-df2b-4e76-8b8b-fdac5747a54a








- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
