### PR TITLE
[Order Details] Show order attribution information

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [**] Orders can be filtered now using specific customers or products [https://github.com/woocommerce/woocommerce-android/pull/10927]
 - [*] Orders: Merchants can now contact their customers through WhatsApp and Telegram apps. [https://github.com/woocommerce/woocommerce-android/pull/10936]
+- [**] Orders: Show the order attribution info in the order detail screen. [https://github.com/woocommerce/woocommerce-android/pull/10981]
 
 17.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderAttributionOrigin.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderAttributionOrigin.kt
@@ -19,6 +19,6 @@ val OrderAttributionInfo.origin
         "organic" -> OrderAttributionOrigin.Organic(source)
         "typein" -> OrderAttributionOrigin.Direct
         "admin" -> OrderAttributionOrigin.Admin
-        "mobile" -> OrderAttributionOrigin.Mobile
+        "mobile_app" -> OrderAttributionOrigin.Mobile
         else -> OrderAttributionOrigin.Unknown
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderAttributionOrigin.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderAttributionOrigin.kt
@@ -1,0 +1,24 @@
+package com.woocommerce.android.model
+
+import org.wordpress.android.fluxc.model.OrderAttributionInfo
+
+sealed interface OrderAttributionOrigin {
+    data class Utm(val source: String?) : OrderAttributionOrigin
+    data class Referral(val source: String?) : OrderAttributionOrigin
+    data class Organic(val source: String?) : OrderAttributionOrigin
+    data object Direct : OrderAttributionOrigin
+    data object Admin : OrderAttributionOrigin
+    data object Mobile : OrderAttributionOrigin
+    data object Unknown : OrderAttributionOrigin
+}
+
+val OrderAttributionInfo.origin
+    get() = when (sourceType) {
+        "utm" -> OrderAttributionOrigin.Utm(source)
+        "referral" -> OrderAttributionOrigin.Referral(source)
+        "organic" -> OrderAttributionOrigin.Organic(source)
+        "typein" -> OrderAttributionOrigin.Direct
+        "admin" -> OrderAttributionOrigin.Admin
+        "mobile" -> OrderAttributionOrigin.Mobile
+        else -> OrderAttributionOrigin.Unknown
+    }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -74,6 +74,7 @@ import com.woocommerce.android.ui.orders.OrderProductActionListener
 import com.woocommerce.android.ui.orders.OrderStatusUpdateSource
 import com.woocommerce.android.ui.orders.details.adapter.OrderDetailShippingLabelsAdapter.OnShippingLabelClickListener
 import com.woocommerce.android.ui.orders.details.editing.OrderEditingViewModel
+import com.woocommerce.android.ui.orders.details.views.OrderDetailAttributionInfoView
 import com.woocommerce.android.ui.orders.details.views.OrderDetailOrderStatusView.Mode
 import com.woocommerce.android.ui.orders.fulfill.OrderFulfillViewModel
 import com.woocommerce.android.ui.orders.list.OrderListFragment
@@ -92,6 +93,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUndoSnackbar
 import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.fluxc.model.OrderAttributionInfo
 import org.wordpress.android.util.DisplayUtils
 import javax.inject.Inject
 
@@ -217,7 +219,6 @@ class OrderDetailFragment :
         binding.customFieldsCard.customFieldsButton.setOnClickListener {
             viewModel.onCustomFieldsButtonClicked()
         }
-
         binding.orderDetailsAICard.aiThankYouNoteButton.setOnClickListener {
             viewModel.onAIThankYouNoteButtonClicked()
         }
@@ -418,6 +419,8 @@ class OrderDetailFragment :
             showGiftCards(it, viewModel.order.currency)
         }
 
+        setupOrderAttributionInfoCard(viewModel.orderAttributionInfo)
+
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowSnackbar -> {
@@ -474,6 +477,20 @@ class OrderDetailFragment :
             giftCardSummaries = giftCardSummaries,
             formatCurrencyForDisplay = currencyFormatter.buildBigDecimalFormatter(currencyCode)
         )
+    }
+
+    private fun setupOrderAttributionInfoCard(orderAttributionInfo: LiveData<OrderAttributionInfo>) {
+        binding.orderDetailOrderAttributionInfo.apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                orderAttributionInfo.observeAsState().value?.let {
+                    WooThemeWithBackground {
+                        OrderDetailAttributionInfoView(attributionInfo = it)
+                    }
+                }
+            }
+        }
     }
 
     private fun navigateToInstallWcShippingFlow() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailRepository.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.util.WooLog.T.ORDERS
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import org.wordpress.android.fluxc.model.OrderAttributionInfo
 import org.wordpress.android.fluxc.model.WCOrderShipmentTrackingModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.shippinglabels.LabelItem
