### PR TITLE
[Better Tablet Products] Adapt toolbar for the nested product details fragments part 2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Toolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Toolbar.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.compose.component
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.TopAppBar
@@ -12,9 +11,11 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
 import com.woocommerce.android.R.drawable
 import com.woocommerce.android.R.string
 import com.woocommerce.android.ui.compose.autoMirror
@@ -138,7 +139,7 @@ fun Toolbar(
     actions: @Composable RowScope.() -> Unit = {}
 ) {
     TopAppBar(
-        backgroundColor = MaterialTheme.colors.surface,
+        backgroundColor = colorResource(id = R.color.color_toolbar),
         title = title,
         navigationIcon = {
             if (navigationIcon != null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListFragment.kt
@@ -3,16 +3,22 @@ package com.woocommerce.android.ui.media
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentMediaUploadErrorListBinding
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MediaUploadErrorListFragment : BaseFragment(R.layout.fragment_media_upload_error_list) {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     private val mediaUploadErrorListAdapter: MediaUploadErrorListAdapter by lazy {
         MediaUploadErrorListAdapter()
     }
@@ -29,6 +35,16 @@ class MediaUploadErrorListFragment : BaseFragment(R.layout.fragment_media_upload
         }
 
         setupObservers(viewModel)
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_downloadable_files_upload_failed),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    findNavController().navigateUp()
+                }
+            }
+        )
     }
 
     private fun setupObservers(viewModel: MediaUploadErrorListViewModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/GroupedProductListFragment.kt
@@ -14,8 +14,10 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCEmptyView
@@ -38,7 +40,8 @@ class GroupedProductListFragment : BaseFragment(R.layout.fragment_grouped_produc
     private var _binding: FragmentGroupedProductListBinding? = null
     private val binding get() = _binding!!
 
-    override fun getFragmentTitle() = resources.getString(viewModel.groupedProductListType.titleId)
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -51,6 +54,18 @@ class GroupedProductListFragment : BaseFragment(R.layout.fragment_grouped_produc
         binding.productsRecycler.layoutManager = LinearLayoutManager(requireActivity())
         binding.productsRecycler.adapter = productListAdapter
         binding.productsRecycler.isMotionEventSplittingEnabled = false
+
+        setupTabletSecondPaneToolbar(
+            title = getString(viewModel.groupedProductListType.titleId),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    if (viewModel.onBackButtonClicked()) {
+                        findNavController().navigateUp()
+                    }
+                }
+            }
+        )
     }
 
     override fun onDestroyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/LinkedProductsFragment.kt
@@ -13,10 +13,12 @@ import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.products.GroupedProductListType.CROSS_SELLS
 import com.woocommerce.android.ui.products.GroupedProductListType.UPSELLS
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitLinkedProducts
 import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -24,7 +26,8 @@ class LinkedProductsFragment : BaseProductFragment(R.layout.fragment_linked_prod
     private var _binding: FragmentLinkedProductsBinding? = null
     private val binding get() = _binding!!
 
-    override fun getFragmentTitle() = getString(R.string.product_detail_linked_products)
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -108,6 +111,16 @@ class LinkedProductsFragment : BaseProductFragment(R.layout.fragment_linked_prod
         binding.addCrossSellProducts.setOnClickListener {
             showGroupedProductFragment(CROSS_SELLS)
         }
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_detail_linked_products),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    viewModel.onBackButtonClicked(ExitLinkedProducts)
+                }
+            }
+        )
     }
 
     override fun onRequestAllowBackPress(): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductBundleFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductBundleFragment.kt
@@ -4,13 +4,16 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentBundleProductListBinding
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.products.adapters.BundleProductListAdapter
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.hilt.android.AndroidEntryPoint
@@ -25,7 +28,8 @@ class ProductBundleFragment : BaseFragment(R.layout.fragment_bundle_product_list
 
     private val productListAdapter: BundleProductListAdapter by lazy { BundleProductListAdapter() }
 
-    override fun getFragmentTitle() = resources.getString(R.string.product_bundle)
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -52,6 +56,16 @@ class ProductBundleFragment : BaseFragment(R.layout.fragment_bundle_product_list
         viewModel.productListViewStateData.observe(viewLifecycleOwner) { old, new ->
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
         }
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_bundle),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    findNavController().navigateUp()
+                }
+            }
+        )
     }
 
     private fun showSkeleton(show: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductExternalLinkFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductExternalLinkFragment.kt
@@ -6,8 +6,10 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentProductExternalLinkBinding
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductDetailViewState
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitExternalLink
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.ActivityUtils
 
@@ -15,6 +17,9 @@ import org.wordpress.android.util.ActivityUtils
 class ProductExternalLinkFragment : BaseProductFragment(R.layout.fragment_product_external_link) {
     private var _binding: FragmentProductExternalLinkBinding? = null
     private val binding get() = _binding!!
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     override fun onResume() {
         super.onResume()
@@ -40,14 +45,22 @@ class ProductExternalLinkFragment : BaseProductFragment(R.layout.fragment_produc
         binding.productButtonText.setOnTextChangedListener {
             viewModel.updateProductDraft(buttonText = it.toString())
         }
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_external_link),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    onRequestAllowBackPress()
+                }
+            }
+        )
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_external_link)
 
     private fun setupObservers(viewModel: ProductDetailViewModel) {
         viewModel.event.observe(viewLifecycleOwner) { event ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductQuantityRulesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductQuantityRulesFragment.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentProductQuantityRulesBinding
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductQuantityRules
 import com.woocommerce.android.ui.products.models.QuantityRules
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -28,6 +29,16 @@ class ProductQuantityRulesFragment : BaseProductFragment(R.layout.fragment_produ
         _binding = FragmentProductQuantityRulesBinding.bind(view)
         viewModel.event.observe(viewLifecycleOwner, Observer(::onEventReceived))
         initializeViews(navArgs.quantityRules)
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_quantity_rules_title),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    viewModel.onBackButtonClicked(ExitProductQuantityRules)
+                }
+            }
+        )
     }
 
     private fun onEventReceived(event: MultiLiveEvent.Event) {
@@ -42,8 +53,6 @@ class ProductQuantityRulesFragment : BaseProductFragment(R.layout.fragment_produ
         binding.maxQuantityValue.text = quantityRules.max?.toString() ?: getString(R.string.empty_max_quantity)
         binding.groupOfValue.text = quantityRules.groupOf?.toString() ?: getString(R.string.empty_group_of)
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_quantity_rules_title)
 
     override fun onRequestAllowBackPress(): Boolean {
         viewModel.onBackButtonClicked(ExitProductQuantityRules)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListFragment.kt
@@ -3,15 +3,15 @@ package com.woocommerce.android.ui.products
 import android.os.Bundle
 import android.view.ActionMode
 import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.MenuItem.OnActionExpandListener
 import android.view.View
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.SearchView.OnQueryTextListener
-import androidx.core.view.MenuProvider
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.selection.SelectionPredicates
 import androidx.recyclerview.selection.SelectionTracker
 import androidx.recyclerview.selection.StorageStrategy
@@ -26,6 +26,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.widgets.SkeletonView
@@ -39,8 +40,7 @@ class ProductSelectionListFragment :
     OnLoadMoreListener,
     OnActionModeEventListener,
     OnQueryTextListener,
-    OnActionExpandListener,
-    MenuProvider {
+    OnActionExpandListener {
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var currencyFormatter: CurrencyFormatter
 
@@ -85,7 +85,6 @@ class ProductSelectionListFragment :
         super.onViewCreated(view, savedInstanceState)
 
         _binding = FragmentProductListBinding.bind(view)
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
 
         setupObservers(viewModel)
 
@@ -130,10 +129,10 @@ class ProductSelectionListFragment :
                     when (selectionCount) {
                         0 -> {
                             actionMode?.finish()
-                            activity?.title = getString(R.string.grouped_product_add)
+                            binding.toolbar.title = getString(R.string.grouped_product_add)
                         }
                         else -> {
-                            actionMode?.title = StringUtils.getQuantityString(
+                            binding.toolbar.title = StringUtils.getQuantityString(
                                 context = requireContext(),
                                 quantity = selectionCount,
                                 default = R.string.product_selection_count,
@@ -143,17 +142,28 @@ class ProductSelectionListFragment :
                     }
                 }
             })
+
+        setupTabletSecondPaneToolbar(
+            title = "",
+            onMenuItemSelected = ::onMenuItemSelected,
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    findNavController().navigateUp()
+                }
+                onCreateMenu(toolbar)
+            }
+        )
     }
 
-    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_product_list_fragment, menu)
+    private fun onCreateMenu(toolbar: Toolbar) {
+        toolbar.inflateMenu(R.menu.menu_product_list_fragment)
 
-        searchMenuItem = menu.findItem(R.id.menu_search)
+        searchMenuItem = toolbar.menu.findItem(R.id.menu_search)
         searchView = searchMenuItem?.actionView as SearchView?
         searchView?.queryHint = getString(R.string.product_search_hint)
     }
 
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
+    private fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_search -> {
                 enableSearchListeners()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListFragment.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.util.setupTabletSecondPaneToolbar
@@ -41,6 +42,9 @@ class ProductSelectionListFragment :
     OnActionModeEventListener,
     OnQueryTextListener,
     OnActionExpandListener {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     @Inject lateinit var uiMessageResolver: UIMessageResolver
     @Inject lateinit var currencyFormatter: CurrencyFormatter
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/product/ProductAddonsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/product/ProductAddonsFragment.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.products.BaseProductFragment
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductAddons
 import com.woocommerce.android.ui.products.addons.AddonListAdapter
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.fluxc.domain.Addon
@@ -42,6 +43,16 @@ class ProductAddonsFragment : BaseProductFragment(R.layout.fragment_product_addo
             .observe(viewLifecycleOwner) { addons ->
                 setupRecyclerViewWith(addons, viewModel.currencyCode)
             }
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_add_ons_title),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    viewModel.onBackButtonClicked(ExitProductAddons)
+                }
+            }
+        )
     }
 
     private fun onEventReceived(event: MultiLiveEvent.Event) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/components/ComponentDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/components/ComponentDetailsFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.core.text.HtmlCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
