### PR TITLE
Hide site credentials login fallback for WP.com sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -836,7 +836,7 @@ class LoginActivity :
         } else {
             val loginEmailFragment = getLoginEmailFragment(
                 siteCredsLayout = false
-            ) ?: WooLoginEmailFragment.newInstance()
+            ) ?: WooLoginEmailFragment.newInstance(showSiteCredentialsFallback = connectSiteInfo?.isWPCom == false)
             changeFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG)
         }
     }
@@ -938,7 +938,10 @@ class LoginActivity :
         unifiedLoginTracker.setFlow(Flow.WORDPRESS_COM.value)
         appPrefsWrapper.setStoreCreationSource(AnalyticsTracker.VALUE_LOGIN)
         changeFragment(
-            fragment = WooLoginEmailFragment.newInstance(email) as Fragment,
+            fragment = WooLoginEmailFragment.newInstance(
+                prefilledEmail = email,
+                showSiteCredentialsFallback = false // We expect user to log in with the prefilled WP.com email
+            ) as Fragment,
             shouldAddToBackStack = true,
             LoginEmailFragment.TAG
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
@@ -15,14 +15,20 @@ import org.wordpress.android.login.LoginEmailFragment
 class WooLoginEmailFragment : LoginEmailFragment() {
     companion object {
         private const val ARG_PREFILLED_EMAIL = "prefilled_email"
-        fun newInstance(prefilledEmail: String? = null): LoginEmailFragment {
+        private const val ARG_SHOW_SITE_CREDENTIALS_FALLBACK = "show_site_credentials_fallback"
+        fun newInstance(
+            prefilledEmail: String? = null,
+            showSiteCredentialsFallback: Boolean = true
+        ): LoginEmailFragment {
             val fragment = WooLoginEmailFragment()
             val args = Bundle()
             args.putString(ARG_PREFILLED_EMAIL, prefilledEmail)
+            args.putBoolean(ARG_SHOW_SITE_CREDENTIALS_FALLBACK, showSiteCredentialsFallback)
             fragment.arguments = args
             return fragment
         }
     }
+
 
     interface Listener {
         fun onWhatIsWordPressLinkClicked()
@@ -40,9 +46,15 @@ class WooLoginEmailFragment : LoginEmailFragment() {
         whatIsWordPressText.setOnClickListener {
             wooLoginEmailListener.onWhatIsWordPressLinkClicked()
         }
+        val showSiteCredentialsFallback = requireArguments().getBoolean(ARG_SHOW_SITE_CREDENTIALS_FALLBACK, false)
         val loginWithSiteCredentials = rootView.findViewById<Button>(R.id.login_with_site_credentials)
-        loginWithSiteCredentials.setOnClickListener {
-            wooLoginEmailListener.onLoginWithSiteCredentialsFallbackClicked()
+        if (showSiteCredentialsFallback) {
+            loginWithSiteCredentials.setOnClickListener {
+                wooLoginEmailListener.onLoginWithSiteCredentialsFallbackClicked()
+            }
+            loginWithSiteCredentials.visibility = View.VISIBLE
+        } else {
+            loginWithSiteCredentials.visibility = View.GONE
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginEmailFragment.kt
@@ -29,7 +29,6 @@ class WooLoginEmailFragment : LoginEmailFragment() {
         }
     }
 
-
     interface Listener {
         fun onWhatIsWordPressLinkClicked()
         fun onLoginWithSiteCredentialsFallbackClicked()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10989 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fix: Avoid showing site credentials login fallback from WP.com email screen when the entered site address belongs to a WP.com site

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Enter a Wp.com (Atomic) site andress in the login flow
2. Check that the screen for login with WP.com email doesn't show any option to login with site credentials
3. Repeat step one entering a Jetpack connected self-hosted site
4. Check the login with site credentials fallback option is available.