@@ -310,6 +311,10 @@ class OrderDetailRepository @Inject constructor(
     suspend fun orderHasMetadata(orderId: Long) = orderStore.hasDisplayableOrderMetadata(orderId, selectedSite.get())
 
     suspend fun getOrderMetadata(orderId: Long) = orderStore.getDisplayableOrderMetadata(orderId, selectedSite.get())
+
+    suspend fun getOrderAttributionInfo(orderId: Long) = OrderAttributionInfo(
+        orderStore.getOrderMetadata(orderId, selectedSite.get())
+    )
 
     companion object {
         const val PRODUCT_SUBSCRIPTION_TYPE = "subscription"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -12,7 +12,6 @@ import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.extensions.isTablet
 import com.woocommerce.android.extensions.whenNotNullNorEmpty
 import com.woocommerce.android.model.GiftCardSummary
 import com.woocommerce.android.model.Order
@@ -70,6 +69,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.wordpress.android.fluxc.model.OrderAttributionInfo
 import org.wordpress.android.fluxc.persistence.entity.OrderMetaDataEntity
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.OptimisticUpdateResult
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult.RemoteUpdateResult
@@ -148,6 +148,9 @@ class OrderDetailViewModel @Inject constructor(
 
     private val _subscriptions = MutableLiveData<List<Subscription>>()
     val subscriptions: LiveData<List<Subscription>> = _subscriptions
+
+    private val _orderAttributionInfo = MutableLiveData<OrderAttributionInfo>()
+    val orderAttributionInfo: LiveData<OrderAttributionInfo> = _orderAttributionInfo
 
     private var isFetchingData = false
 
@@ -795,6 +798,8 @@ class OrderDetailViewModel @Inject constructor(
         if (shipmentTracking.isVisible) {
             _shipmentTrackings.value = shipmentTracking.list
         }
+
+        _orderAttributionInfo.value = orderDetailRepository.getOrderAttributionInfo(navArgs.orderId)
 
         val orderEligibleForInPersonPayments = viewState.orderInfo?.isPaymentCollectableWithCardReader == true
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailAttributionInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailAttributionInfoView.kt
@@ -1,23 +1,35 @@
 package com.woocommerce.android.ui.orders.details.views
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Card
 import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.woocommerce.android.R
 import com.woocommerce.android.model.OrderAttributionOrigin
 import com.woocommerce.android.model.origin
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import org.wordpress.android.fluxc.model.OrderAttributionInfo
 
 @Composable
@@ -45,54 +57,92 @@ private fun OrderAttributionContent(
     Column(
         verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
         modifier = modifier
-            .fillMaxWidth()
-            .padding(dimensionResource(id = R.dimen.major_100))
     ) {
+        var detailsExpanded by rememberSaveable { mutableStateOf(false) }
+
         OrderAttributionInfoRow(
             title = stringResource(id = R.string.order_detail_attribution_origin),
             value = attributionInfo.origin.label
         )
 
-        attributionInfo.sourceType?.let { sourceType ->
-            OrderAttributionInfoRow(
-                title = stringResource(id = R.string.order_detail_attribution_source_type),
-                value = sourceType
-            )
+        AnimatedVisibility(
+            enter = expandVertically(),
+            exit = shrinkVertically(),
+            visible = detailsExpanded,
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
+            ) {
+                attributionInfo.sourceType?.let { sourceType ->
+                    OrderAttributionInfoRow(
+                        title = stringResource(id = R.string.order_detail_attribution_source_type),
+                        value = sourceType
+                    )
+                }
+
+                attributionInfo.campaign?.let { campaign ->
+                    OrderAttributionInfoRow(
+                        title = stringResource(id = R.string.order_detail_attribution_campaign),
+                        value = campaign
+                    )
+                }
+
+                attributionInfo.source?.let { source ->
+                    OrderAttributionInfoRow(
+                        title = stringResource(id = R.string.order_detail_attribution_source),
+                        value = source
+                    )
+                }
+
+                attributionInfo.medium?.let { medium ->
+                    OrderAttributionInfoRow(
+                        title = stringResource(id = R.string.order_detail_attribution_medium),
+                        value = medium
+                    )
+                }
+
+                attributionInfo.deviceType?.let { deviceType ->
+                    OrderAttributionInfoRow(
+                        title = stringResource(id = R.string.order_detail_attribution_device_type),
+                        value = deviceType
+                    )
+                }
+
+                attributionInfo.sessionPageViews?.let { sessionPageViews ->
+                    OrderAttributionInfoRow(
+                        title = stringResource(id = R.string.order_detail_attribution_session_page_views),
+                        value = sessionPageViews
+                    )
+                }
+            }
         }
 
-        attributionInfo.campaign?.let { campaign ->
-            OrderAttributionInfoRow(
-                title = stringResource(id = R.string.order_detail_attribution_campaign),
-                value = campaign
-            )
-        }
-
-        attributionInfo.source?.let { source ->
-            OrderAttributionInfoRow(
-                title = stringResource(id = R.string.order_detail_attribution_source),
-                value = source
-            )
-        }
-
-        attributionInfo.medium?.let { medium ->
-            OrderAttributionInfoRow(
-                title = stringResource(id = R.string.order_detail_attribution_medium),
-                value = medium
-            )
-        }
-
-        attributionInfo.deviceType?.let { deviceType ->
-            OrderAttributionInfoRow(
-                title = stringResource(id = R.string.order_detail_attribution_device_type),
-                value = deviceType
-            )
-        }
-
-        attributionInfo.sessionPageViews?.let { sessionPageViews ->
-            OrderAttributionInfoRow(
-                title = stringResource(id = R.string.order_detail_attribution_session_page_views),
-                value = sessionPageViews
-            )
+        if (attributionInfo.hasAdditionalDetails) {
+            WCTextButton(
+                onClick = { detailsExpanded = !detailsExpanded },
+                contentPadding = PaddingValues(
+                    horizontal = dimensionResource(id = R.dimen.major_100),
+                    vertical = ButtonDefaults.TextButtonContentPadding.calculateTopPadding()
+                ),
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = stringResource(
+                            id = if (detailsExpanded) R.string.hide_details else R.string.show_details
+                        ).uppercase()
+                    )
+                    Icon(
+                        painter = painterResource(
+                            id = if (detailsExpanded) R.drawable.ic_arrow_up
+                            else R.drawable.ic_arrow_down
+                        ),
+                        contentDescription = null
+                    )
+                }
+            }
         }
     }
 }
@@ -107,7 +157,10 @@ private fun OrderAttributionInfoRow(
         horizontalArrangement = Arrangement.SpaceBetween,
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = dimensionResource(id = R.dimen.minor_100))
+            .padding(
+                horizontal = dimensionResource(id = R.dimen.major_100),
+                vertical = dimensionResource(id = R.dimen.minor_100)
+            )
     ) {
         Text(
             text = title,
@@ -146,3 +199,11 @@ private val OrderAttributionOrigin.label
         OrderAttributionOrigin.Mobile -> stringResource(id = R.string.order_detail_attribution_mobile_origin)
         OrderAttributionOrigin.Unknown -> stringResource(id = R.string.order_detail_attribution_unknown_origin)
     }
+
+private val OrderAttributionInfo.hasAdditionalDetails
+    get() = campaign != null ||
+        source != null ||
+        sourceType != null ||
+        medium != null ||
+        deviceType != null ||
+        sessionPageViews != null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailAttributionInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailAttributionInfoView.kt
@@ -52,6 +52,48 @@ private fun OrderAttributionContent(
             title = stringResource(id = R.string.order_detail_attribution_origin),
             value = attributionInfo.origin.label
         )
+
+        attributionInfo.sourceType?.let { sourceType ->
+            OrderAttributionInfoRow(
+                title = stringResource(id = R.string.order_detail_attribution_source_type),
+                value = sourceType
+            )
+        }
+
+        attributionInfo.campaign?.let { campaign ->
+            OrderAttributionInfoRow(
+                title = stringResource(id = R.string.order_detail_attribution_campaign),
+                value = campaign
+            )
+        }
+
+        attributionInfo.source?.let { source ->
+            OrderAttributionInfoRow(
+                title = stringResource(id = R.string.order_detail_attribution_source),
+                value = source
+            )
+        }
+
+        attributionInfo.medium?.let { medium ->
+            OrderAttributionInfoRow(
+                title = stringResource(id = R.string.order_detail_attribution_medium),
+                value = medium
+            )
+        }
+
+        attributionInfo.deviceType?.let { deviceType ->
+            OrderAttributionInfoRow(
+                title = stringResource(id = R.string.order_detail_attribution_device_type),
+                value = deviceType
+            )
+        }
+
+        attributionInfo.sessionPageViews?.let { sessionPageViews ->
+            OrderAttributionInfoRow(
+                title = stringResource(id = R.string.order_detail_attribution_session_page_views),
+                value = sessionPageViews
+            )
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailAttributionInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailAttributionInfoView.kt
@@ -1,0 +1,106 @@
+package com.woocommerce.android.ui.orders.details.views
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Card
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import com.woocommerce.android.R
+import com.woocommerce.android.model.OrderAttributionOrigin
+import com.woocommerce.android.model.origin
+import org.wordpress.android.fluxc.model.OrderAttributionInfo
+
+@Composable
+fun OrderDetailAttributionInfoView(attributionInfo: OrderAttributionInfo) {
+    Column {
+        Text(
+            text = stringResource(id = R.string.order_detail_attribution_header).uppercase(),
+            fontWeight = FontWeight.Medium,
+            style = MaterialTheme.typography.subtitle1,
+            modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100))
+        )
+        Card(
+            shape = RectangleShape
+        ) {
+            OrderAttributionContent(attributionInfo)
+        }
+    }
+}
+
+@Composable
+private fun OrderAttributionContent(
+    attributionInfo: OrderAttributionInfo,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(dimensionResource(id = R.dimen.major_100))
+    ) {
+        OrderAttributionInfoRow(
+            title = stringResource(id = R.string.order_detail_attribution_origin),
+            value = attributionInfo.origin.label
+        )
+    }
+}
+
+@Composable
+private fun OrderAttributionInfoRow(
+    title: String,
+    value: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = dimensionResource(id = R.dimen.minor_100))
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.body1,
+            color = MaterialTheme.colors.onSurface,
+            modifier = Modifier.padding(end = dimensionResource(id = R.dimen.major_100))
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.body1,
+            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+        )
+    }
+}
+
+private val OrderAttributionOrigin.label
+    @Composable
+    get() = when (this) {
+        is OrderAttributionOrigin.Utm -> stringResource(
+            id = R.string.order_detail_attribution_utm_origin,
+            source ?: stringResource(id = R.string.order_detail_attribution_unknown_origin)
+        )
+
+        is OrderAttributionOrigin.Referral -> stringResource(
+            id = R.string.order_detail_attribution_referral_origin,
+            source ?: stringResource(id = R.string.order_detail_attribution_unknown_origin)
+        )
+
+        is OrderAttributionOrigin.Organic -> stringResource(
+            id = R.string.order_detail_attribution_organic_origin,
+            source ?: stringResource(id = R.string.order_detail_attribution_unknown_origin)
+        )
+
+        OrderAttributionOrigin.Direct -> stringResource(id = R.string.order_detail_attribution_direct_origin)
+        OrderAttributionOrigin.Admin -> stringResource(id = R.string.order_detail_attribution_admin_origin)
+        OrderAttributionOrigin.Mobile -> stringResource(id = R.string.order_detail_attribution_mobile_origin)
+        OrderAttributionOrigin.Unknown -> stringResource(id = R.string.order_detail_attribution_unknown_origin)
+    }

