### PR TITLE
Pass selected range to analytics hub

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -88,7 +88,7 @@ class AnalyticsHubViewModel @Inject constructor(
 
     private val rangeSelectionState: MutableStateFlow<StatsTimeRangeSelection> = savedState.getStateFlow(
         scope = viewModelScope,
-        initialValue = navArgs.targetGranularity.generateLocalizedSelectionData()
+        initialValue = navArgs.rangeSelection
     )
 
     private val mutableState = MutableStateFlow(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -661,7 +661,7 @@ class MainActivity :
         startActivityForResult(intent, RequestCodes.SETTINGS)
     }
 
-    override fun showAnalytics(targetPeriod: StatsTimeRangeSelection.SelectionType) {
+    override fun showAnalytics(targetPeriod: StatsTimeRangeSelection) {
         val action = MyStoreFragmentDirections.actionMyStoreToAnalytics(targetPeriod)
         navController.navigateSafely(action)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -56,5 +56,5 @@ interface MainNavigationRouter {
     fun showFeedbackSurvey()
     fun showSettingsScreen()
 
-    fun showAnalytics(targetPeriod: StatsTimeRangeSelection.SelectionType)
+    fun showAnalytics(targetPeriod: StatsTimeRangeSelection)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -241,11 +241,9 @@ class MyStoreViewModel @Inject constructor(
 
     fun onViewAnalyticsClicked() {
         AnalyticsTracker.track(AnalyticsEvent.DASHBOARD_SEE_MORE_ANALYTICS_TAPPED)
-        val targetPeriod = when (val state = revenueStatsState.value) {
-            is RevenueStatsViewState.Content -> state.statsRangeSelection.selectionType
-            else -> SelectionType.TODAY
+        selectedDateRange.value?.let {
+            triggerEvent(MyStoreEvent.OpenAnalytics(it))
         }
-        triggerEvent(MyStoreEvent.OpenAnalytics(targetPeriod))
     }
 
     fun onShareStoreClicked() {
@@ -510,7 +508,7 @@ class MyStoreViewModel @Inject constructor(
             val productId: Long
         ) : MyStoreEvent()
 
-        data class OpenAnalytics(val analyticsPeriod: SelectionType) : MyStoreEvent()
+        data class OpenAnalytics(val analyticsPeriod: StatsTimeRangeSelection) : MyStoreEvent()
 
         data object ShowPrivacyBanner : MyStoreEvent()
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -32,11 +32,7 @@
             app:enterAnim="@anim/activity_fade_in"
             app:exitAnim="@null"
             app:popEnterAnim="@null"
-            app:popExitAnim="@anim/activity_fade_out">
-            <argument
-                android:name="rangeSelection"
-                app:argType="com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection" />
-        </action>
+            app:popExitAnim="@anim/activity_fade_out" />
         <action
             android:id="@+id/action_myStore_to_onboardingFragment"
             app:destination="@id/storeOnboardingFragment" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -16,7 +16,7 @@
     <include app:graph="@navigation/nav_graph_site_picker" />
     <include app:graph="@navigation/nav_graph_domain_change" />
     <include app:graph="@navigation/nav_graph_blaze_campaign_creation" />
-    <include app:graph="@navigation/nav_graph_order_creations"/>
+    <include app:graph="@navigation/nav_graph_order_creations" />
 
     <fragment
         android:id="@+id/dashboard"
@@ -34,8 +34,8 @@
             app:popEnterAnim="@null"
             app:popExitAnim="@anim/activity_fade_out">
             <argument
-                android:name="targetGranularity"
-                app:argType="com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection$SelectionType" />
+                android:name="rangeSelection"
+                app:argType="com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection" />
         </action>
         <action
             android:id="@+id/action_myStore_to_onboardingFragment"
@@ -96,8 +96,8 @@
         tools:layout="@layout/fragment_order_list">
         <argument
             android:name="orderId"
-            app:argType="long"
-            android:defaultValue="-1L"/>
+            android:defaultValue="-1L"
+            app:argType="long" />
         <action
             android:id="@+id/action_orderListFragment_to_orderDetailFragment"
             app:destination="@id/nav_graph_orders">
@@ -210,8 +210,7 @@
             app:enterAnim="@anim/activity_fade_in"
             app:exitAnim="@null"
             app:popEnterAnim="@null"
-            app:popExitAnim="@anim/activity_fade_out">
-        </action>
+            app:popExitAnim="@anim/activity_fade_out"></action>
     </fragment>
     <dialog
         android:id="@+id/updateStockStatusFragment"
@@ -219,7 +218,7 @@
         android:label="UpdateProductStockStatusFragment">
         <argument
             android:name="selectedProductIds"
-            app:argType="long[]"/>
+            app:argType="long[]" />
     </dialog>
     <fragment
         android:id="@+id/scanToUpdateInventory"
@@ -240,8 +239,8 @@
         android:label="fragment_analytics"
         tools:layout="@layout/fragment_analytics">
         <argument
-            android:name="targetGranularity"
-            app:argType="com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection$SelectionType" />
+            android:name="rangeSelection"
+            app:argType="com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection" />
         <action
             android:id="@+id/action_AnalyticsFragment_to_DateRangeSelector"
             app:destination="@id/analyticsDateRangeSelectorDialog" />
@@ -252,8 +251,7 @@
     <fragment
         android:id="@+id/analyticsSettings"
         android:name="com.woocommerce.android.ui.analytics.hub.settings.AnalyticsHubSettingFragment"
-        android:label="fragment_analytics_settings"
-        />
+        android:label="fragment_analytics_settings" />
     <dialog
         android:id="@+id/analyticsDateRangeSelectorDialog"
         android:name="com.woocommerce.android.ui.ItemSelectorDialog"
@@ -357,26 +355,26 @@
         <argument
             android:name="sku"
             app:argType="string"
-            app:nullable="true"/>
+            app:nullable="true" />
         <argument
             android:name="barcodeFormat"
             app:argType="com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper$BarcodeFormat"
-            app:nullable="true"/>
+            app:nullable="true" />
         <argument
             android:name="couponEditResult"
+            android:defaultValue="@null"
             app:argType="com.woocommerce.android.ui.orders.creation.coupon.edit.OrderCreateCouponDetailsViewModel$CouponEditResult"
-            app:nullable="true"
-            android:defaultValue="@null"/>
+            app:nullable="true" />
         <argument
             android:name="giftCardCode"
+            android:defaultValue="@null"
             app:argType="string"
-            app:nullable="true"
-            android:defaultValue="@null"/>
+            app:nullable="true" />
         <argument
             android:name="giftCardAmount"
+            android:defaultValue="@null"
             app:argType="java.math.BigDecimal"
-            app:nullable="true"
-            android:defaultValue="@null"/>
+            app:nullable="true" />
 
     </action>
 
@@ -791,5 +789,5 @@
     <fragment
         android:id="@+id/orderConnectivityToolFragment"
         android:name="com.woocommerce.android.ui.orders.connectivitytool.OrderConnectivityToolFragment"
-        android:label="OrderConnectivityToolFragment"/>
+        android:label="OrderConnectivityToolFragment" />
 </navigation>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.analytics
 
+import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -92,7 +93,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
 
     private val updateStats: UpdateAnalyticsHubStats = mock()
     private val observeLastUpdate: ObserveLastUpdate = mock()
-    private val savedState = AnalyticsHubFragmentArgs(targetGranularity = TODAY).toSavedStateHandle()
+    private lateinit var savedState: SavedStateHandle
     private val transactionLauncher = mock<AnalyticsHubTransactionLauncher>()
     private val feedbackRepository: FeedbackRepository = mock()
     private val tracker: AnalyticsTrackerWrapper = mock()
@@ -127,6 +128,14 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
         localeProvider = mock {
             on { provideLocale() } doReturn testLocale
         }
+        savedState = AnalyticsHubFragmentArgs(
+            TODAY.generateSelectionData(
+                calendar = testCalendar,
+                locale = testLocale,
+                referenceStartDate = Date(),
+                referenceEndDate = Date()
+            )
+        ).toSavedStateHandle()
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11146 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With the refactoring applied to the My Store tab, we don't use `StatsGranularity` anymore but directly work with `StatsTimeRangeSelection`. We can simplify the code now and pass it directly to the AnalytcisHub screen. 

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Launch the app
2. For each of the stats tabs (including the custom range tab) click on `See all store analytics` and verify the displayed range on the analytics screen is correct. 
