### PR TITLE
[Tablet Support M2] Issue 10863 - Fix order list reload on search view expand

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -754,6 +754,10 @@ class OrderListFragment :
     override fun onQueryTextChange(newText: String): Boolean {
         // only display the order status list if the search query is empty
         if (newText.isEmpty()) {
+            if (searchQuery.isNotEmpty()) {
+                viewModel.loadOrders()
+            }
+
             searchQuery = ""
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10863
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
The issue encountered in the `OrderListFragment` was that the order list would not show any results after a search query didn't find items and it was cleared.

The solution implemented in the `onQueryTextChange` method now ensures that `viewModel.loadOrders()` is only invoked when there is an actual change in the search query from a non-empty to an empty string. This means that the full list of orders is reloaded only when the user clears the search input.

### Testing instructions

1. Go to orders list for a store that has some orders
2. Search for something that will return a result
3. Use X is search bar to clear search results
4. Edit order in right pane
5. Notice that going back to the order's list shows all the items. 


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

[Search-Fix-New.webm](https://github.com/woocommerce/woocommerce-android/assets/1509205/bfa17681-9e3f-4a03-b847-fd0d91a94595)



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