--- a/WooCommerce/src/main/res/layout/fragment_order_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_detail.xml
@@ -181,6 +181,11 @@
                         android:visibility="gone"
                         tools:visibility="visible" />
 
+                    <androidx.compose.ui.platform.ComposeView
+                        android:id="@+id/orderDetail_orderAttributionInfo"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
+
                     <!-- Order Notes -->
                     <com.woocommerce.android.ui.orders.details.views.OrderDetailOrderNotesView
                         android:id="@+id/orderDetail_noteList"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="products_total">Products total</string>
     <string name="discount">Discount</string>
     <string name="details">Details</string>
+    <string name="show_details">Show Details</string>
     <string name="hide_details">Hide Details</string>
     <string name="retry">Retry</string>
     <string name="undo">Undo</string>
@@ -890,7 +891,7 @@
     <string name="order_detail_use_as_shipping_address">Use as Shipping Address</string>
     <string name="order_detail_payment_header">PAYMENT TOTALS</string>
     <string name="order_detail_custom_amounts_header">CUSTOM AMOUNTS</string>
-    <string name="order_detail_attribution_header">Order information</string>
+    <string name="order_detail_attribution_header">Order attribution</string>
     <string name="order_detail_attribution_origin">Origin</string>
     <string name="order_detail_attribution_organic_origin">Organic: %1$s</string>
     <string name="order_detail_attribution_referral_origin">Referral: %1$s</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -902,6 +902,7 @@
     <string name="order_detail_attribution_source_type">Source type</string>
     <string name="order_detail_attribution_source">Source</string>
     <string name="order_detail_attribution_medium">Medium</string>
