### PR TITLE
Blaze: Add new payment method

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -63,6 +63,7 @@ object AppUrls {
         "https://woo.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29"
 
     const val WPCOM_ADD_PAYMENT_METHOD = "https://wordpress.com/me/purchases/add-payment-method"
+    const val FETCH_PAYMENT_METHOD_URL_PATH = "me/payment-methods"
     const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS =
         "https://woo.com/document/woopayments/in-person-payments/getting-started-with-in-person-payments/"
     const val STRIPE_LEARN_MORE_ABOUT_PAYMENTS =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -237,8 +237,7 @@ class BlazeRepository @Inject constructor(
     private fun createPaymentMethodUrls(): PaymentMethodUrls {
         return PaymentMethodUrls(
             formUrl = WPCOM_ADD_PAYMENT_METHOD,
-            successUrl = FETCH_PAYMENT_METHOD_URL_PATH,
-            idUrlParameter = "pmid"
+            successUrl = FETCH_PAYMENT_METHOD_URL_PATH
         )
     }
 
@@ -416,8 +415,7 @@ class BlazeRepository @Inject constructor(
     @Parcelize
     data class PaymentMethodUrls(
         val formUrl: String,
-        val successUrl: String,
-        val idUrlParameter: String
+        val successUrl: String
     ) : Parcelable
 
     sealed class CampaignCreationError(message: String?) : Exception(message) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.blaze
 
 import android.os.Parcelable
+import com.woocommerce.android.AppUrls.FETCH_PAYMENT_METHOD_URL_PATH
 import com.woocommerce.android.AppUrls.WPCOM_ADD_PAYMENT_METHOD
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.OnChangedException
@@ -236,7 +237,7 @@ class BlazeRepository @Inject constructor(
     private fun createPaymentMethodUrls(): PaymentMethodUrls {
         return PaymentMethodUrls(
             formUrl = WPCOM_ADD_PAYMENT_METHOD,
-            successUrl = "me/payment-methods",
+            successUrl = FETCH_PAYMENT_METHOD_URL_PATH,
             idUrlParameter = "pmid"
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.UserAgent
 import javax.inject.Inject

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModel.kt
@@ -18,7 +18,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.UserAgent
-import java.net.URL
 import javax.inject.Inject
 
 @HiltViewModel
@@ -66,7 +65,7 @@ class BlazeCampaignPaymentMethodsListViewModel @Inject constructor(
             viewModelScope.launch {
                 val urls = navArgs.paymentMethodsData.addPaymentMethodUrls
                 if (url.contains(urls.successUrl)) {
-                        blazeRepository.fetchPaymentMethods().fold(
+                    blazeRepository.fetchPaymentMethods().fold(
                         onSuccess = { data ->
                             val newPayment = data.savedPaymentMethods.firstOrNull {
                                 !navArgs.paymentMethodsData.savedPaymentMethods.contains(it)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryScreen.kt
@@ -419,7 +419,6 @@ private fun BlazeCampaignPaymentSummaryScreenPreview() {
                         BlazeRepository.PaymentMethodUrls(
                             formUrl = "https://example.com/form",
                             successUrl = "https://example.com/success",
-                            idUrlParameter = "id"
                         )
                     ),
                     onClick = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/totals/OrderCreateEditTotalsHelper.kt
@@ -86,7 +86,9 @@ class OrderCreateEditTotalsHelper @Inject constructor(
                 enabled = canCreateOrder,
                 onClick = onRecalculateButtonClicked,
             )
-        } else null
+        } else {
+            null
+        }
     }
 
     private fun ViewState.getMainButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woocommerce.android.AppUrls
+import com.woocommerce.android.AppUrls.FETCH_PAYMENT_METHOD_URL_PATH
 import com.woocommerce.android.NavGraphOrdersDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentEditShippingLabelPaymentBinding
@@ -34,8 +35,6 @@ import com.woocommerce.android.widgets.SkeletonView
 import com.woocommerce.android.widgets.WCEmptyView
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-
-private const val FETCH_PAYMENT_METHOD_URL_PATH = "me/payment-methods"
 
 @AndroidEntryPoint
 class EditShippingLabelPaymentFragment :

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -793,6 +793,7 @@ class ProductSelectorViewModel @Inject constructor(
     enum class SelectionMode {
         SINGLE,
         MULTIPLE,
+
         /**
          * Used e.g. in two-pane UI when product selector is always visible next to order summary.
          * In this mode the confirmation button and toolbar are hidden.

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModelTests.kt
@@ -110,7 +110,7 @@ class BlazeCampaignPaymentMethodsListViewModelTests : BaseUnitTest() {
                 creditCardType = CreditCardType.MASTERCARD
             )
         )
-        setup() {
+        setup {
             whenever(blazeRepository.fetchPaymentMethods()).thenReturn(
                 Result.success(
                     BlazeRepository.PaymentMethodsData(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentMethodsListViewModelTests.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.blaze.creation.payment
 
+import com.woocommerce.android.model.CreditCardType
 import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.util.captureValues
@@ -11,11 +12,13 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BlazeCampaignPaymentMethodsListViewModelTests : BaseUnitTest() {
 
     private val accountRepository: AccountRepository = mock()
+    private val blazeRepository: BlazeRepository = mock()
     private lateinit var viewModel: BlazeCampaignPaymentMethodsListViewModel
 
     suspend fun setup(
@@ -33,7 +36,8 @@ class BlazeCampaignPaymentMethodsListViewModelTests : BaseUnitTest() {
             accountRepository = accountRepository,
             userAgent = mock(),
             wpComWebViewAuthenticator = mock(),
-            analyticsTrackerWrapper = mock()
+            analyticsTrackerWrapper = mock(),
+            blazeRepository = blazeRepository
         )
     }
 
@@ -98,7 +102,24 @@ class BlazeCampaignPaymentMethodsListViewModelTests : BaseUnitTest() {
 
     @Test
     fun `when payment success URL is detected, then select the added payment method`() = testBlocking {
-        setup()
+        val newPayment = BlazeRepository.PaymentMethod(
+            id = "3",
+            name = "MasterCard 5678",
+            info = BlazeRepository.PaymentMethod.PaymentMethodInfo.CreditCard(
+                cardHolderName = "Jane Doe",
+                creditCardType = CreditCardType.MASTERCARD
+            )
+        )
+        setup() {
+            whenever(blazeRepository.fetchPaymentMethods()).thenReturn(
+                Result.success(
+                    BlazeRepository.PaymentMethodsData(
+                        savedPaymentMethods = BlazePaymentSampleData.userPaymentMethods + newPayment,
+                        addPaymentMethodUrls = BlazePaymentSampleData.paymentMethodsUrls
+                    )
+                )
+            )
+        }
         val urls = BlazePaymentSampleData.paymentMethodsUrls
 
         val viewState = viewModel.viewState.captureValues()
@@ -108,9 +129,9 @@ class BlazeCampaignPaymentMethodsListViewModelTests : BaseUnitTest() {
             val webViewState = viewState.last()
                 as BlazeCampaignPaymentMethodsListViewModel.ViewState.AddPaymentMethodWebView
 
-            webViewState.onUrlLoaded("${urls.successUrl}?${urls.idUrlParameter}=123")
+            webViewState.onUrlLoaded(urls.successUrl)
         }.last()
 
-        assertThat(event).isEqualTo(MultiLiveEvent.Event.ExitWithResult("123"))
+        assertThat(event).isEqualTo(MultiLiveEvent.Event.ExitWithResult(newPayment.id))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazePaymentSampleData.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazePaymentSampleData.kt
@@ -25,7 +25,6 @@ object BlazePaymentSampleData {
     val paymentMethodsUrls = BlazeRepository.PaymentMethodUrls(
         formUrl = "https://example.com/form",
         successUrl = "https://example.com/success",
-        idUrlParameter = "id"
     )
     val paymentMethodsData = BlazeRepository.PaymentMethodsData(
         savedPaymentMethods = userPaymentMethods,

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2977-6c50715285f7551773d3c8a3e8787274f31cec44'
+    fluxCVersion = 'trunk-3d208595f6ce11d01fd5dacfdc229368b56ab3e8'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Implements a subtask of #10722 and adds a way to add a new payment method.

**To test:**
1. Make sure you have at least 1 existing payment method in your account
2. Start creating a new Blaze campaign
3. In the payment summary, tap on the current payment method
4. Tap on Add new card CTA
5. Fill out the CC information and save it
6. Notice the new payment method is loaded and automatically selected