### PR TITLE
[Products] Bulk Stock Status Default Selection Enhancement

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DropDown.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DropDown.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.ExposedDropdownMenuDefaults
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,9 +30,11 @@ fun <T> WcExposedDropDown(
     var expanded by remember { mutableStateOf(false) }
     var selectedText by remember { mutableStateOf(currentValue) }
 
-    Box(
-        modifier = modifier
-    ) {
+    LaunchedEffect(currentValue) {
+        selectedText = currentValue
+    }
+
+    Box(modifier = modifier) {
         ExposedDropdownMenuBox(
             expanded = expanded,
             onExpandedChange = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/UpdateProductStockStatusFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/UpdateProductStockStatusFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
@@ -14,6 +15,7 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.windowSizeClass
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.products.UpdateProductStockStatusViewModel.UpdateStockStatusUiState
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DisplayUtils
@@ -47,22 +49,22 @@ class UpdateProductStockStatusFragment : DialogFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {
-            viewModel.viewState.observeAsState().value?.let { uiState ->
-                UpdateProductStockStatusScreen(
-                    currentStockStatusState = uiState.currentStockStatusState,
-                    statusMessage = uiState.statusMessage,
-                    currentProductStockStatus = uiState.currentProductStockStatus,
-                    stockStatuses = uiState.stockStockStatuses,
-                    isProgressDialogVisible = uiState.isProgressDialogVisible,
-                    onStockStatusChanged = { newStatus ->
-                        viewModel.onStockStatusSelected(newStatus)
-                    },
-                    onNavigationUpClicked = { viewModel.onBackPressed() },
-                    onUpdateClicked = {
-                        viewModel.onDoneButtonClicked()
-                    }
-                )
-            }
+            val uiState by viewModel.viewState.observeAsState(UpdateStockStatusUiState())
+
+            UpdateProductStockStatusScreen(
+                currentStockStatusState = uiState.currentStockStatusState,
+                statusMessage = uiState.statusMessage,
+                currentProductStockStatus = uiState.currentProductStockStatus,
+                stockStatuses = uiState.stockStockStatuses,
+                isProgressDialogVisible = uiState.isProgressDialogVisible,
+                onStockStatusChanged = { newStatus ->
+                    viewModel.onStockStatusSelected(newStatus)
+                },
+                onNavigationUpClicked = { viewModel.onBackPressed() },
+                onUpdateClicked = {
+                    viewModel.onDoneButtonClicked()
+                }
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/UpdateProductStockStatusFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/UpdateProductStockStatusFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
@@ -15,7 +14,6 @@ import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.extensions.windowSizeClass
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.composeView
-import com.woocommerce.android.ui.products.UpdateProductStockStatusViewModel.UpdateStockStatusUiState
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DisplayUtils
@@ -49,22 +47,22 @@ class UpdateProductStockStatusFragment : DialogFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {
-            val uiState by viewModel.viewState.observeAsState(UpdateStockStatusUiState())
-
-            UpdateProductStockStatusScreen(
-                currentStockStatusState = uiState.currentStockStatusState,
-                statusMessage = uiState.statusMessage,
-                currentProductStockStatus = uiState.currentProductStockStatus,
-                stockStatuses = uiState.stockStockStatuses,
-                isProgressDialogVisible = uiState.isProgressDialogVisible,
-                onStockStatusChanged = { newStatus ->
-                    viewModel.onStockStatusSelected(newStatus)
-                },
-                onNavigationUpClicked = { viewModel.onBackPressed() },
-                onUpdateClicked = {
-                    viewModel.onDoneButtonClicked()
-                }
-            )
+            viewModel.viewState.observeAsState().value?.let { uiState ->
+                UpdateProductStockStatusScreen(
+                    currentStockStatusState = uiState.currentStockStatusState,
+                    statusMessage = uiState.statusMessage,
+                    currentProductStockStatus = uiState.currentProductStockStatus,
+                    stockStatuses = uiState.stockStockStatuses,
+                    isProgressDialogVisible = uiState.isProgressDialogVisible,
+                    onStockStatusChanged = { newStatus ->
+                        viewModel.onStockStatusSelected(newStatus)
+                    },
+                    onNavigationUpClicked = { viewModel.onBackPressed() },
+                    onUpdateClicked = {
+                        viewModel.onDoneButtonClicked()
+                    }
+                )
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/UpdateProductStockStatusViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/UpdateProductStockStatusViewModel.kt
@@ -159,9 +159,16 @@ class UpdateProductStockStatusViewModel @Inject constructor(
                 StockStatusState.Common(distinctStatuses.firstOrNull() ?: ProductStockStatus.InStock)
             }
 
+            val commonProductStockStatus = if (distinctStatuses.size == 1) {
+                distinctStatuses.first()
+            } else {
+                ProductStockStatus.InStock
+            }
+
             stockStatusUiState.update {
                 it.copy(
                     statusMessage = statusMessage,
+                    currentProductStockStatus = commonProductStockStatus,
                     currentStockStatusState = stockStatusState
                 )
             }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/UpdateProductStockStatusViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/UpdateProductStockStatusViewModelTest.kt
@@ -390,6 +390,64 @@ class UpdateProductStockStatusViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `given all products are OutOfStock, when viewModel is initialized, then OutOfStock is pre-selected`() =
+        testBlocking {
+            // Given
+            val stockStatusInfos = listOf(
+                ProductStockStatusInfo(
+                    productId = 1L,
+                    stockStatus = ProductStockStatus.OutOfStock,
+                    manageStock = false,
+                    isVariable = false
+                ),
+                ProductStockStatusInfo(
+                    productId = 2L,
+                    stockStatus = ProductStockStatus.OutOfStock,
+                    manageStock = false,
+                    isVariable = false
+                )
+            )
+            mockFetchStockStatuses(stockStatusInfos)
+            setupViewModel(stockStatusInfos.map { it.productId })
+
+            // When
+            var state: UpdateStockStatusUiState? = null
+            viewModel.viewState.observeForever { state = it }
+
+            // Then
+            assertThat(state?.currentProductStockStatus).isEqualTo(ProductStockStatus.OutOfStock)
+        }
+
+    @Test
+    fun `given products have mixed stock statuses, when viewModel is initialized, then InStock is pre-selected`() =
+        testBlocking {
+            // Given
+            val stockStatusInfos = listOf(
+                ProductStockStatusInfo(
+                    productId = 1L,
+                    stockStatus = ProductStockStatus.OutOfStock,
+                    manageStock = false,
+                    isVariable = false
+                ),
+                ProductStockStatusInfo(
+                    productId = 2L,
+                    stockStatus = ProductStockStatus.InStock,
+                    manageStock = false,
+                    isVariable = false
+                )
+            )
+            mockFetchStockStatuses(stockStatusInfos)
+            setupViewModel(stockStatusInfos.map { it.productId })
+
+            // When
+            var state: UpdateStockStatusUiState? = null
+            viewModel.viewState.observeForever { state = it }
+
+            // Then
+            assertThat(state?.currentProductStockStatus).isEqualTo(ProductStockStatus.InStock)
+        }
+
     private fun setupViewModel(selectedProductIds: List<Long>) {
         viewModel = UpdateProductStockStatusViewModel(
             savedStateHandle = UpdateProductStockStatusFragmentArgs(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11140
<!-- Id number of the GitHub issue this PR addresses. -->

### Description

This pull request introduces a significant improvement to the bulk stock status updating feature. Before this update, when users accessed the bulk stock status updating functionality within the Products section, the 'In Stock' option was pre-selected by default in the dropdown menu, regardless of the actual stock statuses of the selected products. This behavior could lead to inaccuracies, particularly when all selected products shared a stock status different from 'In Stock'.

The code changes made address this issue by enhancing the default selection logic in the dropdown menu. Now, the default selection dynamically adapts based on the collective stock status of the selected products. If all selected products share the same stock status, this shared status will be pre-selected in the dropdown, accurately reflecting the current situation and simplifying the bulk editing process.

### Testing instructions

1. Go to the 'Products' section of the app.
2. Select multiple products that share the same stock status (e.g., all 'Out of Stock').
3. Initiate a bulk action to update the stock status.
4. Observe that the dropdown menu defaults to 'Out of Stock' to reflect the shared stock status of the selected products.

### Images/gif


https://github.com/woocommerce/woocommerce-android/assets/1509205/8c831704-72b4-4e3b-98fc-b1587c252a67


### Notes

The only thing I notice is that when you visit the UI, the initial state is loaded and then when the new state is derived  it updates the view. 

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
