### PR TITLE
[Better Tablet Products] Products settings back clicks didn't safe the pick

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListToolbarHelper.kt
@@ -9,12 +9,13 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.navigation.findNavController
+import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentProductListBinding
+import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.util.IsTabletLogicNeeded
 import org.wordpress.android.util.ActivityUtils
@@ -28,7 +29,7 @@ class ProductListToolbarHelper @Inject constructor(
     SearchView.OnQueryTextListener,
     Toolbar.OnMenuItemClickListener,
     WCProductSearchTabView.ProductSearchTypeChangedListener {
-    private var fragment: ProductListFragment? = null
+    private var listFragment: ProductListFragment? = null
     private var viewModel: ProductListViewModel? = null
     private var binding: FragmentProductListBinding? = null
 
@@ -42,13 +43,23 @@ class ProductListToolbarHelper @Inject constructor(
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
                     if (isTabletLogicNeeded()) {
-                        if (binding?.detailNavContainer?.findNavController()?.popBackStack() != true) {
-                            fragment?.findNavController()?.popBackStack()
+                        val navHostFragment = binding?.detailNavContainer?.getFragment<NavHostFragment?>()
+                        val detailsFragment = navHostFragment?.childFragmentManager?.fragments?.getOrNull(0)
+                        if (detailsFragment is MainActivity.Companion.BackPressListener) {
+                            if (detailsFragment.onRequestAllowBackPress()) {
+                                if (!navHostFragment.findNavController().popBackStack()) {
+                                    listFragment?.findNavController()?.popBackStack()
+                                }
+                            }
+                        } else {
+                            if (navHostFragment?.findNavController()?.popBackStack() == false) {
+                                listFragment?.findNavController()?.popBackStack()
+                            }
                         }
                     } else if (searchMenuItem?.isActionViewExpanded == true) {
                         searchMenuItem?.collapseActionView()
                     } else {
-                        fragment?.findNavController()?.navigateUp()
+                        listFragment?.findNavController()?.navigateUp()
                     }
                 }
             }
@@ -60,7 +71,7 @@ class ProductListToolbarHelper @Inject constructor(
         productListViewModel: ProductListViewModel,
         binding: FragmentProductListBinding
     ) {
-        this.fragment = fragment
+        this.listFragment = fragment
         this.viewModel = productListViewModel
         this.binding = binding
 
@@ -76,7 +87,7 @@ class ProductListToolbarHelper @Inject constructor(
 
     override fun onDestroy(owner: LifecycleOwner) {
         disableSearchListeners()
-        fragment = null
+        listFragment = null
         searchMenuItem = null
         scanBarcodeMenuItem = null
         searchView = null
@@ -95,7 +106,7 @@ class ProductListToolbarHelper @Inject constructor(
             R.id.menu_scan_barcode -> {
                 AnalyticsTracker.track(AnalyticsEvent.PRODUCT_LIST_PRODUCT_BARCODE_SCANNING_TAPPED)
                 ProductListFragmentDirections.actionProductListFragmentToScanToUpdateInventory().let {
-                    fragment?.findNavController()?.navigate(it)
+                    listFragment?.findNavController()?.navigate(it)
                 }
                 searchMenuItem?.collapseActionView()
                 true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductCatalogVisibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductCatalogVisibilityFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.View.OnClickListener
 import android.widget.CheckedTextView
 import androidx.annotation.IdRes
-import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -55,7 +54,7 @@ class ProductCatalogVisibilityFragment :
             onMenuItemSelected = { _ -> false },
             onCreateMenu = { toolbar ->
                 toolbar.setNavigationOnClickListener {
-                    findNavController().navigateUp()
+                    onRequestAllowBackPress()
                 }
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductMenuOrderFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductMenuOrderFragment.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.products.settings
 
 import android.os.Bundle
 import android.view.View
-import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -35,7 +34,7 @@ class ProductMenuOrderFragment : BaseProductSettingsFragment(R.layout.fragment_p
             onMenuItemSelected = { _ -> false },
             onCreateMenu = { toolbar ->
                 toolbar.setNavigationOnClickListener {
-                    findNavController().navigateUp()
+                    onRequestAllowBackPress()
                 }
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSlugFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductSlugFragment.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.products.settings
 
 import android.os.Bundle
 import android.view.View
-import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -34,7 +33,7 @@ class ProductSlugFragment : BaseProductSettingsFragment(R.layout.fragment_produc
             onMenuItemSelected = { _ -> false },
             onCreateMenu = { toolbar ->
                 toolbar.setNavigationOnClickListener {
-                    findNavController().navigateUp()
+                    onRequestAllowBackPress()
                 }
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductStatusFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductStatusFragment.kt
@@ -5,7 +5,6 @@ import android.view.View
 import android.view.View.OnClickListener
 import android.widget.CheckedTextView
 import androidx.annotation.IdRes
-import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -63,7 +62,7 @@ class ProductStatusFragment : BaseProductSettingsFragment(R.layout.fragment_prod
             onMenuItemSelected = { _ -> false },
             onCreateMenu = { toolbar ->
                 toolbar.setNavigationOnClickListener {
-                    findNavController().navigateUp()
+                    onRequestAllowBackPress()
                 }
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductVisibilityFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/settings/ProductVisibilityFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.View.OnClickListener
 import android.widget.CheckedTextView
 import androidx.annotation.IdRes
-import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -59,7 +58,7 @@ class ProductVisibilityFragment : BaseProductSettingsFragment(R.layout.fragment_
             onMenuItemSelected = { _ -> false },
             onCreateMenu = { toolbar ->
                 toolbar.setNavigationOnClickListener {
-                    findNavController().navigateUp()
+                    onRequestAllowBackPress()
                 }
             }
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11015
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes a bug when on the product settings secondary screens the selection was not propagated up

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Try both on a tablet and a phone
* Products
* Product
* Product settings
* Change: status, visibility, slug, menu order, catalog visibility
* Come back with both system back or toolbar back
* Notice that the change was propagated

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/26655e42-5c61-4995-a64f-0d698e8138a2



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
