### PR TITLE
Update fluxc version to 2.72.1 tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-97a7bd8e6f0147979a65912f9af4af21ff34b684'
+    fluxCVersion = '2.72.1'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
This PR updates FluxC version from the commit hash version to the latest tag.

https://github.com/wordpress-mobile/WordPress-FluxC-Android/releases/tag/2.72.1