### PR TITLE
[Better Tablet Products] Adapt toolbar for the nested product details fragments Part 1

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/SingleProductScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/SingleProductScreen.kt
@@ -23,7 +23,7 @@ class SingleProductScreen : Screen {
         // Navigation bar:
         Espresso.onView(
             Matchers.allOf(
-                ViewMatchers.withId(R.id.toolbar),
+                ViewMatchers.withId(R.id.productDetailToolbar),
                 ViewMatchers.withChild(ViewMatchers.withText(product.name))
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
@@ -17,9 +17,11 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.dialog.WooDialog
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.AIProductDescriptionBottomSheetFragment.Companion.KEY_AI_GENERATED_DESCRIPTION_RESULT
+import com.woocommerce.android.util.setupToolbar
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.ToastUtils
@@ -59,7 +61,8 @@ class AztecEditorFragment :
 
     private var titleFromProductAIDescriptionDialog: String? = null
 
-    override fun getFragmentTitle() = navArgs.aztecTitle
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -74,6 +77,16 @@ class AztecEditorFragment :
             binding.aztecCaption.visibility = View.VISIBLE
             binding.aztecCaption.text = navArgs.aztecCaption
         }
+
+        setupToolbar(
+            title = navArgs.aztecTitle,
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    navigateBackWithResult(editorHasChanges())
+                }
+            }
+        )
 
         with(binding.aiButton) {
             visibility = if (selectedSite.getOrNull()?.isEligibleForAI == true) View.VISIBLE else View.GONE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
@@ -21,7 +21,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.AIProductDescriptionBottomSheetFragment.Companion.KEY_AI_GENERATED_DESCRIPTION_RESULT
-import com.woocommerce.android.util.setupToolbar
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.ToastUtils
@@ -78,7 +78,7 @@ class AztecEditorFragment :
             binding.aztecCaption.text = navArgs.aztecCaption
         }
 
-        setupToolbar(
+        setupTabletSecondPaneToolbar(
             title = navArgs.aztecTitle,
             onMenuItemSelected = { _ -> false },
             onCreateMenu = { toolbar ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductEditorFragment.kt
@@ -8,6 +8,7 @@ import androidx.annotation.LayoutRes
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -19,6 +20,9 @@ abstract class BaseProductEditorFragment(@LayoutRes private val layoutRes: Int) 
     BaseFragment(), BackPressListener {
     @Inject lateinit var currencyFormatter: CurrencyFormatter
     @Inject lateinit var uiMessageResolver: UIMessageResolver
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     companion object {
         const val KEY_SHIPPING_DIALOG_RESULT = "key_shipping_dialog_result"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/BaseProductFragment.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.dialog.WooDialog
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
@@ -23,6 +24,9 @@ import javax.inject.Inject
 abstract class BaseProductFragment : BaseFragment, BackPressListener {
     @Inject lateinit var navigator: ProductNavigator
     @Inject lateinit var uiMessageResolver: UIMessageResolver
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -4,13 +4,11 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.Toolbar
 import androidx.core.text.HtmlCompat
-import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -36,6 +34,7 @@ import com.woocommerce.android.ui.products.ProductImagesViewModel.ShowStorageCho
 import com.woocommerce.android.ui.products.ProductImagesViewModel.ShowWPMediaPicker
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.setHomeIcon
+import com.woocommerce.android.util.setupToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -55,7 +54,6 @@ import javax.inject.Inject
 class ProductImagesFragment :
     BaseProductEditorFragment(R.layout.fragment_product_images),
     OnGalleryImageInteractionListener,
-    MenuProvider,
     MediaPickerResultHandler {
     private val navArgs: ProductImagesFragmentArgs by navArgs()
     private val viewModel: ProductImagesViewModel by fixedHiltNavGraphViewModels(R.id.nav_graph_image_gallery)
@@ -83,8 +81,6 @@ class ProductImagesFragment :
 
         _binding = FragmentProductImagesBinding.bind(view)
 
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
-
         setupObservers(viewModel)
         setupViews()
     }
@@ -100,10 +96,10 @@ class ProductImagesFragment :
         imageSourceDialog?.dismiss()
     }
 
-    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
+    private fun onCreateMenu(toolbar: Toolbar) {
         when (viewModel.viewStateData.liveData.value?.productImagesState) {
             is ProductImagesState.Dragging -> {
-                inflater.inflate(R.menu.menu_dragging, menu)
+                toolbar.inflateMenu(R.menu.menu_dragging)
                 setHomeIcon(R.drawable.ic_gridicons_cross_24dp)
             }
 
@@ -115,7 +111,7 @@ class ProductImagesFragment :
         }
     }
 
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
+    private fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (viewModel.viewStateData.liveData.value?.productImagesState) {
             is ProductImagesState.Dragging -> {
                 when (item.itemId) {
@@ -146,6 +142,12 @@ class ProductImagesFragment :
                 ChromeCustomTabUtils.launchUrl(it.context, AppUrls.PRODUCT_IMAGE_UPLOADS_TROUBLESHOOTING)
             }
         }
+
+        setupToolbar(
+            title = R.string.product_images_title,
+            onMenuItemSelected = ::onMenuItemSelected,
+            onCreateMenu = ::onCreateMenu
+        )
     }
 
     override fun onGalleryImageDeleteIconClicked(image: Image) {
@@ -237,8 +239,6 @@ class ProductImagesFragment :
         binding.imageGallery.showProductImages(images, this)
         binding.imageGallery.setPlaceholderImageUris(uris)
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_images_title)
 
     override fun onGalleryImageClicked(image: Image) {
         viewModel.onGalleryImageClicked(image)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -144,7 +144,7 @@ class ProductImagesFragment :
         }
 
         setupToolbar(
-            title = R.string.product_images_title,
+            title = getString(R.string.product_images_title),
             onMenuItemSelected = ::onMenuItemSelected,
             onCreateMenu = ::onCreateMenu
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductImagesFragment.kt
@@ -34,7 +34,7 @@ import com.woocommerce.android.ui.products.ProductImagesViewModel.ShowStorageCho
 import com.woocommerce.android.ui.products.ProductImagesViewModel.ShowWPMediaPicker
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.setHomeIcon
-import com.woocommerce.android.util.setupToolbar
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -143,7 +143,7 @@ class ProductImagesFragment :
             }
         }
 
-        setupToolbar(
+        setupTabletSecondPaneToolbar(
             title = getString(R.string.product_images_title),
             onMenuItemSelected = ::onMenuItemSelected,
             onCreateMenu = ::onCreateMenu

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryFragment.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.products.ProductItemSelectorDialog.ProductItemSelectorDialogListener
 import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -58,8 +59,6 @@ class ProductInventoryFragment :
         super.onDestroyView()
         _binding = null
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_inventory)
 
     private fun setupObservers(viewModel: ProductInventoryViewModel) {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
@@ -194,6 +193,16 @@ class ProductInventoryFragment :
                 viewModel.onDataChanged(isSoldIndividually = isChecked)
             }
         }
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_inventory),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    onExit()
+                }
+            }
+        )
     }
 
     private fun enableManageStockStatus(isStockManaged: Boolean, isStockStatusVisible: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ShippingClass
 import com.woocommerce.android.ui.products.ProductShippingClassFragment.Companion.SELECTED_SHIPPING_CLASS_RESULT
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -51,8 +52,6 @@ class ProductShippingFragment : BaseProductEditorFragment(R.layout.fragment_prod
         super.onDestroyView()
         _binding = null
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_shipping_settings)
 
     private fun setupObservers(viewModel: ProductShippingViewModel) {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
@@ -125,6 +124,16 @@ class ProductShippingFragment : BaseProductEditorFragment(R.layout.fragment_prod
         binding.productOneTimeShipping.setOnCheckedChangeListener { _, value ->
             viewModel.onDataChanged(oneTimeShipping = value)
         }
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_shipping_settings),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    onExit()
+                }
+            }
+        )
     }
 
     private fun editableToFloat(editable: Editable?): Float {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
@@ -1,11 +1,9 @@
 package com.woocommerce.android.ui.products.categories
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.core.view.MenuProvider
+import androidx.appcompat.widget.Toolbar
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -16,7 +14,9 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
@@ -30,8 +30,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class AddProductCategoryFragment :
     BaseFragment(R.layout.fragment_add_product_category),
-    BackPressListener,
-    MenuProvider {
+    BackPressListener {
     companion object {
         const val ARG_ADDED_CATEGORY = "arg-added-category"
     }
@@ -49,7 +48,8 @@ class AddProductCategoryFragment :
         navGraphId = R.id.nav_graph_add_product_category
     )
 
-    override fun getFragmentTitle() = getString(R.string.product_add_category)
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     override fun onResume() {
         super.onResume()
@@ -61,13 +61,12 @@ class AddProductCategoryFragment :
         activity?.let { ActivityUtils.hideKeyboard(it) }
     }
 
-    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
-        menu.clear()
-        inflater.inflate(R.menu.menu_done, menu)
-        doneMenuItem = menu.findItem(R.id.menu_done)
+    private fun onCreateMenu(toolbar: Toolbar) {
+        toolbar.inflateMenu(R.menu.menu_done)
+        doneMenuItem = toolbar.menu.findItem(R.id.menu_done)
     }
 
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
+    private fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_done -> {
                 AnalyticsTracker.track(AnalyticsEvent.ADD_PRODUCT_CATEGORY_SAVE_TAPPED)
@@ -83,7 +82,6 @@ class AddProductCategoryFragment :
 
         _binding = FragmentAddProductCategoryBinding.bind(view)
 
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
         setupObservers(viewModel)
 
         binding.productCategoryName.setOnTextChangedListener {
@@ -102,6 +100,19 @@ class AddProductCategoryFragment :
                 findNavController().navigateSafely(action)
             }
         }
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_add_category),
+            onMenuItemSelected = ::onMenuItemSelected,
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    if (viewModel.onBackButtonClicked(getCategoryName(), binding.productCategoryParent.getText())) {
+                        requireActivity().onBackPressedDispatcher.onBackPressed()
+                    }
+                }
+                onCreateMenu(toolbar)
+            }
+        )
     }
 
     override fun onDestroyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
