### PR TITLE
[Stats custom range] Handle restoring custom range independently of currently selected tab

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -392,6 +392,9 @@ class MyStoreFragment :
     private fun setupStateObservers() {
         myStoreViewModel.appbarState.observe(viewLifecycleOwner) { requireActivity().invalidateOptionsMenu() }
 
+        myStoreViewModel.customRange.observe(viewLifecycleOwner) { customRange ->
+            binding.myStoreStats.handleCustomRangeTab(customRange)
+        }
         myStoreViewModel.selectedDateRange.observe(viewLifecycleOwner) { statsTimeRangeSelection ->
             binding.myStoreStats.loadDashboardStats(statsTimeRangeSelection)
             binding.myStoreTopPerformers.onDateGranularityChanged(statsTimeRangeSelection.selectionType)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
 import com.woocommerce.android.ui.analytics.ranges.revenueStatsGranularity
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.Companion.SUPPORTED_RANGES_ON_MY_STORE_TAB
+import com.woocommerce.android.ui.mystore.data.DateRange
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.FeatureFlag
@@ -129,7 +130,12 @@ class MyStoreStatsView @JvmOverloads constructor(
     val customRangeButton = binding.customRangeButton
 
     val tabLayout = binding.statsTabLayout
-    private var customRangeTab: Tab? = null
+    private val customRangeTab: Tab by lazy {
+        tabLayout.newTab().apply {
+            setText(getStringForRangeType(SelectionType.CUSTOM))
+            tag = SelectionType.CUSTOM
+        }
+    }
 
     private lateinit var coroutineScope: CoroutineScope
     private val chartUserInteractions = MutableSharedFlow<Unit>()
@@ -199,10 +205,22 @@ class MyStoreStatsView @JvmOverloads constructor(
         applyCustomRange(statsTimeRangeSelection)
     }
 
+    fun handleCustomRangeTab(customRange: DateRange?) {
+        if (customRange != null) {
+            customRangeButton.isVisible = false
+            if (customRangeTab.view.parent == null) {
+                tabLayout.addTab(customRangeTab)
+            }
+        } else {
+            customRangeButton.isVisible = true
+            if (customRangeTab.view.parent != null) {
+                tabLayout.removeTab(customRangeTab)
+            }
+        }
+    }
+
     private fun applyCustomRange(selectedTimeRange: StatsTimeRangeSelection) {
         if (selectedTimeRange.selectionType == SelectionType.CUSTOM) {
-            addCustomRangeTabIfMissing()
-            customRangeButton.isVisible = false
             customRangeLabel.isVisible = true
             customRangeGranularityLabel.isVisible = true
             customRangeLabel.text = selectedTimeRange.currentRangeDescription
@@ -210,17 +228,6 @@ class MyStoreStatsView @JvmOverloads constructor(
         } else {
             customRangeLabel.isVisible = false
             customRangeGranularityLabel.isVisible = false
-        }
-    }
-
-    private fun addCustomRangeTabIfMissing() {
-        if (customRangeTab == null) {
-            val tab = tabLayout.newTab().apply {
-                setText(getStringForRangeType(SelectionType.CUSTOM))
-                tag = SelectionType.CUSTOM
-            }
-            customRangeTab = tab
-            tabLayout.addTab(tab)
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11155 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds logic to make sure the last selected custom range is restored regardless of the last selected tab when the app was stopped.

### Testing instructions
1. Clear the app's data (or manually remove the file `/data/data/com.woocommerce.android.dev/files/datastore/custom_date_range_configuration.preferences_pb` (assuming the `wasabiDebug` variant)
2. Open the app.
3. Confirm the custom range tab is hidden and the "Add Range" button is shown.
4. Add a custom range.
5. Confirm the custom range tab is added.
6. Select a different tab.
7. Kill the app.
8. Restart the app.
9. Confirm the custom range tab is restored, while the last restored tab is selected.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
