### PR TITLE
Fix remaining plugin check call when refreshing an Order with shipping labels

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -748,9 +748,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private fun fetchOrderShippingLabelsAsync() = async {
-        val plugin = pluginsInformation[WooCommerceStore.WooPlugin.WOO_SERVICES.pluginName]
-
-        if (plugin == null || plugin.isOperational) {
+        if (shippingLabelOnboardingRepository.isShippingPluginReady) {
             orderDetailRepository.fetchOrderShippingLabels(navArgs.orderId)
         }
         orderDetailsTransactionLauncher.onShippingLabelFetchingCompleted()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -27,10 +27,10 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
-            CUSTOM_RANGE_ANALYTICS -> PackageUtils.isDebugBuild()
+            CUSTOM_RANGE_ANALYTICS,
+            NEW_SHIPPING_SUPPORT -> PackageUtils.isDebugBuild()
 
             CONNECTIVITY_TOOL,
-            NEW_SHIPPING_SUPPORT,
             BLAZE_I3 -> true
 
             IAP_FOR_STORE_CREATION -> false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -27,10 +27,10 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
-            CUSTOM_RANGE_ANALYTICS,
-            NEW_SHIPPING_SUPPORT -> PackageUtils.isDebugBuild()
+            CUSTOM_RANGE_ANALYTICS -> PackageUtils.isDebugBuild()
 
             CONNECTIVITY_TOOL,
+            NEW_SHIPPING_SUPPORT,
             BLAZE_I3 -> true
 
             IAP_FOR_STORE_CREATION -> false


### PR DESCRIPTION
Summary
==========
Add a remaining plugin check in the `OrderDetailViewModel` that was only accounting for the WCS&T supporting and ignoring the new Shipping plugin existence. 

How to Test
==========
1. In your store, install and activate the new Woo Shipping plugin (ask me in case you need the file). Deactivate the legacy WooCommerce Shipping & Tax.
2. Go through the Shipping Label Purchase flow and verify that it works succesfully.
3. Check that refunding shipping labels works as before.
4. Check also that the shipping labels are shown in the order details once they are purchased.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.