### PR TITLE
Clear product and customer filters when switching sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/data/OrderFiltersRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/data/OrderFiltersRepository.kt
@@ -24,7 +24,7 @@ class OrderFiltersRepository @Inject constructor(
 
     init {
         selectedSite.observe()
-            .distinctUntilChanged { old, new -> old?.id == new?.id}
+            .distinctUntilChanged { old, new -> old?.id == new?.id }
             .onEach {
                 productFilter = null
                 customerFilter = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/data/OrderFiltersRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/data/OrderFiltersRepository.kt
@@ -1,20 +1,35 @@
 package com.woocommerce.android.ui.orders.filters.data
 
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.filters.data.OrderListFilterCategory.CUSTOMER
 import com.woocommerce.android.ui.orders.filters.data.OrderListFilterCategory.PRODUCT
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class OrderFiltersRepository @Inject constructor(
     private val appSharedPrefs: AppPrefsWrapper,
-    private val selectedSite: SelectedSite
+    private val selectedSite: SelectedSite,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) {
     var productFilter: Long? = null
 
     var customerFilter: Long? = null
+
+    init {
+        selectedSite.observe()
+            .distinctUntilChanged { old, new -> old?.id == new?.id}
+            .onEach {
+                productFilter = null
+                customerFilter = null
+            }.launchIn(appCoroutineScope)
+    }
 
     fun setSelectedFilters(
         filterCategory: OrderListFilterCategory,
@@ -24,9 +39,11 @@ class OrderFiltersRepository @Inject constructor(
             PRODUCT -> {
                 productFilter = selectedFilters.firstOrNull()?.toLongOrNull()
             }
+
             CUSTOMER -> {
                 customerFilter = selectedFilters.firstOrNull()?.toLongOrNull()
             }
+
             else -> {
                 selectedSite.getIfExists()?.let {
                     appSharedPrefs.setOrderFilters(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11036 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
We recently added support for filtering orders using products and customers, and we decided that, unlike the other filters, we won't save the filtering data across different sessions, it will be saved only in memory. This difference led to a bug that we missed clearing the filters when switching sites, and this PR fixes this.

### Testing instructions
1. Open the app.
2. Open the orders list screen and apply a product or customer filter.
3. Switch store.
4. Confirm the filters were cleared.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
