### PR TITLE
[Better Errors] Add Connectivity use cases unit tests

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/connectivitytool/useCases/InternetConnectionCheckUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/connectivitytool/useCases/InternetConnectionCheckUseCaseTest.kt
@@ -1,0 +1,58 @@
+package com.woocommerce.android.ui.orders.connectivitytool.useCases
+
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus.Failure
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus.InProgress
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus.Success
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class InternetConnectionCheckUseCaseTest : BaseUnitTest() {
+    private lateinit var sut: InternetConnectionCheckUseCase
+    private lateinit var networkStatus: NetworkStatus
+
+    @Before
+    fun setUp() {
+        networkStatus = mock()
+        sut = InternetConnectionCheckUseCase(networkStatus)
+    }
+
+    @Test
+    fun `when network is connected then emit Success`() = testBlocking {
+        // Given
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        whenever(networkStatus.isConnected()).thenReturn(true)
+
+        // When
+        sut.invoke().onEach {
+            stateEvents.add(it)
+        }.launchIn(this)
+
+        // Then
+        assertThat(stateEvents).isEqualTo(listOf(InProgress, Success))
+    }
+
+    @Test
+    fun `when network is not connected then emit Failure`() = testBlocking {
+        // Given
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        whenever(networkStatus.isConnected()).thenReturn(false)
+
+        // When
+        sut.invoke().onEach {
+            stateEvents.add(it)
+        }.launchIn(this)
+
+        // Then
+        assertThat(stateEvents).isEqualTo(listOf(InProgress, Failure))
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/connectivitytool/useCases/StoreConnectionCheckUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/connectivitytool/useCases/StoreConnectionCheckUseCaseTest.kt
@@ -1,0 +1,73 @@
+package com.woocommerce.android.ui.orders.connectivitytool.useCases
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus.Failure
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus.InProgress
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus.Success
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.WCSSRModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.WooCommerceStore
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StoreConnectionCheckUseCaseTest : BaseUnitTest() {
+    private lateinit var sut: StoreConnectionCheckUseCase
+    private lateinit var wooCommerceStore: WooCommerceStore
+    private lateinit var selectedSite: SelectedSite
+
+    @Before
+    fun setUp() {
+        wooCommerceStore = mock()
+        selectedSite = mock()
+        sut = StoreConnectionCheckUseCase(wooCommerceStore, selectedSite)
+    }
+
+    @Test
+    fun `when fetchSSR returns an error then emit Failure`() = testBlocking {
+        // Given
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        val response = WooResult<WCSSRModel>(
+            WooError(
+                type = WooErrorType.GENERIC_ERROR,
+                original = BaseRequest.GenericErrorType.NETWORK_ERROR
+            )
+        )
+        whenever(wooCommerceStore.fetchSSR(selectedSite.get())).thenReturn(response)
+
+        // When
+        sut.invoke().onEach {
+            stateEvents.add(it)
+        }.launchIn(this)
+
+        // Then
+        assertThat(stateEvents).isEqualTo(listOf(InProgress, Failure))
+    }
+
+    @Test
+    fun `when fetchSSR returns no error then emit Success`() = testBlocking {
+        // Given
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        val response = WooResult(WCSSRModel(remoteSiteId = 123L))
+        whenever(wooCommerceStore.fetchSSR(selectedSite.get())).thenReturn(response)
+
+        // When
+        sut.invoke().onEach {
+            stateEvents.add(it)
+        }.launchIn(this)
+
+        // Then
+        assertThat(stateEvents).isEqualTo(listOf(InProgress, Success))
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/connectivitytool/useCases/StoreOrdersCheckUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/connectivitytool/useCases/StoreOrdersCheckUseCaseTest.kt
@@ -1,0 +1,73 @@
+package com.woocommerce.android.ui.orders.connectivitytool.useCases
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus.Failure
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus.InProgress
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus.Success
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCOrderStore.HasOrdersResult
+import org.wordpress.android.fluxc.store.WCOrderStore.OrderError
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StoreOrdersCheckUseCaseTest : BaseUnitTest() {
+    private lateinit var sut: StoreOrdersCheckUseCase
+    private lateinit var orderStore: WCOrderStore
+    private lateinit var selectedSite: SelectedSite
+
+    @Before
+    fun setUp() {
+        orderStore = mock()
+        selectedSite = mock()
+        sut = StoreOrdersCheckUseCase(orderStore, selectedSite)
+    }
+
+    @Test
+    fun `when fetchHasOrders returns success then emit Success`() = testBlocking {
+        // Given
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        whenever(
+            orderStore.fetchHasOrders(
+                site = selectedSite.get(),
+                status = null
+            )
+        ).thenReturn(HasOrdersResult.Success(hasOrders = true))
+
+        // When
+        sut.invoke().onEach {
+            stateEvents.add(it)
+        }.launchIn(this)
+
+        // Then
+        assertThat(stateEvents).isEqualTo(listOf(InProgress, Success))
+    }
+
+    @Test
+    fun `when fetchHasOrders returns failure then emit Failure`() = testBlocking {
+        // Given
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        whenever(
+            orderStore.fetchHasOrders(
+                site = selectedSite.get(),
+                status = null
+            )
+        ).thenReturn(HasOrdersResult.Failure(OrderError()))
+
+        // When
+        sut.invoke().onEach {
+            stateEvents.add(it)
+        }.launchIn(this)
+
+        // Then
+        assertThat(stateEvents).isEqualTo(listOf(InProgress, Failure))
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/connectivitytool/useCases/WordPressConnectionCheckUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/connectivitytool/useCases/WordPressConnectionCheckUseCaseTest.kt
@@ -1,0 +1,79 @@
+package com.woocommerce.android.ui.orders.connectivitytool.useCases
+
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus.Failure
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus.InProgress
+import com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolViewModel.ConnectivityCheckStatus.Success
+import com.woocommerce.android.util.BuildConfigWrapper
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.store.WhatsNewStore
+import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewErrorType
+import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewFetchError
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WordPressConnectionCheckUseCaseTest : BaseUnitTest() {
+    private lateinit var sut: WordPressConnectionCheckUseCase
+    private lateinit var whatsNewStore: WhatsNewStore
+    private lateinit var buildConfigWrapper: BuildConfigWrapper
+
+    @Before
+    fun setUp() {
+        whatsNewStore = mock()
+        buildConfigWrapper = mock()
+        sut = WordPressConnectionCheckUseCase(whatsNewStore, buildConfigWrapper)
+    }
+
+    @Test
+    fun `when fetchRemoteAnnouncements returns an error then emit Failure`() = testBlocking {
+        // Given
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        val response = WhatsNewStore.OnWhatsNewFetched(
+            fetchError = WhatsNewFetchError(WhatsNewErrorType.GENERIC_ERROR)
+        )
+        whenever(buildConfigWrapper.versionName).thenReturn("1.0.0")
+        whenever(
+            whatsNewStore.fetchRemoteAnnouncements(
+                versionName = "1.0.0",
+                appId = WhatsNewStore.WhatsNewAppId.WOO_ANDROID
+            )
+        ).thenReturn(response)
+
+        // When
+        sut.invoke().onEach {
+            stateEvents.add(it)
+        }.launchIn(this)
+
+        // Then
+        assertThat(stateEvents).isEqualTo(listOf(InProgress, Failure))
+    }
+
+    @Test
+    fun `when fetchRemoteAnnouncements returns no error then emit Success`() = testBlocking {
+        // Given
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        val response = WhatsNewStore.OnWhatsNewFetched()
+        whenever(buildConfigWrapper.versionName).thenReturn("1.0.0")
+        whenever(
+            whatsNewStore.fetchRemoteAnnouncements(
+                versionName = "1.0.0",
+                appId = WhatsNewStore.WhatsNewAppId.WOO_ANDROID
+            )
+        ).thenReturn(response)
+
+        // When
+        sut.invoke().onEach {
+            stateEvents.add(it)
+        }.launchIn(this)
+
+        // Then
+        assertThat(stateEvents).isEqualTo(listOf(InProgress, Success))
+    }
+}


### PR DESCRIPTION
Summary
==========
This PR only introduces the unit tests for https://github.com/woocommerce/woocommerce-android/pull/11001 and will be merged once that PR is approved.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.