### PR TITLE
Adds login fallback with site credentials for Jetpack connected stores

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 17.8
 -----
+- [*] Login: Enables login with site credentials for Jetpack connected sites as a fallback to WP.com email login [https://github.com/woocommerce/woocommerce-android/pull/11055]
 
 
 17.7

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -883,6 +883,10 @@ class LoginActivity :
         unifiedLoginTracker.trackClick(Click.WHAT_IS_WORDPRESS_COM)
     }
 
+    override fun onLoginWithSiteCredentialsFallbackClicked() {
+        loginViaSiteCredentials(AppPrefs.getLoginSiteAddress())
+    }
+
     override fun onCreateAccountClicked() {
         changeFragment(SignUpFragment.newInstance(SITE_PICKER), true, SignUpFragment.TAG)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -14,7 +14,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.withStarted
 import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
-import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.AppUrls.LOGIN_WITH_EMAIL_WHAT_IS_WORDPRESS_COM_ACCOUNT
@@ -308,8 +307,7 @@ class LoginActivity :
 
     override fun startOver() {
         // Clear logged in url from AppPrefs
-        AppPrefs.removeLoginSiteAddress()
-
+        appPrefsWrapper.removeLoginSiteAddress()
         // Pop all the fragments from the backstack until we get to the Prologue fragment
         supportFragmentManager.popBackStack(LoginPrologueFragment.TAG, 0)
     }
@@ -344,8 +342,7 @@ class LoginActivity :
 
     private fun startLoginViaWPCom() {
         // Clean previously saved site address, e.g: if merchants return from a store address flow.
-        AppPrefs.removeLoginSiteAddress()
-
+        appPrefsWrapper.removeLoginSiteAddress()
         unifiedLoginTracker.setFlow(Flow.WORDPRESS_COM.value)
         showEmailLoginScreen()
     }
@@ -529,7 +526,7 @@ class LoginActivity :
     override fun gotWpcomSiteInfo(siteAddress: String?) {
         // Save site address to app prefs so it's available to MainActivity regardless of how the user
         // logs into the app.
-        siteAddress?.let { AppPrefs.setLoginSiteAddress(it) }
+        siteAddress?.let { appPrefsWrapper.setLoginSiteAddress(it) }
         showEmailLoginScreen(siteAddress)
     }
 
@@ -544,8 +541,7 @@ class LoginActivity :
         // in the login process.
         val protocolRegex = Regex("^(http[s]?://)", IGNORE_CASE)
         val siteAddressClean = inputSiteAddress.replaceFirst(protocolRegex, "")
-        AppPrefs.setLoginSiteAddress(siteAddressClean)
-
+        appPrefsWrapper.setLoginSiteAddress(siteAddressClean)
         if (hasJetpack || connectSiteInfo?.isWPCom == true) {
             showEmailLoginScreen(null)
         } else {
@@ -571,7 +567,7 @@ class LoginActivity :
     override fun gotXmlRpcEndpoint(inputSiteAddress: String?, endpointAddress: String?) {
         // Save site address to app prefs so it's available to MainActivity regardless of how the user
         // logs into the app.
-        inputSiteAddress?.let { AppPrefs.setLoginSiteAddress(it) }
+        inputSiteAddress?.let { appPrefsWrapper.setLoginSiteAddress(it) }
 
         showUsernamePasswordScreen(inputSiteAddress, endpointAddress, null, null)
     }
@@ -884,7 +880,7 @@ class LoginActivity :
     }
 
     override fun onLoginWithSiteCredentialsFallbackClicked() {
-        loginViaSiteCredentials(AppPrefs.getLoginSiteAddress())
+        loginViaSiteCredentials(appPrefsWrapper.getLoginSiteAddress())
     }
 
     override fun onCreateAccountClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
@@ -26,6 +26,7 @@ class WooLoginEmailFragment : LoginEmailFragment() {
 
     interface Listener {
         fun onWhatIsWordPressLinkClicked()
+        fun onLoginWithSiteCredentialsFallbackClicked()
     }
 
     private lateinit var wooLoginEmailListener: Listener
@@ -38,6 +39,10 @@ class WooLoginEmailFragment : LoginEmailFragment() {
         val whatIsWordPressText = rootView.findViewById<Button>(R.id.login_what_is_wordpress)
         whatIsWordPressText.setOnClickListener {
             wooLoginEmailListener.onWhatIsWordPressLinkClicked()
+        }
+        val loginWithSiteCredentials = rootView.findViewById<Button>(R.id.login_with_site_credentials)
+        loginWithSiteCredentials.setOnClickListener {
+            wooLoginEmailListener.onLoginWithSiteCredentialsFallbackClicked()
         }
     }
 

--- a/WooCommerce/src/main/res/layout/fragment_login_email_screen.xml
+++ b/WooCommerce/src/main/res/layout/fragment_login_email_screen.xml
@@ -105,6 +105,18 @@
                 android:layout_height="wrap_content" />
 
             <com.google.android.material.button.MaterialButton
+                android:id="@+id/login_with_site_credentials"
+                style="@style/Widget.LoginFlow.Button.Secondary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:layout_marginEnd="@dimen/margin_extra_large"
+                android:text="@string/wp_email_input_fallback_log_in_with_site_credentials"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/login_continue_button" />
+
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/continue_with_google"
                 style="@style/Widget.LoginFlow.Button.Secondary"
                 android:layout_width="match_parent"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3213,6 +3213,7 @@
     <string name="reset_your_password">Reset your password</string>
     <string name="signup_confirmation_title">Signup confirmation</string>
     <string name="what_is_wordpress_link">What is WordPress.com?</string>
+    <string name="wp_email_input_fallback_log_in_with_site_credentials">Log in with your site credentials</string>
 
     <string name="login_site_address">Site address</string>
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10989
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds login fallback with site credentials for Jetpack connected stores in the WP.com email fragment. 

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Login using a site address from a Jetpack connected store.
2. In the WP.com email fragment click on the "Log in with site credentials" button at the bottom
3. Login successfully using the site credentials

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/f805f85f-b0df-4768-bd16-291e4f362235
