### PR TITLE
[Stats] Refactor widget's code to require a specific range

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/GetWidgetStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/GetWidgetStats.kt
@@ -4,18 +4,15 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.tools.connectionType
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.revenueStatsGranularity
 import com.woocommerce.android.ui.analytics.ranges.visitorStatsGranularity
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.mystore.data.StatsRepository
-import com.woocommerce.android.ui.mystore.domain.asRangeSelection
 import com.woocommerce.android.util.CoroutineDispatchers
-import com.woocommerce.android.util.DateUtils
-import com.woocommerce.android.util.locale.LocaleProvider
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
-import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import javax.inject.Inject
 
 class GetWidgetStats @Inject constructor(
@@ -23,12 +20,10 @@ class GetWidgetStats @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val statsRepository: StatsRepository,
     private val coroutineDispatchers: CoroutineDispatchers,
-    private val networkStatus: NetworkStatus,
-    private val dateUtils: DateUtils,
-    private val localeProvider: LocaleProvider
+    private val networkStatus: NetworkStatus
 ) {
     suspend operator fun invoke(
-        granularity: StatsGranularity,
+        rangeSelection: StatsTimeRangeSelection,
         siteModel: SiteModel?
     ): WidgetStatsResult {
         return withContext(coroutineDispatchers.io) {
@@ -43,11 +38,6 @@ class GetWidgetStats @Inject constructor(
                 siteModel == null -> WidgetStatsResult.WidgetStatsFailure("No site selected")
                 else -> {
                     val areVisitorStatsSupported = siteModel.connectionType == SiteConnectionType.Jetpack
-
-                    val rangeSelection = granularity.asRangeSelection(
-                        dateUtils = dateUtils,
-                        locale = localeProvider.provideLocale()
-                    )
 
                     // Fetch stats, always force to refresh data.
                     val fetchedStats = statsRepository.fetchStats(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/UpdateTodayStatsWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/UpdateTodayStatsWorker.kt
@@ -20,6 +20,7 @@ import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 
+@Suppress("LongParameterList")
 @HiltWorker
 class UpdateTodayStatsWorker @AssistedInject constructor(
     @Assisted private val appContext: Context,


### PR DESCRIPTION
### Description
This PR just builds on top of the last one #11033, it refactors the widgets code to require a specific range instead of using the granularity as one.

### Testing instructions
Smoke test the widget and confirm there are no regressions.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
