### PR TITLE
[Tablet Support] Order Details - Pencil Icon Clickability in Customer Note Section

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -230,6 +230,10 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         binding.customerInfoCustomerNote.setIsReadOnly(isReadOnly)
 
         if (!isReadOnly) {
+            binding.customerInfoCustomerNote.binding.notEmptyLabel.setClickableParent(
+                binding.customerInfoCustomerNoteSection
+            )
+
             binding.customerInfoCustomerNoteSection.setOnClickListener {
                 val action =
                     OrderDetailFragmentDirections.actionOrderDetailFragmentToEditCustomerOrderNoteFragment(


### PR DESCRIPTION
Closes: #10914
<!-- Id number of the GitHub issue this PR addresses. -->

### Description

In this PR I introduce a minor change to `OrderDetailCustomerInfoView` which addresses a critical usability issue where the pencil icon, used for editing customer notes, was not responding to click events as expected. 

This problem was rooted in the interaction complexities introduced by `WCSelectableTextView`, a custom view designed to enhance text selection capabilities within our app. Specifically, when `WCSelectableTextView` is in a selectable state, it inadvertently intercepts click events, preventing them from reaching intended targets like our pencil icon. 

To circumvent this, I employed the `setClickableParent` method, a strategy already proven effective in other parts of the codebase, such as the billing address section in `OrderDetailCustomerInfoView`.
 
By applying this method, I directed the click events from the `WCSelectableTextView` to a parent view that correctly handles the action, restoring the pencil icon's expected functionality. 

### Testing instructions

1. Go to an order. 
2. Open Order Details. 
3. Add a Customer Note. 
4. Save it. 
5. Utilize the pencil icon to edit the note. 
6. Notice it allows the customer note to be edited. 

<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
