### PR TITLE
[POC] build: do not run ksp and hilt tasks for unit tests

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -185,6 +185,13 @@ android {
     }
 }
 
+for (taskName in gradle.startParameter.taskNames) {
+    if (taskName.contains("UnitTest")) {
+        tasks.matching { it.name.startsWith("ksp") || it.name.startsWith("hilt") }
+                .configureEach { enabled = false }
+    }
+}
+
 dependencies {
     implementation("org.wordpress:libaddressinput.common:$libaddressinputVersion") {
         exclude group: "org.json", module: "json"


### PR DESCRIPTION
To improve unit tests execution time
