### PR TITLE
[Order creation] Add @Preview annotation for prices

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -714,7 +714,6 @@ fun ExpandableProductCardPreview() {
     }
 }
 
-
 @Preview
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
@@ -747,7 +746,6 @@ fun ExpandableProductCardUnsyncedPreview() {
         ExpandableProductCard(state, product, {}, {}, {}, {}, { _, _ -> })
     }
 }
-
 
 @Preview
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -688,7 +688,8 @@ fun ExpandableProductCardPreview() {
     val item = Order.Item.EMPTY.copy(
         name = "Test Product Long Long Long Long Long Long Name",
         quantity = 3.0f,
-        sku = "123"
+        sku = "123",
+        itemId = 10L
     )
     val product = OrderCreationProduct.ProductItem(
         item = item,
@@ -712,6 +713,41 @@ fun ExpandableProductCardPreview() {
         ExpandableProductCard(state, product, {}, {}, {}, {}, { _, _ -> })
     }
 }
+
+
+@Preview
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun ExpandableProductCardUnsyncedPreview() {
+    val item = Order.Item.EMPTY.copy(
+        name = "Test Product Long Long Long Long Long Long Name",
+        quantity = 3.0f,
+        sku = "123",
+        itemId = 0L
+    )
+    val product = OrderCreationProduct.ProductItem(
+        item = item,
+        productInfo = ProductInfo(
+            imageUrl = "",
+            isStockManaged = true,
+            stockQuantity = 3.0,
+            stockStatus = ProductStockStatus.InStock,
+            pricePreDiscount = "$10",
+            priceTotal = "$30",
+            priceSubtotal = "$30",
+            discountAmount = "$5",
+            priceAfterDiscount = "$25",
+            hasDiscount = true,
+            isConfigurable = false,
+            productType = ProductType.SIMPLE
+        )
+    )
+    val state = remember { mutableStateOf(OrderCreateEditViewModel.ViewState()) }
+    WooThemeWithBackground {
+        ExpandableProductCard(state, product, {}, {}, {}, {}, { _, _ -> })
+    }
+}
+
 
 @Preview
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
@@ -756,7 +792,8 @@ fun ExtendedConfigurableProductCardContentPreview() {
         quantity = 3.0f,
         total = 23.toBigDecimal(),
         subtotal = 30.toBigDecimal(),
-        sku = "SKU123"
+        sku = "SKU123",
+        itemId = 10L
     )
     val product = OrderCreationProduct.ProductItem(
         item = item,
@@ -779,57 +816,4 @@ fun ExtendedConfigurableProductCardContentPreview() {
     WooThemeWithBackground {
         ExtendedProductCardContent(state, product, {}, {}, {}) {}
     }
-}
-
-@SuppressLint("UnrememberedMutableState")
-@Composable
-@Preview
-fun PreviewExpandableProductCard() {
-    val state = mutableStateOf<OrderCreateEditViewModel.ViewState?>(null)
-    val mockAttribute = Order.Item.Attribute("", "")
-    val mockOrderItem = Order.Item(
-        1,
-        0,
-        "",
-        BigDecimal("0"),
-        "",
-        0.0f,
-        BigDecimal("0"),
-        BigDecimal("0"),
-        BigDecimal("0"),
-        0,
-        listOf(mockAttribute),
-        0,
-        null,
-        0
-    )
-
-    val productInfo = ProductInfo(
-        "imageUrl",
-        true,
-        10.0,
-        ProductStockStatus.InStock,
-        ProductType.SIMPLE,
-        false,
-        "100",
-        "100",
-        "100",
-        "10",
-        "90",
-        true
-    )
-
-    val product = OrderCreationProduct.ProductItem(
-        item = mockOrderItem,
-        productInfo = productInfo
-    )
-
-    ExpandableProductCard(
-        state = state,
-        product = product,
-        onRemoveProductClicked = {},
-        onDiscountButtonClicked = {},
-        onItemAmountChanged = { _ -> }, onEditConfigurationClicked = {}, // No operation during preview
-        onProductExpanded = { _, _ -> }
-    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -780,3 +780,56 @@ fun ExtendedConfigurableProductCardContentPreview() {
         ExtendedProductCardContent(state, product, {}, {}, {}) {}
     }
 }
+
+@SuppressLint("UnrememberedMutableState")
+@Composable
+@Preview
+fun PreviewExpandableProductCard() {
+    val state = mutableStateOf<OrderCreateEditViewModel.ViewState?>(null)
+    val mockAttribute = Order.Item.Attribute("", "")
+    val mockOrderItem = Order.Item(
+        1,
+        0,
+        "",
+        BigDecimal("0"),
+        "",
+        0.0f,
+        BigDecimal("0"),
+        BigDecimal("0"),
+        BigDecimal("0"),
+        0,
+        listOf(mockAttribute),
+        0,
+        null,
+        0
+    )
+
+    val productInfo = ProductInfo(
+        "imageUrl",
+        true,
+        10.0,
+        ProductStockStatus.InStock,
+        ProductType.SIMPLE,
+        false,
+        "100",
+        "100",
+        "100",
+        "10",
+        "90",
+        true
+    )
+
+    val product = OrderCreationProduct.ProductItem(
+        item = mockOrderItem,
+        productInfo = productInfo
+    )
+
+    ExpandableProductCard(
+        state = state,
+        product = product,
+        onRemoveProductClicked = {},
+        onDiscountButtonClicked = {},
+        onItemAmountChanged = { _ -> }, onEditConfigurationClicked = {}, // No operation during preview
+        onProductExpanded = { _, _ -> }
+    )
+}


### PR DESCRIPTION

Closes: #10712

### Description  

Following @kidinov 's suggestion, I have added two preview annotations for the ExpandableProductCard. This includes a regular preview and a dark mode preview. Because of my previous [change](https://github.com/woocommerce/woocommerce-android/pull/10673), while loading and syncing, these sections of the checkout process were hidden which made debugging more complex.

Utilizing the `@Preview` annotation, we can now visually preview within Android Studio the view components for price and quantity, even when not synced. 

### Testing instructions  
- Open the `ExpandableProductCard` component in Android Studio.
- Verify that the preview pane shows both the regular and dark mode layout for an unsynced state.

### Images/gif  

<img width="279" alt="Screenshot 2024-02-08 at 15 29 57" src="https://github.com/woocommerce/woocommerce-android/assets/947561/ee179212-88d4-435a-ba9a-4475ca37257f">


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary.

