### PR TITLE
[Tablet Support M3] UI improvements for narrow screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -106,7 +106,7 @@ class OrderCreateEditFormFragment :
     BackPressListener {
     private companion object {
         private const val TABLET_PANES_WIDTH_RATIO = 0.5F
-        private const val XL_TABLET_PANES_WIDTH_RATIO = 0.68F
+        private const val XL_TABLET_PANES_WIDTH_RATIO = 0.6F
     }
     private val viewModel by fixedHiltNavGraphViewModels<OrderCreateEditViewModel>(R.id.nav_graph_order_creations)
     private val sharedViewModel: ProductSelectorSharedViewModel by activityViewModels()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -168,6 +168,8 @@ fun ExpandableProductCard(
                 }
                 .padding(horizontal = dimensionResource(id = R.dimen.major_100)),
             style = MaterialTheme.typography.body2,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             color = colorResource(id = R.color.color_on_surface_disabled)
         )
         if (!isExpanded && product.productInfo.hasDiscount) {
@@ -209,6 +211,8 @@ fun ExpandableProductCard(
                         .constrainAs(quantity) {
                             start.linkTo(name.start)
                             top.linkTo(stock.bottom)
+                            end.linkTo(price.start)
+                            width = Dimension.fillToConstraints
                         }
                         .padding(
                             start = dimensionResource(id = R.dimen.major_100),
@@ -216,6 +220,8 @@ fun ExpandableProductCard(
                             bottom = dimensionResource(id = R.dimen.major_100),
                         ),
                     style = MaterialTheme.typography.body2,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                     text = getQuantityWithTotalText(product),
                     color = colorResource(id = R.color.color_on_surface_disabled)
                 )
@@ -223,6 +229,7 @@ fun ExpandableProductCard(
                     modifier = Modifier.constrainAs(price) {
                         end.linkTo(chevron.start)
                         top.linkTo(quantity.top)
+                        start.linkTo(quantity.end)
                     },
                     style = MaterialTheme.typography.body2,
                     text = product.productInfo.priceAfterDiscount,
@@ -682,7 +689,9 @@ fun AmountPickerPreview() {
     }
 }
 
+@Preview(widthDp = 220)
 @Preview
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES, widthDp = 220)
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ExpandableProductCardPreview() {
@@ -699,11 +708,11 @@ fun ExpandableProductCardPreview() {
             isStockManaged = true,
             stockQuantity = 3.0,
             stockStatus = ProductStockStatus.InStock,
-            pricePreDiscount = "$10",
-            priceTotal = "$30",
-            priceSubtotal = "$30",
+            pricePreDiscount = "$1000",
+            priceTotal = "$3000",
+            priceSubtotal = "$3000",
             discountAmount = "$5",
-            priceAfterDiscount = "$25",
+            priceAfterDiscount = "$2995",
             hasDiscount = true,
             isConfigurable = false,
             productType = ProductType.SIMPLE


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10868 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR improves UI of the expandable product card Composable shown in the Order Summary pane. It added missing constraints and adjusted maxLines and overflow properties of the texts. In addition, the ratio of panes width was slightly adjusted to optimize the usability of the Order Summary pane.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Verify expandable product cards look right in different screen size configurations.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|---|---|
|![Screenshot_20240320_180843](https://github.com/woocommerce/woocommerce-android/assets/4527432/3d43b3c8-3a3e-445c-a742-46273aa2b1e7)|![Screenshot_20240320_180733](https://github.com/woocommerce/woocommerce-android/assets/4527432/c24c70a0-648f-48a3-a6e5-180a4ddc13b1)|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
