### PR TITLE
[Tablet Support M2] Issue 10860 - Improve Order List & Details UI in Small Tablets

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.details
 
+import android.content.res.Configuration
 import android.graphics.Color
 import android.os.Bundle
 import android.view.Menu
@@ -101,6 +102,7 @@ class OrderDetailFragment :
     companion object {
         val TAG: String = OrderDetailFragment::class.java.simpleName
         private const val MARGINS_FOR_TABLET: Float = 0.1F
+        private const val MARGINS_FOR_SMALL_TABLET_PORTRAIT: Float = 0.025F
     }
 
     private val viewModel: OrderDetailViewModel by viewModels()
@@ -229,11 +231,32 @@ class OrderDetailFragment :
     private fun isOrderListFragmentNotVisible() = parentFragment?.parentFragment !is OrderListFragment
 
     private fun setMarginsIfTablet() {
+        val isSmallTablet = resources.getBoolean(R.bool.is_small_tablet)
+        val isPortrait = resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
+
         if (isTablet()) {
-            val layoutParams = binding.skeletonView.layoutParams as FrameLayout.LayoutParams
             val windowWidth = DisplayUtils.getWindowPixelWidth(requireContext())
-            layoutParams.marginStart = (windowWidth * MARGINS_FOR_TABLET).toInt()
-            layoutParams.marginEnd = (windowWidth * MARGINS_FOR_TABLET).toInt()
+            val layoutParams = binding.orderDetailContainer.layoutParams as FrameLayout.LayoutParams
+
+            if (isSmallTablet && isPortrait) {
+                val marginHorizontal = (windowWidth * MARGINS_FOR_SMALL_TABLET_PORTRAIT).toInt()
+                layoutParams.setMargins(
+                    marginHorizontal,
+                    layoutParams.topMargin,
+                    marginHorizontal,
+                    layoutParams.bottomMargin
+                )
+            } else {
+                val marginHorizontal = (windowWidth * MARGINS_FOR_TABLET).toInt()
+                layoutParams.setMargins(
+                    marginHorizontal,
+                    layoutParams.topMargin,
+                    marginHorizontal,
+                    layoutParams.bottomMargin
+                )
+            }
+
+            binding.orderDetailContainer.layoutParams = layoutParams
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -231,7 +231,7 @@ class OrderDetailFragment :
     private fun isOrderListFragmentNotVisible() = parentFragment?.parentFragment !is OrderListFragment
 
     private fun setMarginsIfTablet() {
-        val isSmallTablet = resources.getBoolean(R.bool.is_small_tablet)
+        val isSmallTablet = !resources.getBoolean(R.bool.is_at_least_720sw)
         val isPortrait = resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
 
         if (isTablet()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.list
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -89,6 +90,7 @@ class OrderListFragment :
 
         private const val JITM_FRAGMENT_TAG = "jitm_orders_fragment"
         private const val TABLET_LANDSCAPE_WIDTH_RATIO = 0.3f
+        private const val TABLET_PORTRAIT_WIDTH_RATIO = 0.40f
         private const val CURRENT_NAV_DESTINATION = "current_nav_destination"
         private const val HANDLER_DELAY = 200L
     }
@@ -282,7 +284,14 @@ class OrderListFragment :
     }
 
     private fun adjustLayoutForTablet() {
-        binding.twoPaneLayoutGuideline.setGuidelinePercent(TABLET_LANDSCAPE_WIDTH_RATIO)
+        val isSmallTablet = resources.getBoolean(R.bool.is_small_tablet)
+        val isPortrait = resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
+
+        if (isSmallTablet && isPortrait) {
+            binding.twoPaneLayoutGuideline.setGuidelinePercent(TABLET_PORTRAIT_WIDTH_RATIO)
+        } else {
+            binding.twoPaneLayoutGuideline.setGuidelinePercent(TABLET_LANDSCAPE_WIDTH_RATIO)
+        }
     }
 
     private fun adjustLayoutForNonTablet() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -284,7 +284,7 @@ class OrderListFragment :
     }
 
     private fun adjustLayoutForTablet() {
-        val isSmallTablet = resources.getBoolean(R.bool.is_small_tablet)
+        val isSmallTablet = !resources.getBoolean(R.bool.is_at_least_720sw)
         val isPortrait = resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
 
         if (isSmallTablet && isPortrait) {

--- a/WooCommerce/src/main/res/values-sw600dp/bools.xml
+++ b/WooCommerce/src/main/res/values-sw600dp/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="is_small_tablet">true</bool>
+</resources>

--- a/WooCommerce/src/main/res/values-sw720dp/bools.xml
+++ b/WooCommerce/src/main/res/values-sw720dp/bools.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <bool name="is_small_tablet">true</bool>
+    <bool name="is_at_least_720sw">true</bool>
 </resources>

--- a/WooCommerce/src/main/res/values/bools.xml
+++ b/WooCommerce/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="is_small_tablet">false</bool>
+</resources>

--- a/WooCommerce/src/main/res/values/bools.xml
+++ b/WooCommerce/src/main/res/values/bools.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <bool name="is_small_tablet">false</bool>
+    <bool name="is_at_least_720sw">false</bool>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10860
<!-- Id number of the GitHub issue this PR addresses. -->

### Description

#### OrderListFragment

I introduced logic to adjust the layout for tablet devices, particularly for small tablets in portrait orientation. The `adjustLayoutForTablet` function checks if the device is a small tablet and if it's in portrait mode. If both conditions are true, it sets the guideline percentage to `TABLET_PORTRAIT_WIDTH_RATIO`, which determines the width allocation for the order list and detail panes. This ratio is used to ensure that the order list and details are displayed side by side with the appropriate space allocation. For larger tablets or when in landscape orientation, a different width ratio, `TABLET_LANDSCAPE_WIDTH_RATIO` which already existed in the codebase is applied.

#### OrderDetailFragment

The `setMarginsIfTablet` function is responsible for adjusting the margins of the order detail container. It uses the `isTablet` utility function to check if the device is a tablet and then applies margin adjustments based on the device's size and orientation. For small tablets in portrait mode, `MARGINS_FOR_SMALL_TABLET_PORTRAIT` is introduced to set the horizontal margins, creating a more visually balanced layout. For other scenarios, such as larger tablets or different orientations, `MARGINS_FOR_TABLET` is used to set the margins accordingly. 

### Testing instructions

Utilize a small and a large tablet. 

#### Small tablet - portrait

1. Put the tablet in portrait mode. 
2. Ensure that you see the Order List and Order Detail side by side and all elements are visible. 

<kbd><img src="https://github.com/woocommerce/woocommerce-android/assets/1509205/c42f716b-259e-4974-a798-68fcbeb5c7ca" width="320"></kbd>

#### Small tablet - landscape

1. Put the tablet in landscape mode. 
2. Ensure that you see the Order List and Order Detail side by side and all elements are visible but there is more spacing. 

<kbd><img src="https://github.com/woocommerce/woocommerce-android/assets/1509205/c42f297a-73d0-4eeb-b169-3f9f40462374" width="840"></kbd>

#### Large tablet - portrait 

1. Put tablet in portrait mode. 
2. Notice that the spacing is as same as before. 

<kbd><img src="https://github.com/woocommerce/woocommerce-android/assets/1509205/794c1623-7b5f-4fd2-b77b-0c693d012175" width="460"></kbd>

#### Large tablet - landscape 

1. Put tablet in landscape mode. 
2. Notice that the spacing is as same as before. 

<kbd><img src="https://github.com/woocommerce/woocommerce-android/assets/1509205/07322300-0529-4c68-9444-c01e4df61238" width="840"></kbd>

<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
