### PR TITLE
build: bump Tracks to `4.0.2`

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProvider.kt
@@ -4,6 +4,7 @@ import com.automattic.android.tracks.crashlogging.CrashLoggingDataProvider
 import com.automattic.android.tracks.crashlogging.CrashLoggingUser
 import com.automattic.android.tracks.crashlogging.EventLevel
 import com.automattic.android.tracks.crashlogging.ExtraKnownKey
+import com.automattic.android.tracks.crashlogging.ReleaseName
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.di.AppCoroutineScope
@@ -73,10 +74,10 @@ class WCCrashLoggingDataProvider @Inject constructor(
 
     override val performanceMonitoringConfig = specifyPerformanceMonitoringConfig()
 
-    override val releaseName: String = if (buildConfig.debug) {
-        DEBUG_RELEASE_NAME
+    override val releaseName: ReleaseName = if (buildConfig.debug) {
+        ReleaseName.SetByApplication(DEBUG_RELEASE_NAME)
     } else {
-        buildConfig.versionName
+        ReleaseName.SetByTracksLibrary
     }
 
     override val sentryDSN: String = BuildConfig.SENTRY_DSN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/WCCrashLoggingDataProviderTest.kt
@@ -4,6 +4,7 @@ import com.automattic.android.tracks.crashlogging.CrashLoggingUser
 import com.automattic.android.tracks.crashlogging.EventLevel.FATAL
 import com.automattic.android.tracks.crashlogging.EventLevel.INFO
 import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
+import com.automattic.android.tracks.crashlogging.ReleaseName
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.BuildConfigWrapper
@@ -48,9 +49,7 @@ class WCCrashLoggingDataProviderTest : BaseUnitTest() {
     private val appPrefs: AppPrefs = mock()
     private val enqueueSendingEncryptedLogs: EnqueueSendingEncryptedLogs = mock()
     private val uuidGenerator: UuidGenerator = mock()
-    private val buildConfig: BuildConfigWrapper = mock {
-        on { versionName } doReturn "test version name"
-    }
+    private val buildConfig: BuildConfigWrapper = mock()
     private val specifyPerformanceMonitoringConfig: SpecifyPerformanceMonitoringConfig = mock {
         on { invoke() } doReturn PerformanceMonitoringConfig.Enabled(1.0)
     }
@@ -224,7 +223,7 @@ class WCCrashLoggingDataProviderTest : BaseUnitTest() {
 
         reinitialize()
 
-        assertThat(sut.releaseName).isEqualTo(buildConfig.versionName)
+        assertThat(sut.releaseName).isEqualTo(ReleaseName.SetByTracksLibrary)
     }
 
     @Test
@@ -233,7 +232,7 @@ class WCCrashLoggingDataProviderTest : BaseUnitTest() {
 
         reinitialize()
 
-        assertThat(sut.releaseName).isEqualTo(DEBUG_RELEASE_NAME)
+        assertThat(sut.releaseName).isEqualTo(ReleaseName.SetByApplication(DEBUG_RELEASE_NAME))
     }
 
     private fun softlyAssertUser(user: CrashLoggingUser?) {

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ ext {
     mediapickerVersion = '0.3.0'
     wordPressLoginVersion = '1.13.0'
     aboutAutomatticVersion = '0.0.6'
-    automatticTracksVersion = '4.0.1'
+    automatticTracksVersion = '4.0.2'
     workManagerVersion = '2.7.1'
     billingVersion = '5.0.0'
     stripeTerminalVersion = '3.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ ext {
     mediapickerVersion = '0.3.0'
     wordPressLoginVersion = '1.13.0'
     aboutAutomatticVersion = '0.0.6'
-    automatticTracksVersion = '3.5.0'
+    automatticTracksVersion = '4.0.1'
     workManagerVersion = '2.7.1'
     billingVersion = '5.0.0'
     stripeTerminalVersion = '3.1.1'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR bumps Tracks to `4.0.2`. The major change here is that we delegate creating a release name to Tracks library (Sentry internally), instead of providing value from our build config. 

This will address a problem of matching a release with the same name from different projects in the same Sentry organization.
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Testing instructions
Not needed. I've run release build with a test exception. New release was available, see below.
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
![Screenshot 2024-03-27 at 19 14 51](https://github.com/woocommerce/woocommerce-android/assets/5845095/4cfc5d28-786a-4878-9fbb-bf133ee1804a)


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
