### PR TITLE
[Tablet support M3] Part 5 - Disable product selector UI while order is being updated

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
@@ -56,3 +56,30 @@ inline fun <T1, T2, T3, T4, T5, T6, T7, R> combine(
         )
     }
 }
+
+@Suppress("LongParameterList")
+inline fun <T1, T2, T3, T4, T5, T6, T7, T8, R> combine(
+    flow: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+    flow4: Flow<T4>,
+    flow5: Flow<T5>,
+    flow6: Flow<T6>,
+    flow7: Flow<T7>,
+    flow8: Flow<T8>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8) -> R
+): Flow<R> {
+    return kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6, flow7, flow8) { args: Array<*> ->
+        @Suppress("UNCHECKED_CAST", "MagicNumber")
+        transform(
+            args[0] as T1,
+            args[1] as T2,
+            args[2] as T3,
+            args[3] as T4,
+            args[4] as T5,
+            args[5] as T6,
+            args[6] as T7,
+            args[7] as T8,
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -432,7 +432,7 @@ class OrderCreateEditFormFragment :
 
                     binding.productsSection.isEachAddButtonEnabled = idle
                 }
-                sharedViewModel.onProductSelectorStateChanged(idle && new.isEditable)
+                sharedViewModel.onProductSelectionStateChanged(idle && new.isEditable)
             }
             new.showOrderUpdateSnackbar.takeIfNotEqualTo(old?.showOrderUpdateSnackbar) { show ->
                 showOrHideErrorSnackBar(show)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -432,6 +432,7 @@ class OrderCreateEditFormFragment :
 
                     binding.productsSection.isEachAddButtonEnabled = idle
                 }
+                sharedViewModel.onProductSelectorStateChanged(idle && new.isEditable)
             }
             new.showOrderUpdateSnackbar.takeIfNotEqualTo(old?.showOrderUpdateSnackbar) { show ->
                 showOrHideErrorSnackBar(show)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -79,6 +79,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUC
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.analytics.IsScreenLargerThanCompactValue
 import com.woocommerce.android.analytics.deviceTypeToAnalyticsString
+import com.woocommerce.android.extensions.WindowSizeClass
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.extensions.runWithContext
 import com.woocommerce.android.model.Address
@@ -173,7 +174,6 @@ import java.math.BigDecimal
 import java.util.Date
 import javax.inject.Inject
 import com.woocommerce.android.model.Product as ModelProduct
-import com.woocommerce.android.extensions.WindowSizeClass
 
 @HiltViewModel
 @Suppress("LargeClass")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.extensions.isNotEqualTo
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.extensions.sumByBigDecimal
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.ui.compose.DeviceType
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel.ViewState
 import com.woocommerce.android.util.CurrencyFormatter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorFragment.kt
@@ -90,6 +90,11 @@ class ProductSelectorFragment : BaseFragment() {
                     sharedViewModel.updateSelectedItems(it)
                 }
             }