@@ -14,7 +15,9 @@ import com.woocommerce.android.databinding.FragmentComponentDetailsBinding
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.QueryType
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.products.ComponentOptions
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.hilt.android.AndroidEntryPoint
@@ -24,8 +27,10 @@ import org.wordpress.android.util.PhotonUtils
 class ComponentDetailsFragment : BaseFragment(R.layout.fragment_component_details) {
     val viewModel: ComponentDetailsViewModel by viewModels()
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     private val skeletonView = SkeletonView()
-    override fun getFragmentTitle() = resources.getString(R.string.product_component_settings)
 
     private val componentsOptionsListAdapter: ComponentOptionsListAdapter by lazy { ComponentOptionsListAdapter() }
 
@@ -74,6 +79,16 @@ class ComponentDetailsFragment : BaseFragment(R.layout.fragment_component_detail
                 binding.componentDetailsRefreshLayout.isRefreshing = it
             }
         }
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_component_settings),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    findNavController().navigateUp()
+                }
+            }
+        )
     }
 
     private fun showComponentOptionsInfo(componentOptions: ComponentOptions, binding: FragmentComponentDetailsBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/components/ComponentListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/components/ComponentListFragment.kt
@@ -11,6 +11,8 @@ import com.woocommerce.android.databinding.FragmentComponentListBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.Component
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -20,7 +22,8 @@ class ComponentListFragment :
     ComponentsListAdapter.OnComponentClickListener {
     val viewModel: ComponentListViewModel by viewModels()
 
-    override fun getFragmentTitle() = resources.getString(R.string.product_components)
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -55,6 +58,16 @@ class ComponentListFragment :
                 else -> event.isHandled = false
             }
         }
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_components),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    findNavController().navigateUp()
+                }
+            }
+        )
     }
 
     override fun onComponentClickListener(component: Component) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsFragment.kt
@@ -1,11 +1,9 @@
 package com.woocommerce.android.ui.products.downloads
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.core.view.MenuProvider
+import androidx.appcompat.widget.Toolbar
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.ItemTouchHelper.DOWN
 import androidx.recyclerview.widget.ItemTouchHelper.UP
@@ -17,14 +15,14 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.ui.products.BaseProductFragment
 import com.woocommerce.android.ui.products.ProductDetailViewModel
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductDownloads
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.DraggableItemTouchHelper
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class ProductDownloadsFragment :
-    BaseProductFragment(R.layout.fragment_product_downloads_list),
-    MenuProvider {
+    BaseProductFragment(R.layout.fragment_product_downloads_list) {
     private val itemTouchHelper by lazy {
         DraggableItemTouchHelper(
             dragDirs = UP or DOWN,
@@ -57,7 +55,6 @@ class ProductDownloadsFragment :
 
         _binding = FragmentProductDownloadsListBinding.bind(view)
 
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
         setupObservers(viewModel)
 
         with(binding.productDownloadsRecycler) {
@@ -65,6 +62,17 @@ class ProductDownloadsFragment :
             layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
             itemTouchHelper.attachToRecyclerView(this)
         }
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_downloadable_files),
+            onMenuItemSelected = ::onMenuItemSelected,
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    viewModel.onBackButtonClicked(ExitProductDownloads)
+                }
+                onCreateMenu(toolbar)
+            }
+        )
     }
 
     override fun onDestroyView() {
@@ -72,12 +80,12 @@ class ProductDownloadsFragment :
         _binding = null
     }
 
-    override fun onCreateMenu(menu: Menu, inflater: MenuInflater) {
-        menu.clear()
-        inflater.inflate(R.menu.menu_product_downloads_list, menu)
+    private fun onCreateMenu(toolbar: Toolbar) {
+        toolbar.menu.clear()
+        toolbar.inflateMenu(R.menu.menu_product_downloads_list)
     }
 
-    override fun onMenuItemSelected(item: MenuItem): Boolean {
+    private fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_product_downloads_settings -> {
                 viewModel.onDownloadsSettingsClicked()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadsSettingsFragment.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.databinding.FragmentProductDownloadsSettingsBindi
 import com.woocommerce.android.ui.products.BaseProductFragment
 import com.woocommerce.android.ui.products.ProductDetailViewModel
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductDownloadsSettings
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -22,6 +23,16 @@ class ProductDownloadsSettingsFragment : BaseProductFragment(R.layout.fragment_p
         _binding = FragmentProductDownloadsSettingsBinding.bind(view)
 
         setupObservers(viewModel)
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_downloadable_files_download_settings),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    viewModel.onBackButtonClicked(ExitProductDownloadsSettings)
+                }
+            }
+        )
     }
 
     override fun onDestroyView() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/BaseProductSettingsFragment.kt
@@ -6,6 +6,7 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.dialog.WooDialog
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import org.wordpress.android.util.ActivityUtils
 
