### PR TITLE
[Better Tablet Products] Fix margins on some screens + toolbar on shipping classes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductShippingClassFragment.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.products
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -15,6 +16,8 @@ import com.woocommerce.android.extensions.show
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ShippingClass
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -36,6 +39,8 @@ class ProductShippingClassFragment : BaseFragment(R.layout.fragment_product_ship
 
     private var _binding: FragmentProductShippingClassListBinding? = null
     private val binding get() = _binding!!
+
+    override val activityAppBarStatus = AppBarStatus.Hidden
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -60,6 +65,16 @@ class ProductShippingClassFragment : BaseFragment(R.layout.fragment_product_ship
         }
 
         viewModel.loadShippingClasses()
+
+        setupTabletSecondPaneToolbar(
+            title = getString(R.string.product_shipping_class),
+            onMenuItemSelected = { _ -> false },
+            onCreateMenu = { toolbar ->
+                toolbar.setNavigationOnClickListener {
+                    findNavController().navigateUp()
+                }
+            }
+        )
     }
 
     override fun onDestroyView() {
@@ -92,8 +107,6 @@ class ProductShippingClassFragment : BaseFragment(R.layout.fragment_product_ship
             }
         }
     }
-
-    override fun getFragmentTitle() = getString(R.string.product_shipping_class)
 
     private fun onShippingClassClicked(shippingClass: ShippingClass) {
         viewModel.onShippingClassClicked(shippingClass)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isDisplaySmallerThan720
 import org.wordpress.android.util.DisplayUtils
@@ -27,7 +28,7 @@ class TabletLayoutSetupHelper @Inject constructor(
 
     fun onRootFragmentCreated(screen: Screen) {
         if (FeatureFlag.BETTER_TABLETS_SUPPORT_PRODUCTS.isEnabled()) {
-            this@TabletLayoutSetupHelper.screen = screen
+            this.screen = screen
             initNavFragment(screen)
 
             screen.listFragment.parentFragmentManager.registerFragmentLifecycleCallbacks(
@@ -61,7 +62,7 @@ class TabletLayoutSetupHelper @Inject constructor(
                         v: View,
                         savedInstanceState: Bundle?
                     ) {
-                        if (f != navHostFragment) {
+                        if (f != navHostFragment && f !is BottomSheetDialogFragment) {
                             setDetailsMargins(v)
                         }
                     }

--- a/WooCommerce/src/main/res/layout/fragment_add_product_category.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_product_category.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     xmlns:tools="http://schemas.android.com/tools"
-    android:background="?attr/colorSurface">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
@@ -17,32 +16,42 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:title="@string/app_name" />
 
-    <!-- Product Category name -->
-    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-        android:id="@+id/product_category_name"
+    <com.woocommerce.android.widgets.WCElevatedLinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginTop="@dimen/major_75"
-        android:layout_marginEnd="@dimen/major_100"
-        android:hint="@string/product_category_name"
-        android:inputType="text"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/major_100"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar" />
+        app:layout_constraintTop_toBottomOf="@+id/toolbar">
 
-    <!-- Parent Category -->
-    <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
-        android:id="@+id/product_category_parent"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/major_100"
-        android:layout_marginTop="@dimen/major_100"
-        android:layout_marginEnd="@dimen/major_100"
-        android:hint="@string/product_category_parent"
-        android:inputType="text"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/product_category_name" />
+        <!-- Product Category name -->
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/product_category_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_75"
+            android:layout_marginEnd="@dimen/major_100"
+            android:hint="@string/product_category_name"
+            android:inputType="text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/toolbar" />
 
+        <!-- Parent Category -->
+        <com.woocommerce.android.widgets.WCMaterialOutlinedSpinnerView
+            android:id="@+id/product_category_parent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginTop="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:hint="@string/product_category_parent"
+            android:inputType="text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/product_category_name" />
+
+    </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/layout/fragment_aztec_editor.xml
+++ b/WooCommerce/src/main/res/layout/fragment_aztec_editor.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/color_surface">
+    android:layout_height="match_parent">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
@@ -21,7 +20,7 @@
         android:id="@+id/bottomToolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
+        android:background="@color/color_surface"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">
@@ -46,7 +45,9 @@
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:background="@color/color_surface"
         android:fillViewport="true"
+        android:orientation="horizontal"
         app:layout_constraintBottom_toTopOf="@+id/bottomToolbar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/fragment_product_menu_order.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_menu_order.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/colorSurface"
     android:orientation="vertical">
 
     <com.google.android.material.appbar.MaterialToolbar
@@ -15,13 +14,18 @@
         android:elevation="@dimen/appbar_elevation"
         tools:title="@string/app_name" />
 
-    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-        android:id="@+id/product_menu_order"
+    <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/major_100"
-        android:hint="@string/product_menu_order"
-        android:inputType="numberSigned"
-        app:helperText="@string/product_menu_order_caption" />
+        android:layout_height="wrap_content">
 
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/product_menu_order"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/major_100"
+            android:hint="@string/product_menu_order"
+            android:inputType="numberSigned"
+            app:helperText="@string/product_menu_order_caption" />
+
+    </androidx.cardview.widget.CardView>
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_shipping_class_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_shipping_class_list.xml
@@ -1,32 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recycler"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        tools:listitem="@layout/product_shipping_class_item" />
+        android:layout_height="@dimen/toolbar_height"
+        android:elevation="@dimen/appbar_elevation"
+        tools:title="@string/app_name" />
 
-    <ProgressBar
-        android:id="@+id/loadingProgress"
-        style="?android:attr/progressBarStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:layout_marginBottom="@dimen/margin_large"
-        android:visibility="gone"
-        tools:visibility="visible" />
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-    <ProgressBar
-        android:id="@+id/loadingMoreProgress"
-        style="?android:attr/progressBarStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal|bottom"
-        android:layout_marginBottom="@dimen/margin_large"
-        android:visibility="gone"
-        tools:visibility="visible" />
-</FrameLayout>
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recycler"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:listitem="@layout/product_shipping_class_item" />
+
+        <ProgressBar
+            android:id="@+id/loadingProgress"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+        <ProgressBar
+            android:id="@+id/loadingMoreProgress"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal|bottom"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:visibility="gone"
+            tools:visibility="visible" />
+    </androidx.cardview.widget.CardView>
+
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_slug.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_slug.xml
@@ -14,13 +14,18 @@
         android:elevation="@dimen/appbar_elevation"
         tools:title="@string/app_name" />
 
-    <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
-        android:id="@+id/editSlug"
+    <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/major_100"
-        android:hint="@string/product_slug"
-        android:inputType="text"
-        app:helperText="@string/product_slug_label" />
+        android:layout_height="wrap_content">
 
+        <com.woocommerce.android.widgets.WCMaterialOutlinedEditTextView
+            android:id="@+id/editSlug"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/major_100"
+            android:hint="@string/product_slug"
+            android:inputType="text"
+            app:helperText="@string/product_slug_label" />
+
+    </androidx.cardview.widget.CardView>
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_status.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_status.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/radioGroup"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/colorSurface"
     android:orientation="vertical">
 
     <com.google.android.material.appbar.MaterialToolbar
@@ -15,40 +13,44 @@
         android:elevation="@dimen/appbar_elevation"
         tools:title="@string/app_name" />
 
-    <CheckedTextView
-        android:layout_marginTop="@dimen/minor_100"
-        android:id="@+id/btnPublishedPrivately"
+    <com.woocommerce.android.widgets.WCElevatedLinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/product_status_privately_published"
-        android:visibility="gone"
-        tools:visibility="visible" />
+        android:orientation="vertical">
 
-    <CheckedTextView
-        android:id="@+id/btnPublished"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/product_status_published" />
+        <CheckedTextView
+            android:id="@+id/btnPublishedPrivately"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/minor_100"
+            android:text="@string/product_status_privately_published"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
-    <View
-        style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/major_100" />
+        <CheckedTextView
+            android:id="@+id/btnPublished"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/product_status_published" />
 
-    <CheckedTextView
-        android:id="@+id/btnDraft"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/product_status_draft" />
+        <View
+            style="@style/Woo.Divider"
+            android:layout_marginStart="@dimen/major_100" />
 
-    <View
-        style="@style/Woo.Divider"
-        android:layout_marginStart="@dimen/major_100" />
+        <CheckedTextView
+            android:id="@+id/btnDraft"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/product_status_draft" />
 
-    <CheckedTextView
-        android:id="@+id/btnPending"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/product_status_pending" />
+        <View
+            style="@style/Woo.Divider"
+            android:layout_marginStart="@dimen/major_100" />
 
-    <View style="@style/Woo.Divider" />
+        <CheckedTextView
+            android:id="@+id/btnPending"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/product_status_pending" />
+    </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 </LinearLayout>

--- a/WooCommerce/src/main/res/layout/fragment_product_visibility.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_visibility.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical">
 
     <com.google.android.material.appbar.MaterialToolbar
@@ -13,16 +14,9 @@
         android:elevation="@dimen/appbar_elevation"
         tools:title="@string/app_name" />
 
-    <ScrollView
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="?attr/colorSurface">
-
-        <LinearLayout
+        <com.woocommerce.android.widgets.WCElevatedLinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/minor_100"
             android:orientation="vertical">
 
             <CheckedTextView
@@ -63,9 +57,5 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/product_visibility_private" />
-
-            <View style="@style/Woo.Divider" />
-
-        </LinearLayout>
-    </ScrollView>
+        </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 </LinearLayout>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10999
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR:
* Removes margins applied to bottom sheets
* Fixes layouts to look consistent with correct margins: Product Settings Visibility, Product Settings Slug, Product Settings Menu Order, Descriptions, Product Settings Category
* Adds toolbar and fixes margin on Product shipping class fragment

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Walk through the mentioned above screens and notice the correct margins and layouts

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/4923871/1a4c1046-b927-45e4-a6a0-322f0f02bd9f


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
