### PR TITLE
Place new Shipping plugin support behind a feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepository.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.FeatureFlag
 import javax.inject.Inject
 
 class ShippingLabelOnboardingRepository @Inject constructor(
@@ -26,8 +27,13 @@ class ShippingLabelOnboardingRepository @Inject constructor(
                 it.isPluginReady() && pluginVersion.semverCompareTo(SUPPORTED_WCS_VERSION) >= 0
             }?.let { return@lazy true }
 
-        orderDetailRepository.getWooShippingPluginInfo()
-            .isPluginReady()
+        if (FeatureFlag.NEW_SHIPPING_SUPPORT.isEnabled()) {
+            orderDetailRepository.getWooShippingPluginInfo()
+                .takeIf { it.isPluginReady() }
+                ?.let { return@lazy true }
+        }
+
+        return@lazy false
     }
 
     fun shouldShowWcShippingBanner(order: Order, eligibleForIpp: Boolean): Boolean =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepository.kt
@@ -44,6 +44,7 @@ class ShippingLabelOnboardingRepository @Inject constructor(
         }
     }
 
+    @Suppress("ReturnCount")
     private fun isShippingLabelSupported(): Boolean {
         orderDetailRepository.getWooServicesPluginInfo()
             .takeIf {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -14,7 +14,8 @@ enum class FeatureFlag {
     ORDER_CREATION_AUTO_TAX_RATE,
     BLAZE_I3,
     CUSTOM_RANGE_ANALYTICS,
-    CONNECTIVITY_TOOL;
+    CONNECTIVITY_TOOL,
+    NEW_SHIPPING_SUPPORT;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -26,7 +27,8 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
-            CUSTOM_RANGE_ANALYTICS -> PackageUtils.isDebugBuild()
+            CUSTOM_RANGE_ANALYTICS,
+            NEW_SHIPPING_SUPPORT -> PackageUtils.isDebugBuild()
 
             CONNECTIVITY_TOOL,
             BLAZE_I3 -> true


### PR DESCRIPTION
Summary
==========
Add a feature flag to better control when we want to release support to the new Woo Shipping plugin.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
