### PR TITLE
[Tablet support M3] – Part 7: Preserve items' selection state across OrderCreateEditFormFragment recreation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -174,8 +174,6 @@ import java.math.BigDecimal
 import java.util.Date
 import javax.inject.Inject
 import com.woocommerce.android.model.Product as ModelProduct
-import android.util.Log
-import kotlinx.coroutines.flow.last
 
 @HiltViewModel
 @Suppress("LargeClass")
@@ -300,10 +298,7 @@ class OrderCreateEditViewModel @Inject constructor(
         .asLiveData()
 
     val selectedItems: StateFlow<List<SelectedItem>> =
-        _orderDraft.map { order -> order.selectedItems() }
-            .toStateFlow(
-                emptyList()
-            )
+        _orderDraft.map { order -> order.selectedItems() }.toStateFlow(emptyList())
 
     fun Order.selectedItems(): List<SelectedItem> = items.map { item ->
             if (item.isVariation) {
@@ -1235,7 +1230,6 @@ class OrderCreateEditViewModel @Inject constructor(
 
     fun onItemsSelectionChanged(selectedItems: List<SelectedItem>) {
         if (_orderDraft.value.selectedItems() != selectedItems) {
-            Log.d("OrderCreateEditViewModel", "onItemsSelectionChanged: ${_orderDraft.value.selectedItems()} vs $selectedItems")
             viewState = viewState.copy(isRecalculateNeeded = true)
             _pendingSelectedItems.value = selectedItems
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.asFlow
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
@@ -301,12 +300,12 @@ class OrderCreateEditViewModel @Inject constructor(
         _orderDraft.map { order -> order.selectedItems() }.toStateFlow(emptyList())
 
     fun Order.selectedItems(): List<SelectedItem> = items.map { item ->
-            if (item.isVariation) {
-                SelectedItem.ProductVariation(item.productId, item.variationId)
-            } else {
-                Product(item.productId)
-            }
+        if (item.isVariation) {
+            SelectedItem.ProductVariation(item.productId, item.variationId)
+        } else {
+            Product(item.productId)
         }
+    }
 
     private val _pendingSelectedItems: MutableStateFlow<List<SelectedItem>> = savedState.getStateFlow(
         viewModelScope,
@@ -1229,10 +1228,9 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     fun onItemsSelectionChanged(selectedItems: List<SelectedItem>) {
-        if (_orderDraft.value.selectedItems() != selectedItems) {
-            viewState = viewState.copy(isRecalculateNeeded = true)
-            _pendingSelectedItems.value = selectedItems
-        }
+        viewState =
+            viewState.copy(isRecalculateNeeded = _orderDraft.value.selectedItems() != selectedItems)
+        _pendingSelectedItems.value = selectedItems
     }
 
     private fun onTotalsSectionRecalculateButtonClicked() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the problem with items' selection state being lost when editing parts of the order (e.g. adding a note, custom amount, etc) – more context: pdfdoF-4GL-p2#comment-5967

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Create new order or edit existing one
2. Select some items without clicking Recalculate
3. Eding other parts of the order, e.g. add custom amount, note, or customer data
4. Go back to the Order Summary, and verify the selection state is preserved and Recalculate button triggers order update correctly

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->