@@ -107,7 +107,7 @@ class AddProductCategoryFragment :
             onCreateMenu = { toolbar ->
                 toolbar.setNavigationOnClickListener {
                     if (viewModel.onBackButtonClicked(getCategoryName(), binding.productCategoryParent.getText())) {
-                        requireActivity().onBackPressedDispatcher.onBackPressed()
+                        findNavController().navigateUp()
                     }
                 }
                 onCreateMenu(toolbar)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ParentCategoryListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ParentCategoryListFragment.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.products.OnLoadMoreListener
 import com.woocommerce.android.util.WooAnimUtils
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
@@ -59,8 +60,6 @@ class ParentCategoryListFragment :
         viewModel.fetchParentCategories()
     }
 
-    override fun getFragmentTitle() = getString(R.string.product_add_category)
-
     @Suppress("DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
@@ -82,6 +81,16 @@ class ParentCategoryListFragment :
                 viewModel.refreshParentCategories()
             }
         }
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_add_category),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    findNavController().navigateUp()
+                }
+            }
+        )
     }
 
     private fun setupObservers(viewModel: AddProductCategoryViewModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ProductCategoriesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/ProductCategoriesFragment.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.ui.products.ProductDetailViewModel
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductCategories
 import com.woocommerce.android.ui.products.categories.AddProductCategoryFragment.Companion.ARG_ADDED_CATEGORY
 import com.woocommerce.android.util.WooAnimUtils
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
@@ -57,6 +58,16 @@ class ProductCategoriesFragment :
         setupObservers(viewModel)
         setupResultHandlers()
         viewModel.fetchProductCategories()
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_price),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    viewModel.onBackButtonClicked(ExitProductCategories)
+                }
+            }
+        )
     }
 
     @Suppress("DEPRECATION")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingFragment.kt
@@ -8,7 +8,6 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
-import com.woocommerce.android.R.string
 import com.woocommerce.android.RequestCodes
 import com.woocommerce.android.databinding.FragmentProductPricingBinding
 import com.woocommerce.android.extensions.capitalize
@@ -28,6 +27,7 @@ import com.woocommerce.android.ui.products.ProductItemSelectorDialog.ProductItem
 import com.woocommerce.android.ui.products.ProductTaxStatus
 import com.woocommerce.android.ui.products.price.ProductPricingViewModel.PricingData
 import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -80,6 +80,15 @@ class ProductPricingFragment :
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentProductPricingBinding.bind(view)
         initSubscriptionViews()
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_price),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    onExit()
+                }
+            }
+        )
         setupObservers(viewModel)
     }
 
@@ -87,8 +96,6 @@ class ProductPricingFragment :
         super.onDestroyView()
         _binding = null
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_price)
 
     private fun setupObservers(viewModel: ProductPricingViewModel) {
         viewModel.viewStateData.observe(viewLifecycleOwner) { old, new ->
@@ -200,13 +207,12 @@ class ProductPricingFragment :
         with(binding.scheduleSaleStartDate) {
             setClickListener {
                 startDatePickerDialog = displayDatePickerDialog(
-                    binding.scheduleSaleStartDate,
-                    OnDateSetListener { _, selectedYear, selectedMonth, dayOfMonth ->
-                        val selectedDate = dateUtils.getDateAtStartOfDay(selectedYear, selectedMonth, dayOfMonth)
+                    binding.scheduleSaleStartDate
+                ) { _, selectedYear, selectedMonth, dayOfMonth ->
+                    val selectedDate = dateUtils.getDateAtStartOfDay(selectedYear, selectedMonth, dayOfMonth)
 
-                        viewModel.onDataChanged(saleStartDate = selectedDate)
-                    }
-                )
+                    viewModel.onDataChanged(saleStartDate = selectedDate)
+                }
             }
         }
 
@@ -215,7 +221,7 @@ class ProductPricingFragment :
             setClickListener {
                 endDatePickerDialog = displayDatePickerDialog(
                     binding.scheduleSaleEndDate,
-                    OnDateSetListener { _, selectedYear, selectedMonth, dayOfMonth ->
+                    { _, selectedYear, selectedMonth, dayOfMonth ->
                         val selectedDate = dateUtils.getDateAtStartOfDay(selectedYear, selectedMonth, dayOfMonth)
 
                         viewModel.onDataChanged(saleEndDate = selectedDate)
@@ -236,7 +242,7 @@ class ProductPricingFragment :
                 setClickListener {
                     productTaxStatusSelectorDialog = ProductItemSelectorDialog.newInstance(
                         this@ProductPricingFragment, RequestCodes.PRODUCT_TAX_STATUS,
-                        getString(string.product_tax_status), ProductTaxStatus.toMap(requireContext()),
+                        getString(R.string.product_tax_status), ProductTaxStatus.toMap(requireContext()),
                         getText()
                     ).also { it.show(parentFragmentManager, ProductItemSelectorDialog.TAG) }
                 }
@@ -290,7 +296,7 @@ class ProductPricingFragment :
                 productTaxClassSelectorDialog = ProductItemSelectorDialog.newInstance(
                     this@ProductPricingFragment,
                     RequestCodes.PRODUCT_TAX_CLASS,
-                    getString(string.product_tax_class),
+                    getString(R.string.product_tax_class),
                     taxClasses.map { it.slug to it.name }.toMap(),
                     binding.productTaxClass.getText()
                 ).also { it.show(parentFragmentManager, ProductItemSelectorDialog.TAG) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductReview
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.reviews.ReviewListAdapter
@@ -26,6 +27,7 @@ import com.woocommerce.android.ui.reviews.ReviewModerationUi
 import com.woocommerce.android.ui.reviews.observeModerationStatus
 import com.woocommerce.android.ui.reviews.reviewList
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -60,7 +62,8 @@ class ProductReviewsFragment :
     private var _binding: FragmentReviewsListBinding? = null
     private val binding get() = _binding!!
 
-    override fun getFragmentTitle() = getString(R.string.product_reviews)
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -107,6 +110,16 @@ class ProductReviewsFragment :
             }
         }
         setUnreadFilterChangedListener()
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_reviews),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    viewModel.onBackButtonClicked()
+                }
+            }
+        )
     }
 
     private fun setupObservers() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeFragment.kt
