### PR TITLE
[Better Tablet Products] Fix blaze opening crash in the 2 pane layout. Fix bottom sheet height on tablets

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSharingDialog.kt
@@ -8,15 +8,15 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.LaunchUrlInChromeTab
+import com.woocommerce.android.widgets.WCBottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class ProductSharingDialog : BottomSheetDialogFragment() {
+class ProductSharingDialog : WCBottomSheetDialogFragment() {
     @Inject
     lateinit var navigator: ProductNavigator
     private val viewModel: ProductSharingViewModel by viewModels()
@@ -34,6 +34,7 @@ class ProductSharingDialog : BottomSheetDialogFragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ProductNavigationTarget -> navigator.navigate(this, event)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCBottomSheetDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCBottomSheetDialogFragment.kt
@@ -8,9 +8,7 @@ import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import com.woocommerce.android.R
 import org.wordpress.android.util.DisplayUtils
-import kotlin.math.min
 
 /**
  * The default behavior of a bottom sheet in landscape causes it to be cut off after the first item,
@@ -41,11 +39,7 @@ open class WCBottomSheetDialogFragment : BottomSheetDialogFragment {
             dialog?.setOnShowListener {
                 val dialog = it as BottomSheetDialog
                 dialog.findViewById<View>(org.wordpress.aztec.R.id.design_bottom_sheet)?.let { sheet ->
-                    dialog.behavior.peekHeight = if (DisplayUtils.isXLargeTablet(requireContext())) {
-                        sheet.height
-                    } else {
-                        min(DisplayUtils.getWindowPixelHeight(requireContext()) / 2, sheet.height)
-                    }
+                    dialog.behavior.peekHeight = DisplayUtils.getWindowPixelHeight(requireContext()) / 2
                     sheet.parent.parent.requestLayout()
                 }
             }

--- a/WooCommerce/src/main/res/navigation/nav_graph_products.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_products.xml
@@ -535,6 +535,7 @@
 
     <include app:graph="@navigation/nav_graph_add_product_category" />
     <include app:graph="@navigation/nav_graph_product_settings" />
+    <include app:graph="@navigation/nav_graph_blaze_campaign_creation" />
 
     <action
         android:id="@+id/action_productDetailFragment_to_productSettingsFragment"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10874
Closes: #[10890](https://github.com/woocommerce/woocommerce-android/issues/10890)
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes:
* Crash on tablets when "promote with blze" clocked
* Height of the bottom sheet of the new product creation flow

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
* With FF ON open products
* Click on a product => promote with blaze
* Notice that it's open
* Click on FAB -> manual -> notice that bottom sheet properly visible

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/b3c69de7-d647-4761-ae28-cba2259ee8f3


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
