### PR TITLE
Update fluxc version to 2.72.0 tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-54e2405183330ae81375b8424cd8ab347f2319d5'
+    fluxCVersion = '2.72.0'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
This PR updates FluxC version from the commit hash version to the latest tag.