### PR TITLE
Fix logic of hiding the custom tab in Stats screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -179,9 +179,7 @@ class MyStoreStatsView @JvmOverloads constructor(
             }
         customRangeTab = tabLayout.newTab().apply {
             setText(R.string.orderfilters_date_range_filter_custom_range)
-            view.isVisible = false
         }
-        tabLayout.addTab(customRangeTab)
     }
 
     override fun onDetachedFromWindow() {
@@ -202,9 +200,11 @@ class MyStoreStatsView @JvmOverloads constructor(
     fun updateCustomDateRange(customDateRange: DateRange?) {
         customRange = customDateRange
         customRangeButton.isVisible = customDateRange == null && FeatureFlag.CUSTOM_RANGE_ANALYTICS.isEnabled()
-        customRangeTab.view.isVisible = customDateRange != null && FeatureFlag.CUSTOM_RANGE_ANALYTICS.isEnabled()
-        tabLayout.selectTab(customRangeTab)
-        tabLayout.scrollX = tabLayout.width
+        if (customDateRange != null && customRangeTab.view.parent == null) {
+            tabLayout.addTab(customRangeTab)
+        } else if (customRangeTab.view.parent != null) {
+            tabLayout.removeTab(customRangeTab)
+        }
     }
 
     fun showSkeleton(show: Boolean) {


### PR DESCRIPTION
### Description
This PR fixes a bug that was identified in the beta testing of the app (p1710845487113119-slack-C03L1NF1EA3), and the root cause is that `isVisible` doesn't work well with `TabLayout`'s tabs, I found many StackOverflow questions about it, and no solutions from what I see, so I updated the logic to remove the tab instead of just adding it.

### Testing instructions
1. Open the app (fresh install).
2. Confirm the "Add" button is shown, and the custom tab is hidden (currently both are shown).
3. Add a custom tab.
4. Confirm the "Add" button was hidden, and the custom tab was added.

### Images/gif
| Before | After |
| --- | --- |
| ![Screenshot_20240319_142727](https://github.com/woocommerce/woocommerce-android/assets/1657201/49601b07-fcea-49f7-a899-fea9ca53eba5) | ![Screenshot_20240319_142552](https://github.com/woocommerce/woocommerce-android/assets/1657201/7126e85c-4733-4d9e-bf1b-18861eed0eba) |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->