### PR TITLE
Skip `hilt` in unit tests. Do not execute `ksp` on unit test sources.

### DIFF
--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -3,7 +3,7 @@
 echo "--- 🧪 Testing"
 set +e
 cp gradle.properties-example gradle.properties
-./gradlew testJalapenoDebug lib:cardreader:testDebug lib:iap:testDebug
+./gradlew testJalapenoDebugUnitTest lib:cardreader:testDebugUnitTest lib:iap:testDebugUnitTest
 TESTS_EXIT_STATUS=$?
 set -e
 

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -551,3 +551,4 @@ if (project.hasProperty("debugStoreFile")) {
     }
 }
 
+apply from: '../config/gradle/build_optimization.gradle'

--- a/config/gradle/build_optimization.gradle
+++ b/config/gradle/build_optimization.gradle
@@ -1,0 +1,9 @@
+for (taskName in gradle.startParameter.taskNames) {
+    if (taskName.contains("UnitTest")) {
+        tasks.matching { it.name.startsWith("hilt") }
+                .configureEach {
+                    logger.warn("Disabling task ${it.name} for unit tests")
+                    enabled = false
+                }
+    }
+}

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -16,6 +16,8 @@ org.gradle.jvmargs=-Xmx8g
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
+ksp.allow.all.target.configuration=false
+
 # Enables Gradle Build Cache - https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching=true
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR disables `ksp` (on test sources) and `hilt` tasks when executing unit tests, to improve their performance.

Following approval of this PR, I'll update our secret `gradle.properties`.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
#### ksp task
1. Assert that `ksp.allow.all.target.configuration=false` is in your `gradle.properties`
2. Run some unit test, e.g. `:WooCommerce:testWasabiDebugUnitTest --tests com.woocommerce.android.model.AddressTest.when name is blank, then nullify the name of data model`
3. Assert, using Gradle Scan, that there are no `ksp(...)UnitTest` tasks executed

#### hilt task
1. Run some unit test, e.g. `:WooCommerce:testWasabiDebugUnitTest --tests com.woocommerce.android.model.AddressTest.when name is blank, then nullify the name of data model`
3. Assert, using Gradle Scan, that all tasks that contain`hilt` in their name are skipped


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
