### PR TITLE
Danger: remove strings.xml check

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -19,8 +19,6 @@ end
 
 common_release_checker.check_internal_release_notes_changed(report_type: :message)
 
-android_release_checker.check_modified_strings_on_release
-
 tracks_checker.check_tracks_changes(
   tracks_files: [
     'AnalyticsTracker.kt',


### PR DESCRIPTION
As discussed with the team, this check doesn't reflect their process, so this PR removes the call.

The check makes sure changes to the `strings.xml` files are only made on release branches, but the team freely changes the base `strings.xml`, while `/values-{language}/strings.xml` are the ones that are changed during the release process.