### PR TITLE
[Bug] IllegalArgumentException Destination not found – Update `navigation-fragment-ktx` to 2.7.7

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,6 @@
 - [*] [Internal] Enhanced product variation delete confirmation dialog visibility and functionality across device rotations [https://github.com/woocommerce/woocommerce-android/pull/10664]
 - [*] [Internal] Added a text along with the receipts file when it is shared [https://github.com/woocommerce/woocommerce-android/pull/10681]
 - [**] Fixed navigation issues [https://github.com/woocommerce/woocommerce-android/pull/10775]
-- [**] Fixed navigation issues [https://github.com/woocommerce/woocommerce-android/pull/10775]
 
 17.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,16 +3,12 @@
 17.4
 -----
 
-
-17.3
------
-- [**] Fixed navigation issues [https://github.com/woocommerce/woocommerce-android/pull/10775]
-
 17.3
 -----
 - [*] [Internal] Enhanced user experience in shipping label creation with automatic scrolling to the first invalid field upon form submission failure [https://github.com/woocommerce/woocommerce-android/pull/10657]
 - [*] [Internal] Enhanced product variation delete confirmation dialog visibility and functionality across device rotations [https://github.com/woocommerce/woocommerce-android/pull/10664]
 - [*] [Internal] Added a text along with the receipts file when it is shared [https://github.com/woocommerce/woocommerce-android/pull/10681]
+- [**] Fixed navigation issues [https://github.com/woocommerce/woocommerce-android/pull/10775]
 - [**] Fixed navigation issues [https://github.com/woocommerce/woocommerce-android/pull/10775]
 
 17.2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 
 17.3
 -----
-
+- [**] Fixed navigation issues [https://github.com/woocommerce/woocommerce-android/pull/10775]
 
 17.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 - [*] [Internal] Enhanced user experience in shipping label creation with automatic scrolling to the first invalid field upon form submission failure [https://github.com/woocommerce/woocommerce-android/pull/10657]
 - [*] [Internal] Enhanced product variation delete confirmation dialog visibility and functionality across device rotations [https://github.com/woocommerce/woocommerce-android/pull/10664]
 - [*] [Internal] Added a text along with the receipts file when it is shared [https://github.com/woocommerce/woocommerce-android/pull/10681]
+- [**] Fixed navigation issues [https://github.com/woocommerce/woocommerce-android/pull/10775]
 
 17.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeCampaignCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeCampaignCreationScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
-import androidx.compose.animation.with
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -85,7 +84,7 @@ fun BlazeCampaignCreationScreen(
     ) { paddingValues ->
         AnimatedContent(
             targetState = viewState,
-            transitionSpec = { fadeIn() togetherWith  fadeOut() }
+            transitionSpec = { fadeIn() togetherWith fadeOut() }
         ) { targetState ->
             when (targetState) {
                 is BlazeCreationViewState.Intro -> BlazeCreationIntroScreen(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeCampaignCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeCampaignCreationScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.animation.with
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -84,7 +85,7 @@ fun BlazeCampaignCreationScreen(
     ) { paddingValues ->
         AnimatedContent(
             targetState = viewState,
-            transitionSpec = { fadeIn() with fadeOut() }
+            transitionSpec = { fadeIn() togetherWith  fadeOut() }
         ) { targetState ->
             when (targetState) {
                 is BlazeCreationViewState.Intro -> BlazeCreationIntroScreen(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -288,9 +288,12 @@ private fun AnimatedVisibilityScope.ErrorState(
         Spacer(modifier = Modifier.weight(1f))
         val buttonsModifier = Modifier
             .fillMaxWidth()
-            .animateEnterExit(enter = slideInVertically(animationSpec = tween(delayMillis = DefaultDurationMillis)) { fullHeight ->
-                fullHeight
-            }, exit = slideOutVertically { fullHeight -> fullHeight })
+            .animateEnterExit(
+                enter = slideInVertically(animationSpec = tween(delayMillis = DefaultDurationMillis)) { fullHeight ->
+                    fullHeight
+                },
+                exit = slideOutVertically { fullHeight -> fullHeight }
+            )
         if (viewState.errorCode != FORBIDDEN_ERROR_CODE) {
             val retryButton = when (viewState.stepType) {
                 JetpackActivationMainViewModel.StepType.Installation ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.animation.with
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
@@ -109,7 +110,7 @@ fun JetpackActivationMainScreen(
             transition.AnimatedContent(
                 contentKey = { it is JetpackActivationMainViewModel.ViewState.ErrorViewState },
                 transitionSpec = {
-                    fadeIn(animationSpec = tween(DefaultDurationMillis, delayMillis = DefaultDurationMillis)) with
+                    fadeIn(animationSpec = tween(DefaultDurationMillis, delayMillis = DefaultDurationMillis)) togetherWith
                         fadeOut(animationSpec = tween(DefaultDurationMillis))
                 },
                 modifier = Modifier.weight(1f)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -110,16 +110,19 @@ fun JetpackActivationMainScreen(
             transition.AnimatedContent(
                 contentKey = { it is JetpackActivationMainViewModel.ViewState.ErrorViewState },
                 transitionSpec = {
-                    fadeIn(animationSpec = tween(DefaultDurationMillis, delayMillis = DefaultDurationMillis)) togetherWith
-                        fadeOut(animationSpec = tween(DefaultDurationMillis))
+                    fadeIn(
+                        animationSpec = tween(
+                            DefaultDurationMillis, delayMillis = DefaultDurationMillis
+                        )
+                    ) togetherWith fadeOut(animationSpec = tween(DefaultDurationMillis))
                 },
                 modifier = Modifier.weight(1f)
             ) { targetState ->
                 when (targetState) {
                     is JetpackActivationMainViewModel.ViewState.ProgressViewState -> ProgressState(
-                        viewState = targetState,
-                        onContinueClick = onContinueClick
+                        viewState = targetState, onContinueClick = onContinueClick
                     )
+
                     is JetpackActivationMainViewModel.ViewState.ErrorViewState -> ErrorState(
                         viewState = targetState,
                         onGetHelpClick = onGetHelpClick,
@@ -285,12 +288,9 @@ private fun AnimatedVisibilityScope.ErrorState(
         Spacer(modifier = Modifier.weight(1f))
         val buttonsModifier = Modifier
             .fillMaxWidth()
-            .animateEnterExit(
-                enter = slideInVertically(animationSpec = tween(delayMillis = DefaultDurationMillis)) { fullHeight ->
-                    fullHeight
-                },
-                exit = slideOutVertically { fullHeight -> fullHeight }
-            )
+            .animateEnterExit(enter = slideInVertically(animationSpec = tween(delayMillis = DefaultDurationMillis)) { fullHeight ->
+                fullHeight
+            }, exit = slideOutVertically { fullHeight -> fullHeight })
         if (viewState.errorCode != FORBIDDEN_ERROR_CODE) {
             val retryButton = when (viewState.stepType) {
                 JetpackActivationMainViewModel.StepType.Installation ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryView.kt
@@ -18,7 +18,6 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
-import androidx.compose.animation.with
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -558,11 +557,11 @@ private fun FundsNumber(
             targetState = valueToDisplay to valueAmount,
             transitionSpec = {
                 if (animationPlayed) {
-                    EnterTransition.None togetherWith  ExitTransition.None
+                    EnterTransition.None togetherWith ExitTransition.None
                 } else if (targetState.second > initialState.second) {
-                    slideInVertically { -it } togetherWith  slideOutVertically { it }
+                    slideInVertically { -it } togetherWith slideOutVertically { it }
                 } else {
-                    slideInVertically { it } togetherWith  slideOutVertically { -it }
+                    slideInVertically { it } togetherWith slideOutVertically { -it }
                 }
             },
             label = "AnimatedFundsNumber"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryView.kt
@@ -17,6 +17,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.animation.with
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -138,7 +139,7 @@ fun PaymentsHubDepositSummaryView(
             .fillMaxWidth()
             .background(colorResource(id = R.color.color_surface))
     ) {
-        val pagerState = rememberPagerState(initialPage = selectedPage)
+        val pagerState = rememberPagerState(initialPage = selectedPage) { pageCount }
         val isInitialLoad = remember { mutableStateOf(true) }
 
         val currencies = overview.infoPerCurrency.keys.toList()
@@ -164,7 +165,6 @@ fun PaymentsHubDepositSummaryView(
         }
 
         HorizontalPager(
-            pageCount = pageCount,
             state = pagerState
         ) { pageIndex ->
             Column(
@@ -558,11 +558,11 @@ private fun FundsNumber(
             targetState = valueToDisplay to valueAmount,
             transitionSpec = {
                 if (animationPlayed) {
-                    EnterTransition.None with ExitTransition.None
+                    EnterTransition.None togetherWith  ExitTransition.None
                 } else if (targetState.second > initialState.second) {
-                    slideInVertically { -it } with slideOutVertically { it }
+                    slideInVertically { -it } togetherWith  slideOutVertically { it }
                 } else {
-                    slideInVertically { it } with slideOutVertically { -it }
+                    slideInVertically { it } togetherWith  slideOutVertically { -it }
                 }
             },
             label = "AnimatedFundsNumber"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.animation.core.updateTransition
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
-import androidx.compose.animation.with
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material.MaterialTheme

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.animation.with
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -49,10 +50,10 @@ fun InstallWCShippingScreen(viewState: ViewState) {
                     // Apply a fade-in/fade-out globally,
                     // then each child will animate the individual components separately
                     fadeIn(tween(500, delayMillis = 500))
-                        .with(fadeOut(tween(500, easing = LinearOutSlowInEasing)))
+                        .togetherWith(fadeOut(tween(500, easing = LinearOutSlowInEasing)))
                 } else {
                     // No-op animation, each screen will define animations for specific components separately
-                    EnterTransition.None.with(ExitTransition.None)
+                    EnterTransition.None.togetherWith(ExitTransition.None)
                 }
             }
         ) { targetState ->

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ pluginManagement {
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.kotlinVersion = '1.9.22'
     gradle.ext.measureBuildsVersion = '2.0.3'
-    gradle.ext.navigationVersion = '2.6.0'
+    gradle.ext.navigationVersion = '2.7.7'
     gradle.ext.sentryVersion = '3.5.0'
     gradle.ext.violationCommentsVersion = '1.69.0'
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10731
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Due to the [bug](https://href.li/?https://issuetracker.google.com/issues/289877514) in the navigation library, the `NavigationController` current destination was incorrect in various scenarios. Updating the version to 2.7.7. solves the problems resulting in `IllegalArgumentException Navigation action/destination cannot be found from the current destination` exception.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
#### Steps to reproduce the bug on `trunk`
1. Go to a product
2. Open product settings
3. Double-click on the back arrow
4. Open QR scanner

Observe the exception – 
```
java.lang.IllegalArgumentException: Navigation action/destination com.woocommerce.android.dev:id/action_productListFragment_to_scanToUpdateInventory cannot be found from the current destination Destination(com.woocommerce.android.dev:id/productDetailFragment) class=com.woocommerce.android.ui.products.ProductDetailFragment
```

#### Fix verification
- [ ] Verify the above issue is solved on this branch.
- [ ] Smoke test navigation in the app.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
