### PR TITLE
[Better Tablet Products] Make it harder to discard changes in a product by selecting another product in 2 panes mode

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 -----
 - [*] Products: Improvements on the products photos screens [https://github.com/woocommerce/woocommerce-android/pull/11131]
 - [**] Products: Fixes for 2 to 1 (and visa-versa) panes transitions [https://github.com/woocommerce/woocommerce-android/pull/11159]
+- [*] Products: Confirmation dialog before switching to another product if current was modified [https://github.com/woocommerce/woocommerce-android/pull/11177]
 
 17.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -355,11 +355,9 @@ class ProductDetailFragment :
         }
 
         viewModel.hasChanges.observe(viewLifecycleOwner) { hasChanges ->
-            if (hasChanges) {
-                productsCommunicationViewModel.pushEvent(
-                    ProductsCommunicationViewModel.CommunicationEvent.ProductHasChanges
-                )
-            }
+            productsCommunicationViewModel.pushEvent(
+                ProductsCommunicationViewModel.CommunicationEvent.ProductChanges(hasChanges)
+            )
         }
 
         observeEvents(viewModel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailFragment.kt
@@ -354,6 +354,14 @@ class ProductDetailFragment :
             showProductCards(it)
         }
 
+        viewModel.hasChanges.observe(viewLifecycleOwner) { hasChanges ->
+            if (hasChanges) {
+                productsCommunicationViewModel.pushEvent(
+                    ProductsCommunicationViewModel.CommunicationEvent.ProductHasChanges
+                )
+            }
+        }
+
         observeEvents(viewModel)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductDetailViewModel.kt
@@ -249,7 +249,7 @@ class ProductDetailViewModel @Inject constructor(
     /**
      * Returns the filtered list of attributes assigned to the product who are enabled for Variations
      */
-    val productDraftVariationAttributes
+    private val productDraftVariationAttributes
         get() = viewState.productDraft?.variationEnabledAttributes ?: emptyList()
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -384,7 +384,10 @@ class ProductListFragment :
                 }
 
                 is ShowDiscardProductChangesConfirmationDialog -> {
-                    showDiscardProductChangesConfirmationDialog(event)
+                    showDiscardProductChangesConfirmationDialog(
+                        event.productName,
+                        event.productId
+                    )
                 }
 
                 else -> event.isHandled = false
@@ -425,14 +428,14 @@ class ProductListFragment :
         findNavController().navigateSafely(action)
     }
 
-    private fun showDiscardProductChangesConfirmationDialog(event: ShowDiscardProductChangesConfirmationDialog) {
+    private fun showDiscardProductChangesConfirmationDialog(productName: String, productId: Long) {
         MaterialAlertDialogBuilder(requireContext())
-            .setTitle(getString(R.string.product_list_unsaved_product_unselected_title, event.productName))
+            .setTitle(getString(R.string.product_list_unsaved_product_unselected_title, productName))
             .setMessage(R.string.product_list_unsaved_product_unselected_message)
             .setCancelable(false)
             .setPositiveButton(R.string.dialog_ok) { _, _ ->
                 productListViewModel.productHasChanges = false
-                productListViewModel.onOpenProduct(event.productId, null)
+                productListViewModel.onOpenProduct(productId, null)
             }
             .setNegativeButton(R.string.cancel, null)
             .show()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -43,6 +43,7 @@ import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ScrollToTop
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.SelectProducts
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowAddProductBottomSheet
+import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowDiscardProductChangesConfirmationDialog
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductFilterScreen
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductSortingBottomSheet
 import com.woocommerce.android.ui.products.ProductListViewModel.ProductListEvent.ShowProductUpdateStockStatusScreen
@@ -382,6 +383,10 @@ class ProductListFragment :
                     showProductUpdateStockStatusScreen(event.productsIds)
                 }
 
+                is ShowDiscardProductChangesConfirmationDialog -> {
+                    showDiscardProductChangesConfirmationDialog(event)
+                }
+
                 else -> event.isHandled = false
             }
         }
@@ -401,7 +406,7 @@ class ProductListFragment :
                 }
 
                 is ProductsCommunicationViewModel.CommunicationEvent.ProductChanges -> {
-                    productListViewModel.onProductChanges(event.hasChanges)
+                    productListViewModel.productHasChanges = event.hasChanges
                 }
 
                 else -> event.isHandled = false
@@ -418,6 +423,19 @@ class ProductListFragment :
             productRemoteIdsToUpdate.toLongArray()
         )
         findNavController().navigateSafely(action)
+    }
+
+    private fun showDiscardProductChangesConfirmationDialog(event: ShowDiscardProductChangesConfirmationDialog) {
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(getString(R.string.product_list_unsaved_product_unselected_title, event.productName))
+            .setMessage(R.string.product_list_unsaved_product_unselected_message)
+            .setCancelable(false)
+            .setPositiveButton(R.string.dialog_ok) { _, _ ->
+                productListViewModel.productHasChanges = false
+                productListViewModel.onOpenProduct(event.productId, null)
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
     }
 
     private fun handleUpdateDialogs(event: ShowUpdateDialog) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListFragment.kt
@@ -400,6 +400,10 @@ class ProductListFragment :
                     productListViewModel.onOpenProduct(event.productId, null)
                 }
 