@@ -3,10 +3,9 @@ package com.woocommerce.android.ui.products.variations.attributes
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.core.view.MenuProvider
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -23,12 +22,13 @@ import com.woocommerce.android.model.ProductAttribute
 import com.woocommerce.android.model.ProductGlobalAttribute
 import com.woocommerce.android.ui.products.BaseProductFragment
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductAddAttribute
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
 
 @AndroidEntryPoint
-class AddAttributeFragment : BaseProductFragment(R.layout.fragment_add_attribute), MenuProvider {
+class AddAttributeFragment : BaseProductFragment(R.layout.fragment_add_attribute) {
     companion object {
         const val TAG: String = "AddAttributeFragment"
         private const val LIST_STATE_KEY = "list_state"
@@ -49,7 +49,6 @@ class AddAttributeFragment : BaseProductFragment(R.layout.fragment_add_attribute
 
         _binding = FragmentAddAttributeBinding.bind(view)
 
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
         initializeViews(savedInstanceState)
         setupObservers()
     }
@@ -76,16 +75,16 @@ class AddAttributeFragment : BaseProductFragment(R.layout.fragment_add_attribute
         }
     }
 
-    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
+    private fun onCreateMenu(toolbar: Toolbar) {
         if (navArgs.isVariationCreation) {
-            moveNextMenuItem = menu.add(Menu.FIRST, ID_ADD_ATTRIBUTES, Menu.FIRST, R.string.next).apply {
+            moveNextMenuItem = toolbar.menu.add(Menu.FIRST, ID_ADD_ATTRIBUTES, Menu.FIRST, R.string.next).apply {
                 setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
                 isVisible = false
             }
         }
     }
 
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
+    private fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             ID_ADD_ATTRIBUTES -> {
                 viewModel.saveAttributeChanges()
@@ -119,6 +118,17 @@ class AddAttributeFragment : BaseProductFragment(R.layout.fragment_add_attribute
         }
 
         viewModel.fetchGlobalAttributes()
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_add_attribute),
+            onMenuItemSelected = ::onMenuItemSelected,
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    viewModel.onBackButtonClicked(ExitProductAddAttribute)
+                }
+                onCreateMenu(toolbar)
+            }
+        )
     }
 
     private fun setupObservers() {
@@ -141,8 +151,6 @@ class AddAttributeFragment : BaseProductFragment(R.layout.fragment_add_attribute
             }
         }
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_add_attribute)
 
     /**
      * Called after fetching global attributes, sets the adapter to show a combined list of the

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeListFragment.kt
@@ -3,10 +3,9 @@ package com.woocommerce.android.ui.products.variations.attributes
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.core.view.MenuProvider
+import androidx.appcompat.widget.Toolbar
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -20,10 +19,11 @@ import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.model.ProductAttribute
 import com.woocommerce.android.ui.products.BaseProductFragment
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductAttributeList
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class AttributeListFragment : BaseProductFragment(R.layout.fragment_attribute_list), MenuProvider {
+class AttributeListFragment : BaseProductFragment(R.layout.fragment_attribute_list) {
     companion object {
         const val TAG: String = "AttributeListFragment"
         private const val LIST_STATE_KEY = "list_state"
@@ -46,7 +46,6 @@ class AttributeListFragment : BaseProductFragment(R.layout.fragment_attribute_li
 
         _binding = FragmentAttributeListBinding.bind(view)
 
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
         initializeViews(savedInstanceState)
         setupObservers()
     }
@@ -64,16 +63,16 @@ class AttributeListFragment : BaseProductFragment(R.layout.fragment_attribute_li
         }
     }
 
-    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+    private fun onCreateMenu(toolbar: Toolbar) {
         if (navArgs.isVariationCreation) {
-            nextMenuItem = menu.add(Menu.FIRST, ID_ATTRIBUTE_LIST, Menu.FIRST, R.string.next).apply {
+            nextMenuItem = toolbar.menu.add(Menu.FIRST, ID_ATTRIBUTE_LIST, Menu.FIRST, R.string.next).apply {
                 setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
                 isVisible = isGeneratingVariation
             }
         }
     }
 
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
+    private fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             ID_ATTRIBUTE_LIST -> {
                 AttributeListFragmentDirections.actionAttributeListFragmentToAttributesAddedFragment()
@@ -102,6 +101,17 @@ class AttributeListFragment : BaseProductFragment(R.layout.fragment_attribute_li
                 viewModel.onAddAttributeButtonClick()
             }
         }
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_variation_attributes),
+            onMenuItemSelected = ::onMenuItemSelected,
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    viewModel.onBackButtonClicked(ExitProductAttributeList)
+                }
+                onCreateMenu(toolbar)
+            }
+        )
     }
 
     private fun setupObservers() {
@@ -118,8 +128,6 @@ class AttributeListFragment : BaseProductFragment(R.layout.fragment_attribute_li
 
         viewModel.loadProductDraftAttributes()
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_variation_attributes)
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributesAddedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributesAddedFragment.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.ui.products.variations.VariationListViewModel.Sho
 import com.woocommerce.android.ui.products.variations.VariationListViewModel.ShowGenerateVariationsError.NoCandidates
 import com.woocommerce.android.ui.products.variations.domain.GenerateVariationCandidates
 import com.woocommerce.android.ui.products.variations.domain.VariationCandidate
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.CustomProgressDialog
@@ -49,9 +50,17 @@ class AttributesAddedFragment :
         }
         setupObservers()
         setupResultHandlers()
-    }
 
-    override fun getFragmentTitle() = getString(R.string.product_variations)
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_variations),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    viewModel.onBackButtonClicked(ExitAttributesAdded)
+                }
+            }
+        )
+    }
 
     private fun setupObservers() {
         viewModel.attributeListViewStateData.observe(viewLifecycleOwner) { old, new ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FragmentSecondPaneExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FragmentSecondPaneExt.kt
@@ -7,12 +7,12 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 
 fun Fragment.setupToolbar(
-    title: Int,
+    title: String,
     onMenuItemSelected: (menuItem: MenuItem) -> Boolean,
     onCreateMenu: (menu: Toolbar) -> Unit
 ) {
     val toolbar = requireView().findViewById<Toolbar>(R.id.toolbar)
-    toolbar.title = getString(title)
+    toolbar.title = title
     toolbar.setOnMenuItemClickListener { menuItem ->
         onMenuItemSelected(menuItem)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FragmentSecondPaneExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FragmentSecondPaneExt.kt
@@ -6,7 +6,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 
-fun Fragment.setupToolbar(
+fun Fragment.setupTabletSecondPaneToolbar(
     title: String,
     onMenuItemSelected: (menuItem: MenuItem) -> Boolean,
     onCreateMenu: (menu: Toolbar) -> Unit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FragmentSecondPaneExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FragmentSecondPaneExt.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.util
+
+import android.view.MenuItem
+import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
+
+fun Fragment.setupToolbar(
+    title: Int,
+    onMenuItemSelected: (menuItem: MenuItem) -> Boolean,
+    onCreateMenu: (menu: Toolbar) -> Unit
+) {
+    val toolbar = requireView().findViewById<Toolbar>(R.id.toolbar)
+    toolbar.title = getString(title)
+    toolbar.setOnMenuItemClickListener { menuItem ->
+        onMenuItemSelected(menuItem)
+    }
+    toolbar.setNavigationOnClickListener { findNavController().navigateUp() }
+
+    onCreateMenu(toolbar)
+}
+

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FragmentSecondPaneExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FragmentSecondPaneExt.kt
@@ -20,4 +20,3 @@ fun Fragment.setupToolbar(
 
     onCreateMenu(toolbar)
 }
-

--- a/WooCommerce/src/main/res/layout/fragment_add_attribute.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_attribute.xml
@@ -7,6 +7,14 @@
     android:orientation="vertical"
     tools:context="com.woocommerce.android.ui.products.variations.attributes.AddAttributeFragment">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
+
     <com.google.android.material.card.MaterialCardView
         style="@style/Woo.Card"
         android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/layout/fragment_add_attribute_terms.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_attribute_terms.xml
@@ -8,6 +8,14 @@
     android:orientation="vertical"
     tools:context="com.woocommerce.android.ui.products.variations.attributes.AddAttributeFragment">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/WooCommerce/src/main/res/layout/fragment_add_product_category.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_product_category.xml
@@ -1,10 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
     android:background="?attr/colorSurface">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
 
     <!-- Product Category name -->
     <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
@@ -18,7 +29,7 @@
         android:inputType="text"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/toolbar" />
 
     <!-- Parent Category -->
     <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView

--- a/WooCommerce/src/main/res/layout/fragment_attribute_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_attribute_list.xml
@@ -1,36 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/colorSurface"
-    tools:context="com.woocommerce.android.ui.products.variations.attributes.AttributeListFragment">
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
+
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:background="?attr/colorSurface"
+        tools:context="com.woocommerce.android.ui.products.variations.attributes.AttributeListFragment">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/addAttributeButton"
-            style="@style/Woo.Button.Outlined"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/margin_extra_large"
-            android:text="@string/product_add_attribute"
-            android:textAllCaps="true" />
-
-        <View
-            android:id="@+id/divider"
-            style="@style/Woo.Divider"
-            android:layout_width="match_parent"/>
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/attributeList"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            tools:itemCount="3"
-            tools:listitem="@layout/attribute_item" />
+            android:orientation="vertical">
 
-    </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/addAttributeButton"
+                style="@style/Woo.Button.Outlined"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/margin_extra_large"
+                android:text="@string/product_add_attribute"
+                android:textAllCaps="true" />
+
+            <View
+                android:id="@+id/divider"
+                style="@style/Woo.Divider"
+                android:layout_width="match_parent" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/attributeList"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                tools:itemCount="3"
+                tools:listitem="@layout/attribute_item" />
+
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_attributes_added.xml
+++ b/WooCommerce/src/main/res/layout/fragment_attributes_added.xml
@@ -1,70 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/colorSurface">
+    android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_horizontal|top"
-        android:orientation="vertical"
-        android:padding="@dimen/major_200">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/completion_title"
-            style="@style/Woo.TextView.Headline5"
-            android:layout_width="wrap_content"
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/colorSurface">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:lineSpacingExtra="5sp"
-            android:text="@string/product_attributes_created_title"
-            android:textAlignment="center"
-            android:textStyle="bold"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:gravity="center_horizontal|top"
+            android:orientation="vertical"
+            android:padding="@dimen/major_200">
 
-        <ImageView
-            android:id="@+id/success_image"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_250"
-            android:src="@drawable/img_welcome_light"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/completion_title" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/completion_title"
+                style="@style/Woo.TextView.Headline5"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:lineSpacingExtra="5sp"
+                android:text="@string/product_attributes_created_title"
+                android:textAlignment="center"
+                android:textStyle="bold"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/completion_help_guide"
-            style="@style/Woo.TextView.Body1"
-            android:layout_width="@dimen/minor_00"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_175"
-            android:layout_marginTop="@dimen/major_200"
-            android:layout_marginEnd="@dimen/major_175"
-            android:lineSpacingExtra="@dimen/minor_50"
-            android:text="@string/product_attributes_created_description"
-            android:textAlignment="center"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/success_image" />
+            <ImageView
+                android:id="@+id/success_image"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_250"
+                android:src="@drawable/img_welcome_light"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/completion_title" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/generate_variation_button"
-            style="@style/Woo.Button.Colored"
-            android:layout_width="@dimen/minor_00"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_300"
-            android:layout_marginTop="@dimen/major_200"
-            android:layout_marginEnd="@dimen/major_300"
-            android:layout_marginBottom="@dimen/major_75"
-            android:text="@string/product_attributes_created_generate_action_text"
-            android:textAllCaps="true"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/completion_help_guide" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/completion_help_guide"
+                style="@style/Woo.TextView.Body1"
+                android:layout_width="@dimen/minor_00"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_175"
+                android:layout_marginTop="@dimen/major_200"
+                android:layout_marginEnd="@dimen/major_175"
+                android:lineSpacingExtra="@dimen/minor_50"
+                android:text="@string/product_attributes_created_description"
+                android:textAlignment="center"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/success_image" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/generate_variation_button"
+                style="@style/Woo.Button.Colored"
+                android:layout_width="@dimen/minor_00"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_300"
+                android:layout_marginTop="@dimen/major_200"
+                android:layout_marginEnd="@dimen/major_300"
+                android:layout_marginBottom="@dimen/major_75"
+                android:text="@string/product_attributes_created_generate_action_text"
+                android:textAllCaps="true"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/completion_help_guide" />
 
-</ScrollView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_aztec_editor.xml
+++ b/WooCommerce/src/main/res/layout/fragment_aztec_editor.xml
@@ -6,8 +6,19 @@
     android:layout_height="match_parent"
     android:background="@color/color_surface">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
+
+    <LinearLayout
+        android:id="@+id/bottomToolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
@@ -21,8 +32,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:background="@drawable/box_button_bg"
-            android:padding="@dimen/minor_100"
             android:contentDescription="@string/ai_product_toolbar_button_tooltip"
+            android:padding="@dimen/minor_100"
             android:src="@drawable/ic_ai" />
 
         <org.wordpress.aztec.toolbar.AztecToolbar
@@ -36,10 +47,10 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:fillViewport="true"
-        app:layout_constraintBottom_toTopOf="@+id/toolbar"
+        app:layout_constraintBottom_toTopOf="@+id/bottomToolbar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@+id/toolbar">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -52,8 +63,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="start|center_horizontal"
-                android:paddingTop="@dimen/major_100"
                 android:paddingStart="@dimen/major_100"
+                android:paddingTop="@dimen/major_100"
                 android:paddingEnd="@dimen/major_100"
                 android:visibility="gone"
                 tools:text="@string/product_purchase_note_caption"

--- a/WooCommerce/src/main/res/layout/fragment_product_categories_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_categories_list.xml
@@ -1,64 +1,79 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/productCategoriesLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.woocommerce.android.ui.products.categories.ProductCategoriesFragment">
+    android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
-        <com.woocommerce.android.ui.products.AddProductElementView
-            android:id="@+id/addProductCategoryView"
-            style="@style/Woo.Card"
+    <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+        android:id="@+id/productCategoriesLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context="com.woocommerce.android.ui.products.categories.ProductCategoriesFragment">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:buttonText="@string/product_add_category"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:visibility="visible" />
+            android:layout_height="match_parent">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/productCategoriesRecycler"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:background="?attr/colorSurface"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/addProductCategoryView"
-            tools:itemCount="25"
-            tools:listitem="@layout/product_category_list_item"
-            tools:visibility="visible" />
+            <com.woocommerce.android.ui.products.AddProductElementView
+                android:id="@+id/addProductCategoryView"
+                style="@style/Woo.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:buttonText="@string/product_add_category"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:visibility="visible" />
 
-        <com.woocommerce.android.widgets.WCEmptyView
-            android:id="@+id/empty_view"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/addProductCategoryView"
-            tools:visibility="gone" />
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/productCategoriesRecycler"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:background="?attr/colorSurface"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/addProductCategoryView"
+                tools:itemCount="25"
+                tools:listitem="@layout/product_category_list_item"
+                tools:visibility="visible" />
 
-        <ProgressBar
-            android:id="@+id/loadMoreCategoriesProgress"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:layout_centerHorizontal="true"
-            android:layout_marginBottom="@dimen/major_75"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            tools:visibility="gone" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+            <com.woocommerce.android.widgets.WCEmptyView
+                android:id="@+id/empty_view"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/addProductCategoryView"
+                tools:visibility="gone" />
+
+            <ProgressBar
+                android:id="@+id/loadMoreCategoriesProgress"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:layout_centerHorizontal="true"
+                android:layout_marginBottom="@dimen/major_75"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                tools:visibility="gone" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_images.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_images.xml
@@ -8,6 +8,17 @@
     android:background="@color/color_surface"
     tools:context="com.woocommerce.android.ui.products.ProductImagesFragment">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        style="@style/Widget.Woo.Toolbar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name"/>
+
     <com.google.android.material.button.MaterialButton
         android:id="@+id/addImageButton"
         style="@style/Woo.Button.Outlined"

--- a/WooCommerce/src/main/res/layout/fragment_product_inventory.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_inventory.xml
@@ -1,135 +1,150 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <com.google.android.material.card.MaterialCardView
-        style="@style/Woo.Card"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        tools:title="@string/app_name"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Woo.Card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <!-- Product SKU -->
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/product_sku"
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/major_75"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:paddingBottom="@dimen/major_75"
-                android:inputType="text"
-                android:hint="@string/product_sku"
-                app:helperText="@string/product_sku_summary"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                android:layout_height="wrap_content">
 
-            <!-- Managing Product Stock -->
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:id="@+id/manageStock_switch"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:text="@string/product_manage_stock"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/product_sku" />
-
-            <!-- Product Stock Status -->
-            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-                android:id="@+id/edit_product_stock_status"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/major_75"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                app:layout_goneMarginBottom="@dimen/major_75"
-                android:inputType="text"
-                android:visibility="gone"
-                tools:visibility="visible"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintBottom_toTopOf="@id/soldIndividually_switch"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/manageStock_switch"
-                android:hint="@string/product_stock_status" />
-
-            <LinearLayout
-                android:id="@+id/manageStock_morePanel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/major_75"
-                app:layout_goneMarginBottom="@dimen/major_75"
-                android:visibility="gone"
-                android:orientation="vertical"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintBottom_toTopOf="@id/soldIndividually_switch"
-                app:layout_constraintTop_toBottomOf="@+id/manageStock_switch"
-                tools:visibility="gone">
-
+                <!-- Product SKU -->
                 <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                    android:id="@+id/product_stock_quantity"
+                    android:id="@+id/product_sku"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_75"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:hint="@string/product_sku"
+                    android:inputType="text"
+                    android:paddingBottom="@dimen/major_75"
+                    app:helperText="@string/product_sku_summary"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <!-- Managing Product Stock -->
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/manageStock_switch"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/major_100"
                     android:layout_marginEnd="@dimen/major_100"
-                    android:inputType="numberSigned"
-                    android:hint="@string/product_inventory_quantity"
-                    app:helperText="@string/product_inventory_quantity_summary" />
+                    android:text="@string/product_manage_stock"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/product_sku" />
 
                 <!-- Product Stock Status -->
                 <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-                    android:id="@+id/edit_product_backorders"
+                    android:id="@+id/edit_product_stock_status"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/minor_100"
                     android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_75"
                     android:layout_marginEnd="@dimen/major_100"
+                    android:hint="@string/product_stock_status"
                     android:inputType="text"
-                    android:hint="@string/product_backorders" />
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toTopOf="@id/soldIndividually_switch"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/manageStock_switch"
+                    app:layout_goneMarginBottom="@dimen/major_75"
+                    tools:visibility="visible" />
 
-            </LinearLayout>
+                <LinearLayout
+                    android:id="@+id/manageStock_morePanel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/major_75"
+                    android:orientation="vertical"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toTopOf="@id/soldIndividually_switch"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/manageStock_switch"
+                    app:layout_goneMarginBottom="@dimen/major_75"
+                    tools:visibility="gone">
 
-            <androidx.constraintlayout.widget.Barrier
-                android:id="@+id/manageStock_barrier"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:barrierDirection="bottom"
-                app:constraint_referenced_ids="manageStock_morePanel,edit_product_stock_status" />
+                    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                        android:id="@+id/product_stock_quantity"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/major_100"
+                        android:layout_marginEnd="@dimen/major_100"
+                        android:hint="@string/product_inventory_quantity"
+                        android:inputType="numberSigned"
+                        app:helperText="@string/product_inventory_quantity_summary" />
 
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/stockManagementPanel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:visibility="visible"
-                app:constraint_referenced_ids="manageStock_barrier,manageStock_morePanel,manageStock_switch,edit_product_stock_status,manageStock_switch,soldIndividually_switch" />
+                    <!-- Product Stock Status -->
+                    <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                        android:id="@+id/edit_product_backorders"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/major_100"
+                        android:layout_marginTop="@dimen/minor_100"
+                        android:layout_marginEnd="@dimen/major_100"
+                        android:hint="@string/product_backorders"
+                        android:inputType="text" />
 
-            <!-- Product Sold Individually switch -->
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:id="@+id/soldIndividually_switch"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_75"
-                android:layout_marginBottom="@dimen/major_75"
-                android:text="@string/product_sold_individually"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/manageStock_barrier"
-                app:layout_constraintBottom_toBottomOf="parent" />
+                </LinearLayout>
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                <androidx.constraintlayout.widget.Barrier
+                    android:id="@+id/manageStock_barrier"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:barrierDirection="bottom"
+                    app:constraint_referenced_ids="manageStock_morePanel,edit_product_stock_status" />
 
-    </com.google.android.material.card.MaterialCardView>
+                <androidx.constraintlayout.widget.Group
+                    android:id="@+id/stockManagementPanel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:visibility="visible"
+                    app:constraint_referenced_ids="manageStock_barrier,manageStock_morePanel,manageStock_switch,edit_product_stock_status,manageStock_switch,soldIndividually_switch" />
 
-</ScrollView>
+                <!-- Product Sold Individually switch -->
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/soldIndividually_switch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_75"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:layout_marginBottom="@dimen/major_75"
+                    android:text="@string/product_sold_individually"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/manageStock_barrier" />
 
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_pricing.xml
@@ -1,254 +1,269 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <com.google.android.material.card.MaterialCardView
-        style="@style/Woo.Card"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+    <ScrollView xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Woo.Card"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <!-- Product Pricing Heading -->
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/product_price_heading"
-                style="@style/Woo.TextView.Headline6"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/product_price"
-                app:layout_constraintStart_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <!-- Product Regular Price -->
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/product_regular_price"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_75"
-                android:layout_marginEnd="@dimen/major_100"
-                android:hint="@string/product_regular_price"
-                android:inputType="numberDecimal|numberSigned"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/product_price_heading" />
-
-            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-                android:id="@+id/subscription_interval"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_75"
-                android:layout_marginEnd="@dimen/major_100"
-                android:hint="@string/product_subscription_interval"
-                app:layout_constraintEnd_toStartOf="@id/subscription_period"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />
-
-            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-                android:id="@+id/subscription_period"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:hint="@string/product_subscription_period"
-                app:layout_constraintBottom_toBottomOf="@id/subscription_interval"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/subscription_interval"
-                app:layout_constraintTop_toTopOf="@id/subscription_interval" />
-
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/subscription_signup_fee"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:hint="@string/subscription_sign_up_fee"
-                android:inputType="numberDecimal|numberSigned"
-                app:helperText="@string/subscription_sign_up_fee_explanation"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/subscription_period" />
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/subscription_group"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                app:constraint_referenced_ids="subscription_period, subscription_interval, subscription_signup_fee" />
-
-            <View
-                android:id="@+id/divider_1"
-                style="@style/Woo.Divider"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                android:layout_marginTop="@dimen/major_100"
-                app:layout_constraintTop_toBottomOf="@+id/subscription_signup_fee" />
-
-            <!-- Product Sale Heading -->
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/product_sale_heading"
-                style="@style/Woo.TextView.Headline6"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/product_sale"
-                app:layout_constraintStart_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/divider_1" />
-
-            <!-- Product Sale Price -->
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/product_sale_price"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/minor_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:layout_marginBottom="@dimen/minor_100"
-                android:hint="@string/product_sale_price"
-                android:inputType="numberDecimal|numberSigned"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/product_sale_heading" />
-
-            <!-- Managing Product Stock -->
-            <com.woocommerce.android.widgets.WCToggleSingleOptionView
-                android:id="@+id/scheduleSale_switch"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_75"
-                android:layout_marginTop="@dimen/minor_100"
-                android:layout_marginEnd="@dimen/major_75"
-                android:importantForAccessibility="yes"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/product_sale_price"
-                app:switchSummary="@string/product_schedule_sale_sublabel"
-                app:switchTitle="@string/product_schedule_sale_label" />
+            android:layout_height="wrap_content">
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/scheduleSale_morePanel"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:visibility="visible"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/scheduleSale_switch">
+                android:layout_height="match_parent">
 
-                <!-- Schedule Sale From -->
+                <!-- Product Pricing Heading -->
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/product_price_heading"
+                    style="@style/Woo.TextView.Headline6"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/product_price"
+                    app:layout_constraintStart_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <!-- Product Regular Price -->
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/product_regular_price"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_75"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:hint="@string/product_regular_price"
+                    android:inputType="numberDecimal|numberSigned"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/product_price_heading" />
+
                 <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-                    android:id="@+id/scheduleSale_startDate"
+                    android:id="@+id/subscription_interval"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_75"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:hint="@string/product_subscription_interval"
+                    app:layout_constraintEnd_toStartOf="@id/subscription_period"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/product_regular_price" />
+
+                <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                    android:id="@+id/subscription_period"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:hint="@string/product_subscription_period"
+                    app:layout_constraintBottom_toBottomOf="@id/subscription_interval"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/subscription_interval"
+                    app:layout_constraintTop_toTopOf="@id/subscription_interval" />
+
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/subscription_signup_fee"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:hint="@string/subscription_sign_up_fee"
+                    android:inputType="numberDecimal|numberSigned"
+                    app:helperText="@string/subscription_sign_up_fee_explanation"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/subscription_period" />
+
+                <androidx.constraintlayout.widget.Group
+                    android:id="@+id/subscription_group"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    app:constraint_referenced_ids="subscription_period, subscription_interval, subscription_signup_fee" />
+
+                <View
+                    android:id="@+id/divider_1"
+                    style="@style/Woo.Divider"
+                    android:layout_marginTop="@dimen/major_100"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/subscription_signup_fee" />
+
+                <!-- Product Sale Heading -->
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/product_sale_heading"
+                    style="@style/Woo.TextView.Headline6"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/product_sale"
+                    app:layout_constraintStart_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/divider_1" />
+
+                <!-- Product Sale Price -->
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/product_sale_price"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/major_100"
                     android:layout_marginTop="@dimen/minor_100"
                     android:layout_marginEnd="@dimen/major_100"
-                    android:hint="@string/product_schedule_sale_from_label"
-                    android:inputType="number"
+                    android:layout_marginBottom="@dimen/minor_100"
+                    android:hint="@string/product_sale_price"
+                    android:inputType="numberDecimal|numberSigned"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toTopOf="@+id/scheduleSale_endDate" />
+                    app:layout_constraintTop_toBottomOf="@+id/product_sale_heading" />
 
-                <!-- Schedule Sale To -->
-                <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-                    android:id="@+id/scheduleSale_endDate"
+                <!-- Managing Product Stock -->
+                <com.woocommerce.android.widgets.WCToggleSingleOptionView
+                    android:id="@+id/scheduleSale_switch"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/major_100"
-                    android:layout_marginStart="@dimen/major_100"
-                    android:layout_marginEnd="@dimen/major_100"
-                    android:hint="@string/product_schedule_sale_to_label"
-                    android:inputType="text"
-                    app:layout_goneMarginBottom="@dimen/major_100"
+                    android:layout_marginStart="@dimen/major_75"
+                    android:layout_marginTop="@dimen/minor_100"
+                    android:layout_marginEnd="@dimen/major_75"
+                    android:importantForAccessibility="yes"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintBottom_toTopOf="@+id/scheduleSale_RemoveEndDateButton"
-                    app:layout_constraintTop_toBottomOf="@+id/scheduleSale_startDate" />
+                    app:layout_constraintTop_toBottomOf="@+id/product_sale_price"
+                    app:switchSummary="@string/product_schedule_sale_sublabel"
+                    app:switchTitle="@string/product_schedule_sale_label" />
 
-                <!-- Remove End Date button -->
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/scheduleSale_RemoveEndDateButton"
-                    style="@style/Woo.Button.TextButton"
-                    android:textAllCaps="false"
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/scheduleSale_morePanel"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:visibility="visible"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/scheduleSale_switch">
+
+                    <!-- Schedule Sale From -->
+                    <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                        android:id="@+id/scheduleSale_startDate"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/major_100"
+                        android:layout_marginTop="@dimen/minor_100"
+                        android:layout_marginEnd="@dimen/major_100"
+                        android:hint="@string/product_schedule_sale_from_label"
+                        android:inputType="number"
+                        app:layout_constraintBottom_toTopOf="@+id/scheduleSale_endDate"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <!-- Schedule Sale To -->
+                    <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                        android:id="@+id/scheduleSale_endDate"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/major_100"
+                        android:layout_marginTop="@dimen/major_100"
+                        android:layout_marginEnd="@dimen/major_100"
+                        android:hint="@string/product_schedule_sale_to_label"
+                        android:inputType="text"
+                        app:layout_constraintBottom_toTopOf="@+id/scheduleSale_RemoveEndDateButton"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/scheduleSale_startDate"
+                        app:layout_goneMarginBottom="@dimen/major_100" />
+
+                    <!-- Remove End Date button -->
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/scheduleSale_RemoveEndDateButton"
+                        style="@style/Woo.Button.TextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/product_schedule_remove_end_date_link_label"
+                        android:textAllCaps="false"
+                        android:visibility="gone"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/scheduleSale_endDate" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <androidx.constraintlayout.widget.Barrier
+                    android:id="@+id/scheduleSale_barrier"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/product_schedule_remove_end_date_link_label"
-                    android:visibility="gone"
+                    app:barrierDirection="bottom"
+                    app:constraint_referenced_ids="scheduleSale_morePanel,scheduleSale_switch" />
+
+                <View
+                    android:id="@+id/divider_2"
+                    style="@style/Woo.Divider"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/scheduleSale_barrier" />
+
+                <!-- Product Tax Heading -->
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/product_tax"
+                    style="@style/Woo.TextView.Headline6"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/product_tax_settings"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/divider_2" />
+
+                <!-- Product Tax Status -->
+                <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                    android:id="@+id/product_tax_status"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_75"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:hint="@string/product_tax_status"
+                    android:inputType="text"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/product_tax" />
+
+                <!-- Product Tax Class -->
+                <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                    android:id="@+id/product_tax_class"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/minor_100"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:layout_marginBottom="@dimen/major_100"
+                    android:hint="@string/product_tax_class"
+                    android:inputType="text"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/scheduleSale_endDate" />
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/product_tax_status" />
+
+                <androidx.constraintlayout.widget.Group
+                    android:id="@+id/product_tax_section"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:constraint_referenced_ids="product_tax,product_tax_class,product_tax_status,divider_2" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.card.MaterialCardView>
 
-            <androidx.constraintlayout.widget.Barrier
-                android:id="@+id/scheduleSale_barrier"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:barrierDirection="bottom"
-                app:constraint_referenced_ids="scheduleSale_morePanel,scheduleSale_switch" />
-
-            <View
-                android:id="@+id/divider_2"
-                style="@style/Woo.Divider"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/scheduleSale_barrier" />
-
-            <!-- Product Tax Heading -->
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/product_tax"
-                style="@style/Woo.TextView.Headline6"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/product_tax_settings"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/divider_2" />
-
-            <!-- Product Tax Status -->
-            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-                android:id="@+id/product_tax_status"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_75"
-                android:layout_marginEnd="@dimen/major_100"
-                android:hint="@string/product_tax_status"
-                android:inputType="text"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/product_tax" />
-
-            <!-- Product Tax Class -->
-            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-                android:id="@+id/product_tax_class"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/minor_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:layout_marginBottom="@dimen/major_100"
-                android:hint="@string/product_tax_class"
-                android:inputType="text"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/product_tax_status" />
-
-            <androidx.constraintlayout.widget.Group
-                android:id="@+id/product_tax_section"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:constraint_referenced_ids="product_tax,product_tax_class,product_tax_status,divider_2" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.card.MaterialCardView>
-
-</ScrollView>
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_shipping.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_shipping.xml
@@ -1,92 +1,108 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:orientation="vertical">
 
-    <com.google.android.material.card.MaterialCardView
-        style="@style/Woo.Card"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
-        <LinearLayout
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Woo.Card"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:layout_height="wrap_content">
 
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/product_weight"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/major_100"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:inputType="numberDecimal"
-                android:maxLength="@integer/maxlength_product_shipping_properties"
-                android:hint="@string/product_weight" />
+                android:orientation="vertical">
 
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/product_length"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/major_75"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:inputType="numberDecimal"
-                android:maxLength="@integer/maxlength_product_shipping_properties"
-                android:hint="@string/product_length" />
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/product_weight"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:hint="@string/product_weight"
+                    android:inputType="numberDecimal"
+                    android:maxLength="@integer/maxlength_product_shipping_properties" />
 
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/product_width"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/major_75"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:inputType="numberDecimal"
-                android:maxLength="@integer/maxlength_product_shipping_properties"
-                android:hint="@string/product_width" />
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/product_length"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_75"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:hint="@string/product_length"
+                    android:inputType="numberDecimal"
+                    android:maxLength="@integer/maxlength_product_shipping_properties" />
 
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/product_height"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:inputType="numberDecimal"
-                android:layout_marginTop="@dimen/major_75"
-                android:layout_marginBottom="@dimen/major_100"
-                android:maxLength="@integer/maxlength_product_shipping_properties"
-                android:hint="@string/product_height" />
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/product_width"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_75"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:hint="@string/product_width"
+                    android:inputType="numberDecimal"
+                    android:maxLength="@integer/maxlength_product_shipping_properties" />
 
-            <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-                android:id="@+id/product_shipping_class_spinner"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/major_100"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:inputType="text"
-                android:hint="@string/product_shipping_class" />
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/product_height"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_75"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:layout_marginBottom="@dimen/major_100"
+                    android:hint="@string/product_height"
+                    android:inputType="numberDecimal"
+                    android:maxLength="@integer/maxlength_product_shipping_properties" />
 
-            <com.woocommerce.android.widgets.WCToggleSingleOptionView
-                android:id="@+id/product_one_time_shipping"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:switchSummary="@string/subscription_one_time_shipping_description"
-                app:switchTitle="@string/subscription_one_time_shipping" />
+                <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+                    android:id="@+id/product_shipping_class_spinner"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:layout_marginBottom="@dimen/major_100"
+                    android:hint="@string/product_shipping_class"
+                    android:inputType="text" />
 
-            <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/product_one_time_shipping_note"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:layout_marginBottom="@dimen/major_100"
-                android:text="@string/subscription_one_time_shipping_note"
-                android:textAppearance="?attr/textAppearanceCaption" />
-        </LinearLayout>
+                <com.woocommerce.android.widgets.WCToggleSingleOptionView
+                    android:id="@+id/product_one_time_shipping"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:switchSummary="@string/subscription_one_time_shipping_description"
+                    app:switchTitle="@string/subscription_one_time_shipping" />
 
-    </com.google.android.material.card.MaterialCardView>
+                <androidx.appcompat.widget.AppCompatTextView
+                    android:id="@+id/product_one_time_shipping_note"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:layout_marginBottom="@dimen/major_100"
+                    android:text="@string/subscription_one_time_shipping_note"
+                    android:textAppearance="?attr/textAppearanceCaption" />
+            </LinearLayout>
 
-</ScrollView>
+        </com.google.android.material.card.MaterialCardView>
+
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_reviews_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_reviews_list.xml
@@ -1,82 +1,96 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/notifsRefreshLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.reviews.ReviewListFragment">
+    android:orientation="vertical">
 
-    <RelativeLayout
-        android:id="@+id/notifsContainer"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
+
+    <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+        android:id="@+id/notifsRefreshLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clickable="true"
-        android:focusable="true">
+        tools:context=".ui.reviews.ReviewListFragment">
 
         <RelativeLayout
-            android:id="@+id/unread_reviews_filter_layout"
+            android:id="@+id/notifsContainer"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="@dimen/major_75">
+            android:layout_height="match_parent"
+            android:clickable="true"
+            android:focusable="true">
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentStart="true"
-                android:layout_centerVertical="true"
-                android:layout_marginStart="@dimen/major_100"
-                android:text="@string/product_review_list_unread_reviews_filter"
-                android:textAppearance="@style/TextAppearance.Woo.Subtitle1"
-                tools:text="Filter by unread reviews" />
-
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/unread_filter_switch"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_centerVertical="true" />
-
-            <View
-                style="@style/Woo.Divider"
+            <RelativeLayout
+                android:id="@+id/unread_reviews_filter_layout"
                 android:layout_width="match_parent"
-                android:layout_below="@+id/unread_filter_switch" />
+                android:layout_height="wrap_content"
+                android:paddingTop="@dimen/major_75">
 
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentStart="true"
+                    android:layout_centerVertical="true"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:text="@string/product_review_list_unread_reviews_filter"
+                    android:textAppearance="@style/TextAppearance.Woo.Subtitle1"
+                    tools:text="Filter by unread reviews" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/unread_filter_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentEnd="true"
+                    android:layout_centerVertical="true" />
+
+                <View
+                    style="@style/Woo.Divider"
+                    android:layout_width="match_parent"
+                    android:layout_below="@+id/unread_filter_switch" />
+
+            </RelativeLayout>
+
+            <!-- Notifications List View -->
+            <LinearLayout
+                android:id="@+id/notifsView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@+id/unread_reviews_filter_layout"
+                android:orientation="vertical"
+                tools:visibility="visible">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/reviewsList"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    tools:itemCount="5"
+                    tools:listitem="@layout/notifs_list_item" />
+            </LinearLayout>
+
+            <com.woocommerce.android.widgets.WCEmptyView
+                android:id="@+id/empty_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@+id/unread_reviews_filter_layout"
+                android:visibility="gone"
+                tools:visibility="gone" />
+
+            <ProgressBar
+                android:id="@+id/notifsLoadMoreProgress"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:layout_centerHorizontal="true"
+                android:layout_marginBottom="@dimen/major_75"
+                android:visibility="gone"
+                tools:visibility="gone" />
         </RelativeLayout>
-
-        <!-- Notifications List View -->
-        <LinearLayout
-            android:id="@+id/notifsView"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_below="@+id/unread_reviews_filter_layout"
-            android:orientation="vertical"
-            tools:visibility="visible">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/reviewsList"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                tools:itemCount="5"
-                tools:listitem="@layout/notifs_list_item" />
-        </LinearLayout>
-
-        <com.woocommerce.android.widgets.WCEmptyView
-            android:id="@+id/empty_view"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_below="@+id/unread_reviews_filter_layout"
-            android:visibility="gone"
-            tools:visibility="gone" />
-
-        <ProgressBar
-            android:id="@+id/notifsLoadMoreProgress"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:layout_centerHorizontal="true"
-            android:layout_marginBottom="@dimen/major_75"
-            android:visibility="gone"
-            tools:visibility="gone" />
-    </RelativeLayout>
-</com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+    </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_variation_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_variation_list.xml
@@ -1,75 +1,91 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/variationListRefreshLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.woocommerce.android.ui.products.variations.VariationListFragment">
+    android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        app:layout_collapseMode="pin"
+        style="@style/Widget.Woo.Toolbar"
+        tools:title="@string/app_name"/>
 
-        <LinearLayout
-            android:id="@+id/variationInfoContainer"
+    <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+        android:id="@+id/variationListRefreshLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context="com.woocommerce.android.ui.products.variations.VariationListFragment">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:background="@color/color_surface"
-            android:orientation="vertical"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            android:layout_height="match_parent">
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/addVariationButton"
-                style="@style/Woo.Button.Outlined"
+            <LinearLayout
+                android:id="@+id/variationInfoContainer"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/margin_extra_large"
-                android:layout_marginTop="@dimen/margin_extra_large"
-                android:layout_marginEnd="@dimen/margin_extra_large"
-                android:text="@string/variation_list_generate_new_variation"
-                android:textAllCaps="true" />
+                android:layout_height="0dp"
+                android:background="@color/color_surface"
+                android:orientation="vertical"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/variationList"
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/addVariationButton"
+                    style="@style/Woo.Button.Outlined"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_extra_large"
+                    android:layout_marginTop="@dimen/margin_extra_large"
+                    android:layout_marginEnd="@dimen/margin_extra_large"
+                    android:text="@string/variation_list_generate_new_variation"
+                    android:textAllCaps="true" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/variationList"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/colorSurface"
+                    tools:itemCount="3"
+                    tools:listitem="@layout/variation_list_item" />
+
+            </LinearLayout>
+
+            <com.woocommerce.android.widgets.ActionableEmptyView
+                android:id="@+id/first_variation_view"
                 android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:visibility="gone"
+                app:aevButton="@string/product_variant_list_empty_action"
+                app:aevImage="@drawable/ic_add_variations"
+                app:aevTitle="@string/product_variant_list_add_first_variation"
+                app:aevTitleAppearance="?attr/textAppearanceHeadline6"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:visibility="gone" />
+
+            <ProgressBar
+                android:id="@+id/loadMoreProgress"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="?attr/colorSurface"
-                tools:itemCount="3"
-                tools:listitem="@layout/variation_list_item" />
+                android:layout_alignParentBottom="true"
+                android:layout_centerHorizontal="true"
+                android:layout_marginBottom="@dimen/major_75"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                tools:visibility="visible" />
 
-        </LinearLayout>
-
-        <com.woocommerce.android.widgets.ActionableEmptyView
-            android:id="@+id/first_variation_view"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone"
-            app:aevButton="@string/product_variant_list_empty_action"
-            app:aevImage="@drawable/ic_add_variations"
-            app:aevTitle="@string/product_variant_list_add_first_variation"
-            app:aevTitleAppearance="?attr/textAppearanceHeadline6"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:visibility="gone" />
-
-        <ProgressBar
-            android:id="@+id/loadMoreProgress"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:layout_centerHorizontal="true"
-            android:layout_marginBottom="@dimen/major_75"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            tools:visibility="visible" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+</LinearLayout>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10870
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds individual toolbars for some fragments that are shown from the product details fragment. The rest will be in the separate PR

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
* **The most important** to make sure that there is NO regression brought to the case when FF is OFF
* It is known that some fragments don't have a Toolbar yet on the 2 panes layout; will be added later

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/657f830d-7f3b-42a1-9ff5-cb210adee0fb



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
