### PR TITLE
Fix ProductImageMap ConcurrentModificationException by Safely Managing WeakReferences

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
@@ -70,9 +70,7 @@ class ProductImageMap @Inject constructor(
                                 weakReference.get()?.onProductFetched(remoteProductId) ?: toRemove.add(weakReference)
                             }
                             // Remove the collected references
-                            toRemove.forEach { weakReference ->
-                                observers.remove(weakReference)
-                            }
+                            observers.removeAll(toRemove)
                         }
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/ProductImageMap.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WCProductStore
 import org.wordpress.android.fluxc.store.WCProductStore.FetchSingleProductPayload
 import java.lang.ref.WeakReference
-import java.util.concurrent.CopyOnWriteArrayList
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -28,7 +27,7 @@ class ProductImageMap @Inject constructor(
         fun onProductFetched(remoteProductId: Long)
     }
 
-    private val observers: MutableList<WeakReference<OnProductFetchedListener>> = CopyOnWriteArrayList()
+    private val observers: MutableList<WeakReference<OnProductFetchedListener>> = mutableListOf()
 
     private val map by lazy {
         HashMap<Long, String>()
@@ -64,11 +63,15 @@ class ProductImageMap @Inject constructor(
                     val result = productStore.fetchSingleProduct(FetchSingleProductPayload(site, remoteProductId))
                     if (!result.isError) {
                         withContext(dispatchers.main) {
+                            // Collect references to remove
+                            val toRemove = mutableListOf<WeakReference<OnProductFetchedListener>>()
                             observers.forEach { weakReference ->
-                                // notify the observer
-                                weakReference.get()?.onProductFetched(remoteProductId)
-                                    // remove the weak reference if the observer was garbage collected
-                                    ?: observers.remove(weakReference)
+                                // notify the observer or collect it for removal if it's been garbage collected
+                                weakReference.get()?.onProductFetched(remoteProductId) ?: toRemove.add(weakReference)
+                            }
+                            // Remove the collected references
+                            toRemove.forEach { weakReference ->
+                                observers.remove(weakReference)
                             }
                         }
                     }


### PR DESCRIPTION
Closes: #10901
### Description

In addressing the `ConcurrentModificationException` within the `ProductImageMap` class, we opted to refine our approach by removing the previously implemented `CopyOnWriteArrayList` and instead directly tackling the issue with WeakReference objects in the observer list. Thanks to @malinajirka for this exploration. 

The revised solution is an improvement to the PR https://github.com/woocommerce/woocommerce-android/pull/10902 It involves a two-step modification process: initially, the code iterates over the observer list, identifying any `WeakReference` objects that have been cleared due to garbage collection and adding them to a temporary list. This method prevents the direct modification of the observer list during iteration, which was the primary cause of the exception. 
Following this, the code iterates over the temporary list to safely remove the identified references from the original observer list. By reverting the `CopyOnWriteArrayList` implementation and focusing on the specific management of `WeakReference` objects, this solution effectively addresses the root cause of the exception, ensuring the integrity of the observer list without incurring the overhead associated with introducing `CopyOnWriteArrayList`.

### Testing instructions

1. Switch from one store to the next.
2. Open the Orders tab.
3. Notice no crash takes place.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
