### PR TITLE
Blaze: Ad destination URL dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -60,14 +60,16 @@ class BlazeRepository @Inject constructor(
         }
     }
 
-    fun getCampaignPreviewDetails(productId: Long): CampaignPreview {
+    suspend fun getCampaignPreviewDetails(productId: Long): CampaignPreview {
         val product = productDetailRepository.getProduct(productId)
+            ?: productDetailRepository.fetchProductOrLoadFromCache(productId)!!
+
         return CampaignPreview(
             productId = productId,
             userTimeZone = timezoneProvider.deviceTimezone.displayName,
-            targetUrl = product?.permalink,
+            targetUrl = product.permalink,
             urlParams = null,
-            campaignImageUrl = product?.firstImageUrl
+            campaignImageUrl = product.firstImageUrl
         )
     }
 
@@ -75,7 +77,7 @@ class BlazeRepository @Inject constructor(
     data class CampaignPreview(
         val productId: Long,
         val userTimeZone: String,
-        val targetUrl: String?,
+        val targetUrl: String,
         val urlParams: Pair<String, String>?,
         val campaignImageUrl: String?,
     ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -65,7 +65,7 @@ class BlazeRepository @Inject constructor(
         return CampaignPreview(
             productId = productId,
             userTimeZone = timezoneProvider.deviceTimezone.displayName,
-            targetUrl = product?.permalink ?: "",
+            targetUrl = product?.permalink,
             urlParams = null,
             campaignImageUrl = product?.firstImageUrl
         )
@@ -75,7 +75,7 @@ class BlazeRepository @Inject constructor(
     data class CampaignPreview(
         val productId: Long,
         val userTimeZone: String,
-        val targetUrl: String,
+        val targetUrl: String?,
         val urlParams: Pair<String, String>?,
         val campaignImageUrl: String?,
     ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationScreen.kt
@@ -1,27 +1,41 @@
 package com.woocommerce.android.ui.blaze.creation.destination
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.RadioButton
+import androidx.compose.material.RadioButtonDefaults
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.window.Dialog
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.blaze.creation.destination.BlazeCampaignCreationAdDestinationViewModel.ViewState
+import com.woocommerce.android.ui.compose.component.DialogButtonsRowLayout
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
@@ -32,7 +46,8 @@ fun BlazeCampaignCreationAdDestinationScreen(viewModel: BlazeCampaignCreationAdD
             previewState,
             viewModel::onBackPressed,
             viewModel::onUrlPropertyTapped,
-            viewModel::onParameterPropertyTapped
+            viewModel::onParameterPropertyTapped,
+            viewModel::onDestinationUrlChanged
         )
     }
 }
@@ -42,7 +57,8 @@ fun AdDestinationScreen(
     viewState: ViewState,
     onBackPressed: () -> Unit,
     onUrlPropertyTapped: () -> Unit,
-    onParametersPropertyTapped: () -> Unit
+    onParametersPropertyTapped: () -> Unit,
+    onDestinationUrlChanged: (String) -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -62,7 +78,7 @@ fun AdDestinationScreen(
         ) {
             AdDestinationProperty(
                 title = stringResource(id = R.string.blaze_campaign_edit_ad_destination_url_property_title),
-                value = viewState.destinationUrl,
+                value = viewState.targetUrl,
                 onPropertyTapped = onUrlPropertyTapped
             )
             Divider()
@@ -72,13 +88,22 @@ fun AdDestinationScreen(
                 onPropertyTapped = onParametersPropertyTapped
             )
         }
+
+        if (viewState.isUrlDialogVisible) {
+            AdDestinationUrlDialog(
+                viewState,
+                onDismissed = { onDestinationUrlChanged(viewState.targetUrl) },
+                onSaveTapped = onDestinationUrlChanged
+            )
+        }
     }
 }
 
 @Composable
 fun AdDestinationProperty(title: String, value: String, onPropertyTapped: () -> Unit) {
     Column(
-        modifier = Modifier
+        modifier =
+        Modifier
             .clickable { onPropertyTapped() }
             .padding(dimensionResource(id = R.dimen.major_100))
             .fillMaxWidth(1f)
@@ -98,18 +123,114 @@ fun AdDestinationProperty(title: String, value: String, onPropertyTapped: () -> 
     }
 }
 
+@Composable
+fun AdDestinationUrlDialog(
+    viewState: ViewState,
+    onDismissed: () -> Unit,
+    onSaveTapped: (String) -> Unit,
+) {
+    Dialog(onDismissRequest = onDismissed) {
+        Column(
+            modifier =
+            Modifier
+                .background(MaterialTheme.colors.surface, MaterialTheme.shapes.medium)
+                .padding(dimensionResource(id = R.dimen.major_100)),
+            verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100))
+        ) {
+            Text(
+                text = stringResource(id = R.string.blaze_campaign_edit_ad_destination_url_property_title),
+                style = MaterialTheme.typography.h6
+            )
+
+            var targetUrl by rememberSaveable {
+                mutableStateOf(viewState.targetUrl)
+            }
+
+            UrlOption(
+                url = viewState.productUrl,
+                targetUrl = targetUrl,
+                title = R.string.blaze_campaign_edit_ad_destination_product_url_option
+            ) {
+                targetUrl = viewState.productUrl
+            }
+
+            UrlOption(
+                url = viewState.siteUrl,
+                targetUrl = targetUrl,
+                title = R.string.blaze_campaign_edit_ad_destination_site_url_option
+            ) {
+                targetUrl = viewState.siteUrl
+            }
+
+            DialogButtonsRowLayout(
+                confirmButton = {
+                    WCTextButton(onClick = {
+                        onSaveTapped(targetUrl)
+                    }) {
+                        Text(text = stringResource(id = R.string.save))
+                    }
+                },
+                dismissButton = {
+                    WCTextButton(onClick = onDismissed) {
+                        Text(text = stringResource(id = android.R.string.cancel))
+                    }
+                },
+                neutralButton = null
+            )
+        }
+    }
+}
+
+@Composable
+private fun UrlOption(
+    url: String,
+    targetUrl: String,
+    @StringRes title: Int,
+    onOptionSelected: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    Row(
+        modifier = Modifier.clickable(
+            indication = null,
+            interactionSource = interactionSource,
+            onClick = onOptionSelected
+        ),
+    ) {
+        RadioButton(
+            selected = url == targetUrl,
+            onClick = onOptionSelected,
+            colors = RadioButtonDefaults.colors(
+                selectedColor = MaterialTheme.colors.primary,
+                unselectedColor = colorResource(id = R.color.color_on_surface_medium)
+            )
+        )
+        Column {
+            Text(stringResource(title))
+            Text(
+                text = url,
+                style = MaterialTheme.typography.subtitle1,
+                color = colorResource(id = R.color.color_on_surface_medium)
+            )
+        }
+    }
+}
+
 @LightDarkThemePreviews
 @Composable
 fun PreviewAdDestinationScreen() {
     WooThemeWithBackground {
         AdDestinationScreen(
             viewState = ViewState(
-                destinationUrl = "https://woocommerce.com",
-                parameters = "utm_source=woocommerce\nutm_medium=android\nutm_campaign=blaze"
+                parameters = "utm_source=woocommerce\nutm_medium=android\nutm_campaign=blaze",
+                productUrl = "https://woocommerce.com/products/1",
+                siteUrl = "https://woocommerce.com",
+                targetUrl = "https://woocommerce.com/products/12",
+                isUrlDialogVisible = true
             ),
             onBackPressed = {},
             onUrlPropertyTapped = {},
-            onParametersPropertyTapped = {}
+            onParametersPropertyTapped = {},
+            onDestinationUrlChanged = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
@@ -3,23 +3,38 @@ package com.woocommerce.android.ui.blaze.creation.destination
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
 class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    resourceProvider: ResourceProvider
+    resourceProvider: ResourceProvider,
+    selectedSite: SelectedSite,
+    productDetailRepository: ProductDetailRepository
 ) : ScopedViewModel(savedStateHandle) {
+    private val navArgs: BlazeCampaignCreationAdDestinationFragmentArgs by savedStateHandle.navArgs()
+    private val targetUrlPrompt = resourceProvider
+            .getString(R.string.blaze_campaign_edit_ad_destination_empty_url_message)
+    private val productUrl = requireNotNull(productDetailRepository.getProduct(navArgs.productId))
+            .permalink
+
     private val _viewState = MutableStateFlow(
         ViewState(
-            destinationUrl = resourceProvider.getString(R.string.blaze_campaign_edit_ad_destination_empty_url_message),
             parameters = resourceProvider
-                .getString(R.string.blaze_campaign_edit_ad_destination_empty_parameters_message)
+                .getString(R.string.blaze_campaign_edit_ad_destination_empty_parameters_message),
+            productUrl = productUrl,
+            siteUrl = selectedSite.get().url,
+            targetUrl = navArgs.targetUrl ?: targetUrlPrompt,
+            isUrlDialogVisible = false
         )
     )
 
@@ -30,15 +45,25 @@ class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
     }
 
     fun onUrlPropertyTapped() {
-        /* TODO */
+        _viewState.update { it.copy(isUrlDialogVisible = true) }
     }
 
     fun onParameterPropertyTapped() {
         /* TODO */
     }
 
+    fun onDestinationUrlChanged(destinationUrl: String) {
+        _viewState.value = _viewState.value.copy(
+            targetUrl = destinationUrl,
+            isUrlDialogVisible = false
+        )
+    }
+
     data class ViewState(
-        val destinationUrl: String,
-        val parameters: String
+        val parameters: String,
+        val productUrl: String,
+        val siteUrl: String,
+        val targetUrl: String,
+        val isUrlDialogVisible: Boolean
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
@@ -23,9 +23,9 @@ class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: BlazeCampaignCreationAdDestinationFragmentArgs by savedStateHandle.navArgs()
     private val targetUrlPrompt = resourceProvider
-            .getString(R.string.blaze_campaign_edit_ad_destination_empty_url_message)
+        .getString(R.string.blaze_campaign_edit_ad_destination_empty_url_message)
     private val productUrl = requireNotNull(productDetailRepository.getProduct(navArgs.productId))
-            .permalink
+        .permalink
 
     private val _viewState = MutableStateFlow(
         ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
@@ -76,7 +76,10 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
                 )
                 is NavigateToAdDestinationScreen -> findNavController().navigateSafely(
                     BlazeCampaignCreationPreviewFragmentDirections
-                        .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignCreationAdDestinationFragment()
+                        .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignCreationAdDestinationFragment(
+                            event.productId,
+                            event.targetUrl
+                        )
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -219,10 +219,11 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         ),
         destinationUrl = CampaignDetailItemUi(
             displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_destination_url),
-            displayValue = targetUrl,
+            displayValue = targetUrl
+                ?: resourceProvider.getString(string.blaze_campaign_edit_ad_destination_url_property_title),
             maxLinesValue = 1,
             onItemSelected = {
-                triggerEvent(NavigateToAdDestinationScreen)
+                triggerEvent(NavigateToAdDestinationScreen(targetUrl, navArgs.productId))
             }
         )
     )
@@ -281,7 +282,10 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
 
     object NavigateToBudgetScreen : MultiLiveEvent.Event()
 
-    object NavigateToAdDestinationScreen : MultiLiveEvent.Event()
+    data class NavigateToAdDestinationScreen(
+        val targetUrl: String?,
+        val productId: Long
+    ) : MultiLiveEvent.Event()
 
     data class NavigateToTargetSelectionScreen(
         val targetType: BlazeTargetType,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -42,7 +42,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     private val currencyFormatter: CurrencyFormatter
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: BlazeCampaignCreationPreviewFragmentArgs by savedStateHandle.navArgs()
-    private val campaign = blazeRepository.getCampaignPreviewDetails(navArgs.productId)
+    private suspend fun getCampaign() = blazeRepository.getCampaignPreviewDetails(navArgs.productId)
 
     private val adDetails = savedStateHandle.getStateFlow<AdDetailsUi>(viewModelScope, Loading)
     private val budget = savedStateHandle.getStateFlow(viewModelScope, getDefaultBudget())
@@ -95,7 +95,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     ) { ad, budget, selectedLanguages, selectedDevices, selectedInterests, selectedLocations ->
         CampaignPreviewUiState(
             adDetails = ad,
-            campaignDetails = campaign.toCampaignDetailsUi(
+            campaignDetails = getCampaign().toCampaignDetailsUi(
                 budget,
                 selectedLanguages,
                 selectedDevices,
@@ -164,7 +164,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
                         productId = navArgs.productId,
                         description = suggestions?.firstOrNull()?.description ?: "",
                         tagLine = suggestions?.firstOrNull()?.tagLine ?: "",
-                        campaignImageUrl = campaign.campaignImageUrl
+                        campaignImageUrl = getCampaign().campaignImageUrl
                     )
                 }
             }
@@ -219,8 +219,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         ),
         destinationUrl = CampaignDetailItemUi(
             displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_destination_url),
-            displayValue = targetUrl
-                ?: resourceProvider.getString(string.blaze_campaign_edit_ad_destination_url_property_title),
+            displayValue = targetUrl,
             maxLinesValue = 1,
             onItemSelected = {
                 triggerEvent(NavigateToAdDestinationScreen(targetUrl, navArgs.productId))

--- a/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
@@ -113,5 +113,13 @@
     <fragment
         android:id="@+id/blazeCampaignCreationAdDestinationFragment"
         android:name="com.woocommerce.android.ui.blaze.creation.destination.BlazeCampaignCreationAdDestinationFragment"
-        android:label="BlazeCampaignCreationAdDestinationFragment" />
+        android:label="BlazeCampaignCreationAdDestinationFragment" >
+        <argument
+            android:name="targetUrl"
+            android:defaultValue="@null"
+            app:nullable="true"
+            app:argType="string" />
+        <argument android:name="productId"
+            app:argType="long" />
+    </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3889,6 +3889,8 @@
     <string name="blaze_campaign_edit_ad_destination_empty_parameters_message">Enter manually</string>
     <string name="blaze_campaign_edit_ad_destination_url_property_title">Destination URL</string>
     <string name="blaze_campaign_edit_ad_destination_parameters_property_title">URL parameters</string>
+    <string name="blaze_campaign_edit_ad_destination_product_url_option">The product URL</string>
+    <string name="blaze_campaign_edit_ad_destination_site_url_option">The site home</string>
     <!--
     Highlights tooltip
     -->


### PR DESCRIPTION
Implements #10715, a subtask of #10665.

<image src="https://github.com/woocommerce/woocommerce-android/assets/1522856/55439455-ac1b-4117-b39b-9e75ddaa81cc" width="300" />

**To test:**
1. Start Blaze campaign creation
2. In the ad preview, tap on Destination URL
3. Tap on Destination URL property
4. Notice a dialog appears, listing a product URL and a site URL
5. Try changing the selection
6. Tap on Save
7. Notice the URL gets updates
8. Tap on the URL property again
9. Notice the right URL is preselected