### PR TITLE
Fix bug, first x axis label was not shown correctly for custom range

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -733,28 +733,6 @@ class MyStoreStatsView @JvmOverloads constructor(
         return resources.getString(R.string.my_store_custom_range_granularity_label, granularityLabel)
     }
 
-    private fun getEntryValueFromRangeType(dateString: String): String {
-        return when (statsTimeRangeSelection.selectionType) {
-            SelectionType.TODAY -> dateUtils.getShortHourString(dateString).orEmpty()
-            SelectionType.WEEK_TO_DATE -> dateUtils.getShortMonthDayString(dateString).orEmpty()
-            SelectionType.MONTH_TO_DATE -> dateUtils.getShortMonthDayString(dateString).orEmpty()
-            SelectionType.YEAR_TO_DATE -> dateUtils.getShortMonthString(dateString).orEmpty()
-            SelectionType.CUSTOM -> getEntryValuesForCustomType(dateString)
-            else -> error("Unsupported range value used in my store tab: ${statsTimeRangeSelection.selectionType}")
-        }.also { result -> trackUnexpectedFormat(result, dateString) }
-    }
-
-    private fun getEntryValuesForCustomType(dateString: String): String {
-        return when (statsTimeRangeSelection.revenueStatsGranularity) {
-            StatsGranularity.HOURS -> dateUtils.getShortHourString(dateString).orEmpty()
-            StatsGranularity.DAYS -> dateUtils.getDayString(dateString).orEmpty()
-
-            StatsGranularity.WEEKS -> dateUtils.getShortMonthDayString(dateString).orEmpty()
-            StatsGranularity.MONTHS -> dateUtils.getShortMonthString(dateString).orEmpty()
-            StatsGranularity.YEARS -> dateString
-        }.also { result -> trackUnexpectedFormat(result, dateString) }
-    }
-
     private fun trackUnexpectedFormat(result: String, dateString: String) {
         if (result.isEmpty()) {
             AnalyticsTracker.track(
@@ -776,14 +754,25 @@ class MyStoreStatsView @JvmOverloads constructor(
                 // if this is the first entry in the chart, then display the month as well as the date
                 // for weekly and monthly stats
                 val dateString = chartRevenueStats.keys.elementAt(index)
-                if (value == axis.mEntries.first()) {
-                    getEntryValueFromRangeType(dateString)
+                if (value == axis.mEntries.first() && statsTimeRangeSelection.selectionType != SelectionType.CUSTOM) {
+                    getEntryValueForFirstItemOfXAxis(dateString)
                 } else {
                     getAxisLabelFromRangeType(dateString)
                 }
             } else {
                 ""
             }
+        }
+
+        private fun getEntryValueForFirstItemOfXAxis(dateString: String): String {
+            return when (statsTimeRangeSelection.selectionType) {
+                SelectionType.TODAY -> dateUtils.getShortHourString(dateString).orEmpty()
+                SelectionType.WEEK_TO_DATE -> dateUtils.getShortMonthDayString(dateString).orEmpty()
+                SelectionType.MONTH_TO_DATE -> dateUtils.getShortMonthDayString(dateString).orEmpty()
+                SelectionType.YEAR_TO_DATE -> dateUtils.getShortMonthString(dateString).orEmpty()
+                SelectionType.CUSTOM -> error("Custom range is unsupported to set a special x axis label")
+                else -> error("Unsupported range value used in my store tab: ${statsTimeRangeSelection.selectionType}")
+            }.also { result -> trackUnexpectedFormat(result, dateString) }
         }
 
         /**


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fix custom range chart bug
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When selecting the custom range tab there was a bug when generating the first label value for the x axis of the chart. 
The following function was always returning `null` and calling `trackUnexpectedFormat(result, dateString). I've removed it: 
```kotlin
private fun getEntryValuesForCustomType(dateString: String): String {
        return when (statsTimeRangeSelection.revenueStatsGranularity) {
            StatsGranularity.HOURS -> dateUtils.getShortHourString(dateString).orEmpty()
            StatsGranularity.DAYS -> dateUtils.getDayString(dateString).orEmpty()

            StatsGranularity.WEEKS -> dateUtils.getShortMonthDayString(dateString).orEmpty()
            StatsGranularity.MONTHS -> dateUtils.getShortMonthString(dateString).orEmpty()
            StatsGranularity.YEARS -> dateString
        }.also { result -> trackUnexpectedFormat(result, dateString) }
    }
```
The reason is this function won't work with the current `dateString` values that are passed when the custom date range is selected due to the format in which the `dates` are returned from the API for each of the days of the selected range. 

With this fix the X axis of the chart now will display the same labels for all the axis. With the prior implementation the first label of the X axis was never displayed. 

| Before  | After |
| ------------- | ------------- |
| <img width="300"  src="https://github.com/woocommerce/woocommerce-android/assets/2663464/fffe673d-bd39-4bdf-ae7d-497c8ed7771d">   | <img width="300"  src="https://github.com/woocommerce/woocommerce-android/assets/2663464/ec758f4d-eeb7-4c8a-a99d-baf0d83a864b">   |

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Launch the app
2. Select a custom range
3. Check that the X axis is not missing labels. 

