### PR TITLE
[Better Tablet Support] If device height is 32dp bigger than sheet height, show full sheet

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 18.0
 -----
 - [*] Products: Improvements on the products photos screens [https://github.com/woocommerce/woocommerce-android/pull/11131]
+- [*] Products: Show full bottom sheet when spaces available [https://github.com/woocommerce/woocommerce-android/pull/11170]
 
 17.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCBottomSheetDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCBottomSheetDialogFragment.kt
@@ -37,14 +37,21 @@ open class WCBottomSheetDialogFragment : BottomSheetDialogFragment {
 
     @CallSuper
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        if (DisplayUtils.isLandscape(requireContext())) {
-            dialog?.setOnShowListener {
-                val dialog = it as BottomSheetDialog
-                dialog.findViewById<View>(org.wordpress.aztec.R.id.design_bottom_sheet)?.let { sheet ->
-                    dialog.behavior.peekHeight = DisplayUtils.getWindowPixelHeight(requireContext()) / 2
-                    sheet.parent.parent.requestLayout()
+        dialog?.setOnShowListener {
+            val dialog = it as BottomSheetDialog
+            dialog.findViewById<View>(org.wordpress.aztec.R.id.design_bottom_sheet)?.let { sheet ->
+                // if device height is 32dp bigger than sheet height, show full sheet
+                val heightPixels = view.context.resources.displayMetrics.heightPixels
+                val topPadding = DisplayUtils.dpToPx(context, TOP_OFFSET_BEFORE_SHOWING_FULL_SHEET_DP)
+                if (heightPixels - topPadding > sheet.height) {
+                    dialog.behavior.peekHeight = DisplayUtils.getWindowPixelHeight(requireContext())
                 }
+                sheet.parent.parent.requestLayout()
             }
         }
+    }
+
+    private companion object {
+        private const val TOP_OFFSET_BEFORE_SHOWING_FULL_SHEET_DP = 32
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11018 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I am not sure if this is a good approach to the problem described:

```
In landscape orientation, the Share button is hidden unless you realize you can move the sheet up to access it. (Tap “Share” for a product and note you can see the message box, write with AI, and learn more, but you don’t see the Share button until you drag to scroll) Let me know if you’d like a screen grab on this, might be specific to smaller size of Nexus 7

pfoUAQ-iv-p2#comment-260
```

The idea is to show full sheet if there is space. I am wondering if there is bad to that approach, wdyt?

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

Try on different screen sizes and aspect ratios
* Products -> Details -> share (or other bottom sheets used on the app)
* Notice that if there is space the whole bottom sheet is shown

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/1c2b1159-7c09-43bb-84e9-6ded98604ad9

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->