### PR TITLE
build: bump measure builds to 2.1.2

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ pluginManagement {
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.kotlinVersion = '1.9.22'
     gradle.ext.kspVersion = '1.9.22-1.0.17'
-    gradle.ext.measureBuildsVersion = '2.0.3'
+    gradle.ext.measureBuildsVersion = '2.1.1'
     gradle.ext.navigationVersion = '2.7.7'
     gradle.ext.sentryVersion = '3.5.0'
     gradle.ext.violationCommentsVersion = '1.69.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ pluginManagement {
     gradle.ext.detektVersion = '1.19.0'
     gradle.ext.kotlinVersion = '1.9.22'
     gradle.ext.kspVersion = '1.9.22-1.0.17'
-    gradle.ext.measureBuildsVersion = '2.1.1'
+    gradle.ext.measureBuildsVersion = '2.1.2'
     gradle.ext.navigationVersion = '2.7.7'
     gradle.ext.sentryVersion = '3.5.0'
     gradle.ext.violationCommentsVersion = '1.69.0'


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates measure-builds to `2.1.2`, which brings configuration phase duration metric and local report files.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Not needed.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
![image](https://github.com/woocommerce/woocommerce-android/assets/5845095/ed81fe52-012f-4d02-a095-485aa2934ae8)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
