### PR TITLE
[Better Tablet Products] Implement selection of a product

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesNotificationHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/ProductImagesNotificationHandler.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.media.MediaFileUploadHandler.ProductImageUploadData
 import com.woocommerce.android.ui.media.MediaUploadErrorListFragmentArgs
+import com.woocommerce.android.ui.products.ProductDetailFragment
 import com.woocommerce.android.ui.products.ProductDetailFragmentArgs
 import com.woocommerce.android.util.StringUtils
 import org.wordpress.android.util.SystemServiceFactory
@@ -190,7 +191,11 @@ class ProductImagesNotificationHandler @Inject constructor(
         NavDeepLinkBuilder(context)
             .setGraph(R.navigation.nav_graph_main)
             .setDestination(R.id.productDetailFragment)
-            .setArguments(ProductDetailFragmentArgs(remoteProductId = productId).toBundle())
+            .setArguments(
+                ProductDetailFragmentArgs(
+                    mode = ProductDetailFragment.Mode.ShowProduct(productId)
+                ).toBundle()
+            )
             .createPendingIntent()
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -101,6 +101,7 @@ import com.woocommerce.android.ui.plans.di.TrialStatusBarFormatterFactory
 import com.woocommerce.android.ui.plans.trial.DetermineTrialStatusBarState.TrialStatusBarState
 import com.woocommerce.android.ui.prefs.AppSettingsActivity
 import com.woocommerce.android.ui.prefs.RequestedAnalyticsValue
+import com.woocommerce.android.ui.products.ProductDetailFragment
 import com.woocommerce.android.ui.products.ProductListFragmentDirections
 import com.woocommerce.android.ui.reviews.ReviewListFragmentDirections
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -946,7 +947,7 @@ class MainActivity :
 
     override fun showProductDetail(remoteProductId: Long, enableTrash: Boolean) {
         val action = NavGraphMainDirections.actionGlobalProductDetailFragment(
-            remoteProductId = remoteProductId,
+            mode = ProductDetailFragment.Mode.ShowProduct(remoteProductId),
             isTrashEnabled = enableTrash
         )
         navController.navigateSafely(action)
@@ -957,7 +958,7 @@ class MainActivity :
         val extras = FragmentNavigatorExtras(sharedView to productCardDetailTransitionName)
 
         val action = NavGraphMainDirections.actionGlobalProductDetailFragment(
-            remoteProductId = remoteProductId,
+            mode = ProductDetailFragment.Mode.ShowProduct(remoteProductId),
             isTrashEnabled = enableTrash
         )
         navController.navigateSafely(directions = action, extras = extras)
@@ -974,7 +975,7 @@ class MainActivity :
     override fun showAddProduct(imageUris: List<String>) {
         showBottomNav()
         val action = NavGraphMainDirections.actionGlobalProductDetailFragment(
-            isAddProduct = true,
+            mode = ProductDetailFragment.Mode.AddNewProduct,
             images = imageUris.toTypedArray()
         )
         navController.navigateSafely(action)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/AIProductDescriptionDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/AIProductDescriptionDialogFragment.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.R.style
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.mystore.AIProductDescriptionDialogViewModel.TryAIProductDescriptionGeneration
+import com.woocommerce.android.ui.products.ProductDetailFragment
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DisplayUtils
@@ -59,7 +60,9 @@ class AIProductDescriptionDialogFragment : DialogFragment() {
 
     private fun openBlankProduct() {
         findNavController().navigateSafely(
-            NavGraphMainDirections.actionGlobalProductDetailFragment(isAddProduct = true)
+            NavGraphMainDirections.actionGlobalProductDetailFragment(
+                mode = ProductDetailFragment.Mode.AddNewProduct,
+            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -69,6 +69,7 @@ import com.woocommerce.android.ui.mystore.MyStoreViewModel.RevenueStatsViewState
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.VisitorStatsViewState
 import com.woocommerce.android.ui.prefs.privacy.banner.PrivacyBannerFragmentDirections
 import com.woocommerce.android.ui.products.AddProductNavigator
+import com.woocommerce.android.ui.products.ProductDetailFragment
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateUtils
@@ -442,7 +443,7 @@ class MyStoreFragment :
             when (event) {
                 is OpenTopPerformer -> findNavController().navigateSafely(
                     NavGraphMainDirections.actionGlobalProductDetailFragment(
-                        remoteProductId = event.productId,
+                        mode = ProductDetailFragment.Mode.ShowProduct(event.productId),
                         isTrashEnabled = false
                     )
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -681,10 +681,12 @@ class ProductDetailFragment :
     @Parcelize
     sealed class Mode : Parcelable {
         @Parcelize
-        data object Loading: Mode()
+        data object Loading : Mode()
+
         @Parcelize
-        data class ShowProduct(val remoteProductId: Long): Mode()
+        data class ShowProduct(val remoteProductId: Long) : Mode()
+
         @Parcelize
-        data object AddNewProduct: Mode()
+        data object AddNewProduct : Mode()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -88,6 +88,7 @@ import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageInteractionListener
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
@@ -676,4 +677,14 @@ class ProductDetailFragment :
     }
 
     override fun getFragmentTitle(): String = productName
+
+    @Parcelize
+    sealed class Mode : Parcelable {
+        @Parcelize
+        data object Loading: Mode()
+        @Parcelize
+        data class ShowProduct(val remoteProductId: Long): Mode()
+        @Parcelize
+        data object AddNewProduct: Mode()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1362,7 +1362,6 @@ class ProductDetailViewModel @Inject constructor(
         }
 
         launch {
-            viewState = viewState.copy(isSkeletonShown = true)
             // fetch product
             val productInDb = productRepository.getProductAsync(remoteProductId)
             if (productInDb != null) {
@@ -1375,6 +1374,7 @@ class ProductDetailViewModel @Inject constructor(
                     fetchProductPassword(remoteProductId)
                 }
             } else {
+                viewState = viewState.copy(isSkeletonShown = true)
                 fetchProduct(remoteProductId)
             }
             viewState = viewState.copy(isSkeletonShown = false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1351,6 +1351,7 @@ class ProductDetailViewModel @Inject constructor(
         }
 
         launch {
+            viewState = viewState.copy(isSkeletonShown = true)
             // fetch product
             val productInDb = productRepository.getProductAsync(remoteProductId)
             if (productInDb != null) {
@@ -1363,7 +1364,6 @@ class ProductDetailViewModel @Inject constructor(
                     fetchProductPassword(remoteProductId)
                 }
             } else {
-                viewState = viewState.copy(isSkeletonShown = true)
                 fetchProduct(remoteProductId)
             }
             viewState = viewState.copy(isSkeletonShown = false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemViewHolder.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products
 
+import android.graphics.Color
 import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
@@ -15,9 +16,19 @@ class ProductItemViewHolder(val viewBinding: ProductListItemBinding) :
     fun bind(
         product: Product,
         currencyFormatter: CurrencyFormatter,
-        isActivated: Boolean = false
+        isActivated: Boolean = false,
+        isProductHighlighted: Boolean = false,
     ) {
         viewBinding.root.isActivated = isActivated
+
+        if (isProductHighlighted) {
+            viewBinding.root.setBackgroundColor(
+                viewBinding.root.context.getColor(R.color.color_item_selected)
+            )
+        } else {
+            viewBinding.root.setBackgroundColor(Color.TRANSPARENT)
+        }
+
         viewBinding.productItemView.bind(
             product = product,
             currencyFormatter = currencyFormatter,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListAdapter.kt
@@ -16,7 +16,8 @@ typealias OnProductClickListener = (remoteProductId: Long, sharedView: View?) ->
 class ProductListAdapter(
     private inline val clickListener: OnProductClickListener? = null,
     private val loadMoreListener: OnLoadMoreListener,
-    private val currencyFormatter: CurrencyFormatter
+    private val currencyFormatter: CurrencyFormatter,
+    private val isProductHighlighted: (Long) -> Boolean,
 ) : ListAdapter<Product, ProductItemViewHolder>(ProductItemDiffCallback) {
     // allow the selection library to track the selections of the user
     var tracker: SelectionTracker<Long>? = null
@@ -43,7 +44,8 @@ class ProductListAdapter(
         holder.bind(
             product,
             currencyFormatter,
-            isActivated = tracker?.isSelected(product.remoteId) ?: false
+            isActivated = tracker?.isSelected(product.remoteId) ?: false,
+            isProductHighlighted = isProductHighlighted(product.remoteId)
         )
 
         holder.itemView.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -160,8 +160,18 @@ class ProductListFragment :
             loadMoreListener = this,
             currencyFormatter = currencyFormatter,
             clickListener = { id, sharedView ->
-                binding.addProductButton.hide()
-                onProductClick(id, sharedView)
+                tabletLayoutSetupHelper.onItemClicked(
+                    getTabletActionToNavigateTo = {
+                        NavGraphMainDirections.actionGlobalProductDetailFragment(
+                            remoteProductId = id,
+                            isTrashEnabled = true,
+                        )
+                    },
+                    navigateWithPhoneNavigation = {
+                        binding.addProductButton.hide()
+                        onProductClick(id, sharedView)
+                    }
+                )
             }
         )
         binding.productsRecycler.layoutManager = LinearLayoutManager(requireActivity())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -45,13 +45,13 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
+import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.OpenProduct
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ScrollToTop
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.SelectProducts
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowAddProductBottomSheet
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductFilterScreen
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductSortingBottomSheet
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowUpdateDialog
-import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.OpenProduct
 import com.woocommerce.android.ui.products.ProductSortAndFiltersCard.ProductSortAndFilterListener
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.StringUtils

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -128,7 +128,9 @@ class ProductListFragment :
         TabletLayoutSetupHelper.Screen.Navigation(
             childFragmentManager,
             R.navigation.nav_graph_products,
-            null,
+            ProductDetailFragmentArgs(
+                mode = ProductDetailFragment.Mode.Loading,
+            ).toBundle()
         )
     }
 
@@ -163,7 +165,7 @@ class ProductListFragment :
                 tabletLayoutSetupHelper.onItemClicked(
                     getTabletActionToNavigateTo = {
                         NavGraphMainDirections.actionGlobalProductDetailFragment(
-                            remoteProductId = id,
+                            mode = ProductDetailFragment.Mode.ShowProduct(id),
                             isTrashEnabled = true,
                         )
                     },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -51,6 +51,7 @@ import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductFilterScreen
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductSortingBottomSheet
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowUpdateDialog
+import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.OpenProduct
 import com.woocommerce.android.ui.products.ProductSortAndFiltersCard.ProductSortAndFilterListener
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.StringUtils
@@ -161,20 +162,7 @@ class ProductListFragment :
         _productAdapter = ProductListAdapter(
             loadMoreListener = this,
             currencyFormatter = currencyFormatter,
-            clickListener = { id, sharedView ->
-                tabletLayoutSetupHelper.onItemClicked(
-                    tabletNavigateTo = {
-                        R.id.nav_graph_products to ProductDetailFragmentArgs(
-                            mode = ProductDetailFragment.Mode.ShowProduct(id),
-                            isTrashEnabled = true,
-                        ).toBundle()
-                    },
-                    navigateWithPhoneNavigation = {
-                        binding.addProductButton.hide()
-                        onProductClick(id, sharedView)
-                    }
-                )
-            }
+            clickListener = { id, sharedView -> productListViewModel.onOpenProduct(id, sharedView) }
         )
         binding.productsRecycler.layoutManager = LinearLayoutManager(requireActivity())
         binding.productsRecycler.adapter = productAdapter
@@ -474,6 +462,18 @@ class ProductListFragment :
                 is ShowProductSortingBottomSheet -> showProductSortingBottomSheet()
                 is SelectProducts -> tracker?.setItemsSelected(event.productsIds, true)
                 is ShowUpdateDialog -> handleUpdateDialogs(event)
+                is OpenProduct -> tabletLayoutSetupHelper.onItemClicked(
+                    tabletNavigateTo = {
+                        R.id.nav_graph_products to ProductDetailFragmentArgs(
+                            mode = ProductDetailFragment.Mode.ShowProduct(event.productId),
+                            isTrashEnabled = true,
+                        ).toBundle()
+                    },
+                    navigateWithPhoneNavigation = {
+                        binding.addProductButton.hide()
+                        onProductClick(event.productId, event.sharedView)
+                    }
+                )
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -163,11 +163,11 @@ class ProductListFragment :
             currencyFormatter = currencyFormatter,
             clickListener = { id, sharedView ->
                 tabletLayoutSetupHelper.onItemClicked(
-                    getTabletActionToNavigateTo = {
-                        NavGraphMainDirections.actionGlobalProductDetailFragment(
+                    tabletNavigateTo = {
+                        R.id.nav_graph_products to ProductDetailFragmentArgs(
                             mode = ProductDetailFragment.Mode.ShowProduct(id),
                             isTrashEnabled = true,
-                        )
+                        ).toBundle()
                     },
                     navigateWithPhoneNavigation = {
                         binding.addProductButton.hide()
@@ -338,6 +338,7 @@ class ProductListFragment :
                 enableSearchListeners()
                 true
             }
+
             R.id.menu_scan_barcode -> {
                 AnalyticsTracker.track(AnalyticsEvent.PRODUCT_LIST_PRODUCT_BARCODE_SCANNING_TAPPED)
                 ProductListFragmentDirections.actionProductListFragmentToScanToUpdateInventory().let {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -466,7 +466,8 @@ class ProductListFragment :
                 is OpenProduct -> {
                     tabletLayoutSetupHelper.onItemClicked(
                         tabletNavigateTo = {
-
+                            productAdapter.notifyItemChanged(event.oldPosition)
+                            productAdapter.notifyItemChanged(event.newPosition)
                             R.id.nav_graph_products to ProductDetailFragmentArgs(
                                 mode = ProductDetailFragment.Mode.ShowProduct(event.productId),
                                 isTrashEnabled = true,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -223,7 +223,6 @@ class ProductListFragment :
                 override fun onSelectionChanged() {
                     val selectionCount = tracker?.selection?.size() ?: 0
                     productListViewModel.onSelectionChanged(selectionCount)
-                    super.onSelectionChanged()
                 }
             })
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -162,7 +162,8 @@ class ProductListFragment :
         _productAdapter = ProductListAdapter(
             loadMoreListener = this,
             currencyFormatter = currencyFormatter,
-            clickListener = { id, sharedView -> productListViewModel.onOpenProduct(id, sharedView) }
+            clickListener = { id, sharedView -> productListViewModel.onOpenProduct(id, sharedView) },
+            isProductHighlighted = { productListViewModel.isProductHighlighted(it) }
         )
         binding.productsRecycler.layoutManager = LinearLayoutManager(requireActivity())
         binding.productsRecycler.adapter = productAdapter
@@ -462,18 +463,21 @@ class ProductListFragment :
                 is ShowProductSortingBottomSheet -> showProductSortingBottomSheet()
                 is SelectProducts -> tracker?.setItemsSelected(event.productsIds, true)
                 is ShowUpdateDialog -> handleUpdateDialogs(event)
-                is OpenProduct -> tabletLayoutSetupHelper.onItemClicked(
-                    tabletNavigateTo = {
-                        R.id.nav_graph_products to ProductDetailFragmentArgs(
-                            mode = ProductDetailFragment.Mode.ShowProduct(event.productId),
-                            isTrashEnabled = true,
-                        ).toBundle()
-                    },
-                    navigateWithPhoneNavigation = {
-                        binding.addProductButton.hide()
-                        onProductClick(event.productId, event.sharedView)
-                    }
-                )
+                is OpenProduct -> {
+                    tabletLayoutSetupHelper.onItemClicked(
+                        tabletNavigateTo = {
+
+                            R.id.nav_graph_products to ProductDetailFragmentArgs(
+                                mode = ProductDetailFragment.Mode.ShowProduct(event.productId),
+                                isTrashEnabled = true,
+                            ).toBundle()
+                        },
+                        navigateWithPhoneNavigation = {
+                            binding.addProductButton.hide()
+                            onProductClick(event.productId, event.sharedView)
+                        }
+                    )
+                }
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -33,7 +33,7 @@ import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductFilterScreen
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductSortingBottomSheet
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowUpdateDialog
-import com.woocommerce.android.util.IsTablet
+import com.woocommerce.android.util.IsTabletLogicNeeded
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -70,7 +70,7 @@ class ProductListViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val selectedSite: SelectedSite,
     private val wooCommerceStore: WooCommerceStore,
-    private val isTablet: IsTablet,
+    private val isTabletLogicNeeded: IsTabletLogicNeeded
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_FILTER_OPTIONS = "key_product_filter_options"
@@ -430,7 +430,7 @@ class ProductListViewModel @Inject constructor(
     }
 
     private fun openFirstLoadedProductOnTablet(products: List<Product>) {
-        if (products.isNotEmpty() && isTablet()) {
+        if (products.isNotEmpty() && isTabletLogicNeeded()) {
             if (openedProduct == null) {
                 openedProduct = products.first().remoteId
             }
@@ -452,7 +452,7 @@ class ProductListViewModel @Inject constructor(
         )
     }
 
-    fun isProductHighlighted(productId: Long) = if (!isTablet()) false else productId == openedProduct
+    fun isProductHighlighted(productId: Long) = if (isTabletLogicNeeded()) productId == openedProduct else false
 
     fun onSelectAllProductsClicked() {
         analyticsTracker.track(PRODUCT_LIST_BULK_UPDATE_SELECT_ALL_TAPPED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -439,8 +439,17 @@ class ProductListViewModel @Inject constructor(
     }
 
     fun onOpenProduct(productId: Long, sharedView: View?) {
+        val oldPositionInList = _productList.value?.indexOfFirst { it.remoteId == openedProduct } ?: 0
         openedProduct = productId
-        triggerEvent(ProductListEvent.OpenProduct(productId, sharedView))
+        val newPositionInList = _productList.value?.indexOfFirst { it.remoteId == productId } ?: 0
+        triggerEvent(
+            ProductListEvent.OpenProduct(
+                productId = productId,
+                oldPosition = oldPositionInList,
+                newPosition = newPositionInList,
+                sharedView = sharedView,
+            )
+        )
     }
 
     fun isProductHighlighted(productId: Long) = if (!isTablet()) false else productId == openedProduct
@@ -726,6 +735,8 @@ class ProductListViewModel @Inject constructor(
         }
         data class OpenProduct(
             val productId: Long,
+            val oldPosition: Int,
+            val newPosition: Int,
             val sharedView: View?
         ) : ProductListEvent()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -425,7 +425,7 @@ class ProductListViewModel @Inject constructor(
         }
     }
 
-    fun enterSelectionMode(count: Int) {
+    private fun enterSelectionMode(count: Int) {
         viewState = viewState.copy(
             productListState = ProductListState.Selecting,
             isAddProductButtonVisible = false,
@@ -433,7 +433,7 @@ class ProductListViewModel @Inject constructor(
         )
     }
 
-    fun exitSelectionMode() {
+    private fun exitSelectionMode() {
         viewState = viewState.copy(
             productListState = ProductListState.Browsing,
             isAddProductButtonVisible = true,
@@ -441,7 +441,7 @@ class ProductListViewModel @Inject constructor(
         )
     }
 
-    fun refreshProducts(scrollToTop: Boolean = false) {
+    private fun refreshProducts(scrollToTop: Boolean = false) {
         if (checkConnection()) {
             loadProducts(scrollToTop = scrollToTop, isRefreshing = true)
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products
 
 import android.os.Parcelable
+import android.view.View
 import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -430,13 +431,13 @@ class ProductListViewModel @Inject constructor(
     private fun selectFirstLoadedProductOnTablet(products: List<Product>) {
         if (openedProduct == null && products.isNotEmpty()) {
             openedProduct = products.first().remoteId
-            onOpenProduct(openedProduct!!)
+            onOpenProduct(openedProduct!!, null)
         }
     }
 
-    fun onOpenProduct(productId: Long) {
+    fun onOpenProduct(productId: Long, sharedView: View?) {
         openedProduct = productId
-        triggerEvent(ProductListEvent.OpenProduct(productId))
+        triggerEvent(ProductListEvent.OpenProduct(productId, sharedView))
     }
 
     fun onSelectAllProductsClicked() {
@@ -718,7 +719,10 @@ class ProductListViewModel @Inject constructor(
             data class Price(override val productsIds: List<Long>) : ShowUpdateDialog()
             data class Status(override val productsIds: List<Long>) : ShowUpdateDialog()
         }
-        data class OpenProduct(val productId: Long) : ProductListEvent()
+        data class OpenProduct(
+            val productId: Long,
+            val sharedView: View?
+        ) : ProductListEvent()
     }
 
     enum class ProductListState { Selecting, Browsing }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -429,7 +429,6 @@ class ProductListViewModel @Inject constructor(
         triggerEvent(SelectProducts(selectedProductsIds))
     }
 
-
     private fun openFirstLoadedProductOnTablet(products: List<Product>) {
         if (products.isNotEmpty() && isTablet()) {
             if (openedProduct == null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -431,8 +431,10 @@ class ProductListViewModel @Inject constructor(
 
 
     private fun openFirstLoadedProductOnTablet(products: List<Product>) {
-        if (openedProduct == null && products.isNotEmpty() && isTablet()) {
-            openedProduct = products.first().remoteId
+        if (products.isNotEmpty() && isTablet()) {
+            if (openedProduct == null) {
+                openedProduct = products.first().remoteId
+            }
             onOpenProduct(openedProduct!!, null)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductFilterScreen
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductSortingBottomSheet
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowUpdateDialog
+import com.woocommerce.android.util.IsTablet
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -69,6 +70,7 @@ class ProductListViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val selectedSite: SelectedSite,
     private val wooCommerceStore: WooCommerceStore,
+    private val isTablet: IsTablet,
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val KEY_PRODUCT_FILTER_OPTIONS = "key_product_filter_options"
@@ -78,7 +80,7 @@ class ProductListViewModel @Inject constructor(
 
     private val _productList = MutableLiveData<List<Product>>()
     val productList: LiveData<List<Product>> = _productList.map {
-        selectFirstLoadedProductOnTablet(it)
+        openFirstLoadedProductOnTablet(it)
         it
     }
 
@@ -428,8 +430,8 @@ class ProductListViewModel @Inject constructor(
     }
 
 
-    private fun selectFirstLoadedProductOnTablet(products: List<Product>) {
-        if (openedProduct == null && products.isNotEmpty()) {
+    private fun openFirstLoadedProductOnTablet(products: List<Product>) {
+        if (openedProduct == null && products.isNotEmpty() && isTablet()) {
             openedProduct = products.first().remoteId
             onOpenProduct(openedProduct!!, null)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -443,6 +443,8 @@ class ProductListViewModel @Inject constructor(
         triggerEvent(ProductListEvent.OpenProduct(productId, sharedView))
     }
 
+    fun isProductHighlighted(productId: Long) = if (!isTablet()) false else productId == openedProduct
+
     fun onSelectAllProductsClicked() {
         analyticsTracker.track(PRODUCT_LIST_BULK_UPDATE_SELECT_ALL_TAPPED)
         productList.value?.map { it.remoteId }?.let { allLoadedProductsIds ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -265,7 +265,7 @@ class ProductNavigator @Inject constructor() {
 
             is ProductNavigationTarget.ViewProductAdd -> {
                 val directions = NavGraphMainDirections.actionGlobalProductDetailFragment(
-                    isAddProduct = true,
+                    mode = ProductDetailFragment.Mode.AddNewProduct,
                     source = target.source
                 )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListFragment.kt
@@ -50,7 +50,8 @@ class ProductSelectionListFragment :
     private val productSelectionListAdapter: ProductListAdapter by lazy {
         ProductListAdapter(
             loadMoreListener = this,
-            currencyFormatter = currencyFormatter
+            currencyFormatter = currencyFormatter,
+            isProductHighlighted = { false }
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIFragment.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.products.ProductDetailFragment
 import com.woocommerce.android.ui.products.ai.AddProductWithAIViewModel.NavigateToProductDetailScreen
 import com.woocommerce.android.ui.products.ai.PackagePhotoViewModel.PackagePhotoData
 import com.woocommerce.android.ui.products.ai.ProductNameSubViewModel.NavigateToAIProductNameBottomSheet
@@ -65,7 +66,7 @@ class AddProductWithAIFragment : BaseFragment(), MediaPickerResultHandler {
                 is NavigateToAIProductNameBottomSheet -> navigateToAIProductName(event.initialName)
                 is NavigateToProductDetailScreen -> findNavController().navigateSafely(
                     directions = NavGraphMainDirections.actionGlobalProductDetailFragment(
-                        remoteProductId = event.productId,
+                        mode = ProductDetailFragment.Mode.ShowProduct(event.productId),
                         isAIContent = true
                     ),
                     navOptions = navOptions {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributesAddedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributesAddedFragment.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.extensions.handleDialogNotice
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.products.BaseProductFragment
+import com.woocommerce.android.ui.products.ProductDetailFragment
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitAttributesAdded
 import com.woocommerce.android.ui.products.variations.GenerateVariationBottomSheetFragment
 import com.woocommerce.android.ui.products.variations.GenerateVariationBottomSheetFragment.Companion.KEY_ADD_NEW_VARIATION
@@ -88,8 +89,9 @@ class AttributesAddedFragment :
         when (event) {
             is ExitAttributesAdded ->
                 AttributesAddedFragmentDirections
-                    .actionAttributesAddedFragmentToProductDetailFragment()
-                    .apply { findNavController().navigateSafely(this) }
+                    .actionAttributesAddedFragmentToProductDetailFragment(
+                        mode = ProductDetailFragment.Mode.AddNewProduct
+                    ).apply { findNavController().navigateSafely(this) }
             is ShowSnackbar -> uiMessageResolver.getSnack(event.message)
             is ShowGenerateVariationConfirmation -> showGenerateVariationConfirmation(event.variationCandidates)
             is ShowGenerateVariationsError -> handleGenerateVariationError(event)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
@@ -7,10 +7,8 @@ import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
-import androidx.navigation.NavDirections
 import androidx.navigation.fragment.NavHostFragment
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.navigateSafely
 import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 
@@ -29,13 +27,17 @@ class TabletLayoutSetupHelper @Inject constructor(
     }
 
     fun onItemClicked(
-        getTabletActionToNavigateTo: () -> NavDirections,
+        tabletNavigateTo: () -> Pair<Int, Bundle>,
         navigateWithPhoneNavigation: () -> Unit
     ) {
         if (FeatureFlag.BETTER_TABLETS_SUPPORT_PRODUCTS.isEnabled() &&
             (DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context))
         ) {
-            navHostFragment.navController.navigateSafely(getTabletActionToNavigateTo())
+            val navigationData = tabletNavigateTo()
+            navHostFragment.navController.navigate(
+                navigationData.first,
+                navigationData.second,
+            )
         } else {
             navigateWithPhoneNavigation()
         }
@@ -58,7 +60,7 @@ class TabletLayoutSetupHelper @Inject constructor(
     private fun initNavFragment(navigation: Screen.Navigation) {
         val fragmentManager = navigation.fragmentManager
         val navGraphId = navigation.navGraphId
-        val bundle = navigation.bundle
+        val bundle = navigation.initialBundle
 
         navHostFragment = NavHostFragment.create(navGraphId, bundle)
 
@@ -94,7 +96,7 @@ class TabletLayoutSetupHelper @Inject constructor(
         data class Navigation(
             val fragmentManager: FragmentManager,
             val navGraphId: Int,
-            val bundle: Bundle?
+            val initialBundle: Bundle?
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
@@ -14,6 +14,7 @@ import javax.inject.Inject
 
 class TabletLayoutSetupHelper @Inject constructor(
     private val context: Context,
+    private val isTabletLogicNeeded: IsTabletLogicNeeded,
 ) : DefaultLifecycleObserver {
     private var screen: Screen? = null
 
@@ -30,9 +31,7 @@ class TabletLayoutSetupHelper @Inject constructor(
         tabletNavigateTo: () -> Pair<Int, Bundle>,
         navigateWithPhoneNavigation: () -> Unit
     ) {
-        if (FeatureFlag.BETTER_TABLETS_SUPPORT_PRODUCTS.isEnabled() &&
-            (DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context))
-        ) {
+        if (isTabletLogicNeeded()) {
             val navigationData = tabletNavigateTo()
             navHostFragment.navController.navigate(
                 navigationData.first,
@@ -44,12 +43,10 @@ class TabletLayoutSetupHelper @Inject constructor(
     }
 
     override fun onCreate(owner: LifecycleOwner) {
-        if (!FeatureFlag.BETTER_TABLETS_SUPPORT_PRODUCTS.isEnabled()) return
+        if (!isTabletLogicNeeded()) return
 
-        if (DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)) {
-            initNavFragment(screen!!.secondPaneNavigation)
-            adjustUIForScreenSize(screen!!.twoPaneLayoutGuideline)
-        }
+        initNavFragment(screen!!.secondPaneNavigation)
+        adjustUIForScreenSize(screen!!.twoPaneLayoutGuideline)
     }
 
     override fun onDestroy(owner: LifecycleOwner) {
@@ -99,4 +96,8 @@ class TabletLayoutSetupHelper @Inject constructor(
             val initialBundle: Bundle?
         )
     }
+}
+
+class IsTabletLogicNeeded @Inject constructor(private val isTablet: IsTablet) {
+    operator fun invoke() = isTablet() && FeatureFlag.BETTER_TABLETS_SUPPORT_PRODUCTS.isEnabled()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
@@ -29,16 +29,15 @@ class TabletLayoutSetupHelper @Inject constructor(
     }
 
     fun onItemClicked(
-        getActionToLaunch: () -> NavDirections,
-        navigateWithRootNavController: () -> Unit
+        getTabletActionToNavigateTo: () -> NavDirections,
+        navigateWithPhoneNavigation: () -> Unit
     ) {
-        if (!FeatureFlag.BETTER_TABLETS_SUPPORT_PRODUCTS.isEnabled() ||
-            DisplayUtils.isTablet(context) ||
-            DisplayUtils.isXLargeTablet(context)
+        if (FeatureFlag.BETTER_TABLETS_SUPPORT_PRODUCTS.isEnabled() &&
+            (DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context))
         ) {
-            navigateWithRootNavController()
+            navHostFragment.navController.navigateSafely(getTabletActionToNavigateTo())
         } else {
-            navHostFragment.navController.navigateSafely(getActionToLaunch())
+            navigateWithPhoneNavigation()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UiHelpers.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UiHelpers.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
 import org.wordpress.android.util.DisplayUtils
+import javax.inject.Inject
 
 object UiHelpers {
     fun getPxOfUiDimen(context: Context, uiDimen: UiDimen): Int =
@@ -81,4 +82,8 @@ object UiHelpers {
         updateVisibility(imageView, image != null)
         image?.let { imageView.setImageDrawable(image) }
     }
+}
+
+class IsTablet @Inject constructor(val context: Context) {
+    operator fun invoke() = DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)
 }

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -132,11 +132,8 @@
         android:id="@+id/detail_nav_container"
         android:layout_width="0dp"
         android:layout_height="match_parent"
-        android:visibility="gone"
-        app:defaultNavHost="false"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@+id/two_pane_layout_guideline"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:visibility="visible" />
+        app:layout_constraintStart_toEndOf="@+id/two_pane_layout_guideline"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -320,13 +320,8 @@
         android:id="@+id/action_global_productDetailFragment"
         app:destination="@id/nav_graph_products">
         <argument
-            android:name="remoteProductId"
-            android:defaultValue="0L"
-            app:argType="long" />
-        <argument
-            android:name="isAddProduct"
-            android:defaultValue="false"
-            app:argType="boolean" />
+            android:name="mode"
+            app:argType="com.woocommerce.android.ui.products.ProductDetailFragment$Mode" />
         <argument
             android:name="isTrashEnabled"
             android:defaultValue="false"

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -9,13 +9,8 @@
         android:name="com.woocommerce.android.ui.products.ProductDetailFragment"
         tools:layout="@layout/fragment_product_detail">
         <argument
-            android:name="remoteProductId"
-            android:defaultValue="0L"
-            app:argType="long" />
-        <argument
-            android:name="isAddProduct"
-            android:defaultValue="false"
-            app:argType="boolean" />
+            android:name="mode"
+            app:argType="com.woocommerce.android.ui.products.ProductDetailFragment$Mode" />
         <argument
             android:name="isTrashEnabled"
             android:defaultValue="false"

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -49,6 +49,7 @@
     <color name="color_scrim_background">@color/woo_black_90_alpha_038</color>
     <color name="color_default_image_background">@color/woo_gray_40</color>
     <color name="color_toolbar">@color/woo_black_900</color>
+    <color name="color_item_selected">@color/woo_black</color>
 
     <!--
         Elevation colors

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -45,6 +45,8 @@
     <color name="color_back_arrow">@color/color_on_surface</color>
     <color name="color_text_link">@color/woo_pink_50</color>
 
+    <color name="color_item_selected">@color/woo_purple_10</color>
+
     <!--
         Icon-related resources that use the surface color should be assigned
         this resource.

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelGenerateVariationFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelGenerateVariationFlowTest.kt
@@ -63,7 +63,7 @@ class ProductDetailViewModelGenerateVariationFlowTest : BaseUnitTest() {
     }
 
     private var savedState: SavedStateHandle =
-        ProductDetailFragmentArgs(remoteProductId = PRODUCT_REMOTE_ID, isAddProduct = false).toSavedStateHandle()
+        ProductDetailFragmentArgs(mode = ProductDetailFragment.Mode.ShowProduct(PRODUCT_REMOTE_ID)).toSavedStateHandle()
 
     private val parameterRepository: ParameterRepository = mock()
     private val generateVariationCandidates: GenerateVariationCandidates = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -108,7 +108,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     }
 
     private var savedState: SavedStateHandle =
-        ProductDetailFragmentArgs(remoteProductId = PRODUCT_REMOTE_ID).toSavedStateHandle()
+        ProductDetailFragmentArgs(ProductDetailFragment.Mode.ShowProduct(PRODUCT_REMOTE_ID)).toSavedStateHandle()
 
     private val siteParams = SiteParameters(
         currencyCode = "USD",
@@ -947,8 +947,10 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `given image uris when app opened, then a product creation is triggered using the images`() = testBlocking {
         val uris = arrayOf("uri1", "uri2")
-        savedState = ProductDetailFragmentArgs(remoteProductId = PRODUCT_REMOTE_ID, images = uris)
-            .toSavedStateHandle()
+        savedState = ProductDetailFragmentArgs(
+            ProductDetailFragment.Mode.ShowProduct(PRODUCT_REMOTE_ID),
+            images = uris
+        ).toSavedStateHandle()
 
         doReturn(product).whenever(productRepository).getProductAsync(any())
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel_AddFlowTest.kt
@@ -86,7 +86,9 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         onBlocking { invoke() } doReturn false
     }
     private var savedState: SavedStateHandle =
-        ProductDetailFragmentArgs(remoteProductId = PRODUCT_REMOTE_ID, isAddProduct = true).toSavedStateHandle()
+        ProductDetailFragmentArgs(
+            mode = ProductDetailFragment.Mode.AddNewProduct
+        ).toSavedStateHandle()
 
     private val siteParams = SiteParameters(
         currencyCode = "USD",
@@ -399,7 +401,9 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     fun `when a new product is saved, then assign the new id to ongoing image uploads`() = testBlocking {
         doReturn(Pair(true, PRODUCT_REMOTE_ID)).whenever(productRepository).addProduct(any())
         doReturn(product).whenever(productRepository).getProductAsync(any())
-        savedState = ProductDetailFragmentArgs(isAddProduct = true).toSavedStateHandle()
+        savedState = ProductDetailFragmentArgs(
+            mode = ProductDetailFragment.Mode.AddNewProduct
+        ).toSavedStateHandle()
 
         setup()
         viewModel.start()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10726 
Closes: #10779 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds a selection of product switches and product details fragment. On top of that I replaced implicit work mode selection of the product details framgnet via passing flags and product id 0 or not 0 to a explicite

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
* Make sure that with flag OFF both tablet and phone work in single pane mode
* Make sure that with flag ON tablet works in two pane mode (with bugs as this is WIP) and phone work in single pane mode

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/63980889-2930-45c4-8e61-7e10c8a00ca8



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->