### PR TITLE
[Better Tablet Products] Show back arrow when product details in new product creation flow on tablets

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -322,6 +322,9 @@ class ProductDetailViewModel @Inject constructor(
     val isTrashEnabled: Boolean
         get() = !isProductUnderCreation && navArgs.isTrashEnabled
 
+    val isAddNewProductFlow: Boolean
+        get() = navArgs.mode == ProductDetailFragment.Mode.AddNewProduct
+
     /**
      * Provides the currencyCode for views who requires display prices
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
@@ -69,7 +69,13 @@ class ProductDetailsToolbarHelper @Inject constructor(
 
         toolbar.navigationIcon =
             when {
-                isTabletLogicNeeded() -> null
+                isTabletLogicNeeded() -> {
+                    if (viewModel?.isAddNewProductFlow == true) {
+                        AppCompatResources.getDrawable(activity, R.drawable.ic_back_24dp)
+                    } else {
+                        null
+                    }
+                }
                 fragment?.findNavController()?.hasBackStackEntry(R.id.products) == true -> {
                     AppCompatResources.getDrawable(activity, R.drawable.ic_back_24dp)
                 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10997
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I noticed that there is no back arrow shown on tablets on the product creation flow. This PR fixes that

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
On a tablet
* Open products
* Click on FAB
* Select manual creation
* Notice that the back arrow is shown and functions

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/4923871/11a84a53-8c38-4239-8856-7b6fcd5164aa




- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
