### PR TITLE
Update semver comparison logic to fix indexOutOfBounds

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/StringExt.kt
@@ -60,10 +60,15 @@ fun String.semverCompareTo(otherVersion: String): Int {
         val thisVersionTokens = substringBefore("-").split(".").map { Integer.parseInt(it) }
         val otherVersionTokens = otherVersion.substringBefore("-").split(".").map { Integer.parseInt(it) }
 
-        thisVersionTokens.forEachIndexed { index, token ->
-            if (token > otherVersionTokens[index]) {
+        val maxLength = maxOf(thisVersionTokens.size, otherVersionTokens.size)
+
+        for (index in 0 until maxLength) {
+            val thisToken = thisVersionTokens.getOrElse(index) { 0 }
+            val otherToken = otherVersionTokens.getOrElse(index) { 0 }
+
+            if (thisToken > otherToken) {
                 return 1
-            } else if (token < otherVersionTokens[index]) {
+            } else if (thisToken < otherToken) {
                 return -1
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptHelperTest.kt
@@ -114,6 +114,30 @@ class PaymentReceiptHelperTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given version 8_7_0_10 site and saved url, when getReceiptUrl, then url returned`() = testBlocking {
+        // GIVEN
+        val site = selectedSite.get()
+        val plugin = mock<SitePluginModel> {
+            on { version }.thenReturn("8.7.0.10")
+        }
+        whenever(
+            wooCommerceStore.getSitePlugin(
+                selectedSite.get(),
+                WooCommerceStore.WooPlugin.WOO_CORE
+            )
+        ).thenReturn(plugin)
+        whenever(orderStore.fetchOrdersReceipt(site, 1, expirationDays = 2)).thenReturn(
+            WooPayload(OrderReceiptResponse("url", "date"))
+        )
+
+        // WHEN
+        val result = helper.getReceiptUrl(1)
+
+        // THEN
+        assertThat(result.getOrThrow()).isEqualTo("url")
+    }
+
+    @Test
     fun `given version 8_7_0 site and remote call fails, when getReceiptUrl, then failure returned`() = testBlocking {
         // GIVEN
         val site = selectedSite.get()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10869 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This issue fixes IndexOutOfBounds exception for cases when one of the versions doesn't follow semver and uses x.y.z.a instead of x.y.z versioning. This causes a critical crash which started appearing after WooCommerce 8.7.0.10 was released as the app compares 8.7.0 with 8.7.0.10 and crashes on IndexOutOfBounds exception.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

Working unit tests should be enough. 


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