+    <string name="order_detail_attribution_campaign">Medium</string>
     <string name="order_detail_attribution_device_type">Device type</string>
     <string name="order_detail_attribution_session_page_views">Session page views</string>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -890,6 +890,20 @@
     <string name="order_detail_use_as_shipping_address">Use as Shipping Address</string>
     <string name="order_detail_payment_header">PAYMENT TOTALS</string>
     <string name="order_detail_custom_amounts_header">CUSTOM AMOUNTS</string>
+    <string name="order_detail_attribution_header">Order information</string>
+    <string name="order_detail_attribution_origin">Origin</string>
+    <string name="order_detail_attribution_organic_origin">Organic: %1$s</string>
+    <string name="order_detail_attribution_referral_origin">Referral: %1$s</string>
+    <string name="order_detail_attribution_utm_origin">Source: %1$s</string>
+    <string name="order_detail_attribution_direct_origin">Direct</string>
+    <string name="order_detail_attribution_admin_origin">Web admin</string>
+    <string name="order_detail_attribution_mobile_origin">Mobile App</string>
+    <string name="order_detail_attribution_unknown_origin">Unknown</string>
+    <string name="order_detail_attribution_source_type">Source type</string>
+    <string name="order_detail_attribution_source">Source</string>
+    <string name="order_detail_attribution_medium">Medium</string>
+    <string name="order_detail_attribution_device_type">Device type</string>
+    <string name="order_detail_attribution_session_page_views">Session page views</string>
 
     <!--
         Shipping label Refunds

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -41,6 +41,7 @@ import com.woocommerce.android.ui.products.ProductDetailRepository
 import com.woocommerce.android.ui.products.addons.AddonRepository
 import com.woocommerce.android.util.ContinuationWrapper
 import com.woocommerce.android.util.captureValues
