### PR TITLE
Custom Range: Add custom range tab

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -158,7 +158,7 @@ class MyStoreFragment :
 
     private val tabSelectedListener = object : TabLayout.OnTabSelectedListener {
         override fun onTabSelected(tab: TabLayout.Tab) {
-            myStoreViewModel.onStatsGranularityChanged(tab.tag as StatsGranularity)
+            myStoreViewModel.onStatsGranularityChanged(tab.tag as? StatsGranularity)
         }
 
         override fun onTabUnselected(tab: TabLayout.Tab) {}
@@ -428,6 +428,9 @@ class MyStoreFragment :
                 topPerformers.isError -> showTopPerformersError()
                 else -> showTopPerformers(topPerformers.topPerformers)
             }
+        }
+        myStoreViewModel.customDateRange.observe(viewLifecycleOwner) { dateRange ->
+            binding.myStoreStats.updateCustomDateRange(dateRange)
         }
         myStoreViewModel.hasOrders.observe(viewLifecycleOwner) { newValue ->
             when (newValue) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -200,6 +200,8 @@ class MyStoreStatsView @JvmOverloads constructor(
         customRange = customDateRange
         customRangeButton.isVisible = customDateRange == null && FeatureFlag.CUSTOM_RANGE_ANALYTICS.isEnabled()
         customRangeTab.view.isVisible = customDateRange != null && FeatureFlag.CUSTOM_RANGE_ANALYTICS.isEnabled()
+        tabLayout.selectTab(customRangeTab)
+        tabLayout.scrollX = tabLayout.width
     }
 
     fun showSkeleton(show: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -26,6 +26,7 @@ import com.github.mikephil.charting.highlight.Highlight
 import com.github.mikephil.charting.listener.ChartTouchListener.ChartGesture
 import com.github.mikephil.charting.listener.OnChartValueSelectedListener
 import com.google.android.material.card.MaterialCardView
+import com.google.android.material.tabs.TabLayout.Tab
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -51,6 +52,7 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.DisplayUtils
+import java.util.Date
 import java.util.Locale
 import kotlin.math.round
 
@@ -79,6 +81,7 @@ class MyStoreStatsView @JvmOverloads constructor(
     private var chartRevenueStats = mapOf<String, Double>()
     private var chartOrderStats = mapOf<String, Long>()
     private var chartVisitorStats = mapOf<String, Int>()
+    private var customRange: Pair<Date, Date>? = null
 
     private var skeletonView = SkeletonView()
 
@@ -122,8 +125,9 @@ class MyStoreStatsView @JvmOverloads constructor(
     private val chartUserInteractions = MutableSharedFlow<Unit>()
     private lateinit var chartUserInteractionsJob: Job
 
-    val tabLayout = binding.statsTabLayout
     val customRangeButton = binding.customRangeButton
+    val tabLayout = binding.statsTabLayout
+    private lateinit var customRangeTab: Tab
 
     @Suppress("LongParameterList")
     fun initView(
@@ -141,8 +145,6 @@ class MyStoreStatsView @JvmOverloads constructor(
         this.currencyFormatter = currencyFormatter
         this.usageTracksEventEmitter = usageTracksEventEmitter
         this.coroutineScope = lifecycleScope
-
-        customRangeButton.isVisible = FeatureFlag.CUSTOM_RANGE_ANALYTICS.isEnabled()
 
         initChart()
 
@@ -172,6 +174,11 @@ class MyStoreStatsView @JvmOverloads constructor(
             }
             tabLayout.addTab(tab)
         }
+        customRangeTab = tabLayout.newTab().apply {
+            setText(R.string.orderfilters_date_range_filter_custom_range)
+            view.isVisible = false
+        }
+        tabLayout.addTab(customRangeTab)
     }
 
     override fun onDetachedFromWindow() {
@@ -187,6 +194,12 @@ class MyStoreStatsView @JvmOverloads constructor(
             mapOf(AnalyticsTracker.KEY_RANGE to granularity.toString().lowercase())
         )
         isRequestingStats = true
+    }
+
+    fun updateCustomDateRange(customDateRange: Pair<Date, Date>?) {
+        customRange = customDateRange
+        customRangeButton.isVisible = customDateRange == null && FeatureFlag.CUSTOM_RANGE_ANALYTICS.isEnabled()
+        customRangeTab.view.isVisible = customDateRange != null && FeatureFlag.CUSTOM_RANGE_ANALYTICS.isEnabled()
     }
 
     fun showSkeleton(show: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -111,6 +111,9 @@ class MyStoreViewModel @Inject constructor(
     private var _lastUpdateStats = MutableLiveData<Long?>()
     val lastUpdateStats: LiveData<Long?> = _lastUpdateStats
 
+    private var _customDateRange = MutableLiveData<Pair<Date, Date>?>()
+    val customDateRange: LiveData<Pair<Date, Date>?> = _customDateRange
+
     private var _lastUpdateTopPerformers = MutableLiveData<Long?>()
     val lastUpdateTopPerformers: LiveData<Long?> = _lastUpdateTopPerformers
 
@@ -188,11 +191,19 @@ class MyStoreViewModel @Inject constructor(
         }
     }
 
-    fun onStatsGranularityChanged(granularity: StatsGranularity) {
+    fun onStatsGranularityChanged(granularity: StatsGranularity?) {
         usageTracksEventEmitter.interacted()
-        _activeStatsGranularity.update { granularity }
-        launch {
-            appPrefsWrapper.setActiveStatsGranularity(granularity.name)
+
+        if (granularity != null) {
+            _activeStatsGranularity.update { granularity }
+            launch {
+                appPrefsWrapper.setActiveStatsGranularity(granularity.name)
+            }
+        } else {
+            WooLog.i(
+                WooLog.T.DASHBOARD,
+                message = "Custom range selected: ${customDateRange.value?.first} - ${customDateRange.value?.second}"
+            )
         }
     }
 
@@ -430,7 +441,7 @@ class MyStoreViewModel @Inject constructor(
     }
 
     fun onCustomRangeSelected(fromDate: Date, toDate: Date) {
-        WooLog.i(WooLog.T.DASHBOARD, "Custom range selected: $fromDate - $toDate")
+        _customDateRange.value = Pair(fromDate, toDate)
     }
 
     fun onAddCustomRangeClicked() {


### PR DESCRIPTION
Implements #10983, a subtask #10963. The PR adds a custom date range tab that is shown after a date range is selected.

<img src="https://github.com/woocommerce/woocommerce-android/assets/1522856/1b5257ab-b3a3-48d0-88cf-f703bf8e8aa6" width="300" />

**To test:**
1. Tap on the custom range button
2. Select a date range
3. Notice the button disappears and a "Custom range" tab appears
4. Tap on the custom date range tab
5. Notice the selected date range is logged in the logcat