### PR TITLE
Danger check: update Tracks label

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -30,7 +30,7 @@ tracks_checker.check_tracks_changes(
   tracks_usage_matchers: [
     /AnalyticsTracker\.track/
   ],
-  tracks_label: 'Tracks'
+  tracks_label: 'category: tracks'
 )
 
 view_changes_checker.check


### PR DESCRIPTION
After a discussion with the team, we decided to update the tracks label check to follow the repo standard with `category: tracks`.