+import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowUndoSnackbar
@@ -68,6 +69,7 @@ import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.OrderAttributionInfo
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
@@ -2146,5 +2148,23 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         viewModel.start()
 
         assertThat(viewModel.orderNavigationIsEnabled()).isFalse
+    }
+
+    @Test
+    fun `when order attribution is loaded, then update state`() = testBlocking {
+        val attribution = OrderAttributionInfo(
+            sourceType = "referral",
+            source = "Woo.com"
+        )
+        whenever(orderDetailRepository.getOrderById(any())).thenReturn(order)
+        whenever(addonsRepository.containsAddonsFrom(any())).thenReturn(false)
+        whenever(orderDetailRepository.getOrderAttributionInfo(ORDER_ID)).thenReturn(attribution)
+
+        createViewModel()
+        viewModel.start()
+
+        val attributionState = viewModel.orderAttributionInfo.getOrAwaitValue()
+
+        assertThat(attributionState).isEqualTo(attribution)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-8cd7b2038aea11d9502fe1c2e82d2c0e75ae22d3'
+    fluxCVersion = '2962-7f93233edf1563346ed666bc305c9868c6296adb'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2962-7f93233edf1563346ed666bc305c9868c6296adb'
+    fluxCVersion = 'trunk-9480c549694d5b1fb1a64b0ab05246bfc959e460'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10962 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds logic to show the order attribution info on the Order details screen, it uses the changes from the FluxC PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2962 to retrieve the attribution information.

### Testing instructions 
**(Instructions Copied from https://github.com/woocommerce/woocommerce-ios/pull/11963 with some changes)**
#### Existing orders
1. Login into the app with your existing store
2. Open an old existing order with no attribution info (order which was created before the Woo 8.5 update)
3. Under the "ORDER INFORMATION" section, the "Origin" row with the value "Unkown" should be displayed.

#### Orders with attribution info
1. Confirm the Order Attribution is enabled for the store, it should be enabled by default. ([Setting](https://github.com/woocommerce/woocommerce-android/assets/1657201/b2a81154-da5d-455c-b113-5cc5a41ceb1b))
2. Login into the app
3. Create orders from the browser (Details below)
4. Open the order from the mobile app
5. Validate that the order attribution info is displayed.
6. Open the order from `wp-admin` page and validate that the order attribution values displayed in the mobile app match.



#### Creating orders with different attribution values

Internal - p1707390894816719/1707387041.549409-slack-C06FSDTSN82

Web PR: https://github.com/woocommerce/woocommerce/pull/39701

There’s a JavaScript snippet on the above Web PR that injects an <a> tag on the current webpage, and then clicks it. Use that to go from certain pages to the shop.

1. Confirm the Order Attribution is enabled for the store, it should be enabled by default. ([Setting](https://github.com/woocommerce/woocommerce-android/assets/1657201/b2a81154-da5d-455c-b113-5cc5a41ceb1b))
2. Open an incognito window and browse to a source site. Example: woo.com, google.com
3. Use the JS snippet from the Web PR https://github.com/woocommerce/woocommerce/pull/39701 to inject a link to your shop, and auto click it.
4. Go through the checkout process
5. Check the results on the Order Edit page and the Woo Mobile App.
6. Repeat 2-5 with several sources:
    - [Woo.com](http://woo.com/) -> should be just a referral
    - [Google.com](http://google.com/) -> should be classed as organic
    - Navigate directly to the shop URL -> should be typein/direct
    - Navigate directly to the shop URL, but include UTM params (?utm_source=FAKESOURCE&utm_medium=mediumparam&utm_campaign=campaignparam) -> should be utm
    - Create an order in the WP dashboard -> should be web admin

### Images/gif
| Order without attribution | Order with attribution (Collapsed) | Order with attribution (expanded) | Web |
| --- | --- | --- | --- |
| ![Screenshot_20240301_123155](https://github.com/woocommerce/woocommerce-android/assets/1657201/a4d7f4f6-80da-40cd-baf1-0fa2c71ff265) | ![Screenshot_20240301_123131](https://github.com/woocommerce/woocommerce-android/assets/1657201/e24bf681-0c01-4865-8ba4-6931b76a490d) | ![Screenshot_20240301_123143](https://github.com/woocommerce/woocommerce-android/assets/1657201/30145f3f-f7d4-4005-baf9-f24c3f2b75fd) | <img width="500" alt="Screenshot 2024-03-01 at 14 52 42" src="https://github.com/woocommerce/woocommerce-android/assets/1657201/41739f3b-6981-4859-82e8-bc8fffafae17"> |


https://github.com/woocommerce/woocommerce-android/assets/1657201/b9f0a587-38bd-4e91-8221-492e5971c8c6

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
