### PR TITLE
FluxC stats code cleanup

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
@@ -14,6 +14,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -117,7 +118,7 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
         // Given a site using a version that doesn't support AUTO_DRAFT
         whenever(wooCommerceStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_CORE))
             .thenReturn(SitePluginModel().apply { version = "6.2.0" })
-        whenever(orderUpdateStore.createOrder(any(), any()))
+        whenever(orderUpdateStore.createOrder(any(), any(), anyOrNull()))
             .thenReturn(WooResult(OrderTestUtils.generateOrder()))
 
         val order = Order.getEmptyOrder(Date(), Date()).copy(
@@ -148,7 +149,7 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
         // Given a site using a version that support AUTO_DRAFT
         whenever(wooCommerceStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_CORE))
             .thenReturn(SitePluginModel().apply { version = OrderCreateEditRepository.AUTO_DRAFT_SUPPORTED_VERSION })
-        whenever(orderUpdateStore.createOrder(any(), any()))
+        whenever(orderUpdateStore.createOrder(any(), any(), anyOrNull()))
             .thenReturn(WooResult(OrderTestUtils.generateOrder()))
 
         val order = Order.getEmptyOrder(Date(), Date()).copy(

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2966-b23aeb4a9e98448cb696af26dace7897ca248103'
+    fluxCVersion = 'trunk-564e35b89b1542924a63043bee20be4c65c21647'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.69.0'
+    fluxCVersion = '2966-b23aeb4a9e98448cb696af26dace7897ca248103'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Preparation for: #11007 and #11008

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR just updates FluxC to confirm that the code cleanup of https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2966 doesn't impact the app.

### Testing instructions
Green CI should be enough, but smoke testing the stats screen won't hurt.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
