### PR TITLE
[Tablet Support M3] Fix syncing selected items state when switching to dual pane

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -163,7 +163,7 @@ class OrderCreateEditFormFragment :
     }
 
     private fun syncSelectedItems() {
-        lifecycleScope.launch(Dispatchers.Main) {
+        lifecycleScope.launch {
             viewModel.pendingSelectedItems.collect {
                 sharedViewModel.updateSelectedItems(it)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -163,7 +163,7 @@ class OrderCreateEditFormFragment :
     }
 
     private fun syncSelectedItems() {
-        lifecycleScope.launch {
+        lifecycleScope.launch(Dispatchers.Main) {
             viewModel.pendingSelectedItems.collect {
                 sharedViewModel.updateSelectedItems(it)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.creation
 
+import com.woocommerce.android.model.Product as ModelProduct
 import android.os.Parcelable
 import android.view.View
 import androidx.annotation.StringRes
@@ -8,8 +9,6 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
-import androidx.lifecycle.distinctUntilChanged
-import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
@@ -172,8 +171,6 @@ import org.wordpress.android.fluxc.utils.putIfNotNull
 import java.math.BigDecimal
 import java.util.Date
 import javax.inject.Inject
-import com.woocommerce.android.model.Product as ModelProduct
-import android.util.Log
 
 @HiltViewModel
 @Suppress("LargeClass")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -173,6 +173,7 @@ import java.math.BigDecimal
 import java.util.Date
 import javax.inject.Inject
 import com.woocommerce.android.model.Product as ModelProduct
+import android.util.Log
 
 @HiltViewModel
 @Suppress("LargeClass")
@@ -429,9 +430,14 @@ class OrderCreateEditViewModel @Inject constructor(
 
     fun onDeviceConfigurationChanged(deviceType: WindowSizeClass) {
         if (viewState.isRecalculateNeeded && deviceType == WindowSizeClass.Compact) {
-            // enforce items recalculation after swithcing to single pane mode from dual pane mode
+            // enforce items recalculation after switching to single pane mode from dual pane mode
             onProductsSelected(pendingSelectedItems.value)
             viewState = viewState.copy(isRecalculateNeeded = false)
+        }
+        if (deviceType != WindowSizeClass.Compact) {
+            // ensure that any items added in single pane mode are displayed in dual pane mode
+            // in the product selector pane after switching to dual pane layout
+            _pendingSelectedItems.value = _orderDraft.value.selectedItems()
         }
         viewState = viewState.copy(windowSizeClass = deviceType)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.creation
 
-import com.woocommerce.android.model.Product as ModelProduct
 import android.os.Parcelable
 import android.view.View
 import androidx.annotation.StringRes
@@ -171,6 +170,7 @@ import org.wordpress.android.fluxc.utils.putIfNotNull
 import java.math.BigDecimal
 import java.util.Date
 import javax.inject.Inject
+import com.woocommerce.android.model.Product as ModelProduct
 
 @HiltViewModel
 @Suppress("LargeClass")

--- a/WooCommerce/src/main/res/layout/fragment_order_create_edit_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_create_edit_form.xml
@@ -5,8 +5,9 @@
     android:layout_height="match_parent"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/two_pane_mode_toolbar"
+        style="@style/Widget.Woo.Toolbar"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:elevation="@dimen/appbar_elevation"
@@ -151,5 +152,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/main_toolbar"
         android:visibility="gone"/>
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="1dp"
+        android:layout_height="0dp"
+        android:background="@color/divider_color"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/product_selector_nav_container"
+        app:layout_constraintTop_toBottomOf="@id/two_pane_mode_toolbar" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11104, #11062
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the bug with order items added to the order in single-pane layout (e.g. phone) not being selected in the product selector in a two-pane layout (tablet). Additionaly it adds minor UI improvements – divider between panes.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Open the app in a single pane mode (portrait phone, or tablet in split mode)
2. Create order and add some products
3. Switch to a dual-pane layout (e.g. landscape phone, or tablet)
4. Verify the products added to the order (2) are selected in the product selector in the left pane

Notice the vertical divider being shown in a two-pane mode.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4527432/1bef9af5-0a34-4567-8065-da7fbaf7cd18

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
