### PR TITLE
[Tablet Support M2] Fix back navigation on Order screen on phones

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -174,7 +174,7 @@ class OrderListFragment :
                             // In this case we need to switch panes – show the list pane instead of details pane.
                             adjustUiForDeviceType(savedInstanceState)
                         } else {
-                            requireActivity().onBackPressedDispatcher.onBackPressed()
+                            findNavController().popBackStack()
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
[Tablet Support M2] Fix back navigation on Order screen on phones

Closes: #10919
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The `OnBackPressedCallback` implementation in `OrderListFragment` had a bug resulting in an infinite loop of invocations.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
To Reproduce
Steps to reproduce the behavior on trunk:

1. Go to Order List
2. Tap on back and wait for app to crash

Verify the back navigation is working well on both tablets and phones

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
