### PR TITLE
Issue/11167 stats custom range hide visitor stats

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -614,7 +614,7 @@ class MyStoreFragment :
     }
 
     private fun handleUnavailableVisitorStats() {
-        binding.myStoreStats.handleUnavailableVisitorStats()
+        binding.myStoreStats.handleJetpackUnavailableVisitorStats()
     }
 
     private fun showErrorSnack() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -86,8 +86,6 @@ class MyStoreStatsView @JvmOverloads constructor(
     private var chartOrderStats = mapOf<String, Long>()
     private var chartVisitorStats = mapOf<String, Int>()
 
-    private var isChartValueSelected = false
-
     private var skeletonView = SkeletonView()
 
     private var isRequestingStats = false
@@ -145,6 +143,10 @@ class MyStoreStatsView @JvmOverloads constructor(
     private lateinit var coroutineScope: CoroutineScope
     private val chartUserInteractions = MutableSharedFlow<Unit>()
     private lateinit var chartUserInteractionsJob: Job
+
+    private var isChartValueSelected = false
+
+    private var isJetpackVisitorStatsUnavailable = false
 
     @Suppress("LongParameterList")
     fun initView(
@@ -441,6 +443,7 @@ class MyStoreStatsView @JvmOverloads constructor(
     }
 
     private fun updateVisitorsValue(date: String) {
+        if (isJetpackVisitorStatsUnavailable) return
         if (statsTimeRangeSelection.revenueStatsGranularity == StatsGranularity.HOURS) {
             // The visitor stats don't support hours granularity, so we need to hide them
             visitorsValue.isVisible = false
@@ -528,6 +531,7 @@ class MyStoreStatsView @JvmOverloads constructor(
     }
 
     fun showVisitorStats(visitorStats: Map<String, Int>) {
+        isJetpackVisitorStatsUnavailable = false
         chartVisitorStats = getFormattedVisitorStats(visitorStats)
         showTotalVisitorStats()
     }
@@ -539,6 +543,7 @@ class MyStoreStatsView @JvmOverloads constructor(
     }
 
     fun handleJetpackUnavailableVisitorStats() {
+        isJetpackVisitorStatsUnavailable = true
         binding.statsViewRow.emptyVisitorsStatsGroup.isVisible = true
         binding.statsViewRow.visitorsValueTextview.isVisible = false
         binding.statsViewRow.emptyVisitorStatsIcon.apply {
@@ -548,6 +553,7 @@ class MyStoreStatsView @JvmOverloads constructor(
     }
 
     private fun showTotalVisitorStats() {
+        if (isJetpackVisitorStatsUnavailable) return
         if (statsTimeRangeSelection.isTotalVisitorsUnavailable()) {
             // When using custom ranges, the total visitors value is not accurate, so we hide it
             hideVisitorStatsForCustomRange()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -58,6 +58,7 @@ import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import org.wordpress.android.util.DisplayUtils
 import java.util.Locale
 import kotlin.math.round
+import kotlin.time.Duration.Companion.days
 
 @FlowPreview
 class MyStoreStatsView @JvmOverloads constructor(
@@ -436,7 +437,8 @@ class MyStoreStatsView @JvmOverloads constructor(
     }
 
     private fun updateVisitorsValue(date: String) {
-        if (statsTimeRangeSelection.selectionType == SelectionType.TODAY) {
+        if (statsTimeRangeSelection.revenueStatsGranularity == StatsGranularity.HOURS) {
+            // The visitor stats don't support hours granularity, so we need to hide them
             visitorsValue.isVisible = false
             visitorsValue.setText(R.string.emdash)
             binding.statsViewRow.emptyVisitorStatsIndicator.isVisible = true

--- a/WooCommerce/src/main/res/layout/dashboard_main_stats_row.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_main_stats_row.xml
@@ -106,7 +106,7 @@
                 app:layout_constraintStart_toStartOf="parent" />
 
             <androidx.constraintlayout.widget.Group
-                android:id="@+id/emptyVisitorsStatsGroup"
+                android:id="@+id/jetpackEmptyVisitorsStatsGroup"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:visibility="gone"

--- a/WooCommerce/src/main/res/layout/dashboard_main_stats_row.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_main_stats_row.xml
@@ -106,16 +106,16 @@
                 app:layout_constraintStart_toStartOf="parent" />
 
             <androidx.constraintlayout.widget.Group
-                android:id="@+id/jetpackEmptyVisitorsStatsGroup"
+                android:id="@+id/emptyVisitorsStatsGroup"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:visibility="gone"
-                app:constraint_referenced_ids="emptyVisitorStatsIndicator, jetpackIconImageView" />
+                app:constraint_referenced_ids="emptyVisitorStatsIndicator, emptyVisitorStatsIcon" />
 
             <androidx.appcompat.widget.AppCompatImageView
-                android:id="@+id/jetpackIconImageView"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:id="@+id/emptyVisitorStatsIcon"
+                android:layout_width="@dimen/image_minor_40"
+                android:layout_height="@dimen/image_minor_40"
                 android:src="@drawable/ic_jetpack_logo"
                 app:layout_constraintBottom_toTopOf="@id/emptyVisitorStatsIndicator"
                 app:layout_constraintStart_toEndOf="@id/emptyVisitorStatsIndicator" />

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -400,6 +400,8 @@
     <string name="my_store_custom_range_granularity_week">Weekly</string>
     <string name="my_store_custom_range_granularity_month">Monthly</string>
     <string name="my_store_custom_range_granularity_year">Yearly</string>
+    <string name="my_store_custom_range_visitors_stats_unavailable_title">Visitors and conversion data not available</string>
+    <string name="my_store_custom_range_visitors_stats_unavailable_message">The stats feature does not support the display of visitors and conversions data for arbitrary date ranges.\n\nHowever, you can tap a value on the graph to see visitors and conversions for that specific range.</string>
 
     <!--
         Sign Up Flow


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11167 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds logic for hiding the visitor stats and conversion rate values when using custom ranges in some specific cases:
1. Hides the hourly visitor count as the API doesn't support the hourly granularity.
2. Hides the total visitor count when the custom range spans over multiple days, as the manual calculation won't be accurate.
3. Shows a dialog that explain why the total visitor count can't be shown for the case 2.

The PR also fixes a bug, see https://github.com/woocommerce/woocommerce-android/pull/11169#discussion_r1539409080

### Testing instructions
##### Jetpack Site
1. Open the app.
2. Create a custom range with a single or two days.
3. Confirm the visitor count and conversion rate are shown.
4. Tap on an hour in the chart.
5. Confirm the visitor stats are hidden.
6. Modify the custom range to include more than 2 days.
7. Confirm the visitor stats are hidden, and an `info` icon is shown.
8. Tap on the visitor stats empty view or the icon.
9. Confirm this shows a dialog that explains why the stats are hidden.
10. Tap on a point in the graph.
11. Confirm the visitor stats are shown.

##### Non-jetpack site
1. Sign in using a Jetpack CP site (or using site credentials).
2. Confirm there is no regression.
3. Confirm the https://github.com/woocommerce/woocommerce-android/pull/11169#discussion_r1539409080 below is fixed.

### Images/gif
https://github.com/woocommerce/woocommerce-android/assets/1657201/0266b71f-2ad4-4ea2-8a24-48e77ff979c1

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->