### PR TITLE
[Better Tablet Products] Adapt toolbar for the 2 pane layout on the details part

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/SingleProductScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/SingleProductScreen.kt
@@ -23,7 +23,7 @@ class SingleProductScreen : Screen {
         // Navigation bar:
         Espresso.onView(
             Matchers.allOf(
-                ViewMatchers.withId(R.id.toolbar),
+                ViewMatchers.withId(R.id.productDetailToolbar),
                 ViewMatchers.withChild(ViewMatchers.withText(product.name))
             )
         )

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/SingleProductScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/SingleProductScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.e2e.screens.products
 
+import android.content.res.Configuration
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
@@ -14,8 +15,13 @@ class SingleProductScreen : Screen {
     constructor() : super(R.id.productDetail_root)
 
     fun goBackToProductsScreen(): ProductListScreen {
-        pressBack()
-        waitForElementToBeDisplayed(R.id.productsRecycler)
+        // pressBack() only needed if device is not a tablet,
+        // on a tablet, products list and product information are on the same screen
+        val isTablet = InstrumentationRegistry.getInstrumentation().targetContext.resources.configuration.screenLayout and Configuration.SCREENLAYOUT_SIZE_MASK >= Configuration.SCREENLAYOUT_SIZE_LARGE
+        if (!isTablet) {
+            pressBack()
+            waitForElementToBeDisplayed(R.id.productsRecycler)
+        }
         return ProductListScreen()
     }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/SingleProductScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/SingleProductScreen.kt
@@ -17,7 +17,10 @@ class SingleProductScreen : Screen {
     fun goBackToProductsScreen(): ProductListScreen {
         // pressBack() only needed if device is not a tablet,
         // on a tablet, products list and product information are on the same screen
-        val isTablet = InstrumentationRegistry.getInstrumentation().targetContext.resources.configuration.screenLayout and Configuration.SCREENLAYOUT_SIZE_MASK >= Configuration.SCREENLAYOUT_SIZE_LARGE
+        val isTablet = InstrumentationRegistry.getInstrumentation().targetContext
+            .resources
+            .configuration
+            .screenLayout and Configuration.SCREENLAYOUT_SIZE_MASK >= Configuration.SCREENLAYOUT_SIZE_LARGE
         if (!isTablet) {
             pressBack()
             waitForElementToBeDisplayed(R.id.productsRecycler)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -10,14 +10,12 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.annotation.IdRes
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -109,13 +107,16 @@ class ProductDetailFragment :
     private var productName = ""
         set(value) {
             field = value
-            updateActivityTitle()
+            toolbarHelper.updateTitle(value)
         }
 
     private var productId: Long = ProductDetailViewModel.DEFAULT_ADD_NEW_PRODUCT_ID
 
     @Inject
     lateinit var blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher
+
+    @Inject
+    lateinit var toolbarHelper: ProductDetailsToolbarHelper
 
     private val skeletonView = SkeletonView()
 
@@ -128,20 +129,7 @@ class ProductDetailFragment :
     private val binding get() = _binding!!
 
     override val activityAppBarStatus: AppBarStatus
-        get() {
-            val navigationIcon = if (findNavController().hasBackStackEntry(R.id.products)) {
-                R.drawable.ic_back_24dp
-            } else {
-                R.drawable.ic_gridicons_cross_24dp
-            }
-            return AppBarStatus.Visible(
-                navigationIcon = navigationIcon
-            )
-        }
-
-    private fun NavController.hasBackStackEntry(@IdRes destinationId: Int) = runCatching {
-        getBackStackEntry(destinationId)
-    }.isSuccess
+        get() = AppBarStatus.Hidden
 
     @Inject lateinit var crashLogging: CrashLogging
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -3,11 +3,9 @@ package com.woocommerce.android.ui.products
 import android.graphics.Color
 import android.os.Bundle
 import android.os.Parcelable
-import android.view.MenuItem
 import android.view.View
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
-import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
@@ -82,14 +80,12 @@ import com.woocommerce.android.widgets.WCProductImageGalleryView.OnGalleryImageI
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
-import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class ProductDetailFragment :
     BaseProductFragment(R.layout.fragment_product_detail),
-    OnGalleryImageInteractionListener,
-    MenuProvider {
+    OnGalleryImageInteractionListener {
     companion object {
         private const val LIST_STATE_KEY = "list_state"
 
@@ -469,54 +465,6 @@ class ProductDetailFragment :
         binding.addImageContainer.setOnClickListener {
             AnalyticsTracker.track(AnalyticsEvent.PRODUCT_DETAIL_ADD_IMAGE_TAPPED)
             viewModel.onAddImageButtonClicked()
-        }
-    }
-
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_publish -> {
-                ActivityUtils.hideKeyboard(activity)
-                viewModel.onPublishButtonClicked()
-                true
-            }
-
-            R.id.menu_save_as_draft -> {
-                viewModel.onSaveAsDraftButtonClicked()
-                true
-            }
-
-            R.id.menu_share -> {
-                viewModel.onShareButtonClicked()
-                true
-            }
-
-            R.id.menu_save -> {
-                ActivityUtils.hideKeyboard(activity)
-                viewModel.onSaveButtonClicked()
-                true
-            }
-
-            R.id.menu_view_product -> {
-                viewModel.onViewProductOnStoreLinkClicked()
-                true
-            }
-
-            R.id.menu_product_settings -> {
-                viewModel.onSettingsButtonClicked()
-                true
-            }
-
-            R.id.menu_duplicate -> {
-                viewModel.onDuplicateProduct()
-                true
-            }
-
-            R.id.menu_trash_product -> {
-                viewModel.onTrashButtonClicked()
-                true
-            }
-
-            else -> false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -142,6 +142,8 @@ class ProductDetailFragment :
 
         _binding = FragmentProductDetailBinding.bind(view)
 
+        toolbarHelper.onViewCreated(this, viewModel, binding)
+
         ViewCompat.setTransitionName(
             binding.root,
             getString(R.string.product_card_detail_transition_name)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
@@ -7,6 +7,7 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.annotation.IdRes
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -14,11 +15,13 @@ import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentProductDetailBinding
+import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
 class ProductDetailsToolbarHelper @Inject constructor(
     private val activity: Activity,
-) : DefaultLifecycleObserver {
+) : DefaultLifecycleObserver,
+    Toolbar.OnMenuItemClickListener {
     private var fragment: ProductDetailFragment? = null
     private var binding: FragmentProductDetailBinding? = null
     private var viewModel: ProductDetailViewModel? = null
@@ -57,6 +60,7 @@ class ProductDetailsToolbarHelper @Inject constructor(
     fun setupToolbar() {
         val toolbar = binding?.productDetailToolbar ?: return
 
+        toolbar.setOnMenuItemClickListener(this)
         toolbar.inflateMenu(R.menu.menu_product_detail_fragment)
         this.menu = toolbar.menu
 
@@ -86,6 +90,54 @@ class ProductDetailsToolbarHelper @Inject constructor(
 
         viewModel?.menuButtonsState?.value?.let {
             toolbar.menu.updateOptions(it)
+        }
+    }
+
+    override fun onMenuItemClick(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.menu_publish -> {
+                ActivityUtils.hideKeyboard(activity)
+                viewModel?.onPublishButtonClicked()
+                true
+            }
+
+            R.id.menu_save_as_draft -> {
+                viewModel?.onSaveAsDraftButtonClicked()
+                true
+            }
+
+            R.id.menu_share -> {
+                viewModel?.onShareButtonClicked()
+                true
+            }
+
+            R.id.menu_save -> {
+                ActivityUtils.hideKeyboard(activity)
+                viewModel?.onSaveButtonClicked()
+                true
+            }
+
+            R.id.menu_view_product -> {
+                viewModel?.onViewProductOnStoreLinkClicked()
+                true
+            }
+
+            R.id.menu_product_settings -> {
+                viewModel?.onSettingsButtonClicked()
+                true
+            }
+
+            R.id.menu_duplicate -> {
+                viewModel?.onDuplicateProduct()
+                true
+            }
+
+            R.id.menu_trash_product -> {
+                viewModel?.onTrashButtonClicked()
+                true
+            }
+
+            else -> false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
@@ -1,8 +1,13 @@
 package com.woocommerce.android.ui.products
 
 import android.app.Activity
+import androidx.annotation.IdRes
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.navigation.NavController
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentProductDetailBinding
 import javax.inject.Inject
 
@@ -29,5 +34,14 @@ class ProductDetailsToolbarHelper @Inject constructor(
     }
 
     private fun setupToolbar(toolbar: Toolbar) {
+        toolbar.navigationIcon = if (fragment?.findNavController()?.hasBackStackEntry(R.id.products) == true) {
+            AppCompatResources.getDrawable(activity, R.drawable.ic_back_24dp)
+        } else {
+            AppCompatResources.getDrawable(activity, R.drawable.ic_gridicons_cross_24dp)
+        }
     }
+
+    private fun NavController.hasBackStackEntry(@IdRes destinationId: Int) = runCatching {
+        getBackStackEntry(destinationId)
+    }.isSuccess
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
@@ -1,10 +1,15 @@
 package com.woocommerce.android.ui.products
 
 import android.app.Activity
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
+import android.view.Menu
+import android.view.MenuItem
 import androidx.annotation.IdRes
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.appcompat.widget.Toolbar
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
@@ -16,29 +21,98 @@ class ProductDetailsToolbarHelper @Inject constructor(
 ) : DefaultLifecycleObserver {
     private var fragment: ProductDetailFragment? = null
     private var binding: FragmentProductDetailBinding? = null
+    private var viewModel: ProductDetailViewModel? = null
+
+    private var menu: Menu? = null
 
     fun onViewCreated(
         fragment: ProductDetailFragment,
+        viewModel: ProductDetailViewModel,
         binding: FragmentProductDetailBinding,
     ) {
         this.fragment = fragment
         this.binding = binding
+        this.viewModel = viewModel
 
         fragment.lifecycle.addObserver(this)
 
-        setupToolbar(binding.productDetailToolbar)
+        setupToolbar()
+
+        viewModel.menuButtonsState.observe(fragment.viewLifecycleOwner) {
+            menu?.updateOptions(it)
+        }
     }
 
     fun updateTitle(title: String) {
         binding?.productDetailToolbar?.title = title
     }
 
-    private fun setupToolbar(toolbar: Toolbar) {
+    override fun onDestroy(owner: LifecycleOwner) {
+        fragment = null
+        binding = null
+        viewModel = null
+        menu = null
+    }
+
+    fun setupToolbar() {
+        val toolbar = binding?.productDetailToolbar ?: return
+
+        toolbar.inflateMenu(R.menu.menu_product_detail_fragment)
+        this.menu = toolbar.menu
+
         toolbar.navigationIcon = if (fragment?.findNavController()?.hasBackStackEntry(R.id.products) == true) {
             AppCompatResources.getDrawable(activity, R.drawable.ic_back_24dp)
         } else {
             AppCompatResources.getDrawable(activity, R.drawable.ic_gridicons_cross_24dp)
         }
+
+        // change the font color of the trash menu item to red, and only show it if it should be enabled
+        with(toolbar.menu.findItem(R.id.menu_trash_product)) {
+            if (this == null) return@with
+            val title = SpannableString(this.title)
+            title.setSpan(
+                ForegroundColorSpan(
+                    ContextCompat.getColor(
+                        activity,
+                        R.color.woo_red_30
+                    )
+                ),
+                0,
+                title.length,
+                0
+            )
+            this.title = title
+        }
+
+        viewModel?.menuButtonsState?.value?.let {
+            toolbar.menu.updateOptions(it)
+        }
+    }
+
+    private fun Menu.updateOptions(state: ProductDetailViewModel.MenuButtonsState) {
+        findItem(R.id.menu_save)?.isVisible = state.saveOption
+        findItem(R.id.menu_save_as_draft)?.isVisible = state.saveAsDraftOption
+        findItem(R.id.menu_view_product)?.isVisible = state.viewProductOption
+        findItem(R.id.menu_publish)?.apply {
+            isVisible = state.publishOption
+            if (state.saveOption) {
+                setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_NEVER)
+            } else {
+                setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_IF_ROOM)
+            }
+        }
+        findItem(R.id.menu_share)?.apply {
+            isVisible = state.shareOption
+
+            setShowAsActionFlags(
+                if (state.showShareOptionAsActionWithText) {
+                    MenuItem.SHOW_AS_ACTION_IF_ROOM
+                } else {
+                    MenuItem.SHOW_AS_ACTION_NEVER
+                }
+            )
+        }
+        findItem(R.id.menu_trash_product)?.isVisible = state.trashOption
     }
 
     private fun NavController.hasBackStackEntry(@IdRes destinationId: Int) = runCatching {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
@@ -63,6 +63,7 @@ class ProductDetailsToolbarHelper @Inject constructor(
         val toolbar = binding?.productDetailToolbar ?: return
 
         toolbar.setOnMenuItemClickListener(this)
+        toolbar.menu.clear()
         toolbar.inflateMenu(R.menu.menu_product_detail_fragment)
         this.menu = toolbar.menu
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
@@ -78,6 +78,10 @@ class ProductDetailsToolbarHelper @Inject constructor(
                 }
             }
 
+        toolbar.setNavigationOnClickListener {
+            fragment?.findNavController()?.navigateUp()
+        }
+
         // change the font color of the trash menu item to red, and only show it if it should be enabled
         with(toolbar.menu.findItem(R.id.menu_trash_product)) {
             if (this == null) return@with

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
@@ -15,11 +15,13 @@ import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentProductDetailBinding
+import com.woocommerce.android.util.IsTabletLogicNeeded
 import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
 class ProductDetailsToolbarHelper @Inject constructor(
     private val activity: Activity,
+    private val isTabletLogicNeeded: IsTabletLogicNeeded,
 ) : DefaultLifecycleObserver,
     Toolbar.OnMenuItemClickListener {
     private var fragment: ProductDetailFragment? = null
@@ -64,11 +66,17 @@ class ProductDetailsToolbarHelper @Inject constructor(
         toolbar.inflateMenu(R.menu.menu_product_detail_fragment)
         this.menu = toolbar.menu
 
-        toolbar.navigationIcon = if (fragment?.findNavController()?.hasBackStackEntry(R.id.products) == true) {
-            AppCompatResources.getDrawable(activity, R.drawable.ic_back_24dp)
-        } else {
-            AppCompatResources.getDrawable(activity, R.drawable.ic_gridicons_cross_24dp)
-        }
+        toolbar.navigationIcon =
+            when {
+                isTabletLogicNeeded() -> null
+                fragment?.findNavController()?.hasBackStackEntry(R.id.products) == true -> {
+                    AppCompatResources.getDrawable(activity, R.drawable.ic_back_24dp)
+                }
+
+                else -> {
+                    AppCompatResources.getDrawable(activity, R.drawable.ic_gridicons_cross_24dp)
+                }
+            }
 
         // change the font color of the trash menu item to red, and only show it if it should be enabled
         with(toolbar.menu.findItem(R.id.menu_trash_product)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.products
+
+import android.app.Activity
+import androidx.appcompat.widget.Toolbar
+import androidx.lifecycle.DefaultLifecycleObserver
+import com.woocommerce.android.databinding.FragmentProductDetailBinding
+import javax.inject.Inject
+
+class ProductDetailsToolbarHelper @Inject constructor(
+    private val activity: Activity,
+) : DefaultLifecycleObserver {
+    private var fragment: ProductDetailFragment? = null
+    private var binding: FragmentProductDetailBinding? = null
+
+    fun onViewCreated(
+        fragment: ProductDetailFragment,
+        binding: FragmentProductDetailBinding,
+    ) {
+        this.fragment = fragment
+        this.binding = binding
+
+        fragment.lifecycle.addObserver(this)
+
+        setupToolbar(binding.productDetailToolbar)
+    }
+
+    fun updateTitle(title: String) {
+        binding?.productDetailToolbar?.title = title
+    }
+
+    private fun setupToolbar(toolbar: Toolbar) {
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -112,19 +112,20 @@ class ProductListFragment :
             feedbackPrefs.getFeatureFeedbackSettings(FeatureFeedbackSettings.Feature.PRODUCT_VARIATIONS)?.feedbackState
                 ?: FeatureFeedbackSettings.FeedbackState.UNANSWERED
 
-    override val twoPaneLayoutGuideline by lazy { binding.twoPaneLayoutGuideline }
+    override val twoPaneLayoutGuideline
+        get() = binding.twoPaneLayoutGuideline
 
-    override val lifecycleKeeper: Lifecycle by lazy { viewLifecycleOwner.lifecycle }
+    override val lifecycleKeeper: Lifecycle
+        get() = viewLifecycleOwner.lifecycle
 
-    override val secondPaneNavigation by lazy {
-        TabletLayoutSetupHelper.Screen.Navigation(
+    override val secondPaneNavigation
+        get() = TabletLayoutSetupHelper.Screen.Navigation(
             childFragmentManager,
             R.navigation.nav_graph_products,
             ProductDetailFragmentArgs(
                 mode = ProductDetailFragment.Mode.Loading,
             ).toBundle()
         )
-    }
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
@@ -141,11 +142,12 @@ class ProductListFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        tabletLayoutSetupHelper.onViewCreated(this)
 
         postponeEnterTransition()
 
         _binding = FragmentProductListBinding.bind(view)
+
+        tabletLayoutSetupHelper.onViewCreated(this)
 
         view.doOnPreDraw { startPostponedEnterTransition() }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
@@ -21,10 +21,13 @@ class TabletLayoutSetupHelper @Inject constructor(
     private lateinit var navHostFragment: NavHostFragment
 
     fun onViewCreated(screen: Screen) {
-        if (!FeatureFlag.BETTER_TABLETS_SUPPORT_PRODUCTS.isEnabled()) return
-
         this.screen = screen
         screen.lifecycleKeeper.addObserver(this)
+
+        if (isTabletLogicNeeded()) {
+            initNavFragment(screen.secondPaneNavigation)
+            adjustUIForScreenSize(screen.twoPaneLayoutGuideline)
+        }
     }
 
     fun onItemClicked(
@@ -40,13 +43,6 @@ class TabletLayoutSetupHelper @Inject constructor(
         } else {
             navigateWithPhoneNavigation()
         }
-    }
-
-    override fun onCreate(owner: LifecycleOwner) {
-        if (!isTabletLogicNeeded()) return
-
-        initNavFragment(screen!!.secondPaneNavigation)
-        adjustUIForScreenSize(screen!!.twoPaneLayoutGuideline)
     }
 
     override fun onDestroy(owner: LifecycleOwner) {

--- a/WooCommerce/src/main/res/layout/fragment_product_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_detail.xml
@@ -24,6 +24,18 @@
             android:fitsSystemWindows="false"
             app:elevation="@dimen/minor_00">
 
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/productDetailToolbar"
+                style="@style/Widget.Woo.Toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/toolbar_height"
+                android:elevation="@dimen/appbar_elevation"
+                app:layout_collapseMode="pin"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:title="@string/app_name" />
+
             <com.google.android.material.appbar.CollapsingToolbarLayout
                 android:id="@+id/collapsing_toolbar"
                 android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -10,10 +10,10 @@
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
         style="@style/Widget.Woo.Toolbar"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="@dimen/toolbar_height"
         app:layout_collapseMode="pin"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/two_pane_layout_guideline"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:title="@string/products" />
@@ -144,8 +144,10 @@
         android:layout_width="0dp"
         android:layout_height="match_parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/two_pane_layout_guideline"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toEndOf="@+id/two_pane_layout_guideline"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_list.xml
@@ -145,6 +145,7 @@
         android:layout_height="match_parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@+id/two_pane_layout_guideline"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10843
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds usage of the fragment's toolbar for Product Details screen, instead of the one from the activity. This needed to have proper support on the tablets.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

* **The most important** to make sure that there is not regression brought to the case when FF is OFF. 
* There is one obvious regression that also exists in the orders tablet support is we animate the toolbar now, but we accept that for now

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/4923871/6bc82bbf-79e3-4bb4-944b-e9946f8ad226


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
