### PR TITLE
Hack Week: Add plugins section to settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -19,6 +19,8 @@ interface MainSettingsContract {
         val isDomainOptionVisible: Boolean
         val isCloseAccountOptionVisible: Boolean
         val isThemePickerOptionVisible: Boolean
+        val isPluginsOptionVisible: Boolean
+        val wooPluginVersion: String
     }
 
     interface View : BaseView<Presenter> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -19,7 +19,6 @@ interface MainSettingsContract {
         val isDomainOptionVisible: Boolean
         val isCloseAccountOptionVisible: Boolean
         val isThemePickerOptionVisible: Boolean
-        val isPluginsOptionVisible: Boolean
         val wooPluginVersion: String
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -228,7 +228,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
                 )
         }
 
-        binding.pluginsContainer.isVisible = presenter.isPluginsOptionVisible
         binding.optionSitePlugins.setOnClickListener {
             findNavController()
                 .navigateSafely(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -227,6 +227,16 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
                     )
                 )
         }
+
+        binding.pluginsContainer.isVisible = presenter.isPluginsOptionVisible
+        binding.optionSitePlugins.setOnClickListener {
+            findNavController()
+                .navigateSafely(
+                    MainSettingsFragmentDirections.actionMainSettingsFragmentToPluginsFragment()
+                )
+        }
+
+        binding.wooPluginVersion.text = presenter.wooPluginVersion
     }
 
     private fun showDomainDashboard() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.util.StringUtils
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.store.WooCommerceStore.WooPlugin.WOO_CORE
 import javax.inject.Inject
 
 class MainSettingsPresenter @Inject constructor(
@@ -106,6 +107,13 @@ class MainSettingsPresenter @Inject constructor(
     override val isCloseAccountOptionVisible: Boolean
         get() = selectedSite.connectionType != SiteConnectionType.ApplicationPasswords &&
             accountRepository.getUserAccount()?.userName != null
+
     override val isThemePickerOptionVisible: Boolean
         get() = selectedSite.get().isWPComAtomic
+
+    override val isPluginsOptionVisible: Boolean
+        get() = !selectedSite.get().isWPCom || selectedSite.get().isWPComAtomic
+
+    override val wooPluginVersion: String
+        get() = wooCommerceStore.getSitePlugin(selectedSite.get(), WOO_CORE)?.version ?: ""
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -111,9 +111,6 @@ class MainSettingsPresenter @Inject constructor(
     override val isThemePickerOptionVisible: Boolean
         get() = selectedSite.get().isWPComAtomic
 
-    override val isPluginsOptionVisible: Boolean
-        get() = !selectedSite.get().isWPCom || selectedSite.get().isWPComAtomic
-
     override val wooPluginVersion: String
         get() = wooCommerceStore.getSitePlugin(selectedSite.get(), WOO_CORE)?.version ?: ""
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/plugins/PluginsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/plugins/PluginsFragment.kt
@@ -1,0 +1,57 @@
+package com.woocommerce.android.ui.prefs.plugins
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class PluginsFragment : BaseFragment() {
+    companion object {
+        const val TAG = "plugins-settings"
+    }
+
+    private val viewModel: PluginsViewModel by viewModels()
+
+    override val activityAppBarStatus = AppBarStatus.Hidden
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        observeEvents()
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                WooThemeWithBackground {
+                    PluginsScreen(viewModel)
+                }
+            }
+        }
+    }
+
+    private fun observeEvents() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AnalyticsTracker.trackViewShown(this)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/plugins/PluginsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/plugins/PluginsScreen.kt
@@ -64,7 +64,7 @@ private fun PluginsScreen(state: ViewState) {
     }
 }
 
