### PR TITLE
[Migrate Simple Payments] Navigation to the order creation screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -1036,9 +1036,7 @@ class MainActivity :
         binding.bottomNav.currentPosition = ORDERS
         binding.bottomNav.active(ORDERS.position)
         val action = OrderListFragmentDirections.actionOrderListFragmentToOrderCreationFragment(
-            OrderCreateEditViewModel.Mode.Creation,
-            null,
-            null,
+            mode = OrderCreateEditViewModel.Mode.Creation
         )
         navController.navigateSafely(action)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -1036,7 +1036,9 @@ class MainActivity :
         binding.bottomNav.currentPosition = ORDERS
         binding.bottomNav.active(ORDERS.position)
         val action = OrderListFragmentDirections.actionOrderListFragmentToOrderCreationFragment(
-            mode = OrderCreateEditViewModel.Mode.Creation
+            OrderCreateEditViewModel.Mode.Creation,
+            null,
+            null,
         )
         navController.navigateSafely(action)
     }
@@ -1127,12 +1129,10 @@ class MainActivity :
         giftCardCode: String?,
         giftCardAmount: BigDecimal?
     ) {
-        NavGraphMainDirections.actionGlobalToOrdercreationfragment(
+        NavGraphMainDirections.actionGlobalToOrderCreationFragment(
             mode = mode,
-            barcodeFormat = null,
             giftCardCode = giftCardCode,
             giftCardAmount = giftCardAmount,
-            sku = null,
         ).apply {
             navController.navigateSafely(this)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1964,7 +1964,7 @@ class OrderCreateEditViewModel @Inject constructor(
 
     sealed class Mode : Parcelable {
         @Parcelize
-        object Creation : Mode()
+        data object Creation : Mode()
 
         @Parcelize
         data class Edit(val orderId: Long) : Mode()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubFragment.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingParams
 import com.woocommerce.android.ui.payments.hub.PaymentsHubViewModel.PaymentsHubEvents.NavigateToTapTooPaySummaryScreen
@@ -117,6 +118,13 @@ class PaymentsHubFragment : BaseFragment(R.layout.fragment_payments_hub) {
                 is PaymentsHubViewModel.PaymentsHubEvents.NavigateToPaymentCollectionScreen -> {
                     findNavController().navigate(
                         PaymentsHubFragmentDirections.actionCardReaderHubFragmentToSimplePayments()
+                    )
+                }
+                is PaymentsHubViewModel.PaymentsHubEvents.NavigateToOrderCreationScreen -> {
+                    findNavController().navigate(
+                        PaymentsHubFragmentDirections.actionCardReaderHubFragmentToOrderCreationFragment(
+                            mode = OrderCreateEditViewModel.Mode.Creation,
+                        )
                     )
                 }
                 is PaymentsHubViewModel.PaymentsHubEvents.OpenGenericWebView -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewModel.kt
@@ -79,7 +79,6 @@ class PaymentsHubViewModel @Inject constructor(
     private val tapToPayUnavailableHandler: PaymentsHubTapToPayUnavailableHandler,
     private val cardReaderDataAction: ClearCardReaderDataAction,
     private val cardReaderManager: CardReaderManager,
-    @Suppress("UnusedPrivateProperty")
     private val simplePaymentsMigrationEnabled: PaymentsHuSimplePaymentsMigrationEnabled,
 ) : ScopedViewModel(savedState) {
     private val arguments: PaymentsHubFragmentArgs by savedState.navArgs()
@@ -346,7 +345,11 @@ class PaymentsHubViewModel @Inject constructor(
 
     private fun onCollectPaymentClicked() {
         trackEvent(AnalyticsEvent.PAYMENTS_HUB_COLLECT_PAYMENT_TAPPED)
-        triggerEvent(PaymentsHubEvents.NavigateToPaymentCollectionScreen)
+        if (simplePaymentsMigrationEnabled()) {
+            triggerEvent(PaymentsHubEvents.NavigateToOrderCreationScreen)
+        } else {
+            triggerEvent(PaymentsHubEvents.NavigateToPaymentCollectionScreen)
+        }
     }
 
     private fun onManageCardReaderClicked() {
@@ -567,9 +570,10 @@ class PaymentsHubViewModel @Inject constructor(
             @StringRes val titleRes: Int
         ) : PaymentsHubEvents()
 
-        object NavigateToPaymentCollectionScreen : PaymentsHubEvents()
-        object NavigateToTapTooPaySummaryScreen : PaymentsHubEvents()
-        object NavigateToTapTooPaySurveyScreen : PaymentsHubEvents()
+        data object NavigateToPaymentCollectionScreen : PaymentsHubEvents()
+        data object NavigateToOrderCreationScreen : PaymentsHubEvents()
+        data object NavigateToTapTooPaySummaryScreen : PaymentsHubEvents()
+        data object NavigateToTapTooPaySurveyScreen : PaymentsHubEvents()
         data class NavigateToCardReaderManualsScreen(
             val countryConfig: CardReaderConfigForSupportedCountry
         ) : PaymentsHubEvents()

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -125,14 +125,6 @@
             <argument
                 android:name="mode"
                 app:argType="com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel$Mode" />
-            <argument
-                android:name="sku"
-                app:argType="string"
-                app:nullable="true" />
-            <argument
-                android:name="barcodeFormat"
-                app:argType="com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper$BarcodeFormat"
-                app:nullable="true" />
         </action>
         <action
             android:id="@+id/action_orderListFragment_to_barcodeScanningFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -125,6 +125,14 @@
             <argument
                 android:name="mode"
                 app:argType="com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel$Mode" />
+            <argument
+                android:name="sku"
+                app:argType="string"
+                app:nullable="true" />
+            <argument
+                android:name="barcodeFormat"
+                app:argType="com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper$BarcodeFormat"
+                app:nullable="true" />
         </action>
         <action
             android:id="@+id/action_orderListFragment_to_barcodeScanningFragment"
@@ -335,17 +343,19 @@
     </fragment>
 
     <action
-        android:id="@+id/action_global_to_ordercreationfragment"
+        android:id="@+id/action_global_to_orderCreationFragment"
         app:destination="@id/nav_graph_order_creations">
         <argument
             android:name="mode"
             app:argType="com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel$Mode" />
         <argument
             android:name="sku"
+            android:defaultValue="@null"
             app:argType="string"
             app:nullable="true" />
         <argument
             android:name="barcodeFormat"
+            android:defaultValue="@null"
             app:argType="com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper$BarcodeFormat"
             app:nullable="true" />
         <argument

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -48,7 +48,7 @@
         </action>
         <action
             android:id="@+id/action_orderCreationFragment_to_orderCreationCustomerFragment"
-            app:destination="@id/orderCreationCustomerFragment"></action>
+            app:destination="@id/orderCreationCustomerFragment" />
         <action
             android:id="@+id/action_orderCreationFragment_to_customerListFragment"
             app:destination="@id/customerListFragment" />
@@ -134,10 +134,12 @@
         <argument
             android:name="sku"
             app:argType="string"
+            android:defaultValue="@null"
             app:nullable="true" />
         <argument
             android:name="barcodeFormat"
             app:argType="com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper$BarcodeFormat"
+            android:defaultValue="@null"
             app:nullable="true" />
         <argument
             android:name="couponEditResult"
@@ -159,7 +161,7 @@
             app:destination="@id/barcodeScanningFragment" />
         <action
             android:id="@+id/action_orderCreationFragment_to_couponSelectorFragment"
-            app:destination="@id/couponSelectorFragment"></action>
+            app:destination="@id/couponSelectorFragment" />
         <action
             android:id="@+id/action_order_creationFragment_to_taxRateSelectorFragment"
             app:destination="@id/taxRateSelectorFragment" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
@@ -3,6 +3,8 @@
     android:id="@+id/paymentFlow"
     app:startDestination="@id/selectPaymentMethodFragment">
 
+    <include app:graph="@navigation/nav_graph_order_creations" />
+
     <fragment
         android:id="@+id/selectPaymentMethodFragment"
         android:name="com.woocommerce.android.ui.payments.methodselection.SelectPaymentMethodFragment"
@@ -150,6 +152,13 @@
             app:exitAnim="@null"
             app:popEnterAnim="@null"
             app:popExitAnim="@anim/activity_fade_out" />
+        <action
+            android:id="@+id/action_cardReaderHubFragment_to_orderCreationFragment"
+            app:destination="@id/nav_graph_order_creations">
+            <argument
+                android:name="mode"
+                app:argType="com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel$Mode" />
+        </action>
     </fragment>
     <fragment
         android:id="@+id/cardReaderDetailFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewModelTest.kt
@@ -1983,6 +1983,40 @@ class PaymentsHubViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `given simple payment migration enabled, on onCollectPaymentClicked, then navigate to order creation screen emitted`() {
+        // GIVEN
+        whenever(simplePaymentsMigrationEnabled()).thenReturn(true)
+
+        // WHEN
+        initViewModel()
+        (viewModel.viewStateData.getOrAwaitValue()).rows.find {
+            it.label == UiStringRes(R.string.card_reader_hub_collect_payment)
+        }!!.onClick!!.invoke()
+
+        // THEN
+        assertThat(viewModel.event.value).isInstanceOf(
+            PaymentsHubViewModel.PaymentsHubEvents.NavigateToOrderCreationScreen::class.java
+        )
+    }
+
+    @Test
+    fun `given simple payment migration disabled, on onCollectPaymentClicked, then navigate to payment collection screen emitted`() {
+        // GIVEN
+        whenever(simplePaymentsMigrationEnabled()).thenReturn(false)
+
+        // WHEN
+        initViewModel()
+        (viewModel.viewStateData.getOrAwaitValue()).rows.find {
+            it.label == UiStringRes(R.string.card_reader_hub_collect_payment)
+        }!!.onClick!!.invoke()
+
+        // THEN
+        assertThat(viewModel.event.value).isInstanceOf(
+            PaymentsHubViewModel.PaymentsHubEvents.NavigateToPaymentCollectionScreen::class.java
+        )
+    }
+
     //endregion
 
     private fun getSuccessWooResult() = WooResult(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11200
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR ads navigate to the order creation screen behind FF. The next PR will add bottom sheet that explains the migration

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Try with both FF on and off
* More -> Payments -> Collect payment
* Notice that with FF on it opens order creation screen
* Notice that with FF off it opens normal IPP flow

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/4923871/f1bfa203-fb35-49dd-a911-f6a614d445be


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
