### PR TITLE
[Better Tablet Product] Removed redundant hiding of the bottom nav bar in AztecEditorFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aztec/AztecEditorFragment.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.main.AppBarStatus
-import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.AIProductDescriptionBottomSheetFragment.Companion.KEY_AI_GENERATED_DESCRIPTION_RESULT
 import com.woocommerce.android.util.setupTabletSecondPaneToolbar
@@ -66,8 +65,6 @@ class AztecEditorFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        (activity as? MainActivity)?.hideBottomNav()
 
         val binding = FragmentAztecEditorBinding.bind(view)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11031 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
`AztecEditorFragment` calls hiding of the activity nav bar, which seems to be completely redundant and hides it on the tablet flow when not needed

`AztecEditorFragment` is started from 4 places, and all of them are nested fragments of the product details flow, so seems to be it's safe to just remove this call
<img width="2031" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/4923871/ace5fe7e-3f58-4e84-beb7-dc1a06d4b9bf">


### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Both on a phone and a tablet try
* Products -> Product Details -> Short description
* Products -> Product Details -> Variations -> Variation -> Describe your product
* Products -> Product Details -> Product Settings -> Purchase Note
* Products -> Product Details -> Description
Notice that the navigation bar is visible on a tablet and not visible on a phone.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/7fadab8b-0ff9-4e67-933f-4591e37b6a1e



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
