### PR TITLE
AI description: Fix the height of the promo dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/AIProductDescriptionDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/AIProductDescriptionDialogFragment.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.util.DisplayUtils
 class AIProductDescriptionDialogFragment : DialogFragment() {
     companion object {
         private const val TABLET_LANDSCAPE_WIDTH_RATIO = 0.35f
-        private const val TABLET_LANDSCAPE_HEIGHT_RATIO = 0.8f
     }
 
     private val viewModel: AIProductDescriptionDialogViewModel by viewModels()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/AIProductDescriptionDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/AIProductDescriptionDialogFragment.kt
@@ -71,7 +71,7 @@ class AIProductDescriptionDialogFragment : DialogFragment() {
         if (isTabletLandscape()) {
             requireDialog().window!!.setLayout(
                 (DisplayUtils.getWindowPixelWidth(requireContext()) * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
-                (DisplayUtils.getWindowPixelHeight(requireContext()) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
+                ViewGroup.LayoutParams.WRAP_CONTENT
             )
         }
     }


### PR DESCRIPTION
This PR fixes the issue where the promo dialog would fill the entire screen height.

![image](https://github.com/woocommerce/woocommerce-android/assets/1522856/81e95835-1082-47d7-8368-ebeed8aba61d)

**To test:**
1. Use a tablet-sized device
2. Create a new WooExpress store
3. Once the store loads, notice the AI promo dialog wraps its content