### PR TITLE
[Tablet Support M2] Bug/10862 crash when no orders

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -34,6 +34,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
+import androidx.navigation.NavOptions
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.NavHostFragment
 import com.automattic.android.tracks.crashlogging.CrashLogging
@@ -1206,7 +1207,11 @@ class MainActivity :
                 remoteNoteId,
                 startPaymentsFlow
             ).toBundle()
-            navController.navigate(R.id.orderDetailFragment, bundle)
+            navController.navigate(
+                R.id.orderDetailFragment,
+                bundle,
+                navOptions = NavOptions.Builder().setLaunchSingleTop(true).build()
+            )
         } ?: run {
             navController.navigateSafely(action)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -254,7 +254,7 @@ class OrderDetailFragment :
         } else {
             binding.toolbar.navigationIcon = AppCompatResources.getDrawable(requireActivity(), R.drawable.ic_back_24dp)
             binding.toolbar.setNavigationOnClickListener {
-                findNavController().navigateUp()
+                if (!findNavController().popBackStack()) requireActivity().onBackPressedDispatcher.onBackPressed()
             }
         }
         val menuEditOrder = menu.findItem(R.id.menu_edit_order)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -165,9 +165,10 @@ class OrderListFragment :
                     } else {
                         val result =
                             _binding?.detailNavContainer?.findNavController()?.navigateUp() ?: false
-                        // There are no more fragments in the back stack, UI used to be a two pane layout (tablet)
-                        // and now it's a single pane layout (phone), e.g. due to a configuration change.
                         if (!result && _binding?.orderRefreshLayout?.isVisible != true && !isTablet()) {
+                            // There are no more fragments in the back stack, UI used to be a two pane layout (tablet)
+                            // and now it's a single pane layout (phone), e.g. due to a configuration change.
+                            // In this case we need to switch panes – show the list pane instead of details pane.
                             adjustUiForDeviceType(savedInstanceState)
                         } else {
                             requireActivity().onBackPressedDispatcher.onBackPressed()
@@ -293,20 +294,21 @@ class OrderListFragment :
 
     private fun adjustLayoutForNonTablet(savedInstanceState: Bundle?) {
         if (savedInstanceState != null && savedInstanceState.getInt(CURRENT_NAV_DESTINATION, -1) != -1) {
-            adjustLayoutForSinglePane()
+            displayDetailPaneOnly()
         } else {
-            _binding?.detailNavContainer?.visibility = View.GONE
-            _binding?.orderRefreshLayout?.visibility = View.VISIBLE
-            _binding?.twoPaneLayoutGuideline?.setGuidelinePercent(1f)
+            displayListPaneOnly()
         }
     }
 
-    private fun adjustLayoutForSinglePane() {
-        // Adjust the detail container to occupy the full width in single-pane mode (e.g., phone)
+    private fun displayListPaneOnly() {
+        _binding?.detailNavContainer?.visibility = View.GONE
+        _binding?.orderRefreshLayout?.visibility = View.VISIBLE
+        _binding?.twoPaneLayoutGuideline?.setGuidelinePercent(1f)
+    }
+
+    private fun displayDetailPaneOnly() {
         _binding?.detailNavContainer?.visibility = View.VISIBLE
         _binding?.twoPaneLayoutGuideline?.setGuidelinePercent(0.0f)
-
-        // Adjust the order list view to be hidden in single-pane mode
         _binding?.orderRefreshLayout?.visibility = View.GONE
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -289,6 +289,8 @@ class OrderListFragment :
 
     private fun adjustLayoutForTablet() {
         binding.twoPaneLayoutGuideline.setGuidelinePercent(TABLET_LANDSCAPE_WIDTH_RATIO)
+        binding.orderRefreshLayout.visibility = View.VISIBLE
+        binding.detailNavContainer.visibility = View.VISIBLE
     }
 
     private fun adjustLayoutForNonTablet(savedInstanceState: Bundle?) {
@@ -558,7 +560,6 @@ class OrderListFragment :
                         emptyView.show(emptyViewType) {
                             ChromeCustomTabUtils.launchUrl(requireActivity(), AppUrls.URL_LEARN_MORE_ORDERS)
                         }
-                        if (isTablet()) displayListPaneOnly()
                     }
 
                     EmptyViewType.ORDER_LIST_FILTERED -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.list
 
+import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -9,7 +10,6 @@ import android.view.MenuItem
 import android.view.MenuItem.OnActionExpandListener
 import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.SearchView.OnQueryTextListener
@@ -72,7 +72,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
-import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 
 @AndroidEntryPoint
 @Suppress("LargeClass")
@@ -310,15 +309,6 @@ class OrderListFragment :
         _binding?.detailNavContainer?.visibility = View.VISIBLE
         _binding?.twoPaneLayoutGuideline?.setGuidelinePercent(0.0f)
         _binding?.orderRefreshLayout?.visibility = View.GONE
-    }
-
-    private fun hideDetailPane(
-        detailContainer: NavHostFragment,
-        orderListViewLayoutParams: LinearLayout.LayoutParams
-    ) {
-        detailContainer.view?.visibility = View.GONE
-        orderListViewLayoutParams.width = LinearLayout.LayoutParams.MATCH_PARENT
-        orderListViewLayoutParams.weight = 0f
     }
 
     private fun initSwipeBehaviour() {
@@ -568,12 +558,7 @@ class OrderListFragment :
                         emptyView.show(emptyViewType) {
                             ChromeCustomTabUtils.launchUrl(requireActivity(), AppUrls.URL_LEARN_MORE_ORDERS)
                         }
-                        val detailContainer = childFragmentManager.findFragmentById(
-                            R.id.detail_nav_container
-                        ) as NavHostFragment
-                        val orderListViewLayoutParams = binding.orderRefreshLayout.layoutParams
-                            as LinearLayout.LayoutParams
-                        hideDetailPane(detailContainer, orderListViewLayoutParams)
+                        if (isTablet()) displayListPaneOnly()
                     }
 
                     EmptyViewType.ORDER_LIST_FILTERED -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -18,6 +18,7 @@ import androidx.core.view.doOnPreDraw
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
 import androidx.paging.PagedList
@@ -72,7 +73,6 @@ import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 import org.wordpress.android.util.ActivityUtils as WPActivityUtils
-import androidx.navigation.findNavController
 
 @AndroidEntryPoint
 @Suppress("LargeClass")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.list
 
-import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -72,6 +71,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
+import org.wordpress.android.util.ActivityUtils as WPActivityUtils
 
 @AndroidEntryPoint
 @Suppress("LargeClass")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10862 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the crash happening on tablets when entering the Orders screen signed into a newly created store without orders.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Create a new store (e.g. inside the app)
2. Go to Orders – app should no longer crash; empty state view should be displayed
3. Create a new order – verify it is visible on the order list

### Images/gif
<video src=https://github.com/woocommerce/woocommerce-android/assets/4527432/b79e0981-22aa-4b21-bb17-ef4c6c708b12 width=600/>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
