### PR TITLE
[Tablet support M2, M3] analytics events update

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -512,6 +512,9 @@ class OrderCreateEditViewModel @Inject constructor(
         handleCouponEditResult(couponEditResult)
     }
 
+    private fun getScreenSizeClassNameForAnalytics(windowSize: WindowSizeClass) =
+        IsScreenLargerThanCompactValue(windowSize != WindowSizeClass.Compact).deviceTypeToAnalyticsString
+
     fun onCustomerNoteEdited(newNote: String) {
         _orderDraft.value.let { order ->
             tracker.track(
@@ -521,6 +524,7 @@ class OrderCreateEditViewModel @Inject constructor(
                     KEY_STATUS to order.status,
                     KEY_TYPE to CUSTOMER,
                     KEY_FLOW to flow,
+                    KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
                 )
             )
         }
@@ -530,7 +534,10 @@ class OrderCreateEditViewModel @Inject constructor(
     fun onIncreaseProductsQuantity(id: Long) {
         tracker.track(
             ORDER_PRODUCT_QUANTITY_CHANGE,
-            mapOf(KEY_FLOW to flow)
+            mapOf(
+                KEY_FLOW to flow,
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
+            )
         )
         _orderDraft.update { adjustProductQuantity(it, id, +1) }
     }
@@ -542,12 +549,20 @@ class OrderCreateEditViewModel @Inject constructor(
                 if (it.quantity == 1F) {
                     tracker.track(
                         ORDER_PRODUCT_REMOVE,
-                        mapOf(KEY_FLOW to flow)
+                        mapOf(
+                            KEY_FLOW to flow,
+                            KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(
+                                viewState.windowSizeClass
+                            )
+                        )
                     )
                 } else {
                     tracker.track(
                         ORDER_PRODUCT_QUANTITY_CHANGE,
-                        mapOf(KEY_FLOW to flow)
+                        mapOf(
+                            KEY_FLOW to flow,
+                            KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
+                        )
                     )
                 }
             }
@@ -558,7 +573,10 @@ class OrderCreateEditViewModel @Inject constructor(
     private fun onIncreaseProductsQuantity(product: OrderCreationProduct) {
         tracker.track(
             ORDER_PRODUCT_QUANTITY_CHANGE,
-            mapOf(KEY_FLOW to flow)
+            mapOf(
+                KEY_FLOW to flow,
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
+            )
         )
         _orderDraft.update { adjustProductQuantity(it, product, +1) }
     }
@@ -569,7 +587,10 @@ class OrderCreateEditViewModel @Inject constructor(
         } else {
             tracker.track(
                 ORDER_PRODUCT_QUANTITY_CHANGE,
-                mapOf(KEY_FLOW to flow)
+                mapOf(
+                    KEY_FLOW to flow,
+                    KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
+                )
             )
             _orderDraft.update { adjustProductQuantity(it, product, -1) }
         }
@@ -590,7 +611,12 @@ class OrderCreateEditViewModel @Inject constructor(
                     else -> {
                         tracker.track(
                             ORDER_PRODUCT_QUANTITY_CHANGE,
-                            mapOf(KEY_FLOW to flow)
+                            mapOf(
+                                KEY_FLOW to flow,
+                                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(
+                                    viewState.windowSizeClass
+                                )
+                            )
                         )
                         _orderDraft.update {
                             adjustProductQuantity(
@@ -612,7 +638,8 @@ class OrderCreateEditViewModel @Inject constructor(
                 KEY_ID to _orderDraft.value.id,
                 KEY_FROM to _orderDraft.value.status.value,
                 KEY_TO to status.value,
-                KEY_FLOW to flow
+                KEY_FLOW to flow,
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass),
             )
         )
         _orderDraft.update { it.copy(status = status) }
@@ -621,7 +648,10 @@ class OrderCreateEditViewModel @Inject constructor(
     fun onRemoveProduct(item: OrderCreationProduct) = viewModelScope.launch {
         tracker.track(
             ORDER_PRODUCT_REMOVE,
-            mapOf(KEY_FLOW to flow)
+            mapOf(
+                KEY_FLOW to flow,
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass),
+            )
         )
         viewState = viewState.copy(isEditable = false)
         _orderDraft.update {
@@ -635,7 +665,8 @@ class OrderCreateEditViewModel @Inject constructor(
                 AnalyticsEvent.ORDER_FORM_BUNDLE_PRODUCT_CONFIGURE_CTA_SHOWN,
                 mapOf(
                     KEY_FLOW to flow,
-                    KEY_SOURCE to VALUE_PRODUCT_CARD
+                    KEY_SOURCE to VALUE_PRODUCT_CARD,
+                    KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass),
                 )
             )
         }
@@ -659,7 +690,8 @@ class OrderCreateEditViewModel @Inject constructor(
                     KEY_PRODUCT_COUNT to selectedItems.size,
                     KEY_SCANNING_SOURCE to source.source,
                     KEY_PRODUCT_ADDED_VIA to addedVia.addedVia,
-                    KEY_HAS_BUNDLE_CONFIGURATION to hasBundleConfiguration
+                    KEY_HAS_BUNDLE_CONFIGURATION to hasBundleConfiguration,
+                    KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass),
                 )
             )
         } ?: run {
@@ -669,7 +701,8 @@ class OrderCreateEditViewModel @Inject constructor(
                     KEY_FLOW to flow,
                     KEY_PRODUCT_COUNT to selectedItems.size,
                     KEY_PRODUCT_ADDED_VIA to addedVia.addedVia,
-                    KEY_HAS_BUNDLE_CONFIGURATION to hasBundleConfiguration
+                    KEY_HAS_BUNDLE_CONFIGURATION to hasBundleConfiguration,
+                    KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass),
                 )
             )
         }
