### PR TITLE
[Better Errors] Connectivity tool accessbility adjustments

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/connectivitytool/ConnectivityCheckCardData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/connectivitytool/ConnectivityCheckCardData.kt
@@ -40,7 +40,7 @@ sealed class ConnectivityCheckCardData(
     @Parcelize
     data class StoreConnectivityCheckData(
         override val connectivityCheckStatus: ConnectivityCheckStatus = NotStarted,
-        override val readMoreAction: OnReadMoreClicked? = null
+        @IgnoredOnParcel override val readMoreAction: OnReadMoreClicked? = null
     ) : Parcelable, ConnectivityCheckCardData(
         title = R.string.orderlist_connectivity_tool_store_check_title,
         suggestion = R.string.orderlist_connectivity_tool_generic_error_suggestion,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/connectivitytool/OrderConnectivityToolScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/connectivitytool/OrderConnectivityToolScreen.kt
@@ -14,8 +14,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.Card
 import androidx.compose.material.CircularProgressIndicator
@@ -74,6 +76,7 @@ fun OrderConnectivityToolScreen(
 ) {
     Column(
         modifier = modifier
+            .verticalScroll(rememberScrollState())
             .fillMaxSize()
             .padding(dimensionResource(id = R.dimen.major_100))
     ) {
@@ -159,7 +162,7 @@ fun ConnectivityCheckCard(
                         icon = R.drawable.ic_rounded_chcekbox_partially_checked,
                         color = R.color.woo_red_50
                     )
-                    NotStarted -> { /* Do nothing */ }
+                    is NotStarted -> { /* Do nothing */ }
                 }
             }
 


### PR DESCRIPTION
Summary
==========
Fix issue #10899 by auditing and adjusting the Connectivity Tool accessibility requirements. Only a bug fix and scroll support were needed.

Screen Captures
==========
| Dark mode  | Big Fonts |
| ------------- | ------------- |
| ![Screenshot_20240308_132527](https://github.com/woocommerce/woocommerce-android/assets/5920403/793887fc-4da0-47b4-976c-8da53db70c4a) | ![Screenshot_20240308_132447](https://github.com/woocommerce/woocommerce-android/assets/5920403/203e8fb1-2759-4c39-9f8a-cb3c5ff0eaf8) |

## Landscape mode
https://github.com/woocommerce/woocommerce-android/assets/5920403/e61073d5-3c80-43b5-b134-8eb261a8f011

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.