### PR TITLE
Issue/10721 blaze add new payment method

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListFragment.kt
@@ -8,11 +8,13 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class BlazeCampaignPaymentMethodsListFragment : BaseFragment() {
@@ -24,6 +26,8 @@ class BlazeCampaignPaymentMethodsListFragment : BaseFragment() {
         get() = AppBarStatus.Hidden
 
     private val viewModel: BlazeCampaignPaymentMethodsListViewModel by viewModels()
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return composeView {
@@ -45,6 +49,7 @@ class BlazeCampaignPaymentMethodsListFragment : BaseFragment() {
                     key = SELECTED_PAYMENT_METHOD_KEY,
                     result = event.data
                 )
+                is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.blaze.creation.payment
 
 import android.content.res.Configuration
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -35,13 +36,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.model.CreditCardType
 import com.woocommerce.android.ui.blaze.BlazeRepository.PaymentMethod
-import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.component.WCWebView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import org.wordpress.android.fluxc.network.UserAgent
 
 @Composable
 fun BlazeCampaignPaymentMethodsListScreen(viewModel: BlazeCampaignPaymentMethodsListViewModel) {
@@ -79,10 +78,7 @@ private fun BlazeCampaignPaymentMethodsListScreen(
 
             is BlazeCampaignPaymentMethodsListViewModel.ViewState.AddPaymentMethodWebView -> {
                 AddPaymentMethodWebView(
-                    formUrl = viewState.formUrl,
-                    onUrlLoaded = viewState.onUrlLoaded,
-                    userAgent = viewState.userAgent,
-                    wpComWebViewAuthenticator = viewState.wpComWebViewAuthenticator,
+                    state = viewState,
                     modifier = Modifier.padding(paddingValues)
                 )
             }
@@ -249,17 +245,18 @@ private fun EmptyPaymentMethodsView(
 
 @Composable
 fun AddPaymentMethodWebView(
-    formUrl: String,
-    onUrlLoaded: (String) -> Unit,
-    userAgent: UserAgent,
-    wpComWebViewAuthenticator: WPComWebViewAuthenticator,
+    state: BlazeCampaignPaymentMethodsListViewModel.ViewState.AddPaymentMethodWebView,
     modifier: Modifier
 ) {
+    BackHandler {
+        state.onDismiss()
+    }
+
     WCWebView(
-        url = formUrl,
-        userAgent = userAgent,
-        wpComAuthenticator = wpComWebViewAuthenticator,
-        onUrlLoaded = onUrlLoaded,
+        url = state.formUrl,
+        userAgent = state.userAgent,
+        wpComAuthenticator = state.wpComWebViewAuthenticator,
+        onUrlLoaded = state.onUrlLoaded,
         modifier = modifier
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListScreen.kt
@@ -35,11 +35,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.model.CreditCardType
 import com.woocommerce.android.ui.blaze.BlazeRepository.PaymentMethod
-import com.woocommerce.android.ui.blaze.BlazeRepository.PaymentMethodUrls
+import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.component.WCWebView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import org.wordpress.android.fluxc.network.UserAgent
 
 @Composable
 fun BlazeCampaignPaymentMethodsListScreen(viewModel: BlazeCampaignPaymentMethodsListViewModel) {
@@ -51,7 +53,9 @@ fun BlazeCampaignPaymentMethodsListScreen(viewModel: BlazeCampaignPaymentMethods
 }
 
 @Composable
-private fun BlazeCampaignPaymentMethodsListScreen(viewState: BlazeCampaignPaymentMethodsListViewModel.ViewState) {
+private fun BlazeCampaignPaymentMethodsListScreen(
+    viewState: BlazeCampaignPaymentMethodsListViewModel.ViewState
+) {
     Scaffold(
         topBar = {
             Toolbar(
@@ -75,8 +79,10 @@ private fun BlazeCampaignPaymentMethodsListScreen(viewState: BlazeCampaignPaymen
 
             is BlazeCampaignPaymentMethodsListViewModel.ViewState.AddPaymentMethodWebView -> {
                 AddPaymentMethodWebView(
-                    urls = viewState.urls,
+                    formUrl = viewState.formUrl,
                     onUrlLoaded = viewState.onUrlLoaded,
+                    userAgent = viewState.userAgent,
+                    wpComWebViewAuthenticator = viewState.wpComWebViewAuthenticator,
                     modifier = Modifier.padding(paddingValues)
                 )
             }
@@ -241,14 +247,21 @@ private fun EmptyPaymentMethodsView(
     }
 }
 
-@Suppress("UNUSED_PARAMETER")
 @Composable
 fun AddPaymentMethodWebView(
-    urls: PaymentMethodUrls,
+    formUrl: String,
     onUrlLoaded: (String) -> Unit,
+    userAgent: UserAgent,
+    wpComWebViewAuthenticator: WPComWebViewAuthenticator,
     modifier: Modifier
 ) {
-    TODO("Not yet implemented")
+    WCWebView(
+        url = formUrl,
+        userAgent = userAgent,
+        wpComAuthenticator = wpComWebViewAuthenticator,
+        onUrlLoaded = onUrlLoaded,
+        modifier = modifier
+    )
 }
 
 @Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
@@ -68,7 +68,7 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
                                 R.string.blaze_campaign_payment_added_successfully
                             )
                         )
-                        MultiLiveEvent.Event.ExitWithResult(paymentMethodId)
+                        triggerEvent(MultiLiveEvent.Event.ExitWithResult(paymentMethodId))
                     },
                     onFailure = {
                         WooLog.e(WooLog.T.BLAZE, "Failed to extract payment method id from URL: $url", it)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
@@ -3,20 +3,23 @@ package com.woocommerce.android.ui.blaze.creation.payment
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.ui.blaze.BlazeRepository
+import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.wordpress.android.fluxc.network.UserAgent
 import javax.inject.Inject
 
 @HiltViewModel
 class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val accountRepository: AccountRepository
+    private val accountRepository: AccountRepository,
+    val userAgent: UserAgent,
+    val wpComWebViewAuthenticator: WPComWebViewAuthenticator
 ) : ScopedViewModel(savedStateHandle) {
-
     private val navArgs by savedStateHandle.navArgs<BlazeCampaignPaymentMethodsListFragmentArgs>()
 
     private val _viewState = MutableStateFlow(
@@ -45,7 +48,9 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
     )
 
     private fun addPaymentMethodWebView(): ViewState = ViewState.AddPaymentMethodWebView(
-        urls = navArgs.paymentMethodsData.addPaymentMethodUrls,
+        formUrl = navArgs.paymentMethodsData.addPaymentMethodUrls.formUrl,
+        userAgent = userAgent,
+        wpComWebViewAuthenticator = wpComWebViewAuthenticator,
         onUrlLoaded = { /* TODO */ },
         onDismiss = { _viewState.value = paymentMethodsListState() }
     )
@@ -64,7 +69,9 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
         ) : ViewState
 
         data class AddPaymentMethodWebView(
-            val urls: BlazeRepository.PaymentMethodUrls,
+            val formUrl: String,
+            val userAgent: UserAgent,
+            val wpComWebViewAuthenticator: WPComWebViewAuthenticator,
             val onUrlLoaded: (String) -> Unit,
             override val onDismiss: () -> Unit
         ) : ViewState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.blaze.creation.payment
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.ui.common.wpcomwebview.WPComWebViewAuthenticator
 import com.woocommerce.android.ui.login.AccountRepository
@@ -19,8 +20,8 @@ import javax.inject.Inject
 class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val accountRepository: AccountRepository,
-    val userAgent: UserAgent,
-    val wpComWebViewAuthenticator: WPComWebViewAuthenticator
+    private val userAgent: UserAgent,
+    private val wpComWebViewAuthenticator: WPComWebViewAuthenticator
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs by savedStateHandle.navArgs<BlazeCampaignPaymentMethodsListFragmentArgs>()
 
@@ -61,8 +62,13 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
                         ?.substringAfter("=")
                         .let { requireNotNull(it) }
                 }.fold(
-                    onSuccess = {
-                        MultiLiveEvent.Event.ExitWithResult(it)
+                    onSuccess = { paymentMethodId ->
+                        triggerEvent(
+                            MultiLiveEvent.Event.ShowSnackbar(
+                                R.string.blaze_campaign_payment_added_successfully
+                            )
+                        )
+                        MultiLiveEvent.Event.ExitWithResult(paymentMethodId)
                     },
                     onFailure = {
                         WooLog.e(WooLog.T.BLAZE, "Failed to extract payment method id from URL: $url", it)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3890,6 +3890,7 @@
     <string name="blaze_campaign_payment_list_header_text">All transactions are secure and encrypted</string>
     <string name="blaze_campaign_payment_list_hint">Credits cards are retrieved from the following WordPress.com account: %1$s &lt;%2$s&gt;</string>
     <string name="blaze_campaign_payment_list_add_new_payment_method_button">Add new card</string>
+    <string name="blaze_campaign_payment_added_successfully">Credit card added successfully</string>
     <!--
     Blaze other
     -->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10721 
<!-- Id number of the GitHub issue this PR addresses. -->

⚠️ Please don't merge until base branch is set to `trunk`.

### Description
This PR handles the payment method addition flow, it adds a WebView that opens the URL we get from the API, and adds logic to handle the WebView callback to extract the payment method ID.

### Testing instructions
There is no straight forward way to test this, as the API is not ready yet. But optionally, you can follow this approach to view the app's behavior using the current WordPress.com URLs:
1. Apply the following patch.
<details>
<summary>
Patch
</summary>

``` patch
Subject: [PATCH] Show a Snackbar when payment method is added
---
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt	(revision 6251bd749e8865824890ab380f878b5417049a90)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt	(date 1707740528591)
@@ -162,8 +162,8 @@
                             )
                         },
                         addPaymentMethodUrls = PaymentMethodUrls(
-                            formUrl = paymentMethods.addPaymentMethodUrls.formUrl,
-                            successUrl = paymentMethods.addPaymentMethodUrls.successUrl,
+                            formUrl = "https://wordpress.com/me/purchases/add-payment-method",
+                            successUrl = "https://public-api.wordpress.com/rest/v1.2/me/payment-methods",
                             idUrlParameter = paymentMethods.addPaymentMethodUrls.idUrlParameter
                         )
                     )
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt	(revision 6251bd749e8865824890ab380f878b5417049a90)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt	(date 1707741713112)
@@ -52,25 +52,12 @@
         wpComWebViewAuthenticator = wpComWebViewAuthenticator,
         onUrlLoaded = { url ->
             if (url.startsWith(navArgs.paymentMethodsData.addPaymentMethodUrls.successUrl)) {
-                runCatching {
-                    URL(url).query?.split("&")
-                        ?.firstOrNull { it.startsWith("payment_method_id=") }
-                        ?.substringAfter("=")
-                        .let { requireNotNull(it) }
-                }.fold(
-                    onSuccess = { paymentMethodId ->
-                        triggerEvent(
-                            MultiLiveEvent.Event.ShowSnackbar(
-                                R.string.blaze_campaign_payment_added_successfully
-                            )
-                        )
-                        MultiLiveEvent.Event.ExitWithResult(paymentMethodId)
-                    },
-                    onFailure = {
-                        WooLog.e(WooLog.T.BLAZE, "Failed to extract payment method id from URL: $url", it)
-                        _viewState.value = paymentMethodsListState()
-                    }
+                triggerEvent(
+                    MultiLiveEvent.Event.ShowSnackbar(
+                        R.string.blaze_campaign_payment_added_successfully
+                    )
                 )
+                MultiLiveEvent.Event.ExitWithResult("payment-method-id-2")
             }
         },
         onDismiss = { _viewState.value = paymentMethodsListState() }
```
</details>

2. Open the campaign creation flow.
3. Click on "Confirm details"
4. Click on the payment row.
5. Click on "Add new credit card"
6. Proceed to adding a new credit card.
7. After finishing, the app should dismiss the WebView, and show a Snackbar.
8. The demo Mastercard credit card should be selected.
9. Don't forget to delete your credit card from the WordPress.com account.

### Images/gif
| Empty payment methods list | non-empty payment methods list | End of the flow |
| --- | --- | --- |
| <video src="https://github.com/woocommerce/woocommerce-android/assets/1657201/2ad8b805-8ff8-42ec-bc8c-fe2dd1f5a531" /> |  <video src="https://github.com/woocommerce/woocommerce-android/assets/1657201/8815910d-e32d-442b-8ea6-ef4a6b0e0885"/> |  <video src="https://github.com/woocommerce/woocommerce-android/assets/1657201/511d0085-e825-48b3-9d0e-7812c01a19d5" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
