### PR TITLE
Automate the Play Store submission

### DIFF
--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -1,9 +1,17 @@
 steps:
+  - input: "What version code do you want to use for the new hotfix release?"
+    fields:
+      - text: "Version Code"
+        key: "version_code"
+        format: "[0-9]+" # Only allow numbers
   - label: "New Hotfix Release"
     plugins:
       - automattic/a8c-ci-toolkit#3.0.1
     command: |
       .buildkite/commands/configure-environment.sh
 
+      # Get the version code from the Buildkite 'input' step
+      VERSION_CODE=$(buildkite-agent meta-data get version_code)
+
       echo '--- :fire: Start New Hotfix Release'
-      bundle exec fastlane new_hotfix_release version:${VERSION} skip_confirm:true
+      bundle exec fastlane new_hotfix_release version_name:${VERSION} version_code:${VERSION_CODE} skip_confirm:true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1125,7 +1125,7 @@ platform :android do
   # Usage:
   # bundle exec fastlane build_and_upload_prototype_build
   #####################################################################################
-  desc 'Builds an APK'
+  desc 'Builds a prototype build and uploads it to S3'
   lane :build_and_upload_prototype_build do |_options|
     UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1116,12 +1116,12 @@ platform :android do
   end
 
   #####################################################################################
-  # build_apk
+  # build_and_upload_prototype_build
   # -----------------------------------------------------------------------------------
-  # This lane builds an apk
+  # This lane builds a prototype build and uploads it to S3
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_apk
+  # bundle exec fastlane build_and_upload_prototype_build
   #####################################################################################
   desc 'Builds an APK'
   lane :build_and_upload_prototype_build do |_options|
@@ -1188,7 +1188,7 @@ platform :android do
 
   # Creates a new GitHub Release for the given version
   #
-  # @param [Hash<String>] version The version to create. Expects keys "name" and "code"
+  # @param [String] version The version to create.
   # @param [Bool] prerelease If true, the GitHub Release will have the prerelease flag
   #
   private_lane :create_gh_release do |options|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -641,9 +641,10 @@ platform :android do
       package_name: APP_PACKAGE_NAME,
       aab: aab_file_path,
       track: 'production',
-      release_status: 'draft',
+      release_status: 'inProgress',
+      rollout: '0.1', # Start the production rollout at 10%
       skip_upload_metadata: false,
-      skip_upload_changelogs: true,
+      skip_upload_changelogs: false,
       skip_upload_images: true,
       skip_upload_screenshots: true,
       json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY,
@@ -694,7 +695,8 @@ platform :android do
       package_name: APP_PACKAGE_NAME,
       aab: aab_file_path,
       track: 'beta',
-      release_status: 'draft',
+      release_status: 'completed',
+      rollout: '1.0', # Rollout to 100% of testers on the beta track
       skip_upload_metadata: true,
       skip_upload_changelogs: true,
       skip_upload_images: true,


### PR DESCRIPTION
This PR automates a few more steps to make releases faster and easier as we turn them over to the product teams: 
- Adds a [Buildkite input step](https://buildkite.com/docs/pipelines/input-step) so that the version code for hotfixes can be manually set during the hotfix creation
- Automates the Play Store submission process. Beta builds will automatically be submitted to review. Production builds will automatically have the release notes uploaded and the rollout percentage set. 
- Clarifies a few comments in the Fastfile

I set the base branch as `release/17.5` instead of `trunk` so that these changes can be tested sooner.