+                is ProductsCommunicationViewModel.CommunicationEvent.ProductChanges -> {
+                    productListViewModel.onProductChanges(event.hasChanges)
+                }
+
                 else -> event.isHandled = false
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -463,7 +463,7 @@ class ProductListViewModel @Inject constructor(
     }
 
     fun onOpenProduct(productId: Long, sharedView: View?) {
-        if (productHasChanges) {
+        if (productHasChanges && isTablet()) {
             triggerEvent(
                 ProductListEvent.ShowDiscardProductChangesConfirmationDialog(
                     productId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -81,6 +81,7 @@ class ProductListViewModel @Inject constructor(
         private const val KEY_PRODUCT_OPENED = "key_product_opened"
     }
 
+    private var productHasChanges: Boolean = false
     private val _productList = MutableLiveData<List<Product>>()
     val productList: LiveData<List<Product>> = _productList.map {
         openFirstLoadedProductOnTablet(it)
@@ -462,6 +463,11 @@ class ProductListViewModel @Inject constructor(
     }
 
     fun onOpenProduct(productId: Long, sharedView: View?) {
+        if (productHasChanges) {
+            productHasChanges = false
+            return
+        }
+
         analyticsTracker.track(
             AnalyticsEvent.PRODUCT_LIST_PRODUCT_TAPPED,
             mapOf(
@@ -482,6 +488,10 @@ class ProductListViewModel @Inject constructor(
                 sharedView = sharedView,
             )
         )
+    }
+
+    fun onProductChanges(hasChanges: Boolean) {
+        productHasChanges = hasChanges
     }
 
     fun isProductHighlighted(productId: Long) = if (isTablet()) productId == openedProductId else false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductListViewModel.kt
@@ -81,7 +81,7 @@ class ProductListViewModel @Inject constructor(
         private const val KEY_PRODUCT_OPENED = "key_product_opened"
     }
 
-    private var productHasChanges: Boolean = false
+    var productHasChanges: Boolean = false
     private val _productList = MutableLiveData<List<Product>>()
     val productList: LiveData<List<Product>> = _productList.map {
         openFirstLoadedProductOnTablet(it)
@@ -464,7 +464,12 @@ class ProductListViewModel @Inject constructor(
 
     fun onOpenProduct(productId: Long, sharedView: View?) {
         if (productHasChanges) {
-            productHasChanges = false
+            triggerEvent(
+                ProductListEvent.ShowDiscardProductChangesConfirmationDialog(
+                    productId,
+                    getProduct(productId)?.name.orEmpty()
+                )
+            )
             return
         }
 
@@ -488,10 +493,6 @@ class ProductListViewModel @Inject constructor(
                 sharedView = sharedView,
             )
         )
-    }
-
-    fun onProductChanges(hasChanges: Boolean) {
-        productHasChanges = hasChanges
     }
 
     fun isProductHighlighted(productId: Long) = if (isTablet()) productId == openedProductId else false
@@ -786,6 +787,10 @@ class ProductListViewModel @Inject constructor(
             data class Price(override val productsIds: List<Long>) : ShowUpdateDialog()
             data class Status(override val productsIds: List<Long>) : ShowUpdateDialog()
         }
+        data class ShowDiscardProductChangesConfirmationDialog(
+            val productId: Long,
+            val productName: String,
+        ) : ProductListEvent()
         data class OpenProduct(
             val productId: Long,
             val oldPosition: Int,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsCommunicationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsCommunicationViewModel.kt
@@ -20,6 +20,7 @@ class ProductsCommunicationViewModel @Inject constructor(
     sealed class CommunicationEvent : MultiLiveEvent.Event() {
         data class ProductTrashed(val productId: Long) : CommunicationEvent()
         data object ProductUpdated : CommunicationEvent()
+        data object ProductHasChanges : CommunicationEvent()
         data class ProductSelected(val productId: Long) : CommunicationEvent()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsCommunicationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductsCommunicationViewModel.kt
@@ -20,7 +20,7 @@ class ProductsCommunicationViewModel @Inject constructor(
     sealed class CommunicationEvent : MultiLiveEvent.Event() {
         data class ProductTrashed(val productId: Long) : CommunicationEvent()
         data object ProductUpdated : CommunicationEvent()
-        data object ProductHasChanges : CommunicationEvent()
+        data class ProductChanges(val hasChanges: Boolean) : CommunicationEvent()
         data class ProductSelected(val productId: Long) : CommunicationEvent()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/TabletLayoutSetupHelper.kt
@@ -91,7 +91,6 @@ class TabletLayoutSetupHelper @Inject constructor(private val context: Context) 
         }
     }
 
-    @Suppress("NestedBlockDepth")
     private fun setDetailsMargins(rootView: View) {
         if (rootView !is ViewGroup) return
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1920,6 +1920,8 @@
     <string name="product_list_filters_selected">Filters \u2022 %d</string>
     <string name="product_list_filters_show_products">Show products</string>
     <string name="product_list_filters_list_item">Selected filter option</string>
+    <string name="product_list_unsaved_product_unselected_title">You about to discard changes to %s</string>
+    <string name="product_list_unsaved_product_unselected_message">Are you sure you want to discard the changes you made to this product?</string>
     <string name="product_search_hint">Search products</string>
     <string name="product_search_hint_active_filters">Search filtered products</string>
     <string name="product_search_all">All products</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11016
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds confirmation dialog if a product was modified and a user possible by mistake clicked on another product from the list

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
In tablet mode:
* Products -> Product
* Modify something in the product but do not save the changes 
* Try to select another product
* Notice confirmation dialog

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/d494fb6b-cc35-4ee2-bd12-2c7b26ca26a6



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
