### PR TITLE
[Better Tablet Products] The informational bubble about the write with ai button is oddly placed

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 18.0
 -----
 - [*] Products: Improvements on the products photos screens [https://github.com/woocommerce/woocommerce-android/pull/11131]
+- [*] Products: Fixed position of the AI tooltip on the 2 pane mode [https://github.com/woocommerce/woocommerce-android/pull/11166]
 
 17.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyButtonView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/WCProductPropertyButtonView.kt
@@ -54,22 +54,22 @@ class WCProductPropertyButtonView @JvmOverloads constructor(
                     override fun onViewAttachedToWindow(v: View) {
                         showPopupWindowWhenEnoughSpace(
                             scrollableView = parent?.findParentNestedScrollView()
-                                ?: error("No NestedScrollView found in parent hierarchy that needed to show AI tooltip"),
+                                ?: error("No NestedScrollView found in parent hierarchy needed to show AI tooltip"),
                             tooltip = it,
                         )
                         removeOnAttachStateChangeListener(this)
                     }
+
+                    fun ViewParent.findParentNestedScrollView(): NestedScrollView? =
+                        if (this is NestedScrollView) {
+                            this
+                        } else {
+                            parent?.findParentNestedScrollView()
+                        }
                 }
             )
         }
     }
-
-    private fun ViewParent.findParentNestedScrollView(): NestedScrollView? =
-        if (this is NestedScrollView) {
-            this
-        } else {
-            parent?.findParentNestedScrollView()
-        }
 
     private fun showPopupWindowWhenEnoughSpace(
         scrollableView: NestedScrollView,

--- a/WooCommerce/src/main/res/layout/product_property_button_view_layout.xml
+++ b/WooCommerce/src/main/res/layout/product_property_button_view_layout.xml
@@ -2,7 +2,6 @@
 <merge
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11017
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR 
* Sets the width of the AI toolbar to the parent view to make it look ok on 2-pane mode
* Show the tooltip only when the AI button amove the bottom of a screen on 230DP

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
* apply patch to show tooltip all the time
[Change_for_testing_toolbar.patch](https://github.com/woocommerce/woocommerce-android/files/14757427/Change_for_testing_toolbar.patch)
* Using tablets and phone, notice that the toolbar is shown when it's possible to show that

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


Before

![image](https://github.com/woocommerce/woocommerce-android/assets/4923871/8841dcb8-1977-4002-8929-fe38f9d95187)


https://github.com/woocommerce/woocommerce-android/assets/4923871/2bc9acdc-9c16-4849-881b-72e475e189f3

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
