### PR TITLE
Blaze: Ad destination parameters

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationFragment.kt
@@ -6,7 +6,11 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.handleResult
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.blaze.creation.destination.BlazeCampaignCreationAdDestinationParametersFragment.Companion.BLAZE_DESTINATION_PARAMETERS_RESULT
+import com.woocommerce.android.ui.blaze.creation.destination.BlazeCampaignCreationAdDestinationViewModel.NavigateToParametersScreen
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -34,11 +38,18 @@ class BlazeCampaignCreationAdDestinationFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+                is NavigateToParametersScreen -> {
+                    val action = BlazeCampaignCreationAdDestinationFragmentDirections
+                        .actionAdDestinationFragmentToAdDestinationParametersFragment(event.url)
+                    findNavController().navigateSafely(action)
+                }
             }
         }
     }
 
     private fun handleResults() {
-        /* TODO */
+        handleResult<String>(BLAZE_DESTINATION_PARAMETERS_RESULT) { url ->
+            viewModel.onDestinationUrlChanged(url)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationFragment.kt
@@ -49,7 +49,7 @@ class BlazeCampaignCreationAdDestinationFragment : BaseFragment() {
 
     private fun handleResults() {
         handleResult<String>(BLAZE_DESTINATION_PARAMETERS_RESULT) { url ->
-            viewModel.onDestinationUrlChanged(url)
+            viewModel.onTargetUrlUpdated(url)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersFragment.kt
@@ -1,0 +1,43 @@
+package com.woocommerce.android.ui.blaze.creation.destination
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class BlazeCampaignCreationAdDestinationParametersFragment : BaseFragment() {
+    companion object {
+        const val BLAZE_DESTINATION_PARAMETERS_RESULT = "blaze_destination_parameters_result"
+    }
+
+    private val viewModel: BlazeCampaignCreationAdDestinationParametersViewModel by viewModels()
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return composeView {
+            BlazeCampaignCreationAdDestinationParametersScreen(viewModel)
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        handleEvents()
+    }
+
+    private fun handleEvents() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is ExitWithResult<*> -> navigateBackWithResult(BLAZE_DESTINATION_PARAMETERS_RESULT, event.data)
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersScreen.kt
@@ -77,7 +77,7 @@ fun AdDestinationParametersScreen(
                 .padding(paddingValues)
                 .fillMaxSize(),
         ) {
-            item {
+            item(key = "header") {
                 WCTextButton(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -90,7 +90,7 @@ fun AdDestinationParametersScreen(
 
             itemsIndexed(
                 items = viewState.parameters.entries.toList(),
-                key = { _, item -> item.key }
+                key = { _, item -> "key${item.key}" }
             ) { index, (key, value) ->
                 Column(
                     modifier = Modifier
@@ -142,34 +142,40 @@ fun AdDestinationParametersScreen(
                 }
             }
 
-            item {
-                Text(
+            item(key = "footer") {
+                Column(
                     modifier = Modifier
-                        .padding(
-                            start = dimensionResource(id = R.dimen.major_100),
-                            end = dimensionResource(id = R.dimen.major_100),
-                            top = dimensionResource(id = R.dimen.major_100),
-                            bottom = dimensionResource(id = R.dimen.minor_100)
+                        .animateItemPlacement()
+                        .fillMaxWidth()
+                ) {
+                    Text(
+                        modifier = Modifier
+                            .padding(
+                                start = dimensionResource(id = R.dimen.major_100),
+                                end = dimensionResource(id = R.dimen.major_100),
+                                top = dimensionResource(id = R.dimen.major_100),
+                                bottom = dimensionResource(id = R.dimen.minor_100)
+                            ),
+                        text = stringResource(
+                            R.string.blaze_campaign_edit_ad_characters_remaining,
+                            viewState.charactersRemaining
                         ),
-                    text = stringResource(
-                        R.string.blaze_campaign_edit_ad_characters_remaining,
-                        viewState.charactersRemaining
-                    ),
-                    style = MaterialTheme.typography.caption,
-                    color = colorResource(id = R.color.color_on_surface_medium)
-                )
-                Text(
-                    modifier = Modifier
-                        .padding(
-                            horizontal = dimensionResource(id = R.dimen.major_100),
+                        style = MaterialTheme.typography.caption,
+                        color = colorResource(id = R.color.color_on_surface_medium)
+                    )
+                    Text(
+                        modifier = Modifier
+                            .padding(
+                                horizontal = dimensionResource(id = R.dimen.major_100),
+                            ),
+                        text = stringResource(
+                            R.string.blaze_campaign_edit_ad_destination_destination_with_parameters,
+                            viewState.url
                         ),
-                    text = stringResource(
-                        R.string.blaze_campaign_edit_ad_destination_destination_with_parameters,
-                        viewState.url
-                    ),
-                    style = MaterialTheme.typography.caption,
-                    color = colorResource(id = R.color.color_on_surface_medium)
-                )
+                        style = MaterialTheme.typography.caption,
+                        color = colorResource(id = R.color.color_on_surface_medium)
+                    )
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersScreen.kt
@@ -1,0 +1,214 @@
+package com.woocommerce.android.ui.blaze.creation.destination
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.Icons.Filled
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.blaze.creation.destination.BlazeCampaignCreationAdDestinationParametersViewModel.ViewState
+import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun BlazeCampaignCreationAdDestinationParametersScreen(
+    viewModel: BlazeCampaignCreationAdDestinationParametersViewModel
+) {
+    viewModel.viewState.observeAsState().value?.let { viewState ->
+        AdDestinationParametersScreen(
+            viewState,
+            viewModel::onBackPressed,
+            viewModel::onAddParameterTapped,
+            viewModel::onParameterTapped,
+            viewModel::onDeleteParameterTapped
+        )
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun AdDestinationParametersScreen(
+    viewState: ViewState,
+    onBackPressed: () -> Unit,
+    onAddParameterTapped: () -> Unit,
+    onParameterTapped: (String) -> Unit,
+    onDeleteParameterTapped: (String) -> Unit
+) {
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = stringResource(id = R.string.blaze_campaign_edit_ad_destination_parameters_property_title),
+                onNavigationButtonClick = onBackPressed,
+                navigationIcon = Filled.ArrowBack
+            )
+        },
+        modifier = Modifier.background(MaterialTheme.colors.surface)
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .background(MaterialTheme.colors.surface)
+                .padding(paddingValues)
+                .fillMaxSize(),
+        ) {
+            item {
+                WCTextButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(dimensionResource(id = R.dimen.minor_50)),
+                    onClick = onAddParameterTapped,
+                    text = stringResource(id = R.string.blaze_campaign_edit_ad_destination_add_parameter_button),
+                    icon = Icons.Default.Add
+                )
+            }
+
+            itemsIndexed(
+                items = viewState.parameters.entries.toList(),
+                key = { _, item -> item.key }
+            ) { index, (key, value) ->
+                Column(
+                    modifier = Modifier
+                        .animateItemPlacement()
+                        .fillMaxWidth()
+                ) {
+                    Row(modifier = Modifier
+                        .clickable { onParameterTapped(key) }
+                        .padding(
+                            start = dimensionResource(id = R.dimen.major_100),
+                            top = dimensionResource(id = R.dimen.minor_100),
+                            bottom = dimensionResource(id = R.dimen.minor_100)
+                        ),
+                        verticalAlignment = CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = key,
+                                style = MaterialTheme.typography.body2,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                text = value,
+                                style = MaterialTheme.typography.body2,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                color = colorResource(id = R.color.color_on_surface_medium)
+                            )
+                        }
+                        IconButton(
+                            onClick = { onDeleteParameterTapped(key) }
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.DeleteOutline,
+                                contentDescription = stringResource(id = R.string.delete),
+                                tint = colorResource(id = R.color.color_on_surface_medium)
+                            )
+                        }
+                    }
+
+                    if (index < viewState.parameters.size) {
+                        Divider(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                        )
+                    }
+                }
+            }
+
+            item {
+                Text(
+                    modifier = Modifier
+                        .padding(
+                            start = dimensionResource(id = R.dimen.major_100),
+                            end = dimensionResource(id = R.dimen.major_100),
+                            top = dimensionResource(id = R.dimen.major_100),
+                            bottom = dimensionResource(id = R.dimen.minor_100)
+                        ),
+                    text = stringResource(
+                        R.string.blaze_campaign_edit_ad_characters_remaining,
+                        viewState.charactersRemaining
+                    ),
+                    style = MaterialTheme.typography.caption,
+                    color = colorResource(id = R.color.color_on_surface_medium)
+                )
+                Text(
+                    modifier = Modifier
+                        .padding(
+                            horizontal = dimensionResource(id = R.dimen.major_100),
+                        ),
+                    text = stringResource(
+                        R.string.blaze_campaign_edit_ad_destination_destination_with_parameters,
+                        viewState.url
+                    ),
+                    style = MaterialTheme.typography.caption,
+                    color = colorResource(id = R.color.color_on_surface_medium)
+                )
+            }
+        }
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+fun PreviewAdDestinationParametersScreen() {
+    WooThemeWithBackground {
+        AdDestinationParametersScreen(
+            viewState = ViewState(
+                baseUrl = "https://woocommerce.com",
+                parameters = mapOf(
+                    "utm_source" to "woocommerce",
+                    "utm_medium" to "android",
+                    "utm_campaign" to "blaze"
+                )
+            ),
+            onBackPressed = {},
+            onAddParameterTapped = {},
+            onParameterTapped = {},
+            onDeleteParameterTapped = {}
+        )
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+fun PreviewEmptyAdDestinationParametersScreen() {
+    WooThemeWithBackground {
+        AdDestinationParametersScreen(
+            viewState = ViewState(
+                baseUrl = "https://woocommerce.com?utm_source=woocommerce&utm_medium=android&utm_campaign=blaze",
+                parameters = emptyMap()
+            ),
+            onBackPressed = {},
+            onAddParameterTapped = {},
+            onParameterTapped = {},
+            onDeleteParameterTapped = {}
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersScreen.kt
@@ -97,13 +97,14 @@ fun AdDestinationParametersScreen(
                         .animateItemPlacement()
                         .fillMaxWidth()
                 ) {
-                    Row(modifier = Modifier
-                        .clickable { onParameterTapped(key) }
-                        .padding(
-                            start = dimensionResource(id = R.dimen.major_100),
-                            top = dimensionResource(id = R.dimen.minor_100),
-                            bottom = dimensionResource(id = R.dimen.minor_100)
-                        ),
+                    Row(
+                        modifier = Modifier
+                            .clickable { onParameterTapped(key) }
+                            .padding(
+                                start = dimensionResource(id = R.dimen.major_100),
+                                top = dimensionResource(id = R.dimen.minor_100),
+                                bottom = dimensionResource(id = R.dimen.minor_100)
+                            ),
                         verticalAlignment = CenterVertically
                     ) {
                         Column(modifier = Modifier.weight(1f)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersViewModel.kt
@@ -42,7 +42,7 @@ class BlazeCampaignCreationAdDestinationParametersViewModel @Inject constructor(
 
     @Suppress("UNUSED_PARAMETER")
     fun onParameterTapped(key: String) {
-        /* TODO: */
+        /* TODO */
     }
 
     fun onDeleteParameterTapped(key: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersViewModel.kt
@@ -2,6 +2,9 @@ package com.woocommerce.android.ui.blaze.creation.destination
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.util.getBaseUrl
+import com.woocommerce.android.util.joinToUrl
+import com.woocommerce.android.util.parseParameters
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -22,8 +25,8 @@ class BlazeCampaignCreationAdDestinationParametersViewModel @Inject constructor(
 
     private val _viewState = MutableStateFlow(
         ViewState(
-            baseUrl = getBaseUrl(navArgs.url),
-            parameters = parseParameters(navArgs.url)
+            baseUrl = navArgs.url.getBaseUrl(),
+            parameters = navArgs.url.parseParameters()
         )
     )
 
@@ -48,31 +51,14 @@ class BlazeCampaignCreationAdDestinationParametersViewModel @Inject constructor(
         }
     }
 
-    private fun getBaseUrl(url: String): String {
-        return url.split("?").getOrNull(0) ?: url
-    }
-
-    private fun parseParameters(url: String): Map<String, String> {
-        val parameters = url.split("?").getOrNull(1) ?: return emptyMap()
-        return parameters.split("&").associate {
-            val (key, value) = it.split("=")
-            key to value
-        }
-    }
-
     data class ViewState(
         private val baseUrl: String,
         val parameters: Map<String, String>
     ) {
-        val url: String
-            get() = buildString {
-                append(baseUrl)
-                append("?")
-                append(parameters.entries.joinToString("&") { (key, value) ->
-                    "$key=$value"
-                })
-            }
-        
+        val url by lazy {
+            parameters.joinToUrl(baseUrl)
+        }
+
         val charactersRemaining: Int
             get() = MAX_CHARACTERS - url.length
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersViewModel.kt
@@ -1,0 +1,79 @@
+package com.woocommerce.android.ui.blaze.creation.destination
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class BlazeCampaignCreationAdDestinationParametersViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedStateHandle) {
+    companion object {
+        // The maximum number of characters allowed in a URL by Chrome
+        private const val MAX_CHARACTERS = 2083
+    }
+    private val navArgs: BlazeCampaignCreationAdDestinationParametersFragmentArgs by savedStateHandle.navArgs()
+
+    private val _viewState = MutableStateFlow(
+        ViewState(
+            baseUrl = getBaseUrl(navArgs.url),
+            parameters = parseParameters(navArgs.url)
+        )
+    )
+
+    val viewState = _viewState.asLiveData()
+
+    fun onBackPressed() {
+        triggerEvent(ExitWithResult(_viewState.value.url))
+    }
+
+    fun onAddParameterTapped() {
+        /* TODO */
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun onParameterTapped(key: String) {
+        /* TODO: */
+    }
+
+    fun onDeleteParameterTapped(key: String) {
+        _viewState.update {
+            it.copy(parameters = it.parameters - key)
+        }
+    }
+
+    private fun getBaseUrl(url: String): String {
+        return url.split("?").getOrNull(0) ?: url
+    }
+
+    private fun parseParameters(url: String): Map<String, String> {
+        val parameters = url.split("?").getOrNull(1) ?: return emptyMap()
+        return parameters.split("&").associate {
+            val (key, value) = it.split("=")
+            key to value
+        }
+    }
+
+    data class ViewState(
+        private val baseUrl: String,
+        val parameters: Map<String, String>
+    ) {
+        val url: String
+            get() = buildString {
+                append(baseUrl)
+                append("?")
+                append(parameters.entries.joinToString("&") { (key, value) ->
+                    "$key=$value"
+                })
+            }
+        
+        val charactersRemaining: Int
+            get() = MAX_CHARACTERS - url.length
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersViewModel.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.blaze.creation.destination
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.util.getBaseUrl
-import com.woocommerce.android.util.joinToString
 import com.woocommerce.android.util.joinToUrl
 import com.woocommerce.android.util.parseParameters
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -61,6 +60,6 @@ class BlazeCampaignCreationAdDestinationParametersViewModel @Inject constructor(
         }
 
         val charactersRemaining: Int
-            get() = MAX_CHARACTERS - parameters.joinToString().length
+            get() = MAX_CHARACTERS - parameters.entries.joinToString("&").length
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.blaze.creation.destination
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.util.getBaseUrl
+import com.woocommerce.android.util.joinToString
 import com.woocommerce.android.util.joinToUrl
 import com.woocommerce.android.util.parseParameters
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -19,7 +20,7 @@ class BlazeCampaignCreationAdDestinationParametersViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         // The maximum number of characters allowed in a URL by Chrome
-        private const val MAX_CHARACTERS = 2083
+        private const val MAX_CHARACTERS = 2096
     }
     private val navArgs: BlazeCampaignCreationAdDestinationParametersFragmentArgs by savedStateHandle.navArgs()
 
@@ -60,6 +61,6 @@ class BlazeCampaignCreationAdDestinationParametersViewModel @Inject constructor(
         }
 
         val charactersRemaining: Int
-            get() = MAX_CHARACTERS - url.length
+            get() = MAX_CHARACTERS - parameters.joinToString().length
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationScreen.kt
@@ -84,7 +84,8 @@ fun AdDestinationScreen(
             Divider()
             AdDestinationProperty(
                 title = stringResource(id = R.string.blaze_campaign_edit_ad_destination_parameters_property_title),
-                value = viewState.parameters,
+                value = viewState.parameters
+                    ?: stringResource(R.string.blaze_campaign_edit_ad_destination_empty_parameters_message),
                 onPropertyTapped = onParametersPropertyTapped
             )
         }
@@ -221,10 +222,10 @@ fun PreviewAdDestinationScreen() {
     WooThemeWithBackground {
         AdDestinationScreen(
             viewState = ViewState(
-                parameters = "utm_source=woocommerce\nutm_medium=android\nutm_campaign=blaze",
                 productUrl = "https://woocommerce.com/products/1",
                 siteUrl = "https://woocommerce.com",
-                targetUrl = "https://woocommerce.com/products/12",
+                targetUrl = "https://woocommerce.com/products/12" +
+                    "?utm_source=woocommerce_android&utm_medium=ad&utm_campaign=blaze",
                 isUrlDialogVisible = true
             ),
             onBackPressed = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationScreen.kt
@@ -78,14 +78,13 @@ fun AdDestinationScreen(
         ) {
             AdDestinationProperty(
                 title = stringResource(id = R.string.blaze_campaign_edit_ad_destination_url_property_title),
-                value = viewState.targetUrl,
+                value = viewState.destinationUrl,
                 onPropertyTapped = onUrlPropertyTapped
             )
             Divider()
             AdDestinationProperty(
                 title = stringResource(id = R.string.blaze_campaign_edit_ad_destination_parameters_property_title),
-                value = viewState.parameters
-                    ?: stringResource(R.string.blaze_campaign_edit_ad_destination_empty_parameters_message),
+                value = viewState.parameters,
                 onPropertyTapped = onParametersPropertyTapped
             )
         }
@@ -93,7 +92,7 @@ fun AdDestinationScreen(
         if (viewState.isUrlDialogVisible) {
             AdDestinationUrlDialog(
                 viewState,
-                onDismissed = { onDestinationUrlChanged(viewState.targetUrl) },
+                onDismissed = { onDestinationUrlChanged(viewState.destinationUrl) },
                 onSaveTapped = onDestinationUrlChanged
             )
         }
@@ -143,30 +142,30 @@ fun AdDestinationUrlDialog(
                 style = MaterialTheme.typography.h6
             )
 
-            var targetUrl by rememberSaveable {
-                mutableStateOf(viewState.targetUrl)
+            var destinationUrl by rememberSaveable {
+                mutableStateOf(viewState.destinationUrl)
             }
 
             UrlOption(
                 url = viewState.productUrl,
-                targetUrl = targetUrl,
+                targetUrl = destinationUrl,
                 title = R.string.blaze_campaign_edit_ad_destination_product_url_option
             ) {
-                targetUrl = viewState.productUrl
+                destinationUrl = viewState.productUrl
             }
 
             UrlOption(
                 url = viewState.siteUrl,
-                targetUrl = targetUrl,
+                targetUrl = destinationUrl,
                 title = R.string.blaze_campaign_edit_ad_destination_site_url_option
             ) {
-                targetUrl = viewState.siteUrl
+                destinationUrl = viewState.siteUrl
             }
 
             DialogButtonsRowLayout(
                 confirmButton = {
                     WCTextButton(onClick = {
-                        onSaveTapped(targetUrl)
+                        onSaveTapped(destinationUrl)
                     }) {
                         Text(text = stringResource(id = R.string.save))
                     }
@@ -224,8 +223,8 @@ fun PreviewAdDestinationScreen() {
             viewState = ViewState(
                 productUrl = "https://woocommerce.com/products/1",
                 siteUrl = "https://woocommerce.com",
-                targetUrl = "https://woocommerce.com/products/12" +
-                    "?utm_source=woocommerce_android&utm_medium=ad&utm_campaign=blaze",
+                destinationUrl = "https://woocommerce.com/products/12",
+                parameters = "utm_source=woocommerce_android\nutm_medium=ad\nutm_campaign=blaze",
                 isUrlDialogVisible = true
             ),
             onBackPressed = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.util.getBaseUrl
+import com.woocommerce.android.util.parseParameters
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -31,7 +32,7 @@ class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
         ViewState(
             productUrl = productUrl.trim('/'),
             siteUrl = selectedSite.get().url.trim('/'),
-            destinationUrl = navArgs.targetUrl.getBaseUrl(),
+            destinationUrl = navArgs.targetUrl.getBaseUrl() + "?a=b&c=d",
             parameters = getParameters(navArgs.targetUrl),
             isUrlDialogVisible = false
         )
@@ -70,10 +71,10 @@ class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
     }
 
     private fun getParameters(url: String): String {
-        return url.split("?")
-            .getOrNull(1)
-            ?.replace("&", "\n")
-            ?: return resourceProvider.getString(R.string.blaze_campaign_edit_ad_destination_empty_parameters_message)
+        return url.parseParameters().entries.joinToString(separator = "\n")
+            .ifBlank {
+                resourceProvider.getString(R.string.blaze_campaign_edit_ad_destination_empty_parameters_message)
+            }
     }
 
     private fun getTargetUrl(baseUrl: String, parameters: String): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
@@ -2,11 +2,10 @@ package com.woocommerce.android.ui.blaze.creation.destination
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
-import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductDetailRepository
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
-import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -17,7 +16,6 @@ import javax.inject.Inject
 @HiltViewModel
 class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    resourceProvider: ResourceProvider,
     selectedSite: SelectedSite,
     productDetailRepository: ProductDetailRepository
 ) : ScopedViewModel(savedStateHandle) {
@@ -27,11 +25,9 @@ class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
 
     private val _viewState = MutableStateFlow(
         ViewState(
-            parameters = resourceProvider
-                .getString(R.string.blaze_campaign_edit_ad_destination_empty_parameters_message),
             productUrl = productUrl,
             siteUrl = selectedSite.get().url,
-            targetUrl = navArgs.targetUrl,
+            targetUrl = navArgs.targetUrl + "?utm_source=woocommerce_android&utm_medium=ad&utm_campaign=blaze",
             isUrlDialogVisible = false
         )
     )
@@ -47,7 +43,7 @@ class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
     }
 
     fun onParameterPropertyTapped() {
-        /* TODO */
+        triggerEvent(NavigateToParametersScreen(_viewState.value.targetUrl))
     }
 
     fun onDestinationUrlChanged(destinationUrl: String) {
@@ -58,10 +54,19 @@ class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
     }
 
     data class ViewState(
-        val parameters: String,
         val productUrl: String,
         val siteUrl: String,
         val targetUrl: String,
         val isUrlDialogVisible: Boolean
-    )
+    ) {
+        val parameters: String?
+            get() = getParameters(targetUrl)
+
+        private fun getParameters(url: String): String? {
+            val parameters = url.split("?").getOrNull(1) ?: return null
+            return parameters.replace("&", "\n")
+        }
+    }
+
+    data class NavigateToParametersScreen(val url: String) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
@@ -49,7 +49,5 @@ fun String.parseParameters(): Map<String, String> {
 
 fun Map<String, String>.joinToUrl(baseUrl: String) = buildString {
     append(baseUrl)
-    appendWithIfNotEmpty(joinToString(), "?")
+    appendWithIfNotEmpty(entries.joinToString("&"), "?")
 }
-
-fun Map<String, String>.joinToString() = entries.joinToString("&") { (key, value) -> "$key=$value" }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.util
 
 import android.content.Context
 import com.woocommerce.android.AppUrls
+import com.woocommerce.android.extensions.appendWithIfNotEmpty
 import dagger.Reusable
 import org.wordpress.android.fluxc.network.discovery.DiscoveryUtils
 import org.wordpress.android.util.LanguageUtils
@@ -33,3 +34,22 @@ class UrlUtils @Inject constructor(
             }
     }
 }
+
+fun String.getBaseUrl(): String {
+    return (split("?").getOrNull(0) ?: this).trimEnd('/')
+}
+
+fun String.parseParameters(): Map<String, String> {
+    val parameters = split("?").getOrNull(1) ?: return emptyMap()
+    return parameters.split("&").filter { it.contains("=") }.associate {
+        val (key, value) = it.split("=")
+        key to value
+    }
+}
+
+fun Map<String, String>.joinToUrl(baseUrl: String) = buildString {
+    append(baseUrl)
+    appendWithIfNotEmpty(joinToString(), "?")
+}
+
+fun Map<String, String>.joinToString() = entries.joinToString("&") { (key, value) -> "$key=$value" }

--- a/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
@@ -119,5 +119,16 @@
             app:argType="string" />
         <argument android:name="productId"
             app:argType="long" />
+        <action
+            android:id="@+id/action_adDestinationFragment_to_adDestinationParametersFragment"
+            app:destination="@id/blazeCampaignCreationAdDestinationParametersFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/blazeCampaignCreationAdDestinationParametersFragment"
+        android:name="com.woocommerce.android.ui.blaze.creation.destination.BlazeCampaignCreationAdDestinationParametersFragment"
+        android:label="BlazeCampaignCreationAdDestinationParametersFragment" >
+        <argument
+            android:name="url"
+            app:argType="string" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3890,6 +3890,8 @@
     <string name="blaze_campaign_edit_ad_destination_parameters_property_title">URL parameters</string>
     <string name="blaze_campaign_edit_ad_destination_product_url_option">The product URL</string>
     <string name="blaze_campaign_edit_ad_destination_site_url_option">The site home</string>
+    <string name="blaze_campaign_edit_ad_destination_add_parameter_button">Add parameter</string>
+    <string name="blaze_campaign_edit_ad_destination_destination_with_parameters">Destination: %s</string>
     <!--
     Highlights tooltip
     -->


### PR DESCRIPTION
Implements #10737, a subtask of #10665.

[Screen_recording_20240209_213359.webm](https://github.com/woocommerce/woocommerce-android/assets/1522856/11b50071-b42b-4c1a-b92f-d21e80c863cb)

**To test:**
1. Apply the patch below to see any parameters
2. Create a new Blaze campaign
3. Tap on the Ad destination property
4. Notice the base URL and parameters are printed out
5. Tap on the URL parameters property
6. Notice the 2 parameters are displayed in a list
7. Notice a full URL is shown below the list
8. Delete one parameter
9. Notice the full URL and remaining character count is updated
10. Tap on back
11. Notice the parameters property got updated

**Patch:**
```kotlin
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt	(revision Staged)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt	(date 1707510168898)
@@ -77,7 +77,7 @@
                 is NavigateToAdDestinationScreen -> findNavController().navigateSafely(
                     BlazeCampaignCreationPreviewFragmentDirections
                         .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignCreationAdDestinationFragment(
-                            event.targetUrl,
+                            event.targetUrl + "?test=true&yes=no",
                             event.productId
                         )
                 )
```