@@ -767,7 +800,12 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     private fun trackBarcodeScanningTapped() {
-        tracker.track(ORDER_CREATION_PRODUCT_BARCODE_SCANNING_TAPPED)
+        tracker.track(
+            ORDER_CREATION_PRODUCT_BARCODE_SCANNING_TAPPED,
+            mapOf(
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
+            )
+        )
     }
 
     fun handleBarcodeScannedStatus(status: CodeScannerStatus) {
@@ -992,7 +1030,8 @@ class OrderCreateEditViewModel @Inject constructor(
         tracker.track(
             PRODUCT_SEARCH_VIA_SKU_SUCCESS,
             mapOf(
-                KEY_SCANNING_SOURCE to source.source
+                KEY_SCANNING_SOURCE to source.source,
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
             )
         )
     }
@@ -1046,7 +1085,8 @@ class OrderCreateEditViewModel @Inject constructor(
             ORDER_CUSTOMER_ADD,
             mapOf(
                 KEY_FLOW to flow,
-                KEY_HAS_DIFFERENT_SHIPPING_DETAILS to hasDifferentShippingDetails
+                KEY_HAS_DIFFERENT_SHIPPING_DETAILS to hasDifferentShippingDetails,
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
             )
         )
 
@@ -1200,7 +1240,8 @@ class OrderCreateEditViewModel @Inject constructor(
             AnalyticsEvent.ORDER_FORM_TOTALS_PANEL_TOGGLED,
             mapOf(
                 KEY_FLOW to flow,
-                KEY_EXPANDED to newTotalsExpandedState
+                KEY_EXPANDED to newTotalsExpandedState,
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass),
             )
         )
     }
@@ -1218,6 +1259,10 @@ class OrderCreateEditViewModel @Inject constructor(
                         buildPropsForOrderCreation()
                             .toMutableMap().apply {
                                 put(KEY_FLOW, flow)
+                                put(
+                                    KEY_HORIZONTAL_SIZE_CLASS,
+                                    getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
+                                )
                             }
                     )
                 }
@@ -1414,7 +1459,8 @@ class OrderCreateEditViewModel @Inject constructor(
                 KEY_ERROR_CONTEXT to this::class.java.simpleName,
                 KEY_ERROR_TYPE to (it as? WooException)?.error?.type?.name,
                 KEY_ERROR_DESC to it.message,
-                KEY_USE_GIFT_CARD to orderDraft.value?.selectedGiftCard.isNotNullOrEmpty()
+                KEY_USE_GIFT_CARD to orderDraft.value?.selectedGiftCard.isNotNullOrEmpty(),
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass),
             )
         )
     }
