### PR TITLE
[Blaze] Error state for location search + Unit tests

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetLocationSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetLocationSelectionViewModel.kt
@@ -13,9 +13,7 @@ import com.woocommerce.android.ui.blaze.Location
 import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState
 import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState.Hidden
 import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState.Inactive
-import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState.NoResults
 import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState.Ready
-import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState.Results
 import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState.Results.SearchItem
 import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState.Searching
 import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SelectionItem
@@ -27,10 +25,12 @@ import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -54,6 +54,7 @@ class BlazeCampaignTargetLocationSelectionViewModel @Inject constructor(
         initialValue = navArgs.locations.map { TargetLocation(it, true) }
     )
     private val searchQuery = savedStateHandle.getStateFlow(viewModelScope, initialValue = "")
+    private val searchTrigger = MutableSharedFlow<Boolean>(extraBufferCapacity = 1)
 
     override val viewState = combine(
         items,
@@ -75,35 +76,45 @@ class BlazeCampaignTargetLocationSelectionViewModel @Inject constructor(
     }
 
     private suspend fun fetchLocations(query: String) = blazeRepository.fetchLocations(query)
-        .getOrNull()
-        ?.asSequence()
-        ?.filterNot { location ->
-            location.id in items.value.map { it.location.id }
-        }?.map { location ->
-            SearchItem(
-                id = location.id.toString(),
-                title = location.name,
-                subtitle = location.parent,
-                type = location.type
-            )
-        }?.toList() ?: emptyList()
+        .map { locations ->
+            locations.asSequence()
+                .filterNot { location ->
+                    location.id in items.value.map { it.location.id }
+                }.map { location ->
+                    SearchItem(
+                        id = location.id.toString(),
+                        title = location.name,
+                        subtitle = location.parent,
+                        type = location.type
+                    )
+                }.toList()
+        }
 
     private fun observeSearchQuery() {
-        searchQuery
-            .debounce { query -> if (query.isEmpty()) 0L else AppConstants.SEARCH_TYPING_DELAY_MS }
-            .onEach { query ->
+        combine(
+            searchTrigger.onStart { emit(false) },
+            searchQuery
+        ) { fromTrigger, query -> Pair(fromTrigger, query) }
+            .debounce { (fromTrigger, query) ->
+                if (fromTrigger || query.isEmpty()) 0L else AppConstants.SEARCH_TYPING_DELAY_MS
+            }
+            .onEach { (_, query) ->
                 if (query.length > 2) {
                     searchState.update { Searching }
 
-                    val items = fetchLocations(query)
-
-                    searchState.update {
-                        if (items.isEmpty()) {
-                            NoResults
-                        } else {
-                            Results(items)
+                    val state = fetchLocations(query).fold(
+                        onSuccess = {
+                            if (it.isEmpty()) {
+                                SearchState.NoResults
+                            } else {
+                                SearchState.Results(it)
+                            }
+                        },
+                        onFailure = {
+                            SearchState.Error
                         }
-                    }
+                    )
+                    searchState.update { state }
                 } else {
                     searchState.update { Ready }
                 }
@@ -168,6 +179,10 @@ class BlazeCampaignTargetLocationSelectionViewModel @Inject constructor(
             isActive -> searchState.update { Ready }
             else -> searchState.update { Inactive }
         }
+    }
+
+    override fun onRetrySearchTapped() {
+        searchTrigger.tryEmit(true)
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionScreen.kt
@@ -45,17 +45,14 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.string
-import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState.Hidden
+import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState
 import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState.Inactive
-import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState.NoResults
-import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState.Ready
-import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState.Results
 import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState.Results.SearchItem
-import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SearchState.Searching
 import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SelectionItem
 import com.woocommerce.android.ui.compose.component.MultiSelectAllItemsButton
 import com.woocommerce.android.ui.compose.component.MultiSelectList
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCSearchField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
@@ -71,7 +68,8 @@ fun BlazeCampaignTargetSelectionScreen(viewModel: TargetSelectionViewModel) {
             onSearchItemTapped = viewModel::onSearchItemTapped,
             onAllButtonTapped = viewModel::onAllButtonTapped,
             onSearchQueryChanged = viewModel::onSearchQueryChanged,
-            onSearchActiveStateChanged = viewModel::onSearchActiveStateChanged
+            onSearchActiveStateChanged = viewModel::onSearchActiveStateChanged,
+            onRetrySearchTapped = viewModel::onRetrySearchTapped
         )
     }
 }
@@ -85,7 +83,8 @@ private fun TargetSelectionScreen(
     onSearchItemTapped: (SearchItem) -> Unit,
     onAllButtonTapped: () -> Unit,
     onSearchQueryChanged: (String) -> Unit,
-    onSearchActiveStateChanged: (Boolean) -> Unit
+    onSearchActiveStateChanged: (Boolean) -> Unit,
+    onRetrySearchTapped: () -> Unit
 ) {
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
@@ -98,7 +97,7 @@ private fun TargetSelectionScreen(
                 onNavigationButtonClick = onBackPressed,
                 navigationIcon = Filled.ArrowBack,
                 actions = {
-                    if (state.searchState is Hidden || state.searchState is Inactive) {
+                    if (state.searchState is SearchState.Hidden || state.searchState is Inactive) {
                         WCTextButton(
                             onClick = onSaveTapped,
                             enabled = state.isSaveButtonEnabled,
@@ -110,14 +109,17 @@ private fun TargetSelectionScreen(
         },
         modifier = Modifier
             .background(MaterialTheme.colors.surface)
-            .clickable(indication = null, interactionSource = interactionSource) { focusManager.clearFocus() } // Clear focus when clicked outside
+            .clickable(
+                indication = null,
+                interactionSource = interactionSource
+            ) { focusManager.clearFocus() } // Clear focus when clicked outside
     ) { paddingValues ->
         Column(
             modifier = Modifier
                 .background(MaterialTheme.colors.surface)
                 .padding(paddingValues)
         ) {
-            if (state.searchState != Hidden) {
+            if (state.searchState != SearchState.Hidden) {
                 val searchQuery = remember { mutableStateOf(state.searchQuery) }
                 val newLineRegex = Regex("[\n\r]")
 
@@ -146,14 +148,20 @@ private fun TargetSelectionScreen(
             }
 
             when (state.searchState) {
-                is Searching, is Results, is NoResults, is Ready -> {
+                is SearchState.Searching,
+                is SearchState.Results,
+                is SearchState.NoResults,
+                is SearchState.Ready,
+                is SearchState.Error -> {
                     SearchList(
-                        state = state,
+                        state = state.searchState,
                         focusManager = focusManager,
                         onSearchItemTapped = onSearchItemTapped,
+                        onRetrySearchTapped = onRetrySearchTapped,
                         modifier = Modifier.weight(1f)
                     )
                 }
+
                 else -> {
                     MultiSelectList(
                         items = state.items,
@@ -177,13 +185,14 @@ private fun TargetSelectionScreen(
 
 @Composable
 private fun SearchList(
-    state: TargetSelectionViewState,
+    state: SearchState,
     focusManager: FocusManager,
     onSearchItemTapped: (SearchItem) -> Unit,
+    onRetrySearchTapped: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    when (state.searchState) {
-        is Searching -> {
+    when (state) {
+        is SearchState.Searching -> {
             Box(
                 modifier = modifier
                     .fillMaxSize()
@@ -196,11 +205,12 @@ private fun SearchList(
                 )
             }
         }
-        is Results -> {
+
+        is SearchState.Results -> {
             LazyColumn(
                 modifier = modifier
             ) {
-                items(state.searchState.resultItems) { item ->
+                items(state.resultItems) { item ->
                     SearchListItem(
                         item = item,
                         onItemTapped = {
@@ -212,11 +222,31 @@ private fun SearchList(
                 }
             }
         }
-        is NoResults -> {
+
+        is SearchState.NoResults -> {
             val image = painterResource(id = R.drawable.search_failed_illustration)
             val message = stringResource(id = string.blaze_campaign_creation_location_search_failed_message)
             ImageWithMessage(modifier, image, message)
         }
+
+        is SearchState.Error -> {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(
+                    space = dimensionResource(id = dimen.major_100),
+                    alignment = Alignment.CenterVertically
+                ),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = modifier
+            ) {
+                ImageWithMessage(
+                    modifier = Modifier.fillMaxWidth(),
+                    image = painterResource(id = R.drawable.search_failed_illustration),
+                    message = stringResource(id = string.blaze_campaign_creation_location_search_failed_message)
+                )
+                WCColoredButton(onClick = onRetrySearchTapped, text = stringResource(id = R.string.retry))
+            }
+        }
+
         else -> {
             val image = painterResource(id = R.drawable.search_illustration)
             val message = stringResource(id = string.blaze_campaign_creation_location_search_message)
@@ -311,7 +341,7 @@ fun PreviewTargetSelectionScreen() {
             ),
             title = "Title",
             searchQuery = "",
-            searchState = Searching
+            searchState = SearchState.Searching
         ),
         onBackPressed = { /*TODO*/ },
         onSaveTapped = { /*TODO*/ },
@@ -319,6 +349,7 @@ fun PreviewTargetSelectionScreen() {
         onSearchItemTapped = {},
         onAllButtonTapped = {},
         onSearchQueryChanged = {},
-        onSearchActiveStateChanged = {}
+        onSearchActiveStateChanged = {},
+        onRetrySearchTapped = {}
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/TargetSelectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/TargetSelectionViewModel.kt
@@ -14,4 +14,5 @@ interface TargetSelectionViewModel {
     fun onSearchItemTapped(item: SearchItem) = Unit
     fun onSearchActiveStateChanged(isActive: Boolean) = Unit
     fun onSearchQueryChanged(query: String) = Unit
+    fun onRetrySearchTapped() = Unit
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/TargetSelectionViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/targets/TargetSelectionViewState.kt
@@ -54,6 +54,9 @@ data class TargetSelectionViewState(
         object NoResults : SearchState()
 
         @Parcelize
+        object Error : SearchState()
+
+        @Parcelize
         data class Results(val resultItems: List<SearchItem>) : SearchState() {
             @Parcelize
             data class SearchItem(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3919,7 +3919,8 @@
     <string name="blaze_campaign_creation_product_selector_title">Ready to promote</string>
     <string name="blaze_campaign_creation_product_selector_cta_button">Promote</string>
     <string name="blaze_campaign_creation_location_search_message">Start typing country, state or city to see available options</string>
-    <string name="blaze_campaign_creation_location_search_failed_message">No location found.\nPlease try again.</string>
+    <string name="blaze_campaign_creation_location_search_no_results_message">No location found.\nPlease try again.</string>
+    <string name="blaze_campaign_creation_location_search_failed_message">Searching failed.\nPlease try again</string>
 
     <!--
     Blaze edit ad destination

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetLocationSelectionViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetLocationSelectionViewModelTests.kt
@@ -1,0 +1,201 @@
+package com.woocommerce.android.ui.blaze.creation.targets
+
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ui.blaze.BlazeRepository
+import com.woocommerce.android.ui.blaze.Location
+import com.woocommerce.android.ui.blaze.creation.targets.BlazeCampaignTargetLocationSelectionViewModel.TargetLocationResult
+import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BlazeCampaignTargetLocationSelectionViewModelTests : BaseUnitTest() {
+    private val sampleLocations = listOf(
+        Location(id = 0, name = "Location 0"),
+        Location(id = 1, name = "Location 1"),
+        Location(id = 2, name = "Location 2"),
+        Location(id = 3, name = "Location 3"),
+    )
+
+    private val analyticsTracker: AnalyticsTrackerWrapper = mock()
+    private val blazeRepository: BlazeRepository = mock {
+        onBlocking { fetchLocations(any()) } doReturn Result.success(sampleLocations)
+    }
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(any()) } doAnswer { it.getArgument<Any?>(0).toString() }
+    }
+    private lateinit var viewModel: BlazeCampaignTargetLocationSelectionViewModel
+
+    suspend fun setup(selectedLocations: List<Location> = emptyList(), prepareMocks: suspend () -> Unit = {}) {
+        prepareMocks()
+        viewModel = BlazeCampaignTargetLocationSelectionViewModel(
+            savedStateHandle = BlazeCampaignTargetLocationSelectionFragmentArgs(
+                locations = selectedLocations.toTypedArray()
+            ).toSavedStateHandle(),
+            resourceProvider = resourceProvider,
+            blazeRepository = blazeRepository,
+            analyticsTrackerWrapper = analyticsTracker
+        )
+    }
+
+    @Test
+    fun `given a list of locations selected, when the view model is created, then show the selected locations`() =
+        testBlocking {
+            val selectedLocations = listOf(sampleLocations[0], sampleLocations[1], sampleLocations[2])
+            setup(selectedLocations)
+
+            val viewState = viewModel.viewState.getOrAwaitValue()
+
+            assertThat(viewState.selectedItems).containsExactly(
+                TargetSelectionViewState.SelectionItem(selectedLocations[0].id.toString(), selectedLocations[0].name),
+                TargetSelectionViewState.SelectionItem(selectedLocations[1].id.toString(), selectedLocations[1].name),
+                TargetSelectionViewState.SelectionItem(selectedLocations[2].id.toString(), selectedLocations[2].name)
+            )
+        }
+
+    @Test
+    fun `when searching for locations, then show returned locations`() = testBlocking {
+        setup()
+
+        val viewState = viewModel.viewState.runAndCaptureValues {
+            viewModel.onSearchActiveStateChanged(true)
+            viewModel.onSearchQueryChanged("query")
+            advanceUntilIdle()
+        }.last()
+
+        assertThat(viewState.searchState).isEqualTo(
+            TargetSelectionViewState.SearchState.Results(
+                resultItems = sampleLocations.map { location ->
+                    TargetSelectionViewState.SearchState.Results.SearchItem(
+                        id = location.id.toString(),
+                        title = location.name,
+                        subtitle = null,
+                        type = null
+                    )
+                }
+            )
+        )
+    }
+
+    @Test
+    fun `when location search fails, then show error state`() = testBlocking {
+        setup {
+            whenever(blazeRepository.fetchLocations(any())) doReturn Result.failure(Exception())
+        }
+
+        val viewState = viewModel.viewState.runAndCaptureValues {
+            viewModel.onSearchActiveStateChanged(true)
+            viewModel.onSearchQueryChanged("query")
+            advanceUntilIdle()
+        }.last()
+
+        assertThat(viewState.searchState).isEqualTo(TargetSelectionViewState.SearchState.Error)
+    }
+
+    @Test
+    fun `when location search returns no results, then show no results state`() = testBlocking {
+        setup {
+            whenever(blazeRepository.fetchLocations(any())) doReturn Result.success(emptyList())
+        }
+
+        val viewState = viewModel.viewState.runAndCaptureValues {
+            viewModel.onSearchActiveStateChanged(true)
+            viewModel.onSearchQueryChanged("query")
+            advanceUntilIdle()
+        }.last()
+
+        assertThat(viewState.searchState).isEqualTo(TargetSelectionViewState.SearchState.NoResults)
+    }
+
+    @Test
+    fun `when retrying location search, then return updated results`() = testBlocking {
+        setup {
+            whenever(blazeRepository.fetchLocations(any())).thenReturn(Result.failure(Exception()))
+                .thenReturn(Result.success(sampleLocations))
+        }
+
+        val viewState = viewModel.viewState.runAndCaptureValues {
+            viewModel.onSearchActiveStateChanged(true)
+            viewModel.onSearchQueryChanged("query")
+            advanceUntilIdle()
+            viewModel.onRetrySearchTapped()
+            advanceUntilIdle()
+        }.last()
+
+        assertThat(viewState.searchState).isEqualTo(
+            TargetSelectionViewState.SearchState.Results(
+                resultItems = sampleLocations.map { location ->
+                    TargetSelectionViewState.SearchState.Results.SearchItem(
+                        id = location.id.toString(),
+                        title = location.name,
+                        subtitle = null,
+                        type = null
+                    )
+                }
+            )
+        )
+    }
+
+    @Test
+    fun `when selecting new locations from search, then update state`() = testBlocking {
+        setup()
+
+        val viewState = viewModel.viewState.runAndCaptureValues {
+            viewModel.onSearchActiveStateChanged(true)
+            viewModel.onSearchItemTapped(
+                sampleLocations[0].let { location ->
+                    TargetSelectionViewState.SearchState.Results.SearchItem(
+                        id = location.id.toString(),
+                        title = location.name,
+                        subtitle = null,
+                        type = null
+                    )
+                }
+            )
+        }.last()
+
+        assertThat(viewState.selectedItems).contains(
+            TargetSelectionViewState.SelectionItem(sampleLocations[0].id.toString(), sampleLocations[0].name)
+        )
+    }
+
+    @Test
+    fun `when toggling location, then update state`() = testBlocking {
+        setup(sampleLocations)
+
+        val viewState = viewModel.viewState.runAndCaptureValues {
+            viewModel.onItemToggled(
+                TargetSelectionViewState.SelectionItem(
+                    id = sampleLocations[0].id.toString(),
+                    title = sampleLocations[0].name
+                )
+            )
+        }.last()
+
+        assertThat(viewState.selectedItems).doesNotContain(
+            TargetSelectionViewState.SelectionItem(sampleLocations[0].id.toString(), sampleLocations[0].name)
+        )
+    }
+
+    @Test
+    fun `when saving, then return selected locations`() = testBlocking {
+        setup(sampleLocations)
+
+        val event = viewModel.event.runAndCaptureValues {
+            viewModel.onSaveTapped()
+        }.last()
+
+        assertThat(event).isEqualTo(MultiLiveEvent.Event.ExitWithResult(TargetLocationResult(sampleLocations)))
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetSelectionViewModelTests.kt
@@ -1,0 +1,131 @@
+package com.woocommerce.android.ui.blaze.creation.targets
+
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ui.blaze.BlazeRepository
+import com.woocommerce.android.ui.blaze.Device
+import com.woocommerce.android.ui.blaze.creation.targets.TargetSelectionViewState.SelectionItem
+import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BlazeCampaignTargetSelectionViewModelTests : BaseUnitTest() {
+    private val sampleDevices = listOf(
+        Device(id = "0", name = "Device 0"),
+        Device(id = "1", name = "Device 1"),
+        Device(id = "2", name = "Device 2"),
+        Device(id = "3", name = "Device 3"),
+    )
+
+    private val devicesFlow = MutableStateFlow(sampleDevices)
+    private val blazeRepository: BlazeRepository = mock {
+        on { observeDevices() } doReturn devicesFlow
+    }
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(any()) } doAnswer { it.getArgument<Any?>(0).toString() }
+    }
+    private val analyticsTracker: AnalyticsTrackerWrapper = mock()
+
+    private lateinit var viewModel: BlazeCampaignTargetSelectionViewModel
+
+    suspend fun setup(selectedIds: List<String> = emptyList(), prepareMocks: suspend () -> Unit = {}) {
+        prepareMocks()
+        viewModel = BlazeCampaignTargetSelectionViewModel(
+            blazeRepository = blazeRepository,
+            savedStateHandle = BlazeCampaignTargetSelectionFragmentArgs(
+                selectedIds = selectedIds.toTypedArray(),
+                targetType = BlazeTargetType.DEVICE
+            ).toSavedStateHandle(),
+            resourceProvider = resourceProvider,
+            analyticsTrackerWrapper = analyticsTracker
+        )
+    }
+
+    @Test
+    fun `given a list of devices selected, when the view model is created, then show the selected devices`() =
+        testBlocking {
+            val selectedDevices = listOf(sampleDevices[0], sampleDevices[1], sampleDevices[2])
+            setup(selectedIds = selectedDevices.map { it.id })
+
+            val viewState = viewModel.viewState.getOrAwaitValue()
+
+            assertThat(viewState.selectedItems).containsExactly(
+                SelectionItem(id = "0", title = "Device 0"),
+                SelectionItem(id = "1", title = "Device 1"),
+                SelectionItem(id = "2", title = "Device 2")
+            )
+        }
+
+    @Test
+    fun `when observing devices, then show returned devices`() = testBlocking {
+        setup()
+
+        devicesFlow.value = sampleDevices.dropLast(1)
+
+        val viewState = viewModel.viewState.getOrAwaitValue()
+
+        assertThat(viewState.items).containsExactly(
+            SelectionItem(id = "0", title = "Device 0"),
+            SelectionItem(id = "1", title = "Device 1"),
+            SelectionItem(id = "2", title = "Device 2")
+        )
+        assertThat(viewState.selectedItems).isEmpty()
+    }
+
+    @Test
+    fun `when an item is selected, then update the selected items`() = testBlocking {
+        setup()
+
+        val viewState = viewModel.viewState.runAndCaptureValues {
+            viewModel.onItemToggled(SelectionItem(id = "0", title = "Device 0"))
+        }.last()
+
+        assertThat(viewState.selectedItems).containsExactly(viewState.items[0])
+    }
+
+    @Test
+    fun `when an item is deselected, then update the selected items`() = testBlocking {
+        setup(selectedIds = listOf("0", "1", "2"))
+
+        val viewState = viewModel.viewState.runAndCaptureValues {
+            viewModel.onItemToggled(SelectionItem(id = "0", title = "Device 0"))
+        }.last()
+
+        assertThat(viewState.selectedItems).doesNotContain(SelectionItem(id = "0", title = "Device 0"))
+    }
+
+    @Test
+    fun `when all items are selected, then select all items`() = testBlocking {
+        setup(selectedIds = listOf("0", "1", "2"))
+
+        val viewState = viewModel.viewState.runAndCaptureValues {
+            viewModel.onAllButtonTapped()
+        }.last()
+
+        assertThat(viewState.selectedItems).isEqualTo(sampleDevices.map { SelectionItem(it.id, it.name) })
+    }
+
+    @Test
+    fun `when save is tapped, then return selected items`() = testBlocking {
+        setup(selectedIds = listOf("0", "1", "2"))
+
+        val selectedItems = viewModel.viewState.runAndCaptureValues {
+            viewModel.onSaveTapped()
+        }.last().selectedItems
+
+        assertThat(selectedItems).containsExactly(
+            SelectionItem(id = "0", title = "Device 0"),
+            SelectionItem(id = "1", title = "Device 1"),
+            SelectionItem(id = "2", title = "Device 2")
+        )
+    }
+}


### PR DESCRIPTION
### Description
This PR adds an error state for location search screen, and adds unit tests for the targeting viewmodels.

### Testing instructions
##### Location Search
1. Start blaze campaign creation.
2. Click on the location row.
3. Disable internet connection.
4. Type something.
5. Notice the error UI.
6. Re-enable internet connection.
7. Tap on "Retry".
8. Confirm it works.

### Images/gif
<img width="309" alt="Screenshot 2024-02-29 at 10 56 01" src="https://github.com/woocommerce/woocommerce-android/assets/1657201/2986f5c3-7463-4f7e-b210-9922ed173aba">


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
