### PR TITLE
Releasing EAH milestone 2

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,9 +2,7 @@
 17.7
 -----
 - [*] Products: Fixed a bug when after configuration change product's search results are lost [https://github.com/woocommerce/woocommerce-android/pull/10995]
-
-17.7
------
+- [***] Stats: Merchants can now customize their analytics by enabling/disabling and reordering the cards in the Analytics Hub. [https://github.com/woocommerce/woocommerce-android/pull/11002]
 
 
 17.6

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
@@ -28,7 +28,6 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.MarginTopItemDecoration
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.util.ChromeCustomTabUtils
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
@@ -59,9 +58,7 @@ class AnalyticsHubFragment : BaseFragment(R.layout.fragment_analytics) {
         super.onViewCreated(view, savedInstanceState)
         bind(view)
         setupResultHandlers(viewModel)
-        if (FeatureFlag.EXPANDED_ANALYTIC_HUB_M2.isEnabled()) {
-            setupMenu()
-        }
+        setupMenu()
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.viewState.flowWithLifecycle(lifecycle).collect { newState -> handleStateChange(newState) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -14,7 +14,6 @@ enum class FeatureFlag {
     BETTER_CUSTOMER_SEARCH_M2,
     ORDER_CREATION_AUTO_TAX_RATE,
     BLAZE_I3,
-    EXPANDED_ANALYTIC_HUB_M2,
     CUSTOM_RANGE_ANALYTICS;
 
     fun isEnabled(context: Context? = null): Boolean {
@@ -29,7 +28,6 @@ enum class FeatureFlag {
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
             BLAZE_I3,
-            EXPANDED_ANALYTIC_HUB_M2,
             CUSTOM_RANGE_ANALYTICS -> PackageUtils.isDebugBuild()
 
             IAP_FOR_STORE_CREATION -> false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10705 

### Description
This PR removes the `EXPANDED_ANALYTIC_HUB_M2` feature flag to release the customization features.

### Test steps

1. On the My store dashboard, tap "See More" to open the Analytics Hub.
2. Tap the Edit button (pencil) to open a Customize Analytics screen where the cards can be managed (added/removed/reordered).
3. Save the changes and confirm the Analytics Hub is updated to reflect the customizations.

### Expected behavior

On the Customize Analytics screen:

* When there are no changes to be saved, the Save button is disabled.
* When there are unsaved changes and the close button is tapped, you can discard the changes.
* Cards can be selected/deselected and reordered.
* At least one card must be selected (the last selected card can't be deselected).

In the Analytics Hub:

* When changes are saved, those changes are immediately reflected in the Analytics Hub.
* If no new cards are enabled, no data is fetched when the changes are saved.
* If new cards are enabled, their data is fetched and they load as expected.

### Environments to test

Color scheme:

- [x] Dark mode
- [x] Light mode

Device orientation:

- [x] Portrait
- [x] Landscape

Store types:

- [x] Store using Jetpack plugin
- [x] Store using Jetpack connection package
- [x] Store without Jetpack

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/b8c0ca9b-f3fa-44c7-830a-5360d7fce31e


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
