### PR TITLE
Fix/prevent detekt from checking vendor directory

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
@@ -86,7 +86,9 @@ class OrderCreateEditTotalsHelper @Inject constructor(
                 enabled = canCreateOrder,
                 onClick = onRecalculateButtonClicked,
             )
-        } else null
+        } else {
+            null
+        }
     }
 
     private fun ViewState.getMainButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -793,6 +793,7 @@ class ProductSelectorViewModel @Inject constructor(
     enum class SelectionMode {
         SINGLE,
         MULTIPLE,
+
         /**
          * Used e.g. in two-pane UI when product selector is always visible next to order summary.
          * In this mode the confirmation button and toolbar are hidden.

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ def detektAll = tasks.register("detektAll", Detekt) {
     baseline.set(file("$rootDir/config/detekt/baseline.xml"))
     config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
     include("**/*.kt")
-    exclude("**/resources/**", "**/build/**", "**/vendor/**")
+    exclude("**/resources/**", "**/build/**", "/vendor/**")
 
     reports {
         xml.required.set(true)

--- a/build.gradle
+++ b/build.gradle
@@ -212,5 +212,9 @@ tasks.register("configureApply") {
     }
 }
 
+tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
+    exclude("vendor/**")
+}
+
 apply from: './config/gradle/jacoco.gradle'
 apply from: './config/gradle/gradle_build_scan.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ def detektAll = tasks.register("detektAll", Detekt) {
     baseline.set(file("$rootDir/config/detekt/baseline.xml"))
     config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
     include("**/*.kt")
-    exclude("**/resources/**", "**/build/**")
+    exclude("**/resources/**", "**/build/**", "**/vendor/**")
 
     reports {
         xml.required.set(true)
@@ -210,10 +210,6 @@ tasks.register("configureApply") {
     doLast {
         println("Done")
     }
-}
-
-tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
-    exclude("vendor/**")
 }
 
 apply from: './config/gradle/jacoco.gradle'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes Detekt to avoid scanning the `vendor` directory. 
Additionally, if fixes a couple formatting Detekt errors that I'm not sure how they made it to `trunk`

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Run detekt locally and check it passes. 
