### PR TITLE
Blaze: Use targeting parameters when calculating forecast

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -160,13 +160,22 @@ class BlazeRepository @Inject constructor(
     suspend fun fetchAdForecast(
         startDate: Date,
         campaignDurationDays: Int,
-        totalBudget: Float
+        totalBudget: Float,
+        targetingParameters: TargetingParameters
     ): Result<BlazeAdForecast> {
         val result = blazeCampaignsStore.fetchBlazeAdForecast(
-            selectedSite.get(),
-            startDate,
-            Date(startDate.time + campaignDurationDays.days.inWholeMilliseconds),
-            totalBudget.roundToInt().toDouble(),
+            siteModel = selectedSite.get(),
+            startDate = startDate,
+            endDate = Date(startDate.time + campaignDurationDays.days.inWholeMilliseconds),
+            totalBudget = totalBudget.roundToInt().toDouble(),
+            targetingParameters = targetingParameters.let {
+                BlazeTargetingParameters(
+                    locations = it.locations.map { location -> location.id },
+                    languages = it.languages.map { language -> language.code },
+                    devices = it.devices.map { device -> device.id },
+                    topics = it.interests.map { interest -> interest.id }
+                )
+            }
         )
         return when {
             result.isError -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/budget/BlazeCampaignBudgetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/budget/BlazeCampaignBudgetViewModel.kt
@@ -158,7 +158,8 @@ class BlazeCampaignBudgetViewModel @Inject constructor(
             repository.fetchAdForecast(
                 startDate = Date(budgetUiState.value.campaignStartDateMillis),
                 campaignDurationDays = budgetUiState.value.durationInDays,
-                totalBudget = budgetUiState.value.totalBudget
+                totalBudget = budgetUiState.value.totalBudget,
+                targetingParameters = navArgs.targetingParameters
             ).onSuccess { fetchAdForecastResult ->
                 campaignForecastState = campaignForecastState.copy(
                     isLoading = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
@@ -58,7 +58,10 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
 
                 is NavigateToBudgetScreen -> findNavController().navigateSafely(
                     BlazeCampaignCreationPreviewFragmentDirections
-                        .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignBudgetFragment(event.budget)
+                        .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignBudgetFragment(
+                            budget = event.budget,
+                            targetingParameters = event.targetingParameters
+                        )
                 )
 
                 is NavigateToEditAdScreen -> findNavController().navigateSafely(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -163,7 +163,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
             displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_budget),
             displayValue = budget.toDisplayValue(),
             onItemSelected = {
-                triggerEvent(NavigateToBudgetScreen(budget))
+                triggerEvent(NavigateToBudgetScreen(budget, targetingParameters))
             },
         ),
         targetDetails = listOf(
@@ -263,7 +263,8 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     )
 
     data class NavigateToBudgetScreen(
-        val budget: BlazeRepository.Budget
+        val budget: BlazeRepository.Budget,
+        val targetingParameters: BlazeRepository.TargetingParameters
     ) : MultiLiveEvent.Event()
 
     data class NavigateToAdDestinationScreen(

--- a/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
@@ -95,6 +95,9 @@
         <argument
             android:name="budget"
             app:argType="com.woocommerce.android.ui.blaze.BlazeRepository$Budget" />
+        <argument
+            android:name="targetingParameters"
+            app:argType="com.woocommerce.android.ui.blaze.BlazeRepository$TargetingParameters" />
     </fragment>
     <fragment
         android:id="@+id/blazeCampaignTargetSelectionFragment"


### PR DESCRIPTION
### Description
This is just a small fix to make sure we pass the targeting parameters when we calculate ad's forecast, this was missed because I made the parameter as optional with a default value (I probably shouldn't have).

### Testing instructions
1. Start Blaze campaign creation.
2. Check the budget screen and confirm the forecast is loaded successfully.
3. Make some changes to the targeting parameters (from my experience Interests is the one that has the higher impact)
4. Go back to the budget screen and confirm the forecast changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
