### PR TITLE
Fix cha-ching sound issue

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [***] Products: Merchants can now bulk update the stock status of their products [https://github.com/woocommerce/woocommerce-android/pull/10943]
 - [*] Products: Fixed a bug when changes to products were not reflected in the product list [https://github.com/woocommerce/woocommerce-android/pull/11048]
 - [**] Orders: Merchants can now move orders to trash [https://github.com/woocommerce/woocommerce-android/pull/11068]
+- [***] Push Notifications: fix a bug that caused new orders notification sound to not play after some app updates [https://github.com/woocommerce/woocommerce-android/pull/11095]
 
 17.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/ChaChingUri.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/ChaChingUri.kt
@@ -6,5 +6,11 @@ import android.net.Uri
 import com.woocommerce.android.R
 
 fun Context.getChaChingUri(): Uri {
-    return Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + packageName + "/" + R.raw.cha_ching)
+    val resourceId = R.raw.cha_ching
+    return Uri.Builder()
+        .scheme(ContentResolver.SCHEME_ANDROID_RESOURCE)
+        .authority(resources.getResourcePackageName(resourceId))
+        .appendPath(resources.getResourceTypeName(resourceId))
+        .appendPath(resources.getResourceEntryName(resourceId))
+        .build()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationChannelsHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationChannelsHandler.kt
@@ -118,9 +118,9 @@ class NotificationChannelsHandler @Inject constructor(
 
     private fun NotificationChannel.getNewOrderNotificationSoundStatus(): NewOrderNotificationSoundStatus {
         if (importance < NotificationManager.IMPORTANCE_DEFAULT) return NewOrderNotificationSoundStatus.DISABLED
-        return when {
-            sound.toString().contains(context.packageName) -> NewOrderNotificationSoundStatus.DEFAULT
-            sound == null -> NewOrderNotificationSoundStatus.DISABLED
+        return when (sound) {
+            context.getChaChingUri() -> NewOrderNotificationSoundStatus.DEFAULT
+            null -> NewOrderNotificationSoundStatus.DISABLED
             else -> NewOrderNotificationSoundStatus.SOUND_MODIFIED
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationChannelsHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationChannelsHandler.kt
@@ -83,6 +83,8 @@ class NotificationChannelsHandler @Inject constructor(
         val sound = channel.sound
         var updatedChannel = channel
         if (sound.toString().matches("^.*\\d+$".toRegex())) {
+            // The channel still uses the Uri based on the resource id, so we need to recreate it
+            WooLog.d(WooLog.T.NOTIFS, "Orders notification channel still uses ID based sound, recreating it.")
             recreateNotificationChannel(NEW_ORDER)
             updatedChannel = notificationManagerCompat.getNotificationChannel(NEW_ORDER.getChannelId())!!
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #1076 
<!-- Id number of the GitHub issue this PR addresses. -->

⚠️ Please don't merge yet, we are waiting for a decision on whether we should apply this to the release 17.8

### Description
This PR fixes the cha-ching sound issue, hopefully for real this time 😅, it brings the following changes:
1. Replaces the cha-ching URI with the one based on the resource name instead of the ID.
2. Adds logic to re-creat notification channel when it uses the old format.
3. Reverts this change https://github.com/woocommerce/woocommerce-android/pull/11080#discussion_r1526074181 as the issue should be solved now.

For more context please check the P2: p91TBi-b22-p2

### Testing instructions
##### Confirm the issue
1. Use `trunk`
3. Build and launch the app.
4. Confirm order notifications sound work (If needed, you can fix the sound issue from the app's settings by recreating the channel).
5. Create a resource `aaa.wav` in the `raw` folder.
6. Build the app using the command line: `./gradlew installWasabiDebug`
7. Launch the app.
8. Notice notifications sound doesn't work well (either silent or will use the default sound depending on your phone).

##### Confirm the solution
1. Use this branch.
2. Repeat 2 to 7 from the above steps.
3. Confirm the notification sound still works well.

##### Remarks:
- In step 6, I noticed that when building using Android Studio, the resource ID didn't change, that's why I asked using the command line.
- To help with notifications testing, the push notification console in MC could be helpful. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->