### PR TITLE
[Blaze] Payment methods list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListFragment.kt
@@ -5,14 +5,21 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class BlazeCampaignPaymentMethodsListFragment : BaseFragment() {
+    companion object {
+        const val SELECTED_PAYMENT_METHOD_KEY = "selectedPaymentMethodId"
+    }
+
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
@@ -22,6 +29,22 @@ class BlazeCampaignPaymentMethodsListFragment : BaseFragment() {
         return composeView {
             WooThemeWithBackground {
                 BlazeCampaignPaymentMethodsListScreen(viewModel)
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        handleResults()
+    }
+
+    private fun handleResults() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+                is MultiLiveEvent.Event.ExitWithResult<*> -> navigateBackWithResult(
+                    key = SELECTED_PAYMENT_METHOD_KEY,
+                    result = event.data
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListFragment.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.ui.blaze.creation.payment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class BlazeCampaignPaymentMethodsListFragment : BaseFragment() {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    private val viewModel: BlazeCampaignPaymentMethodsListViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return composeView {
+            WooThemeWithBackground {
+                BlazeCampaignPaymentMethodsListScreen(viewModel)
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
@@ -1,8 +1,281 @@
 package com.woocommerce.android.ui.blaze.creation.payment
 
+import android.content.res.Configuration
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.outlined.VerifiedUser
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.woocommerce.android.R
+import com.woocommerce.android.model.CreditCardType
+import com.woocommerce.android.ui.blaze.BlazeRepository.PaymentMethod
+import com.woocommerce.android.ui.blaze.BlazeRepository.PaymentMethodUrls
+import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 fun BlazeCampaignPaymentMethodsListScreen(viewModel: BlazeCampaignPaymentMethodsListViewModel) {
+    viewModel.viewState.observeAsState().value?.let {
+        BlazeCampaignPaymentMethodsListScreen(
+            viewState = it
+        )
+    }
+}
+
+@Composable
+private fun BlazeCampaignPaymentMethodsListScreen(viewState: BlazeCampaignPaymentMethodsListViewModel.ViewState) {
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = stringResource(id = R.string.blaze_campaign_payment_list_screen_title),
+                onNavigationButtonClick = viewState.onDismiss,
+                navigationIcon = when (viewState) {
+                    is BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList -> Icons.Default.ArrowBack
+                    is BlazeCampaignPaymentMethodsListViewModel.ViewState.AddPaymentMethodWebView -> Icons.Default.Clear
+                }
+            )
+        },
+        backgroundColor = MaterialTheme.colors.surface
+    ) { paddingValues ->
+        when (viewState) {
+            is BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList -> {
+                PaymentMethodsList(
+                    paymentMethods = viewState.paymentMethods,
+                    onPaymentMethodClicked = viewState.onPaymentMethodClicked,
+                    onAddPaymentMethodClicked = viewState.onAddPaymentMethodClicked,
+                    modifier = Modifier.padding(paddingValues)
+                )
+            }
+
+            is BlazeCampaignPaymentMethodsListViewModel.ViewState.AddPaymentMethodWebView -> {
+                AddPaymentMethodWebView(
+                    urls = viewState.urls,
+                    onUrlLoaded = viewState.onUrlLoaded,
+                    modifier = Modifier.padding(paddingValues)
+                )
+            }
+        }
+    }
+}
+
+@Suppress("UNUSED_PARAMETER")
+@Composable
+private fun PaymentMethodsList(
+    paymentMethods: List<PaymentMethod>,
+    onPaymentMethodClicked: (PaymentMethod) -> Unit,
+    onAddPaymentMethodClicked: () -> Unit,
+    modifier: Modifier
+) {
+    Column(modifier) {
+        PaymentMethodsHeader(Modifier.fillMaxWidth())
+        if (paymentMethods.isEmpty()) {
+            EmptyPaymentMethodsView(
+                onAddPaymentMethodClicked = onAddPaymentMethodClicked,
+                modifier = modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+            )
+        } else {
+            PaymentMethodsListView(
+                paymentMethods = paymentMethods,
+                onPaymentMethodClicked = onPaymentMethodClicked,
+                onAddPaymentMethodClicked = onAddPaymentMethodClicked,
+                modifier = modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun PaymentMethodsHeader(modifier: Modifier = Modifier) {
+    Row(modifier.padding(dimensionResource(id = R.dimen.major_100))) {
+        Icon(
+            imageVector = Icons.Outlined.VerifiedUser,
+            tint = MaterialTheme.colors.primary,
+            contentDescription = null
+        )
+        Spacer(modifier = Modifier.padding(dimensionResource(id = R.dimen.minor_100)))
+        Text(text = stringResource(id = R.string.blaze_campaign_payment_list_header_text))
+    }
+}
+
+@Composable
+private fun PaymentMethodsListView(
+    paymentMethods: List<PaymentMethod>,
+    onPaymentMethodClicked: (PaymentMethod) -> Unit,
+    onAddPaymentMethodClicked: () -> Unit,
+    modifier: Modifier
+) {
+    LazyColumn(modifier = modifier) {
+        items(paymentMethods) { paymentMethod ->
+            Column {
+                PaymentMethodItem(
+                    paymentMethod = paymentMethod,
+                    onPaymentMethodClicked = { onPaymentMethodClicked(paymentMethod) },
+                    isSelected = true
+                )
+            }
+            Divider()
+        }
+
+        item {
+            Text(
+                text = stringResource(id = R.string.blaze_campaign_payment_list_hint, "username", "email"),
+                style = MaterialTheme.typography.caption,
+                color = MaterialTheme.colors.onSurface.copy(
+                    alpha = ContentAlpha.medium
+                ),
+                modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))
+            )
+        }
+
+        item {
+            WCTextButton(
+                onClick = onAddPaymentMethodClicked,
+                icon = Icons.Default.Add,
+                text = stringResource(id = R.string.blaze_campaign_payment_list_add_new_payment_method_button)
+            )
+        }
+    }
+}
+
+@Composable
+private fun PaymentMethodItem(
+    paymentMethod: PaymentMethod,
+    onPaymentMethodClicked: () -> Unit,
+    isSelected: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .clickable(onClick = onPaymentMethodClicked)
+            .padding(dimensionResource(id = R.dimen.major_100))
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = paymentMethod.name,
+                style = MaterialTheme.typography.subtitle1
+            )
+            paymentMethod.subtitle?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.body2,
+                    color = MaterialTheme.colors.onSurface.copy(
+                        alpha = ContentAlpha.medium
+                    )
+                )
+            }
+        }
+
+        if (isSelected) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                tint = MaterialTheme.colors.primary,
+                contentDescription = null
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmptyPaymentMethodsView(
+    onAddPaymentMethodClicked: () -> Unit,
+    modifier: Modifier
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier.padding(
+            horizontal = dimensionResource(id = R.dimen.major_100),
+            vertical = dimensionResource(id = R.dimen.major_200)
+        )
+    ) {
+        Text(text = stringResource(id = R.string.blaze_campaign_payment_list_empty_state_text))
+        Spacer(modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100)))
+        WCColoredButton(
+            onClick = onAddPaymentMethodClicked,
+            text = stringResource(id = R.string.blaze_campaign_payment_list_add_payment_method_button)
+        )
+    }
+}
+
+@Suppress("UNUSED_PARAMETER")
+@Composable
+fun AddPaymentMethodWebView(
+    urls: PaymentMethodUrls,
+    onUrlLoaded: (String) -> Unit,
+    modifier: Modifier
+) {
     TODO("Not yet implemented")
+}
+
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Composable
+private fun EmptyPaymentMethodsListPreview() {
+    WooThemeWithBackground {
+        BlazeCampaignPaymentMethodsListScreen(
+            viewState = BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList(
+                paymentMethods = emptyList(),
+                onPaymentMethodClicked = {},
+                onAddPaymentMethodClicked = {},
+                onDismiss = {}
+            )
+        )
+    }
+}
+
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Composable
+private fun PaymentMethodsListPreview() {
+    WooThemeWithBackground {
+        BlazeCampaignPaymentMethodsListScreen(
+            viewState = BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList(
+                paymentMethods = listOf(
+                    PaymentMethod(
+                        id = "1",
+                        name = "Visa",
+                        subtitle = "John Doe",
+                        type = PaymentMethod.PaymentMethodType.CreditCard(CreditCardType.VISA)
+                    ),
+                    PaymentMethod(
+                        id = "2",
+                        name = "MasterCard",
+                        subtitle = "John Doe",
+                        type = PaymentMethod.PaymentMethodType.CreditCard(CreditCardType.MASTERCARD)
+                    )
+                ),
+                onPaymentMethodClicked = {},
+                onAddPaymentMethodClicked = {},
+                onDismiss = {}
+            )
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
@@ -1,11 +1,13 @@
 package com.woocommerce.android.ui.blaze.creation.payment
 
 import android.content.res.Configuration
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -27,6 +29,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
@@ -220,12 +223,19 @@ private fun EmptyPaymentMethodsView(
             vertical = dimensionResource(id = R.dimen.major_200)
         )
     ) {
+        Spacer(modifier = Modifier.weight(1f))
         Text(text = stringResource(id = R.string.blaze_campaign_payment_list_empty_state_text))
-        Spacer(modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100)))
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+        Image(
+            painter = painterResource(id = R.drawable.img_empty_orders_all_fulfilled),
+            contentDescription = null
+        )
+        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
         WCColoredButton(
             onClick = onAddPaymentMethodClicked,
             text = stringResource(id = R.string.blaze_campaign_payment_list_add_payment_method_button)
         )
+        Spacer(modifier = Modifier.weight(2f))
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.blaze.creation.payment
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun BlazeCampaignPaymentMethodsListScreen(viewModel: BlazeCampaignPaymentMethodsListViewModel) {
+    TODO("Not yet implemented")
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.outlined.VerifiedUser
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
@@ -65,6 +66,7 @@ private fun BlazeCampaignPaymentMethodsListScreen(viewState: BlazeCampaignPaymen
             is BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList -> {
                 PaymentMethodsList(
                     paymentMethods = viewState.paymentMethods,
+                    selectedPaymentMethod = viewState.selectedPaymentMethod!!,
                     onPaymentMethodClicked = viewState.onPaymentMethodClicked,
                     onAddPaymentMethodClicked = viewState.onAddPaymentMethodClicked,
                     modifier = Modifier.padding(paddingValues)
@@ -82,10 +84,10 @@ private fun BlazeCampaignPaymentMethodsListScreen(viewState: BlazeCampaignPaymen
     }
 }
 
-@Suppress("UNUSED_PARAMETER")
 @Composable
 private fun PaymentMethodsList(
     paymentMethods: List<PaymentMethod>,
+    selectedPaymentMethod: PaymentMethod,
     onPaymentMethodClicked: (PaymentMethod) -> Unit,
     onAddPaymentMethodClicked: () -> Unit,
     modifier: Modifier
@@ -102,6 +104,7 @@ private fun PaymentMethodsList(
         } else {
             PaymentMethodsListView(
                 paymentMethods = paymentMethods,
+                selectedPaymentMethod = selectedPaymentMethod,
                 onPaymentMethodClicked = onPaymentMethodClicked,
                 onAddPaymentMethodClicked = onAddPaymentMethodClicked,
                 modifier = modifier
@@ -128,6 +131,7 @@ private fun PaymentMethodsHeader(modifier: Modifier = Modifier) {
 @Composable
 private fun PaymentMethodsListView(
     paymentMethods: List<PaymentMethod>,
+    selectedPaymentMethod: PaymentMethod,
     onPaymentMethodClicked: (PaymentMethod) -> Unit,
     onAddPaymentMethodClicked: () -> Unit,
     modifier: Modifier
@@ -138,7 +142,7 @@ private fun PaymentMethodsListView(
                 PaymentMethodItem(
                     paymentMethod = paymentMethod,
                     onPaymentMethodClicked = { onPaymentMethodClicked(paymentMethod) },
-                    isSelected = true
+                    isSelected = paymentMethod == selectedPaymentMethod
                 )
             }
             Divider()
@@ -243,6 +247,7 @@ private fun EmptyPaymentMethodsListPreview() {
         BlazeCampaignPaymentMethodsListScreen(
             viewState = BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList(
                 paymentMethods = emptyList(),
+                selectedPaymentMethod = null,
                 onPaymentMethodClicked = {},
                 onAddPaymentMethodClicked = {},
                 onDismiss = {}
@@ -255,23 +260,27 @@ private fun EmptyPaymentMethodsListPreview() {
 @Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Composable
 private fun PaymentMethodsListPreview() {
+    val paymentMethods = remember {
+        listOf(
+            PaymentMethod(
+                id = "1",
+                name = "Visa",
+                subtitle = "John Doe",
+                type = PaymentMethod.PaymentMethodType.CreditCard(CreditCardType.VISA)
+            ),
+            PaymentMethod(
+                id = "2",
+                name = "MasterCard",
+                subtitle = "John Doe",
+                type = PaymentMethod.PaymentMethodType.CreditCard(CreditCardType.MASTERCARD)
+            )
+        )
+    }
     WooThemeWithBackground {
         BlazeCampaignPaymentMethodsListScreen(
             viewState = BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList(
-                paymentMethods = listOf(
-                    PaymentMethod(
-                        id = "1",
-                        name = "Visa",
-                        subtitle = "John Doe",
-                        type = PaymentMethod.PaymentMethodType.CreditCard(CreditCardType.VISA)
-                    ),
-                    PaymentMethod(
-                        id = "2",
-                        name = "MasterCard",
-                        subtitle = "John Doe",
-                        type = PaymentMethod.PaymentMethodType.CreditCard(CreditCardType.MASTERCARD)
-                    )
-                ),
+                paymentMethods = paymentMethods,
+                selectedPaymentMethod = paymentMethods.first(),
                 onPaymentMethodClicked = {},
                 onAddPaymentMethodClicked = {},
                 onDismiss = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
@@ -66,7 +66,7 @@ private fun BlazeCampaignPaymentMethodsListScreen(viewState: BlazeCampaignPaymen
             is BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList -> {
                 PaymentMethodsList(
                     paymentMethods = viewState.paymentMethods,
-                    selectedPaymentMethod = viewState.selectedPaymentMethod!!,
+                    selectedPaymentMethod = viewState.selectedPaymentMethod,
                     onPaymentMethodClicked = viewState.onPaymentMethodClicked,
                     onAddPaymentMethodClicked = viewState.onAddPaymentMethodClicked,
                     modifier = Modifier.padding(paddingValues)
@@ -87,7 +87,7 @@ private fun BlazeCampaignPaymentMethodsListScreen(viewState: BlazeCampaignPaymen
 @Composable
 private fun PaymentMethodsList(
     paymentMethods: List<PaymentMethod>,
-    selectedPaymentMethod: PaymentMethod,
+    selectedPaymentMethod: PaymentMethod?,
     onPaymentMethodClicked: (PaymentMethod) -> Unit,
     onAddPaymentMethodClicked: () -> Unit,
     modifier: Modifier
@@ -104,7 +104,7 @@ private fun PaymentMethodsList(
         } else {
             PaymentMethodsListView(
                 paymentMethods = paymentMethods,
-                selectedPaymentMethod = selectedPaymentMethod,
+                selectedPaymentMethod = selectedPaymentMethod!!,
                 onPaymentMethodClicked = onPaymentMethodClicked,
                 onAddPaymentMethodClicked = onAddPaymentMethodClicked,
                 modifier = modifier
@@ -265,14 +265,18 @@ private fun PaymentMethodsListPreview() {
             PaymentMethod(
                 id = "1",
                 name = "Visa",
-                subtitle = "John Doe",
-                type = PaymentMethod.PaymentMethodType.CreditCard(CreditCardType.VISA)
+                info = PaymentMethod.PaymentMethodInfo.CreditCard(
+                    CreditCardType.VISA,
+                    "John Doe"
+                )
             ),
             PaymentMethod(
                 id = "2",
                 name = "MasterCard",
-                subtitle = "John Doe",
-                type = PaymentMethod.PaymentMethodType.CreditCard(CreditCardType.MASTERCARD)
+                info = PaymentMethod.PaymentMethodInfo.CreditCard(
+                    CreditCardType.MASTERCARD,
+                    "John Doe"
+                )
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
@@ -68,10 +68,7 @@ private fun BlazeCampaignPaymentMethodsListScreen(viewState: BlazeCampaignPaymen
         when (viewState) {
             is BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList -> {
                 PaymentMethodsList(
-                    paymentMethods = viewState.paymentMethods,
-                    selectedPaymentMethod = viewState.selectedPaymentMethod,
-                    onPaymentMethodClicked = viewState.onPaymentMethodClicked,
-                    onAddPaymentMethodClicked = viewState.onAddPaymentMethodClicked,
+                    state = viewState,
                     modifier = Modifier.padding(paddingValues)
                 )
             }
@@ -89,27 +86,26 @@ private fun BlazeCampaignPaymentMethodsListScreen(viewState: BlazeCampaignPaymen
 
 @Composable
 private fun PaymentMethodsList(
-    paymentMethods: List<PaymentMethod>,
-    selectedPaymentMethod: PaymentMethod?,
-    onPaymentMethodClicked: (PaymentMethod) -> Unit,
-    onAddPaymentMethodClicked: () -> Unit,
+    state: BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList,
     modifier: Modifier
 ) {
     Column(modifier) {
         PaymentMethodsHeader(Modifier.fillMaxWidth())
-        if (paymentMethods.isEmpty()) {
+        if (state.paymentMethods.isEmpty()) {
             EmptyPaymentMethodsView(
-                onAddPaymentMethodClicked = onAddPaymentMethodClicked,
+                onAddPaymentMethodClicked = state.onAddPaymentMethodClicked,
                 modifier = modifier
                     .fillMaxWidth()
                     .weight(1f)
             )
         } else {
             PaymentMethodsListView(
-                paymentMethods = paymentMethods,
-                selectedPaymentMethod = selectedPaymentMethod!!,
-                onPaymentMethodClicked = onPaymentMethodClicked,
-                onAddPaymentMethodClicked = onAddPaymentMethodClicked,
+                paymentMethods = state.paymentMethods,
+                accountEmail = state.accountEmail,
+                accountUsername = state.accountUsername,
+                selectedPaymentMethod = state.selectedPaymentMethod!!,
+                onPaymentMethodClicked = state.onPaymentMethodClicked,
+                onAddPaymentMethodClicked = state.onAddPaymentMethodClicked,
                 modifier = modifier
                     .fillMaxWidth()
                     .weight(1f)
@@ -135,6 +131,8 @@ private fun PaymentMethodsHeader(modifier: Modifier = Modifier) {
 private fun PaymentMethodsListView(
     paymentMethods: List<PaymentMethod>,
     selectedPaymentMethod: PaymentMethod,
+    accountEmail: String,
+    accountUsername: String,
     onPaymentMethodClicked: (PaymentMethod) -> Unit,
     onAddPaymentMethodClicked: () -> Unit,
     modifier: Modifier
@@ -153,7 +151,11 @@ private fun PaymentMethodsListView(
 
         item {
             Text(
-                text = stringResource(id = R.string.blaze_campaign_payment_list_hint, "username", "email"),
+                text = stringResource(
+                    id = R.string.blaze_campaign_payment_list_hint,
+                    accountUsername,
+                    accountEmail
+                ),
                 style = MaterialTheme.typography.caption,
                 color = MaterialTheme.colors.onSurface.copy(
                     alpha = ContentAlpha.medium
@@ -258,6 +260,8 @@ private fun EmptyPaymentMethodsListPreview() {
             viewState = BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList(
                 paymentMethods = emptyList(),
                 selectedPaymentMethod = null,
+                accountEmail = "email",
+                accountUsername = "username",
                 onPaymentMethodClicked = {},
                 onAddPaymentMethodClicked = {},
                 onDismiss = {}
@@ -295,6 +299,8 @@ private fun PaymentMethodsListPreview() {
             viewState = BlazeCampaignPaymentMethodsListViewModel.ViewState.PaymentMethodsList(
                 paymentMethods = paymentMethods,
                 selectedPaymentMethod = paymentMethods.first(),
+                accountEmail = "email",
+                accountUsername = "username",
                 onPaymentMethodClicked = {},
                 onAddPaymentMethodClicked = {},
                 onDismiss = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.blaze.creation.payment
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedStateHandle) {
+
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.blaze.creation.payment
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.ui.blaze.BlazeRepository
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,7 +17,7 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
 
     private val navArgs by savedStateHandle.navArgs<BlazeCampaignPaymentMethodsListFragmentArgs>()
 
-    private val _viewState: MutableStateFlow<ViewState> = MutableStateFlow(
+    private val _viewState = MutableStateFlow(
         if (navArgs.paymentMethodsData.savedPaymentMethods.isEmpty()) {
             addPaymentMethodWebView()
         } else {
@@ -25,29 +26,35 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
     )
     val viewState = _viewState.asLiveData()
 
-    private fun paymentMethodsListState() = ViewState.PaymentMethodsList(
+    private fun paymentMethodsListState(): ViewState = ViewState.PaymentMethodsList(
         paymentMethods = navArgs.paymentMethodsData.savedPaymentMethods,
         onPaymentMethodClicked = { /* TODO */ },
         onAddPaymentMethodClicked = {
             _viewState.value = addPaymentMethodWebView()
-        }
+        },
+        onDismiss = { triggerEvent(MultiLiveEvent.Event.Exit) }
     )
 
-    private fun addPaymentMethodWebView() = ViewState.AddPaymentMethodWebView(
-        urls = navArgs.paymentMethodsData.paymentMethodUrls,
-        onUrlLoaded = { /* TODO */ }
+    private fun addPaymentMethodWebView(): ViewState = ViewState.AddPaymentMethodWebView(
+        urls = navArgs.paymentMethodsData.addPaymentMethodUrls,
+        onUrlLoaded = { /* TODO */ },
+        onDismiss = { _viewState.value = paymentMethodsListState() }
     )
 
     sealed interface ViewState {
+        val onDismiss: () -> Unit
+
         data class PaymentMethodsList(
             val paymentMethods: List<BlazeRepository.PaymentMethod>,
             val onPaymentMethodClicked: (BlazeRepository.PaymentMethod) -> Unit,
-            val onAddPaymentMethodClicked: () -> Unit
+            val onAddPaymentMethodClicked: () -> Unit,
+            override val onDismiss: () -> Unit
         ) : ViewState
 
         data class AddPaymentMethodWebView(
             val urls: BlazeRepository.PaymentMethodUrls,
-            val onUrlLoaded: (String) -> Unit
+            val onUrlLoaded: (String) -> Unit,
+            override val onDismiss: () -> Unit
         ) : ViewState
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
@@ -28,6 +28,9 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
 
     private fun paymentMethodsListState(): ViewState = ViewState.PaymentMethodsList(
         paymentMethods = navArgs.paymentMethodsData.savedPaymentMethods,
+        selectedPaymentMethod = navArgs.paymentMethodsData.savedPaymentMethods.firstOrNull {
+            it.id == navArgs.selectedPaymentMethodId
+        },
         onPaymentMethodClicked = { /* TODO */ },
         onAddPaymentMethodClicked = {
             _viewState.value = addPaymentMethodWebView()
@@ -46,6 +49,7 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
 
         data class PaymentMethodsList(
             val paymentMethods: List<BlazeRepository.PaymentMethod>,
+            val selectedPaymentMethod: BlazeRepository.PaymentMethod?,
             val onPaymentMethodClicked: (BlazeRepository.PaymentMethod) -> Unit,
             val onAddPaymentMethodClicked: () -> Unit,
             override val onDismiss: () -> Unit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
@@ -31,7 +31,9 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
         selectedPaymentMethod = navArgs.paymentMethodsData.savedPaymentMethods.firstOrNull {
             it.id == navArgs.selectedPaymentMethodId
         },
-        onPaymentMethodClicked = { /* TODO */ },
+        onPaymentMethodClicked = {
+            triggerEvent(MultiLiveEvent.Event.ExitWithResult(it.id))
+        },
         onAddPaymentMethodClicked = {
             _viewState.value = addPaymentMethodWebView()
         },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
@@ -1,8 +1,12 @@
 package com.woocommerce.android.ui.blaze.creation.payment
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
 
 @HiltViewModel
@@ -10,4 +14,40 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
 
+    private val navArgs by savedStateHandle.navArgs<BlazeCampaignPaymentMethodsListFragmentArgs>()
+
+    private val _viewState: MutableStateFlow<ViewState> = MutableStateFlow(
+        if (navArgs.paymentMethodsData.savedPaymentMethods.isEmpty()) {
+            addPaymentMethodWebView()
+        } else {
+            paymentMethodsListState()
+        }
+    )
+    val viewState = _viewState.asLiveData()
+
+    private fun paymentMethodsListState() = ViewState.PaymentMethodsList(
+        paymentMethods = navArgs.paymentMethodsData.savedPaymentMethods,
+        onPaymentMethodClicked = { /* TODO */ },
+        onAddPaymentMethodClicked = {
+            _viewState.value = addPaymentMethodWebView()
+        }
+    )
+
+    private fun addPaymentMethodWebView() = ViewState.AddPaymentMethodWebView(
+        urls = navArgs.paymentMethodsData.paymentMethodUrls,
+        onUrlLoaded = { /* TODO */ }
+    )
+
+    sealed interface ViewState {
+        data class PaymentMethodsList(
+            val paymentMethods: List<BlazeRepository.PaymentMethod>,
+            val onPaymentMethodClicked: (BlazeRepository.PaymentMethod) -> Unit,
+            val onAddPaymentMethodClicked: () -> Unit
+        ) : ViewState
+
+        data class AddPaymentMethodWebView(
+            val urls: BlazeRepository.PaymentMethodUrls,
+            val onUrlLoaded: (String) -> Unit
+        ) : ViewState
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.blaze.creation.payment
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.ui.blaze.BlazeRepository
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
@@ -12,7 +13,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val accountRepository: AccountRepository
 ) : ScopedViewModel(savedStateHandle) {
 
     private val navArgs by savedStateHandle.navArgs<BlazeCampaignPaymentMethodsListFragmentArgs>()
@@ -31,6 +33,8 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
         selectedPaymentMethod = navArgs.paymentMethodsData.savedPaymentMethods.firstOrNull {
             it.id == navArgs.selectedPaymentMethodId
         },
+        accountEmail = accountRepository.getUserAccount()?.email ?: "",
+        accountUsername = accountRepository.getUserAccount()?.userName ?: "",
         onPaymentMethodClicked = {
             triggerEvent(MultiLiveEvent.Event.ExitWithResult(it.id))
         },
@@ -52,6 +56,8 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
         data class PaymentMethodsList(
             val paymentMethods: List<BlazeRepository.PaymentMethod>,
             val selectedPaymentMethod: BlazeRepository.PaymentMethod?,
+            val accountEmail: String,
+            val accountUsername: String,
             val onPaymentMethodClicked: (BlazeRepository.PaymentMethod) -> Unit,
             val onAddPaymentMethodClicked: () -> Unit,
             override val onDismiss: () -> Unit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
@@ -31,6 +32,7 @@ class BlazeCampaignPaymentSummaryFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         handleEvents()
+        handleResults()
     }
 
     private fun handleEvents() {
@@ -47,6 +49,12 @@ class BlazeCampaignPaymentSummaryFragment : BaseFragment() {
                     )
                 }
             }
+        }
+    }
+
+    private fun handleResults() {
+        handleResult<String>(BlazeCampaignPaymentMethodsListFragment.SELECTED_PAYMENT_METHOD_KEY) {
+            viewModel.onPaymentMethodSelected(it)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryFragment.kt
@@ -41,7 +41,8 @@ class BlazeCampaignPaymentSummaryFragment : BaseFragment() {
                     findNavController().navigateSafely(
                         BlazeCampaignPaymentSummaryFragmentDirections
                             .actionBlazeCampaignPaymentSummaryFragmentToBlazeCampaignPaymentMethodsListFragment(
-                                event.paymentMethodsData
+                                paymentMethodsData = event.paymentMethodsData,
+                                selectedPaymentMethodId = event.selectedPaymentMethodId
                             )
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -36,6 +37,14 @@ class BlazeCampaignPaymentSummaryFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+                is BlazeCampaignPaymentSummaryViewModel.NavigateToPaymentsListScreen -> {
+                    findNavController().navigateSafely(
+                        BlazeCampaignPaymentSummaryFragmentDirections
+                            .actionBlazeCampaignPaymentSummaryFragmentToBlazeCampaignPaymentMethodsListFragment(
+                                event.paymentMethodsData
+                            )
+                    )
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryScreen.kt
@@ -84,7 +84,8 @@ fun BlazeCampaignPaymentSummaryScreen(
             )
 
             PaymentMethod(
-                paymentMethodState = state.paymentMethodState,
+                paymentMethodsState = state.paymentMethodsState,
+                selectedPaymentMethod = state.selectedPaymentMethod,
                 modifier = Modifier.fillMaxWidth()
             )
 
@@ -94,8 +95,7 @@ fun BlazeCampaignPaymentSummaryScreen(
             WCColoredButton(
                 onClick = { /*TODO*/ },
                 text = stringResource(id = R.string.blaze_campaign_payment_summary_submit_campaign),
-                enabled = (state.paymentMethodState as? BlazeCampaignPaymentSummaryViewModel.PaymentMethodState.Success)
-                    ?.isPaymentMethodSelected == true,
+                enabled = state.isPaymentMethodSelected,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = dimensionResource(id = R.dimen.major_100))
@@ -182,14 +182,15 @@ private fun PaymentTotals(
 
 @Composable
 private fun PaymentMethod(
-    paymentMethodState: BlazeCampaignPaymentSummaryViewModel.PaymentMethodState,
+    paymentMethodsState: BlazeCampaignPaymentSummaryViewModel.PaymentMethodsState,
+    selectedPaymentMethod: BlazeRepository.PaymentMethod?,
     modifier: Modifier
 ) {
     Column(modifier) {
         Divider()
 
-        when (paymentMethodState) {
-            BlazeCampaignPaymentSummaryViewModel.PaymentMethodState.Loading -> {
+        when (paymentMethodsState) {
+            BlazeCampaignPaymentSummaryViewModel.PaymentMethodsState.Loading -> {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))
@@ -204,21 +205,21 @@ private fun PaymentMethod(
                 }
             }
 
-            is BlazeCampaignPaymentSummaryViewModel.PaymentMethodState.Success -> {
+            is BlazeCampaignPaymentSummaryViewModel.PaymentMethodsState.Success -> {
                 PaymentMethodInfo(
-                    paymentMethod = paymentMethodState.selectedPaymentMethod,
-                    onClick = paymentMethodState.onClick,
+                    paymentMethod = selectedPaymentMethod,
+                    onClick = paymentMethodsState.onClick,
                     modifier = Modifier
                 )
             }
 
-            is BlazeCampaignPaymentSummaryViewModel.PaymentMethodState.Error -> {
+            is BlazeCampaignPaymentSummaryViewModel.PaymentMethodsState.Error -> {
                 Text(
                     text = stringResource(id = R.string.blaze_campaign_payment_summary_error_loading_payment_methods),
                     style = MaterialTheme.typography.body2,
                     modifier = Modifier
                         .padding(dimensionResource(id = R.dimen.major_100))
-                        .clickable(onClick = paymentMethodState.onRetry)
+                        .clickable(onClick = paymentMethodsState.onRetry)
                 )
             }
         }
@@ -283,7 +284,7 @@ fun BlazeCampaignPaymentSummaryScreenPreview() {
                     startDate = Date(),
                     currencyCode = "$"
                 ),
-                paymentMethodState = BlazeCampaignPaymentSummaryViewModel.PaymentMethodState.Success(
+                paymentMethodsState = BlazeCampaignPaymentSummaryViewModel.PaymentMethodsState.Success(
                     BlazeRepository.PaymentMethodsData(
                         listOf(
                             BlazeRepository.PaymentMethod(
@@ -302,7 +303,8 @@ fun BlazeCampaignPaymentSummaryScreenPreview() {
                         )
                     ),
                     onClick = {}
-                )
+                ),
+                selectedPaymentMethodId = "1"
             ),
             onBackClick = {}
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryScreen.kt
@@ -94,6 +94,8 @@ fun BlazeCampaignPaymentSummaryScreen(
             WCColoredButton(
                 onClick = { /*TODO*/ },
                 text = stringResource(id = R.string.blaze_campaign_payment_summary_submit_campaign),
+                enabled = (state.paymentMethodState as? BlazeCampaignPaymentSummaryViewModel.PaymentMethodState.Success)
+                    ?.isPaymentMethodSelected == true,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = dimensionResource(id = R.dimen.major_100))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt
@@ -43,7 +43,15 @@ class BlazeCampaignPaymentSummaryViewModel @Inject constructor(
                 onSuccess = { paymentMethodsData ->
                     PaymentMethodState.Success(
                         paymentMethodsData = paymentMethodsData,
-                        onClick = { triggerEvent(NavigateToPaymentsListScreen(paymentMethodsData)) }
+                        onClick = {
+                            triggerEvent(
+                                NavigateToPaymentsListScreen(
+                                    paymentMethodsData = paymentMethodsData,
+                                    // TODO we should handle selecting different payment methods
+                                    selectedPaymentMethodId = paymentMethodsData.savedPaymentMethods.firstOrNull()?.id
+                                )
+                            )
+                        }
                     )
                 },
                 onFailure = { PaymentMethodState.Error { fetchPaymentMethodData() } }
@@ -70,6 +78,7 @@ class BlazeCampaignPaymentSummaryViewModel @Inject constructor(
     }
 
     data class NavigateToPaymentsListScreen(
-        val paymentMethodsData: PaymentMethodsData
+        val paymentMethodsData: PaymentMethodsData,
+        val selectedPaymentMethodId: String?
     ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt
@@ -63,6 +63,7 @@ class BlazeCampaignPaymentSummaryViewModel @Inject constructor(
             val onClick: () -> Unit
         ) : PaymentMethodState {
             val selectedPaymentMethod = paymentMethodsData.savedPaymentMethods.firstOrNull()
+            val isPaymentMethodSelected = selectedPaymentMethod != null
         }
 
         data class Error(val onRetry: () -> Unit) : PaymentMethodState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt
@@ -40,10 +40,10 @@ class BlazeCampaignPaymentSummaryViewModel @Inject constructor(
         paymentMethodState.value = PaymentMethodState.Loading
         launch {
             paymentMethodState.value = blazeRepository.fetchPaymentMethods().fold(
-                onSuccess = {
+                onSuccess = { paymentMethodsData ->
                     PaymentMethodState.Success(
-                        it,
-                        onClick = { /* TODO */ }
+                        paymentMethodsData = paymentMethodsData,
+                        onClick = { triggerEvent(NavigateToPaymentsListScreen(paymentMethodsData)) }
                     )
                 },
                 onFailure = { PaymentMethodState.Error { fetchPaymentMethodData() } }
@@ -67,4 +67,8 @@ class BlazeCampaignPaymentSummaryViewModel @Inject constructor(
 
         data class Error(val onRetry: () -> Unit) : PaymentMethodState
     }
+
+    data class NavigateToPaymentsListScreen(
+        val paymentMethodsData: PaymentMethodsData
+    ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
@@ -143,5 +143,16 @@
         <argument
             android:name="budget"
             app:argType="com.woocommerce.android.ui.blaze.BlazeRepository$Budget" />
+        <action
+            android:id="@+id/action_blazeCampaignPaymentSummaryFragment_to_blazeCampaignPaymentMethodsListFragment"
+            app:destination="@id/blazeCampaignPaymentMethodsListFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/blazeCampaignPaymentMethodsListFragment"
+        android:name="com.woocommerce.android.ui.blaze.creation.payment.BlazeCampaignPaymentMethodsListFragment"
+        android:label="BlazeCampaignPaymentMethodsListFragment" >
+        <argument
+            android:name="paymentMethodsData"
+            app:argType="com.woocommerce.android.ui.blaze.BlazeRepository$PaymentMethodsData" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
@@ -154,5 +154,9 @@
         <argument
             android:name="paymentMethodsData"
             app:argType="com.woocommerce.android.ui.blaze.BlazeRepository$PaymentMethodsData" />
+        <argument
+            android:name="selectedPaymentMethodId"
+            app:argType="string"
+            app:nullable="true" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3884,7 +3884,12 @@
     <string name="blaze_campaign_payment_summary_error_loading_payment_methods">Loading payment methods failed, please retry by clicking here!</string>
     <string name="blaze_campaign_payment_summary_submit_campaign">Submit campaign</string>
     <string name="blaze_campaign_payment_summary_terms_and_conditions">By clicking \"Submit campaign\" you agree to the &lt;a href=\'termsOfService\'&gt;&lt;u&gt;Terms of Service&lt;/u&gt;&lt;/a&gt; and &lt;a href=\'advertisingPolicy\'&gt;&lt;u&gt;Advertising Policy&lt;/u&gt;&lt;/a&gt;, and authorize your payment method to be charged for the budget and duration you chose. &lt;a href=\'learnMore\'&gt;&lt;u&gt;Learn more&lt;/u&gt;&lt;/a&gt; about how budgets and payments for Promoted Posts work.</string>
-
+    <string name="blaze_campaign_payment_list_screen_title">Payment method</string>
+    <string name="blaze_campaign_payment_list_empty_state_text">Please add a new payment method</string>
+    <string name="blaze_campaign_payment_list_add_payment_method_button">Add credit card</string>
+    <string name="blaze_campaign_payment_list_header_text">All transactions are secure and encrypted</string>
+    <string name="blaze_campaign_payment_list_hint">Credits cards are retrieved from the following WordPress.com account: %1$s &lt;%2$s&gt;</string>
+    <string name="blaze_campaign_payment_list_add_new_payment_method_button">Add new card</string>
     <!--
     Blaze other
     -->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10721 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds a screen that list payment methods list for the Blaze campaign creation flow.

### Testing instructions
1. Sign in using WordPress.com
2. Start Blaze campaign creation.
3. Click on "Confirm details".
4. Click on the Payment Method row.
5. Confirm it opens a screen where the available payment methods are listed (for now the API is mocked, so the list contains two sample credit cards).
6. Select a different payment method.
7. Confirm this navigates you back to the previous screen, and the selected method has been updated.

### Images/gif
| Empty payment methods list | Non-empty payment methods list |
| ---- | ---- |
| ![Screenshot_20240212_120435](https://github.com/woocommerce/woocommerce-android/assets/1657201/27d42116-4fe4-48b5-b48a-1f46025a5019) | ![Screenshot_20240212_115521](https://github.com/woocommerce/woocommerce-android/assets/1657201/64f64481-5f7a-4f31-918c-0b66c1923189) |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
