### PR TITLE
[Tablet Support M2] Prevent ConcurrentModificationException in ProductImageMap with CopyOnWriteArrayList

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload
 import java.lang.ref.WeakReference
+import java.util.concurrent.CopyOnWriteArrayList
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -27,7 +28,7 @@ class ProductImageMap @Inject constructor(
         fun onProductFetched(remoteProductId: Long)
     }
 
-    private val observers: MutableList<WeakReference<OnProductFetchedListener>> = mutableListOf()
+    private val observers: MutableList<WeakReference<OnProductFetchedListener>> = CopyOnWriteArrayList()
 
     private val map by lazy {
         HashMap<Long, String>()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10901
<!-- Id number of the GitHub issue this PR addresses. -->

### Description

To address the `ConcurrentModificationException` in the `ProductImageMap` class during concurrent modifications and iterations over the observer list, I opted to switch from a standard `ArrayList` to `CopyOnWriteArrayList`. This decision comes after considering alternatives like `ConcurrentHashMap` and explicit synchronization we had discussed.
 
CopyOnWriteArrayList aligns well with our use case, where observer list reads far outnumber writes, providing thread-safe operations without the overhead of synchronization.

I'm open to feedback and willing to explore other options if there are concerns about this approach.

### Testing instructions

1. Switch from one store to the next. 
2. Open the Orders tab. 
3. Notice no crash takes place.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
