### PR TITLE
Blaze: Refactor the parameter-handling

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -146,14 +146,16 @@ class BlazeRepository @Inject constructor(
             userTimeZone = timezoneProvider.deviceTimezone.displayName,
             tagLine = "",
             description = "",
-            targetUrl = product.permalink,
-            urlParams = emptyMap(),
             campaignImage = product.images.firstOrNull().let {
                 if (it != null) BlazeCampaignImage.RemoteImage(it.id, it.source)
                 else BlazeCampaignImage.None
             },
             budget = getDefaultBudget(),
-            targetingParameters = TargetingParameters()
+            targetingParameters = TargetingParameters(),
+            destinationParameters = DestinationParameters(
+                targetUrl = product.permalink,
+                parameters = emptyMap()
+            )
         )
     }
 
@@ -250,8 +252,8 @@ class BlazeRepository @Inject constructor(
                 startDate = campaignDetails.budget.startDate,
                 endDate = campaignDetails.budget.endDate,
                 budget = campaignDetails.budget.totalBudget.toDouble(),
-                targetUrl = campaignDetails.targetUrl,
-                urlParams = campaignDetails.urlParams,
+                targetUrl = campaignDetails.destinationParameters.targetUrl,
+                urlParams = campaignDetails.destinationParameters.parameters,
                 mainImage = image,
                 targetingParameters = campaignDetails.targetingParameters.let {
                     BlazeTargetingParameters(
@@ -307,11 +309,10 @@ class BlazeRepository @Inject constructor(
         val tagLine: String,
         val description: String,
         val userTimeZone: String,
-        val targetUrl: String,
-        val urlParams: Map<String, String>,
         val campaignImage: BlazeCampaignImage,
         val budget: Budget,
-        val targetingParameters: TargetingParameters
+        val targetingParameters: TargetingParameters,
+        val destinationParameters: DestinationParameters
     ) : Parcelable
 
     sealed interface BlazeCampaignImage : Parcelable {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -291,6 +291,7 @@ class BlazeRepository @Inject constructor(
                         }
                     }
             }
+
             is BlazeCampaignImage.RemoteImage -> mediaFilesRepository.fetchWordPressMedia(image.mediaId)
             is BlazeCampaignImage.None -> error("No image provided for Blaze Campaign Creation")
         }
@@ -315,6 +316,7 @@ class BlazeRepository @Inject constructor(
 
     sealed interface BlazeCampaignImage : Parcelable {
         val uri: String
+
         @Parcelize
         data object None : BlazeCampaignImage {
             override val uri: String
@@ -334,6 +336,12 @@ class BlazeRepository @Inject constructor(
         val languages: List<Language> = emptyList(),
         val devices: List<Device> = emptyList(),
         val interests: List<Interest> = emptyList()
+    ) : Parcelable
+
+    @Parcelize
+    data class DestinationParameters(
+        val targetUrl: String,
+        val parameters: Map<String, String>
     ) : Parcelable
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationFragment.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.blaze.BlazeRepository.DestinationParameters
 import com.woocommerce.android.ui.blaze.creation.destination.BlazeCampaignCreationAdDestinationParametersFragment.Companion.BLAZE_DESTINATION_PARAMETERS_RESULT
 import com.woocommerce.android.ui.blaze.creation.destination.BlazeCampaignCreationAdDestinationViewModel.NavigateToParametersScreen
 import com.woocommerce.android.ui.compose.composeView
@@ -44,7 +45,7 @@ class BlazeCampaignCreationAdDestinationFragment : BaseFragment() {
                 is ExitWithResult<*> -> navigateBackWithResult(BLAZE_DESTINATION_RESULT, event.data)
                 is NavigateToParametersScreen -> {
                     val action = BlazeCampaignCreationAdDestinationFragmentDirections
-                        .actionAdDestinationFragmentToAdDestinationParametersFragment(event.url)
+                        .actionAdDestinationFragmentToAdDestinationParametersFragment(event.destinationParameters)
                     findNavController().navigateSafely(action)
                 }
             }
@@ -52,8 +53,8 @@ class BlazeCampaignCreationAdDestinationFragment : BaseFragment() {
     }
 
     private fun handleResults() {
-        handleResult<String>(BLAZE_DESTINATION_PARAMETERS_RESULT) { url ->
-            viewModel.onTargetUrlUpdated(url)
+        handleResult<DestinationParameters>(BLAZE_DESTINATION_PARAMETERS_RESULT) {
+            viewModel.onDestinationParametersUpdated(it.targetUrl, it.parameters)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersBottomSheet.kt
@@ -163,7 +163,7 @@ fun PreviewParameterBottomSheet() {
     WooThemeWithBackground {
         ParameterBottomSheet(
             paramsState = Editing(
-                baseUrl = "https://example.com",
+                targetUrl = "https://example.com",
                 parameters = emptyMap(),
                 key = "key",
                 value = "value"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersScreen.kt
@@ -233,7 +233,7 @@ fun PreviewAdDestinationParametersScreen() {
     WooThemeWithBackground {
         AdDestinationParametersScreen(
             viewState = ViewState(
-                baseUrl = "https://woocommerce.com",
+                targetUrl = "https://woocommerce.com",
                 parameters = mapOf(
                     "utm_source" to "woocommerce",
                     "utm_medium" to "android",
@@ -258,7 +258,7 @@ fun PreviewEmptyAdDestinationParametersScreen() {
     WooThemeWithBackground {
         AdDestinationParametersScreen(
             viewState = ViewState(
-                baseUrl = "https://woocommerce.com?utm_source=woocommerce&utm_medium=android&utm_campaign=blaze",
+                targetUrl = "https://woocommerce.com?utm_source=woocommerce&utm_medium=android&utm_campaign=blaze",
                 parameters = emptyMap(),
                 bottomSheetState = ViewState.ParameterBottomSheetState.Hidden
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationScreen.kt
@@ -47,7 +47,7 @@ fun BlazeCampaignCreationAdDestinationScreen(viewModel: BlazeCampaignCreationAdD
             viewModel::onBackPressed,
             viewModel::onUrlPropertyTapped,
             viewModel::onParameterPropertyTapped,
-            viewModel::onDestinationUrlChanged
+            viewModel::onDestinationParametersUpdated
         )
     }
 }
@@ -58,7 +58,7 @@ fun AdDestinationScreen(
     onBackPressed: () -> Unit,
     onUrlPropertyTapped: () -> Unit,
     onParametersPropertyTapped: () -> Unit,
-    onDestinationUrlChanged: (String) -> Unit
+    onTargetUrlChanged: (String) -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -78,13 +78,13 @@ fun AdDestinationScreen(
         ) {
             AdDestinationProperty(
                 title = stringResource(id = R.string.blaze_campaign_edit_ad_destination_url_property_title),
-                value = viewState.destinationUrl,
+                value = viewState.targetUrl,
                 onPropertyTapped = onUrlPropertyTapped
             )
             Divider()
             AdDestinationProperty(
                 title = stringResource(id = R.string.blaze_campaign_edit_ad_destination_parameters_property_title),
-                value = viewState.parameters.ifBlank {
+                value = viewState.joinedParameters.ifBlank {
                     stringResource(R.string.blaze_campaign_edit_ad_destination_empty_parameters_message)
                 },
                 onPropertyTapped = onParametersPropertyTapped
@@ -92,10 +92,10 @@ fun AdDestinationScreen(
         }
 
         if (viewState.isUrlDialogVisible) {
-            AdDestinationUrlDialog(
+            TargetUrlDialog(
                 viewState,
-                onDismissed = { onDestinationUrlChanged(viewState.destinationUrl) },
-                onSaveTapped = onDestinationUrlChanged
+                onDismissed = { onTargetUrlChanged(viewState.targetUrl) },
+                onSaveTapped = onTargetUrlChanged
             )
         }
     }
@@ -126,7 +126,7 @@ fun AdDestinationProperty(title: String, value: String, onPropertyTapped: () -> 
 }
 
 @Composable
-fun AdDestinationUrlDialog(
+fun TargetUrlDialog(
     viewState: ViewState,
     onDismissed: () -> Unit,
     onSaveTapped: (String) -> Unit,
@@ -144,30 +144,30 @@ fun AdDestinationUrlDialog(
                 style = MaterialTheme.typography.h6
             )
 
-            var destinationUrl by rememberSaveable {
-                mutableStateOf(viewState.destinationUrl)
+            var targetUrl by rememberSaveable {
+                mutableStateOf(viewState.targetUrl)
             }
 
             UrlOption(
                 url = viewState.productUrl,
-                targetUrl = destinationUrl,
+                targetUrl = targetUrl,
                 title = R.string.blaze_campaign_edit_ad_destination_product_url_option
             ) {
-                destinationUrl = viewState.productUrl
+                targetUrl = viewState.productUrl
             }
 
             UrlOption(
                 url = viewState.siteUrl,
-                targetUrl = destinationUrl,
+                targetUrl = targetUrl,
                 title = R.string.blaze_campaign_edit_ad_destination_site_url_option
             ) {
-                destinationUrl = viewState.siteUrl
+                targetUrl = viewState.siteUrl
             }
 
             DialogButtonsRowLayout(
                 confirmButton = {
                     WCTextButton(onClick = {
-                        onSaveTapped(destinationUrl)
+                        onSaveTapped(targetUrl)
                     }) {
                         Text(text = stringResource(id = R.string.save))
                     }
@@ -225,14 +225,14 @@ fun PreviewAdDestinationScreen() {
             viewState = ViewState(
                 productUrl = "https://woocommerce.com/products/1",
                 siteUrl = "https://woocommerce.com",
-                destinationUrl = "https://woocommerce.com/products/12",
-                parameters = "utm_source=woocommerce_android\nutm_medium=ad\nutm_campaign=blaze",
+                targetUrl = "https://woocommerce.com/products/12",
+                parameters = emptyMap(),
                 isUrlDialogVisible = true
             ),
             onBackPressed = {},
             onUrlPropertyTapped = {},
             onParametersPropertyTapped = {},
-            onDestinationUrlChanged = {}
+            onTargetUrlChanged = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
@@ -3,9 +3,8 @@ package com.woocommerce.android.ui.blaze.creation.destination
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.blaze.BlazeRepository.DestinationParameters
 import com.woocommerce.android.ui.products.ProductDetailRepository
-import com.woocommerce.android.util.getBaseUrl
-import com.woocommerce.android.util.parseParameters
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -22,15 +21,14 @@ class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
     productDetailRepository: ProductDetailRepository
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: BlazeCampaignCreationAdDestinationFragmentArgs by savedStateHandle.navArgs()
-    private val productUrl = requireNotNull(productDetailRepository.getProduct(navArgs.productId))
-        .permalink
+    private val productUrl = requireNotNull(productDetailRepository.getProduct(navArgs.productId)).permalink
 
     private val _viewState = MutableStateFlow(
         ViewState(
-            productUrl = productUrl.trim('/'),
-            siteUrl = selectedSite.get().url.trim('/'),
-            destinationUrl = navArgs.targetUrl.getBaseUrl(),
-            parameters = getParameters(navArgs.targetUrl),
+            productUrl = productUrl,
+            siteUrl = selectedSite.get().url,
+            targetUrl = navArgs.destinationParameters.targetUrl,
+            parameters = navArgs.destinationParameters.parameters,
             isUrlDialogVisible = false
         )
     )
@@ -38,7 +36,7 @@ class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
     val viewState = _viewState.asLiveData()
 
     fun onBackPressed() {
-        triggerEvent(ExitWithResult(getTargetUrl(_viewState.value.destinationUrl, _viewState.value.parameters)))
+        triggerEvent(ExitWithResult(DestinationParameters(_viewState.value.targetUrl, _viewState.value.parameters)))
     }
 
     fun onUrlPropertyTapped() {
@@ -47,45 +45,30 @@ class BlazeCampaignCreationAdDestinationViewModel @Inject constructor(
 
     fun onParameterPropertyTapped() {
         triggerEvent(
-            NavigateToParametersScreen(getTargetUrl(_viewState.value.destinationUrl, _viewState.value.parameters))
+            NavigateToParametersScreen(DestinationParameters(_viewState.value.targetUrl, _viewState.value.parameters))
         )
     }
 
-    fun onTargetUrlUpdated(targetUrl: String) {
+    fun onDestinationParametersUpdated(targetUrl: String, parameters: Map<String, String>? = null) {
         _viewState.update {
             it.copy(
-                destinationUrl = targetUrl.getBaseUrl(),
-                parameters = getParameters(targetUrl),
+                targetUrl = targetUrl,
+                parameters = parameters ?: it.parameters,
+                isUrlDialogVisible = false
             )
-        }
-    }
-
-    fun onDestinationUrlChanged(destinationUrl: String) {
-        _viewState.value = _viewState.value.copy(
-            destinationUrl = destinationUrl,
-            isUrlDialogVisible = false
-        )
-    }
-
-    private fun getParameters(url: String): String {
-        return url.parseParameters().entries.joinToString(separator = "\n")
-    }
-
-    private fun getTargetUrl(baseUrl: String, parameters: String): String {
-        return if (parameters.isEmpty()) {
-            baseUrl
-        } else {
-            "$baseUrl?${parameters.replace("\n", "&")}"
         }
     }
 
     data class ViewState(
         val productUrl: String,
         val siteUrl: String,
-        val destinationUrl: String,
-        val parameters: String,
+        val targetUrl: String,
+        val parameters: Map<String, String>,
         val isUrlDialogVisible: Boolean
-    )
+    ) {
+        val joinedParameters: String
+            get() = parameters.entries.joinToString(separator = "\n")
+    }
 
-    data class NavigateToParametersScreen(val url: String) : MultiLiveEvent.Event()
+    data class NavigateToParametersScreen(val destinationParameters: DestinationParameters) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.navigateToHelpScreen
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.blaze.BlazeRepository.Budget
+import com.woocommerce.android.ui.blaze.BlazeRepository.DestinationParameters
 import com.woocommerce.android.ui.blaze.creation.ad.BlazeCampaignCreationEditAdFragment
 import com.woocommerce.android.ui.blaze.creation.ad.BlazeCampaignCreationEditAdViewModel.EditAdResult
 import com.woocommerce.android.ui.blaze.creation.budget.BlazeCampaignBudgetFragment
@@ -93,8 +94,8 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
                 is NavigateToAdDestinationScreen -> findNavController().navigateSafely(
                     BlazeCampaignCreationPreviewFragmentDirections
                         .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignCreationAdDestinationFragment(
-                            event.targetUrl,
-                            event.productId
+                            event.productId,
+                            event.destinationParameters
                         )
                 )
                 is NavigateToPaymentSummary -> findNavController().navigateSafely(
@@ -120,8 +121,8 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
         handleResult<TargetLocationResult>(BlazeCampaignTargetLocationSelectionFragment.BLAZE_TARGET_LOCATION_RESULT) {
             viewModel.onTargetLocationsUpdated(it.locations)
         }
-        handleResult<String>(BlazeCampaignCreationAdDestinationFragment.BLAZE_DESTINATION_RESULT) {
-            viewModel.onDestinationUpdated(it, emptyMap())
+        handleResult<DestinationParameters>(BlazeCampaignCreationAdDestinationFragment.BLAZE_DESTINATION_RESULT) {
+            viewModel.onDestinationUpdated(it.targetUrl, it.parameters)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
@@ -122,7 +122,7 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
             viewModel.onTargetLocationsUpdated(it.locations)
         }
         handleResult<DestinationParameters>(BlazeCampaignCreationAdDestinationFragment.BLAZE_DESTINATION_RESULT) {
-            viewModel.onDestinationUpdated(it.targetUrl, it.parameters)
+            viewModel.onDestinationUpdated(it)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -107,12 +107,14 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
                         it?.copy(targetingParameters = it.targetingParameters.copy(languages = selectedLanguages))
                     }
                 }
+
                 DEVICE -> blazeRepository.observeDevices().first().let { devices ->
                     val selectedDevices = devices.filter { selectedIds.contains(it.id) }
                     campaignDetails.update {
                         it?.copy(targetingParameters = it.targetingParameters.copy(devices = selectedDevices))
                     }
                 }
+
                 INTEREST -> blazeRepository.observeInterests().first().let { interests ->
                     val selectedInterests = interests.filter { selectedIds.contains(it.id) }
                     campaignDetails.update {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType.DEVICE
 import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType.INTEREST
 import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType.LANGUAGE
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.joinToUrl
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -132,6 +133,10 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         }
     }
 
+    fun onDestinationUpdated(url: String, parameters: Map<String, String>) {
+        campaignDetails.update { it?.copy(targetUrl = url, urlParams = parameters) }
+    }
+
     fun onConfirmClicked() {
         campaignDetails.value?.let {
             triggerEvent(NavigateToPaymentSummary(it))
@@ -209,10 +214,15 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         ),
         destinationUrl = CampaignDetailItemUi(
             displayTitle = resourceProvider.getString(string.blaze_campaign_preview_details_destination_url),
-            displayValue = targetUrl.ifBlank { targetUrl },
+            displayValue = urlParams.joinToUrl(targetUrl),
             maxLinesValue = 1,
             onItemSelected = {
-                triggerEvent(NavigateToAdDestinationScreen(targetUrl, navArgs.productId))
+                triggerEvent(
+                    NavigateToAdDestinationScreen(
+                        productId = navArgs.productId,
+                        destinationParameters = BlazeRepository.DestinationParameters(targetUrl, urlParams)
+                    )
+                )
             }
         )
     )
@@ -270,8 +280,8 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
     ) : MultiLiveEvent.Event()
 
     data class NavigateToAdDestinationScreen(
-        val targetUrl: String,
-        val productId: Long
+        val productId: Long,
+        val destinationParameters: BlazeRepository.DestinationParameters
     ) : MultiLiveEvent.Event()
 
     data class NavigateToTargetSelectionScreen(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -360,6 +360,7 @@ class ProductDetailViewModel @Inject constructor(
                 if (navArgs.isAIContent && !appPrefsWrapper.isAiProductCreationSurveyDismissed)
                     triggerEventWithDelay(ShowAiProductCreationSurveyBottomSheet, delay = 500)
             }
+
             is ProductDetailFragment.Mode.Loading -> {
                 viewState = viewState.copy(isSkeletonShown = true)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
@@ -7,7 +7,6 @@ import dagger.Reusable
 import org.wordpress.android.fluxc.network.discovery.DiscoveryUtils
 import org.wordpress.android.util.LanguageUtils
 import org.wordpress.android.util.UrlUtils
-import java.net.URLDecoder
 import java.net.URLEncoder
 import javax.inject.Inject
 
@@ -34,19 +33,6 @@ class UrlUtils @Inject constructor(
                 // Strip url from known usual trailing paths
                 DiscoveryUtils.stripKnownPaths(it)
             }
-    }
-}
-
-fun String.getBaseUrl(): String {
-    return (split("?").getOrNull(0) ?: this).trimEnd('/')
-}
-
-fun String.parseParameters(): Map<String, String> {
-    fun decode(value: String) = URLDecoder.decode(value, "UTF-8")
-    val parameters = split("?").getOrNull(1) ?: return emptyMap()
-    return parameters.split("&").filter { it.contains("=") }.associate {
-        val (key, value) = it.split("=")
-        decode(key) to decode(value)
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UrlUtils.kt
@@ -41,6 +41,6 @@ fun Map<String, String>.joinToUrl(baseUrl: String): String = buildString {
     append(baseUrl)
     appendWithIfNotEmpty(
         line = entries.joinToString("&") { (key, value) -> "${encode(key)}=${encode(value)}" },
-        separator = "?"
+        separator = if (baseUrl.contains("?")) "&" else "?"
     )
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
@@ -131,22 +131,22 @@
         android:name="com.woocommerce.android.ui.blaze.creation.destination.BlazeCampaignCreationAdDestinationFragment"
         android:label="BlazeCampaignCreationAdDestinationFragment">
         <argument
-            android:name="targetUrl"
-            app:argType="string" />
-        <argument
             android:name="productId"
             app:argType="long" />
         <action
             android:id="@+id/action_adDestinationFragment_to_adDestinationParametersFragment"
             app:destination="@id/blazeCampaignCreationAdDestinationParametersFragment" />
+        <argument
+            android:name="destinationParameters"
+            app:argType="com.woocommerce.android.ui.blaze.BlazeRepository$DestinationParameters" />
     </fragment>
     <fragment
         android:id="@+id/blazeCampaignCreationAdDestinationParametersFragment"
         android:name="com.woocommerce.android.ui.blaze.creation.destination.BlazeCampaignCreationAdDestinationParametersFragment"
         android:label="BlazeCampaignCreationAdDestinationParametersFragment">
         <argument
-            android:name="url"
-            app:argType="string" />
+            android:name="destinationParameters"
+            app:argType="com.woocommerce.android.ui.blaze.BlazeRepository$DestinationParameters" />
     </fragment>
     <fragment
         android:id="@+id/blazeCampaignPaymentSummaryFragment"


### PR DESCRIPTION
This PR refactors the way destination parameters are passed around as arguments and returned to address the fact that the target URL may already contain URL parameters that should not be affected by a Blaze campaign.


<details><summary>Patch for testing</summary>

```Patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt	(revision Staged)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModel.kt	(date 1708091355920)
@@ -21,7 +21,7 @@
     productDetailRepository: ProductDetailRepository
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: BlazeCampaignCreationAdDestinationFragmentArgs by savedStateHandle.navArgs()
-    private val productUrl = requireNotNull(productDetailRepository.getProduct(navArgs.productId)).permalink
+    private val productUrl = requireNotNull(productDetailRepository.getProduct(navArgs.productId)).permalink + "?product=1"
 
     private val _viewState = MutableStateFlow(
         ViewState(
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt	(revision Staged)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt	(date 1708091355917)
@@ -146,7 +146,7 @@
             userTimeZone = timezoneProvider.deviceTimezone.displayName,
             tagLine = "",
             description = "",
-            targetUrl = product.permalink,
+            targetUrl = product.permalink + "?product=1",
             urlParams = emptyMap(),
             campaignImage = product.images.firstOrNull().let {
                 if (it != null) BlazeCampaignImage.RemoteImage(it.id, it.source)

``` 
</details> 

**To test:**
1. Start a Blaze campaign
2. Tap on the Destination property
3. Notice the target URL already contains the product URL parameter, but no campaign parameters
4. Add a new campaign parameter
5. Notice it is added to the URL
6. Tap the back button to return to the Blaze preview screen
7. Notice the URL is correctly updated