### PR TITLE
Fix NPE when attempting to re-create orders notification channel

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationChannelsHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationChannelsHandler.kt
@@ -82,7 +82,7 @@ class NotificationChannelsHandler @Inject constructor(
     private fun checkAndTrackNewOrderNotificationSound(channel: NotificationChannel) {
         val sound = channel.sound
         var updatedChannel = channel
-        if (sound?.toString()?.matches("^.*\\d+$".toRegex()) == true) {
+        if (sound?.toString()?.matches("^android\\.resource.*\\d+$".toRegex()) == true) {
             // The channel still uses the Uri based on the resource id, so we need to recreate it
             WooLog.d(WooLog.T.NOTIFS, "Orders notification channel still uses ID based sound, recreating it.")
             recreateNotificationChannel(NEW_ORDER)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationChannelsHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationChannelsHandler.kt
@@ -82,7 +82,7 @@ class NotificationChannelsHandler @Inject constructor(
     private fun checkAndTrackNewOrderNotificationSound(channel: NotificationChannel) {
         val sound = channel.sound
         var updatedChannel = channel
-        if (sound.toString().matches("^.*\\d+$".toRegex())) {
+        if (sound?.toString()?.matches("^.*\\d+$".toRegex()) == true) {
             // The channel still uses the Uri based on the resource id, so we need to recreate it
             WooLog.d(WooLog.T.NOTIFS, "Orders notification channel still uses ID based sound, recreating it.")
             recreateNotificationChannel(NEW_ORDER)


### PR DESCRIPTION
### Description
When working on the Cha-ching fix in #11095, I added a logic to re-create the notification channel if it was still using the old Uri format (with resource ID), but the logic is causing an NPE crash if the sound was disabled instead. 

### Testing instructions
There is nothing to test, just code review to confirm the logic is correct.


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
