### PR TITLE
Products - Stock Status - Adjust Dialog Dimensions Based on Device Orientation and Window Size

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/UpdateProductStockStatusFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/UpdateProductStockStatusFragment.kt
@@ -31,11 +31,11 @@ class UpdateProductStockStatusFragment : DialogFragment() {
     companion object {
         const val UPDATE_STOCK_STATUS_EXIT_STATE_KEY = "update_stock_status_exit_state_key"
 
-        private const val TABLET_LANDSCAPE_WIDTH_RATIO = 0.35f
-        private const val TABLET_LANDSCAPE_HEIGHT_RATIO = 0.8f
+        private const val MEDIUM_WIDTH_RATIO = 0.5f
+        private const val MEDIUM_HEIGHT_RATIO = 0.8f
 
-        private const val TABLET_PORTRAIT_WIDTH_RATIO = 0.8f
-        private const val TABLET_PORTRAIT_HEIGHT_RATIO = 0.5f
+        private const val EXPANDED_WIDTH_RATIO = 0.35f
+        private const val EXPANDED_HEIGHT_RATIO = 0.8f
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -74,30 +74,21 @@ class UpdateProductStockStatusFragment : DialogFragment() {
 
     override fun onStart() {
         super.onStart()
-        if (isTabletLandscape()) {
-            dialog?.window?.setLayout(
-                (DisplayUtils.getWindowPixelWidth(requireContext()) * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
-                (DisplayUtils.getWindowPixelHeight(requireContext()) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
-            )
-        } else if (isTabletPortrait()) {
-            dialog?.window?.setLayout(
-                (DisplayUtils.getWindowPixelWidth(requireContext()) * TABLET_PORTRAIT_WIDTH_RATIO).toInt(),
-                (DisplayUtils.getWindowPixelHeight(requireContext()) * TABLET_PORTRAIT_HEIGHT_RATIO).toInt()
-            )
+        val windowSizeClass = context?.windowSizeClass
+        val width = DisplayUtils.getWindowPixelWidth(requireContext())
+        val height = DisplayUtils.getWindowPixelHeight(requireContext())
+
+        val (widthRatio, heightRatio) = when (windowSizeClass) {
+            WindowSizeClass.Compact -> 1f to 1f
+            WindowSizeClass.Medium -> MEDIUM_WIDTH_RATIO to MEDIUM_HEIGHT_RATIO
+            WindowSizeClass.ExpandedAndBigger -> EXPANDED_WIDTH_RATIO to EXPANDED_HEIGHT_RATIO
+            else -> 1f to 1f
         }
-    }
 
-    private fun isTabletLandscape(): Boolean {
-        val isLandscape = DisplayUtils.isLandscape(context)
-
-        return (context?.windowSizeClass != WindowSizeClass.Compact) && isLandscape
-    }
-
-    private fun isTabletPortrait(): Boolean {
-        val isTablet = DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)
-        val isPortrait = !DisplayUtils.isLandscape(context)
-
-        return isTablet && isPortrait
+        dialog?.window?.setLayout(
+            (width * widthRatio).toInt(),
+            (height * heightRatio).toInt()
+        )
     }
 
     private fun setupObservers() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/UpdateProductStockStatusFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/UpdateProductStockStatusFragment.kt
@@ -31,11 +31,11 @@ class UpdateProductStockStatusFragment : DialogFragment() {
     companion object {
         const val UPDATE_STOCK_STATUS_EXIT_STATE_KEY = "update_stock_status_exit_state_key"
 
-        private const val MEDIUM_WIDTH_RATIO = 0.5f
-        private const val MEDIUM_HEIGHT_RATIO = 0.8f
+        private const val LANDSCAPE_WIDTH_RATIO = 0.5f
+        private const val LANDSCAPE_HEIGHT_RATIO = 0.8f
 
-        private const val EXPANDED_WIDTH_RATIO = 0.35f
-        private const val EXPANDED_HEIGHT_RATIO = 0.8f
+        private const val PORTRAIT_WIDTH_RATIO = 0.7f
+        private const val PORTRAIT_HEIGHT_RATIO = 0.5f
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -78,11 +78,12 @@ class UpdateProductStockStatusFragment : DialogFragment() {
         val width = DisplayUtils.getWindowPixelWidth(requireContext())
         val height = DisplayUtils.getWindowPixelHeight(requireContext())
 
-        val (widthRatio, heightRatio) = when (windowSizeClass) {
-            WindowSizeClass.Compact -> 1f to 1f
-            WindowSizeClass.Medium -> MEDIUM_WIDTH_RATIO to MEDIUM_HEIGHT_RATIO
-            WindowSizeClass.ExpandedAndBigger -> EXPANDED_WIDTH_RATIO to EXPANDED_HEIGHT_RATIO
-            else -> 1f to 1f
+        val isLandscape = DisplayUtils.isLandscape(context)
+
+        val (widthRatio, heightRatio) = when {
+            windowSizeClass == WindowSizeClass.Compact -> 1f to 1f
+            isLandscape -> LANDSCAPE_WIDTH_RATIO to LANDSCAPE_HEIGHT_RATIO
+            else -> PORTRAIT_WIDTH_RATIO to PORTRAIT_HEIGHT_RATIO
         }
 
         dialog?.window?.setLayout(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11138
<!-- Id number of the GitHub issue this PR addresses. -->

### Description

This solution involved enhancing the `UpdateProductStockStatusFragment` to dynamically adjust the dialog window size based on both the device's window size class and its orientation (landscape or portrait). This was achieved by defining separate width and height ratios for landscape and portrait orientations within the companion object. These ratios are then applied in the onStart method, where the device's current window size class and orientation are evaluated to determine the appropriate set of ratios to use. This approach ensures that the dialog's dimensions are optimized for the device's screen size and orientation, providing a better user experience across a wide range of devices, from compact phones to larger tablets and foldables in both portrait and landscape modes.

### Testing instructions

- **Test with phone, small tablet and large tablet**

1. Go to the Products Screen. 
2. Select products. 
3. Click Update stock status
4. Notice that the dialog UI looks optimal in both landscape and portrait mode.

### Images/gif

## Phone

**Portrait**

<kbd><img src="https://github.com/woocommerce/woocommerce-android/assets/1509205/e5d06758-bb18-4887-98ad-19cdb4d2385c" width="320"></kbd>

**Landscape**

<kbd><img src="https://github.com/woocommerce/woocommerce-android/assets/1509205/ba99ecda-ac09-4acf-8e1d-d179775ee047" width="480"></kbd>

## Small Tablet

**Portrait**

<kbd><img src="https://github.com/woocommerce/woocommerce-android/assets/1509205/b9912a6c-76fc-4ea5-ac92-19719ed34f37" width="360"></kbd>

**Landscape**

<kbd><img src="https://github.com/woocommerce/woocommerce-android/assets/1509205/1984c155-6d8f-4cea-a9b7-ba37b5c07859" width="540"></kbd>

## Large Tablet 

**Portrait**

<kbd><img src="https://github.com/woocommerce/woocommerce-android/assets/1509205/64d97ea5-8efb-4d6f-acb0-76dd5e5b5d65" width="480"></kbd>

**Landscape**

<kbd><img src="https://github.com/woocommerce/woocommerce-android/assets/1509205/05312bab-3101-441f-a68b-3b509b4b6667" width="640"></kbd>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
