### PR TITLE
Adds existing Blaze tracking to the new native implementation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListFragment.kt
@@ -69,7 +69,7 @@ class BlazeCampaignListFragment : BaseFragment() {
 
     private fun openBlazeCreationFlow() {
         lifecycleScope.launch {
-            blazeCampaignCreationDispatcher.startCampaignCreation()
+            blazeCampaignCreationDispatcher.startCampaignCreation(source = BlazeFlowSource.CAMPAIGN_LIST)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListFragment.kt
@@ -49,7 +49,7 @@ class BlazeCampaignListFragment : BaseFragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        blazeCampaignCreationDispatcher.attachFragment(this)
+        blazeCampaignCreationDispatcher.attachFragment(this, BlazeFlowSource.CAMPAIGN_LIST)
 
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/BlazeCampaignCreationDispatcher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/BlazeCampaignCreationDispatcher.kt
@@ -36,10 +36,13 @@ class BlazeCampaignCreationDispatcher @Inject constructor(
 ) {
     private var fragmentReference: WeakReference<BaseFragment> = WeakReference(null)
 
-    fun attachFragment(fragment: BaseFragment) {
+    fun attachFragment(fragment: BaseFragment, source: BlazeFlowSource) {
         this.fragmentReference = WeakReference(fragment)
         fragment.handleResult<Collection<SelectedItem>>(ProductSelectorFragment.PRODUCT_SELECTOR_RESULT) {
-            this.fragmentReference.get()?.showCampaignPreview(it.first().id)
+            this.fragmentReference.get()?.showCampaignPreview(
+                productId = it.first().id,
+                source = source
+            )
         }
     }
 
@@ -103,7 +106,7 @@ class BlazeCampaignCreationDispatcher @Inject constructor(
                 ?.showIntro(event.productId, event.blazeSource)
 
             is BlazeCampaignCreationDispatcherEvent.ShowBlazeCampaignCreationForm -> fragmentReference.get()
-                ?.showCampaignPreview(event.productId)
+                ?.showCampaignPreview(event.productId, event.blazeSource)
 
             is BlazeCampaignCreationDispatcherEvent.ShowProductSelectorScreen -> fragmentReference.get()
                 ?.showProductSelector()
@@ -120,10 +123,13 @@ class BlazeCampaignCreationDispatcher @Inject constructor(
         )
     }
 
-    private fun BaseFragment.showCampaignPreview(productId: Long) {
+    private fun BaseFragment.showCampaignPreview(productId: Long, source: BlazeFlowSource) {
         findNavController().navigateToBlazeGraph(
             startDestination = R.id.blazeCampaignCreationPreviewFragment,
-            bundle = BlazeCampaignCreationPreviewFragmentArgs(productId).toBundle()
+            bundle = BlazeCampaignCreationPreviewFragmentArgs(
+                productId = productId,
+                source = source
+            ).toBundle()
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/BlazeCampaignCreationDispatcher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/BlazeCampaignCreationDispatcher.kt
@@ -6,6 +6,9 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
 import com.woocommerce.android.R
 import com.woocommerce.android.R.string
+import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_ENTRY_POINT_TAPPED
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
@@ -32,7 +35,8 @@ import javax.inject.Inject
 class BlazeCampaignCreationDispatcher @Inject constructor(
     private val blazeRepository: BlazeRepository,
     private val productListRepository: ProductListRepository,
-    private val coroutineDispatchers: CoroutineDispatchers
+    private val coroutineDispatchers: CoroutineDispatchers,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
 ) {
     private var fragmentReference: WeakReference<BaseFragment> = WeakReference(null)
 
@@ -56,7 +60,13 @@ class BlazeCampaignCreationDispatcher @Inject constructor(
                 BlazeCampaignCreationDispatcherEvent.ShowBlazeCampaignCreationIntro(productId, source)
             )
 
-            else -> startCampaignCreationWithoutIntro(productId, source, handler)
+            else -> {
+                analyticsTracker.track(
+                    stat = BLAZE_ENTRY_POINT_TAPPED,
+                    properties = mapOf(AnalyticsTracker.KEY_BLAZE_SOURCE to source.trackingName)
+                )
+                startCampaignCreationWithoutIntro(productId, source, handler)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroFragment.kt
@@ -44,7 +44,8 @@ class BlazeCampaignCreationIntroFragment : BaseFragment() {
                     findNavController().navigateSafely(
                         directions = BlazeCampaignCreationIntroFragmentDirections
                             .actionBlazeCampaignCreationIntroFragmentToBlazeCampaignCreationPreviewFragment(
-                                productId = event.productId
+                                productId = event.productId,
+                                source = event.source
                             ),
                         navOptions = navOptions {
                             popUpTo(R.id.blazeCampaignCreationIntroFragment) { inclusive = true }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroViewModel.kt
@@ -22,9 +22,9 @@ import javax.inject.Inject
 @HiltViewModel
 class BlazeCampaignCreationIntroViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    analyticsTracker: AnalyticsTrackerWrapper,
     private val productListRepository: ProductListRepository,
     private val coroutineDispatchers: CoroutineDispatchers,
-    private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: BlazeCampaignCreationIntroFragmentArgs by savedStateHandle.navArgs()
     fun onContinueClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_INTRO_DISPLAYED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.products.ProductListRepository
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.util.CoroutineDispatchers
@@ -37,11 +38,16 @@ class BlazeCampaignCreationIntroViewModel @Inject constructor(
 
         launch {
             if (navArgs.productId != -1L) {
-                triggerEvent(ShowCampaignCreationForm(navArgs.productId))
+                triggerEvent(ShowCampaignCreationForm(navArgs.productId, BlazeFlowSource.INTRO_VIEW))
             } else {
                 val products = getPublishedProducts()
                 when {
-                    products.size == 1 -> triggerEvent(ShowCampaignCreationForm(products.first().remoteId))
+                    products.size == 1 -> triggerEvent(
+                        ShowCampaignCreationForm(
+                            products.first().remoteId, BlazeFlowSource.INTRO_VIEW
+                        )
+                    )
+
                     products.isNotEmpty() -> triggerEvent(ShowProductSelector)
                     else -> {
                         WooLog.w(WooLog.T.BLAZE, "No products available to create a campaign")
@@ -64,9 +70,9 @@ class BlazeCampaignCreationIntroViewModel @Inject constructor(
     }
 
     fun onProductSelected(productId: Long) {
-        triggerEvent(ShowCampaignCreationForm(productId))
+        triggerEvent(ShowCampaignCreationForm(productId, BlazeFlowSource.INTRO_VIEW))
     }
 
     object ShowProductSelector : MultiLiveEvent.Event()
-    data class ShowCampaignCreationForm(val productId: Long) : MultiLiveEvent.Event()
+    data class ShowCampaignCreationForm(val productId: Long, val source: BlazeFlowSource) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroViewModel.kt
@@ -1,6 +1,9 @@
 package com.woocommerce.android.ui.blaze.creation.intro
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_INTRO_DISPLAYED
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.products.ProductListRepository
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.util.CoroutineDispatchers
@@ -20,7 +23,8 @@ import javax.inject.Inject
 class BlazeCampaignCreationIntroViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val productListRepository: ProductListRepository,
-    private val coroutineDispatchers: CoroutineDispatchers
+    private val coroutineDispatchers: CoroutineDispatchers,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: BlazeCampaignCreationIntroFragmentArgs by savedStateHandle.navArgs()
     fun onContinueClick() {
@@ -46,6 +50,13 @@ class BlazeCampaignCreationIntroViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    init {
+        analyticsTracker.track(
+            stat = BLAZE_INTRO_DISPLAYED,
+            properties = mapOf(AnalyticsTracker.KEY_BLAZE_SOURCE to navArgs.source.trackingName)
+        )
     }
 
     fun onDismissClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.blaze.creation.intro
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_ENTRY_POINT_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_INTRO_DISPLAYED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -23,13 +24,17 @@ import javax.inject.Inject
 @HiltViewModel
 class BlazeCampaignCreationIntroViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    analyticsTracker: AnalyticsTrackerWrapper,
     private val productListRepository: ProductListRepository,
     private val coroutineDispatchers: CoroutineDispatchers,
+    private val analyticsTracker: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: BlazeCampaignCreationIntroFragmentArgs by savedStateHandle.navArgs()
     fun onContinueClick() {
         suspend fun getPublishedProducts() = withContext(coroutineDispatchers.io) {
+            analyticsTracker.track(
+                stat = BLAZE_ENTRY_POINT_TAPPED,
+                properties = mapOf(AnalyticsTracker.KEY_BLAZE_SOURCE to BlazeFlowSource.INTRO_VIEW.trackingName)
+            )
             productListRepository.getProductList(
                 productFilterOptions = mapOf(ProductFilterOption.STATUS to ProductStatus.PUBLISH.value),
                 sortType = ProductSorting.DATE_DESC,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -5,9 +5,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R.string
-import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_ENTRY_POINT_TAPPED
-import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.extensions.formatToMMMdd
 import com.woocommerce.android.ui.blaze.BlazeRepository
@@ -43,7 +40,6 @@ import kotlin.time.Duration.Companion.days
 @HiltViewModel
 class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val blazeRepository: BlazeRepository,
     private val resourceProvider: ResourceProvider,
     private val currencyFormatter: CurrencyFormatter
@@ -114,10 +110,6 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
 
     init {
         loadData()
-        analyticsTrackerWrapper.track(
-            stat = BLAZE_ENTRY_POINT_TAPPED,
-            properties = mapOf(AnalyticsTracker.KEY_BLAZE_SOURCE to navArgs.source.trackingName)
-        )
     }
 
     fun onBackPressed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R.string
+import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_ENTRY_POINT_TAPPED
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.combine
 import com.woocommerce.android.extensions.formatToMMMdd
 import com.woocommerce.android.ui.blaze.BlazeRepository
@@ -40,6 +43,7 @@ import kotlin.time.Duration.Companion.days
 @HiltViewModel
 class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val blazeRepository: BlazeRepository,
     private val resourceProvider: ResourceProvider,
     private val currencyFormatter: CurrencyFormatter
@@ -110,6 +114,10 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
 
     init {
         loadData()
+        analyticsTrackerWrapper.track(
+            stat = BLAZE_ENTRY_POINT_TAPPED,
+            properties = mapOf(AnalyticsTracker.KEY_BLAZE_SOURCE to navArgs.source.trackingName)
+        )
     }
 
     fun onBackPressed() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -76,7 +76,7 @@ class MoreMenuFragment : TopLevelFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        blazeCampaignCreationDispatcher.attachFragment(this)
+        blazeCampaignCreationDispatcher.attachFragment(this, BlazeFlowSource.MORE_MENU_ITEM)
         setupObservers()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -114,7 +115,7 @@ class MoreMenuFragment : TopLevelFragment() {
 
     private fun openBlazeCreationFlow() {
         lifecycleScope.launch {
-            blazeCampaignCreationDispatcher.startCampaignCreation()
+            blazeCampaignCreationDispatcher.startCampaignCreation(source = BlazeFlowSource.MORE_MENU_ITEM)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -279,7 +279,10 @@ class MyStoreFragment :
 
     private fun openBlazeCreationFlow(productId: Long?) {
         lifecycleScope.launch {
-            blazeCampaignCreationDispatcher.startCampaignCreation(productId)
+            blazeCampaignCreationDispatcher.startCampaignCreation(
+                source = BlazeFlowSource.MY_STORE_SECTION,
+                productId = productId
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -176,7 +176,7 @@ class MyStoreFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
-        blazeCampaignCreationDispatcher.attachFragment(this)
+        blazeCampaignCreationDispatcher.attachFragment(this, BlazeFlowSource.MY_STORE_SECTION)
 
         _binding = FragmentMyStoreBinding.bind(view)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -160,7 +160,7 @@ class ProductDetailFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        blazeCampaignCreationDispatcher.attachFragment(this)
+        blazeCampaignCreationDispatcher.attachFragment(this, BlazeFlowSource.PRODUCT_DETAIL_PROMOTE_BUTTON)
 
         _binding = FragmentProductDetailBinding.bind(view)
         requireActivity().addMenuProvider(this, viewLifecycleOwner)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -46,6 +46,7 @@ import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.ui.aztec.AztecEditorFragment
 import com.woocommerce.android.ui.aztec.AztecEditorFragment.Companion.ARG_AZTEC_EDITOR_TEXT
 import com.woocommerce.android.ui.aztec.AztecEditorFragment.Companion.ARG_AZTEC_TITLE_FROM_AI_DESCRIPTION
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.dialog.WooDialog
@@ -407,7 +408,10 @@ class ProductDetailFragment :
 
     private fun openBlazeCreationFlow(productId: Long) {
         lifecycleScope.launch {
-            blazeCampaignCreationDispatcher.startCampaignCreation(productId = productId)
+            blazeCampaignCreationDispatcher.startCampaignCreation(
+                source = BlazeFlowSource.PRODUCT_DETAIL_PROMOTE_BUTTON,
+                productId = productId
+            )
         }
     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
@@ -54,6 +54,10 @@
             android:name="productId"
             android:defaultValue="-1L"
             app:argType="long" />
+        <argument
+            android:name="source"
+            app:argType="com.woocommerce.android.ui.blaze.BlazeUrlsHelper$BlazeFlowSource"
+            app:nullable="false" />
         <action
             android:id="@+id/action_blazeCampaignCreationPreviewFragment_to_blazeCampaignCreationEditAdFragment"
             app:destination="@id/blazeCampaignCreationEditAdFragment" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
@@ -14,6 +14,10 @@
             android:name="productId"
             android:defaultValue="-1L"
             app:argType="long" />
+        <argument
+            android:name="source"
+            app:argType="com.woocommerce.android.ui.blaze.BlazeUrlsHelper$BlazeFlowSource"
+            app:nullable="false" />
         <action
             android:id="@+id/action_blazeCampaignCreationIntroFragment_to_nav_graph_product_selector"
             app:destination="@id/nav_graph_product_selector">

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/BlazeCampaignCreationDispatcherTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/BlazeCampaignCreationDispatcherTests.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.blaze.creation
 
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher.BlazeCampaignCreationDispatcherEvent
@@ -19,6 +20,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 class BlazeCampaignCreationDispatcherTests : BaseUnitTest() {
     private val productListRepository: ProductListRepository = mock()
     private val blazeRepository: BlazeRepository = mock()
+    private val analyticsTracker: AnalyticsTrackerWrapper = mock()
 
     private lateinit var dispatcher: BlazeCampaignCreationDispatcher
 
@@ -29,7 +31,8 @@ class BlazeCampaignCreationDispatcherTests : BaseUnitTest() {
         dispatcher = BlazeCampaignCreationDispatcher(
             blazeRepository = blazeRepository,
             productListRepository = productListRepository,
-            coroutineDispatchers = coroutinesTestRule.testDispatchers
+            coroutineDispatchers = coroutinesTestRule.testDispatchers,
+            analyticsTracker = analyticsTracker
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/BlazeCampaignCreationDispatcherTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/BlazeCampaignCreationDispatcherTests.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.blaze.creation
 
 import com.woocommerce.android.ui.blaze.BlazeRepository
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher.BlazeCampaignCreationDispatcherEvent
 import com.woocommerce.android.ui.products.ProductListRepository
 import com.woocommerce.android.ui.products.ProductStatus
@@ -39,9 +40,14 @@ class BlazeCampaignCreationDispatcherTests : BaseUnitTest() {
         }
 
         var event: BlazeCampaignCreationDispatcherEvent? = null
-        dispatcher.startCampaignCreation { event = it }
+        dispatcher.startCampaignCreation(source = BlazeFlowSource.MY_STORE_SECTION) { event = it }
 
-        assertThat(event).isEqualTo(BlazeCampaignCreationDispatcherEvent.ShowBlazeCampaignCreationIntro(null))
+        assertThat(event).isEqualTo(
+            BlazeCampaignCreationDispatcherEvent.ShowBlazeCampaignCreationIntro(
+                productId = null,
+                blazeSource = BlazeFlowSource.MY_STORE_SECTION
+            )
+        )
     }
 
     @Test
@@ -58,7 +64,7 @@ class BlazeCampaignCreationDispatcherTests : BaseUnitTest() {
             }
 
             var event: BlazeCampaignCreationDispatcherEvent? = null
-            dispatcher.startCampaignCreation { event = it }
+            dispatcher.startCampaignCreation(source = BlazeFlowSource.MY_STORE_SECTION) { event = it }
 
             assertThat(event).isEqualTo(BlazeCampaignCreationDispatcherEvent.ShowProductSelectorScreen)
         }
@@ -77,9 +83,17 @@ class BlazeCampaignCreationDispatcherTests : BaseUnitTest() {
             }
 
             var event: BlazeCampaignCreationDispatcherEvent? = null
-            dispatcher.startCampaignCreation(productId = 1L) { event = it }
+            dispatcher.startCampaignCreation(
+                source = BlazeFlowSource.MY_STORE_SECTION,
+                productId = 1L
+            ) { event = it }
 
-            assertThat(event).isEqualTo(BlazeCampaignCreationDispatcherEvent.ShowBlazeCampaignCreationForm(1L))
+            assertThat(event).isEqualTo(
+                BlazeCampaignCreationDispatcherEvent.ShowBlazeCampaignCreationForm(
+                    productId = 1L,
+                    blazeSource = BlazeFlowSource.MY_STORE_SECTION
+                )
+            )
         }
 
     @Test
@@ -96,8 +110,13 @@ class BlazeCampaignCreationDispatcherTests : BaseUnitTest() {
             }
 
             var event: BlazeCampaignCreationDispatcherEvent? = null
-            dispatcher.startCampaignCreation { event = it }
+            dispatcher.startCampaignCreation(source = BlazeFlowSource.MY_STORE_SECTION) { event = it }
 
-            assertThat(event).isEqualTo(BlazeCampaignCreationDispatcherEvent.ShowBlazeCampaignCreationForm(1L))
+            assertThat(event).isEqualTo(
+                BlazeCampaignCreationDispatcherEvent.ShowBlazeCampaignCreationForm(
+                    productId = 1L,
+                    blazeSource = BlazeFlowSource.MY_STORE_SECTION,
+                )
+            )
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroViewModelTests.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.blaze.creation.intro
 
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.products.ProductListRepository
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductTestUtils
@@ -16,15 +18,20 @@ import kotlin.test.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class BlazeCampaignCreationIntroViewModelTests : BaseUnitTest() {
     private val productListRepository: ProductListRepository = mock()
+    private val analyticsTracker: AnalyticsTrackerWrapper = mock()
 
     private lateinit var viewModel: BlazeCampaignCreationIntroViewModel
 
     suspend fun setup(productId: Long, setupMocks: suspend () -> Unit = {}) {
         setupMocks()
         viewModel = BlazeCampaignCreationIntroViewModel(
-            savedStateHandle = BlazeCampaignCreationIntroFragmentArgs(productId).toSavedStateHandle(),
+            savedStateHandle = BlazeCampaignCreationIntroFragmentArgs(
+                productId = productId,
+                source = BlazeFlowSource.MY_STORE_SECTION
+            ).toSavedStateHandle(),
             productListRepository = productListRepository,
-            coroutineDispatchers = coroutinesTestRule.testDispatchers
+            coroutineDispatchers = coroutinesTestRule.testDispatchers,
+            analyticsTracker = analyticsTracker,
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/intro/BlazeCampaignCreationIntroViewModelTests.kt
@@ -42,7 +42,12 @@ class BlazeCampaignCreationIntroViewModelTests : BaseUnitTest() {
         viewModel.onContinueClick()
 
         val event = viewModel.event.value
-        assertThat(event).isEqualTo(BlazeCampaignCreationIntroViewModel.ShowCampaignCreationForm(1L))
+        assertThat(event).isEqualTo(
+            BlazeCampaignCreationIntroViewModel.ShowCampaignCreationForm(
+                productId = 1L,
+                source = BlazeFlowSource.INTRO_VIEW
+            )
+        )
     }
 
     @Test
@@ -60,7 +65,12 @@ class BlazeCampaignCreationIntroViewModelTests : BaseUnitTest() {
             viewModel.onContinueClick()
 
             val event = viewModel.event.value
-            assertThat(event).isEqualTo(BlazeCampaignCreationIntroViewModel.ShowCampaignCreationForm(1L))
+            assertThat(event).isEqualTo(
+                BlazeCampaignCreationIntroViewModel.ShowCampaignCreationForm(
+                    productId = 1L,
+                    source = BlazeFlowSource.INTRO_VIEW
+                )
+            )
         }
 
     @Test
@@ -88,7 +98,12 @@ class BlazeCampaignCreationIntroViewModelTests : BaseUnitTest() {
         viewModel.onProductSelected(1L)
 
         val event = viewModel.event.value
-        assertThat(event).isEqualTo(BlazeCampaignCreationIntroViewModel.ShowCampaignCreationForm(1L))
+        assertThat(event).isEqualTo(
+            BlazeCampaignCreationIntroViewModel.ShowCampaignCreationForm(
+                productId = 1L,
+                source = BlazeFlowSource.INTRO_VIEW
+            )
+        )
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #10784 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds tracking for the events that already existed for Blaze i2 but weren't being tracked in the new native screens: 
`_blaze_intro_displayed`
`_blaze_entry_point_tapped`

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

`_blaze_intro_displayed`

1. Trigger Blaze campaign creation flow from a site that doesn't have any campaigns. 
2. The intro view will be displayed. Check for the following log: `🔵 Tracked: blaze_intro_displayed, Properties: {"source":"my_store_section"` 
3. Repeat the same interactions from the different Blaze CTAs: more menu, campaign list, and product detail. Check the correct `source` property is added to the event.

`_blaze_entry_point_tapped`
1. Trigger Blaze campaign creation flow from a site that doesn't have any campaigns. 
2. From intro view click on start a campaign. The following should be tracked: `blaze_entry_point_tapped, Properties: {"source":"intro_view"`
3. Open a site that has Blaze existing campaigns
4. Trigger campaign creation flow
5. The preview screen should be opened and the following event should be tracked: `blaze_entry_point_tapped, Properties: {"source":"my_store_section"`
6. Repeat the same interactions from the different Blaze CTAs: more menu, campaign list, and product detail. Check the correct `source` property is added to the event.
