### PR TITLE
Add EXPANDED_ANALYTIC_HUB_M2 feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -12,7 +12,8 @@ enum class FeatureFlag {
     IAP_FOR_STORE_CREATION,
     BETTER_CUSTOMER_SEARCH_M2,
     ORDER_CREATION_AUTO_TAX_RATE,
-    BLAZE_I3;
+    BLAZE_I3,
+    EXPANDED_ANALYTIC_HUB_M2;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -24,7 +25,8 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
-            BLAZE_I3 -> PackageUtils.isDebugBuild()
+            BLAZE_I3,
+            EXPANDED_ANALYTIC_HUB_M2 -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false
         }


### PR DESCRIPTION
Closes: #10698

### Description
Adds a feature flag `EXPANDED_ANALYTIC_HUB_M2` to hide development for customizing the Analytics Hub. This flag isn't being used yet.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->