### PR TITLE
[Tablet support M3] Part 4 – Order summary product buttons update

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -39,6 +39,7 @@ import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.isNotNullOrEmpty
+import com.woocommerce.android.extensions.isTablet
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
@@ -372,24 +373,7 @@ class OrderCreateEditFormFragment :
 
     private fun FragmentOrderCreateEditFormBinding.initProductsSection() {
         productsSection.hideHeader()
-        productsSection.setProductSectionButtons(
-            addProductsButton = AddButton(
-                text = getString(R.string.order_creation_add_products),
-                onClickListener = {
-                    viewModel.onAddProductClicked()
-                }
-            ),
-            addProductsViaScanButton = AddButton(
-                text = getString(R.string.order_creation_add_product_via_barcode_scanning),
-                onClickListener = { viewModel.onScanClicked() }
-            ),
-            addCustomAmountsButton = AddButton(
-                text = getString(R.string.order_creation_add_custom_amounts),
-                onClickListener = {
-                    navigateToCustomAmountsDialog()
-                }
-            )
-        )
+        renderDefaultProductsSectionButtons()
     }
 
     private fun FragmentOrderCreateEditFormBinding.initAdditionalInfoCollectionSection() {
@@ -568,18 +552,27 @@ class OrderCreateEditFormFragment :
         binding.productsSection.hideAddProductsHeaderActions()
         binding.productsSection.hideHeader()
         binding.productsSection.content = null
-        binding.productsSection.setProductSectionButtons(
-            addProductsButton = AddButton(
-                text = getString(R.string.order_creation_add_products),
-                onClickListener = {
-                    viewModel.onAddProductClicked()
-                }
-            ),
-            addProductsViaScanButton = AddButton(
-                text = getString(R.string.order_creation_add_product_via_barcode_scanning),
-                onClickListener = { viewModel.onScanClicked() }
-            ),
-        )
+        if (!isTablet()) {
+            binding.productsSection.setProductSectionButtons(
+                addProductsButton = AddButton(
+                    text = getString(R.string.order_creation_add_products),
+                    onClickListener = {
+                        viewModel.onAddProductClicked()
+                    }
+                ),
+                addProductsViaScanIconButton = AddButton(
+                    text = getString(R.string.order_creation_add_product_via_barcode_scanning),
+                    onClickListener = { viewModel.onScanClicked() }
+                ),
+            )
+        } else {
+            binding.productsSection.setProductSectionButtons(
+                addProductsViaScanButton = AddButton(
+                    text = getString(R.string.order_creation_scan_products),
+                    onClickListener = { viewModel.onScanClicked() },
+                )
+            )
+        }
     }
 
     private fun productAddedCustomAmountUnset(binding: FragmentOrderCreateEditFormBinding) {
@@ -621,26 +614,44 @@ class OrderCreateEditFormFragment :
         binding.productsSection.hideAddProductsHeaderActions()
         binding.productsSection.hideHeader()
         binding.productsSection.content = null
-        binding.productsSection.setProductSectionButtons(
-            addProductsButton = AddButton(
-                text = getString(R.string.order_creation_add_products),
-                onClickListener = {
-                    viewModel.onAddProductClicked()
-                }
-            ),
-            addProductsViaScanButton = AddButton(
-                text = getString(R.string.order_creation_add_product_via_barcode_scanning),
-                onClickListener = { viewModel.onScanClicked() }
-            ),
-            addCustomAmountsButton =
-            AddButton(
-                text = getString(R.string.order_creation_add_custom_amounts),
-                onClickListener = {
-                    navigateToCustomAmountsDialog()
-                }
-            )
-        )
+        binding.renderDefaultProductsSectionButtons()
         binding.customAmountsSection.hide()
+    }
+
+    private fun FragmentOrderCreateEditFormBinding.renderDefaultProductsSectionButtons() {
+        if (!isTablet()) {
+            productsSection.setProductSectionButtons(
+                addProductsButton = AddButton(
+                    text = getString(R.string.order_creation_add_products),
+                    onClickListener = {
+                        viewModel.onAddProductClicked()
+                    }
+                ),
+                addProductsViaScanIconButton = AddButton(
+                    text = getString(R.string.order_creation_add_product_via_barcode_scanning),
+                    onClickListener = { viewModel.onScanClicked() }
+                ),
+                addCustomAmountsButton = AddButton(
+                    text = getString(R.string.order_creation_add_custom_amounts),
+                    onClickListener = {
+                        navigateToCustomAmountsDialog()
+                    }
+                )
+            )
+        } else {
+            productsSection.setProductSectionButtons(
+                addProductsViaScanButton = AddButton(
+                    text = getString(R.string.order_creation_scan_products),
+                    onClickListener = { viewModel.onScanClicked() },
+                ),
+                addCustomAmountsButton = AddButton(
+                    text = getString(R.string.order_creation_add_custom_amounts),
+                    onClickListener = {
+                        navigateToCustomAmountsDialog()
+                    }
+                )
+            )
+        }
     }
 
     private fun navigateToCustomAmountsDialog(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
@@ -130,16 +130,35 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
     }
 
     fun setProductSectionButtons(
-        addProductsButton: AddButton,
+        addProductsButton: AddButton? = null,
         addCustomAmountsButton: AddButton? = null,
-        addProductsViaScanButton: AddButton? = null
+        addProductsViaScanIconButton: AddButton? = null,
+        addProductsViaScanButton: AddButton? = null,
     ) {
         binding.addButtonsLayout.removeAllViews()
         val container = RelativeLayout(context)
-        val addingProductsManuallyButtonId = View.generateViewId()
-        addProductsButton(addProductsButton, container, addingProductsManuallyButtonId)
-        addProductsViaScanButton(addProductsViaScanButton, container)
-        addCustomAmountsButton(addCustomAmountsButton, container, addingProductsManuallyButtonId)
+        val addProductsManuallyButtonId = View.generateViewId()
+        addProductsButton(
+            addProductsButton = addProductsButton,
+            container = container,
+            id = addProductsManuallyButtonId
+        )
+        addProductsViaScanIconButton(
+            addProductsViaScanIconButton = addProductsViaScanIconButton,
+            container = container
+        )
+        val addProductsButtonId = if (addProductsButton == null) null else addProductsManuallyButtonId
+        addProductsViaScanButton(
+            addProductsViaScanButton = addProductsViaScanButton,
+            container = container,
+            addingProductsManuallyButtonId = addProductsButtonId,
+            id = addProductsManuallyButtonId,
+        )
+        addCustomAmountsButton(
+            addCustomAmountsButton = addCustomAmountsButton,
+            container = container,
+            addingProductsManuallyButtonId = addProductsManuallyButtonId,
+        )
         binding.addButtonsLayout.addView(container)
     }
 
