### PR TITLE
Issue/11141 restore selected range

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -133,9 +133,11 @@ class MyStoreViewModel @Inject constructor(
     private val refreshTrigger = MutableSharedFlow<RefreshState>(extraBufferCapacity = 1)
 
     private val _selectedRangeType = savedState.getStateFlow(viewModelScope, getSelectedRangeTypeIfAny())
-    private val customRangeFlow = customDateRangeDataStore.dateRange.filterNotNull()
 
-    private val _selectedDateRange = combine(_selectedRangeType, customRangeFlow) { selectionType, customRange ->
+    private val _selectedDateRange = combine(
+        _selectedRangeType,
+        customDateRangeDataStore.dateRange.filterNotNull()
+    ) { selectionType, customRange ->
         when (selectionType) {
             SelectionType.CUSTOM -> {
                 selectionType.generateSelectionData(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -54,7 +54,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -136,15 +135,15 @@ class MyStoreViewModel @Inject constructor(
 
     private val _selectedDateRange = combine(
         _selectedRangeType,
-        customDateRangeDataStore.dateRange.filterNotNull()
+        customDateRangeDataStore.dateRange
     ) { selectionType, customRange ->
         when (selectionType) {
             SelectionType.CUSTOM -> {
                 selectionType.generateSelectionData(
                     calendar = Calendar.getInstance(),
                     locale = Locale.getDefault(),
-                    referenceStartDate = customRange.startDate,
-                    referenceEndDate = customRange.endDate
+                    referenceStartDate = customRange?.startDate ?: Date(),
+                    referenceEndDate = customRange?.endDate ?: Date()
                 )
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -450,6 +450,9 @@ class MyStoreViewModel @Inject constructor(
     }
 
     fun onCustomRangeSelected(fromMillis: Long, toMillis: Long) {
+        if (_selectedRangeType.value != SelectionType.CUSTOM) {
+            onStatsGranularityChanged(SelectionType.CUSTOM)
+        }
         viewModelScope.launch {
             customDateRangeDataStore.updateDateRange(fromMillis, toMillis)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -471,12 +471,6 @@ class MyStoreViewModel @Inject constructor(
 
     fun onCustomRangeSelected(fromMillis: Long, toMillis: Long) {
         onStatsGranularityChanged(SelectionType.CUSTOM)
-        _customRange.update {
-            AnalyticsHubTimeRange(
-                Date(fromMillis),
-                Date(toMillis)
-            )
-        }
         viewModelScope.launch {
             customDateRangeDataStore.updateDateRange(fromMillis, toMillis)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -248,15 +248,6 @@ class MyStoreViewModel @Inject constructor(
         refreshTrigger.tryEmit(RefreshState(isForced = true))
     }
 
-    fun getSelectedSiteName(): String =
-        selectedSite.getIfExists()?.let { site ->
-            if (!site.displayName.isNullOrBlank()) {
-                site.displayName
-            } else {
-                site.name
-            }
-        } ?: ""
-
     fun onViewAnalyticsClicked() {
         AnalyticsTracker.track(AnalyticsEvent.DASHBOARD_SEE_MORE_ANALYTICS_TAPPED)
         val targetPeriod = when (val state = revenueStatsState.value) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -29,6 +29,7 @@ import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.Selec
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.MyStoreEvent.OpenDatePicker
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.MyStoreEvent.ShowAIProductDescriptionDialog
 import com.woocommerce.android.ui.mystore.data.CustomDateRangeDataStore
+import com.woocommerce.android.ui.mystore.data.DateRange
 import com.woocommerce.android.ui.mystore.domain.GetStats
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.HasOrders
 import com.woocommerce.android.ui.mystore.domain.GetStats.LoadStatsResult.PluginNotActive
@@ -54,6 +55,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -136,14 +138,16 @@ class MyStoreViewModel @Inject constructor(
     private val _selectedDateRange = combine(
         _selectedRangeType,
         customDateRangeDataStore.dateRange
+            .onStart { emit(DateRange(Date(), Date())) }
+            .filterNotNull()
     ) { selectionType, customRange ->
         when (selectionType) {
             SelectionType.CUSTOM -> {
                 selectionType.generateSelectionData(
                     calendar = Calendar.getInstance(),
                     locale = Locale.getDefault(),
-                    referenceStartDate = customRange?.startDate ?: Date(),
-                    referenceEndDate = customRange?.endDate ?: Date()
+                    referenceStartDate = customRange.startDate,
+                    referenceEndDate = customRange.endDate
                 )
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -210,6 +211,12 @@ class MyStoreViewModel @Inject constructor(
         // A notification is only displayed when the store has never been opened before
         notificationScheduler.cancelScheduledNotification(STORE_CREATION_FINISHED)
         updateShareStoreButtonVisibility()
+        launch {
+            customDateRangeDataStore.dateRange
+                .filterNotNull()
+                .map { AnalyticsHubTimeRange(it.startDate, it.endDate) }
+                .collectLatest { _customRange.value = it }
+        }
     }
 
     private fun updateShareStoreButtonVisibility() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -470,7 +470,6 @@ class MyStoreViewModel @Inject constructor(
     }
 
     fun onCustomRangeSelected(fromMillis: Long, toMillis: Long) {
-        onStatsGranularityChanged(SelectionType.CUSTOM)
         viewModelScope.launch {
             customDateRangeDataStore.updateDateRange(fromMillis, toMillis)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11141 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Restores selected custom range

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. From My Store tab add a new custom range
2. Check the data is loaded successfully for given custom range
3. Kill the app
4. Restart the app
5. Check that the last custom range selected is restored correctly

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/b94d1445-3d06-4c11-bc0c-202558727eb3