-    @Composable
+@Composable
 private fun Plugins(plugins: List<ViewState.Loaded.Plugin>) {
     LazyColumn {
         items(plugins) { plugin ->
@@ -104,12 +104,4 @@ private fun PreviewPlugins() {
             )
         )
     )
-}
-
-
-
-@LightDarkThemePreviews
-@Composable
-private fun PreviewLoading() {
-    PluginsScreen(ViewState.Loading)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/plugins/PluginsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/plugins/PluginsScreen.kt
@@ -1,0 +1,115 @@
+package com.woocommerce.android.ui.prefs.plugins
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons.Filled
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.ProgressIndicator
+import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.prefs.plugins.PluginsViewModel.ViewState
+
+@Composable
+fun PluginsScreen(viewModel: PluginsViewModel) {
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = stringResource(id = R.string.settings_plugins),
+                onNavigationButtonClick = viewModel::onBackPressed,
+                navigationIcon = Filled.ArrowBack
+            )
+        },
+        modifier = Modifier.background(MaterialTheme.colors.surface)
+    ) { paddingValues ->
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            viewModel.viewState.observeAsState().value?.let { state ->
+                PluginsScreen(state)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PluginsScreen(state: ViewState) {
+    when (state) {
+        is ViewState.Loading -> {
+            ProgressIndicator()
+        }
+        is ViewState.Error -> {
+            Error()
+        }
+        is ViewState.Loaded -> {
+            Plugins(state.plugins)
+        }
+    }
+}
+
+    @Composable
+private fun Plugins(plugins: List<ViewState.Loaded.Plugin>) {
+    LazyColumn {
+        items(plugins) { plugin ->
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(dimensionResource(R.dimen.major_100))
+            ) {
+                Text(
+                    text = plugin.name,
+                    style = MaterialTheme.typography.subtitle1
+                )
+                Text(text = plugin.version)
+            }
+
+            if (plugins.last() != plugin) {
+                Divider()
+            }
+        }
+    }
+}
+
+@Composable
+private fun Error() {
+    // Error state
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun PreviewPlugins() {
+    PluginsScreen(
+        ViewState.Loaded(
+            plugins = listOf(
+                ViewState.Loaded.Plugin("Plugin 1", "1.0"),
+                ViewState.Loaded.Plugin("Plugin 2", "2.0"),
+                ViewState.Loaded.Plugin("Plugin 3", "3.0")
+            )
+        )
+    )
+}
+
+
+
+@LightDarkThemePreviews
+@Composable
+private fun PreviewLoading() {
+    PluginsScreen(ViewState.Loading)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/plugins/PluginsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/plugins/PluginsViewModel.kt
@@ -1,0 +1,58 @@
+package com.woocommerce.android.ui.prefs.plugins
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.extensions.isNotNullOrEmpty
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.prefs.plugins.PluginsViewModel.ViewState.Loaded.Plugin
+import com.woocommerce.android.ui.prefs.plugins.PluginsViewModel.ViewState.Loading
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+@HiltViewModel
+class PluginsViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    wooStore: WooCommerceStore,
+    site: SelectedSite
+) : ScopedViewModel(savedStateHandle) {
+    private val _viewState = MutableStateFlow<ViewState>(Loading)
+    val viewState = _viewState.asLiveData()
+
+    init {
+        viewModelScope.launch {
+            val result = wooStore.fetchSitePlugins(site.get())
+            if (result.isError || result.model == null) {
+                _viewState.value = ViewState.Error
+            } else {
+                _viewState.value = ViewState.Loaded(
+                    plugins = result.model!!
+                        .filter { it.version.isNotNullOrEmpty() }
+                        .map { Plugin(it.displayName, it.version) }
+                )
+            }
+        }
+    }
+
+    fun onBackPressed() {
+        triggerEvent(Exit)
+    }
+
+    sealed interface ViewState {
+        data object Loading : ViewState
+        data object Error : ViewState
+        data class Loaded(
+            val plugins: List<Plugin> = emptyList()
+        ) : ViewState {
+            data class Plugin(
+                val name: String,
+                val version: String
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -33,6 +33,64 @@
         <View style="@style/Woo.Divider" />
 
         <LinearLayout
+            android:id="@+id/plugins_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <!--
+                    Plugins
+            -->
+            <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_plugins" />
+
+            <!--
+                Store plugins
+            -->
+            <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                android:id="@+id/option_site_plugins"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:optionTitle="@string/settings_option_installed_plugins" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_marginVertical="@dimen/major_100"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/woo_plugin_info"
+                    android:textColor="@color/color_on_surface"
+                    android:textAppearance="?attr/textAppearanceBody1"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_app_title_aligned"
+                    android:text="@string/settings_woo_plugin_version" />
+
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/woo_plugin_version"
+                    android:textAppearance="?attr/textAppearanceBody1"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    android:layout_marginHorizontal="@dimen/major_100"
+                    tools:text="8.6.1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </LinearLayout>
+
+        <View style="@style/Woo.Divider" />
+
+        <LinearLayout
             android:id="@+id/store_settings_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -94,9 +152,9 @@
                 app:toggleOptionDesc="@string/store_onboarding_setting_description"
                 app:toggleOptionTitle="@string/store_onboarding_setting_title" />
 
-            <View style="@style/Woo.Divider" />
-
         </LinearLayout>
+
+        <View style="@style/Woo.Divider" />
 
         <!--
             Notifications

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -61,6 +61,9 @@
         <action
             android:id="@+id/action_mainSettingsFragment_to_notificationSettingsFragment"
             app:destination="@id/notificationSettingsFragment" />
+        <action
+            android:id="@+id/action_mainSettingsFragment_to_pluginsFragment"
+            app:destination="@id/pluginsFragment" />
     </fragment>
     <fragment
         android:id="@+id/privacySettingsFragment"
@@ -195,4 +198,8 @@
         android:id="@+id/notificationSettingsFragment"
         android:name="com.woocommerce.android.ui.prefs.notifications.NotificationSettingsFragment"
         android:label="NotificationSettingsFragment" />
+    <fragment
+        android:id="@+id/pluginsFragment"
+        android:name="com.woocommerce.android.ui.prefs.plugins.PluginsFragment"
+        android:label="PluginsFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2333,6 +2333,9 @@
     <string name="dev_options">Developer Options</string>
     <string name="settings_account">Account Settings</string>
     <string name="settings_themes">Themes</string>
+    <string name="settings_plugins">Plugins</string>
+    <string name="settings_option_installed_plugins">Installed Plugins</string>
+    <string name="settings_woo_plugin_version">WooCommerce Version</string>
 
     <!--
         Developer Options Screen


### PR DESCRIPTION
This is the first part of the Hack week project, which adds the WooCommerce plugin version information and a list of installed plugins to the main settings.

| Settings | Plugins |
|--------|--------|
| ![image](https://github.com/woocommerce/woocommerce-android/assets/1522856/e45432ce-c856-4afa-8ff8-4700596e5648) | ![image](https://github.com/woocommerce/woocommerce-android/assets/1522856/75f1cc78-8b94-4564-8eff-aa3b13a94b9f) |

**To test:**
1. Log in to a self-hosted site
2. Go to More menu
3. Go to Settings
4. Notice a new Plugins section appears
5. Verify the correct Woo plugin version is displayed
6. Tap on Installed plugins
7. Notice a list of installed plugins is shown

1. Log in to a non-atomic WP.com site
2. Go to More menu
3. Go to Settings
4. Notice the Plugins section is not shown