### PR TITLE
[Tablet support M3] Part 6 – UI updates

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -93,6 +93,7 @@ import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import com.woocommerce.android.widgets.CustomProgressDialog
 import com.woocommerce.android.widgets.WCReadMoreTextView
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
@@ -161,11 +162,11 @@ class OrderCreateEditFormFragment :
     }
 
     private fun syncSelectedItems() {
-        sharedViewModel.updateSelectedItems(viewModel.selectedItems.value)
         lifecycleScope.launch {
             viewModel.selectedItems.collect(sharedViewModel::updateSelectedItems)
         }
-        lifecycleScope.launch {
+        lifecycleScope.launch(Dispatchers.Main) {
+            sharedViewModel.updateSelectedItems(viewModel.selectedItems.value)
             sharedViewModel.selectedItems.collect(viewModel::onItemsSelectionChanged)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -563,7 +563,12 @@ class OrderCreateEditFormFragment :
 
     private fun productAddedCustomAmountUnset(binding: FragmentOrderCreateEditFormBinding) {
         if (viewModel.viewStateData.liveData.value?.isEditable == true) {
-            binding.productsSection.showAddProductsHeaderActions()
+            if (requireContext().windowSizeClass == WindowSizeClass.Compact) {
+                binding.productsSection.showAddProductsHeaderActions()
+            } else {
+                binding.productsSection.hideAddProductsHeaderActions()
+                binding.productsSection.showScanProductsHeaderAction()
+            }
         } else {
             binding.productsSection.hideAddProductsHeaderActions()
         }
@@ -588,8 +593,13 @@ class OrderCreateEditFormFragment :
         binding.customAmountsSection.removeCustomSectionButtons()
         binding.customAmountsSection.showHeader()
         if (viewModel.viewStateData.liveData.value?.isEditable == true) {
+            if (requireContext().windowSizeClass == WindowSizeClass.Compact) {
+                binding.productsSection.showAddProductsHeaderActions()
+            } else {
+                binding.productsSection.hideAddProductsHeaderActions()
+                binding.productsSection.showScanProductsHeaderAction()
+            }
             binding.customAmountsSection.showAddAction()
-            binding.productsSection.showAddProductsHeaderActions()
         } else {
             binding.customAmountsSection.hideAddAction()
             binding.productsSection.hideAddProductsHeaderActions()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -1194,6 +1194,9 @@ class OrderCreateEditFormFragment :
             isLocked = false
             isEachAddButtonEnabled = true
         }
+        if (requireContext().windowSizeClass != WindowSizeClass.Compact) {
+            sharedViewModel.onProductSelectionStateChanged(true)
+        }
     }
 
     private fun FragmentOrderCreateEditFormBinding.hideEditableControls() {
@@ -1219,6 +1222,9 @@ class OrderCreateEditFormFragment :
         customAmountsSection.apply {
             isLocked = true
             isEachAddButtonEnabled = false
+        }
+        if (requireContext().windowSizeClass != WindowSizeClass.Compact) {
+            sharedViewModel.onProductSelectionStateChanged(false)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/OrderCreateEditSectionView.kt
@@ -89,6 +89,10 @@ class OrderCreateEditSectionView @JvmOverloads constructor(
         binding.barcodeIcon.show()
     }
 
+    fun showScanProductsHeaderAction() {
+        binding.barcodeIcon.show()
+    }
+
     fun showAddAction() {
         binding.addIcon.show()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorSharedViewModel.kt
@@ -3,12 +3,11 @@ package com.woocommerce.android.ui.products.selector
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
-import com.woocommerce.android.viewmodel.getStateFlow
-
 
 @HiltViewModel
 class ProductSelectorSharedViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorSharedViewModel.kt
@@ -1,18 +1,25 @@
 package com.woocommerce.android.ui.products.selector
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
+import com.woocommerce.android.viewmodel.getStateFlow
+
 
 @HiltViewModel
 class ProductSelectorSharedViewModel @Inject constructor(
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
 
-    private val _selectedItems = MutableStateFlow(emptyList<ProductSelectorViewModel.SelectedItem>())
+    private val _selectedItems = savedState.getStateFlow(
+        scope = viewModelScope,
+        initialValue = emptyList<ProductSelectorViewModel.SelectedItem>(),
+        key = "key_selected_items"
+    )
     val selectedItems: StateFlow<List<ProductSelectorViewModel.SelectedItem>> = _selectedItems
 
     fun updateSelectedItems(selectedItems: List<ProductSelectorViewModel.SelectedItem>) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### [Tablet support M3] Part 6 – UI updates

This PR addresses several issues discovered during Tablet Support M3 testing (pdfdoF-4GL-p2#comment-5958):
1. The "+" icon becoming visible after adding products to order in tablet mode 
<img width="200" alt="Screenshot 2024-03-14 at 14 45 12" src="https://github.com/woocommerce/woocommerce-android/assets/4527432/ba3a2617-2c70-4ed4-983b-cfbd9bb699d3">

2. Product selector being enabled despite an order being not editable in edit mode, e.g. after being marked completed.
3. "Recalculate" button re-appearing after config change (e.g. screen rotation)

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Verify that the the "+" icon (add products) icon is never shown on the detail pane on tablets
2. Verify that product selector is always disabled (no selection is possible) when the order is not editable (e.g. marked completed, payment collected)
3. Verify that "Recalculate" button doesn't reappear after rotating the screen if there are no pending product selection changes
4. Verify that selected products (on the left pane) that are not synced are preserved after configuration change, e.g.  rotation

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->