### PR TITLE
Stop using customized release name for Tracks / Sentry

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.extensions.filterNotNull
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.locale.LocaleProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt
@@ -34,7 +34,6 @@ class WCCrashLoggingDataProvider @Inject constructor(
     private val uuidGenerator: UuidGenerator,
     @AppCoroutineScope private val appScope: CoroutineScope,
     specifyPerformanceMonitoringConfig: SpecifyPerformanceMonitoringConfig,
-    buildConfig: BuildConfigWrapper,
     selectedSite: SelectedSite,
     dispatcher: Dispatcher,
 ) : CrashLoggingDataProvider {
@@ -72,12 +71,6 @@ class WCCrashLoggingDataProvider @Inject constructor(
         get() = localeProvider.provideLocale()
 
     override val performanceMonitoringConfig = specifyPerformanceMonitoringConfig()
-
-    override val releaseName: String = if (buildConfig.debug) {
-        DEBUG_RELEASE_NAME
-    } else {
-        buildConfig.versionName
-    }
 
     override val sentryDSN: String = BuildConfig.SENTRY_DSN
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProviderTest.kt
@@ -48,9 +48,6 @@ class WCCrashLoggingDataProviderTest : BaseUnitTest() {
     private val appPrefs: AppPrefs = mock()
     private val enqueueSendingEncryptedLogs: EnqueueSendingEncryptedLogs = mock()
     private val uuidGenerator: UuidGenerator = mock()
-    private val buildConfig: BuildConfigWrapper = mock {
-        on { versionName } doReturn "test version name"
-    }
     private val specifyPerformanceMonitoringConfig: SpecifyPerformanceMonitoringConfig = mock {
         on { invoke() } doReturn PerformanceMonitoringConfig.Enabled(1.0)
     }
@@ -64,7 +61,6 @@ class WCCrashLoggingDataProviderTest : BaseUnitTest() {
             appPrefs = appPrefs,
             enqueueSendingEncryptedLogs = enqueueSendingEncryptedLogs,
             uuidGenerator = uuidGenerator,
-            buildConfig = buildConfig,
             appScope = TestScope(coroutinesTestRule.testDispatcher),
             dispatcher = Dispatcher(),
             specifyPerformanceMonitoringConfig = specifyPerformanceMonitoringConfig
@@ -216,24 +212,6 @@ class WCCrashLoggingDataProviderTest : BaseUnitTest() {
 
         verify(enqueueSendingEncryptedLogs, times(1)).invoke(generatedUuid, FATAL)
         assertThat(extras).containsValue(generatedUuid)
-    }
-
-    @Test
-    fun `should provide version name for release name for not debug build`() {
-        whenever(buildConfig.debug).thenReturn(false)
-
-        reinitialize()
-
-        assertThat(sut.releaseName).isEqualTo(buildConfig.versionName)
-    }
-
-    @Test
-    fun `should provide debug name for release name for debug build`() {
-        whenever(buildConfig.debug).thenReturn(true)
-
-        reinitialize()
-
-        assertThat(sut.releaseName).isEqualTo(DEBUG_RELEASE_NAME)
     }
 
     private fun softlyAssertUser(user: CrashLoggingUser?) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProviderTest.kt
@@ -6,8 +6,6 @@ import com.automattic.android.tracks.crashlogging.EventLevel.INFO
 import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.BuildConfigWrapper
-import com.woocommerce.android.util.crashlogging.WCCrashLoggingDataProvider.Companion.DEBUG_RELEASE_NAME
 import com.woocommerce.android.util.crashlogging.WCCrashLoggingDataProvider.Companion.EXTRA_UUID
 import com.woocommerce.android.util.crashlogging.WCCrashLoggingDataProvider.Companion.SITE_ID_KEY
 import com.woocommerce.android.util.crashlogging.WCCrashLoggingDataProvider.Companion.SITE_URL_KEY

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ ext {
     mediapickerVersion = '0.3.0'
     wordPressLoginVersion = '1.13.0'
     aboutAutomatticVersion = '0.0.6'
-    automatticTracksVersion = '3.5.0'
+    automatticTracksVersion = '204-6de0efb95d8415c20ec0fa2fb8bdb23f05f499d5'
     workManagerVersion = '2.7.1'
     billingVersion = '5.0.0'
     stripeTerminalVersion = '3.1.1'


### PR DESCRIPTION
### Description

See https://github.com/Automattic/Automattic-Tracks-Android/pull/204 for context.

I'll update the version once a new Tracks release is available.


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
