### PR TITLE
[hotfix][17.2] Revert `navigationVersion` bump

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,11 @@
 17.3
 -----
 - [*] [Internal] Enhanced user experience in shipping label creation with automatic scrolling to the first invalid field upon form submission failure [https://github.com/woocommerce/woocommerce-android/pull/10657]
+
+17.2.1
+-----
+- [**] Fixed navigation bug causing app to crash in some scenarios [https://github.com/woocommerce/woocommerce-android/pull/10786]
+
 17.2
 -----
 - [**] [Available for users with WooCommerce version of 8.7+, which is not released yet] Every order have a receipt now. The receipts can be shared via many apps installed on the phone [https://github.com/woocommerce/woocommerce-android/pull/10650]

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -280,8 +280,7 @@ dependencies {
     implementation "com.github.bumptech.glide:glide:$glideVersion"
     kapt "com.github.bumptech.glide:compiler:$glideVersion"
     implementation "com.github.bumptech.glide:volley-integration:$glideVersion@aar"
-    implementation 'com.google.android.play:app-update-ktx:2.1.0'
-    implementation 'com.google.android.play:review-ktx:2.0.1'
+    implementation "com.google.android.play:core:$googlePlayCoreVersion"
 
     implementation 'com.google.android.gms:play-services-code-scanner:16.1.0'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ pluginManagement {
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.kotlinVersion = '1.8.21'
     gradle.ext.measureBuildsVersion = '2.0.3'
-    gradle.ext.navigationVersion = '2.6.0'
+    gradle.ext.navigationVersion = '2.5.3'
     gradle.ext.sentryVersion = '3.5.0'
     gradle.ext.violationCommentsVersion = '1.69.0'
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
This PR intends to revert the dependency version bump introduced in #10593 and release it as a hotfix to version **17.2** of the app.

**💡 This PR's branch is checked out from the 17.2 tag.** 

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Due to the [bug](https://href.li/?https://issuetracker.google.com/issues/289877514) in the navigation library, the `NavigationController` current destination was incorrect in various scenarios. 

Updating the version to 2.7.7. solves the problems resulting in `IllegalArgumentException Navigation action/destination cannot be found from the current destination` exception. We will ship the upgraded version in the 17.3 release as a beta fix (https://github.com/woocommerce/woocommerce-android/pull/10775).

However, given the growing number of affected users, we decided to revert the navigation dependency update to the old version (2.5.3) and release it as a hotfix to version 17.2.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Verify the following crash happens on the **17.2** tag (`git checkout tags/17.2`):

1. Go to a product
2. Open product settings
3. Double-click on the back arrow
4. Open QR scanner

Observe the exception –
```Java
java.lang.IllegalArgumentException: Navigation action/destination 

com.woocommerce.android.dev:id/action_productListFragment_to_scanToUpdateInventory 

cannot be found from the current destination Destination(com.woocommerce.android.dev:id/productDetailFragment) 

class=com.woocommerce.android.ui.products.ProductDetailFragment
```

Now, checkout the current branch and verify it's fixed.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->