### PR TITLE
Activate the New shipping plugin support

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -26,12 +26,12 @@ enum class FeatureFlag {
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
-            ORDER_CREATION_AUTO_TAX_RATE,
-            NEW_SHIPPING_SUPPORT -> PackageUtils.isDebugBuild()
+            ORDER_CREATION_AUTO_TAX_RATE -> PackageUtils.isDebugBuild()
 
             CONNECTIVITY_TOOL,
             BLAZE_I3,
-            CUSTOM_RANGE_ANALYTICS -> true
+            CUSTOM_RANGE_ANALYTICS,
+            NEW_SHIPPING_SUPPORT -> true
 
             IAP_FOR_STORE_CREATION -> false
         }


### PR DESCRIPTION
Summary
==========
Activates the support for the new Shipping plugin.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.