### PR TITLE
Product Search - List and Detail Pane Optimization

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -138,6 +138,9 @@ class ProductListFragment :
             ).toBundle()
         )
 
+    override val isSearchActive: Boolean
+        get() = productListViewModel.isSearching()
+
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
@@ -160,10 +160,10 @@ class TabletLayoutSetupHelper @Inject constructor(private val context: Context) 
     }
 
     private fun adjustLayoutForNonTablet(screen: Screen) {
-        if (screen.twoPanesWereShownBeforeConfigChange) {
-            displayDetailPaneOnly(screen)
-        } else {
+        if (screen.isSearchActive || screen.twoPanesWereShownBeforeConfigChange) {
             displayListPaneOnly(screen)
+        } else {
+            displayDetailPaneOnly(screen)
         }
     }
 
@@ -197,6 +197,8 @@ class TabletLayoutSetupHelper @Inject constructor(private val context: Context) 
         val twoPanesWereShownBeforeConfigChange: Boolean
 
         val listFragment: Fragment
+
+        val isSearchActive: Boolean
 
         data class Navigation(
             val detailsNavGraphId: Int,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11090
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
To address the requirement of prioritizing the display of the list pane in tablet layout when the user is in search mode, I introduced a flexible solution within the `TabletLayoutSetupHelper` class. By extending the `Screen` interface to include a `isSearchActive` property, I enabled the `ProductListFragment` to communicate its search status dynamically. This modification allowed the `adjustLayoutForNonTablet` method in `TabletLayoutSetupHelper` to conditionally adjust the UI based on the search mode's activation. Specifically, when search mode is active, the layout now prioritizes displaying the list pane only.

### Testing instructions

#### Steps to Reproduce the Behavior
1. Open the application on a mobile device and ensure it is in landscape mode.
2. Navigate to the products screen.
3. Perform a search so that the search detail pane is displayed.
4. Rotate the device to portrait mode.

   **Expected Outcome**: Previously, this action caused the detail pane to occupy the entire screen, obscuring the search results list. After rotating the device, the list pane showing search results should now be visible, allowing users to interact with the search results effectively.

#### Suggested Fix Evaluation
- Consider whether the X (close) button should turn into a back button in certain states to improve navigation and usability.
- Evaluate the effectiveness of the fix in ensuring the search results list is prioritized and visible, especially after rotating the device post-search.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
