### PR TITLE
Bug: Can't edit Blaze ad description

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
@@ -109,7 +109,7 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
     }
 
     fun onDescriptionChanged(description: String) {
-        updateSuggestion(AiSuggestionForAd(_viewState.value.tagLine, description.take(TAGLINE_MAX_LENGTH)))
+        updateSuggestion(AiSuggestionForAd(_viewState.value.tagLine, description.take(DESCRIPTION_MAX_LENGTH)))
     }
 
     fun onLocalImageSelected(uri: String) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes bug<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Attempting to edit the Blaze Ad description results in the wrong `max_length` value being set, which removes the possibility to edit the Ad description. 

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Trigger Blaze campaign creation flow
2. Click `Edit ad`
3. Edit the description value and check value is set correctly

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/2663464/434aeef4-10ce-4622-94b2-7dcd671e8320