+            lifecycleScope.launch {
+                sharedViewModel.isProductSelectionActive.collect {
+                    viewModel.onProductSelectionStateChanged(it)
+                }
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -312,6 +312,7 @@ private fun displayProductsSection(
                 onClickLabel = stringResource(id = string.product_selector_select_product_label, product.title),
                 imageContentDescription = stringResource(string.product_image_content_description),
                 isCogwheelVisible = product is ListItem.ConfigurableListItem,
+                enabled = state.selectionEnabled,
                 onEditConfiguration = {
                     (product as? ListItem.ConfigurableListItem)?.let(onEditConfiguration)
                 }
@@ -432,6 +433,7 @@ private fun ProductList(
                     onClickLabel = stringResource(id = string.product_selector_select_product_label, product.title),
                     imageContentDescription = stringResource(string.product_image_content_description),
                     isCogwheelVisible = product is ListItem.ConfigurableListItem,
+                    enabled = state.selectionEnabled,
                     onEditConfiguration = {
                         (product as? ListItem.ConfigurableListItem)?.let(onEditConfiguration)
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorSharedViewModel.kt
@@ -22,7 +22,7 @@ class ProductSelectorSharedViewModel @Inject constructor(
     private val _isProductSelectionActive: MutableStateFlow<Boolean> = MutableStateFlow(true)
     val isProductSelectionActive: StateFlow<Boolean> = _isProductSelectionActive
 
-    fun onProductSelectorStateChanged(isEnabled: Boolean) {
+    fun onProductSelectionStateChanged(isEnabled: Boolean) {
         _isProductSelectionActive.value = isEnabled
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorSharedViewModel.kt
@@ -18,4 +18,11 @@ class ProductSelectorSharedViewModel @Inject constructor(
     fun updateSelectedItems(selectedItems: List<ProductSelectorViewModel.SelectedItem>) {
         _selectedItems.value = selectedItems
     }
+
+    private val _isProductSelectionActive: MutableStateFlow<Boolean> = MutableStateFlow(true)
+    val isProductSelectionActive: StateFlow<Boolean> = _isProductSelectionActive
+
+    fun onProductSelectorStateChanged(isEnabled: Boolean) {
+        _isProductSelectionActive.value = isEnabled
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -106,6 +106,9 @@ class ProductSelectorViewModel @Inject constructor(
     private val popularProducts: MutableStateFlow<List<Product>> = MutableStateFlow(emptyList())
     private val recentProducts: MutableStateFlow<List<Product>> = MutableStateFlow(emptyList())
 
+    private val selectionEnabled: MutableStateFlow<Boolean> =
+        savedState.getStateFlow(viewModelScope, true, "key_selection_enabled")
+
     private val selectedItemsSource: MutableMap<Long, ProductSourceForTracking> = mutableMapOf()
 
     private var fetchProductsJob: Job? = null
@@ -126,7 +129,8 @@ class ProductSelectorViewModel @Inject constructor(
         flow5 = selectedItems,
         flow6 = filterState,
         flow7 = searchState,
-    ) { products, popularProducts, recentProducts, loadingState, selectedIds, filterState, searchState ->
+        flow8 = selectionEnabled,
+    ) { products, popularProducts, recentProducts, loadingState, selectedIds, filterState, searchState, enabled ->
         ViewState(
             loadingState = loadingState,
             products = products.map {
@@ -140,6 +144,7 @@ class ProductSelectorViewModel @Inject constructor(
             selectionMode = navArgs.selectionMode,
             screenTitleOverride = navArgs.screenTitleOverride,
             ctaButtonTextOverride = navArgs.ctaButtonTextOverride,
+            selectionEnabled = enabled,
         )
     }.asLiveData()
 
@@ -641,6 +646,10 @@ class ProductSelectorViewModel @Inject constructor(
         _selectedItems.value = selectedItems
     }
 
+    fun onProductSelectionStateChanged(productSelectionEnabled: Boolean) {
+        selectionEnabled.value = productSelectionEnabled
+    }
+
     data class ViewState(
         val loadingState: LoadingState,
         val products: List<ListItem>,
@@ -652,6 +661,7 @@ class ProductSelectorViewModel @Inject constructor(
         val selectionMode: SelectionMode,
         val screenTitleOverride: String? = null,
         val ctaButtonTextOverride: String? = null,
+        val selectionEnabled: Boolean = true,
     ) {
         val isDoneButtonEnabled: Boolean = selectionMode == SelectionMode.MULTIPLE || selectedItemsCount > 0
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/components/SelectorListItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/components/SelectorListItem.kt
@@ -52,13 +52,14 @@ fun SelectorListItem(
     selectionState: SelectionState,
     isArrowVisible: Boolean,
     isCogwheelVisible: Boolean,
+    enabled: Boolean,
     onEditConfiguration: () -> Unit,
     onItemClick: () -> Unit,
 ) {
     Row(
         modifier = Modifier
             .clickable(
-                enabled = true,
+                enabled = enabled,
                 role = Role.Button,
                 onClick = {
                     onItemClick()
@@ -187,5 +188,6 @@ private fun SelectorListItemPreview() =
         onClickLabel = null,
         imageContentDescription = null,
         isCogwheelVisible = true,
+        enabled = true,
         onEditConfiguration = {}
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorScreen.kt
@@ -180,6 +180,7 @@ private fun VariationList(
                     onClickLabel = stringResource(id = string.product_selector_select_variation_label, variation.title),
                     imageContentDescription = stringResource(string.product_image_content_description),
                     isCogwheelVisible = false,
+                    enabled = true,
                     onEditConfiguration = {}
                 ) {
                     onVariationClick(variation)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### [Tablet support M3] Part 5 - Disabling product selector UI while an order is being updated

Closes: #10868 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR disables product selection in the product selector in the tablet layout while an order is being synced (after pressing "Recalculate" button).

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Go to the order creation form on tablet
2. Select some products and click the "Recalculate" button. This will trigger order sync and the progress bar will appear
3. Verify that it's impossible to select/unselect products while the sync is in progress

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
