### PR TITLE
[Beta fix 17.5] Fix NullPointerException in OrderListFragment::onSaveInstanceState

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -341,10 +341,9 @@ class OrderListFragment :
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putBoolean(STATE_KEY_IS_SEARCHING, isSearching)
         outState.putString(STATE_KEY_SEARCH_QUERY, searchQuery)
-        super.onSaveInstanceState(outState)
-        val navHostFragment = childFragmentManager.findFragmentById(R.id.detailPaneContainer) as NavHostFragment
-        val currentDestinationId = navHostFragment.navController.currentDestination?.id
         if (isTablet()) {
+            val navHostFragment = childFragmentManager.findFragmentById(R.id.detailPaneContainer) as? NavHostFragment
+            val currentDestinationId = navHostFragment?.navController?.currentDestination?.id
             outState.putInt(CURRENT_NAV_DESTINATION, currentDestinationId ?: -1)
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10935
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR intends to fix `NullPointerException` discovered in Sentry: [WOOCOMMERCE-ANDROID-9FX](https://a8c.sentry.io/issues/5014186560/?referrer=github_integration)

I wasn't able to reproduce the crash on my devices. However, the PR addresses the potential place where `NullPointerException` is occurring by making the class cast operation safe and introducing null checks.

### Testing instructions
Verify that the app does not crash when `OrderListFragment::onSaveInstanceState` is called on both tablet and phone.

To seek for reproducing the crash, checkout the branch `release/17.5`.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