@@ -18,6 +19,9 @@ import org.wordpress.android.util.ActivityUtils
 abstract class BaseProductSettingsFragment : BaseFragment, BackPressListener {
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     @CallSuper
     override fun onStop() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductCatalogVisibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductCatalogVisibilityFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.View.OnClickListener
 import android.widget.CheckedTextView
 import androidx.annotation.IdRes
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -14,6 +15,7 @@ import com.woocommerce.android.ui.products.settings.ProductCatalogVisibility.CAT
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibility.HIDDEN
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibility.SEARCH
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibility.VISIBLE
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -47,6 +49,16 @@ class ProductCatalogVisibilityFragment :
         binding.btnVisibilityCatalog.setOnClickListener(this)
         binding.btnVisibilitySearch.setOnClickListener(this)
         binding.btnVisibilityHidden.setOnClickListener(this)
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_catalog_visibility),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    findNavController().navigateUp()
+                }
+            }
+        )
     }
 
     override fun onDestroyView() {
@@ -88,8 +100,6 @@ class ProductCatalogVisibilityFragment :
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_catalog_visibility)
 
     private fun getButtonForVisibility(visibility: String): CheckedTextView {
         return when (ProductCatalogVisibility.fromString(visibility)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductMenuOrderFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductMenuOrderFragment.kt
@@ -2,10 +2,12 @@ package com.woocommerce.android.ui.products.settings
 
 import android.os.Bundle
 import android.view.View
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentProductMenuOrderBinding
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import org.wordpress.android.util.StringUtils
 
 /**
@@ -27,6 +29,16 @@ class ProductMenuOrderFragment : BaseProductSettingsFragment(R.layout.fragment_p
         _binding = FragmentProductMenuOrderBinding.bind(view)
 
         binding.productMenuOrder.text = navArgs.menuOrder.toString()
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_menu_order),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    findNavController().navigateUp()
+                }
+            }
+        )
     }
 
     override fun onDestroyView() {
@@ -46,6 +58,4 @@ class ProductMenuOrderFragment : BaseProductSettingsFragment(R.layout.fragment_p
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_menu_order)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSettingsFragment.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.products.ProductNavigationTarget.ViewProductPu
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.settings.ProductCatalogVisibilityFragment.Companion.ARG_CATALOG_VISIBILITY
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -100,6 +101,16 @@ class ProductSettingsFragment : BaseProductFragment(R.layout.fragment_product_se
         }
 
         setupResultHandlers()
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_settings),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    viewModel.onBackButtonClicked(ExitSettings)
+                }
+            }
+        )
     }
 
     private fun setupResultHandlers() {
@@ -147,8 +158,6 @@ class ProductSettingsFragment : BaseProductFragment(R.layout.fragment_product_se
         viewModel.onBackButtonClicked(ExitSettings)
         return false
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_settings)
 
     private fun updateProductView() {
         if (!isAdded) return

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSlugFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSlugFragment.kt
@@ -2,10 +2,12 @@ package com.woocommerce.android.ui.products.settings
 
 import android.os.Bundle
 import android.view.View
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentProductSlugBinding
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 
 /**
  * Settings screen which enables editing a product's slug
@@ -26,6 +28,16 @@ class ProductSlugFragment : BaseProductSettingsFragment(R.layout.fragment_produc
         _binding = FragmentProductSlugBinding.bind(view)
 
         binding.editSlug.text = navArgs.slug
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_slug),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    findNavController().navigateUp()
+                }
+            }
+        )
     }
 
     override fun onDestroyView() {
@@ -48,6 +60,4 @@ class ProductSlugFragment : BaseProductSettingsFragment(R.layout.fragment_produc
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_slug)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductStatusFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductStatusFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.View.OnClickListener
 import android.widget.CheckedTextView
 import androidx.annotation.IdRes
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -14,6 +15,7 @@ import com.woocommerce.android.ui.products.ProductStatus.DRAFT
 import com.woocommerce.android.ui.products.ProductStatus.PENDING
 import com.woocommerce.android.ui.products.ProductStatus.PRIVATE
 import com.woocommerce.android.ui.products.ProductStatus.PUBLISH
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 
 /**
  * Settings screen which enables choosing a product status
@@ -55,6 +57,16 @@ class ProductStatusFragment : BaseProductSettingsFragment(R.layout.fragment_prod
             binding.btnPublishedPrivately.visibility = View.GONE
             binding.btnPublished.visibility = View.VISIBLE
         }
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_status),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    findNavController().navigateUp()
+                }
+            }
+        )
     }
 
     override fun onDestroyView() {
@@ -87,8 +99,6 @@ class ProductStatusFragment : BaseProductSettingsFragment(R.layout.fragment_prod
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_status)
 
     private fun getButtonForStatus(status: String): CheckedTextView? {
         return when (ProductStatus.fromString(status)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductVisibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductVisibilityFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.View.OnClickListener
 import android.widget.CheckedTextView
 import androidx.annotation.IdRes
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -13,6 +14,7 @@ import com.woocommerce.android.databinding.FragmentProductVisibilityBinding
 import com.woocommerce.android.ui.products.settings.ProductVisibility.PASSWORD_PROTECTED
 import com.woocommerce.android.ui.products.settings.ProductVisibility.PRIVATE
 import com.woocommerce.android.ui.products.settings.ProductVisibility.PUBLIC
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.util.ActivityUtils
 
@@ -50,6 +52,16 @@ class ProductVisibilityFragment : BaseProductSettingsFragment(R.layout.fragment_
             isApplicationPasswordsLogin = navArgs.isApplicationPasswordsLogin,
             selectedVisibility = selectedVisibility,
             password = password
+        )
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_visibility),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    findNavController().navigateUp()
+                }
+            }
         )
     }
 
@@ -129,8 +141,6 @@ class ProductVisibilityFragment : BaseProductSettingsFragment(R.layout.fragment_
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_visibility)
 
     override fun validateChanges(): Boolean {
         if (selectedVisibility == PASSWORD_PROTECTED.toString() && getPassword().isEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/ProductSubscriptionExpirationFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/ProductSubscriptionExpirationFragment.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Card
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -23,11 +24,11 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.fragment.navArgs
-import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.string
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WcExposedDropDown
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.products.BaseProductFragment
@@ -45,8 +46,6 @@ class ProductSubscriptionExpirationFragment : BaseProductFragment() {
     private val resourceProvider: ResourceProvider by lazy { ResourceProvider(requireContext()) }
     private var selectedExpiration: Int? = null
 
-    override fun getFragmentTitle() = getString(R.string.product_subscription_expiration_title)
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
@@ -56,7 +55,8 @@ class ProductSubscriptionExpirationFragment : BaseProductFragment() {
                 WooThemeWithBackground {
                     SubscriptionExpirationPicker(
                         items = subscription.expirationDisplayOptions(resourceProvider),
-                        currentValue = subscription.expirationDisplayValue(resourceProvider)
+                        currentValue = subscription.expirationDisplayValue(resourceProvider),
+                        onBackPressed = { viewModel.onBackButtonClicked(ExitProductSubscriptionExpiration) }
                     )
                 }
             }
@@ -82,32 +82,43 @@ class ProductSubscriptionExpirationFragment : BaseProductFragment() {
     @Composable
     private fun SubscriptionExpirationPicker(
         items: Map<String, Int>,
-        currentValue: String
+        currentValue: String,
+        onBackPressed: () -> Unit,
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize(),
-        ) {
-            Card(
-                shape = RectangleShape,
+        Scaffold(
+            topBar = {
+                Toolbar(
+                    title = stringResource(id = string.product_subscription_expiration_title),
+                    onNavigationButtonClick = onBackPressed,
+                )
+            }
+        ) { paddingValues ->
+            Box(
                 modifier = Modifier
-                    .fillMaxWidth()
+                    .fillMaxSize(),
             ) {
-                Row(
+                Card(
+                    shape = RectangleShape,
                     modifier = Modifier
-                        .background(colorResource(id = color.color_surface))
-                        .padding(dimensionResource(id = dimen.major_100)),
-                    verticalAlignment = Alignment.CenterVertically
+                        .fillMaxWidth()
+                        .padding(paddingValues)
                 ) {
-                    Text(stringResource(id = string.subscription_expire))
-                    WcExposedDropDown(
-                        items = items.keys.toTypedArray(),
-                        onSelected = { selectedExpiration = items[it] },
-                        currentValue = currentValue,
+                    Row(
                         modifier = Modifier
                             .background(colorResource(id = color.color_surface))
-                            .padding(start = dimensionResource(id = dimen.major_100))
-                    )
+                            .padding(dimensionResource(id = dimen.major_100)),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(stringResource(id = string.subscription_expire))
+                        WcExposedDropDown(
+                            items = items.keys.toTypedArray(),
+                            onSelected = { selectedExpiration = items[it] },
+                            currentValue = currentValue,
+                            modifier = Modifier
+                                .background(colorResource(id = color.color_surface))
+                                .padding(start = dimensionResource(id = dimen.major_100))
+                        )
+                    }
                 }
             }
         }
@@ -118,7 +129,8 @@ class ProductSubscriptionExpirationFragment : BaseProductFragment() {
     private fun PreviewSubscriptionExpirationPicker() {
         SubscriptionExpirationPicker(
             items = mapOf("Never" to 0, "1 month" to 1, "2 months" to 2, "3 months" to 3, "4 months" to 4),
-            currentValue = "Never"
+            currentValue = "Never",
+            onBackPressed = { }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.ui.products.ProductDetailViewModel
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductExitEvent.ExitProductTags
 import com.woocommerce.android.ui.products.tags.ProductTagsAdapter.OnProductTagClickListener
 import com.woocommerce.android.util.WooAnimUtils
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.SkeletonView
@@ -49,6 +50,16 @@ class ProductTagsFragment :
 
         setupObservers(viewModel)
         viewModel.loadProductTags()
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_tags),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    viewModel.onProductTagsBackButtonClicked()
+                }
+            }
+        )
     }
 
     override fun onDestroyView() {
@@ -56,8 +67,6 @@ class ProductTagsFragment :
         super.onDestroyView()
         _binding = null
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_tags)
 
     override fun onResume() {
         super.onResume()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/RenameAttributeFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/RenameAttributeFragment.kt
@@ -2,17 +2,19 @@ package com.woocommerce.android.ui.products.variations.attributes
 
 import android.os.Bundle
 import android.view.View
-import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentRenameAttributeBinding
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import org.wordpress.android.util.ActivityUtils
 
-class RenameAttributeFragment : Fragment(R.layout.fragment_rename_attribute), BackPressListener {
+class RenameAttributeFragment : BaseFragment(R.layout.fragment_rename_attribute), BackPressListener {
     companion object {
         const val TAG: String = "RenameAttributeFragment"
         const val KEY_RENAME_ATTRIBUTE_RESULT = "key_rename_attribute_result"
@@ -23,9 +25,11 @@ class RenameAttributeFragment : Fragment(R.layout.fragment_rename_attribute), Ba
 
     private val navArgs: RenameAttributeFragmentArgs by navArgs()
 
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         _binding = FragmentRenameAttributeBinding.bind(view)
-        requireActivity().title = getString(R.string.product_rename_attribute)
 
         if (savedInstanceState == null) {
             binding.attributeName.text = navArgs.attributeName
@@ -37,6 +41,16 @@ class RenameAttributeFragment : Fragment(R.layout.fragment_rename_attribute), Ba
             }
             true
         }
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_rename_attribute),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    navigateBack(binding.attributeName.text)
+                }
+            }
+        )
     }
 
     override fun onDestroyView() {

--- a/WooCommerce/src/main/res/layout/fragment_bundle_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_bundle_product_list.xml
@@ -5,6 +5,17 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/productsRecycler"
         android:layout_width="match_parent"
@@ -14,7 +25,7 @@
         app:layout_constraintBottom_toTopOf="@+id/notice"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar"
         app:layout_constraintVertical_chainStyle="packed"
         app:layout_constraintVertical_bias="0"
         tools:itemCount="2"

--- a/WooCommerce/src/main/res/layout/fragment_component_details.xml
+++ b/WooCommerce/src/main/res/layout/fragment_component_details.xml
@@ -1,182 +1,196 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/componentDetailsRefreshLayout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
+
+    <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+        android:id="@+id/componentDetailsRefreshLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.core.widget.NestedScrollView
-            android:id="@+id/componentDetails"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toTopOf="@+id/notice"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHeight_default="wrap"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0"
-            app:layout_constraintVertical_chainStyle="packed">
+            android:layout_height="match_parent">
 
-            <androidx.appcompat.widget.LinearLayoutCompat
+            <androidx.core.widget.NestedScrollView
+                android:id="@+id/componentDetails"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="vertical">
+                android:layout_height="0dp"
+                app:layout_constraintBottom_toTopOf="@+id/notice"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHeight_default="wrap"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_bias="0"
+                app:layout_constraintVertical_chainStyle="packed">
 
-                <com.google.android.material.card.MaterialCardView
+                <androidx.appcompat.widget.LinearLayoutCompat
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:elevation="@dimen/minor_10">
+                    android:layout_height="match_parent"
+                    android:orientation="vertical">
 
-                    <androidx.appcompat.widget.LinearLayoutCompat
+                    <com.google.android.material.card.MaterialCardView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="vertical">
+                        android:elevation="@dimen/minor_10">
 
-                        <com.woocommerce.android.widgets.BorderedImageView
-                            android:id="@+id/componentImage"
-                            android:layout_width="wrap_content"
-                            android:layout_height="@dimen/image_major_120"
-                            android:layout_gravity="start"
-                            android:layout_margin="@dimen/major_100"
-                            android:adjustViewBounds="true"
-                            android:contentDescription="@string/product_image_content_description"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toTopOf="parent"
-                            tools:layout_width="@dimen/image_major_120"
-                            tools:src="@drawable/ic_product" />
-
-                        <com.google.android.material.divider.MaterialDivider
-                            android:layout_width="match_parent"
-                            android:layout_height="1dp" />
-
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/componentTitle"
-                            style="@style/Woo.TextView.Headline6"
+                        <androidx.appcompat.widget.LinearLayoutCompat
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/major_100"
-                            android:ellipsize="end"
-                            android:maxLines="2"
-                            tools:text="This is the name" />
+                            android:orientation="vertical">
 
-                        <com.google.android.material.divider.MaterialDivider
-                            android:layout_width="match_parent"
-                            android:layout_height="1dp" />
+                            <com.woocommerce.android.widgets.BorderedImageView
+                                android:id="@+id/componentImage"
+                                android:layout_width="wrap_content"
+                                android:layout_height="@dimen/image_major_120"
+                                android:layout_gravity="start"
+                                android:layout_margin="@dimen/major_100"
+                                android:adjustViewBounds="true"
+                                android:contentDescription="@string/product_image_content_description"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintTop_toTopOf="parent"
+                                tools:layout_width="@dimen/image_major_120"
+                                tools:src="@drawable/ic_product" />
 
-                        <com.google.android.material.textview.MaterialTextView
-                            style="@style/Woo.TextView.Subtitle1"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/major_100"
-                            android:text="@string/product_description" />
+                            <com.google.android.material.divider.MaterialDivider
+                                android:layout_width="match_parent"
+                                android:layout_height="1dp" />
 
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/componentDescription"
-                            style="@style/Woo.Card.Body"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="start"
-                            android:layout_marginBottom="@dimen/major_100"
-                            android:ellipsize="end"
-                            android:lineSpacingExtra="@dimen/minor_25"
-                            android:textAlignment="viewStart"
-                            tools:text="textPropertyValue thil wrap." />
+                            <com.google.android.material.textview.MaterialTextView
+                                android:id="@+id/componentTitle"
+                                style="@style/Woo.TextView.Headline6"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="@dimen/major_100"
+                                android:ellipsize="end"
+                                android:maxLines="2"
+                                tools:text="This is the name" />
 
-                    </androidx.appcompat.widget.LinearLayoutCompat>
+                            <com.google.android.material.divider.MaterialDivider
+                                android:layout_width="match_parent"
+                                android:layout_height="1dp" />
 
-                </com.google.android.material.card.MaterialCardView>
+                            <com.google.android.material.textview.MaterialTextView
+                                style="@style/Woo.TextView.Subtitle1"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="@dimen/major_100"
+                                android:text="@string/product_description" />
 
-                <com.google.android.material.card.MaterialCardView
-                    android:id="@+id/componentOptionsSection"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/minor_100"
-                    android:elevation="@dimen/minor_10">
+                            <com.google.android.material.textview.MaterialTextView
+                                android:id="@+id/componentDescription"
+                                style="@style/Woo.Card.Body"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="start"
+                                android:layout_marginBottom="@dimen/major_100"
+                                android:ellipsize="end"
+                                android:lineSpacingExtra="@dimen/minor_25"
+                                android:textAlignment="viewStart"
+                                tools:text="textPropertyValue thil wrap." />
 
-                    <androidx.appcompat.widget.LinearLayoutCompat
+                        </androidx.appcompat.widget.LinearLayoutCompat>
+
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:id="@+id/componentOptionsSection"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:paddingBottom="@dimen/minor_100">
+                        android:layout_marginTop="@dimen/minor_100"
+                        android:elevation="@dimen/minor_10">
 
-                        <com.google.android.material.textview.MaterialTextView
-                            style="@style/Woo.Card.Header"
+                        <androidx.appcompat.widget.LinearLayoutCompat
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/major_100"
-                            android:text="@string/component_options" />
+                            android:orientation="vertical"
+                            android:paddingBottom="@dimen/minor_100">
 
-                        <View
-                            style="@style/Woo.Divider"
-                            android:layout_marginStart="@dimen/major_100"
-                            android:layout_marginBottom="@dimen/major_75" />
+                            <com.google.android.material.textview.MaterialTextView
+                                style="@style/Woo.Card.Header"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="@dimen/major_100"
+                                android:text="@string/component_options" />
 
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/componentOptionsType"
-                            style="@style/Woo.Card.Title"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginBottom="@dimen/minor_50"
-                            tools:text="Products" />
+                            <View
+                                style="@style/Woo.Divider"
+                                android:layout_marginStart="@dimen/major_100"
+                                android:layout_marginBottom="@dimen/major_75" />
 
-                        <androidx.recyclerview.widget.RecyclerView
-                            android:id="@+id/componentOptionsRecycler"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginBottom="@dimen/major_150"
-                            tools:itemCount="2"
-                            tools:listitem="@layout/component_option_item_view" />
+                            <com.google.android.material.textview.MaterialTextView
+                                android:id="@+id/componentOptionsType"
+                                style="@style/Woo.Card.Title"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginBottom="@dimen/minor_50"
+                                tools:text="Products" />
 
-                        <View
-                            android:id="@+id/componentOptionsRecyclerDivider"
-                            style="@style/Woo.Divider"
-                            android:layout_marginStart="@dimen/major_100"
-                            android:layout_marginBottom="@dimen/major_75" />
+                            <androidx.recyclerview.widget.RecyclerView
+                                android:id="@+id/componentOptionsRecycler"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginBottom="@dimen/major_150"
+                                tools:itemCount="2"
+                                tools:listitem="@layout/component_option_item_view" />
 
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/componentOptionsDefaultLabel"
-                            style="@style/Woo.Card.Title"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginBottom="@dimen/minor_50"
-                            android:text="@string/component_default_option" />
+                            <View
+                                android:id="@+id/componentOptionsRecyclerDivider"
+                                style="@style/Woo.Divider"
+                                android:layout_marginStart="@dimen/major_100"
+                                android:layout_marginBottom="@dimen/major_75" />
 
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/componentOptionsDefault"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginHorizontal="@dimen/major_100"
-                            android:layout_marginTop="@dimen/minor_100"
-                            android:layout_marginBottom="@dimen/minor_50"
-                            tools:text="This is the name of the default option" />
+                            <com.google.android.material.textview.MaterialTextView
+                                android:id="@+id/componentOptionsDefaultLabel"
+                                style="@style/Woo.Card.Title"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginBottom="@dimen/minor_50"
+                                android:text="@string/component_default_option" />
 
-                    </androidx.appcompat.widget.LinearLayoutCompat>
+                            <com.google.android.material.textview.MaterialTextView
+                                android:id="@+id/componentOptionsDefault"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginHorizontal="@dimen/major_100"
+                                android:layout_marginTop="@dimen/minor_100"
+                                android:layout_marginBottom="@dimen/minor_50"
+                                tools:text="This is the name of the default option" />
 
-                </com.google.android.material.card.MaterialCardView>
-            </androidx.appcompat.widget.LinearLayoutCompat>
-        </androidx.core.widget.NestedScrollView>
+                        </androidx.appcompat.widget.LinearLayoutCompat>
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/notice"
-            style="@style/Woo.TextView.Caption"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/minor_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:drawableStart="@drawable/ic_deprecated_info_outline_24dp"
-            android:drawablePadding="@dimen/minor_100"
-            android:gravity="center_vertical"
-            android:text="@string/component_products_info_notice"
-            android:visibility="visible"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/componentDetails" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+                    </com.google.android.material.card.MaterialCardView>
+                </androidx.appcompat.widget.LinearLayoutCompat>
+            </androidx.core.widget.NestedScrollView>
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/notice"
+                style="@style/Woo.TextView.Caption"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/minor_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:drawableStart="@drawable/ic_deprecated_info_outline_24dp"
+                android:drawablePadding="@dimen/minor_100"
+                android:gravity="center_vertical"
+                android:text="@string/component_products_info_notice"
+                android:visibility="visible"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/componentDetails" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_component_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_component_list.xml
@@ -5,6 +5,17 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/productsRecycler"
         android:layout_width="match_parent"
@@ -14,7 +25,7 @@
         app:layout_constraintBottom_toTopOf="@+id/notice"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar"
         app:layout_constraintVertical_chainStyle="packed"
         app:layout_constraintVertical_bias="0"
         tools:itemCount="2"

--- a/WooCommerce/src/main/res/layout/fragment_grouped_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_grouped_product_list.xml
@@ -7,6 +7,17 @@
     android:layout_height="match_parent"
     tools:context="com.woocommerce.android.ui.products.GroupedProductListFragment">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
+
     <com.woocommerce.android.ui.products.AddProductElementView
         android:id="@+id/addGroupedProductView"
         style="@style/Woo.Card"
@@ -14,7 +25,7 @@
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
         app:buttonText="@string/grouped_product_add"
         android:visibility="gone"
         tools:visibility="visible"/>

--- a/WooCommerce/src/main/res/layout/fragment_grouped_product_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_grouped_product_list.xml
@@ -51,7 +51,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/addGroupedProductView"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
         tools:visibility="visible" />
 
     <ProgressBar

--- a/WooCommerce/src/main/res/layout/fragment_linked_products.xml
+++ b/WooCommerce/src/main/res/layout/fragment_linked_products.xml
@@ -1,124 +1,137 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/color_surface">
+    android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/major_100">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
-        <!-- Upsells -->
-        <ImageView
-            android:id="@+id/upsells_icon"
-            android:layout_width="wrap_content"
+    <ScrollView xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/color_surface">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:importantForAccessibility="no"
-            android:paddingEnd="@dimen/major_100"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/ic_gridicons_arrow_up" />
+            android:layout_margin="@dimen/major_100">
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/upsells_label"
-            style="@style/Woo.TextView.Subtitle1"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="0dp"
-            android:text="@string/upsells_label"
-            app:layout_constraintStart_toEndOf="@+id/upsells_icon"
-            app:layout_constraintTop_toTopOf="parent" />
+            <!-- Upsells -->
+            <ImageView
+                android:id="@+id/upsells_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:importantForAccessibility="no"
+                android:paddingEnd="@dimen/major_100"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/ic_gridicons_arrow_up" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/upsells_desc"
-            style="@style/Woo.TextView.Body2"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/minor_100"
-            android:text="@string/upsells_desc"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/upsells_icon"
-            app:layout_constraintTop_toBottomOf="@+id/upsells_label" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/upsells_label"
+                style="@style/Woo.TextView.Subtitle1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="0dp"
+                android:text="@string/upsells_label"
+                app:layout_constraintStart_toEndOf="@+id/upsells_icon"
+                app:layout_constraintTop_toTopOf="parent" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/upsells_count"
-            style="@style/Woo.TextView.Body2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
-            app:layout_constraintStart_toEndOf="@id/upsells_icon"
-            app:layout_constraintTop_toBottomOf="@+id/upsells_desc"
-            tools:text="2 upsells" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/upsells_desc"
+                style="@style/Woo.TextView.Body2"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/minor_100"
+                android:text="@string/upsells_desc"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/upsells_icon"
+                app:layout_constraintTop_toBottomOf="@+id/upsells_label" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/add_upsell_products"
-            style="@style/Woo.Button.Outlined"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
-            android:text="@string/add_products_button"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/upsells_label"
-            app:layout_constraintTop_toBottomOf="@+id/upsells_count" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/upsells_count"
+                style="@style/Woo.TextView.Body2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_100"
+                app:layout_constraintStart_toEndOf="@id/upsells_icon"
+                app:layout_constraintTop_toBottomOf="@+id/upsells_desc"
+                tools:text="2 upsells" />
 
-        <!-- Cross-sells -->
-        <ImageView
-            android:id="@+id/cross_sells_icon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
-            android:importantForAccessibility="no"
-            android:paddingEnd="@dimen/major_100"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/add_upsell_products"
-            app:srcCompat="@drawable/ic_gridicons_sync" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/add_upsell_products"
+                style="@style/Woo.Button.Outlined"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_100"
+                android:text="@string/add_products_button"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/upsells_label"
+                app:layout_constraintTop_toBottomOf="@+id/upsells_count" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/cross_sells_label"
-            style="@style/Woo.TextView.Subtitle1"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="0dp"
-            android:text="@string/cross_sells_label"
-            app:layout_constraintStart_toEndOf="@+id/cross_sells_icon"
-            app:layout_constraintTop_toTopOf="@+id/cross_sells_icon" />
+            <!-- Cross-sells -->
+            <ImageView
+                android:id="@+id/cross_sells_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_100"
+                android:importantForAccessibility="no"
+                android:paddingEnd="@dimen/major_100"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/add_upsell_products"
+                app:srcCompat="@drawable/ic_gridicons_sync" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/cross_sells_desc"
-            style="@style/Woo.TextView.Body2"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/minor_100"
-            android:text="@string/cross_sells_desc"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/cross_sells_icon"
-            app:layout_constraintTop_toBottomOf="@+id/cross_sells_label" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/cross_sells_label"
+                style="@style/Woo.TextView.Subtitle1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="0dp"
+                android:text="@string/cross_sells_label"
+                app:layout_constraintStart_toEndOf="@+id/cross_sells_icon"
+                app:layout_constraintTop_toTopOf="@+id/cross_sells_icon" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/cross_sells_count"
-            style="@style/Woo.TextView.Body2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
-            app:layout_constraintStart_toEndOf="@id/cross_sells_icon"
-            app:layout_constraintTop_toBottomOf="@+id/cross_sells_desc"
-            tools:text="2 cross-sells" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/cross_sells_desc"
+                style="@style/Woo.TextView.Body2"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/minor_100"
+                android:text="@string/cross_sells_desc"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/cross_sells_icon"
+                app:layout_constraintTop_toBottomOf="@+id/cross_sells_label" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/add_cross_sell_products"
-            style="@style/Woo.Button.Outlined"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/major_100"
-            android:text="@string/add_products_button"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/cross_sells_label"
-            app:layout_constraintTop_toBottomOf="@+id/cross_sells_count" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/cross_sells_count"
+                style="@style/Woo.TextView.Body2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_100"
+                app:layout_constraintStart_toEndOf="@id/cross_sells_icon"
+                app:layout_constraintTop_toBottomOf="@+id/cross_sells_desc"
+                tools:text="2 cross-sells" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/add_cross_sell_products"
+                style="@style/Woo.Button.Outlined"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_100"
+                android:text="@string/add_products_button"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/cross_sells_label"
+                app:layout_constraintTop_toBottomOf="@+id/cross_sells_count" />
 
-</ScrollView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
+    </ScrollView>
+
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_media_upload_error_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_media_upload_error_list.xml
@@ -6,13 +6,24 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/media_upload_error_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
         tools:itemCount="2"
         tools:listitem="@layout/media_upload_error_item" />
 

--- a/WooCommerce/src/main/res/layout/fragment_product_addons.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_addons.xml
@@ -1,33 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/addons_list"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            tools:itemCount="3"
-            tools:listitem="@layout/product_addon_card" />
+            android:orientation="vertical">
 
-        <com.google.android.material.textview.MaterialTextView
-            style="@style/Woo.TextView.Caption"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/minor_10"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:text="@string/product_add_ons_details_info_notice"
-            android:drawableStart="@drawable/ic_deprecated_info_outline_24dp"
-            android:drawablePadding="@dimen/minor_100"
-            android:gravity="center_vertical"
-            android:visibility="visible"
-            tools:text="You can edit product add-ons in the web dashboard." />
-    </LinearLayout>
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/addons_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                tools:itemCount="3"
+                tools:listitem="@layout/product_addon_card" />
 
-</androidx.core.widget.NestedScrollView>
+            <com.google.android.material.textview.MaterialTextView
+                style="@style/Woo.TextView.Caption"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/minor_10"
+                android:layout_marginEnd="@dimen/major_100"
+                android:drawableStart="@drawable/ic_deprecated_info_outline_24dp"
+                android:drawablePadding="@dimen/minor_100"
+                android:gravity="center_vertical"
+                android:text="@string/product_add_ons_details_info_notice"
+                android:visibility="visible"
+                tools:text="You can edit product add-ons in the web dashboard." />
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_catalog_visibility.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_catalog_visibility.xml
@@ -1,85 +1,100 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
-        <com.woocommerce.android.widgets.WCElevatedLinearLayout
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <com.google.android.material.textview.MaterialTextView
-                style="@style/TextAppearance.Woo.Body2"
+            <com.woocommerce.android.widgets.WCElevatedLinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:padding="@dimen/major_100"
-                android:text="@string/product_visibility_headline"
-                android:textColor="@color/color_on_surface_high" />
-        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+                android:layout_height="match_parent"
+                android:orientation="vertical">
 
-        <com.woocommerce.android.widgets.WCElevatedLinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginTop="@dimen/minor_100"
-            android:orientation="vertical">
+                <com.google.android.material.textview.MaterialTextView
+                    style="@style/TextAppearance.Woo.Body2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="@dimen/major_100"
+                    android:text="@string/product_visibility_headline"
+                    android:textColor="@color/color_on_surface_high" />
+            </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:id="@+id/btnFeatured"
+            <com.woocommerce.android.widgets.WCElevatedLinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:padding="@dimen/major_100"
-                android:text="@string/product_featured" />
-        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+                android:layout_height="match_parent"
+                android:layout_marginTop="@dimen/minor_100"
+                android:orientation="vertical">
 
-        <com.woocommerce.android.widgets.WCElevatedLinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginTop="@dimen/minor_100"
-            android:orientation="vertical">
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/btnFeatured"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="@dimen/major_100"
+                    android:text="@string/product_featured" />
+            </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 
-            <CheckedTextView
-                android:id="@+id/btnVisibilityVisible"
+            <com.woocommerce.android.widgets.WCElevatedLinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/product_catalog_visibility_visible" />
+                android:layout_height="match_parent"
+                android:layout_marginTop="@dimen/minor_100"
+                android:orientation="vertical">
 
-            <View
-                style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_100" />
+                <CheckedTextView
+                    android:id="@+id/btnVisibilityVisible"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/product_catalog_visibility_visible" />
 
-            <CheckedTextView
-                android:id="@+id/btnVisibilityCatalog"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/product_catalog_visibility_catalog" />
+                <View
+                    style="@style/Woo.Divider"
+                    android:layout_marginStart="@dimen/major_100" />
 
-            <View
-                style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_100" />
+                <CheckedTextView
+                    android:id="@+id/btnVisibilityCatalog"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/product_catalog_visibility_catalog" />
 
-            <CheckedTextView
-                android:id="@+id/btnVisibilitySearch"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/product_catalog_visibility_search" />
+                <View
+                    style="@style/Woo.Divider"
+                    android:layout_marginStart="@dimen/major_100" />
 
-            <View
-                style="@style/Woo.Divider"
-                android:layout_marginStart="@dimen/major_100" />
+                <CheckedTextView
+                    android:id="@+id/btnVisibilitySearch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/product_catalog_visibility_search" />
 
-            <CheckedTextView
-                android:id="@+id/btnVisibilityHidden"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/product_catalog_visibility_hidden" />
+                <View
+                    style="@style/Woo.Divider"
+                    android:layout_marginStart="@dimen/major_100" />
 
-            <View style="@style/Woo.Divider" />
+                <CheckedTextView
+                    android:id="@+id/btnVisibilityHidden"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/product_catalog_visibility_hidden" />
 
-        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
-    </LinearLayout>
-</ScrollView>
+                <View style="@style/Woo.Divider" />
+
+            </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_download_details.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_download_details.xml
@@ -1,70 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <com.google.android.material.card.MaterialCardView
-        style="@style/Woo.Card"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.core.widget.NestedScrollView xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Woo.Card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/product_download_url"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:hint="@string/product_downloadable_files_url"
-                android:inputType="text"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/product_download_url_info"
-                style="@style/Woo.TextView.Caption"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_150"
-                android:layout_marginEnd="@dimen/major_150"
-                android:text="@string/product_downloadable_files_url_info"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/product_download_url" />
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/product_download_url"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:hint="@string/product_downloadable_files_url"
+                    android:inputType="text"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/product_download_name"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_150"
-                android:layout_marginEnd="@dimen/major_100"
-                android:hint="@string/product_downloadable_files_name"
-                android:inputType="text"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/product_download_url_info" />
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/product_download_url_info"
+                    style="@style/Woo.TextView.Caption"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_150"
+                    android:layout_marginEnd="@dimen/major_150"
+                    android:text="@string/product_downloadable_files_url_info"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/product_download_url" />
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/product_download_name_info"
-                style="@style/Woo.TextView.Caption"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_150"
-                android:layout_marginEnd="@dimen/major_150"
-                android:layout_marginBottom="@dimen/major_100"
-                android:text="@string/product_downloadable_files_name_info"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/product_download_name" />
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/product_download_name"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_150"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:hint="@string/product_downloadable_files_name"
+                    android:inputType="text"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/product_download_url_info" />
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.card.MaterialCardView>
-</androidx.core.widget.NestedScrollView>
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/product_download_name_info"
+                    style="@style/Woo.TextView.Caption"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_150"
+                    android:layout_marginEnd="@dimen/major_150"
+                    android:layout_marginBottom="@dimen/major_100"
+                    android:text="@string/product_downloadable_files_name_info"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/product_download_name" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.card.MaterialCardView>
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_downloads_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_downloads_list.xml
@@ -5,6 +5,17 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:title="@string/app_name" />
+
     <com.woocommerce.android.ui.products.AddProductElementView
         android:id="@+id/addProductDownloadsView"
         style="@style/Woo.Card"
@@ -12,7 +23,7 @@
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar"
         app:buttonText="@string/product_downloadable_files_add" />
 
     <androidx.recyclerview.widget.RecyclerView

--- a/WooCommerce/src/main/res/layout/fragment_product_downloads_settings.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_downloads_settings.xml
@@ -1,69 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <com.google.android.material.card.MaterialCardView
-        style="@style/Woo.Card"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Woo.Card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/product_download_limit"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_100"
-                android:layout_marginEnd="@dimen/major_100"
-                android:hint="@string/product_downloadable_files_limit"
-                android:inputType="number"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/product_download_limit_info"
-                style="@style/Woo.TextView.Caption"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_150"
-                android:layout_marginEnd="@dimen/major_150"
-                android:text="@string/product_downloadable_files_limit_info"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/product_download_limit" />
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/product_download_limit"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_100"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:hint="@string/product_downloadable_files_limit"
+                    android:inputType="number"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-                android:id="@+id/product_download_expiry"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_100"
-                android:layout_marginTop="@dimen/major_150"
-                android:layout_marginEnd="@dimen/major_100"
-                android:hint="@string/product_downloadable_files_expiry"
-                android:inputType="number"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/product_download_limit_info" />
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/product_download_limit_info"
+                    style="@style/Woo.TextView.Caption"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_150"
+                    android:layout_marginEnd="@dimen/major_150"
+                    android:text="@string/product_downloadable_files_limit_info"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/product_download_limit" />
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/product_download_expiry_info"
-                style="@style/Woo.TextView.Caption"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/major_150"
-                android:layout_marginEnd="@dimen/major_150"
-                android:layout_marginBottom="@dimen/major_100"
-                android:text="@string/product_downloadable_files_expiry_info"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/product_download_expiry" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.card.MaterialCardView>
-</androidx.core.widget.NestedScrollView>
+                <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                    android:id="@+id/product_download_expiry"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:layout_marginTop="@dimen/major_150"
+                    android:layout_marginEnd="@dimen/major_100"
+                    android:hint="@string/product_downloadable_files_expiry"
+                    android:inputType="number"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/product_download_limit_info" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/product_download_expiry_info"
+                    style="@style/Woo.TextView.Caption"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/major_150"
+                    android:layout_marginEnd="@dimen/major_150"
+                    android:layout_marginBottom="@dimen/major_100"
+                    android:text="@string/product_downloadable_files_expiry_info"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/product_download_expiry" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.card.MaterialCardView>
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_external_link.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_external_link.xml
@@ -1,37 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <com.woocommerce.android.widgets.WCElevatedLinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/major_100">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/product_url"
+    <ScrollView xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.woocommerce.android.widgets.WCElevatedLinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_75"
-            android:layout_marginEnd="@dimen/major_100"
-            android:hint="@string/product_external_link"
-            android:inputType="text"
-            app:helperText="@string/product_external_link_label" />
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/major_100">
 
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/product_button_text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/major_75"
-            android:layout_marginEnd="@dimen/major_100"
-            android:hint="@string/product_external_link_button_text"
-            android:inputType="text"
-            app:helperText="@string/product_external_link_button_text_label" />
-    </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/product_url"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_75"
+                android:layout_marginEnd="@dimen/major_100"
+                android:hint="@string/product_external_link"
+                android:inputType="text"
+                app:helperText="@string/product_external_link_label" />
 
-</ScrollView>
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/product_button_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/major_75"
+                android:layout_marginEnd="@dimen/major_100"
+                android:hint="@string/product_external_link_button_text"
+                android:inputType="text"
+                app:helperText="@string/product_external_link_button_text_label" />
+        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 
+    </ScrollView>
+
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_image_viewer.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_image_viewer.xml
@@ -10,6 +10,7 @@
 
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/viewPager"
+        android:layout_marginVertical="@dimen/major_375"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 

--- a/WooCommerce/src/main/res/layout/fragment_product_menu_order.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_menu_order.xml
@@ -1,9 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/colorSurface">
+    android:background="?attr/colorSurface"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
     <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
         android:id="@+id/product_menu_order"
@@ -14,5 +24,4 @@
         android:inputType="numberSigned"
         app:helperText="@string/product_menu_order_caption" />
 
-</ScrollView>
-
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_quantity_rules.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_quantity_rules.xml
@@ -1,134 +1,148 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <androidx.appcompat.widget.LinearLayoutCompat
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
-        <com.google.android.material.card.MaterialCardView
-            style="@style/Woo.Card"
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.appcompat.widget.LinearLayoutCompat
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="match_parent"
+            android:orientation="vertical">
 
-            <androidx.appcompat.widget.LinearLayoutCompat
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Woo.Card"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:layout_height="wrap_content">
 
                 <androidx.appcompat.widget.LinearLayoutCompat
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:focusable="true"
-                    android:orientation="vertical"
-                    android:screenReaderFocusable="true"
-                    tools:ignore="UnusedAttribute">
+                    android:orientation="vertical">
 
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/min_quantity_title"
-                        style="@style/Woo.Card.Title"
-                        android:layout_width="wrap_content"
+                    <androidx.appcompat.widget.LinearLayoutCompat
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:focusable="false"
-                        android:text="@string/min_quantity"
-                        android:textStyle="bold" />
+                        android:focusable="true"
+                        android:orientation="vertical"
+                        android:screenReaderFocusable="true"
+                        tools:ignore="UnusedAttribute">
 
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/min_quantity_value"
-                        style="@style/Woo.Card.Body"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/minor_100"
-                        tools:text="2"
-                        tools:visibility="visible" />
-                </androidx.appcompat.widget.LinearLayoutCompat>
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/min_quantity_title"
+                            style="@style/Woo.Card.Title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:focusable="false"
+                            android:text="@string/min_quantity"
+                            android:textStyle="bold" />
 
-                <com.google.android.material.divider.MaterialDivider
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:layout_marginStart="@dimen/major_100"
-                    android:layout_marginEnd="@dimen/major_100" />
-
-                <androidx.appcompat.widget.LinearLayoutCompat
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:focusable="true"
-                    android:orientation="vertical"
-                    android:screenReaderFocusable="true"
-                    tools:ignore="UnusedAttribute">
-
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/max_quantity_title"
-                        style="@style/Woo.Card.Title"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:focusable="false"
-                        android:text="@string/max_quantity"
-                        android:textStyle="bold" />
-
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/max_quantity_value"
-                        style="@style/Woo.Card.Body"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/minor_100"
-                        android:focusable="false"
-                        tools:text="24" />
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/min_quantity_value"
+                            style="@style/Woo.Card.Body"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="@dimen/minor_100"
+                            tools:text="2"
+                            tools:visibility="visible" />
+                    </androidx.appcompat.widget.LinearLayoutCompat>
 
                     <com.google.android.material.divider.MaterialDivider
                         android:layout_width="match_parent"
                         android:layout_height="1dp"
                         android:layout_marginStart="@dimen/major_100"
                         android:layout_marginEnd="@dimen/major_100" />
+
+                    <androidx.appcompat.widget.LinearLayoutCompat
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:focusable="true"
+                        android:orientation="vertical"
+                        android:screenReaderFocusable="true"
+                        tools:ignore="UnusedAttribute">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/max_quantity_title"
+                            style="@style/Woo.Card.Title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:focusable="false"
+                            android:text="@string/max_quantity"
+                            android:textStyle="bold" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/max_quantity_value"
+                            style="@style/Woo.Card.Body"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="@dimen/minor_100"
+                            android:focusable="false"
+                            tools:text="24" />
+
+                        <com.google.android.material.divider.MaterialDivider
+                            android:layout_width="match_parent"
+                            android:layout_height="1dp"
+                            android:layout_marginStart="@dimen/major_100"
+                            android:layout_marginEnd="@dimen/major_100" />
+                    </androidx.appcompat.widget.LinearLayoutCompat>
+
+                    <androidx.appcompat.widget.LinearLayoutCompat
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:focusable="true"
+                        android:orientation="vertical"
+                        android:screenReaderFocusable="true"
+                        tools:ignore="UnusedAttribute">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/group_of_title"
+                            style="@style/Woo.Card.Title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:focusable="false"
+                            android:text="@string/group_of"
+                            android:textStyle="bold" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/group_of_value"
+                            style="@style/Woo.Card.Body"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="@dimen/minor_100"
+                            android:focusable="false"
+                            tools:text="2" />
+                    </androidx.appcompat.widget.LinearLayoutCompat>
                 </androidx.appcompat.widget.LinearLayoutCompat>
 
-                <androidx.appcompat.widget.LinearLayoutCompat
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:focusable="true"
-                    android:orientation="vertical"
-                    android:screenReaderFocusable="true"
-                    tools:ignore="UnusedAttribute">
+            </com.google.android.material.card.MaterialCardView>
 
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/group_of_title"
-                        style="@style/Woo.Card.Title"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:focusable="false"
-                        android:text="@string/group_of"
-                        android:textStyle="bold" />
+            <com.google.android.material.textview.MaterialTextView
+                style="@style/Woo.TextView.Caption"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginTop="@dimen/minor_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:drawableStart="@drawable/ic_deprecated_info_outline_24dp"
+                android:drawablePadding="@dimen/minor_100"
+                android:gravity="center_vertical"
+                android:text="@string/quantity_rules_info_notice"
+                android:visibility="visible"
+                tools:text="You can edit product subscriptions in the web dashboard." />
+        </androidx.appcompat.widget.LinearLayoutCompat>
 
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/group_of_value"
-                        style="@style/Woo.Card.Body"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/minor_100"
-                        android:focusable="false"
-                        tools:text="2" />
-                </androidx.appcompat.widget.LinearLayoutCompat>
-            </androidx.appcompat.widget.LinearLayoutCompat>
+    </androidx.core.widget.NestedScrollView>
 
-        </com.google.android.material.card.MaterialCardView>
-
-        <com.google.android.material.textview.MaterialTextView
-            style="@style/Woo.TextView.Caption"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginTop="@dimen/minor_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:drawableStart="@drawable/ic_deprecated_info_outline_24dp"
-            android:drawablePadding="@dimen/minor_100"
-            android:gravity="center_vertical"
-            android:text="@string/quantity_rules_info_notice"
-            android:visibility="visible"
-            tools:text="You can edit product subscriptions in the web dashboard." />
-    </androidx.appcompat.widget.LinearLayoutCompat>
-
-</androidx.core.widget.NestedScrollView>
-
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_settings.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_settings.xml
@@ -1,122 +1,139 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
-        <com.woocommerce.android.widgets.WCElevatedLinearLayout
+    <ScrollView xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-                android:id="@+id/productStatus"
+            <com.woocommerce.android.widgets.WCElevatedLinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:optionTitle="@string/product_status"
-                tools:optionValue="Draft" />
+                android:orientation="vertical">
 
-            <View style="@style/Woo.Divider.TitleAligned" />
+                <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                    android:id="@+id/productStatus"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:optionTitle="@string/product_status"
+                    tools:optionValue="Draft" />
 
-            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-                android:id="@+id/productVisibility"
+                <View style="@style/Woo.Divider.TitleAligned" />
+
+                <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                    android:id="@+id/productVisibility"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:optionTitle="@string/product_visibility"
+                    tools:optionValue="Draft" />
+
+                <View style="@style/Woo.Divider.TitleAligned" />
+
+                <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                    android:id="@+id/productCatalogVisibility"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:optionTitle="@string/product_catalog_visibility"
+                    tools:optionValue="Shop only" />
+
+                <View
+                    android:id="@+id/productIsVirtualDivider"
+                    style="@style/Woo.Divider.TitleAligned" />
+
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/productIsVirtual"
+                    style="@style/Widget.Woo.Settings"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="@dimen/major_100"
+                    android:text="@string/product_is_virtual" />
+
+                <View
+                    android:id="@+id/productIsDownloadableDivider"
+                    style="@style/Woo.Divider.TitleAligned" />
+
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/productIsDownloadable"
+                    style="@style/Widget.Woo.Settings"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="@dimen/major_100"
+                    android:text="@string/product_is_downloadable" />
+            </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+
+            <com.woocommerce.android.widgets.WCElevatedLinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:optionTitle="@string/product_visibility"
-                tools:optionValue="Draft" />
+                android:layout_marginTop="@dimen/minor_100"
+                android:orientation="vertical">
 
-            <View style="@style/Woo.Divider.TitleAligned" />
+                <com.google.android.material.textview.MaterialTextView
+                    style="@style/Widget.Woo.Settings.CategoryHeader"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="@dimen/major_100"
+                    android:text="@string/more_options"
+                    android:textColor="@color/color_on_surface_disabled" />
 
-            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-                android:id="@+id/productCatalogVisibility"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:optionTitle="@string/product_catalog_visibility"
-                tools:optionValue="Shop only" />
+                <View style="@style/Woo.Divider.TitleAligned" />
 
-            <View android:id="@+id/productIsVirtualDivider" style="@style/Woo.Divider.TitleAligned" />
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/productReviewsAllowed"
+                    style="@style/Widget.Woo.Settings"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="@dimen/major_100"
+                    android:text="@string/product_enable_reviews" />
 
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:id="@+id/productIsVirtual"
-                style="@style/Widget.Woo.Settings"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:padding="@dimen/major_100"
-                android:text="@string/product_is_virtual" />
+                <View
+                    android:id="@+id/productReviewsAllowedDivider"
+                    style="@style/Woo.Divider.TitleAligned" />
 
-            <View android:id="@+id/productIsDownloadableDivider" style="@style/Woo.Divider.TitleAligned" />
+                <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                    android:id="@+id/productSlug"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:optionTitle="@string/product_slug"
+                    tools:optionValue="Slug" />
 
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:id="@+id/productIsDownloadable"
-                style="@style/Widget.Woo.Settings"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:padding="@dimen/major_100"
-                android:text="@string/product_is_downloadable" />
-        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+                <View style="@style/Woo.Divider.TitleAligned" />
 
-        <com.woocommerce.android.widgets.WCElevatedLinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/minor_100"
-            android:orientation="vertical">
+                <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                    android:id="@+id/productPurchaseNote"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:optionTitle="@string/product_purchase_note"
+                    app:optionValueMaxLines="2"
+                    tools:optionValue="Purchase note" />
 
-            <com.google.android.material.textview.MaterialTextView
-                style="@style/Widget.Woo.Settings.CategoryHeader"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:padding="@dimen/major_100"
-                android:text="@string/more_options"
-                android:textColor="@color/color_on_surface_disabled" />
+                <View style="@style/Woo.Divider.TitleAligned" />
 
-            <View style="@style/Woo.Divider.TitleAligned" />
+                <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                    android:id="@+id/productMenuOrder"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:optionTitle="@string/product_menu_order"
+                    tools:optionValue="0" />
 
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:id="@+id/productReviewsAllowed"
-                style="@style/Widget.Woo.Settings"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:padding="@dimen/major_100"
-                android:text="@string/product_enable_reviews" />
+                <View style="@style/Woo.Divider" />
 
-            <View
-                android:id="@+id/productReviewsAllowedDivider"
-                style="@style/Woo.Divider.TitleAligned" />
-
-            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-                android:id="@+id/productSlug"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:optionTitle="@string/product_slug"
-                tools:optionValue="Slug" />
-
-            <View style="@style/Woo.Divider.TitleAligned" />
-
-            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-                android:id="@+id/productPurchaseNote"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:optionTitle="@string/product_purchase_note"
-                app:optionValueMaxLines="2"
-                tools:optionValue="Purchase note" />
-
-            <View style="@style/Woo.Divider.TitleAligned" />
-
-            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
-                android:id="@+id/productMenuOrder"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:optionTitle="@string/product_menu_order"
-                tools:optionValue="0" />
-
-            <View style="@style/Woo.Divider" />
-
-        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
-    </LinearLayout>
-</ScrollView>
+            </com.woocommerce.android.widgets.WCElevatedLinearLayout>
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_slug.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_slug.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/colorSurface">
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
     <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
         android:id="@+id/editSlug"
@@ -15,4 +23,4 @@
         android:inputType="text"
         app:helperText="@string/product_slug_label" />
 
-</FrameLayout>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_status.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_status.xml
@@ -5,10 +5,18 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?attr/colorSurface"
-    android:orientation="vertical"
-    android:paddingTop="@dimen/minor_100">
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
     <CheckedTextView
+        android:layout_marginTop="@dimen/minor_100"
         android:id="@+id/btnPublishedPrivately"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WooCommerce/src/main/res/layout/fragment_product_tags.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_tags.xml
@@ -1,63 +1,78 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/productTagsLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.woocommerce.android.ui.products.tags.ProductTagsFragment">
+    android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
-        <com.woocommerce.android.ui.products.tags.AddProductTagView
-            android:id="@+id/addProductTagView"
-            style="@style/Woo.Card"
+    <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/productTagsLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context="com.woocommerce.android.ui.products.tags.ProductTagsFragment">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:layout_height="match_parent">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/productTagsRecycler"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:background="?attr/colorSurface"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/addProductTagView"
-            app:layout_constraintVertical_bias="0.0"
-            tools:itemCount="25"
-            tools:listitem="@layout/product_tag_list_item"
-            tools:visibility="visible" />
+            <com.woocommerce.android.ui.products.tags.AddProductTagView
+                android:id="@+id/addProductTagView"
+                style="@style/Woo.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-        <com.woocommerce.android.widgets.WCEmptyView
-            android:id="@+id/empty_view"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/addProductTagView"
-            app:layout_constraintVertical_bias="0.0"
-            tools:visibility="gone" />
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/productTagsRecycler"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:background="?attr/colorSurface"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/addProductTagView"
+                app:layout_constraintVertical_bias="0.0"
+                tools:itemCount="25"
+                tools:listitem="@layout/product_tag_list_item"
+                tools:visibility="visible" />
 
-        <ProgressBar
-            android:id="@+id/loadMoreTagsProgress"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:layout_centerHorizontal="true"
-            android:layout_marginBottom="@dimen/major_75"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            tools:visibility="gone" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+            <com.woocommerce.android.widgets.WCEmptyView
+                android:id="@+id/empty_view"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/addProductTagView"
+                app:layout_constraintVertical_bias="0.0"
+                tools:visibility="gone" />
+
+            <ProgressBar
+                android:id="@+id/loadMoreTagsProgress"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:layout_centerHorizontal="true"
+                android:layout_marginBottom="@dimen/major_75"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                tools:visibility="gone" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_visibility.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_visibility.xml
@@ -1,57 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/colorSurface">
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/minor_100"
-        android:orientation="vertical">
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
-        <CheckedTextView
-            android:id="@+id/btnPublic"
+    <ScrollView
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/colorSurface">
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/product_visibility_public" />
+            android:layout_marginTop="@dimen/minor_100"
+            android:orientation="vertical">
 
-        <View
-            style="@style/Woo.Divider"
-            android:layout_marginStart="@dimen/major_100" />
+            <CheckedTextView
+                android:id="@+id/btnPublic"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/product_visibility_public" />
 
-        <CheckedTextView
-            android:id="@+id/btnPasswordProtected"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/product_visibility_password_protected" />
+            <View
+                style="@style/Woo.Divider"
+                android:layout_marginStart="@dimen/major_100" />
 
-        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-            android:id="@+id/editPassword"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/major_100"
-            android:layout_marginEnd="@dimen/major_100"
-            android:layout_marginBottom="@dimen/major_100"
-            android:inputType="textPassword"
-            android:visibility="gone"
-            android:hint="@string/product_visibility_password_protected_hint"
-            app:hintEnabled="true"
-            tools:visibility="visible" />
+            <CheckedTextView
+                android:id="@+id/btnPasswordProtected"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/product_visibility_password_protected" />
 
-        <View
-            style="@style/Woo.Divider"
-            android:layout_marginStart="@dimen/major_100" />
+            <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+                android:id="@+id/editPassword"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_100"
+                android:layout_marginEnd="@dimen/major_100"
+                android:layout_marginBottom="@dimen/major_100"
+                android:hint="@string/product_visibility_password_protected_hint"
+                android:inputType="textPassword"
+                android:visibility="gone"
+                app:hintEnabled="true"
+                tools:visibility="visible" />
 
-        <CheckedTextView
-            android:id="@+id/btnPrivate"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/product_visibility_private" />
+            <View
+                style="@style/Woo.Divider"
+                android:layout_marginStart="@dimen/major_100" />
 
-        <View style="@style/Woo.Divider" />
+            <CheckedTextView
+                android:id="@+id/btnPrivate"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/product_visibility_private" />
 
-    </LinearLayout>
-</ScrollView>
+            <View style="@style/Woo.Divider" />
+
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_rename_attribute.xml
+++ b/WooCommerce/src/main/res/layout/fragment_rename_attribute.xml
@@ -8,6 +8,14 @@
     android:orientation="vertical"
     tools:context="com.woocommerce.android.ui.products.variations.attributes.RenameAttributeFragment">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
+
     <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
         android:id="@+id/attributeName"
         android:layout_width="match_parent"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10879
<!-- Id number of the GitHub issue this PR addresses. --


### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds individual toolbars for some fragments that are shown from the product details fragment

1 commit == 1 fragment

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

* **The most important** to make sure that there is regression brought to the case when FF is OFF
* It is known that some fragments don't have a Toolbar yet on the 2 panes layout

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/4923871/57bcfd32-5d87-4f02-8b20-7542ae7be9c1



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
