### PR TITLE
Generalize the toolbar fix when changing visibility during a pending animation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -61,7 +61,6 @@ import com.woocommerce.android.ui.appwidgets.WidgetUpdater
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
-import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.login.LoginActivity
@@ -206,9 +205,6 @@ class MainActivity :
     private val fragmentLifecycleObserver: FragmentLifecycleCallbacks = object : FragmentLifecycleCallbacks() {
         override fun onFragmentViewCreated(fm: FragmentManager, f: Fragment, v: View, savedInstanceState: Bundle?) {
             if (f is DialogFragment) return
-
-            if (f is BlazeCampaignCreationPreviewFragment) // Context on why this is needed check GH issue #10563
-                animatorHelper.cancelToolbarAnimation()
 
             when (val appBarStatus = (f as? BaseFragment)?.activityAppBarStatus ?: AppBarStatus.Visible()) {
                 is AppBarStatus.Visible -> {
@@ -490,6 +486,9 @@ class MainActivity :
     }
 
     private fun showToolbar(animate: Boolean) {
+        // Cancel any pending toolbar animations
+        animatorHelper.cancelToolbarAnimation()
+
         if (binding.collapsingToolbar.layoutParams.height == animatorHelper.toolbarHeight) return
         if (animate) {
             animatorHelper.animateToolbarHeight(show = true) {
@@ -505,6 +504,9 @@ class MainActivity :
     }
 
     private fun hideToolbar(animate: Boolean) {
+        // Cancel any pending toolbar animations
+        animatorHelper.cancelToolbarAnimation()
+
         if (binding.collapsingToolbar.layoutParams.height == 0) return
         if (animate) {
             animatorHelper.animateToolbarHeight(show = false) {


### PR DESCRIPTION
### Description
To fix #10603, we added an `if` to cancel the toolbar animation when showing the Blaze fragment, this PR just generalizes this logic, as it might occur for any cases where we trigger a navigation that updates the Toolbar status while an animation is still ongoing.

@JorgeMucientes this is not urgent, just something that I noticed while catching up.

### Testing instructions
Confirm the issue #10603 is still fixed and preferably smoke test some screens of the app to confirm non-regression.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
