### PR TITLE
Issue/10785 blaze creation endpoint

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -246,7 +246,7 @@ class BlazeRepository @Inject constructor(
                 mainImage = image,
                 targetingParameters = campaignDetails.targetingParameters.let {
                     BlazeTargetingParameters(
-                        locations = it.locations.map { location -> location.id.toString() },
+                        locations = it.locations.map { location -> location.id },
                         languages = it.languages.map { language -> language.code },
                         devices = it.devices.map { device -> device.id },
                         topics = it.interests.map { interest -> interest.id }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -34,6 +34,7 @@ class BlazeRepository @Inject constructor(
     private val timezoneProvider: TimezoneProvider,
 ) {
     companion object {
+        private const val BLAZE_CAMPAIGN_CREATION_ORIGIN = "wc-android"
         const val BLAZE_DEFAULT_CURRENCY_CODE = "USD" // For now only USD are supported
         const val DEFAULT_CAMPAIGN_DURATION = 7 // Days
         const val CAMPAIGN_MINIMUM_DAILY_SPEND = 5f // USD
@@ -230,7 +231,7 @@ class BlazeRepository @Inject constructor(
         val result = blazeCampaignsStore.createCampaign(
             selectedSite.get(),
             request = BlazeCampaignCreationRequest(
-                origin = "wc-android",
+                origin = BLAZE_CAMPAIGN_CREATION_ORIGIN,
                 originVersion = BuildConfig.VERSION_NAME,
                 type = BlazeCampaignType.PRODUCT,
                 paymentMethodId = paymentMethodId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -260,7 +260,10 @@ class BlazeRepository @Inject constructor(
                 Result.failure(OnChangedException(result.error))
             }
 
-            else -> Result.success(Unit)
+            else -> {
+                WooLog.d(WooLog.T.BLAZE, "Campaign created successfully")
+                Result.success(Unit)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdFragment.kt
@@ -55,17 +55,13 @@ class BlazeCampaignCreationEditAdFragment : BaseFragment(), MediaPickerResultHan
 
     override fun onDeviceMediaSelected(imageUris: List<Uri>, source: String) {
         if (imageUris.isNotEmpty()) {
-            onImageSelected(imageUris.first().toString())
+            viewModel.onLocalImageSelected(imageUris.first().toString())
         }
     }
 
     override fun onWPMediaSelected(images: List<Image>) {
         if (images.isNotEmpty()) {
-            onImageSelected(images.first().source)
+            viewModel.onWPMediaSelected(images.first())
         }
-    }
-
-    private fun onImageSelected(mediaUri: String) {
-        viewModel.onImageChanged(mediaUri)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdScreen.kt
@@ -48,6 +48,7 @@ import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
 import com.woocommerce.android.mediapicker.MediaPickerDialog
+import com.woocommerce.android.ui.blaze.BlazeRepository.BlazeCampaignImage
 import com.woocommerce.android.ui.blaze.creation.ad.BlazeCampaignCreationEditAdViewModel.ViewState
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
@@ -295,7 +296,7 @@ private fun AdImageSection(viewState: ViewState, onChangeImageTapped: () -> Unit
         ) {
             SubcomposeAsyncImage(
                 model = Builder(LocalContext.current)
-                    .data(viewState.adImageUrl)
+                    .data(viewState.adImage.uri)
                     .crossfade(true)
                     .fallback(drawable.blaze_campaign_product_placeholder)
                     .placeholder(drawable.blaze_campaign_product_placeholder)
@@ -365,7 +366,7 @@ fun PreviewCampaignEditAdContent() {
     WooThemeWithBackground {
         CampaignEditAdContent(
             viewState = ViewState(
-                adImageUrl = "https://rb.gy/gmjuwb"
+                adImage = BlazeCampaignImage.RemoteImage(0,"https://rb.gy/gmjuwb")
             ),
             onTagLineChanged = { },
             onDescriptionChanged = { },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdScreen.kt
@@ -366,7 +366,7 @@ fun PreviewCampaignEditAdContent() {
     WooThemeWithBackground {
         CampaignEditAdContent(
             viewState = ViewState(
-                adImage = BlazeCampaignImage.RemoteImage(0,"https://rb.gy/gmjuwb")
+                adImage = BlazeCampaignImage.RemoteImage(0, "https://rb.gy/gmjuwb")
             ),
             onTagLineChanged = { },
             onDescriptionChanged = { },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.ui.blaze.BlazeRepository.AiSuggestionForAd
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -33,7 +34,7 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
 
     private val _viewState = savedStateHandle.getStateFlow(
         scope = viewModelScope,
-        initialValue = ViewState(navArgs.adImageUrl)
+        initialValue = ViewState(navArgs.adImage)
     )
     val viewState = _viewState.asLiveData()
 
@@ -85,7 +86,7 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
                 EditAdResult(
                     tagline = _viewState.value.tagLine,
                     description = _viewState.value.description,
-                    campaignImageUrl = _viewState.value.adImageUrl
+                    campaignImage = _viewState.value.adImage
                 )
             )
         )
@@ -116,9 +117,19 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
         updateSuggestion(AiSuggestionForAd(_viewState.value.tagLine, description.take(TAGLINE_MAX_LENGTH)))
     }
 
-    fun onImageChanged(url: String) {
+    fun onLocalImageSelected(uri: String) {
         _viewState.update {
-            _viewState.value.copy(adImageUrl = url)
+            _viewState.value.copy(adImage = BlazeRepository.BlazeCampaignImage.LocalImage(uri))
+        }
+    }
+
+    fun onWPMediaSelected(image: Product.Image) {
+        _viewState.update {
+            _viewState.value.copy(
+                adImage = BlazeRepository.BlazeCampaignImage.RemoteImage(
+                    mediaId = image.id, uri = image.source
+                )
+            )
         }
     }
 
@@ -140,7 +151,7 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
 
     @Parcelize
     data class ViewState(
-        val adImageUrl: String?,
+        val adImage: BlazeRepository.BlazeCampaignImage,
         val suggestions: List<AiSuggestionForAd> = emptyList(),
         val suggestionIndex: Int = 0,
         val isMediaPickerDialogVisible: Boolean = false
@@ -163,6 +174,6 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
     data class EditAdResult(
         val tagline: String,
         val description: String,
-        val campaignImageUrl: String?
+        val campaignImage: BlazeRepository.BlazeCampaignImage
     ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt
@@ -34,7 +34,7 @@ class BlazeCampaignPaymentSummaryViewModel @Inject constructor(
         paymentMethodsState
     ) { selectedPaymentMethodId, paymentMethodState ->
         ViewState(
-            budget = navArgs.budget,
+            budget = navArgs.campaignDetails.budget,
             paymentMethodsState = paymentMethodState,
             selectedPaymentMethodId = selectedPaymentMethodId
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
@@ -91,7 +91,7 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
                 is NavigateToPaymentSummary -> findNavController().navigateSafely(
                     BlazeCampaignCreationPreviewFragmentDirections
                         .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignPaymentSummaryFragment(
-                            event.budget
+                            event.campaignDetails
                         )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
@@ -59,10 +59,10 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
                 is NavigateToEditAdScreen -> findNavController().navigateSafely(
                     BlazeCampaignCreationPreviewFragmentDirections
                         .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignCreationEditAdFragment(
-                            event.productId,
-                            event.tagLine,
-                            event.description,
-                            event.campaignImageUrl
+                            productId = event.productId,
+                            tagline = event.tagLine,
+                            description = event.description,
+                            adImage = event.campaignImage
                         )
                 )
 
@@ -100,7 +100,7 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
 
     private fun handleResults() {
         handleResult<EditAdResult>(BlazeCampaignCreationEditAdFragment.EDIT_AD_RESULT) {
-            viewModel.onAdUpdated(it.tagline, it.description, it.campaignImageUrl)
+            viewModel.onAdUpdated(it.tagline, it.description, it.campaignImage)
         }
         handleResult<Budget>(BlazeCampaignBudgetFragment.EDIT_BUDGET_AND_DURATION_RESULT) {
             viewModel.onBudgetAndDurationUpdated(it)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.blaze.creation.preview
 
-import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
@@ -25,7 +24,6 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
@@ -232,11 +230,9 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         LOADED
     }
 
-    sealed interface AdDetailsUi : Parcelable {
-        @Parcelize
+    sealed interface AdDetailsUi {
         data object Loading : AdDetailsUi
 
-        @Parcelize
         data class AdDetails(
             val productId: Long,
             val description: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -129,7 +129,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
 
     fun onConfirmClicked() {
         campaignDetails.value?.let {
-            triggerEvent(NavigateToPaymentSummary(it.budget))
+            triggerEvent(NavigateToPaymentSummary(it))
         }
     }
 
@@ -283,8 +283,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         val campaignImage: BlazeRepository.BlazeCampaignImage
     ) : MultiLiveEvent.Event()
 
-    // TODO we need to pass more details to use in the campaign creation
     data class NavigateToPaymentSummary(
-        val budget: BlazeRepository.Budget
+        val campaignDetails: BlazeRepository.CampaignDetails
     ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -167,9 +167,12 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
                 displayValue = targetingParameters.languages.joinToString { it.name }
                     .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
                 onItemSelected = {
-                    triggerEvent(NavigateToTargetSelectionScreen(
-                        targetType = LANGUAGE,
-                        selectedIds = targetingParameters.languages.map { it.code }))
+                    triggerEvent(
+                        NavigateToTargetSelectionScreen(
+                            targetType = LANGUAGE,
+                            selectedIds = targetingParameters.languages.map { it.code }
+                        )
+                    )
                 },
             ),
             CampaignDetailItemUi(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -53,7 +53,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
                     productId = navArgs.productId,
                     description = campaignDetails.description,
                     tagLine = campaignDetails.tagLine,
-                    campaignImageUrl = campaignDetails.campaignImageUrl
+                    campaignImageUrl = campaignDetails.campaignImage.uri
                 )
             },
             campaignDetails = campaignDetails.toCampaignDetailsUi()
@@ -75,18 +75,18 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
                     productId = navArgs.productId,
                     tagLine = it.tagLine,
                     description = it.description,
-                    campaignImageUrl = it.campaignImageUrl
+                    campaignImage = it.campaignImage
                 )
             )
         }
     }
 
-    fun onAdUpdated(tagline: String, description: String, campaignImageUrl: String?) {
+    fun onAdUpdated(tagline: String, description: String, campaignImage: BlazeRepository.BlazeCampaignImage) {
         campaignDetails.update {
             it?.copy(
                 tagLine = tagline,
                 description = description,
-                campaignImageUrl = campaignImageUrl
+                campaignImage = campaignImage
             )
         }
     }
@@ -280,7 +280,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         val productId: Long,
         val tagLine: String,
         val description: String,
-        val campaignImageUrl: String?
+        val campaignImage: BlazeRepository.BlazeCampaignImage
     ) : MultiLiveEvent.Event()
 
     // TODO we need to pass more details to use in the campaign creation

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -5,19 +5,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R.string
-import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.extensions.formatToMMMdd
 import com.woocommerce.android.ui.blaze.BlazeRepository
-import com.woocommerce.android.ui.blaze.BlazeRepository.Budget
-import com.woocommerce.android.ui.blaze.BlazeRepository.CampaignPreview
-import com.woocommerce.android.ui.blaze.BlazeRepository.Companion.CAMPAIGN_MINIMUM_DAILY_SPEND
-import com.woocommerce.android.ui.blaze.BlazeRepository.Companion.DEFAULT_CAMPAIGN_DURATION
-import com.woocommerce.android.ui.blaze.Device
-import com.woocommerce.android.ui.blaze.Interest
-import com.woocommerce.android.ui.blaze.Language
 import com.woocommerce.android.ui.blaze.Location
-import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.AdDetailsUi.AdDetails
-import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.AdDetailsUi.Loading
 import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType
 import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType.DEVICE
 import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType.INTEREST
@@ -26,16 +16,17 @@ import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
-import java.util.Date
 import javax.inject.Inject
-import kotlin.time.Duration.Companion.days
 
 @HiltViewModel
 class BlazeCampaignCreationPreviewViewModel @Inject constructor(
@@ -45,66 +36,27 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     private val currencyFormatter: CurrencyFormatter
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: BlazeCampaignCreationPreviewFragmentArgs by savedStateHandle.navArgs()
-    private suspend fun getCampaign() = blazeRepository.getCampaignPreviewDetails(navArgs.productId)
-
-    private val adDetails = savedStateHandle.getStateFlow<AdDetailsUi>(viewModelScope, Loading)
-    private val budget = savedStateHandle.getStateFlow(viewModelScope, getDefaultBudget())
-
-    private val languages = blazeRepository.observeLanguages()
-    private val devices = blazeRepository.observeDevices()
-    private val interests = blazeRepository.observeInterests()
-
-    private val selectedLanguageCodes = savedStateHandle.getStateFlow<List<String>>(
+    private val campaignDetails = savedStateHandle.getNullableStateFlow(
         scope = viewModelScope,
-        initialValue = emptyList(),
-        key = "selectedLanguages"
+        key = "campaignDetails",
+        initialValue = null,
+        clazz = BlazeRepository.CampaignDetails::class.java
     )
 
-    private val selectedLanguages = combine(languages, selectedLanguageCodes) { languages, selectedCodes ->
-        languages.filter { it.code in selectedCodes }
-    }
+    private val adDetailsState = savedStateHandle.getStateFlow(viewModelScope, AdDetailsUiState.LOADING)
 
-    private val selectedDeviceIds = savedStateHandle.getStateFlow<List<String>>(
-        scope = viewModelScope,
-        initialValue = emptyList(),
-        key = "selectedDevices"
-    )
-
-    private val selectedDevices = combine(devices, selectedDeviceIds) { devices, selectedIds ->
-        devices.filter { it.id in selectedIds }
-    }
-    private val selectedInterestIds = savedStateHandle.getStateFlow<List<String>>(
-        scope = viewModelScope,
-        initialValue = emptyList(),
-        key = "selectedInterests"
-    )
-
-    private val selectedInterests = combine(interests, selectedInterestIds) { interests, selectedIds ->
-        interests.filter { it.id in selectedIds }
-    }
-
-    private val selectedLocations = savedStateHandle.getStateFlow<List<Location>>(
-        scope = viewModelScope,
-        initialValue = emptyList()
-    )
-
-    val viewState = combine(
-        adDetails,
-        budget,
-        selectedLanguages,
-        selectedDevices,
-        selectedInterests,
-        selectedLocations
-    ) { ad, budget, selectedLanguages, selectedDevices, selectedInterests, selectedLocations ->
+    val viewState = combine(campaignDetails.filterNotNull(), adDetailsState) { campaignDetails, adDetailsState ->
         CampaignPreviewUiState(
-            adDetails = ad,
-            campaignDetails = getCampaign().toCampaignDetailsUi(
-                budget,
-                selectedLanguages,
-                selectedDevices,
-                selectedInterests,
-                selectedLocations
-            )
+            adDetails = when (adDetailsState) {
+                AdDetailsUiState.LOADING -> AdDetailsUi.Loading
+                AdDetailsUiState.LOADED -> AdDetailsUi.AdDetails(
+                    productId = navArgs.productId,
+                    description = campaignDetails.description,
+                    tagLine = campaignDetails.tagLine,
+                    campaignImageUrl = campaignDetails.campaignImageUrl
+                )
+            },
+            campaignDetails = campaignDetails.toCampaignDetailsUi()
         )
     }.asLiveData()
 
@@ -117,7 +69,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     }
 
     fun onEditAdClicked() {
-        (adDetails.value as? AdDetails)?.let {
+        campaignDetails.value?.let {
             triggerEvent(
                 NavigateToEditAdScreen(
                     productId = navArgs.productId,
@@ -130,65 +82,80 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     }
 
     fun onAdUpdated(tagline: String, description: String, campaignImageUrl: String?) {
-        adDetails.update {
-            AdDetails(
-                productId = navArgs.productId,
-                description = description,
+        campaignDetails.update {
+            it?.copy(
                 tagLine = tagline,
+                description = description,
                 campaignImageUrl = campaignImageUrl
             )
         }
     }
 
-    fun onBudgetAndDurationUpdated(updatedBudget: Budget) {
-        budget.update { updatedBudget }
+    fun onBudgetAndDurationUpdated(updatedBudget: BlazeRepository.Budget) {
+        campaignDetails.update { it?.copy(budget = updatedBudget) }
     }
 
     fun onTargetSelectionUpdated(targetType: BlazeTargetType, selectedIds: List<String>) {
         launch {
             when (targetType) {
-                LANGUAGE -> selectedLanguageCodes.update { selectedIds }
-                DEVICE -> selectedDeviceIds.update { selectedIds }
-                INTEREST -> selectedInterestIds.update { selectedIds }
+                LANGUAGE -> blazeRepository.observeLanguages().first().let { languages ->
+                    val selectedLanguages = languages.filter { selectedIds.contains(it.code) }
+                    campaignDetails.update {
+                        it?.copy(targetingParameters = it.targetingParameters.copy(languages = selectedLanguages))
+                    }
+                }
+                DEVICE -> blazeRepository.observeDevices().first().let { devices ->
+                    val selectedDevices = devices.filter { selectedIds.contains(it.id) }
+                    campaignDetails.update {
+                        it?.copy(targetingParameters = it.targetingParameters.copy(devices = selectedDevices))
+                    }
+                }
+                INTEREST -> blazeRepository.observeInterests().first().let { interests ->
+                    val selectedInterests = interests.filter { selectedIds.contains(it.id) }
+                    campaignDetails.update {
+                        it?.copy(targetingParameters = it.targetingParameters.copy(interests = selectedInterests))
+                    }
+                }
                 else -> Unit
             }
         }
     }
 
     fun onTargetLocationsUpdated(locations: List<Location>) {
-        selectedLocations.update { locations }
+        campaignDetails.update {
+            it?.copy(targetingParameters = it.targetingParameters.copy(locations = locations))
+        }
     }
 
     fun onConfirmClicked() {
-        triggerEvent(NavigateToPaymentSummary(budget.value))
+        campaignDetails.value?.let {
+            triggerEvent(NavigateToPaymentSummary(it.budget))
+        }
     }
 
     private fun loadData() {
         launch {
+            if (campaignDetails.value == null) {
+                launch { campaignDetails.value = blazeRepository.generateDefaultCampaignDetails(navArgs.productId) }
+            }
+
             blazeRepository.fetchLanguages()
             blazeRepository.fetchDevices()
             blazeRepository.fetchInterests()
 
             blazeRepository.fetchAdSuggestions(navArgs.productId).getOrNull().let { suggestions ->
-                adDetails.update {
-                    AdDetails(
-                        productId = navArgs.productId,
-                        description = suggestions?.firstOrNull()?.description ?: "",
-                        tagLine = suggestions?.firstOrNull()?.tagLine ?: "",
-                        campaignImageUrl = getCampaign().campaignImageUrl
+                adDetailsState.value = AdDetailsUiState.LOADED
+                campaignDetails.update {
+                    it?.copy(
+                        tagLine = suggestions?.firstOrNull()?.tagLine.orEmpty(),
+                        description = suggestions?.firstOrNull()?.description.orEmpty()
                     )
                 }
             }
         }
     }
 
-    private fun CampaignPreview.toCampaignDetailsUi(
-        budget: Budget,
-        languages: List<Language>,
-        devices: List<Device>,
-        interests: List<Interest>,
-        locations: List<Location>
-    ) = CampaignDetailsUi(
+    private fun BlazeRepository.CampaignDetails.toCampaignDetailsUi() = CampaignDetailsUi(
         budget = CampaignDetailItemUi(
             displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_budget),
             displayValue = budget.toDisplayValue(),
@@ -199,34 +166,36 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         targetDetails = listOf(
             CampaignDetailItemUi(
                 displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_language),
-                displayValue = languages.joinToString { it.name }
+                displayValue = targetingParameters.languages.joinToString { it.name }
                     .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
                 onItemSelected = {
-                    triggerEvent(NavigateToTargetSelectionScreen(LANGUAGE, languages.map { it.code }))
+                    triggerEvent(NavigateToTargetSelectionScreen(
+                        targetType = LANGUAGE,
+                        selectedIds = targetingParameters.languages.map { it.code }))
                 },
             ),
             CampaignDetailItemUi(
                 displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_devices),
-                displayValue = devices.joinToString { it.name }
+                displayValue = targetingParameters.devices.joinToString { it.name }
                     .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
                 onItemSelected = {
-                    triggerEvent(NavigateToTargetSelectionScreen(DEVICE, devices.map { it.id }))
+                    triggerEvent(NavigateToTargetSelectionScreen(DEVICE, targetingParameters.devices.map { it.id }))
                 },
             ),
             CampaignDetailItemUi(
                 displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_location),
-                displayValue = locations.joinToString { it.name }
+                displayValue = targetingParameters.locations.joinToString { it.name }
                     .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
                 onItemSelected = {
-                    triggerEvent(NavigateToTargetLocationSelectionScreen(locations))
+                    triggerEvent(NavigateToTargetLocationSelectionScreen(targetingParameters.locations))
                 },
             ),
             CampaignDetailItemUi(
                 displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_interests),
-                displayValue = interests.joinToString { it.description }
+                displayValue = targetingParameters.interests.joinToString { it.description }
                     .ifEmpty { resourceProvider.getString(string.blaze_campaign_preview_target_default_value) },
                 onItemSelected = {
-                    triggerEvent(NavigateToTargetSelectionScreen(INTEREST, interests.map { it.id }))
+                    triggerEvent(NavigateToTargetSelectionScreen(INTEREST, targetingParameters.interests.map { it.id }))
                 },
             ),
         ),
@@ -240,7 +209,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         )
     )
 
-    private fun Budget.toDisplayValue(): String {
+    private fun BlazeRepository.Budget.toDisplayValue(): String {
         val totalBudgetWithCurrency = currencyFormatter.formatCurrency(
             totalBudget.toBigDecimal(),
             currencyCode
@@ -253,22 +222,19 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         return "$totalBudgetWithCurrency,  $duration"
     }
 
-    private fun getDefaultBudget() = Budget(
-        totalBudget = DEFAULT_CAMPAIGN_DURATION * CAMPAIGN_MINIMUM_DAILY_SPEND,
-        spentBudget = 0f,
-        currencyCode = BlazeRepository.BLAZE_DEFAULT_CURRENCY_CODE,
-        durationInDays = DEFAULT_CAMPAIGN_DURATION,
-        startDate = Date().apply { time += 1.days.inWholeMilliseconds }, // By default start tomorrow
-    )
-
     data class CampaignPreviewUiState(
         val adDetails: AdDetailsUi,
         val campaignDetails: CampaignDetailsUi,
     )
 
+    enum class AdDetailsUiState {
+        LOADING,
+        LOADED
+    }
+
     sealed interface AdDetailsUi : Parcelable {
         @Parcelize
-        object Loading : AdDetailsUi
+        data object Loading : AdDetailsUi
 
         @Parcelize
         data class AdDetails(
@@ -293,7 +259,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     )
 
     data class NavigateToBudgetScreen(
-        val budget: Budget
+        val budget: BlazeRepository.Budget
     ) : MultiLiveEvent.Event()
 
     data class NavigateToAdDestinationScreen(

--- a/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
@@ -142,8 +142,8 @@
         android:name="com.woocommerce.android.ui.blaze.creation.payment.BlazeCampaignPaymentSummaryFragment"
         android:label="BlazeCampaignPaymentSummaryFragment">
         <argument
-            android:name="budget"
-            app:argType="com.woocommerce.android.ui.blaze.BlazeRepository$Budget" />
+            android:name="campaignDetails"
+            app:argType="com.woocommerce.android.ui.blaze.BlazeRepository$CampaignDetails" />
         <action
             android:id="@+id/action_blazeCampaignPaymentSummaryFragment_to_blazeCampaignPaymentMethodsListFragment"
             app:destination="@id/blazeCampaignPaymentMethodsListFragment" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
@@ -85,10 +85,8 @@
             android:defaultValue=""
             app:argType="string" />
         <argument
-            android:name="adImageUrl"
-            android:defaultValue="@null"
-            app:argType="string"
-            app:nullable="true" />
+            android:name="adImage"
+            app:argType="com.woocommerce.android.ui.blaze.BlazeRepository$BlazeCampaignImage" />
     </fragment>
     <fragment
         android:id="@+id/blazeCampaignBudgetFragment"

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.66.0'
+    fluxCVersion = '2954-b6a6f03406478755900160b8dc52de6ea593986c'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2954-b6a6f03406478755900160b8dc52de6ea593986c'
+    fluxCVersion = 'trunk-3a4c421cb0a18898c23dc95fef044e991b16868d'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10785 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR has the following changes:
1. Updates FluxC to include the changes of https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2954
2. Does a heavy refactoring of the models, more on this below.
3. Adds repository function that handles campaign creation.
4. The above function handles uploading media when needed.

For the models refactoring, it has two parts:
1. Introduce a class `CampaignDetails` that includes all of the Blaze campaign details, and I did this for two reasons:
    a. Avoid having ton of arguments in the `createCampaign` function in the Repository.
    b. We can pass this model to the payment screen to proceed with the campaign creation.
Although this means now that we save the whole Campaign details to the SavedState, I think the above benefits and the code simplicity is worth it, and we should still be on the safe side as it's not a large object by any means, please let me know what you think.
2. Refactoring to how we model the campaign image, as we need to keep track of the source of the image and its eventual ID to fetch the `MediaModel` of the image before using it for the campaign creation.

### Testing instructions
Please smoke test the whole campaign creation flow, the refactoring touches almost everything.

For the campaign creation, please use the below patch:
<details>
<summary>
Patch
</summary>

```Patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt	(revision d706b3dc17cca83ed42dcb3894cec6ddac57ea14)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt	(date 1707844170628)
@@ -5,6 +5,7 @@
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.ui.blaze.BlazeRepository.PaymentMethodsData
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
@@ -48,6 +49,21 @@
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
+    fun onSubmitCampaign() {
+        val selectedPaymentMethodId = selectedPaymentMethodId.value
+        requireNotNull(selectedPaymentMethodId) { "Selected payment method is null" }
+
+        launch {
+            blazeRepository.createCampaign(
+                campaignDetails = navArgs.campaignDetails,
+                paymentMethodId = selectedPaymentMethodId
+            ).fold(
+                onSuccess = { WooLog.d(WooLog.T.BLAZE, "Campaign Created Successfully") },
+                onFailure = { /* Handle error */ }
+            )
+        }
+    }
+
     fun onPaymentMethodSelected(paymentMethodId: String) {
         selectedPaymentMethodId.value = paymentMethodId
 
```
</details>


Then test campaign creation, and confirm it logs: "Campaign Created Successfully" is logged to Logcat.


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
