### PR TITLE
Fix Jetpack CP login

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 17.2
 -----
 - [**] [Available for users with WooCommerce version of 8.7+, which is not released yet] Every order have a receipt now. The receipts can be shared via many apps installed on the phone [https://github.com/woocommerce/woocommerce-android/pull/10650]
+- [*] Fix login for sites with Jetpack Connection Package [https://github.com/woocommerce/woocommerce-android/pull/10688]
 
 17.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -187,9 +187,7 @@ class SitePickerViewModel @Inject constructor(
     }
 
     private fun onSitesLoaded(sites: List<SiteModel>) {
-        val filteredSites = sites.filter { !it.isJetpackCPConnected }
-
-        if (filteredSites.isEmpty()) {
+        if (sites.isEmpty()) {
             when {
                 loginSiteAddress != null -> showAccountMismatchScreen(loginSiteAddress!!)
                 navArgs.openedFromLogin -> onEmptyStoresList()
@@ -198,8 +196,8 @@ class SitePickerViewModel @Inject constructor(
             return
         }
 
-        val wooSites = filteredSites.filter { it.hasWooCommerce }
-        val nonWooSites = filteredSites.filter { !it.hasWooCommerce }
+        val wooSites = sites.filter { it.hasWooCommerce }
+        val nonWooSites = sites.filter { !it.hasWooCommerce }
 
         if (_sites.value == null) {
             // Track events only on the first call
@@ -231,7 +229,7 @@ class SitePickerViewModel @Inject constructor(
             }
         }
         sitePickerViewState = sitePickerViewState.copy(
-            hasConnectedStores = filteredSites.isNotEmpty(),
+            hasConnectedStores = sites.isNotEmpty(),
             isPrimaryBtnVisible = wooSites.isNotEmpty(),
             isNoStoresViewVisible = false,
             currentSitePickerState = SitePickerState.StoreListState
@@ -263,7 +261,7 @@ class SitePickerViewModel @Inject constructor(
      * - Has WooCommerce installed
      */
     private fun processLoginSiteAddress(url: String) {
-        val site = repository.getSiteBySiteUrl(url)?.takeIf { !it.isJetpackCPConnected }
+        val site = repository.getSiteBySiteUrl(url)
         when {
             site == null -> {
                 // The url doesn't match any sites for this account.


### PR DESCRIPTION
### Description
This commit b28e92811bd767112dffd84129c9c9671f1bbd80 that removed the Jetpack CP feature flag accidentally broke the Jetpack CP login, as it filtered out all of the JetpackCPConnected sites from the site picker's logic.
This PR fixes this.

This was identified after investigating this p1707195959834669/1705664280.448529-slack-C03L1NF1EA3

### Testing instructions
1. Create a Jetpack CP site.
2. Confirm login works correctly to this site.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->