@@ -1465,7 +1511,10 @@ class OrderCreateEditViewModel @Inject constructor(
     fun onShippingRemoved() {
         tracker.track(
             ORDER_SHIPPING_METHOD_REMOVE,
-            mapOf(KEY_FLOW to flow)
+            mapOf(
+                KEY_FLOW to flow,
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
+            )
         )
         _orderDraft.update { draft ->
             draft.copy(
@@ -1521,7 +1570,8 @@ class OrderCreateEditViewModel @Inject constructor(
                         KEY_CUSTOM_AMOUNT_TAX_STATUS to when (customAmountUIModel.taxStatus.isTaxable) {
                             true -> VALUE_CUSTOM_AMOUNT_TAX_STATUS_TAXABLE
                             false -> VALUE_CUSTOM_AMOUNT_TAX_STATUS_NONE
-                        }
+                        },
+                        KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass),
                     )
                 )
                 updateCustomAmount(draft, customAmountUIModel)
@@ -1534,7 +1584,8 @@ class OrderCreateEditViewModel @Inject constructor(
                         KEY_CUSTOM_AMOUNT_TAX_STATUS to when (customAmountUIModel.taxStatus.isTaxable) {
                             true -> VALUE_CUSTOM_AMOUNT_TAX_STATUS_TAXABLE
                             false -> VALUE_CUSTOM_AMOUNT_TAX_STATUS_NONE
-                        }
+                        },
+                        KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass),
                     )
                 )
                 addCustomAmount(draft, customAmountUIModel)
@@ -1542,7 +1593,10 @@ class OrderCreateEditViewModel @Inject constructor(
             draft.copy(feesLines = feesList)
         }
         viewState = viewState.copy(isEditable = true)
-        tracker.track(ADD_CUSTOM_AMOUNT_DONE_TAPPED)
+        tracker.track(
+            ADD_CUSTOM_AMOUNT_DONE_TAPPED,
+            mapOf(KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass))
+        )
         trackIfNameAdded(customAmountUIModel)
         trackIfPercentageBasedCustomAmount(customAmountUIModel)
     }
@@ -1612,13 +1666,19 @@ class OrderCreateEditViewModel @Inject constructor(
             draft.copy(feesLines = feesList)
         }
         viewState = viewState.copy(isEditable = true)
