### PR TITLE
Add missing % symbol to tax lines

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
@@ -176,7 +176,7 @@ class OrderCreateEditTotalsHelper @Inject constructor(
                 )
             ) + taxLines.map {
                 TotalsSectionsState.Line.SimpleSmall(
-                    label = "${it.label} · ${it.ratePercent}",
+                    label = "${it.label} · ${it.ratePercent}%",
                     value = bigDecimalFormatter(BigDecimal(it.taxTotal))
                 )
             } + TotalsSectionsState.Line.LearnMore(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelperTest.kt
@@ -181,9 +181,9 @@ class OrderCreateEditTotalsHelperTest {
         val taxesLines = (actual.lines[5] as TotalsSectionsState.Line.Block).lines
         assertThat((taxesLines[0] as TotalsSectionsState.Line.Simple).label).isEqualTo("Taxes")
         assertThat((taxesLines[0] as TotalsSectionsState.Line.Simple).value).isEqualTo("16.00$")
-        assertThat((taxesLines[1] as TotalsSectionsState.Line.SimpleSmall).label).isEqualTo("tax 1 · 5.0")
+        assertThat((taxesLines[1] as TotalsSectionsState.Line.SimpleSmall).label).isEqualTo("tax 1 · 5.0%")
         assertThat((taxesLines[1] as TotalsSectionsState.Line.SimpleSmall).value).isEqualTo("10.00$")
-        assertThat((taxesLines[2] as TotalsSectionsState.Line.SimpleSmall).label).isEqualTo("tax 2 · 6.0")
+        assertThat((taxesLines[2] as TotalsSectionsState.Line.SimpleSmall).label).isEqualTo("tax 2 · 6.0%")
         assertThat((taxesLines[2] as TotalsSectionsState.Line.SimpleSmall).value).isEqualTo("11.00$")
         assertThat((taxesLines[3] as TotalsSectionsState.Line.LearnMore).text).isEqualTo(taxBasedOnSettingLabel)
         assertThat((taxesLines[3] as TotalsSectionsState.Line.LearnMore).buttonText).isEqualTo("learn More")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10713
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the missing "%" symbol next to tax rate percentage values in tax lines in the order creation form.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Open order creation/edition form with some items
2. Verify that tax rate percentage values are now followed by the "%" char as shown in the pictures below.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Before | After |
|---|---|
|<img width="306" alt="Screenshot 2024-02-07 at 21 36 02" src="https://github.com/woocommerce/woocommerce-android/assets/4527432/5cc3a62e-276e-40bc-b32d-84f16e7628be">|<img width="310" alt="Screenshot 2024-02-07 at 21 33 05" src="https://github.com/woocommerce/woocommerce-android/assets/4527432/9756f39d-7855-4ee7-b645-35bdd872c779">|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