@@ -172,22 +191,22 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
             )
             addCustomAmountsButtonParams.addRule(RelativeLayout.ALIGN_PARENT_START)
             addingProductsManuallyButtonId?.let {
-                addCustomAmountsButtonParams.addRule(RelativeLayout.BELOW, addingProductsManuallyButtonId)
+                addCustomAmountsButtonParams.addRule(RelativeLayout.BELOW, it)
             }
             addingCustomAmountsButton.layoutParams = addCustomAmountsButtonParams
             container.addView(addingCustomAmountsButton)
         }
     }
 
-    private fun addProductsViaScanButton(
-        addProductsViaScanButton: AddButton?,
+    private fun addProductsViaScanIconButton(
+        addProductsViaScanIconButton: AddButton?,
         container: RelativeLayout
     ) {
-        addProductsViaScanButton?.let {
+        addProductsViaScanIconButton?.let {
             val addingProductsViaScanningButton = ImageView(context, null)
             addingProductsViaScanningButton.setImageResource(R.drawable.ic_barcode)
             val margins = resources.getDimensionPixelSize(R.dimen.major_100)
-            addingProductsViaScanningButton.setOnClickListener { addProductsViaScanButton.onClickListener() }
+            addingProductsViaScanningButton.setOnClickListener { addProductsViaScanIconButton.onClickListener() }
             val addProductsViaScanningButtonParams = RelativeLayout.LayoutParams(
                 LayoutParams.WRAP_CONTENT,
                 LayoutParams.WRAP_CONTENT
@@ -199,11 +218,37 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
         }
     }
 
+    private fun addProductsViaScanButton(
+        addProductsViaScanButton: AddButton?,
+        container: RelativeLayout,
+        addingProductsManuallyButtonId: Int?,
+        id: Int,
+    ) {
+        addProductsViaScanButton ?: return
+        val addProductButtonsParams = RelativeLayout.LayoutParams(
+            LayoutParams.WRAP_CONTENT,
+            LayoutParams.WRAP_CONTENT
+        )
+        addProductButtonsParams.addRule(RelativeLayout.ALIGN_PARENT_START)
+        val scanToAddProductButton = MaterialButton(context, null, R.attr.secondaryTextButtonStyle)
+        scanToAddProductButton.text = addProductsViaScanButton.text
+        scanToAddProductButton.icon = AppCompatResources.getDrawable(context, R.drawable.ic_barcode)
+        scanToAddProductButton.id = id
+        addingProductsManuallyButtonId?.let {
+            addProductButtonsParams.addRule(RelativeLayout.BELOW, it)
+        }
+        scanToAddProductButton.layoutParams = addProductButtonsParams
+        scanToAddProductButton.setOnClickListener { addProductsViaScanButton.onClickListener() }
+
+        container.addView(scanToAddProductButton)
+    }
+
     private fun addProductsButton(
-        addProductsButton: AddButton,
+        addProductsButton: AddButton?,
         container: RelativeLayout,
         id: Int,
     ) {
+        addProductsButton ?: return
         val addProductButtonsParams = RelativeLayout.LayoutParams(
             LayoutParams.WRAP_CONTENT,
             LayoutParams.WRAP_CONTENT

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -556,6 +556,7 @@
     <string name="order_creation_add_products">Add products</string>
     <string name="order_creation_add_custom_amounts">Add custom amount</string>
     <string name="order_creation_add_product_via_barcode_scanning">Add products via scanner</string>
+    <string name="order_creation_scan_products">Scan products</string>
     <string name="order_creation_set_tax_rate">Set New Tax Rate</string>
     <string name="order_creation_edit_tax_rate">Edit Tax Rate Setting</string>
     <string name="order_creation_add_fee">Add fee</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10618 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adjusts the appearance of the products section's buttons in tablet mode:
* "+ Add products" button is visible only on a phone. On tablet, the product selector is open all the time, so it's redundant.
* "Scan products" is visible as an icon on the phone and a full button on the tablet.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Verify that the buttons are shown correctly on tablet and phone.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Tablet|Phone|
|---|---|
|<img width=600 src=https://github.com/woocommerce/woocommerce-android/assets/4527432/7193043d-4368-4672-a0f9-252b0bb15eaf/>|<img width=300 src=https://github.com/woocommerce/woocommerce-android/assets/4527432/4839e6eb-975c-484e-84fe-649fda9a065b/>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
