### PR TITLE
[Better Tablet Product] Up arrow is missing after ai product creation flow on tablet

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -578,7 +578,10 @@ class ProductDetailFragment :
         data object Empty : Mode()
 
         @Parcelize
-        data class ShowProduct(val remoteProductId: Long) : Mode()
+        data class ShowProduct(
+            val remoteProductId: Long,
+            val afterGeneratedWithAi: Boolean = false,
+        ) : Mode()
 
         @Parcelize
         data object AddNewProduct : Mode()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -263,7 +263,7 @@ class ProductDetailViewModel @Inject constructor(
         .combine(_hasChanges) { productDraft, hasChanges ->
             Pair(productDraft, hasChanges)
         }.map { (productDraft, hasChanges) ->
-            val canBeSavedAsDraft = isAddFlowEntryPoint &&
+            val canBeSavedAsDraft = this.isAddNewProductFlow &&
                 !isProductStoredAtSite &&
                 productDraft.status != DRAFT
             val isNotPublishedUnderCreation = isProductUnderCreation &&
@@ -309,14 +309,14 @@ class ProductDetailViewModel @Inject constructor(
     /**
      * Returns boolean value of [navArgs.isAddProduct] to determine if the view model was started for the **add** flow
      */
-    private val isAddFlowEntryPoint: Boolean
+    val isAddNewProductFlow: Boolean
         get() = navArgs.mode == ProductDetailFragment.Mode.AddNewProduct
 
     /**
      * Validates if the view model was started for the **add** flow AND there is an already valid product to modify.
      */
     val isProductUnderCreation: Boolean
-        get() = isAddFlowEntryPoint and isProductStoredAtSite.not()
+        get() = this.isAddNewProductFlow and isProductStoredAtSite.not()
 
     /**
      * Returns boolean value of [navArgs.isTrashEnabled] to determine if the detail fragment should enable
@@ -324,9 +324,6 @@ class ProductDetailViewModel @Inject constructor(
      */
     val isTrashEnabled: Boolean
         get() = !isProductUnderCreation && navArgs.isTrashEnabled
-
-    val isAddNewProductFlow: Boolean
-        get() = navArgs.mode == ProductDetailFragment.Mode.AddNewProduct
 
     /**
      * Provides the currencyCode for views who requires display prices
@@ -399,7 +396,7 @@ class ProductDetailViewModel @Inject constructor(
 
     private fun initializeStoredProductAfterRestoration() {
         launch {
-            if (isAddFlowEntryPoint && !isProductStoredAtSite) {
+            if (this@ProductDetailViewModel.isAddNewProductFlow && !isProductStoredAtSite) {
                 storedProduct.value = createDefaultProductForAddFlow()
             } else {
                 when (val mode = navArgs.mode) {
@@ -1036,7 +1033,7 @@ class ProductDetailViewModel @Inject constructor(
         navArgs.source == STORE_ONBOARDING || productListRepository.getProductList().isEmpty()
 
     /**
-     * during a product creation flow flagged by [isAddFlowEntryPoint],
+     * during a product creation flow flagged by [isAddNewProductFlow],
      * we may have to POST the product before hand in order to operate
      * some remotes properties of the Product.
      * (e.g. Variable Product when editing the Attributes and Variations)
@@ -2024,7 +2021,7 @@ class ProductDetailViewModel @Inject constructor(
             draftChanges
                 .distinctUntilChanged { old, new -> old?.remoteId == new?.remoteId }
                 .map { getRemoteProductId() }
-                .filter { productId -> productId != DEFAULT_ADD_NEW_PRODUCT_ID || isAddFlowEntryPoint }
+                .filter { productId -> productId != DEFAULT_ADD_NEW_PRODUCT_ID || this@ProductDetailViewModel.isAddNewProductFlow }
                 .collectLatest { productId ->
                     mediaFileUploadHandler.observeCurrentUploads(productId)
                         .map { list -> list.map { it.toUri() } }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -399,7 +399,7 @@ class ProductDetailViewModel @Inject constructor(
 
     private fun initializeStoredProductAfterRestoration() {
         launch {
-            if (this@ProductDetailViewModel.isAddNewProductFlow && !isProductStoredAtSite) {
+            if (isAddNewProductFlow && !isProductStoredAtSite) {
                 storedProduct.value = createDefaultProductForAddFlow()
             } else {
                 when (val mode = navArgs.mode) {
@@ -2024,10 +2024,7 @@ class ProductDetailViewModel @Inject constructor(
             draftChanges
                 .distinctUntilChanged { old, new -> old?.remoteId == new?.remoteId }
                 .map { getRemoteProductId() }
-                .filter { productId ->
-                    productId != DEFAULT_ADD_NEW_PRODUCT_ID ||
-                        this@ProductDetailViewModel.isAddNewProductFlow
-                }
+                .filter { productId -> productId != DEFAULT_ADD_NEW_PRODUCT_ID || isAddNewProductFlow }
                 .collectLatest { productId ->
                     mediaFileUploadHandler.observeCurrentUploads(productId)
                         .map { list -> list.map { it.toUri() } }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -2024,7 +2024,10 @@ class ProductDetailViewModel @Inject constructor(
             draftChanges
                 .distinctUntilChanged { old, new -> old?.remoteId == new?.remoteId }
                 .map { getRemoteProductId() }
-                .filter { productId -> productId != DEFAULT_ADD_NEW_PRODUCT_ID || this@ProductDetailViewModel.isAddNewProductFlow }
+                .filter { productId ->
+                    productId != DEFAULT_ADD_NEW_PRODUCT_ID ||
+                        this@ProductDetailViewModel.isAddNewProductFlow
+                }
                 .collectLatest { productId ->
                     mediaFileUploadHandler.observeCurrentUploads(productId)
                         .map { list -> list.map { it.toUri() } }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -319,7 +319,7 @@ class ProductDetailViewModel @Inject constructor(
      * Validates if the view model was started for the **add** flow AND there is an already valid product to modify.
      */
     val isProductUnderCreation: Boolean
-        get() = this.isAddNewProductFlow and isProductStoredAtSite.not()
+        get() = isAddNewProductFlow and isProductStoredAtSite.not()
 
     /**
      * Returns boolean value of [navArgs.isTrashEnabled] to determine if the detail fragment should enable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -309,8 +309,11 @@ class ProductDetailViewModel @Inject constructor(
     /**
      * Returns boolean value of [navArgs.isAddProduct] to determine if the view model was started for the **add** flow
      */
-    val isAddNewProductFlow: Boolean
+    private val isAddNewProductFlow: Boolean
         get() = navArgs.mode == ProductDetailFragment.Mode.AddNewProduct
+
+    val startMode: ProductDetailFragment.Mode
+        get() = navArgs.mode
 
     /**
      * Validates if the view model was started for the **add** flow AND there is an already valid product to modify.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailsToolbarHelper.kt
@@ -70,7 +70,11 @@ class ProductDetailsToolbarHelper @Inject constructor(
         toolbar.navigationIcon =
             when {
                 isTabletLogicNeeded() -> {
-                    if (viewModel?.isAddNewProductFlow == true) {
+                    val startMode = viewModel?.startMode
+                    val isAddNewModeCreationFlow = startMode == ProductDetailFragment.Mode.AddNewProduct
+                    val isProductShownAfterGenerationWithAi = startMode is ProductDetailFragment.Mode.ShowProduct &&
+                        startMode.afterGeneratedWithAi
+                    if (isAddNewModeCreationFlow || isProductShownAfterGenerationWithAi) {
                         AppCompatResources.getDrawable(activity, R.drawable.ic_back_24dp)
                     } else {
                         null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AddProductWithAIFragment.kt
@@ -66,8 +66,10 @@ class AddProductWithAIFragment : BaseFragment(), MediaPickerResultHandler {
                 is NavigateToAIProductNameBottomSheet -> navigateToAIProductName(event.initialName)
                 is NavigateToProductDetailScreen -> findNavController().navigateSafely(
                     directions = NavGraphMainDirections.actionGlobalProductDetailFragment(
-                        mode = ProductDetailFragment.Mode.ShowProduct(event.productId),
-                        isAIContent = true
+                        mode = ProductDetailFragment.Mode.ShowProduct(
+                            remoteProductId = event.productId,
+                            afterGeneratedWithAi = true,
+                        )
                     ),
                     navOptions = navOptions {
                         popUpTo(R.id.addProductWithAIFragment) { inclusive = true }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -61,7 +61,7 @@ import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
-open class VariationDetailFragment :
+class VariationDetailFragment :
     BaseFragment(R.layout.fragment_variation_detail),
     BackPressListener,
     OnGalleryImageInteractionListener,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailFragment.kt
@@ -32,6 +32,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.dialog.WooDialogFragment
 import com.woocommerce.android.ui.dialog.WooDialogFragment.DialogInteractionListener
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.products.BaseProductEditorFragment
 import com.woocommerce.android.ui.products.ProductInventoryViewModel.InventoryData
@@ -60,7 +61,7 @@ import org.wordpress.android.util.ActivityUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class VariationDetailFragment :
+open class VariationDetailFragment :
     BaseFragment(R.layout.fragment_variation_detail),
     BackPressListener,
     OnGalleryImageInteractionListener,
@@ -69,6 +70,8 @@ class VariationDetailFragment :
         private const val LIST_STATE_KEY = "list_state"
         const val KEY_VARIATION_DETAILS_RESULT = "key_variation_details_result"
     }
+
+    override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
 
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -372,10 +372,6 @@
             android:defaultValue="false"
             app:argType="boolean" />
         <argument
-            android:name="isAIContent"
-            android:defaultValue="false"
-            app:argType="boolean" />
-        <argument
             android:name="images"
             android:defaultValue="@null"
             app:argType="string[]"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11034
Closes: #11037
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After a product created with AI flow up arrow was not shown. The PR fixes that

Also, I removed the second toolbar on the product variation details screen

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Try both on a tablet and a phone
* Products -> FAB -> Create a product with AI
* Finish AI flow -> Publish product
* Notice that the up arrow is visible now and functions

**To validate the #11037 .** 
* Open a product with variations
* Variations -> Select a variation
* Notice 1 toolbar on a phone

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/83eb5572-cfb5-41fc-b200-d9964171f5d7

<img width="400" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/4923871/33e0e398-85f3-4527-8596-bff0846397d9">


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
