### PR TITLE
[Bug • Product Reviews] Fix endless navigation in product Reviews

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
@@ -83,7 +83,7 @@ class ProductReviewsFragment :
         _reviewsAdapter = ReviewListAdapter(this)
         val unreadReviewItemDecoration = UnreadItemDecoration(requireContext(), this)
 
-        binding.reviewsList.reviewsList.apply {
+        binding.reviewsList.apply {
             layoutManager = LinearLayoutManager(context)
             itemAnimator = DefaultItemAnimator()
             setHasFixedSize(false)
@@ -101,7 +101,7 @@ class ProductReviewsFragment :
             })
         }
 
-        binding.reviewsList.apply {
+        binding.apply {
             // Set the scrolling view in the custom SwipeRefreshLayout
             notifsRefreshLayout.scrollUpChild = reviewsList
             notifsRefreshLayout.setOnRefreshListener {
@@ -126,7 +126,7 @@ class ProductReviewsFragment :
         viewModel.productReviewsViewStateData.observe(viewLifecycleOwner) { old, new ->
             new.isSkeletonShown?.takeIfNotEqualTo(old?.isSkeletonShown) { showSkeleton(it) }
             new.isRefreshing?.takeIfNotEqualTo(old?.isRefreshing) {
-                binding.reviewsList.notifsRefreshLayout.isRefreshing = it
+                binding.notifsRefreshLayout.isRefreshing = it
             }
             new.isLoadingMore?.takeIfNotEqualTo(old?.isLoadingMore) { showLoadMoreProgress(it) }
             new.isEmptyViewVisible?.takeIfNotEqualTo(old?.isEmptyViewVisible) { showEmptyView(it) }
@@ -156,13 +156,13 @@ class ProductReviewsFragment :
     }
 
     private fun showLoadMoreProgress(show: Boolean) {
-        binding.reviewsList.notifsLoadMoreProgress.visibility = if (show) View.VISIBLE else View.GONE
+        binding.notifsLoadMoreProgress.visibility = if (show) View.VISIBLE else View.GONE
     }
 
     private fun showSkeleton(show: Boolean) {
         when (show) {
             true -> {
-                skeletonView.show(binding.reviewsList.notifsView, R.layout.skeleton_notif_list, delayed = true)
+                skeletonView.show(binding.notifsView, R.layout.skeleton_notif_list, delayed = true)
                 showEmptyView(false)
             }
 
@@ -172,22 +172,22 @@ class ProductReviewsFragment :
 
     private fun showEmptyView(show: Boolean) {
         if (show) {
-            if (binding.reviewsList.unreadFilterSwitch.isChecked) {
-                binding.reviewsList.unreadReviewsFilterLayout.show()
-                binding.reviewsList.emptyView.show(EmptyViewType.UNREAD_FILTERED_REVIEW_LIST)
+            if (binding.unreadFilterSwitch.isChecked) {
+                binding.unreadReviewsFilterLayout.show()
+                binding.emptyView.show(EmptyViewType.UNREAD_FILTERED_REVIEW_LIST)
             } else {
-                binding.reviewsList.emptyView.show(EmptyViewType.REVIEW_LIST) {
+                binding.emptyView.show(EmptyViewType.REVIEW_LIST) {
                     ChromeCustomTabUtils.launchUrl(requireActivity(), AppUrls.URL_LEARN_MORE_REVIEWS)
                 }
-                binding.reviewsList.unreadReviewsFilterLayout.hide()
+                binding.unreadReviewsFilterLayout.hide()
             }
         } else {
-            binding.reviewsList.emptyView.hide()
+            binding.emptyView.hide()
         }
     }
 
     private fun setUnreadFilterChangedListener() {
-        binding.reviewsList.unreadFilterSwitch.setOnCheckedChangeListener { _, isChecked ->
+        binding.unreadFilterSwitch.setOnCheckedChangeListener { _, isChecked ->
             viewModel.onUnreadReviewsFilterChanged(isChecked)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
@@ -154,7 +154,7 @@ class ReviewDetailFragment :
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
-                is Exit -> exitDetailView()
+                is Exit -> findNavController().popBackStack()
                 is NavigateBackFromNotification -> exitReviewDetailOpenedFromNotification()
                 is Reply -> navigateToReply()
             }
@@ -240,16 +240,6 @@ class ReviewDetailFragment :
             skeletonView.show(binding.container, R.layout.skeleton_notif_detail, delayed = true)
         } else {
             skeletonView.hide()
-        }
-    }
-
-    private fun exitDetailView() {
-        if (isStateSaved) {
-            runOnStartFunc = { findNavController().popBackStack() }
-        } else {
-            findNavController().navigateSafely(
-                ReviewDetailFragmentDirections.actionReviewDetailFromNotificationToReviewListFragment()
-            )
         }
     }
 

--- a/WooCommerce/src/main/res/layout/fragment_product_reviews_list.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_reviews_list.xml
@@ -13,7 +13,85 @@
         android:elevation="@dimen/appbar_elevation"
         tools:title="@string/app_name" />
 
-    <include
-        android:id="@+id/reviewsList"
-        layout="@layout/fragment_reviews_list" />
+    <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+        android:id="@+id/notifsRefreshLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.reviews.ReviewListFragment"
+        tools:showIn="@layout/fragment_reviews_list">
+
+        <RelativeLayout
+            android:id="@+id/notifsContainer"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clickable="true"
+            android:focusable="true">
+
+            <RelativeLayout
+                android:id="@+id/unread_reviews_filter_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="@dimen/major_75">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentStart="true"
+                    android:layout_centerVertical="true"
+                    android:layout_marginStart="@dimen/major_100"
+                    android:text="@string/product_review_list_unread_reviews_filter"
+                    android:textAppearance="@style/TextAppearance.Woo.Subtitle1"
+                    tools:text="Filter by unread reviews" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/unread_filter_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentEnd="true"
+                    android:layout_centerVertical="true" />
+
+                <View
+                    style="@style/Woo.Divider"
+                    android:layout_width="match_parent"
+                    android:layout_below="@+id/unread_filter_switch" />
+
+            </RelativeLayout>
+
+            <!-- Notifications List View -->
+            <LinearLayout
+                android:id="@+id/notifsView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@+id/unread_reviews_filter_layout"
+                android:orientation="vertical"
+                tools:visibility="visible">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/reviewsList"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    tools:itemCount="5"
+                    tools:listitem="@layout/notifs_list_item" />
+            </LinearLayout>
+
+            <com.woocommerce.android.widgets.WCEmptyView
+                android:id="@+id/empty_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@+id/unread_reviews_filter_layout"
+                android:visibility="gone"
+                tools:visibility="gone" />
+
+            <ProgressBar
+                android:id="@+id/notifsLoadMoreProgress"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:layout_centerHorizontal="true"
+                android:layout_marginBottom="@dimen/major_75"
+                android:visibility="gone"
+                tools:visibility="gone" />
+        </RelativeLayout>
+    </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
 </LinearLayout>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10906 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix the issue that caused a broken navigation when coming back from a product review, provoking an endless cycle in navigation.

The reason behind this issue was that we were relying on whether the stave was saved to ascertain if the product review was opened from a notification. After some other changes, the state was not saved even if opening the review from the usual product flow, causing us to try to go back as if the review was opened from a notification. To fix it, we just listen to the `Exit` event to pop back the stack, instead of relying on the state status.

Apart from that, we fixed a crash added by this change. The crash occurred because the `ProductReviewsFragment` was reusing the layout file definition of the `ReviewListFragment`. This confused the Android OS when returning to the Reviews list view, leading to incompatible view IDs and issues with saving state. The fix involved discontinuing the reuse of the layout and giving `ProductReviewsFragment` its own layout definition.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

#### Products Flow

1. Open the app
2. Go to products
3. Open a product view a review
4. Tap on Reviews
5. Tap on a review
6. Go back to the reviews list
7. Go back
8. You should see now the products review

#### Notification

1. Send a notification with a review data (You can follow this https://github.com/woocommerce/woocommerce-android/pull/7174 instructions for that)
2. Tap on the notification. The product review should be open.
3. Go back to the reviews list.
4. Go back. It should open the Menu

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
#### Products Flow

https://github.com/woocommerce/woocommerce-android/assets/1864060/afefc874-6f05-409b-8fcf-0878358d5420

#### Notification

https://github.com/woocommerce/woocommerce-android/assets/1864060/8c645ce4-bfde-40e6-957c-7a9b42c60645



- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->