### PR TITLE
Refactor Address handling to avoid using shared viewmodels

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomerAddFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditCustomerAddFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
@@ -52,7 +53,7 @@ class OrderCreateEditCustomerAddFragment :
     }
 
     private val sharedViewModel by fixedHiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
-    private val addressViewModel by fixedHiltNavGraphViewModels<AddressViewModel>(R.id.nav_graph_order_creations)
+    private val addressViewModel by viewModels<AddressViewModel>()
 
     private val editingOfAddedCustomer: OrderCreateEditCustomerAddFragmentArgs by navArgs()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListFragment.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
-import com.woocommerce.android.ui.orders.details.editing.address.AddressViewModel
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
@@ -23,7 +22,6 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class CustomerListFragment : BaseFragment() {
     private val viewModel by viewModels<CustomerListViewModel>()
-    private val addressViewModel by fixedHiltNavGraphViewModels<AddressViewModel>(R.id.nav_graph_order_creations)
     private val sharedViewModel by fixedHiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
 
     override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
@@ -48,22 +46,14 @@ class CustomerListFragment : BaseFragment() {
             when (event) {
                 is CustomerSelected -> {
                     sharedViewModel.onCustomerEdited(event.customer)
-                    addressViewModel.onAddressesChanged(event.customer)
-
                     findNavController().popBackStack(R.id.orderCreationFragment, false)
                 }
                 is AddCustomer -> {
-                    addressViewModel.clearSelectedAddress()
-                    addressViewModel.onFieldEdited(
-                        AddressViewModel.AddressType.BILLING,
-                        AddressViewModel.Field.Email,
-                        event.email.orEmpty(),
-                    )
-
                     findNavController().navigateSafely(
                         CustomerListFragmentDirections
                             .actionCustomerListFragmentToOrderCreationCustomerFragment(
-                                editingOfAddedCustomer = false
+                                editingOfAddedCustomer = false,
+                                initialEmail = event.email.orEmpty()
                             )
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BaseAddressEditingFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updateMargins
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.switchmaterial.SwitchMaterial
 import com.woocommerce.android.R
@@ -23,7 +24,6 @@ import com.woocommerce.android.ui.searchfilter.SearchFilterItem
 import com.woocommerce.android.util.UiHelpers.getPxOfUiDimen
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.combineWith
-import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
 
@@ -36,7 +36,7 @@ abstract class BaseAddressEditingFragment :
         const val SELECT_STATE_REQUEST = "select_state_request"
     }
 
-    private val addressViewModel by fixedHiltNavGraphViewModels<AddressViewModel>(R.id.nav_graph_orders)
+    private val addressViewModel by viewModels<AddressViewModel>()
 
     abstract val storedAddress: Address
     abstract val addressType: AddressViewModel.AddressType

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/BillingAddressEditingFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.details.editing.address
 
+import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentBaseEditAddressBinding
@@ -7,6 +8,8 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.ui.main.AppBarStatus
 
 class BillingAddressEditingFragment : BaseAddressEditingFragment() {
+    private val args by navArgs<BillingAddressEditingFragmentArgs>()
+
     override val analyticsValue: String = AnalyticsTracker.ORDER_EDIT_BILLING_ADDRESS
 
     override val activityAppBarStatus: AppBarStatus
@@ -14,8 +17,9 @@ class BillingAddressEditingFragment : BaseAddressEditingFragment() {
             navigationIcon = R.drawable.ic_gridicons_cross_24dp
         )
 
-    override val storedAddress: Address
-        get() = sharedViewModel.order.billingAddress
+    override val storedAddress: Address by lazy {
+        args.storedAddress
+    }
 
     override val addressType: AddressViewModel.AddressType = AddressViewModel.AddressType.BILLING
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/ShippingAddressEditingFragment.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.details.editing.address
 
 import android.view.View
+import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentBaseEditAddressBinding
@@ -10,13 +11,16 @@ import com.woocommerce.android.ui.main.AppBarStatus
 class ShippingAddressEditingFragment : BaseAddressEditingFragment() {
     override val analyticsValue: String = AnalyticsTracker.ORDER_EDIT_SHIPPING_ADDRESS
 
+    private val args by navArgs<ShippingAddressEditingFragmentArgs>()
+
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Visible(
             navigationIcon = R.drawable.ic_gridicons_cross_24dp
         )
 
-    override val storedAddress: Address
-        get() = sharedViewModel.order.shippingAddress
+    override val storedAddress: Address by lazy {
+        args.storedAddress
+    }
 
     override val addressType: AddressViewModel.AddressType = AddressViewModel.AddressType.SHIPPING
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -111,7 +111,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         binding.customerInfoBillingAddr.setIsReadOnly(isReadOnly)
         if (!isReadOnly) {
             binding.customerInfoBillingAddressSection.setOnClickListener {
-                navigateToBillingAddressEditingView(order.id)
+                navigateToBillingAddressEditingView(order)
             }
             binding.customerInfoBillingAddr.binding.notEmptyLabel.setClickableParent(
                 binding.customerInfoBillingAddressSection
@@ -273,7 +273,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
 
         if (!isReadOnly) {
             binding.customerInfoShippingAddressSection.setOnClickListener {
-                navigateToShippingAddressEditingView(order.id)
+                navigateToShippingAddressEditingView(order)
             }
             binding.customerInfoShippingAddr.binding.notEmptyLabel.setClickableParent(
                 binding.customerInfoShippingAddressSection
@@ -281,15 +281,15 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         }
     }
 
-    private fun navigateToShippingAddressEditingView(orderId: Long) {
+    private fun navigateToShippingAddressEditingView(order: Order) {
         OrderDetailFragmentDirections
-            .actionOrderDetailFragmentToShippingAddressEditingFragment(orderId)
+            .actionOrderDetailFragmentToShippingAddressEditingFragment(order.id, order.billingAddress)
             .let { findNavController().navigateSafely(it) }
     }
 
-    private fun navigateToBillingAddressEditingView(orderId: Long) {
+    private fun navigateToBillingAddressEditingView(order: Order) {
         OrderDetailFragmentDirections
-            .actionOrderDetailFragmentToBillingAddressEditingFragment(orderId)
+            .actionOrderDetailFragmentToBillingAddressEditingFragment(order.id, order.billingAddress)
             .let { findNavController().navigateSafely(it) }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.parcelable
 import com.woocommerce.android.extensions.show
+import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderCustomerHelper
 import com.woocommerce.android.ui.orders.details.OrderDetailFragmentDirections
@@ -111,7 +112,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         binding.customerInfoBillingAddr.setIsReadOnly(isReadOnly)
         if (!isReadOnly) {
             binding.customerInfoBillingAddressSection.setOnClickListener {
-                navigateToBillingAddressEditingView(order)
+                navigateToBillingAddressEditingView(order.billingAddress)
             }
             binding.customerInfoBillingAddr.binding.notEmptyLabel.setClickableParent(
                 binding.customerInfoBillingAddressSection
@@ -273,7 +274,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
 
         if (!isReadOnly) {
             binding.customerInfoShippingAddressSection.setOnClickListener {
-                navigateToShippingAddressEditingView(order)
+                navigateToShippingAddressEditingView(order.shippingAddress)
             }
             binding.customerInfoShippingAddr.binding.notEmptyLabel.setClickableParent(
                 binding.customerInfoShippingAddressSection
@@ -281,15 +282,15 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         }
     }
 
-    private fun navigateToShippingAddressEditingView(order: Order) {
+    private fun navigateToShippingAddressEditingView(address: Address) {
         OrderDetailFragmentDirections
-            .actionOrderDetailFragmentToShippingAddressEditingFragment(order.id, order.billingAddress)
+            .actionOrderDetailFragmentToShippingAddressEditingFragment(storedAddress = address)
             .let { findNavController().navigateSafely(it) }
     }
 
-    private fun navigateToBillingAddressEditingView(order: Order) {
+    private fun navigateToBillingAddressEditingView(address: Address) {
         OrderDetailFragmentDirections
-            .actionOrderDetailFragmentToBillingAddressEditingFragment(order.id, order.billingAddress)
+            .actionOrderDetailFragmentToBillingAddressEditingFragment(storedAddress = address)
             .let { findNavController().navigateSafely(it) }
     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -210,6 +210,11 @@
         <argument
             android:name="editingOfAddedCustomer"
             app:argType="boolean" />
+        <argument
+            android:name="initialEmail"
+            app:argType="string"
+            app:nullable="true"
+            android:defaultValue="@null"/>
         <action
             android:id="@+id/action_search_filter_fragment"
             app:destination="@id/searchFilterFragment" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -584,10 +584,6 @@
         android:label="ShippingAddressEditingFragment"
         tools:layout="@layout/fragment_base_edit_address" >
         <argument
-            android:name="orderId"
-            app:argType="long"
-            app:nullable="false" />
-        <argument
             android:name="storedAddress"
             app:argType="com.woocommerce.android.model.Address" />
     </fragment>
@@ -596,10 +592,6 @@
         android:name="com.woocommerce.android.ui.orders.details.editing.address.BillingAddressEditingFragment"
         android:label="BillingAddressEditingFragment"
         tools:layout="@layout/fragment_base_edit_address" >
-        <argument
-            android:name="orderId"
-            app:argType="long"
-            app:nullable="false" />
         <argument
             android:name="storedAddress"
             app:argType="com.woocommerce.android.model.Address" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -587,6 +587,9 @@
             android:name="orderId"
             app:argType="long"
             app:nullable="false" />
+        <argument
+            android:name="storedAddress"
+            app:argType="com.woocommerce.android.model.Address" />
     </fragment>
     <fragment
         android:id="@+id/billingAddressEditingFragment"
@@ -597,6 +600,9 @@
             android:name="orderId"
             app:argType="long"
             app:nullable="false" />
+        <argument
+            android:name="storedAddress"
+            app:argType="com.woocommerce.android.model.Address" />
     </fragment>
     <fragment
         android:id="@+id/customOrderFieldsFragment"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR refactors the Address handling for order creation/editing to avoid depending on Shared ViewModels which tightly couple the ViewModel to the Order flow.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