-        tracker.track(ORDER_CREATION_REMOVE_CUSTOM_AMOUNT_TAPPED)
+        tracker.track(
+            ORDER_CREATION_REMOVE_CUSTOM_AMOUNT_TAPPED,
+            mapOf(KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass))
+        )
     }
 
     fun onFeeRemoved() {
         tracker.track(
             ORDER_FEE_REMOVE,
-            mapOf(KEY_FLOW to flow)
+            mapOf(
+                KEY_FLOW to flow,
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
+            )
         )
         _orderDraft.update { draft ->
             draft.copy(
@@ -1677,7 +1737,10 @@ class OrderCreateEditViewModel @Inject constructor(
         } else {
             triggerEvent(TaxRateSelector(getTaxRatesInfoDialogState(_orderDraft.value.taxLines)))
         }
-        tracker.track(AnalyticsEvent.ORDER_CREATION_SET_NEW_TAX_RATE_TAPPED)
+        tracker.track(
+            AnalyticsEvent.ORDER_CREATION_SET_NEW_TAX_RATE_TAPPED,
+            mapOf(KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass))
+        )
     }
 
     fun onTaxRateSelected(taxRate: TaxRate) = launch(Dispatchers.IO) {
@@ -1717,7 +1780,12 @@ class OrderCreateEditViewModel @Inject constructor(
 
     fun onSetNewTaxRateClicked() = launch {
         triggerEvent(TaxRateSelector(getTaxRatesInfoDialogState(_orderDraft.value.taxLines)))
-        tracker.track(AnalyticsEvent.TAX_RATE_AUTO_TAX_RATE_SET_NEW_RATE_FOR_ORDER_TAPPED)
+        tracker.track(
+            AnalyticsEvent.TAX_RATE_AUTO_TAX_RATE_SET_NEW_RATE_FOR_ORDER_TAPPED,
+            mapOf(
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
+            )
+        )
     }
 
     fun onStopUsingTaxRateClicked() = launch {
@@ -1725,7 +1793,12 @@ class OrderCreateEditViewModel @Inject constructor(
         updateAutoTaxRateSettingState()
         updateTaxRateSelectorButtonState()
         clearCustomerAddresses()
-        tracker.track(AnalyticsEvent.TAX_RATE_AUTO_TAX_RATE_CLEAR_ADDRESS_TAPPED)
+        tracker.track(
+            AnalyticsEvent.TAX_RATE_AUTO_TAX_RATE_CLEAR_ADDRESS_TAPPED,
+            mapOf(
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
+            )
+        )
     }
 
     fun onDiscountButtonClicked(product: OrderCreationProduct) {
@@ -1735,7 +1808,10 @@ class OrderCreateEditViewModel @Inject constructor(
         } else {
             AnalyticsEvent.ORDER_PRODUCT_DISCOUNT_ADD_BUTTON_TAPPED
         }
-        tracker.track(analyticsEvent)
+        tracker.track(
+            analyticsEvent,
+            mapOf(KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass))
+        )
     }
 
     fun onEditConfiguration(product: OrderCreationProduct) {
@@ -1819,7 +1895,8 @@ class OrderCreateEditViewModel @Inject constructor(
             AnalyticsEvent.ORDER_FORM_GIFT_CARD_SET,
             mapOf(
                 KEY_FLOW to flow,
-                KEY_IS_GIFT_CARD_REMOVED to giftCardWasRemoved
+                KEY_IS_GIFT_CARD_REMOVED to giftCardWasRemoved,
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -730,7 +730,7 @@ class OrderListFragment :
         viewModel.trackOrderClickEvent(
             orderId,
             orderStatus,
-            requireContext().windowSizeClass != WindowSizeClass.Compact
+            requireContext().windowSizeClass
         )
 
         if (requireContext().windowSizeClass != WindowSizeClass.Compact) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -25,7 +25,10 @@ import com.woocommerce.android.analytics.AnalyticsEvent.ORDER_LIST_TOP_BANNER_TR
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HORIZONTAL_SIZE_CLASS
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.analytics.IsScreenLargerThanCompactValue
+import com.woocommerce.android.analytics.deviceTypeToAnalyticsString
 import com.woocommerce.android.extensions.NotificationReceivedEvent
+import com.woocommerce.android.extensions.WindowSizeClass
 import com.woocommerce.android.extensions.filter
 import com.woocommerce.android.extensions.filterNotNull
 import com.woocommerce.android.model.FeatureFeedbackSettings
@@ -351,7 +354,7 @@ class OrderListViewModel @Inject constructor(
      * Track user clicked to open an order and the status of that order, along with some
      * data about the order custom fields
      */
-    fun trackOrderClickEvent(orderId: Long, orderStatus: String, isTablet: Boolean = false) = launch {
+    fun trackOrderClickEvent(orderId: Long, orderStatus: String, windowSize: WindowSizeClass) = launch {
         val (customFieldsCount, customFieldsSize) =
             orderDetailRepository.getOrderMetadata(orderId)
                 .map { it.value.utf8Size() }
@@ -371,10 +374,13 @@ class OrderListViewModel @Inject constructor(
                 AnalyticsTracker.KEY_STATUS to orderStatus,
                 AnalyticsTracker.KEY_CUSTOM_FIELDS_COUNT to customFieldsCount,
                 AnalyticsTracker.KEY_CUSTOM_FIELDS_SIZE to customFieldsSize,
-                KEY_HORIZONTAL_SIZE_CLASS to isTablet
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(windowSize)
             )
         )
     }
+
+    private fun getScreenSizeClassNameForAnalytics(windowSize: WindowSizeClass) =
+        IsScreenLargerThanCompactValue(windowSize != WindowSizeClass.Compact).deviceTypeToAnalyticsString
 
     /**
      * Activates the provided list by first removing the LiveData sources for the active list,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -168,7 +168,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         val mockedSite = SiteModel().also { it.adminUrl = "https://test.com" }
         whenever(selectedSite.get()).thenReturn(mockedSite)
         sut.onSetTaxRateClicked()
-        verify(tracker).track(AnalyticsEvent.ORDER_CREATION_SET_NEW_TAX_RATE_TAPPED)
+        verify(tracker).track(AnalyticsEvent.ORDER_CREATION_SET_NEW_TAX_RATE_TAPPED, mapOf(KEY_HORIZONTAL_SIZE_CLASS to "compact"))
     }
 
     @Test
@@ -176,7 +176,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         val mockedSite = SiteModel().also { it.adminUrl = "https://test.com" }
         whenever(selectedSite.get()).thenReturn(mockedSite)
         sut.onSetNewTaxRateClicked()
-        verify(tracker).track(AnalyticsEvent.TAX_RATE_AUTO_TAX_RATE_SET_NEW_RATE_FOR_ORDER_TAPPED)
+        verify(tracker).track(AnalyticsEvent.TAX_RATE_AUTO_TAX_RATE_SET_NEW_RATE_FOR_ORDER_TAPPED, mapOf(KEY_HORIZONTAL_SIZE_CLASS to "compact"))
     }
 
     @Test
@@ -1373,7 +1373,8 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
             verify(tracker).track(
                 AnalyticsEvent.PRODUCT_SEARCH_VIA_SKU_SUCCESS,
                 mapOf(
-                    AnalyticsTracker.KEY_SCANNING_SOURCE to "order_list"
+                    AnalyticsTracker.KEY_SCANNING_SOURCE to "order_list",
+                    KEY_HORIZONTAL_SIZE_CLASS to "compact"
                 )
             )
         }
@@ -1497,7 +1498,8 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
                     KEY_PRODUCT_COUNT to 1,
                     AnalyticsTracker.KEY_SCANNING_SOURCE to ScanningSource.ORDER_LIST.source,
                     KEY_PRODUCT_ADDED_VIA to ProductAddedVia.SCANNING.addedVia,
-                    KEY_HAS_BUNDLE_CONFIGURATION to false
+                    KEY_HAS_BUNDLE_CONFIGURATION to false,
+                    KEY_HORIZONTAL_SIZE_CLASS to "compact"
                 )
             )
         }
@@ -1543,7 +1545,8 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
                     KEY_PRODUCT_COUNT to 1,
                     AnalyticsTracker.KEY_SCANNING_SOURCE to ScanningSource.ORDER_LIST.source,
                     KEY_PRODUCT_ADDED_VIA to ProductAddedVia.SCANNING.addedVia,
-                    KEY_HAS_BUNDLE_CONFIGURATION to false
+                    KEY_HAS_BUNDLE_CONFIGURATION to false,
+                    KEY_HORIZONTAL_SIZE_CLASS to "compact"
                 )
             )
         }
@@ -1981,14 +1984,16 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
                 AnalyticsEvent.ORDER_FORM_TOTALS_PANEL_TOGGLED,
                 mapOf(
                     KEY_FLOW to VALUE_FLOW_CREATION,
-                    KEY_EXPANDED to false
+                    KEY_EXPANDED to false,
+                    KEY_HORIZONTAL_SIZE_CLASS to "compact"
                 )
             )
             verify(tracker).track(
                 AnalyticsEvent.ORDER_FORM_TOTALS_PANEL_TOGGLED,
                 mapOf(
                     KEY_FLOW to VALUE_FLOW_CREATION,
-                    KEY_EXPANDED to true
+                    KEY_EXPANDED to true,
+                    KEY_HORIZONTAL_SIZE_CLASS to "compact"
                 )
             )
         }
@@ -2082,7 +2087,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
 
         sut.onCustomAmountUpsert(customAmountUIModel)
 
-        verify(tracker).track(ADD_CUSTOM_AMOUNT_DONE_TAPPED)
+        verify(tracker).track(ADD_CUSTOM_AMOUNT_DONE_TAPPED, mapOf(KEY_HORIZONTAL_SIZE_CLASS to "compact"))
     }
 
     @Test
@@ -2112,7 +2117,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
 
         sut.onCustomAmountUpsert(customAmountUIModel)
 
-        verify(tracker).track(ADD_CUSTOM_AMOUNT_DONE_TAPPED)
+        verify(tracker).track(ADD_CUSTOM_AMOUNT_DONE_TAPPED, mapOf(KEY_HORIZONTAL_SIZE_CLASS to "compact"))
     }
 
     @Test
@@ -2182,7 +2187,8 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
             ORDER_FEE_UPDATE,
             mapOf(
                 KEY_FLOW to VALUE_FLOW_CREATION,
-                KEY_CUSTOM_AMOUNT_TAX_STATUS to "none"
+                KEY_CUSTOM_AMOUNT_TAX_STATUS to "none",
+                KEY_HORIZONTAL_SIZE_CLASS to "compact"
             )
         )
     }
@@ -2234,7 +2240,8 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
             ORDER_FEE_ADD,
             mapOf(
                 KEY_FLOW to VALUE_FLOW_CREATION,
-                KEY_CUSTOM_AMOUNT_TAX_STATUS to VALUE_CUSTOM_AMOUNT_TAX_STATUS_TAXABLE
+                KEY_CUSTOM_AMOUNT_TAX_STATUS to VALUE_CUSTOM_AMOUNT_TAX_STATUS_TAXABLE,
+                KEY_HORIZONTAL_SIZE_CLASS to "compact"
             )
         )
     }
@@ -2255,7 +2262,8 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
             ORDER_FEE_ADD,
             mapOf(
                 KEY_FLOW to VALUE_FLOW_CREATION,
-                KEY_CUSTOM_AMOUNT_TAX_STATUS to VALUE_CUSTOM_AMOUNT_TAX_STATUS_NONE
+                KEY_CUSTOM_AMOUNT_TAX_STATUS to VALUE_CUSTOM_AMOUNT_TAX_STATUS_NONE,
+                KEY_HORIZONTAL_SIZE_CLASS to "compact"
             )
         )
     }
@@ -2315,7 +2323,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
 
         sut.onCustomAmountRemoved(customAmountUIModel)
 
-        verify(tracker).track(ORDER_CREATION_REMOVE_CUSTOM_AMOUNT_TAPPED)
+        verify(tracker).track(ORDER_CREATION_REMOVE_CUSTOM_AMOUNT_TAPPED, mapOf(KEY_HORIZONTAL_SIZE_CLASS to "compact"))
     }
     //endregion
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -168,7 +168,9 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         val mockedSite = SiteModel().also { it.adminUrl = "https://test.com" }
         whenever(selectedSite.get()).thenReturn(mockedSite)
         sut.onSetTaxRateClicked()
-        verify(tracker).track(AnalyticsEvent.ORDER_CREATION_SET_NEW_TAX_RATE_TAPPED, mapOf(KEY_HORIZONTAL_SIZE_CLASS to "compact"))
+        verify(
+            tracker
+        ).track(AnalyticsEvent.ORDER_CREATION_SET_NEW_TAX_RATE_TAPPED, mapOf(KEY_HORIZONTAL_SIZE_CLASS to "compact"))
     }
 
     @Test
@@ -176,7 +178,12 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         val mockedSite = SiteModel().also { it.adminUrl = "https://test.com" }
         whenever(selectedSite.get()).thenReturn(mockedSite)
         sut.onSetNewTaxRateClicked()
-        verify(tracker).track(AnalyticsEvent.TAX_RATE_AUTO_TAX_RATE_SET_NEW_RATE_FOR_ORDER_TAPPED, mapOf(KEY_HORIZONTAL_SIZE_CLASS to "compact"))
+        verify(
+            tracker
+        ).track(
+            AnalyticsEvent.TAX_RATE_AUTO_TAX_RATE_SET_NEW_RATE_FOR_ORDER_TAPPED,
+            mapOf(KEY_HORIZONTAL_SIZE_CLASS to "compact")
+        )
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -207,7 +207,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 AnalyticsTracker.KEY_FLOW to tracksFlow,
                 AnalyticsTracker.KEY_PRODUCT_COUNT to 1,
                 KEY_PRODUCT_ADDED_VIA to ProductAddedVia.MANUALLY.addedVia,
-                AnalyticsTracker.KEY_HAS_BUNDLE_CONFIGURATION to false
+                AnalyticsTracker.KEY_HAS_BUNDLE_CONFIGURATION to false,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
             ),
         )
     }
@@ -229,7 +230,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 AnalyticsTracker.KEY_FLOW to tracksFlow,
                 AnalyticsTracker.KEY_PRODUCT_COUNT to 4,
                 KEY_PRODUCT_ADDED_VIA to ProductAddedVia.MANUALLY.addedVia,
-                AnalyticsTracker.KEY_HAS_BUNDLE_CONFIGURATION to false
+                AnalyticsTracker.KEY_HAS_BUNDLE_CONFIGURATION to false,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
             ),
         )
     }
@@ -249,6 +251,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             mapOf(
                 AnalyticsTracker.KEY_FLOW to tracksFlow,
                 AnalyticsTracker.KEY_HAS_DIFFERENT_SHIPPING_DETAILS to false,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
             )
         )
     }
@@ -317,6 +320,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 AnalyticsTracker.KEY_STATUS to Order.Status.Pending,
                 AnalyticsTracker.KEY_TYPE to AnalyticsTracker.Companion.OrderNoteType.CUSTOMER,
                 AnalyticsTracker.KEY_FLOW to tracksFlow,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact",
             )
         )
     }
@@ -331,7 +335,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 AnalyticsTracker.KEY_ID to 0L,
                 AnalyticsTracker.KEY_FROM to Order.Status.Pending.value,
                 AnalyticsTracker.KEY_TO to Order.Status.Cancelled.value,
-                AnalyticsTracker.KEY_FLOW to tracksFlow
+                AnalyticsTracker.KEY_FLOW to tracksFlow,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
             )
         )
     }
@@ -346,7 +351,10 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         sut.onIncreaseProductsQuantity(productId)
         verify(tracker).track(
             AnalyticsEvent.ORDER_PRODUCT_QUANTITY_CHANGE,
-            mapOf(AnalyticsTracker.KEY_FLOW to tracksFlow)
+            mapOf(
+                AnalyticsTracker.KEY_FLOW to tracksFlow,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
+            )
         )
     }
 
@@ -360,7 +368,10 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         sut.onDecreaseProductsQuantity(productId)
         verify(tracker).track(
             AnalyticsEvent.ORDER_PRODUCT_QUANTITY_CHANGE,
-            mapOf(AnalyticsTracker.KEY_FLOW to tracksFlow)
+            mapOf(
+                AnalyticsTracker.KEY_FLOW to tracksFlow,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
+            )
         )
     }
 
@@ -374,7 +385,10 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         sut.onDecreaseProductsQuantity(productId)
         verify(tracker).track(
             AnalyticsEvent.ORDER_PRODUCT_REMOVE,
-            mapOf(AnalyticsTracker.KEY_FLOW to tracksFlow)
+            mapOf(
+                AnalyticsTracker.KEY_FLOW to tracksFlow,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
+            )
         )
     }
 
@@ -395,7 +409,10 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         sut.onRemoveProduct(productToRemove)
         verify(tracker).track(
             AnalyticsEvent.ORDER_PRODUCT_REMOVE,
-            mapOf(AnalyticsTracker.KEY_FLOW to tracksFlow)
+            mapOf(
+                AnalyticsTracker.KEY_FLOW to tracksFlow,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
+            )
         )
     }
 
@@ -413,7 +430,10 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         sut.onFeeRemoved()
         verify(tracker).track(
             AnalyticsEvent.ORDER_FEE_REMOVE,
-            mapOf(AnalyticsTracker.KEY_FLOW to tracksFlow)
+            mapOf(
+                AnalyticsTracker.KEY_FLOW to tracksFlow,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
+            )
         )
     }
 
@@ -432,7 +452,10 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         sut.onShippingRemoved()
         verify(tracker).track(
             AnalyticsEvent.ORDER_SHIPPING_METHOD_REMOVE,
-            mapOf(AnalyticsTracker.KEY_FLOW to tracksFlow)
+            mapOf(
+                AnalyticsTracker.KEY_FLOW to tracksFlow,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
+            )
         )
     }
 
@@ -487,7 +510,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             AnalyticsEvent.ORDER_FORM_GIFT_CARD_SET,
             mapOf(
                 AnalyticsTracker.KEY_FLOW to tracksFlow,
-                AnalyticsTracker.KEY_IS_GIFT_CARD_REMOVED to false
+                AnalyticsTracker.KEY_IS_GIFT_CARD_REMOVED to false,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
             )
         )
     }
@@ -503,7 +527,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             AnalyticsEvent.ORDER_FORM_GIFT_CARD_SET,
             mapOf(
                 AnalyticsTracker.KEY_FLOW to tracksFlow,
-                AnalyticsTracker.KEY_IS_GIFT_CARD_REMOVED to false
+                AnalyticsTracker.KEY_IS_GIFT_CARD_REMOVED to false,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
             )
         )
 
@@ -513,7 +538,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             AnalyticsEvent.ORDER_FORM_GIFT_CARD_SET,
             mapOf(
                 AnalyticsTracker.KEY_FLOW to tracksFlow,
-                AnalyticsTracker.KEY_IS_GIFT_CARD_REMOVED to true
+                AnalyticsTracker.KEY_IS_GIFT_CARD_REMOVED to true,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
             )
         )
     }
@@ -1405,7 +1431,10 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
 
         sut.onScanClicked()
 
-        verify(tracker).track(AnalyticsEvent.ORDER_CREATION_PRODUCT_BARCODE_SCANNING_TAPPED)
+        verify(tracker).track(
+            AnalyticsEvent.ORDER_CREATION_PRODUCT_BARCODE_SCANNING_TAPPED,
+            mapOf(AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact")
+        )
     }
 
     @Test
@@ -1536,7 +1565,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             verify(tracker).track(
                 PRODUCT_SEARCH_VIA_SKU_SUCCESS,
                 mapOf(
-                    KEY_SCANNING_SOURCE to "order_creation"
+                    KEY_SCANNING_SOURCE to "order_creation",
+                    AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
                 )
             )
         }
@@ -1706,7 +1736,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                     AnalyticsTracker.KEY_PRODUCT_COUNT to 1,
                     KEY_SCANNING_SOURCE to ScanningSource.ORDER_CREATION.source,
                     KEY_PRODUCT_ADDED_VIA to ProductAddedVia.SCANNING.addedVia,
-                    AnalyticsTracker.KEY_HAS_BUNDLE_CONFIGURATION to false
+                    AnalyticsTracker.KEY_HAS_BUNDLE_CONFIGURATION to false,
+                    AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
                 )
             )
         }
@@ -1739,7 +1770,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                     AnalyticsTracker.KEY_PRODUCT_COUNT to 1,
                     KEY_SCANNING_SOURCE to ScanningSource.ORDER_CREATION.source,
                     KEY_PRODUCT_ADDED_VIA to ProductAddedVia.SCANNING.addedVia,
-                    AnalyticsTracker.KEY_HAS_BUNDLE_CONFIGURATION to false
+                    AnalyticsTracker.KEY_HAS_BUNDLE_CONFIGURATION to false,
+                    AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
                 )
             )
         }
@@ -2296,7 +2328,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 AnalyticsEvent.ORDER_FORM_BUNDLE_PRODUCT_CONFIGURE_CTA_SHOWN,
                 mapOf(
                     AnalyticsTracker.KEY_FLOW to tracksFlow,
-                    AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_PRODUCT_CARD
+                    AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_PRODUCT_CARD,
+                    AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
                 )
             )
         }
@@ -2416,7 +2449,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 AnalyticsTracker.KEY_FLOW to tracksFlow,
                 AnalyticsTracker.KEY_PRODUCT_COUNT to selectedItems.size,
                 KEY_PRODUCT_ADDED_VIA to ProductAddedVia.MANUALLY.addedVia,
-                AnalyticsTracker.KEY_HAS_BUNDLE_CONFIGURATION to true
+                AnalyticsTracker.KEY_HAS_BUNDLE_CONFIGURATION to true,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
             )
         )
     }
@@ -2439,7 +2473,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 AnalyticsTracker.KEY_FLOW to tracksFlow,
                 AnalyticsTracker.KEY_PRODUCT_COUNT to selectedItems.size,
                 KEY_PRODUCT_ADDED_VIA to ProductAddedVia.MANUALLY.addedVia,
-                AnalyticsTracker.KEY_HAS_BUNDLE_CONFIGURATION to false
+                AnalyticsTracker.KEY_HAS_BUNDLE_CONFIGURATION to false,
+                AnalyticsTracker.KEY_HORIZONTAL_SIZE_CLASS to "compact"
             )
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11066, #10988
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR reviews analytic events tracked in order list and order creation/edition flows and adds the "horizontal_size_class" property to the analytics events. As in iOS implementation – large screens (e.g. tablets) are marked with "regular" value and compact with "compact" value.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Review analytics events logs in logcat (under "Tracks") keyword and verify the "horizontal_size_class" property is tracked with the correct values for tablets and phones.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->