### PR TITLE
[Better Tablet Products] Changes to the products are not reflected in the list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 17.8
 -----
-
+- [*] Products: Fixed a bug when changes to products were not reflected in the product list [https://github.com/woocommerce/woocommerce-android/pull/11048]
 
 17.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -364,7 +364,7 @@ class ProductDetailFragment :
 
                 is ShowAiProductCreationSurveyBottomSheet -> openAIProductCreationSurveyBottomSheet()
                 is ProductUpdated -> productsCommunicationViewModel.pushEvent(
-                    ProductsCommunicationViewModel.CommunicationEvent.ProductUpdated(event.product)
+                    ProductsCommunicationViewModel.CommunicationEvent.ProductUpdated
                 )
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -50,6 +50,7 @@ import com.woocommerce.android.ui.products.ProductDetailViewModel.OpenProductDet
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductDetailViewState.AuxiliaryState.Error
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductDetailViewState.AuxiliaryState.Loading
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductDetailViewState.AuxiliaryState.None
+import com.woocommerce.android.ui.products.ProductDetailViewModel.ProductUpdated
 import com.woocommerce.android.ui.products.ProductDetailViewModel.RefreshMenu
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ShowAIProductDescriptionBottomSheet
 import com.woocommerce.android.ui.products.ProductDetailViewModel.ShowAiProductCreationSurveyBottomSheet
@@ -362,6 +363,9 @@ class ProductDetailFragment :
                 )
 
                 is ShowAiProductCreationSurveyBottomSheet -> openAIProductCreationSurveyBottomSheet()
+                is ProductUpdated -> productsCommunicationViewModel.pushEvent(
+                    ProductsCommunicationViewModel.CommunicationEvent.ProductUpdated(event.product)
+                )
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1906,7 +1906,7 @@ class ProductDetailViewModel @Inject constructor(
             viewState = viewState.copy(
                 productDraft = null
             )
-            triggerEvent(ProductUpdated(product))
+            triggerEvent(ProductUpdated)
             loadRemoteProduct(product.remoteId)
         } else {
             triggerEvent(ShowSnackbar(R.string.product_detail_update_product_error))
@@ -2520,7 +2520,7 @@ class ProductDetailViewModel @Inject constructor(
 
     object ShowAiProductCreationSurveyBottomSheet : Event()
 
-    data class ProductUpdated(val product: Product) : Event()
+    object ProductUpdated : Event()
 
     data class TrashProduct(val productId: Long) : Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -1906,6 +1906,7 @@ class ProductDetailViewModel @Inject constructor(
             viewState = viewState.copy(
                 productDraft = null
             )
+            triggerEvent(ProductUpdated(product))
             loadRemoteProduct(product.remoteId)
         } else {
             triggerEvent(ShowSnackbar(R.string.product_detail_update_product_error))
@@ -2518,6 +2519,8 @@ class ProductDetailViewModel @Inject constructor(
     ) : Event()
 
     object ShowAiProductCreationSurveyBottomSheet : Event()
+
+    data class ProductUpdated(val product: Product) : Event()
 
     data class TrashProduct(val productId: Long) : Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -390,6 +390,9 @@ class ProductListFragment :
                 is ProductsCommunicationViewModel.CommunicationEvent.ProductTrashed -> {
                     trashProduct(event.productId)
                 }
+                is ProductsCommunicationViewModel.CommunicationEvent.ProductUpdated -> {
+                    productListViewModel.reloadProductsFromDb()
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsCommunicationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsCommunicationViewModel.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.products
 
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.model.Product
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -20,6 +19,6 @@ class ProductsCommunicationViewModel @Inject constructor(
 
     sealed class CommunicationEvent : MultiLiveEvent.Event() {
         data class ProductTrashed(val productId: Long) : CommunicationEvent()
-        data class ProductUpdated(val product: Product) : CommunicationEvent()
+        data object ProductUpdated : CommunicationEvent()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsCommunicationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsCommunicationViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.model.Product
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -19,5 +20,6 @@ class ProductsCommunicationViewModel @Inject constructor(
 
     sealed class CommunicationEvent : MultiLiveEvent.Event() {
         data class ProductTrashed(val productId: Long) : CommunicationEvent()
+        data class ProductUpdated(val product: Product) : CommunicationEvent()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModelTest.kt
@@ -1051,6 +1051,20 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `given product updated successfuly, when onPublishButtonClicked, then ProductUpdated event emitted`() = testBlocking {
+        // GIVEN
+        whenever(productRepository.getProductAsync(any())).thenReturn(product)
+        whenever(productRepository.updateProduct(any())).thenReturn(true)
+        viewModel.start()
+
+        // WHEN
+        viewModel.onPublishButtonClicked()
+
+        // THEN
+        assertThat(viewModel.event.value).isEqualTo(ProductDetailViewModel.ProductUpdated)
+    }
+
     private val productsDraft
         get() = viewModel.productDetailViewStateData.liveData.value?.productDraft
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11026
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes a bug when in 2 pane mode changes to the products are not reflected in the list

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Try that on a phone and a tablet to make sure no regressions are introduced
* Open products -> Product
* Modify a product e.g. prices -> Save the change
* Notice that it's reflected in the list

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/830263b4-a5d3-40bc-9303-84b68144b39a



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
