### PR TITLE
[Better Tablet Products] Fix back navigation on 2 pane layout

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListToolbarHelper.kt
@@ -9,6 +9,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.navigation.findNavController
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
@@ -41,7 +42,9 @@ class ProductListToolbarHelper @Inject constructor(
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
                     if (isTabletLogicNeeded()) {
-                        fragment?.findNavController()?.navigateUp()
+                        if (binding?.detailNavContainer?.findNavController()?.popBackStack() != true) {
+                            fragment?.findNavController()?.popBackStack()
+                        }
                     } else if (searchMenuItem?.isActionViewExpanded == true) {
                         searchMenuItem?.collapseActionView()
                     } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
+import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
 import com.woocommerce.android.R
 import org.wordpress.android.util.DisplayUtils
@@ -35,10 +36,14 @@ class TabletLayoutSetupHelper @Inject constructor(
         navigateWithPhoneNavigation: () -> Unit
     ) {
         if (isTabletLogicNeeded()) {
+            val navOptions = NavOptions.Builder()
+                .setPopUpTo(navHostFragment.navController.graph.startDestinationId, true)
+                .build()
             val navigationData = tabletNavigateTo()
             navHostFragment.navController.navigate(
-                navigationData.first,
-                navigationData.second,
+                resId = navigationData.first,
+                args = navigationData.second,
+                navOptions = navOptions
             )
         } else {
             navigateWithPhoneNavigation()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10831
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes back navigation on 2 panes layout

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
* Open products
* Select product
* Open any product attributes
* Use the system "back" button 
* Notice that it behaves the same way as the on-screen "up" button

Make sure that there is no regression when FF is OFF.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/6088c9e7-60c1-41fa-a067-847e5e20ae15


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
