### PR TITLE
Fix MainBottomNavigationView NPE

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -25,7 +25,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
 ) : BottomNavigationView(context, attrs),
     OnItemSelectedListener,
     OnItemReselectedListener {
-    private lateinit var navController: NavController
+    private var _navController: NavController? = null
     private lateinit var listener: MainNavigationListener
     private lateinit var ordersBadge: BadgeDrawable
     private lateinit var moreMenuBadge: BadgeDrawable
@@ -42,15 +42,15 @@ class MainBottomNavigationView @JvmOverloads constructor(
         }
 
     fun init(navController: NavController, listener: MainNavigationListener) {
+        this._navController = navController
         this.listener = listener
-        this.navController = navController
 
         addTopDivider()
         createBadges()
 
         assignNavigationListeners(true)
         val weakReference = WeakReference(this)
-        navController.addOnDestinationChangedListener(
+        _navController?.addOnDestinationChangedListener(
             object : NavController.OnDestinationChangedListener {
                 override fun onDestinationChanged(
                     controller: NavController,
@@ -59,7 +59,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
                 ) {
                     val view = weakReference.get()
                     if (view == null) {
-                        navController.removeOnDestinationChangedListener(this)
+                        _navController?.removeOnDestinationChangedListener(this)
                         return
                     }
                     view.menu.forEach { item ->
@@ -137,10 +137,12 @@ class MainBottomNavigationView @JvmOverloads constructor(
     }
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
-        val navSuccess = NavigationUI.onNavDestinationSelected(item, navController)
-        if (navSuccess) {
-            listener.onNavItemSelected(findNavigationPositionById(item.itemId))
-            return true
+        _navController?.let { navController ->
+            val navSuccess = NavigationUI.onNavDestinationSelected(item, navController)
+            if (navSuccess) {
+                listener.onNavItemSelected(findNavigationPositionById(item.itemId))
+                return true
+            }
         }
         return false
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -25,7 +25,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
 ) : BottomNavigationView(context, attrs),
     OnItemSelectedListener,
     OnItemReselectedListener {
-    private var _navController: NavController? = null
+    private var navController: NavController? = null
     private lateinit var listener: MainNavigationListener
     private lateinit var ordersBadge: BadgeDrawable
     private lateinit var moreMenuBadge: BadgeDrawable
@@ -42,7 +42,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
         }
 
     fun init(navController: NavController, listener: MainNavigationListener) {
-        this._navController = navController
+        this.navController = navController
         this.listener = listener
 
         addTopDivider()
@@ -50,7 +50,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
 
         assignNavigationListeners(true)
         val weakReference = WeakReference(this)
-        _navController?.addOnDestinationChangedListener(
+        this.navController?.addOnDestinationChangedListener(
             object : NavController.OnDestinationChangedListener {
                 override fun onDestinationChanged(
                     controller: NavController,
@@ -59,7 +59,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
                 ) {
                     val view = weakReference.get()
                     if (view == null) {
-                        _navController?.removeOnDestinationChangedListener(this)
+                        this@MainBottomNavigationView.navController?.removeOnDestinationChangedListener(this)
                         return
                     }
                     view.menu.forEach { item ->
@@ -137,7 +137,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
     }
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
-        _navController?.let { navController ->
+        navController?.let { navController ->
             val navSuccess = NavigationUI.onNavDestinationSelected(item, navController)
             if (navSuccess) {
                 listener.onNavItemSelected(findNavigationPositionById(item.itemId))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11063
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The issue was a `NullPointerException` occurring when attempting to use a NavController that might not have been initialized at the time of navigation item selection. This was leading to crashes in the app. The provided fix introduces safe handling of the nullable navController throughout the MainBottomNavigationView class.

There could be another issue that is causing this. I wasn't able to reproduce the issue when using the app. 

### Testing instructions
Smoke test the navigation bar to ensure that it works as expected. 

<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
