### PR TITLE
[Tablet Support M2] [Bug] Navigation on back press doesn't pop details backstack

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -160,7 +160,9 @@ class OrderListFragment :
                 override fun handleOnBackPressed() {
                     selectedOrder.selectOrder(-1L)
                     if (isTablet()) {
-                        findNavController().popBackStack()
+                        if (!binding.detailPaneContainer.findNavController().popBackStack()) {
+                            findNavController().popBackStack()
+                        }
                     } else if (isSearching) {
                         handleSearchViewCollapse()
                     } else {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #https://github.com/woocommerce/woocommerce-android/issues/10908
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In the two-pane mode on the Orders screen, the back button navigation redirects directly to the My Store screen. Instead, we should navigate up the detail pane's nav stack first, and when it's empty navigate up the main back stack of fragments.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
To reproduce the bug on base branch:
1. Open Orders in two-pane mode
2. Navigate to next fragment in detail pane, eg. click + Add note
3. Press back button 
Observe that we are redirected to My Store instead of going back to order details in the detail pane.

Verify this is fixed on the current branch.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->