### PR TITLE
[Backend Receipt] Add a text that we share along with the file

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,8 @@
 17.3
 -----
 - [*] [Internal] Enhanced user experience in shipping label creation with automatic scrolling to the first invalid field upon form submission failure [https://github.com/woocommerce/woocommerce-android/pull/10657]
+- [*] [Internal] Added a text along with the receipts file when it is shared [https://github.com/woocommerce/woocommerce-android/pull/10681]
+
 17.2
 -----
 - [**] [Available for users with WooCommerce version of 8.7+, which is not released yet] Every order have a receipt now. The receipts can be shared via many apps installed on the phone [https://github.com/woocommerce/woocommerce-android/pull/10650]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptShare.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptShare.kt
@@ -4,7 +4,9 @@ import android.app.Application
 import android.content.Intent
 import android.os.Environment
 import androidx.core.content.FileProvider
+import com.woocommerce.android.R
 import com.woocommerce.android.media.FileUtils
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.FileDownloader
 import java.io.File
 import javax.inject.Inject
@@ -13,6 +15,7 @@ class PaymentReceiptShare @Inject constructor(
     private val fileUtils: FileUtils,
     private val fileDownloader: FileDownloader,
     private val context: Application,
+    private val selectedSite: SelectedSite,
 ) {
     @Suppress("TooGenericExceptionCaught")
     suspend operator fun invoke(receiptUrl: String, orderNumber: Long): ReceiptShareResult {
@@ -35,9 +38,15 @@ class PaymentReceiptShare @Inject constructor(
             context.packageName + ".provider",
             receiptFile
         )
+
+        val text = context.getString(
+            R.string.card_reader_payment_receipt_email_subject,
+            selectedSite.get().name.orEmpty()
+        )
         val intent = Intent(Intent.ACTION_SEND).apply {
             type = "application/*"
             putExtra(Intent.EXTRA_STREAM, uri)
+            putExtra(Intent.EXTRA_TEXT, text)
         }
         return try {
             context.startActivity(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptShare.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptShare.kt
@@ -17,7 +17,6 @@ class PaymentReceiptShare @Inject constructor(
     private val context: Application,
     private val selectedSite: SelectedSite,
 ) {
-    @Suppress("TooGenericExceptionCaught")
     suspend operator fun invoke(receiptUrl: String, orderNumber: Long): ReceiptShareResult {
         val receiptFile = fileUtils.createTempTimeStampedFile(
             storageDir = context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS)
@@ -32,6 +31,7 @@ class PaymentReceiptShare @Inject constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun tryShare(receiptFile: File): ReceiptShareResult {
         val uri = FileProvider.getUriForFile(
             context,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptShareTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptShareTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.payments.receipt
 
 import android.app.Application
 import com.woocommerce.android.media.FileUtils
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.FileDownloader
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -22,11 +23,13 @@ class PaymentReceiptShareTest : BaseUnitTest() {
     private val context: Application = mock {
         on { getExternalFilesDir(anyOrNull()) }.thenReturn(file)
     }
+    private val selectedSite: SelectedSite = mock()
 
     private val sut = PaymentReceiptShare(
         fileUtils = fileUtils,
         fileDownloader = fileDownloader,
         context = context,
+        selectedSite,
     )
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10670
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds `Your receipt from {name of a store}` text to the intent when we share an HTML receipt

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
* Open an order with a receipt
* Open a receipt and try to share it
* Notice that (if the app supports that) you'll see `Your receipt from {name of a store}` text shared with the file

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/ad3d61a1-7169-4b91-9d13-82c9d68b3333



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
