### PR TITLE
[Better Tablet Products] Add nav host fragment to contain product detail fragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -127,9 +127,9 @@ class ProductListFragment :
     override val lifecycleKeeper: Lifecycle
         get() = viewLifecycleOwner.lifecycle
 
-    override val navigation: TabletHelper.Screen.Navigation
+    override val secondPaneNavigation: TabletHelper.Screen.Navigation
         get() = TabletHelper.Screen.Navigation(
-            childFragmentManager.findFragmentById(R.id.detail_nav_container)?.findNavController(),
+            childFragmentManager,
             R.navigation.nav_graph_products,
             null,
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -58,6 +58,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 
 @Suppress("LargeClass")
@@ -74,6 +75,9 @@ class ProductListFragment :
     companion object {
         val TAG: String = ProductListFragment::class.java.simpleName
         const val PRODUCT_FILTER_RESULT_KEY = "product_filter_result"
+
+        private const val TABLET_PANES_WIDTH_RATIO = 0.5F
+        private const val XL_TABLET_PANES_WIDTH_RATIO = 0.68F
     }
 
     @Inject
@@ -122,6 +126,10 @@ class ProductListFragment :
         enterTransition = fadeThroughTransition
         exitTransition = fadeThroughTransition
         reenterTransition = fadeThroughTransition
+
+        val navController =
+            childFragmentManager.findFragmentById(R.id.detail_nav_container)?.findNavController()
+        navController?.setGraph(R.navigation.nav_graph_products)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -161,6 +169,7 @@ class ProductListFragment :
 
         initAddProductFab(binding.addProductButton)
         addSelectionTracker()
+        binding.adjustUIForScreenSize()
 
         when {
             productListViewModel.isSearching() -> {
@@ -171,6 +180,16 @@ class ProductListFragment :
             else -> {
                 productListViewModel.reloadProductsFromDb(excludeProductId = pendingTrashProductId)
             }
+        }
+    }
+
+    private fun FragmentProductListBinding.adjustUIForScreenSize() {
+        if (DisplayUtils.isTablet(context)) {
+            twoPaneLayoutGuideline.setGuidelinePercent(TABLET_PANES_WIDTH_RATIO)
+        } else if (DisplayUtils.isXLargeTablet(context)) {
+            twoPaneLayoutGuideline.setGuidelinePercent(XL_TABLET_PANES_WIDTH_RATIO)
+        } else {
+            twoPaneLayoutGuideline.setGuidelinePercent(1.0f)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -115,6 +115,15 @@ class ProductListFragment :
             feedbackPrefs.getFeatureFeedbackSettings(FeatureFeedbackSettings.Feature.PRODUCT_VARIATIONS)?.feedbackState
                 ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val transitionDuration = resources.getInteger(R.integer.default_fragment_transition).toLong()
+        val fadeThroughTransition = MaterialFadeThrough().apply { duration = transitionDuration }
+        enterTransition = fadeThroughTransition
+        exitTransition = fadeThroughTransition
+        reenterTransition = fadeThroughTransition
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         postponeEnterTransition()
@@ -236,15 +245,6 @@ class ProductListFragment :
         }
 
         super.onViewStateRestored(savedInstanceState)
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        val transitionDuration = resources.getInteger(R.integer.default_fragment_transition).toLong()
-        val fadeThroughTransition = MaterialFadeThrough().apply { duration = transitionDuration }
-        enterTransition = fadeThroughTransition
-        exitTransition = fadeThroughTransition
-        reenterTransition = fadeThroughTransition
     }
 
     override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -54,7 +54,7 @@ import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent
 import com.woocommerce.android.ui.products.ProductSortAndFiltersCard.ProductSortAndFilterListener
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.StringUtils
-import com.woocommerce.android.util.TabletHelper
+import com.woocommerce.android.util.TabletLayoutSetupHelper
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
@@ -72,7 +72,7 @@ class ProductListFragment :
     WCProductSearchTabView.ProductSearchTypeChangedListener,
     ActionMode.Callback,
     MenuProvider,
-    TabletHelper.Screen {
+    TabletLayoutSetupHelper.Screen {
     companion object {
         val TAG: String = ProductListFragment::class.java.simpleName
         const val PRODUCT_FILTER_RESULT_KEY = "product_filter_result"
@@ -91,7 +91,7 @@ class ProductListFragment :
     lateinit var addProductNavigator: AddProductNavigator
 
     @Inject
-    lateinit var tabletHelper: TabletHelper
+    lateinit var tabletLayoutSetupHelper: TabletLayoutSetupHelper
 
     private var _productAdapter: ProductListAdapter? = null
     private val productAdapter: ProductListAdapter
@@ -125,7 +125,7 @@ class ProductListFragment :
     override val lifecycleKeeper: Lifecycle by lazy { viewLifecycleOwner.lifecycle }
 
     override val secondPaneNavigation by lazy {
-        TabletHelper.Screen.Navigation(
+        TabletLayoutSetupHelper.Screen.Navigation(
             childFragmentManager,
             R.navigation.nav_graph_products,
             null,
@@ -144,7 +144,7 @@ class ProductListFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        tabletHelper.onViewCreated(this)
+        tabletLayoutSetupHelper.onViewCreated(this)
 
         postponeEnterTransition()
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -11,7 +11,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.SearchView.OnQueryTextListener
-import androidx.constraintlayout.widget.Guideline
 import androidx.core.view.MenuCompat
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewGroupCompat
@@ -121,18 +120,17 @@ class ProductListFragment :
             feedbackPrefs.getFeatureFeedbackSettings(FeatureFeedbackSettings.Feature.PRODUCT_VARIATIONS)?.feedbackState
                 ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
-    override val twoPaneLayoutGuideline: Guideline
-        get() = binding.twoPaneLayoutGuideline
+    override val twoPaneLayoutGuideline by lazy { binding.twoPaneLayoutGuideline }
 
-    override val lifecycleKeeper: Lifecycle
-        get() = viewLifecycleOwner.lifecycle
+    override val lifecycleKeeper: Lifecycle by lazy { viewLifecycleOwner.lifecycle }
 
-    override val secondPaneNavigation: TabletHelper.Screen.Navigation
-        get() = TabletHelper.Screen.Navigation(
+    override val secondPaneNavigation by lazy {
+        TabletHelper.Screen.Navigation(
             childFragmentManager,
             R.navigation.nav_graph_products,
             null,
         )
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletHelper.kt
@@ -18,18 +18,19 @@ class TabletHelper @Inject constructor(
     private var screen: Screen? = null
 
     fun onViewCreated(screen: Screen) {
+        if (!FeatureFlag.BETTER_TABLETS_SUPPORT_PRODUCTS.isEnabled()) return
+
         this.screen = screen
         screen.lifecycleKeeper.addObserver(this)
     }
 
     override fun onCreate(owner: LifecycleOwner) {
+        if (!FeatureFlag.BETTER_TABLETS_SUPPORT_PRODUCTS.isEnabled()) return
+
         if (DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)) {
             initNavFragment(screen!!.secondPaneNavigation)
+            adjustUIForScreenSize(screen!!.twoPaneLayoutGuideline)
         }
-    }
-
-    override fun onStart(owner: LifecycleOwner) {
-        adjustUIForScreenSize(screen!!.twoPaneLayoutGuideline)
     }
 
     override fun onDestroy(owner: LifecycleOwner) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletHelper.kt
@@ -51,12 +51,14 @@ class TabletHelper @Inject constructor(
     }
 
     private fun adjustUIForScreenSize(twoPaneLayoutGuideline: Guideline) {
-        if (DisplayUtils.isTablet(context)) {
-            twoPaneLayoutGuideline.setGuidelinePercent(TABLET_PANES_WIDTH_RATIO)
-        } else if (DisplayUtils.isXLargeTablet(context)) {
-            twoPaneLayoutGuideline.setGuidelinePercent(XL_TABLET_PANES_WIDTH_RATIO)
-        } else {
-            twoPaneLayoutGuideline.setGuidelinePercent(1.0f)
+        when {
+            DisplayUtils.isTablet(context) -> {
+                twoPaneLayoutGuideline.setGuidelinePercent(TABLET_PANES_WIDTH_RATIO)
+            }
+            DisplayUtils.isXLargeTablet(context) -> {
+                twoPaneLayoutGuideline.setGuidelinePercent(XL_TABLET_PANES_WIDTH_RATIO)
+            }
+            else -> twoPaneLayoutGuideline.setGuidelinePercent(1.0f)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletHelper.kt
@@ -3,10 +3,12 @@ package com.woocommerce.android.util
 import android.content.Context
 import android.os.Bundle
 import androidx.constraintlayout.widget.Guideline
+import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
-import androidx.navigation.NavController
+import androidx.navigation.fragment.NavHostFragment
+import com.woocommerce.android.R
 import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 
@@ -22,7 +24,7 @@ class TabletHelper @Inject constructor(
 
     override fun onCreate(owner: LifecycleOwner) {
         if (DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)) {
-            initNavFragment(screen!!.navigation)
+            initNavFragment(screen!!.secondPaneNavigation)
         }
     }
 
@@ -36,11 +38,15 @@ class TabletHelper @Inject constructor(
     }
 
     private fun initNavFragment(navigation: Screen.Navigation) {
-        val navController = navigation.navController!!
-        val navGraphId = navigation.navGraph
+        val fragmentManager = navigation.fragmentManager
+        val navGraphId = navigation.navGraphId
         val bundle = navigation.bundle
 
-        navController.setGraph(navGraphId, bundle)
+        val navHostFragment = NavHostFragment.create(navGraphId, bundle)
+
+        fragmentManager.beginTransaction()
+            .replace(R.id.detail_nav_container, navHostFragment)
+            .commit()
     }
 
     private fun adjustUIForScreenSize(twoPaneLayoutGuideline: Guideline) {
@@ -55,17 +61,17 @@ class TabletHelper @Inject constructor(
 
     private companion object {
         const val TABLET_PANES_WIDTH_RATIO = 0.5F
-        const val XL_TABLET_PANES_WIDTH_RATIO = 0.68F
+        const val XL_TABLET_PANES_WIDTH_RATIO = 0.33F
     }
 
     interface Screen {
         val twoPaneLayoutGuideline: Guideline
-        val navigation: Navigation
+        val secondPaneNavigation: Navigation
         val lifecycleKeeper: Lifecycle
 
         data class Navigation(
-            val navController: NavController?,
-            val navGraph: Int,
+            val fragmentManager: FragmentManager,
+            val navGraphId: Int,
             val bundle: Bundle?
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletHelper.kt
@@ -1,0 +1,72 @@
+package com.woocommerce.android.util
+
+import android.content.Context
+import android.os.Bundle
+import androidx.constraintlayout.widget.Guideline
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.navigation.NavController
+import org.wordpress.android.util.DisplayUtils
+import javax.inject.Inject
+
+class TabletHelper @Inject constructor(
+    private val context: Context,
+) : DefaultLifecycleObserver {
+    private var screen: Screen? = null
+
+    fun onViewCreated(screen: Screen) {
+        this.screen = screen
+        screen.lifecycleKeeper.addObserver(this)
+    }
+
+    override fun onCreate(owner: LifecycleOwner) {
+        if (DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)) {
+            initNavFragment(screen!!.navigation)
+        }
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        adjustUIForScreenSize(screen!!.twoPaneLayoutGuideline)
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        screen!!.lifecycleKeeper.removeObserver(this)
+        screen = null
+    }
+
+    private fun initNavFragment(navigation: Screen.Navigation) {
+        val navController = navigation.navController!!
+        val navGraphId = navigation.navGraph
+        val bundle = navigation.bundle
+
+        navController.setGraph(navGraphId, bundle)
+    }
+
+    private fun adjustUIForScreenSize(twoPaneLayoutGuideline: Guideline) {
+        if (DisplayUtils.isTablet(context)) {
+            twoPaneLayoutGuideline.setGuidelinePercent(TABLET_PANES_WIDTH_RATIO)
+        } else if (DisplayUtils.isXLargeTablet(context)) {
+            twoPaneLayoutGuideline.setGuidelinePercent(XL_TABLET_PANES_WIDTH_RATIO)
+        } else {
+            twoPaneLayoutGuideline.setGuidelinePercent(1.0f)
+        }
+    }
+
+    private companion object {
+        const val TABLET_PANES_WIDTH_RATIO = 0.5F
+        const val XL_TABLET_PANES_WIDTH_RATIO = 0.68F
+    }
+
+    interface Screen {
+        val twoPaneLayoutGuideline: Guideline
+        val navigation: Navigation
+        val lifecycleKeeper: Lifecycle
+
+        data class Navigation(
+            val navController: NavController?,
+            val navGraph: Int,
+            val bundle: Bundle?
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
@@ -12,7 +12,7 @@ import com.woocommerce.android.R
 import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 
-class TabletHelper @Inject constructor(
+class TabletLayoutSetupHelper @Inject constructor(
     private val context: Context,
 ) : DefaultLifecycleObserver {
     private var screen: Screen? = null

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -1,112 +1,137 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/productsRefreshLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.woocommerce.android.ui.products.ProductListFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+    <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+        android:id="@+id/productsRefreshLayout"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/detail_nav_container"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <!-- Product search type view -->
-        <com.woocommerce.android.ui.products.WCProductSearchTabView
-            android:id="@+id/productsSearchTabView"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:visibility="visible" />
+            android:layout_height="match_parent">
 
-        <!-- Products work in progress notice card -->
-        <com.woocommerce.android.ui.products.FeatureWIPNoticeCard
-            android:id="@+id/products_wip_card"
-            style="@style/Woo.Card.Expandable"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/minor_100"
-            android:visibility="gone"
-            app:layout_constraintBottom_toTopOf="@+id/products_sort_filter_card"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/productsSearchTabView"
-            tools:visibility="visible" />
+            <!-- Product search type view -->
+            <com.woocommerce.android.ui.products.WCProductSearchTabView
+                android:id="@+id/productsSearchTabView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:visibility="visible" />
 
-        <!-- Products filter and sort view -->
-        <com.woocommerce.android.ui.products.ProductSortAndFiltersCard
-            android:id="@+id/products_sort_filter_card"
-            style="@style/Woo.Card"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/minor_00"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/products_wip_card"
-            tools:visibility="visible" />
+            <!-- Products work in progress notice card -->
+            <com.woocommerce.android.ui.products.FeatureWIPNoticeCard
+                android:id="@+id/products_wip_card"
+                style="@style/Woo.Card.Expandable"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/minor_100"
+                android:visibility="gone"
+                app:layout_constraintBottom_toTopOf="@+id/products_sort_filter_card"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/productsSearchTabView"
+                tools:visibility="visible" />
 
-        <androidx.compose.ui.platform.ComposeView
-            android:id="@+id/blaze_banner_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/empty_state_bg_color"
-            android:paddingBottom="@dimen/minor_100"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/products_sort_filter_card" />
+            <!-- Products filter and sort view -->
+            <com.woocommerce.android.ui.products.ProductSortAndFiltersCard
+                android:id="@+id/products_sort_filter_card"
+                style="@style/Woo.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/minor_00"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/products_wip_card"
+                tools:visibility="visible" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/productsRecycler"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:background="?attr/colorSurface"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/blaze_banner_view"
-            tools:itemCount="5"
-            tools:listitem="@layout/product_list_item" />
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/blaze_banner_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/empty_state_bg_color"
+                android:paddingBottom="@dimen/minor_100"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/products_sort_filter_card" />
 
-        <com.woocommerce.android.widgets.WCEmptyView
-            android:id="@+id/empty_view"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/productsSearchTabView" />
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/productsRecycler"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:background="?attr/colorSurface"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/blaze_banner_view"
+                tools:itemCount="5"
+                tools:listitem="@layout/product_list_item" />
 
-        <ProgressBar
-            android:id="@+id/loadMoreProgress"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:layout_centerHorizontal="true"
-            android:layout_marginBottom="@dimen/major_75"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            tools:visibility="gone" />
+            <com.woocommerce.android.widgets.WCEmptyView
+                android:id="@+id/empty_view"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/productsSearchTabView" />
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/addProductButton"
-            style="@style/Woo.AddButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/major_100"
-            android:contentDescription="@string/add_products_button"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            tools:visibility="visible" />
+            <ProgressBar
+                android:id="@+id/loadMoreProgress"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:layout_centerHorizontal="true"
+                android:layout_marginBottom="@dimen/major_75"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                tools:visibility="gone" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/addProductButton"
+                style="@style/Woo.AddButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/major_100"
+                android:contentDescription="@string/add_products_button"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                tools:visibility="visible" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/detail_nav_container"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        app:defaultNavHost="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_percent="0.67"
+        app:navGraph="@navigation/nav_graph_products"
+        tools:visibility="visible" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -12,7 +12,7 @@
         android:layout_width="0dp"
         android:layout_height="match_parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/detail_nav_container"
+        app:layout_constraintEnd_toStartOf="@+id/two_pane_layout_guideline"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
@@ -120,18 +120,22 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
 
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/two_pane_layout_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        tools:layout_constraintGuide_percent=".33" />
+
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/detail_nav_container"
-        android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="0dp"
         android:layout_height="match_parent"
         android:visibility="gone"
         app:defaultNavHost="false"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/two_pane_layout_guideline"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_percent="0.67"
-        app:navGraph="@navigation/nav_graph_products"
         tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -125,6 +125,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        app:layout_constraintGuide_percent="1.0"
         tools:layout_constraintGuide_percent=".33" />
 
     <androidx.fragment.app.FragmentContainerView


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10724
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The pull request includes updates to prepare for a future two-pane layout on the product list screen behind the feature flag. That's known that currently it's not functional as I don't pass product id to the product details fragment

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
When FF flag is on
* Go to the products screen on a tablet and notice that 2 panes are visible for some time and then gone
* Go to the products screen on a tablet and notice that there are not changes

When FF flag is off
* Both tablets and phone should behave exactly as now

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/4923871/2c4cd0aa-f0ed-4019-b84c-fbda780e8dc2

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
