### PR TITLE
Dynamic dashboard/preparations

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/TabNavComponent.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/TabNavComponent.kt
@@ -7,9 +7,9 @@ import com.woocommerce.android.e2e.screens.mystore.MyStoreScreen
 import com.woocommerce.android.e2e.screens.orders.OrderListScreen
 import com.woocommerce.android.e2e.screens.products.ProductListScreen
 
-class TabNavComponent : Screen(R.id.dashboard) {
+class TabNavComponent : Screen(R.id.my_store) {
     fun gotoMyStoreScreen(): MyStoreScreen {
-        clickOn(R.id.dashboard)
+        clickOn(R.id.my_store)
         return MyStoreScreen()
     }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/login/WelcomeScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/login/WelcomeScreen.kt
@@ -8,7 +8,7 @@ import com.woocommerce.android.e2e.screens.TabNavComponent
 class WelcomeScreen : Screen {
     companion object {
         fun logoutIfNeeded(composeTestRule: ComposeContentTestRule): WelcomeScreen {
-            if (isElementDisplayed(R.id.dashboard)) {
+            if (isElementDisplayed(R.id.my_store)) {
                 TabNavComponent()
                     .gotoMoreMenuScreen()
                     .openSettings(composeTestRule)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/StatsComponent.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/StatsComponent.kt
@@ -6,7 +6,7 @@ import com.woocommerce.android.e2e.helpers.util.Screen
 class StatsComponent : Screen(R.id.dashboardStats_root) {
     override fun recover() {
         super.recover()
-        clickOn(R.id.dashboard)
+        clickOn(R.id.my_store)
     }
 
     private fun waitForGraphToLoad() {

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/notifications/NotificationsScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/notifications/NotificationsScreen.kt
@@ -12,10 +12,10 @@ import com.woocommerce.android.notifications.WooNotificationType.NEW_ORDER
 
 /**
  * This is not a screen per-se, as it shows the notification drawer with a push notification.
- * This is why we provide an [R.id.dashboard] as the [elementID].
+ * This is why we provide an [R.id.my_store] as the [elementID].
  */
 class NotificationsScreen(private val wooNotificationBuilder: WooNotificationBuilder) :
-    Screen(R.id.dashboard) {
+    Screen(R.id.my_store) {
     init {
         displayNotification()
         openNotificationShade()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/AIProductDescriptionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/AIProductDescriptionDialog.kt
@@ -1,0 +1,84 @@
+package com.woocommerce.android.ui.dashboard
+
+import android.content.res.Configuration
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun AIProductDescriptionDialog(
+    onTryNowButtonClick: () -> Unit,
+    onMaybeLaterButtonClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .background(
+                color = colorResource(id = R.color.color_surface)
+            )
+            .padding(dimensionResource(id = R.dimen.major_100))
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Image(
+                modifier = Modifier.fillMaxWidth(),
+                painter = painterResource(R.drawable.img_ai_dialog),
+                contentDescription = "Generate AI Description",
+            )
+            Text(
+                modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100)),
+                text = stringResource(id = R.string.ai_product_description_dialog_title),
+                style = MaterialTheme.typography.h5,
+                textAlign = TextAlign.Center
+            )
+            Text(
+                modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100)),
+                text = stringResource(id = R.string.ai_product_description_dialog_message),
+                style = MaterialTheme.typography.body1,
+                textAlign = TextAlign.Center
+            )
+            WCColoredButton(
+                modifier = Modifier
+                    .padding(top = dimensionResource(id = R.dimen.major_100))
+                    .fillMaxWidth(),
+                onClick = onTryNowButtonClick
+            ) {
+                Text(stringResource(id = R.string.try_it_now))
+            }
+            WCOutlinedButton(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = onMaybeLaterButtonClick
+            ) {
+                Text(stringResource(id = R.string.maybe_later))
+            }
+        }
+    }
+}
+
+@Preview(name = "Light Mode")
+@Preview(name = "Dark Mode", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
+@Composable
+fun PreviewAIProductDescriptionDialog() {
+    WooThemeWithBackground {
+        AIProductDescriptionDialog({}, {})
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/AIProductDescriptionDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/AIProductDescriptionDialogFragment.kt
@@ -1,0 +1,80 @@
+package com.woocommerce.android.ui.dashboard
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.NavGraphMainDirections
+import com.woocommerce.android.R.style
+import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.dashboard.AIProductDescriptionDialogViewModel.TryAIProductDescriptionGeneration
+import com.woocommerce.android.ui.products.ProductDetailFragment
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.util.DisplayUtils
+
+@AndroidEntryPoint
+class AIProductDescriptionDialogFragment : DialogFragment() {
+    companion object {
+        private const val TABLET_LANDSCAPE_WIDTH_RATIO = 0.35f
+    }
+
+    private val viewModel: AIProductDescriptionDialogViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setStyle(STYLE_NO_TITLE, style.Theme_Woo_Dialog_RoundedCorners)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        // Specify transition animations
+        dialog?.window?.attributes?.windowAnimations = style.Woo_Animations_Dialog
+
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    AIProductDescriptionDialog(viewModel::onTryNowButtonClicked, viewModel::onDismissButtonClicked)
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is TryAIProductDescriptionGeneration -> openBlankProduct()
+                is Exit -> findNavController().navigateUp()
+            }
+        }
+    }
+
+    private fun openBlankProduct() {
+        findNavController().navigateSafely(
+            NavGraphMainDirections.actionGlobalProductDetailFragment(
+                mode = ProductDetailFragment.Mode.AddNewProduct,
+            )
+        )
+    }
+
+    override fun onStart() {
+        super.onStart()
+        if (isTabletLandscape()) {
+            requireDialog().window!!.setLayout(
+                (DisplayUtils.getWindowPixelWidth(requireContext()) * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        }
+    }
+
+    private fun isTabletLandscape() = (DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)) &&
+        DisplayUtils.isLandscape(context)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/AIProductDescriptionDialogViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/AIProductDescriptionDialogViewModel.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.ui.dashboard
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class AIProductDescriptionDialogViewModel @Inject constructor(
+    savedState: SavedStateHandle
+) : ScopedViewModel(savedState) {
+    fun onTryNowButtonClicked() {
+        triggerEvent(TryAIProductDescriptionGeneration)
+    }
+
+    fun onDismissButtonClicked() {
+        triggerEvent(Exit)
+    }
+
+    object TryAIProductDescriptionGeneration : MultiLiveEvent.Event()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/BarChartGestureListener.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/BarChartGestureListener.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.ui.dashboard
+
+import android.view.MotionEvent
+import com.github.mikephil.charting.listener.ChartTouchListener.ChartGesture
+import com.github.mikephil.charting.listener.OnChartGestureListener
+
+/**
+ * Interface that overrides the [OnChartGestureListener] class so as to NOT
+ * implement unused methods to the implementing class
+ */
+interface BarChartGestureListener : OnChartGestureListener {
+    override fun onChartLongPressed(me: MotionEvent?) {}
+    override fun onChartSingleTapped(me: MotionEvent?) {}
+    override fun onChartDoubleTapped(me: MotionEvent?) {}
+    override fun onChartTranslate(me: MotionEvent?, dX: Float, dY: Float) {}
+    override fun onChartScale(me: MotionEvent?, scaleX: Float, scaleY: Float) {}
+    override fun onChartGestureStart(me: MotionEvent?, lastPerformedGesture: ChartGesture?) {}
+    override fun onChartFling(me1: MotionEvent?, me2: MotionEvent?, velocityX: Float, velocityY: Float) {}
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -158,9 +158,9 @@ class DashboardFragment :
             myStoreViewModel.onTabSelected(tab.tag as? SelectionType ?: SelectionType.TODAY)
         }
 
-        override fun onTabUnselected(tab: TabLayout.Tab) {}
+        override fun onTabUnselected(tab: TabLayout.Tab) = Unit
 
-        override fun onTabReselected(tab: TabLayout.Tab) {}
+        override fun onTabReselected(tab: TabLayout.Tab) = Unit
     }
 
     private val handler = Handler(Looper.getMainLooper())
@@ -342,7 +342,8 @@ class DashboardFragment :
             is StoreOnboardingViewModel.NavigateToAddProduct ->
                 with(addProductNavigator) {
                     findNavController().navigateToAddProducts(
-                        aiBottomSheetAction = DashboardFragmentDirections.actionDashboardToAddProductWithAIBottomSheet(),
+                        aiBottomSheetAction = DashboardFragmentDirections
+                            .actionDashboardToAddProductWithAIBottomSheet(),
                         typesBottomSheetAction = DashboardFragmentDirections.actionDashboardToProductTypesBottomSheet()
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -1,0 +1,753 @@
+package com.woocommerce.android.ui.dashboard
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.view.MenuProvider
+import androidx.core.view.isVisible
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.withCreated
+import androidx.navigation.fragment.FragmentNavigatorExtras
+import androidx.navigation.fragment.findNavController
+import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.tabs.TabLayout
+import com.google.android.material.transition.MaterialElevationScale
+import com.google.android.play.core.review.ReviewManagerFactory
+import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.FeedbackPrefs
+import com.woocommerce.android.NavGraphMainDirections
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.FragmentDashboardBinding
+import com.woocommerce.android.extensions.hide
+import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.scrollStartEvents
+import com.woocommerce.android.extensions.setClickableText
+import com.woocommerce.android.extensions.show
+import com.woocommerce.android.extensions.showDateRangePicker
+import com.woocommerce.android.extensions.startHelpActivity
+import com.woocommerce.android.extensions.verticalOffsetChanges
+import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.base.TopLevelFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
+import com.woocommerce.android.ui.blaze.MyStoreBlazeView
+import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel
+import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.MyStoreBlazeCampaignState
+import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenAnalytics
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenDatePicker
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenTopPerformer
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShareStore
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowAIProductDescriptionDialog
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowPrivacyBanner
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.OrderState
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.RevenueStatsViewState
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.VisitorStatsViewState
+import com.woocommerce.android.ui.feedback.SurveyType
+import com.woocommerce.android.ui.jitm.JitmFragment
+import com.woocommerce.android.ui.jitm.JitmMessagePathsProvider
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.ui.main.MainNavigationRouter
+import com.woocommerce.android.ui.onboarding.StoreOnboardingCollapsed
+import com.woocommerce.android.ui.onboarding.StoreOnboardingViewModel
+import com.woocommerce.android.ui.onboarding.StoreOnboardingViewModel.NavigateToSetupPayments.taskId
+import com.woocommerce.android.ui.prefs.privacy.banner.PrivacyBannerFragmentDirections
+import com.woocommerce.android.ui.products.AddProductNavigator
+import com.woocommerce.android.ui.products.ProductDetailFragment
+import com.woocommerce.android.util.ActivityUtils
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.WooAnimUtils
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
+import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
+import com.woocommerce.android.widgets.WooClickableSpan
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import org.wordpress.android.util.NetworkUtils
+import java.util.Calendar
+import java.util.Date
+import javax.inject.Inject
+import kotlin.math.abs
+
+@AndroidEntryPoint
+@OptIn(FlowPreview::class)
+class DashboardFragment :
+    TopLevelFragment(R.layout.fragment_dashboard),
+    MenuProvider {
+    companion object {
+        val TAG: String = DashboardFragment::class.java.simpleName
+        fun newInstance() = DashboardFragment()
+        private const val JITM_FRAGMENT_TAG = "jitm_fragment"
+    }
+
+    private val myStoreViewModel: DashboardViewModel by viewModels()
+    private val storeOnboardingViewModel: StoreOnboardingViewModel by activityViewModels()
+    private val myStoreBlazeViewModel: MyStoreBlazeViewModel by viewModels()
+
+    @Inject
+    lateinit var selectedSite: SelectedSite
+
+    @Inject
+    lateinit var currencyFormatter: CurrencyFormatter
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
+
+    @Inject
+    lateinit var dateUtils: DateUtils
+
+    @Inject
+    lateinit var usageTracksEventEmitter: DashboardStatsUsageTracksEventEmitter
+
+    @Inject
+    lateinit var appPrefsWrapper: AppPrefsWrapper
+
+    @Inject
+    lateinit var feedbackPrefs: FeedbackPrefs
+
+    @Inject
+    lateinit var addProductNavigator: AddProductNavigator
+
+    @Inject
+    lateinit var blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher
+
+    private var _binding: FragmentDashboardBinding? = null
+    private val binding get() = _binding!!
+
+    private var errorSnackbar: Snackbar? = null
+
+    private val mainNavigationRouter
+        get() = activity as? MainNavigationRouter
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Visible(
+            navigationIcon = null,
+            hasShadow = true,
+        )
+
+    private var isEmptyViewVisible: Boolean = false
+    private var wasPreviouslyStopped = false
+
+    private val tabLayout: TabLayout
+        get() = binding.myStoreStats.tabLayout
+
+    private val tabSelectedListener = object : TabLayout.OnTabSelectedListener {
+        override fun onTabSelected(tab: TabLayout.Tab) {
+            myStoreViewModel.onTabSelected(tab.tag as? SelectionType ?: SelectionType.TODAY)
+        }
+
+        override fun onTabUnselected(tab: TabLayout.Tab) {}
+
+        override fun onTabReselected(tab: TabLayout.Tab) {}
+    }
+
+    private val handler = Handler(Looper.getMainLooper())
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        lifecycle.addObserver(myStoreViewModel.performanceObserver)
+        lifecycle.addObserver(storeOnboardingViewModel)
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
+        blazeCampaignCreationDispatcher.attachFragment(this, BlazeFlowSource.MY_STORE_SECTION)
+
+        _binding = FragmentDashboardBinding.bind(view)
+
+        binding.myStoreRefreshLayout.setOnRefreshListener {
+            binding.myStoreRefreshLayout.isRefreshing = false
+            myStoreViewModel.onPullToRefresh()
+            storeOnboardingViewModel.onPullToRefresh()
+            binding.myStoreStats.clearStatsHeaderValues()
+            binding.myStoreStats.clearChartData()
+            refreshJitm()
+        }
+
+        binding.myStoreStats.initView(
+            selectedSite,
+            dateUtils,
+            currencyFormatter,
+            usageTracksEventEmitter,
+            viewLifecycleOwner.lifecycleScope
+        ) { myStoreViewModel.onViewAnalyticsClicked() }
+
+        binding.myStoreTopPerformers.initView(selectedSite, dateUtils)
+
+        val contactUsText = getString(R.string.my_store_stats_availability_contact_us)
+        binding.myStoreStatsAvailabilityMessage.setClickableText(
+            content = getString(R.string.my_store_stats_availability_description, contactUsText),
+            clickableContent = contactUsText,
+            clickAction = WooClickableSpan { activity?.startHelpActivity(HelpOrigin.MY_STORE) }
+        )
+
+        prepareJetpackBenefitsBanner()
+
+        tabLayout.addOnTabSelectedListener(tabSelectedListener)
+
+        binding.myStoreStats.customRangeButton.setOnClickListener {
+            myStoreViewModel.onAddCustomRangeClicked()
+        }
+        binding.myStoreStats.customRangeLabel.setOnClickListener {
+            myStoreViewModel.onAddCustomRangeClicked()
+        }
+
+        binding.statsScrollView.scrollStartEvents()
+            .onEach { usageTracksEventEmitter.interacted() }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
+
+        setupStateObservers()
+        setupOnboardingView()
+        setUpBlazeCampaignView()
+
+        initJitm(savedInstanceState)
+    }
+
+    private fun setUpBlazeCampaignView() {
+        myStoreBlazeViewModel.blazeViewState.observe(viewLifecycleOwner) { blazeCampaignState ->
+            if (blazeCampaignState is MyStoreBlazeCampaignState.Hidden) {
+                binding.blazeCampaignView.hide()
+            } else {
+                binding.blazeCampaignView.apply {
+                    setContent {
+                        WooThemeWithBackground {
+                            MyStoreBlazeView(
+                                state = blazeCampaignState,
+                                onDismissBlazeView = myStoreBlazeViewModel::onBlazeViewDismissed,
+                            )
+                        }
+                    }
+                    show()
+                }
+            }
+        }
+        myStoreBlazeViewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MyStoreBlazeViewModel.LaunchBlazeCampaignCreationUsingWebView -> openBlazeWebView(
+                    url = event.url,
+                    source = event.source
+                )
+
+                is MyStoreBlazeViewModel.LaunchBlazeCampaignCreation -> openBlazeCreationFlow(event.productId)
+
+                is MyStoreBlazeViewModel.ShowAllCampaigns -> {
+                    findNavController().navigateSafely(
+                        DashboardFragmentDirections.actionDashboardToBlazeCampaignListFragment()
+                    )
+                }
+
+                is MyStoreBlazeViewModel.ShowCampaignDetails -> {
+                    findNavController().navigateSafely(
+                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+                            urlToLoad = event.url,
+                            urlsToTriggerExit = arrayOf(event.urlToTriggerExit),
+                            title = getString(R.string.blaze_campaign_details_title)
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    private fun openBlazeCreationFlow(productId: Long?) {
+        lifecycleScope.launch {
+            blazeCampaignCreationDispatcher.startCampaignCreation(
+                source = BlazeFlowSource.MY_STORE_SECTION,
+                productId = productId
+            )
+        }
+    }
+
+    private fun openBlazeWebView(url: String, source: BlazeFlowSource) {
+        findNavController().navigateSafely(
+            NavGraphMainDirections.actionGlobalBlazeCampaignCreationFragment(
+                urlToLoad = url,
+                source = source
+            )
+        )
+    }
+
+    @Suppress("LongMethod")
+    private fun setupOnboardingView() {
+        storeOnboardingViewModel.viewState.observe(viewLifecycleOwner) { state ->
+            when (state.show) {
+                false -> binding.storeOnboardingView.hide()
+                else -> {
+                    binding.storeOnboardingView.apply {
+                        show()
+                        AnalyticsTracker.track(stat = AnalyticsEvent.STORE_ONBOARDING_SHOWN)
+                        // Dispose of the Composition when the view's LifecycleOwner is destroyed
+                        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                        setContent {
+                            WooThemeWithBackground {
+                                StoreOnboardingCollapsed(
+                                    onboardingState = state,
+                                    onViewAllClicked = storeOnboardingViewModel::viewAllClicked,
+                                    onShareFeedbackClicked = storeOnboardingViewModel::onShareFeedbackClicked,
+                                    onTaskClicked = storeOnboardingViewModel::onTaskClicked,
+                                    onHideOnboardingClicked = storeOnboardingViewModel::onHideOnboardingClicked
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        storeOnboardingViewModel.event.observe(viewLifecycleOwner) { event ->
+            event.handle()
+        }
+    }
+
+    private fun Event.handle() {
+        when (this) {
+            is StoreOnboardingViewModel.NavigateToOnboardingFullScreen -> openOnboardingInFullScreen()
+            is StoreOnboardingViewModel.NavigateToSurvey ->
+                NavGraphMainDirections.actionGlobalFeedbackSurveyFragment(SurveyType.STORE_ONBOARDING).apply {
+                    findNavController().navigateSafely(this)
+                }
+
+            is StoreOnboardingViewModel.NavigateToLaunchStore ->
+                findNavController().navigateSafely(
+                    directions = DashboardFragmentDirections.actionDashboardToLaunchStoreFragment()
+                )
+
+            is StoreOnboardingViewModel.NavigateToDomains ->
+                findNavController().navigateSafely(
+                    directions = DashboardFragmentDirections.actionDashboardToNavGraphDomainChange()
+                )
+
+            is StoreOnboardingViewModel.NavigateToAddProduct ->
+                with(addProductNavigator) {
+                    findNavController().navigateToAddProducts(
+                        aiBottomSheetAction = DashboardFragmentDirections.actionDashboardToAddProductWithAIBottomSheet(),
+                        typesBottomSheetAction = DashboardFragmentDirections.actionDashboardToProductTypesBottomSheet()
+                    )
+                }
+
+            is StoreOnboardingViewModel.NavigateToSetupPayments ->
+                findNavController().navigateSafely(
+                    directions = DashboardFragmentDirections.actionDashboardToPaymentsPreSetupFragment(
+                        taskId = taskId
+                    )
+                )
+
+            is StoreOnboardingViewModel.NavigateToSetupWooPayments ->
+                findNavController().navigateSafely(
+                    directions = DashboardFragmentDirections.actionDashboardToWooPaymentsSetupInstructionsFragment()
+                )
+
+            is StoreOnboardingViewModel.NavigateToAboutYourStore ->
+                findNavController().navigateSafely(
+                    DashboardFragmentDirections.actionDashboardToAboutYourStoreFragment()
+                )
+
+            is StoreOnboardingViewModel.ShowNameYourStoreDialog -> {
+                findNavController()
+                    .navigateSafely(
+                        DashboardFragmentDirections.actionDashboardToNameYourStoreDialogFragment(fromOnboarding = true)
+                    )
+            }
+
+            is ShowDialog -> showDialog()
+        }
+    }
+
+    private fun openOnboardingInFullScreen() {
+        exitTransition = MaterialElevationScale(false).apply {
+            duration = resources.getInteger(R.integer.default_fragment_transition).toLong()
+        }
+        reenterTransition = MaterialElevationScale(true).apply {
+            duration = resources.getInteger(R.integer.default_fragment_transition).toLong()
+        }
+        val transitionName = getString(R.string.store_onboarding_full_screen_transition_name)
+        val extras = FragmentNavigatorExtras(binding.storeOnboardingView to transitionName)
+        findNavController().navigateSafely(
+            directions = DashboardFragmentDirections.actionDashboardToOnboardingFragment(),
+            extras = extras
+        )
+    }
+
+    @Suppress("ComplexMethod", "MagicNumber", "LongMethod")
+    private fun setupStateObservers() {
+        myStoreViewModel.appbarState.observe(viewLifecycleOwner) { requireActivity().invalidateOptionsMenu() }
+
+        myStoreViewModel.customRange.observe(viewLifecycleOwner) { customRange ->
+            binding.myStoreStats.handleCustomRangeTab(customRange)
+        }
+        myStoreViewModel.selectedDateRange.observe(viewLifecycleOwner) { statsTimeRangeSelection ->
+            binding.myStoreStats.loadDashboardStats(statsTimeRangeSelection)
+            binding.myStoreTopPerformers.onDateGranularityChanged(statsTimeRangeSelection.selectionType)
+            if (tabLayout.getTabAt(tabLayout.selectedTabPosition)?.tag != statsTimeRangeSelection.selectionType) {
+                val index = (0..tabLayout.tabCount)
+                    .firstOrNull { tabLayout.getTabAt(it)?.tag == statsTimeRangeSelection.selectionType }
+                index?.let {
+                    // Small delay needed to ensure tablayout scrolls to the selected tab if tab is not visible on screen.
+                    handler.postDelayed({ tabLayout.getTabAt(index)?.select() }, 300)
+                }
+            }
+        }
+        myStoreViewModel.revenueStatsState.observe(viewLifecycleOwner) { revenueStats ->
+            when (revenueStats) {
+                is RevenueStatsViewState.Content -> showStats(revenueStats.revenueStats)
+                RevenueStatsViewState.GenericError -> showStatsError()
+                RevenueStatsViewState.Loading -> showChartSkeleton(true)
+                RevenueStatsViewState.PluginNotActiveError -> updateStatsAvailabilityError()
+            }
+        }
+        myStoreViewModel.visitorStatsState.observe(viewLifecycleOwner) { stats ->
+            when (stats) {
+                is VisitorStatsViewState.Content -> showVisitorStats(stats.stats)
+                VisitorStatsViewState.Error -> {
+                    binding.jetpackBenefitsBanner.root.isVisible = false
+                    binding.myStoreStats.showVisitorStatsError()
+                }
+
+                is VisitorStatsViewState.Unavailable -> onVisitorStatsUnavailable(stats)
+            }
+        }
+        myStoreViewModel.topPerformersState.observe(viewLifecycleOwner) { topPerformers ->
+            when {
+                topPerformers.isLoading -> showTopPerformersLoading()
+                topPerformers.isError -> showTopPerformersError()
+                else -> showTopPerformers(topPerformers.topPerformers)
+            }
+        }
+        myStoreViewModel.hasOrders.observe(viewLifecycleOwner) { newValue ->
+            when (newValue) {
+                OrderState.Empty -> showEmptyView(true)
+                OrderState.AtLeastOne -> showEmptyView(false)
+            }
+        }
+        myStoreViewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is OpenTopPerformer -> findNavController().navigateSafely(
+                    NavGraphMainDirections.actionGlobalProductDetailFragment(
+                        mode = ProductDetailFragment.Mode.ShowProduct(event.productId),
+                        isTrashEnabled = false
+                    )
+                )
+
+                is OpenAnalytics -> {
+                    mainNavigationRouter?.showAnalytics(event.analyticsPeriod)
+                }
+
+                is ShowPrivacyBanner ->
+                    findNavController().navigate(
+                        PrivacyBannerFragmentDirections.actionGlobalPrivacyBannerFragment()
+                    )
+
+                is ShareStore -> ActivityUtils.shareStoreUrl(requireActivity(), event.storeUrl)
+
+                is ShowAIProductDescriptionDialog ->
+                    findNavController().navigateSafely(
+                        DashboardFragmentDirections.actionDashboardToAIProductDescriptionDialogFragment()
+                    )
+
+                is OpenDatePicker -> showDateRangePicker(
+                    fromMillis = event.fromDate.time,
+                    toMillis = event.toDate.time
+                ) { start, end ->
+                    myStoreViewModel.onCustomRangeSelected(StatsTimeRange(Date(start), Date(end)))
+                }
+
+                else -> event.isHandled = false
+            }
+        }
+        myStoreViewModel.lastUpdateStats.observe(viewLifecycleOwner) { lastUpdateMillis ->
+            binding.myStoreStats.showLastUpdate(lastUpdateMillis)
+        }
+        myStoreViewModel.lastUpdateTopPerformers.observe(viewLifecycleOwner) { lastUpdateMillis ->
+            binding.myStoreTopPerformers.showLastUpdate(lastUpdateMillis)
+        }
+        myStoreViewModel.storeName.observe(viewLifecycleOwner) { storeName ->
+            ((activity) as MainActivity).setSubtitle(storeName)
+        }
+    }
+
+    private fun onVisitorStatsUnavailable(state: VisitorStatsViewState.Unavailable) {
+        handleUnavailableVisitorStats()
+
+        val jetpackBenefitsBanner = state.benefitsBanner
+        if (jetpackBenefitsBanner.show) {
+            binding.jetpackBenefitsBanner.dismissButton.setOnClickListener {
+                jetpackBenefitsBanner.onDismiss()
+            }
+        }
+        if (jetpackBenefitsBanner.show && !binding.jetpackBenefitsBanner.root.isVisible) {
+            AnalyticsTracker.track(
+                stat = AnalyticsEvent.FEATURE_JETPACK_BENEFITS_BANNER,
+                properties = mapOf(AnalyticsTracker.KEY_JETPACK_BENEFITS_BANNER_ACTION to "shown")
+            )
+        }
+        binding.jetpackBenefitsBanner.root.isVisible = jetpackBenefitsBanner.show
+    }
+
+    private fun showTopPerformersLoading() {
+        binding.myStoreTopPerformers.showErrorView(false)
+        binding.myStoreTopPerformers.showSkeleton(true)
+    }
+
+    @Suppress("ForbiddenComment")
+    private fun prepareJetpackBenefitsBanner() {
+        appPrefsWrapper.setJetpackInstallationIsFromBanner(false)
+        binding.jetpackBenefitsBanner.root.isVisible = false
+        binding.jetpackBenefitsBanner.root.setOnClickListener {
+            AnalyticsTracker.track(
+                stat = AnalyticsEvent.FEATURE_JETPACK_BENEFITS_BANNER,
+                properties = mapOf(AnalyticsTracker.KEY_JETPACK_BENEFITS_BANNER_ACTION to "tapped")
+            )
+            appPrefsWrapper.setJetpackInstallationIsFromBanner(true)
+            findNavController().navigateSafely(DashboardFragmentDirections.actionDashboardToJetpackBenefitsDialog())
+        }
+        // For the banner to be above the bottom navigation view when the toolbar is expanded
+        viewLifecycleOwner.lifecycleScope.launch {
+            // Due to this issue https://issuetracker.google.com/issues/181325977, we need to make sure
+            // we are using `withCreated` here, since if this view doesn't reach the created state,
+            // the scope will not get cancelled.
+            // TODO: revisit this once https://issuetracker.google.com/issues/127528777 is implemented
+            // (no update as of Oct 2023)
+            val appBarLayout = requireActivity().findViewById<View>(R.id.app_bar_layout) as? AppBarLayout
+            withCreated {
+                appBarLayout?.verticalOffsetChanges()
+                    ?.onEach { verticalOffset ->
+                        binding.jetpackBenefitsBanner.root.translationY =
+                            (abs(verticalOffset) - appBarLayout.totalScrollRange).toFloat()
+                    }
+                    ?.launchIn(this)
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        handleFeedbackRequestCardState()
+        AnalyticsTracker.trackViewShown(this)
+        // Avoid executing interacted() on first load. Only when the user navigated away from the fragment.
+        if (wasPreviouslyStopped) {
+            usageTracksEventEmitter.interacted()
+            wasPreviouslyStopped = false
+        }
+    }
+
+    override fun onStop() {
+        wasPreviouslyStopped = true
+        errorSnackbar?.dismiss()
+        super.onStop()
+    }
+
+    override fun onDestroyView() {
+        handler.removeCallbacksAndMessages(null)
+        tabLayout.removeOnTabSelectedListener(tabSelectedListener)
+        super.onDestroyView()
+        _binding = null
+    }
+
+    override fun onDestroy() {
+        lifecycle.removeObserver(storeOnboardingViewModel)
+        super.onDestroy()
+    }
+
+    private fun showStats(revenueStatsModel: RevenueStatsUiModel?) {
+        binding.myStoreStats.showErrorView(false)
+        showChartSkeleton(false)
+
+        tabLayout.isVisible = AppPrefs.isV4StatsSupported()
+
+        binding.myStoreStats.updateView(revenueStatsModel)
+
+        // update the stats today widget if we're viewing today's stats
+        if (myStoreViewModel.selectedDateRange.value?.selectionType == SelectionType.TODAY) {
+            (activity as? MainActivity)?.updateStatsWidgets()
+        }
+    }
+
+    private fun showStatsError() {
+        showChartSkeleton(false)
+        binding.myStoreStats.showErrorView(true)
+        showErrorSnack()
+    }
+
+    private fun updateStatsAvailabilityError() {
+        binding.myStoreRefreshLayout.visibility = View.GONE
+        WooAnimUtils.fadeIn(binding.statsErrorScrollView)
+        showChartSkeleton(false)
+    }
+
+    private fun showTopPerformers(topPerformers: List<TopPerformerProductUiModel>) {
+        binding.myStoreTopPerformers.showSkeleton(false)
+        binding.myStoreTopPerformers.showErrorView(false)
+        binding.myStoreTopPerformers.updateView(topPerformers)
+    }
+
+    private fun showTopPerformersError() {
+        binding.myStoreTopPerformers.showSkeleton(false)
+        binding.myStoreTopPerformers.showErrorView(true)
+        showErrorSnack()
+    }
+
+    private fun showVisitorStats(visitorStats: Map<String, Int>) {
+        binding.jetpackBenefitsBanner.root.isVisible = false
+        binding.myStoreStats.showVisitorStats(visitorStats)
+    }
+
+    private fun handleUnavailableVisitorStats() {
+        binding.myStoreStats.handleJetpackUnavailableVisitorStats()
+    }
+
+    private fun showErrorSnack() {
+        if (errorSnackbar?.isShownOrQueued == false || NetworkUtils.isNetworkAvailable(context)) {
+            errorSnackbar = uiMessageResolver.getSnack(R.string.dashboard_stats_error)
+            errorSnackbar?.show()
+        }
+    }
+
+    private fun initJitm(savedInstanceState: Bundle?) {
+        // Show banners only if onboarding list is not displayed
+        if (!binding.storeOnboardingView.isVisible && savedInstanceState == null) {
+            childFragmentManager.beginTransaction()
+                .replace(
+                    R.id.jitmFragment,
+                    JitmFragment.newInstance(JitmMessagePathsProvider.MY_STORE),
+                    JITM_FRAGMENT_TAG
+                )
+                .commit()
+        }
+    }
+
+    private fun refreshJitm() {
+        childFragmentManager.findFragmentByTag(JITM_FRAGMENT_TAG)?.let {
+            (it as JitmFragment).refreshJitms()
+        }
+    }
+
+    override fun getFragmentTitle() = getString(R.string.my_store)
+
+    override fun getFragmentSubtitle(): String = myStoreViewModel.storeName.value ?: ""
+
+    override fun scrollToTop() {
+        binding.statsScrollView.smoothScrollTo(0, 0)
+    }
+
+    private fun showChartSkeleton(show: Boolean) {
+        binding.myStoreStats.showErrorView(false)
+        binding.myStoreStats.showSkeleton(show)
+    }
+
+    /**
+     * This method verifies if the feedback card should be visible.
+     *
+     * If it should but it's not, the feedback card is reconfigured and presented
+     * If should not and it's visible, the card visibility is changed to gone
+     * If should be and it's already visible, nothing happens
+     */
+    private fun handleFeedbackRequestCardState() = with(binding.storeFeedbackRequestCard) {
+        if (feedbackPrefs.userFeedbackIsDue && visibility == View.GONE) {
+            setupFeedbackRequestCard()
+        } else if (feedbackPrefs.userFeedbackIsDue.not() && visibility == View.VISIBLE) {
+            visibility = View.GONE
+        }
+    }
+
+    private fun setupFeedbackRequestCard() {
+        binding.storeFeedbackRequestCard.visibility = View.VISIBLE
+        val negativeCallback = {
+            mainNavigationRouter?.showFeedbackSurvey()
+            binding.storeFeedbackRequestCard.visibility = View.GONE
+            feedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
+        }
+        binding.storeFeedbackRequestCard.initView(negativeCallback, ::handleFeedbackRequestPositiveClick)
+    }
+
+    private fun handleFeedbackRequestPositiveClick() {
+        // set last feedback date to now and hide the card
+        feedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
+        binding.storeFeedbackRequestCard.visibility = View.GONE
+
+        // Request a ReviewInfo object from the Google Reviews API. If this fails
+        // we just move on as there isn't anything we can do.
+        val manager = ReviewManagerFactory.create(requireContext())
+        val reviewRequest = manager.requestReviewFlow()
+        reviewRequest.addOnCompleteListener {
+            if (activity != null && it.isSuccessful) {
+                // Request to start the Review flow so the user can be prompted to submit
+                // a play store review. The prompt will only appear if the user hasn't already
+                // reached their quota for how often we can ask for a review.
+                val reviewInfo = it.result
+                val flow = manager.launchReviewFlow(requireActivity(), reviewInfo)
+                flow.addOnFailureListener { ex ->
+                    WooLog.e(WooLog.T.DASHBOARD, "Error launching google review API flow.", ex)
+                }
+            } else {
+                // There was an error, just log and continue. Google doesn't really tell you what
+                // type of scenario would cause an error.
+                WooLog.e(
+                    WooLog.T.DASHBOARD,
+                    "Error fetching ReviewInfo object from Review API to start in-app review process",
+                    it.exception
+                )
+            }
+        }
+    }
+
+    private fun showEmptyView(show: Boolean) {
+        val dashboardVisibility: Int
+        if (show) {
+            dashboardVisibility = View.GONE
+            binding.emptyView.show(EmptyViewType.DASHBOARD) {
+                myStoreViewModel.onShareStoreClicked()
+            }
+        } else {
+            binding.emptyView.hide()
+            dashboardVisibility = View.VISIBLE
+        }
+        tabLayout.isVisible = !show && AppPrefs.isV4StatsSupported()
+        binding.myStoreStats.visibility = dashboardVisibility
+        binding.myStoreTopPerformers.visibility = dashboardVisibility
+        isEmptyViewVisible = show
+    }
+
+    override fun shouldExpandToolbar() = binding.statsScrollView.scrollY == 0
+
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.menu_my_store_fragment, menu)
+    }
+
+    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+        return when (menuItem.itemId) {
+            R.id.menu_share_store -> {
+                myStoreViewModel.onShareStoreClicked()
+                true
+            }
+
+            else -> false
+        }
+    }
+
+    override fun onPrepareMenu(menu: Menu) {
+        menu.findItem(R.id.menu_share_store).isVisible =
+            myStoreViewModel.appbarState.value?.showShareStoreButton ?: false
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsAvailabilityListener.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsAvailabilityListener.kt
@@ -1,0 +1,5 @@
+package com.woocommerce.android.ui.dashboard
+
+interface DashboardStatsAvailabilityListener {
+    fun onDashboardStatsRevertedNoticeCardDismissed()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsLineChart.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsLineChart.kt
@@ -1,0 +1,62 @@
+package com.woocommerce.android.ui.dashboard
+
+import android.content.Context
+import android.graphics.Point
+import android.util.AttributeSet
+import android.view.MotionEvent
+import com.github.mikephil.charting.charts.LineChart
+import com.woocommerce.android.R
+import kotlin.math.abs
+
+/**
+ * Creating a custom BarChart to fix this issue:
+ * https://github.com/woocommerce/woocommerce-android/issues/1048
+ */
+class DashboardStatsLineChart(context: Context, attrs: AttributeSet) : LineChart(
+    context,
+    attrs
+) {
+    init {
+        val typedArray = context.theme.obtainStyledAttributes(attrs, R.styleable.DashboardStatsBarChart, 0, 0)
+        typedArray.recycle()
+    }
+
+    private val startTouchPoint = Point(0, 0)
+
+    /**
+     * Method added to prevent the chart's parent view (i.e ScrollView) from
+     * intercepting the touch events during a horizontal scrubbing interaction
+     */
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        if (data != null) {
+            when (event.action) {
+                MotionEvent.ACTION_DOWN -> {
+                    startTouchPoint.x = event.x.toInt()
+                    startTouchPoint.y = event.y.toInt()
+                }
+                MotionEvent.ACTION_MOVE -> {
+                    val movement = Point(
+                        abs(event.x.toInt() - startTouchPoint.x),
+                        abs(event.y.toInt() - startTouchPoint.y)
+                    )
+                    // swallow the event if this is a horizontal scrub, which we determine by
+                    // checking if the vertical motion is less than the horizontal motion
+                    if (movement.y < movement.x) {
+                        // see https://github.com/PhilJay/MPAndroidChart/issues/925
+                        parent.requestDisallowInterceptTouchEvent(true)
+                        super.onTouchEvent(event)
+                        return true
+                    }
+                }
+                // according to the docs, we must make sure to reset the intercept setting
+                // when the user ends this event
+                MotionEvent.ACTION_CANCEL,
+                MotionEvent.ACTION_UP -> {
+                    parent.requestDisallowInterceptTouchEvent(false)
+                }
+            }
+        }
+
+        return super.onTouchEvent(event)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsRevertedNoticeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsRevertedNoticeCard.kt
@@ -1,0 +1,44 @@
+package com.woocommerce.android.ui.dashboard
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import com.google.android.material.card.MaterialCardView
+import com.woocommerce.android.AppUrls
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.MyStoreStatsRevertedNoticeBinding
+import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.WooAnimUtils
+
+/**
+ * Dashboard card that displays a reverted notice message if the WooCommerce Admin plugin
+ * is disabled/uninstalled from a site but the v4 stats is already displayed to the user
+ */
+class DashboardStatsRevertedNoticeCard @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(ctx, attrs, defStyleAttr) {
+    private val binding = MyStoreStatsRevertedNoticeBinding.inflate(LayoutInflater.from(ctx), this)
+
+    fun initView(listener: DashboardStatsAvailabilityListener) {
+        binding.myStoreRevertedViewMore.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                WooAnimUtils.fadeIn(binding.myStoreRevertedMorePanel)
+            } else {
+                WooAnimUtils.fadeOut(binding.myStoreRevertedMorePanel)
+            }
+        }
+
+        binding.btnLearnMore.setOnClickListener {
+            AnalyticsTracker.track(AnalyticsEvent.DASHBOARD_NEW_STATS_REVERTED_BANNER_LEARN_MORE_TAPPED)
+            ChromeCustomTabUtils.launchUrl(context, AppUrls.WOOCOMMERCE_PLUGIN)
+        }
+
+        binding.btnDismiss.setOnClickListener {
+            AnalyticsTracker.track(AnalyticsEvent.DASHBOARD_NEW_STATS_REVERTED_BANNER_DISMISS_TAPPED)
+            listener.onDashboardStatsRevertedNoticeCardDismissed()
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsUsageTracksEventEmitter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsUsageTracksEventEmitter.kt
@@ -1,0 +1,107 @@
+package com.woocommerce.android.ui.dashboard
+
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.di.AppCoroutineScope
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Accepts interaction events from the Analytics / My Store UI and decides whether the group of interactions can be
+ * considered as a _usage_ of the UI.
+ *
+ * See p91TBi-6Cl-p2 for more information about the algorithm.
+ *
+ * The UI should call [interacted] when these events happen:
+ *
+ * - Scrolling
+ * - Pull-to-refresh
+ * - Tapping on the bars in the chart
+ * - Changing the tab
+ * - Navigating to the My Store tab
+ * - Tapping on a product in the Top Performers list
+ *
+ * If we ever change the algorithm in the future, we should probably consider renaming the Tracks event to avoid
+ * incorrect comparisons with old events. We should also make sure to change the iOS code if we're changing anything
+ * in here. Both platforms should have the same algorithm so we are able to compare both.
+ */
+@Singleton
+class DashboardStatsUsageTracksEventEmitter @Inject constructor(
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val selectedSite: SelectedSite
+) {
+    private companion object {
+        /**
+         * The minimum amount of time (seconds) that the merchant have interacted with the
+         * Analytics UI before an event is triggered.
+         */
+        const val MINIMUM_INTERACTION_TIME = 10
+
+        /**
+         * The minimum number of Analytics UI interactions before an event is triggered.
+         */
+        const val INTERACTIONS_THRESHOLD = 5
+
+        /**
+         * The maximum number of seconds in between interactions before we will consider the
+         * merchant to have been idle. If they were idle, the time and interactions counting
+         * will be reset.
+         */
+        const val IDLE_TIME_THRESHOLD = 20
+    }
+
+    private var interactions = 0
+    private var firstInteractionTime: Date? = null
+    private var lastInteractionTime: Date? = null
+
+    init {
+        // Reset if the user changed to a different site.
+        selectedSite.observe()
+            .onEach { reset() }
+            .launchIn(appCoroutineScope)
+    }
+
+    fun interacted(interactionTime: Date = Date()) {
+        // Check if they were idle for some time.
+        lastInteractionTime?.let {
+            if (DateTimeUtils.secondsBetween(interactionTime, it) >= IDLE_TIME_THRESHOLD) {
+                reset()
+            }
+        }
+
+        val firstInteractionTime = firstInteractionTime ?: run {
+            interactions = 1
+            firstInteractionTime = interactionTime
+            lastInteractionTime = interactionTime
+
+            return
+        }
+
+        interactions++
+        lastInteractionTime = interactionTime
+
+        if (DateTimeUtils.secondsBetween(interactionTime, firstInteractionTime) >= MINIMUM_INTERACTION_TIME &&
+            interactions >= INTERACTIONS_THRESHOLD
+        ) {
+            reset()
+            analyticsTrackerWrapper.track(AnalyticsEvent.USED_ANALYTICS)
+        }
+    }
+
+    private fun reset() {
+        interactions = 0
+        firstInteractionTime = null
+        lastInteractionTime = null
+    }
+
+    fun interactedWithCustomRange() {
+        analyticsTrackerWrapper.track(AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_INTERACTED)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -63,6 +63,7 @@ import kotlin.math.round
 import kotlin.time.Duration.Companion.days
 
 @FlowPreview
+@Suppress("MagicNumber")
 class DashboardStatsView @JvmOverloads constructor(
     ctx: Context,
     attrs: AttributeSet? = null,
@@ -98,7 +99,7 @@ class DashboardStatsView @JvmOverloads constructor(
                 binding.chart.setNoDataText(null)
                 binding.chart.clear()
             } else {
-                // TODO: add a custom empty view
+                // TODO add a custom empty view
                 binding.chart.setNoDataText(context.getString(R.string.dashboard_state_no_data))
             }
             field = value

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -1,0 +1,900 @@
+package com.woocommerce.android.ui.dashboard
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
+import android.widget.TextView
+import androidx.annotation.ColorRes
+import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
+import androidx.core.view.doOnDetach
+import androidx.core.view.isVisible
+import androidx.core.widget.addTextChangedListener
+import androidx.lifecycle.LifecycleCoroutineScope
+import com.github.mikephil.charting.charts.Chart
+import com.github.mikephil.charting.components.AxisBase
+import com.github.mikephil.charting.components.MarkerImage
+import com.github.mikephil.charting.components.XAxis
+import com.github.mikephil.charting.data.Entry
+import com.github.mikephil.charting.data.LineData
+import com.github.mikephil.charting.data.LineDataSet
+import com.github.mikephil.charting.formatter.ValueFormatter
+import com.github.mikephil.charting.highlight.Highlight
+import com.github.mikephil.charting.listener.ChartTouchListener.ChartGesture
+import com.github.mikephil.charting.listener.OnChartValueSelectedListener
+import com.google.android.material.card.MaterialCardView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.tabs.TabLayout.Tab
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_DATE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_GRANULARITY
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_RANGE
+import com.woocommerce.android.databinding.MyStoreStatsBinding
+import com.woocommerce.android.extensions.convertedFrom
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.analytics.ranges.revenueStatsGranularity
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.Companion.SUPPORTED_RANGES_ON_MY_STORE_TAB
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.WooAnimUtils
+import com.woocommerce.android.util.WooAnimUtils.Duration
+import com.woocommerce.android.util.roundToTheNextPowerOfTen
+import com.woocommerce.android.widgets.SkeletonView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import org.wordpress.android.util.DisplayUtils
+import java.util.Locale
+import kotlin.math.round
+import kotlin.time.Duration.Companion.days
+
+@FlowPreview
+class DashboardStatsView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(ctx, attrs, defStyleAttr), OnChartValueSelectedListener, BarChartGestureListener {
+    private val binding = MyStoreStatsBinding.inflate(LayoutInflater.from(ctx), this)
+
+    companion object {
+        private const val LINE_CHART_DOT_OFFSET = -5
+        private const val EVENT_EMITTER_INTERACTION_DEBOUNCE = 1000L
+    }
+
+    private lateinit var statsTimeRangeSelection: StatsTimeRangeSelection
+    private lateinit var selectedSite: SelectedSite
+    private lateinit var dateUtils: DateUtils
+    private lateinit var currencyFormatter: CurrencyFormatter
+    private lateinit var usageTracksEventEmitter: DashboardStatsUsageTracksEventEmitter
+
+    private var revenueStatsModel: RevenueStatsUiModel? = null
+    private var chartRevenueStats = mapOf<String, Double>()
+    private var chartOrderStats = mapOf<String, Long>()
+    private var chartVisitorStats = mapOf<String, Int>()
+
+    private var skeletonView = SkeletonView()
+
+    private var isRequestingStats = false
+        set(value) {
+            // if we're requesting chart data we clear the existing data so it doesn't continue
+            // to appear, and we remove the chart's empty string so it doesn't briefly show
+            // up before the chart data is added once the request completes
+            if (value) {
+                clearStatsHeaderValues()
+                binding.chart.setNoDataText(null)
+                binding.chart.clear()
+            } else {
+                // TODO: add a custom empty view
+                binding.chart.setNoDataText(context.getString(R.string.dashboard_state_no_data))
+            }
+            field = value
+        }
+
+    private val fadeHandler = Handler(Looper.getMainLooper())
+
+    private val statsDateValue
+        get() = binding.statsViewRow.statsDateTextView
+
+    private val revenueValue
+        get() = binding.statsViewRow.totalRevenueTextView
+
+    private val ordersValue
+        get() = binding.statsViewRow.ordersValueTextView
+
+    private val visitorsValue
+        get() = binding.statsViewRow.visitorsValueTextview
+
+    private val lastUpdated
+        get() = binding.statsViewRow.lastUpdatedTextView
+
+    private val conversionValue
+        get() = binding.statsViewRow.conversionValueTextView
+
+    val customRangeLabel
+        get() = binding.statsViewRow.statsCustomDateRangeTextView
+
+    private val customRangeGranularityLabel
+        get() = binding.customRangeGranularityLabel
+
+    val customRangeButton = binding.customRangeButton
+
+    val tabLayout = binding.statsTabLayout
+    private val customRangeTab: Tab by lazy {
+        tabLayout.newTab().apply {
+            setText(getStringForRangeType(SelectionType.CUSTOM))
+            tag = SelectionType.CUSTOM
+        }
+    }
+
+    private lateinit var coroutineScope: CoroutineScope
+    private val chartUserInteractions = MutableSharedFlow<Unit>()
+    private lateinit var chartUserInteractionsJob: Job
+
+    private var isChartValueSelected = false
+
+    private var isJetpackVisitorStatsUnavailable = false
+
+    @Suppress("LongParameterList")
+    fun initView(
+        selectedSite: SelectedSite,
+        dateUtils: DateUtils,
+        currencyFormatter: CurrencyFormatter,
+        usageTracksEventEmitter: DashboardStatsUsageTracksEventEmitter,
+        lifecycleScope: LifecycleCoroutineScope,
+        onViewAnalyticsClick: () -> Unit
+    ) {
+        this.selectedSite = selectedSite
+        this.dateUtils = dateUtils
+        this.currencyFormatter = currencyFormatter
+        this.usageTracksEventEmitter = usageTracksEventEmitter
+        this.coroutineScope = lifecycleScope
+
+        initChart()
+
+        binding.viewAnalyticsButton.setOnClickListener {
+            onViewAnalyticsClick()
+        }
+
+        visitorsValue.addTextChangedListener {
+            updateConversionRate()
+        }
+
+        ordersValue.addTextChangedListener {
+            updateConversionRate()
+        }
+
+        chartUserInteractionsJob = coroutineScope.launch {
+            chartUserInteractions
+                .debounce(EVENT_EMITTER_INTERACTION_DEBOUNCE)
+                .collect {
+                    usageTracksEventEmitter.interacted()
+
+                    if (statsTimeRangeSelection.selectionType == SelectionType.CUSTOM) {
+                        usageTracksEventEmitter.interactedWithCustomRange()
+                    }
+                }
+        }
+
+        customRangeButton.isVisible = FeatureFlag.CUSTOM_RANGE_ANALYTICS.isEnabled()
+        // Create tabs and add to appbar
+        SUPPORTED_RANGES_ON_MY_STORE_TAB
+            .filter { it != SelectionType.CUSTOM }
+            .forEach { rangeType ->
+                val tab = tabLayout.newTab().apply {
+                    setText(getStringForRangeType(rangeType))
+                    tag = rangeType
+                }
+                tabLayout.addTab(tab)
+            }
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        chartUserInteractionsJob.cancel()
+    }
+
+    fun loadDashboardStats(selectedTimeRange: StatsTimeRangeSelection) {
+        this.statsTimeRangeSelection = selectedTimeRange
+        // Track range change
+        AnalyticsTracker.track(
+            AnalyticsEvent.DASHBOARD_MAIN_STATS_DATE,
+            mapOf(KEY_RANGE to selectedTimeRange.selectionType.toString().lowercase())
+        )
+        isRequestingStats = true
+        applyCustomRange(statsTimeRangeSelection)
+    }
+
+    fun handleCustomRangeTab(customRange: StatsTimeRange?) {
+        if (customRange != null) {
+            customRangeButton.isVisible = false
+            if (customRangeTab.view.parent == null) {
+                tabLayout.addTab(customRangeTab)
+            }
+        } else {
+            customRangeButton.isVisible = true
+            if (customRangeTab.view.parent != null) {
+                tabLayout.removeTab(customRangeTab)
+            }
+        }
+    }
+
+    private fun applyCustomRange(selectedTimeRange: StatsTimeRangeSelection) {
+        if (selectedTimeRange.selectionType == SelectionType.CUSTOM) {
+            customRangeLabel.isVisible = true
+            customRangeGranularityLabel.isVisible = true
+            customRangeLabel.text = selectedTimeRange.currentRangeDescription
+            customRangeGranularityLabel.text = getStringForGranularity(selectedTimeRange.revenueStatsGranularity)
+        } else {
+            customRangeLabel.isVisible = false
+            customRangeGranularityLabel.isVisible = false
+        }
+    }
+
+    fun showSkeleton(show: Boolean) {
+        if (show) {
+            skeletonView.show(
+                binding.statsContent,
+                R.layout.skeleton_dashboard_stats,
+                delayed = true
+            )
+        } else {
+            skeletonView.hide()
+        }
+    }
+
+    private fun getChartXAxisLabelCount(): Int {
+        val resId = when (statsTimeRangeSelection.selectionType) {
+            SelectionType.TODAY -> R.integer.stats_label_count_days
+            SelectionType.WEEK_TO_DATE -> R.integer.stats_label_count_weeks
+            SelectionType.MONTH_TO_DATE -> R.integer.stats_label_count_months
+            SelectionType.YEAR_TO_DATE -> R.integer.stats_label_count_years
+            SelectionType.CUSTOM -> R.integer.stats_label_count_custom_range
+            else -> error("Unsupported range value used in my store tab: ${statsTimeRangeSelection.selectionType}")
+        }
+        val chartRevenueStatsSize = chartRevenueStats.keys.size
+        val barLabelCount = context.resources.getInteger(resId)
+        return if (chartRevenueStatsSize < barLabelCount) {
+            chartRevenueStatsSize
+        } else {
+            barLabelCount
+        }
+    }
+
+    /**
+     * One-time chart initialization with settings common to all granularities.
+     */
+    private fun initChart() {
+        with(binding.chart) {
+            with(xAxis) {
+                position = XAxis.XAxisPosition.BOTTOM
+                setDrawGridLines(false)
+                setDrawAxisLine(false)
+                granularity = 1f // Don't break x axis values down further than 1 unit of time
+                textColor = ContextCompat.getColor(context, R.color.graph_label_color)
+                // Couldn't use the dimension resource here due to the way this component is written :/
+                textSize = 10f
+            }
+            with(axisLeft) {
+                setLabelCount(3, true)
+                valueFormatter = RevenueAxisFormatter()
+                setDrawGridLines(true)
+                gridLineWidth = 1f
+                gridColor = ContextCompat.getColor(context, R.color.graph_grid_color)
+                setDrawAxisLine(false)
+                textColor = ContextCompat.getColor(context, R.color.graph_label_color)
+                // Couldn't use the dimension resource here due to the way this component is written :/
+                textSize = 10f
+            }
+            axisRight.isEnabled = false
+            description.isEnabled = false
+            legend.isEnabled = false
+
+            // touch has to be enabled in order to show a marker when dragging across the line chart
+            setTouchEnabled(true)
+            setPinchZoom(false)
+            isScaleXEnabled = false
+            isScaleYEnabled = false
+            isDragEnabled = true
+
+            setNoDataTextColor(ContextCompat.getColor(context, R.color.graph_no_data_text_color))
+            getPaint(Chart.PAINT_INFO).textSize = context.resources.getDimension(R.dimen.text_minor_125)
+        }
+        binding.chart.setOnChartValueSelectedListener(this)
+        binding.chart.onChartGestureListener = this
+    }
+
+    /**
+     * Called when nothing has been selected or an "un-select" has been made.
+     */
+    override fun onNothingSelected() {
+        // update the total values of the chart here
+        binding.chart.highlightValue(null)
+        updateChartView()
+        showTotalVisitorStats()
+        updateDate(revenueStatsModel, statsTimeRangeSelection)
+        updateColorForStatsHeaderValues(R.color.color_on_surface_high)
+        onUserInteractionWithChart()
+        if (statsTimeRangeSelection.selectionType == SelectionType.CUSTOM) statsDateValue.isVisible = false
+        isChartValueSelected = false
+    }
+
+    private fun onUserInteractionWithChart() {
+        coroutineScope.launch {
+            chartUserInteractions.emit(Unit)
+        }
+    }
+
+    private fun updateColorForStatsHeaderValues(@ColorRes colorRes: Int) {
+        val color = ContextCompat.getColor(context, colorRes)
+        revenueValue.setTextColor(color)
+        ordersValue.setTextColor(color)
+        visitorsValue.setTextColor(color)
+        conversionValue.setTextColor(color)
+    }
+
+    /**
+     * Method to update the date value for a given [revenueStatsModel] based on the [rangeType]
+     * This is used to display the date bar when the **stats tab is loaded**
+     * [StatsGranularity.DAYS] would be Tuesday, Aug 08
+     * [StatsGranularity.WEEKS] would be Aug 4 - Aug 08
+     * [StatsGranularity.MONTHS] would be August
+     * [StatsGranularity.YEARS] would be 2019
+     */
+    private fun updateDate(
+        revenueStats: RevenueStatsUiModel?,
+        statsTimeRangeSelection: StatsTimeRangeSelection
+    ) {
+        if (revenueStats?.intervalList.isNullOrEmpty()) {
+            statsDateValue.visibility = View.GONE
+        } else {
+            val rangeType = statsTimeRangeSelection.selectionType
+            val startInterval = revenueStats?.intervalList?.first()?.interval
+            val startDate = startInterval?.let { getDateValueFromRangeType(it, rangeType) }
+
+            val dateRangeString = when (rangeType) {
+                SelectionType.WEEK_TO_DATE -> {
+                    val endInterval = revenueStats?.intervalList?.last()?.interval
+                    val endDate = endInterval?.let { getDateValueFromRangeType(it, rangeType) }
+                    String.format(Locale.getDefault(), "%s – %s", startDate, endDate)
+                }
+
+                else -> startDate
+            }
+            if (statsTimeRangeSelection.selectionType != SelectionType.CUSTOM) statsDateValue.isVisible = true
+            statsDateValue.text = dateRangeString
+        }
+    }
+
+    /**
+     * Method to get the date value for a given [dateString] based on the [rangeType]
+     * This is used to populate the date bar when the **stats tab is loaded**
+     * [TODAY] would be Tuesday, Aug 08
+     * [WEEK_TO_DATE] would be Aug 4
+     * [MONTH_TO_DATE] would be August
+     * [YEAR_TO_DATE] would be 2019
+     * [CUSTOM] Any of the above formats depending on the custom range length
+     */
+    private fun getDateValueFromRangeType(
+        dateString: String,
+        rangeType: SelectionType
+    ): String {
+        return when (rangeType) {
+            SelectionType.TODAY -> dateUtils.getDayMonthDateString(dateString).orEmpty()
+            SelectionType.WEEK_TO_DATE -> dateUtils.getShortMonthDayString(dateString).orEmpty()
+            SelectionType.MONTH_TO_DATE -> dateUtils.getMonthString(dateString).orEmpty()
+            SelectionType.YEAR_TO_DATE -> dateUtils.getYearString(dateString).orEmpty()
+            SelectionType.CUSTOM -> getDateValueFromGranularity(
+                dateString,
+                statsTimeRangeSelection.revenueStatsGranularity
+            )
+            else -> error("Unsupported range value used in my store tab: $rangeType")
+        }.also { result -> trackUnexpectedFormat(result, dateString) }
+    }
+
+    /**
+     * Method to get the date value for a given [dateString] based on the [rangeType]
+     * This is used to populate the date bar when the **stats tab is loaded**
+     * [StatsGranularity.DAYS] would be Tuesday, Aug 08
+     * [StatsGranularity.WEEKS] would be Aug 4
+     * [StatsGranularity.MONTHS] would be August
+     * [StatsGranularity.YEARS] would be 2019
+     */
+    private fun getDateValueFromGranularity(
+        dateString: String,
+        activeGranularity: StatsGranularity
+    ): String {
+        return when (activeGranularity) {
+            StatsGranularity.HOURS -> dateUtils.getFriendlyDayHourString(dateString).orEmpty()
+            StatsGranularity.DAYS -> dateUtils.getDayMonthDateString(dateString).orEmpty()
+            StatsGranularity.WEEKS -> dateUtils.getShortMonthDayString(dateString).orEmpty()
+            StatsGranularity.MONTHS -> dateUtils.getMonthString(dateString).orEmpty()
+            StatsGranularity.YEARS -> dateString
+        }.also { result -> trackUnexpectedFormat(result, dateString) }
+    }
+
+    override fun onValueSelected(entry: Entry?, h: Highlight?) {
+        if (entry == null) return
+        // display the revenue for this entry
+        val formattedRevenue = currencyFormatter.getFormattedAmountZeroRounded(
+            entry.y.toDouble(),
+            revenueStatsModel?.currencyCode.orEmpty()
+        )
+        revenueValue.text = formattedRevenue
+
+        // display the order count for this entry
+        val date = getDateFromIndex(entry.x.toInt())
+        val orderCount = chartOrderStats[date]?.toInt() ?: 0
+        ordersValue.text = orderCount.toString()
+        updateVisitorsValue(date)
+        updateConversionRate()
+        updateDateOnScrubbing(date, statsTimeRangeSelection.selectionType)
+        updateColorForStatsHeaderValues(R.color.color_secondary)
+        onUserInteractionWithChart()
+        statsDateValue.isVisible = true
+        isChartValueSelected = true
+    }
+
+    private fun updateVisitorsValue(date: String) {
+        if (isJetpackVisitorStatsUnavailable) return
+        if (statsTimeRangeSelection.revenueStatsGranularity == StatsGranularity.HOURS) {
+            // The visitor stats don't support hours granularity, so we need to hide them
+            visitorsValue.isVisible = false
+            visitorsValue.setText(R.string.emdash)
+            binding.statsViewRow.emptyVisitorStatsIndicator.isVisible = true
+        } else {
+            visitorsValue.isVisible = true
+            binding.statsViewRow.emptyVisitorsStatsGroup.isVisible = false
+            visitorsValue.text = chartVisitorStats[date]?.toString() ?: "0"
+        }
+    }
+
+    /**
+     * Method to update the date value for a given [dateString] based on the [SelectionType]
+     * This is used to display the date bar when the **scrubbing interaction is taking place**
+     * [SelectionType.TODAY] would be Tuesday, Aug 08›7am
+     * [SelectionType.WEEK_TO_DATE] would be Tuesday, Aug 08›7am
+     * [SelectionType.MONTH_TO_DATE] would be Aug 08
+     * [SelectionType.YEAR_TO_DATE] would be August›08
+     * [SelectionType.CUSTOM] Any of the above formats depending on the custom range length
+     */
+    private fun updateDateOnScrubbing(dateString: String, rangeType: SelectionType) {
+        statsDateValue.text = when (rangeType) {
+            SelectionType.TODAY -> dateUtils.getFriendlyDayHourString(dateString).orEmpty()
+            SelectionType.WEEK_TO_DATE -> dateUtils.getShortMonthDayString(dateString).orEmpty()
+            SelectionType.MONTH_TO_DATE -> dateUtils.getLongMonthDayString(dateString).orEmpty()
+            SelectionType.YEAR_TO_DATE -> dateUtils.getFriendlyLongMonthYear(dateString).orEmpty()
+            SelectionType.CUSTOM -> getDisplayDateForGranularity(
+                dateString,
+                statsTimeRangeSelection.revenueStatsGranularity
+            )
+
+            else -> error("Unsupported range value used in my store tab: $rangeType")
+        }.also { result -> trackUnexpectedFormat(result, dateString) }
+    }
+
+    /**
+     * Returns a display date for the given date and granularity [StatsGranularity]
+     * [StatsGranularity.HOURS] would be 7am, 8am, 9am
+     * [StatsGranularity.DAYS] would be Aug 1, 2, 3
+     * [StatsGranularity.WEEKS] would be 31 Jan, 5 Feb, 12 Feb, 19 Feb, 26 Feb
+     * [StatsGranularity.MONTHS] would be Sept, Oct, Nov, Dec
+     * [StatsGranularity.YEARS] would be 2019, 2020, 2021, 2022
+     */
+    private fun getDisplayDateForGranularity(dateString: String, statsGranularity: StatsGranularity): String =
+        when (statsGranularity) {
+            StatsGranularity.HOURS -> dateUtils.getShortHourString(dateString).orEmpty()
+            StatsGranularity.DAYS -> dateUtils.getDayString(dateString).orEmpty()
+            StatsGranularity.WEEKS -> dateUtils.getShortMonthDayStringForWeek(dateString).orEmpty()
+            StatsGranularity.MONTHS -> dateUtils.getShortMonthString(dateString).orEmpty()
+            StatsGranularity.YEARS -> dateString
+        }.also { result -> trackUnexpectedFormat(result, dateString) }
+
+    /**
+     * Method called when a touch-gesture has ended on the chart (ACTION_UP, ACTION_CANCEL)
+     * If the touch gesture has ended, then display the entire chart data again
+     */
+    override fun onChartGestureEnd(me: MotionEvent?, lastPerformedGesture: ChartGesture?) {
+        if (lastPerformedGesture == ChartGesture.DRAG || lastPerformedGesture == ChartGesture.FLING) {
+            onNothingSelected()
+        }
+    }
+
+    fun updateView(revenueStatsModel: RevenueStatsUiModel?) {
+        updateDate(revenueStatsModel, statsTimeRangeSelection)
+        this.revenueStatsModel = revenueStatsModel
+
+        // There are times when the stats v4 api returns no grossRevenue or ordersCount for a site
+        // https://github.com/woocommerce/woocommerce-android/issues/1455#issuecomment-540401646
+        this.chartRevenueStats = revenueStatsModel?.intervalList?.associate {
+            it.interval!! to (it.sales ?: 0.0)
+        } ?: mapOf()
+
+        this.chartOrderStats = revenueStatsModel?.intervalList?.associate {
+            it.interval!! to (it.ordersCount ?: 0)
+        } ?: mapOf()
+
+        updateChartView()
+    }
+
+    fun showErrorView(show: Boolean) {
+        isRequestingStats = false
+        binding.dashboardStatsError.isVisible = show
+        binding.chart.isVisible = !show
+    }
+
+    fun showVisitorStats(visitorStats: Map<String, Int>) {
+        isJetpackVisitorStatsUnavailable = false
+        chartVisitorStats = getFormattedVisitorStats(visitorStats)
+        showTotalVisitorStats()
+    }
+
+    fun showVisitorStatsError() {
+        binding.statsViewRow.emptyVisitorStatsIndicator.isVisible = true
+        binding.statsViewRow.emptyVisitorsStatsGroup.isVisible = false
+        binding.statsViewRow.visitorsValueTextview.isVisible = false
+    }
+
+    fun handleJetpackUnavailableVisitorStats() {
+        isJetpackVisitorStatsUnavailable = true
+        binding.statsViewRow.emptyVisitorsStatsGroup.isVisible = true
+        binding.statsViewRow.visitorsValueTextview.isVisible = false
+        binding.statsViewRow.emptyVisitorStatsIcon.apply {
+            setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_jetpack_logo))
+            imageTintList = null
+        }
+    }
+
+    private fun showTotalVisitorStats() {
+        if (isJetpackVisitorStatsUnavailable) return
+        if (statsTimeRangeSelection.isTotalVisitorsUnavailable()) {
+            // When using custom ranges, the total visitors value is not accurate, so we hide it
+            hideVisitorStatsForCustomRange()
+            return
+        } else {
+            // Make sure the empty view is hidden
+            binding.statsViewRow.emptyVisitorsStatsGroup.isVisible = false
+            val totalVisitors = chartVisitorStats.values.sum()
+            fadeInLabelValue(visitorsValue, totalVisitors.toString())
+        }
+    }
+
+    private fun hideVisitorStatsForCustomRange() {
+        fun showDialog() {
+            // Make sure the dialog is shown only when appropriate
+            if (!statsTimeRangeSelection.isTotalVisitorsUnavailable() || isChartValueSelected) return
+
+            val dialog = MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.my_store_custom_range_visitors_stats_unavailable_title)
+                .setMessage(R.string.my_store_custom_range_visitors_stats_unavailable_message)
+                .setPositiveButton(R.string.dialog_ok, null)
+                .show()
+
+            doOnDetach {
+                // To prevent leaking the dialog's window
+                dialog.dismiss()
+            }
+        }
+
+        binding.statsViewRow.visitorsValueTextview.isVisible = false
+        binding.statsViewRow.emptyVisitorsStatsGroup.isVisible = true
+        binding.statsViewRow.conversionValueTextView.isVisible = false
+        binding.statsViewRow.emptyConversionRateIndicator.isVisible = true
+
+        binding.statsViewRow.emptyVisitorStatsIcon.apply {
+            setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_tintable_info_outline_24dp))
+            imageTintList = ContextCompat.getColorStateList(context, R.color.color_primary)
+            setOnClickListener { showDialog() }
+        }
+
+        binding.statsViewRow.emptyVisitorStatsIndicator.setOnClickListener {
+            showDialog()
+        }
+    }
+
+    fun showLastUpdate(lastUpdateMillis: Long?) {
+        if (lastUpdateMillis != null) {
+            val lastUpdateFormatted = dateUtils.getDateOrTimeFromMillis(lastUpdateMillis)
+            lastUpdated.isVisible = true
+            fadeInLabelValue(
+                lastUpdated,
+                String.format(
+                    Locale.getDefault(),
+                    resources.getString(R.string.last_update),
+                    lastUpdateFormatted
+                )
+            )
+        } else {
+            lastUpdated.isVisible = false
+        }
+    }
+
+    @Suppress("MagicNumber")
+    private fun updateConversionRate() {
+        val ordersCount = ordersValue.text.toString().toIntOrNull()
+        val visitorsCount = visitorsValue.text.toString().toIntOrNull()?.takeIf {
+            visitorsValue.isVisible
+        }
+
+        if (visitorsCount == null || ordersCount == null) {
+            conversionValue.isVisible = false
+            binding.statsViewRow.emptyConversionRateIndicator.isVisible = true
+            return
+        }
+        val conversionRateDisplayValue = ordersCount convertedFrom visitorsCount
+        val color = ContextCompat.getColor(context, R.color.color_on_surface_high)
+        conversionValue.setTextColor(color)
+        binding.statsViewRow.emptyConversionRateIndicator.isVisible = false
+        conversionValue.isVisible = true
+        conversionValue.text = conversionRateDisplayValue
+    }
+
+    fun clearStatsHeaderValues() {
+        statsDateValue.text = ""
+        lastUpdated.text = ""
+        updateColorForStatsHeaderValues(R.color.skeleton_color)
+
+        visitorsValue.setText(R.string.emdash)
+        revenueValue.setText(R.string.emdash)
+        ordersValue.setText(R.string.emdash)
+        conversionValue.setText(R.string.emdash)
+    }
+
+    fun clearChartData() {
+        binding.chart.data?.clearValues()
+    }
+
+    private fun updateChartView() {
+        val wasEmpty = binding.chart.lineData?.let { it.dataSetCount == 0 } ?: true
+
+        val grossRevenue = revenueStatsModel?.totalSales ?: 0.0
+        val revenue = currencyFormatter.getFormattedAmountZeroRounded(
+            grossRevenue,
+            revenueStatsModel?.currencyCode.orEmpty()
+        )
+
+        val orderCount = revenueStatsModel?.totalOrdersCount ?: 0
+        val orders = orderCount.toString()
+
+        fadeInLabelValue(revenueValue, revenue)
+        fadeInLabelValue(ordersValue, orders)
+
+        if (chartRevenueStats.isEmpty() || revenueStatsModel?.totalSales == 0.toDouble()) {
+            isRequestingStats = false
+            return
+        }
+
+        val dataSet = generateLineDataSet(chartRevenueStats).apply {
+            color = ContextCompat.getColor(context, R.color.color_primary)
+            setDrawValues(false)
+            isHighlightEnabled = true
+            highLightColor = ContextCompat.getColor(context, R.color.graph_data_color)
+            highlightLineWidth = 1.5f
+            setDrawHorizontalHighlightIndicator(false)
+            setDrawCircles(false)
+            lineWidth = 2f
+            if (chartRevenueStats.all { it.value <= 0 }) {
+                setDrawFilled(false)
+            } else {
+                fillDrawable = ContextCompat.getDrawable(context, R.drawable.line_chart_fill_gradient)
+                setDrawFilled(true)
+            }
+        }
+
+        // determine the min revenue so we can set the min value for the left axis, which should be zero unless
+        // the stats contain any negative revenue
+        val minRevenue = dataSet.values.minOf { it.y }
+        val maxRevenue = dataSet.values.maxOf { it.y }
+        val duration = context.resources.getInteger(android.R.integer.config_shortAnimTime)
+        with(binding.chart) {
+            data = LineData(dataSet)
+            if (wasEmpty) {
+                animateY(duration)
+            }
+            with(xAxis) {
+                labelCount = getChartXAxisLabelCount()
+                valueFormatter = StartEndDateAxisFormatter()
+            }
+            with(axisLeft) {
+                if (minRevenue < 0) {
+                    setDrawZeroLine(true)
+                    zeroLineColor = ContextCompat.getColor(context, R.color.divider_color)
+                }
+                axisMinimum = minRevenue.roundToTheNextPowerOfTen()
+                axisMaximum = maxRevenue.roundToTheNextPowerOfTen()
+            }
+            val dot = MarkerImage(context, R.drawable.chart_highlight_dot)
+            val offset = DisplayUtils.dpToPx(context, LINE_CHART_DOT_OFFSET).toFloat()
+            dot.setOffset(offset, offset)
+            marker = dot
+        }
+        isRequestingStats = false
+    }
+
+    private fun getDateFromIndex(dateIndex: Int) = chartRevenueStats.keys.elementAt(dateIndex - 1)
+
+    /**
+     * Method to format the incoming visitor stats data
+     * The [visitorStats] map keys are in a different date format compared to [chartRevenueStats] map date format.
+     * To add scrubbing interaction, we are converting the [visitorStats] date format to [chartRevenueStats] date format
+     * [StatsGranularity.WEEKS] format is the same for both
+     * [StatsGranularity.MONTHS] format is the same for both
+     * [StatsGranularity.YEARS] visitor stats date format (yyyy-MM-dd) to yyyy-MM
+     * [StatsGranularity.DAYS] format is the same for both
+     */
+    private fun getFormattedVisitorStats(visitorStats: Map<String, Int>): Map<String, Int> {
+        return if (statsTimeRangeSelection.selectionType == SelectionType.YEAR_TO_DATE) {
+            visitorStats.mapKeys {
+                dateUtils.getYearMonthString(it.key) ?: it.key.take("yyyy-MM".length)
+            }
+        } else {
+            visitorStats
+        }
+    }
+
+    private fun fadeInLabelValue(view: TextView, value: String) {
+        // do nothing if value hasn't changed
+        if (view.text.toString() == value) {
+            return
+        }
+
+        // fade out the current value
+        val duration = Duration.SHORT
+        WooAnimUtils.fadeOut(view, duration, View.INVISIBLE)
+
+        // fade in the new value after fade out finishes
+        val delay = duration.toMillis(context) + 100
+        fadeHandler.postDelayed(
+            {
+                WooAnimUtils.fadeIn(view, duration)
+                val color = ContextCompat.getColor(context, R.color.color_on_surface_high)
+                view.setTextColor(color)
+                view.text = value
+            },
+            delay
+        )
+    }
+
+    private fun generateLineDataSet(revenueStats: Map<String, Double>): LineDataSet {
+        chartRevenueStats = revenueStats
+        val entries = chartRevenueStats.values.mapIndexed { index, value ->
+            Entry((index + 1).toFloat(), value.toFloat())
+        }
+        return LineDataSet(entries, "")
+    }
+
+    @StringRes
+    private fun getStringForRangeType(rangeType: SelectionType): Int {
+        return when (rangeType) {
+            SelectionType.TODAY -> R.string.today
+            SelectionType.WEEK_TO_DATE -> R.string.this_week
+            SelectionType.MONTH_TO_DATE -> R.string.this_month
+            SelectionType.YEAR_TO_DATE -> R.string.this_year
+            SelectionType.CUSTOM -> R.string.orderfilters_date_range_filter_custom_range
+            else -> error("Unsupported range value used in my store tab: $rangeType")
+        }
+    }
+
+    private fun getStringForGranularity(granularity: StatsGranularity): String {
+        val granularityLabel = when (granularity) {
+            StatsGranularity.HOURS -> resources.getString(R.string.my_store_custom_range_granularity_hour)
+            StatsGranularity.DAYS -> resources.getString(R.string.my_store_custom_range_granularity_day)
+            StatsGranularity.WEEKS -> resources.getString(R.string.my_store_custom_range_granularity_week)
+            StatsGranularity.MONTHS -> resources.getString(R.string.my_store_custom_range_granularity_month)
+            StatsGranularity.YEARS -> resources.getString(R.string.my_store_custom_range_granularity_year)
+        }
+        return resources.getString(R.string.my_store_custom_range_granularity_label, granularityLabel)
+    }
+
+    private fun trackUnexpectedFormat(result: String, dateString: String) {
+        if (result.isEmpty()) {
+            AnalyticsTracker.track(
+                AnalyticsEvent.STATS_UNEXPECTED_FORMAT,
+                mapOf(
+                    KEY_DATE to dateString,
+                    KEY_GRANULARITY to statsTimeRangeSelection.selectionType.identifier,
+                    KEY_RANGE to revenueStatsModel?.rangeId
+                )
+            )
+        }
+    }
+
+    private fun StatsTimeRangeSelection.isTotalVisitorsUnavailable() = selectionType == SelectionType.CUSTOM &&
+        currentRange.end.time - currentRange.start.time > 2.days.inWholeMilliseconds
+
+    private inner class StartEndDateAxisFormatter : ValueFormatter() {
+        override fun getAxisLabel(value: Float, axis: AxisBase): String {
+            var index = round(value).toInt() - 1
+            index = if (index == -1) index + 1 else index
+            return if (index > -1 && index < chartRevenueStats.keys.size) {
+                // if this is the first entry in the chart, then display the month as well as the date
+                // for weekly and monthly stats
+                val dateString = chartRevenueStats.keys.elementAt(index)
+                if (value == axis.mEntries.first() && statsTimeRangeSelection.selectionType != SelectionType.CUSTOM) {
+                    getEntryValueForFirstItemOfXAxis(dateString)
+                } else {
+                    getAxisLabelFromRangeType(dateString)
+                }
+            } else {
+                ""
+            }
+        }
+
+        private fun getEntryValueForFirstItemOfXAxis(dateString: String): String {
+            return when (statsTimeRangeSelection.selectionType) {
+                SelectionType.TODAY -> dateUtils.getShortHourString(dateString).orEmpty()
+                SelectionType.WEEK_TO_DATE -> dateUtils.getShortMonthDayString(dateString).orEmpty()
+                SelectionType.MONTH_TO_DATE -> dateUtils.getShortMonthDayString(dateString).orEmpty()
+                SelectionType.YEAR_TO_DATE -> dateUtils.getShortMonthString(dateString).orEmpty()
+                SelectionType.CUSTOM -> error("Custom range is unsupported to set a special x axis label")
+                else -> error("Unsupported range value used in my store tab: ${statsTimeRangeSelection.selectionType}")
+            }.also { result -> trackUnexpectedFormat(result, dateString) }
+        }
+
+        /**
+         * Displays the x-axis labels in the following format based on [SelectionType]
+         * [SelectionType.TODAY] would be 7am, 8am, 9am
+         * [SelectionType.WEEK_TO_DATE] would be 7am, 8am, 9am
+         * [SelectionType.MONTH_TO_DATE] would be Aug 31, Sept 1, 2, 3
+         * [SelectionType.YEAR_TO_DATE] would be Aug 1, 2, 3
+         * [SelectionType.CUSTOM] Any of the above formats depending on the custom range length
+         */
+        private fun getAxisLabelFromRangeType(dateString: String): String {
+            return when (statsTimeRangeSelection.selectionType) {
+                SelectionType.TODAY -> dateUtils.getShortHourString(dateString).orEmpty()
+                SelectionType.WEEK_TO_DATE -> getWeekLabelValue(dateString)
+                SelectionType.MONTH_TO_DATE -> dateUtils.getDayString(dateString).orEmpty()
+                SelectionType.YEAR_TO_DATE -> dateUtils.getShortMonthString(dateString).orEmpty()
+                SelectionType.CUSTOM -> getDisplayDateForGranularity(
+                    dateString,
+                    statsTimeRangeSelection.revenueStatsGranularity
+                )
+                else -> error("Unsupported range value used in my store tab: ${statsTimeRangeSelection.selectionType}")
+            }.also { result -> trackUnexpectedFormat(result, dateString) }
+        }
+
+        /**
+         * Method returns the formatted date for the [StatsGranularity.WEEKS] tab,
+         * if the date string is the first day of the month. i.e. date is equal to 1,
+         * then the formatted date would be `MM-d` format.
+         * Otherwise the formatted date would be `d` format
+         */
+        private fun getWeekLabelValue(dateString: String): String {
+            val formattedDateString = dateUtils.getDayString(dateString)
+            return if (formattedDateString == "1") {
+                dateUtils.getShortMonthDayString(dateString).orEmpty()
+            } else {
+                formattedDateString.orEmpty()
+            }
+        }
+    }
+
+    private inner class RevenueAxisFormatter : ValueFormatter() {
+        override fun getAxisLabel(value: Float, axis: AxisBase): String {
+            return if (-1 < value && value < 1 && value != 0f) {
+                currencyFormatter.formatCurrency(
+                    value.toBigDecimal(),
+                    revenueStatsModel?.currencyCode.orEmpty()
+                )
+            } else {
+                currencyFormatter.formatCurrencyRounded(
+                    value.toDouble(),
+                    revenueStatsModel?.currencyCode.orEmpty()
+                ).replace(".0", "")
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopPerformersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopPerformersView.kt
@@ -1,0 +1,162 @@
+package com.woocommerce.android.ui.dashboard
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.CenterCrop
+import com.bumptech.glide.load.resource.bitmap.RoundedCorners
+import com.google.android.material.card.MaterialCardView
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.databinding.MyStoreTopPerformersBinding
+import com.woocommerce.android.databinding.TopPerformersListItemBinding
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.widgets.SkeletonView
+import java.util.Locale
+
+class DashboardTopPerformersView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(ctx, attrs, defStyleAttr) {
+    private val binding = MyStoreTopPerformersBinding.inflate(LayoutInflater.from(ctx), this, true)
+
+    private lateinit var selectedSite: SelectedSite
+    private lateinit var dateUtils: DateUtils
+
+    private var skeletonView = SkeletonView()
+
+    private val lastUpdated
+        get() = binding.lastUpdatedTextView
+
+    fun initView(
+        selectedSite: SelectedSite,
+        dateUtils: DateUtils,
+    ) {
+        this.selectedSite = selectedSite
+        this.dateUtils = dateUtils
+        binding.topPerformersRecycler.layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context)
+        binding.topPerformersRecycler.adapter = TopPerformersAdapter()
+        binding.topPerformersRecycler.itemAnimator = androidx.recyclerview.widget.DefaultItemAnimator()
+
+        // Setting this field to false ensures that the RecyclerView children do NOT receive the multiple clicks,
+        // and only processes the first click event. More details on this issue can be found here:
+        // https://github.com/woocommerce/woocommerce-android/issues/2074
+        binding.topPerformersRecycler.isMotionEventSplittingEnabled = false
+    }
+
+    fun onDateGranularityChanged(selectionType: SelectionType) {
+        AnalyticsTracker.track(
+            AnalyticsEvent.DASHBOARD_TOP_PERFORMERS_DATE,
+            mapOf(AnalyticsTracker.KEY_RANGE to selectionType.identifier)
+        )
+        binding.topPerformersRecycler.adapter = TopPerformersAdapter()
+        showEmptyView(false)
+    }
+
+    fun showSkeleton(show: Boolean) {
+        if (show) {
+            skeletonView.show(
+                binding.topPerformersLinearLayout,
+                R.layout.skeleton_dashboard_top_performers,
+                delayed = true
+            )
+        } else {
+            skeletonView.hide()
+        }
+    }
+
+    private fun showEmptyView(show: Boolean) {
+        binding.topPerformersEmptyViewLinearLayout.isVisible = show
+    }
+
+    fun updateView(topPerformers: List<TopPerformerProductUiModel>) {
+        (binding.topPerformersRecycler.adapter as TopPerformersAdapter).submitList(topPerformers)
+        showEmptyView(topPerformers.isEmpty())
+    }
+
+    fun showErrorView(show: Boolean) {
+        showEmptyView(false)
+        binding.topPerformersEmptyViewLinearLayout.isVisible = show
+        binding.topPerformersRecycler.isVisible = !show
+    }
+
+    fun showLastUpdate(lastUpdateMillis: Long?) {
+        if (lastUpdateMillis != null) {
+            val lastUpdateFormatted = dateUtils.getDateOrTimeFromMillis(lastUpdateMillis)
+            lastUpdated.isVisible = true
+            lastUpdated.text = String.format(
+                Locale.getDefault(),
+                resources.getString(R.string.last_update),
+                lastUpdateFormatted
+            )
+        } else {
+            lastUpdated.isVisible = false
+        }
+    }
+
+    class TopPerformersViewHolder(val viewBinding: TopPerformersListItemBinding) :
+        RecyclerView.ViewHolder(viewBinding.root)
+
+    class TopPerformersAdapter : ListAdapter<TopPerformerProductUiModel, TopPerformersViewHolder>(ItemDiffCallback) {
+        init {
+            setHasStableIds(true)
+        }
+
+        override fun getItemId(position: Int): Long = getItem(position).productId
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TopPerformersViewHolder {
+            return TopPerformersViewHolder(
+                TopPerformersListItemBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+            )
+        }
+
+        override fun onBindViewHolder(holder: TopPerformersViewHolder, position: Int) {
+            val topPerformer = getItem(position)
+            val imageCornerRadius = holder.itemView.context.resources.getDimensionPixelSize(R.dimen.corner_radius_image)
+            holder.viewBinding.textProductName.text = topPerformer.name
+            holder.viewBinding.itemsSoldTextView.text = topPerformer.timesOrdered
+            holder.viewBinding.netSalesTextView.text = topPerformer.netSales
+            holder.viewBinding.divider.isVisible = position < itemCount - 1
+            Glide.with(holder.itemView.context)
+                .load(topPerformer.imageUrl)
+                .transform(CenterCrop(), RoundedCorners(imageCornerRadius))
+                .placeholder(ContextCompat.getDrawable(holder.itemView.context, R.drawable.ic_product))
+                .into(holder.viewBinding.imageProduct)
+
+            holder.itemView.setOnClickListener {
+                topPerformer.onClick(topPerformer.productId)
+            }
+        }
+    }
+
+    object ItemDiffCallback : DiffUtil.ItemCallback<TopPerformerProductUiModel>() {
+        override fun areItemsTheSame(
+            oldItem: TopPerformerProductUiModel,
+            newItem: TopPerformerProductUiModel
+        ): Boolean {
+            return oldItem.productId == newItem.productId
+        }
+
+        override fun areContentsTheSame(
+            oldItem: TopPerformerProductUiModel,
+            newItem: TopPerformerProductUiModel
+        ): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTransactionLauncher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTransactionLauncher.kt
@@ -1,0 +1,84 @@
+package com.woocommerce.android.ui.dashboard
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import com.automattic.android.tracks.crashlogging.performance.PerformanceTransactionRepository
+import com.automattic.android.tracks.crashlogging.performance.TransactionId
+import com.automattic.android.tracks.crashlogging.performance.TransactionOperation
+import com.automattic.android.tracks.crashlogging.performance.TransactionStatus
+import com.woocommerce.android.analytics.AnalyticsEvent.DASHBOARD_WAITING_TIME_LOADED
+import com.woocommerce.android.analytics.WaitingTimeTracker
+import com.woocommerce.android.util.CoroutineDispatchers
+import dagger.hilt.android.scopes.ViewModelScoped
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@ViewModelScoped
+class DashboardTransactionLauncher @Inject constructor(
+    private val performanceTransactionRepository: PerformanceTransactionRepository,
+    dispatchers: CoroutineDispatchers,
+) : LifecycleEventObserver {
+    private companion object {
+        const val TRANSACTION_NAME = "Dashboard"
+    }
+
+    private var performanceTransactionId: TransactionId? = null
+    private val conditionsToSatisfy = MutableStateFlow(Conditions.values().toList())
+    private val validatorScope = CoroutineScope(dispatchers.main + Job())
+    private val waitingTimeTracker = WaitingTimeTracker(DASHBOARD_WAITING_TIME_LOADED)
+
+    init {
+        validatorScope.launch {
+            conditionsToSatisfy.collect { toSatisfy ->
+                if (toSatisfy.isEmpty()) {
+                    performanceTransactionId?.let {
+                        performanceTransactionRepository.finishTransaction(it, TransactionStatus.SUCCESSFUL)
+                    }
+                    waitingTimeTracker.end()
+                }
+            }
+        }
+    }
+
+    private enum class Conditions {
+        STORE_STATISTICS_FETCHED,
+        TOP_PERFORMERS_FETCHED
+    }
+
+    fun onStoreStatisticsFetched() = satisfyCondition(Conditions.STORE_STATISTICS_FETCHED)
+
+    fun onTopPerformersFetched() = satisfyCondition(Conditions.TOP_PERFORMERS_FETCHED)
+
+    fun clear() {
+        validatorScope.cancel()
+    }
+
+    private fun satisfyCondition(condition: Conditions) {
+        conditionsToSatisfy.value = (conditionsToSatisfy.value - condition)
+    }
+
+    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+        when (event) {
+            Lifecycle.Event.ON_CREATE -> {
+                performanceTransactionId =
+                    performanceTransactionRepository.startTransaction(TRANSACTION_NAME, TransactionOperation.UI_LOAD)
+                waitingTimeTracker.start()
+            }
+            Lifecycle.Event.ON_STOP -> {
+                performanceTransactionId?.let {
+                    performanceTransactionRepository.finishTransaction(it, TransactionStatus.ABORTED)
+                }
+                performanceTransactionId = null
+                waitingTimeTracker.abort()
+            }
+            else -> {
+                // no-op
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardUiModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardUiModels.kt
@@ -1,0 +1,29 @@
+package com.woocommerce.android.ui.dashboard
+
+data class JetpackBenefitsBannerUiModel(
+    val show: Boolean = false,
+    val onDismiss: () -> Unit = {}
+)
+
+data class RevenueStatsUiModel(
+    val intervalList: List<StatsIntervalUiModel> = emptyList(),
+    val totalOrdersCount: Int? = null,
+    val totalSales: Double? = null,
+    val currencyCode: String?,
+    val rangeId: String
+)
+
+data class StatsIntervalUiModel(
+    val interval: String? = null,
+    val ordersCount: Long? = null,
+    val sales: Double? = null
+)
+
+data class TopPerformerProductUiModel(
+    val productId: Long,
+    val name: String,
+    val timesOrdered: String,
+    val netSales: String,
+    val imageUrl: String?,
+    val onClick: (Long) -> Unit
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -1,0 +1,557 @@
+package com.woocommerce.android.ui.dashboard
+
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsEvent.DASHBOARD_STORE_TIMEZONE_DIFFER_FROM_DEVICE
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.isEligibleForAI
+import com.woocommerce.android.extensions.isNotNullOrEmpty
+import com.woocommerce.android.extensions.isSitePublic
+import com.woocommerce.android.extensions.offsetInHours
+import com.woocommerce.android.network.ConnectionChangeReceiver
+import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsUpdateDataStore
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenDatePicker
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowAIProductDescriptionDialog
+import com.woocommerce.android.ui.dashboard.domain.GetStats
+import com.woocommerce.android.ui.dashboard.domain.GetStats.LoadStatsResult.HasOrders
+import com.woocommerce.android.ui.dashboard.domain.GetStats.LoadStatsResult.PluginNotActive
+import com.woocommerce.android.ui.dashboard.domain.GetStats.LoadStatsResult.RevenueStatsError
+import com.woocommerce.android.ui.dashboard.domain.GetStats.LoadStatsResult.RevenueStatsSuccess
+import com.woocommerce.android.ui.dashboard.domain.GetStats.LoadStatsResult.VisitorStatUnavailable
+import com.woocommerce.android.ui.dashboard.domain.GetStats.LoadStatsResult.VisitorsStatsError
+import com.woocommerce.android.ui.dashboard.domain.GetStats.LoadStatsResult.VisitorsStatsSuccess
+import com.woocommerce.android.ui.dashboard.domain.GetTopPerformers
+import com.woocommerce.android.ui.dashboard.domain.GetTopPerformers.TopPerformerProduct
+import com.woocommerce.android.ui.dashboard.domain.ObserveLastUpdate
+import com.woocommerce.android.ui.mystore.data.CustomDateRangeDataStore
+import com.woocommerce.android.ui.prefs.privacy.banner.domain.ShouldShowPrivacyBanner
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.TimezoneProvider
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.apache.commons.text.StringEscapeUtils
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.model.WCRevenueStatsModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.utils.putIfNotNull
+import org.wordpress.android.util.FormatUtils
+import org.wordpress.android.util.PhotonUtils
+import java.math.BigDecimal
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+@HiltViewModel
+class DashboardViewModel @Inject constructor(
+    savedState: SavedStateHandle,
+    private val networkStatus: NetworkStatus,
+    private val resourceProvider: ResourceProvider,
+    private val wooCommerceStore: WooCommerceStore,
+    private val getStats: GetStats,
+    private val getTopPerformers: GetTopPerformers,
+    private val currencyFormatter: CurrencyFormatter,
+    private val selectedSite: SelectedSite,
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val usageTracksEventEmitter: DashboardStatsUsageTracksEventEmitter,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val myStoreTransactionLauncher: DashboardTransactionLauncher,
+    private val timezoneProvider: TimezoneProvider,
+    private val observeLastUpdate: ObserveLastUpdate,
+    private val customDateRangeDataStore: CustomDateRangeDataStore,
+    private val dateUtils: DateUtils,
+    shouldShowPrivacyBanner: ShouldShowPrivacyBanner
+) : ScopedViewModel(savedState) {
+    companion object {
+        private const val DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER = 5
+        val SUPPORTED_RANGES_ON_MY_STORE_TAB = listOf(
+            SelectionType.TODAY,
+            SelectionType.WEEK_TO_DATE,
+            SelectionType.MONTH_TO_DATE,
+            SelectionType.YEAR_TO_DATE,
+            SelectionType.CUSTOM
+        )
+    }
+
+    val performanceObserver: LifecycleObserver = myStoreTransactionLauncher
+
+    private var _revenueStatsState = MutableLiveData<RevenueStatsViewState>()
+    val revenueStatsState: LiveData<RevenueStatsViewState> = _revenueStatsState
+
+    private var _visitorStatsState = MutableLiveData<VisitorStatsViewState>()
+    val visitorStatsState: LiveData<VisitorStatsViewState> = _visitorStatsState
+
+    private var _topPerformersState = MutableLiveData<TopPerformersState>()
+    val topPerformersState: LiveData<TopPerformersState> = _topPerformersState
+
+    private var _hasOrders = MutableLiveData<OrderState>()
+    val hasOrders: LiveData<OrderState> = _hasOrders
+
+    private var _lastUpdateStats = MutableLiveData<Long?>()
+    val lastUpdateStats: LiveData<Long?> = _lastUpdateStats
+
+    private var _lastUpdateTopPerformers = MutableLiveData<Long?>()
+    val lastUpdateTopPerformers: LiveData<Long?> = _lastUpdateTopPerformers
+
+    private var _appbarState = MutableLiveData<AppbarState>()
+    val appbarState: LiveData<AppbarState> = _appbarState
+
+    private val refreshTrigger = MutableSharedFlow<RefreshState>(extraBufferCapacity = 1)
+
+    private val _selectedRangeType = savedState.getStateFlow(viewModelScope, getSelectedRangeTypeIfAny())
+
+    private val _customRange = customDateRangeDataStore.dateRange
+        .stateIn(
+            viewModelScope,
+            started = SharingStarted.WhileSubscribed(),
+            initialValue = null
+        )
+    val customRange = _customRange.asLiveData()
+    private val _selectedDateRange = combine(_selectedRangeType, _customRange) { selectionType, customRange ->
+        when (selectionType) {
+            SelectionType.CUSTOM -> {
+                selectionType.generateSelectionData(
+                    calendar = Calendar.getInstance(),
+                    locale = Locale.getDefault(),
+                    referenceStartDate = customRange?.start ?: Date(),
+                    referenceEndDate = customRange?.end ?: Date()
+                )
+            }
+
+            else -> {
+                selectionType.generateSelectionData(
+                    calendar = Calendar.getInstance(),
+                    locale = Locale.getDefault(),
+                    referenceStartDate = dateUtils.getCurrentDateInSiteTimeZone() ?: Date(),
+                    referenceEndDate = dateUtils.getCurrentDateInSiteTimeZone() ?: Date()
+                )
+            }
+        }
+    }
+    val selectedDateRange: LiveData<StatsTimeRangeSelection> = _selectedDateRange.asLiveData()
+
+    val storeName = selectedSite.observe().map { site ->
+        if (!site?.displayName.isNullOrBlank()) {
+            site?.displayName
+        } else {
+            site?.name
+        } ?: resourceProvider.getString(R.string.store_name_default)
+    }.asLiveData()
+
+    init {
+        ConnectionChangeReceiver.getEventBus().register(this)
+
+        _topPerformersState.value = TopPerformersState(isLoading = true)
+
+        viewModelScope.launch {
+            combine(
+                _selectedDateRange,
+                refreshTrigger.onStart { emit(RefreshState()) }
+            ) { selectedRange, refreshEvent ->
+                Pair(selectedRange, refreshEvent.shouldRefresh)
+            }.collectLatest { (selectedRange, isForceRefresh) ->
+                coroutineScope {
+                    launch { loadStoreStats(selectedRange, isForceRefresh) }
+                    launch { loadTopPerformersStats(selectedRange, isForceRefresh) }
+                }
+            }
+        }
+        observeTopPerformerUpdates()
+        trackLocalTimezoneDifferenceFromStore()
+
+        launch {
+            shouldShowPrivacyBanner().let {
+                if (it) {
+                    triggerEvent(DashboardEvent.ShowPrivacyBanner)
+                }
+            }
+        }
+
+        if (selectedSite.getOrNull()?.isEligibleForAI == true &&
+            !appPrefsWrapper.wasAIProductDescriptionPromoDialogShown
+        ) {
+            triggerEvent(ShowAIProductDescriptionDialog)
+            appPrefsWrapper.wasAIProductDescriptionPromoDialogShown = true
+        }
+
+        updateShareStoreButtonVisibility()
+    }
+
+    private fun updateShareStoreButtonVisibility() {
+        _appbarState.value = AppbarState(showShareStoreButton = selectedSite.get().isSitePublic)
+    }
+
+    override fun onCleared() {
+        ConnectionChangeReceiver.getEventBus().unregister(this)
+        super.onCleared()
+    }
+
+    @Suppress("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onEventMainThread(event: ConnectionChangeEvent) {
+        if (event.isConnected) {
+            refreshTrigger.tryEmit(RefreshState())
+        }
+    }
+
+    fun onTabSelected(selectionType: SelectionType) {
+        usageTracksEventEmitter.interacted()
+        _selectedRangeType.update { selectionType }
+        appPrefsWrapper.setActiveStatsTab(selectionType.name)
+
+        if (selectionType == SelectionType.CUSTOM) {
+            analyticsTrackerWrapper.track(
+                AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_TAB_SELECTED
+            )
+        }
+    }
+
+    fun onPullToRefresh() {
+        usageTracksEventEmitter.interacted()
+        analyticsTrackerWrapper.track(AnalyticsEvent.DASHBOARD_PULLED_TO_REFRESH)
+        refreshTrigger.tryEmit(RefreshState(isForced = true))
+    }
+
+    fun onViewAnalyticsClicked() {
+        AnalyticsTracker.track(AnalyticsEvent.DASHBOARD_SEE_MORE_ANALYTICS_TAPPED)
+        selectedDateRange.value?.let {
+            triggerEvent(DashboardEvent.OpenAnalytics(it))
+        }
+    }
+
+    fun onShareStoreClicked() {
+        AnalyticsTracker.track(AnalyticsEvent.DASHBOARD_SHARE_YOUR_STORE_BUTTON_TAPPED)
+        triggerEvent(
+            DashboardEvent.ShareStore(storeUrl = selectedSite.get().url)
+        )
+    }
+
+    private suspend fun loadStoreStats(selectedRange: StatsTimeRangeSelection, forceRefresh: Boolean) {
+        if (!networkStatus.isConnected()) {
+            _revenueStatsState.value = RevenueStatsViewState.Content(null, selectedRange)
+            _visitorStatsState.value = VisitorStatsViewState.Content(emptyMap())
+            return
+        }
+        _revenueStatsState.value = RevenueStatsViewState.Loading
+        getStats(forceRefresh, selectedRange)
+            .collect {
+                when (it) {
+                    is RevenueStatsSuccess -> onRevenueStatsSuccess(it, selectedRange)
+                    is RevenueStatsError -> _revenueStatsState.value = RevenueStatsViewState.GenericError
+                    PluginNotActive -> _revenueStatsState.value = RevenueStatsViewState.PluginNotActiveError
+                    is VisitorsStatsSuccess -> _visitorStatsState.value = VisitorStatsViewState.Content(it.stats)
+                    is VisitorsStatsError -> _visitorStatsState.value = VisitorStatsViewState.Error
+                    is VisitorStatUnavailable -> onVisitorStatsUnavailable(it.connectionType)
+                    is HasOrders -> _hasOrders.value = if (it.hasOrder) OrderState.AtLeastOne else OrderState.Empty
+                }
+                myStoreTransactionLauncher.onStoreStatisticsFetched()
+            }
+        launch {
+            observeLastUpdate(
+                selectedRange,
+                listOf(
+                    AnalyticsUpdateDataStore.AnalyticData.REVENUE,
+                    AnalyticsUpdateDataStore.AnalyticData.VISITORS
+                )
+            ).collect { lastUpdateMillis -> _lastUpdateStats.value = lastUpdateMillis }
+        }
+        launch {
+            observeLastUpdate(
+                selectedRange,
+                AnalyticsUpdateDataStore.AnalyticData.TOP_PERFORMERS
+            ).collect { lastUpdateMillis -> _lastUpdateTopPerformers.value = lastUpdateMillis }
+        }
+    }
+
+    private fun onRevenueStatsSuccess(
+        result: RevenueStatsSuccess,
+        selectedRange: StatsTimeRangeSelection
+    ) {
+        _revenueStatsState.value = RevenueStatsViewState.Content(
+            result.stats?.toStoreStatsUiModel(),
+            selectedRange
+        )
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.DASHBOARD_MAIN_STATS_LOADED,
+            buildMap {
+                put(AnalyticsTracker.KEY_RANGE, selectedRange.selectionType.identifier)
+                putIfNotNull(AnalyticsTracker.KEY_ID to result.stats?.rangeId)
+            }
+        )
+    }
+
+    private fun onVisitorStatsUnavailable(connectionType: SiteConnectionType) {
+        val daysSinceDismissal = TimeUnit.MILLISECONDS.toDays(
+            System.currentTimeMillis() - appPrefsWrapper.getJetpackBenefitsDismissalDate()
+        )
+        val supportsJetpackInstallation = connectionType == SiteConnectionType.JetpackConnectionPackage ||
+            connectionType == SiteConnectionType.ApplicationPasswords
+        val showBanner = supportsJetpackInstallation && daysSinceDismissal >= DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER
+        val benefitsBanner = JetpackBenefitsBannerUiModel(
+            show = showBanner,
+            onDismiss = {
+                _visitorStatsState.value =
+                    VisitorStatsViewState.Unavailable(JetpackBenefitsBannerUiModel(show = false))
+                appPrefsWrapper.recordJetpackBenefitsDismissal()
+                analyticsTrackerWrapper.track(
+                    stat = AnalyticsEvent.FEATURE_JETPACK_BENEFITS_BANNER,
+                    properties = mapOf(AnalyticsTracker.KEY_JETPACK_BENEFITS_BANNER_ACTION to "dismissed")
+                )
+            }
+        )
+        _visitorStatsState.value = VisitorStatsViewState.Unavailable(benefitsBanner)
+    }
+
+    private suspend fun loadTopPerformersStats(selectedRange: StatsTimeRangeSelection, forceRefresh: Boolean) {
+        if (!networkStatus.isConnected()) return
+
+        _topPerformersState.value = _topPerformersState.value?.copy(isLoading = true, isError = false)
+        val result = getTopPerformers.fetchTopPerformers(selectedRange, forceRefresh)
+        result.fold(
+            onFailure = { _topPerformersState.value = _topPerformersState.value?.copy(isError = true) },
+            onSuccess = {
+                analyticsTrackerWrapper.track(
+                    AnalyticsEvent.DASHBOARD_TOP_PERFORMERS_LOADED,
+                    mapOf(AnalyticsTracker.KEY_RANGE to selectedRange.selectionType.identifier)
+                )
+            }
+        )
+        _topPerformersState.value = _topPerformersState.value?.copy(isLoading = false)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun observeTopPerformerUpdates() {
+        viewModelScope.launch {
+            _selectedDateRange
+                .flatMapLatest { dateRange ->
+                    getTopPerformers.observeTopPerformers(dateRange)
+                }
+                .collectLatest {
+                    _topPerformersState.value = _topPerformersState.value?.copy(
+                        topPerformers = it.toTopPerformersUiList(),
+                    )
+                }
+        }
+    }
+
+    private fun trackLocalTimezoneDifferenceFromStore() {
+        val selectedSite = selectedSite.getIfExists() ?: return
+        val siteTimezone = selectedSite.timezone.takeIf { it.isNotNullOrEmpty() } ?: return
+        val localTimeZoneOffset = timezoneProvider.deviceTimezone.offsetInHours.toString()
+
+        val shouldTriggerTimezoneTrack = appPrefsWrapper.isTimezoneTrackEventNeverTriggeredFor(
+            siteId = selectedSite.siteId,
+            localTimezone = localTimeZoneOffset,
+            storeTimezone = siteTimezone
+        ) && selectedSite.timezone != localTimeZoneOffset
+
+        if (shouldTriggerTimezoneTrack) {
+            analyticsTrackerWrapper.track(
+                stat = DASHBOARD_STORE_TIMEZONE_DIFFER_FROM_DEVICE,
+                properties = mapOf(
+                    AnalyticsTracker.KEY_STORE_TIMEZONE to siteTimezone,
+                    AnalyticsTracker.KEY_LOCAL_TIMEZONE to localTimeZoneOffset
+                )
+            )
+            appPrefsWrapper.setTimezoneTrackEventTriggeredFor(
+                siteId = selectedSite.siteId,
+                localTimezone = localTimeZoneOffset,
+                storeTimezone = siteTimezone
+            )
+        }
+    }
+
+    private fun onTopPerformerSelected(productId: Long) {
+        triggerEvent(DashboardEvent.OpenTopPerformer(productId))
+        analyticsTrackerWrapper.track(AnalyticsEvent.TOP_EARNER_PRODUCT_TAPPED)
+        usageTracksEventEmitter.interacted()
+    }
+
+    private fun WCRevenueStatsModel.toStoreStatsUiModel(): RevenueStatsUiModel {
+        val totals = parseTotal()
+        return RevenueStatsUiModel(
+            intervalList = getIntervalList().toStatsIntervalUiModelList(),
+            totalOrdersCount = totals?.ordersCount,
+            totalSales = totals?.totalSales,
+            currencyCode = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode,
+            rangeId = rangeId
+        )
+    }
+
+    private fun List<WCRevenueStatsModel.Interval>.toStatsIntervalUiModelList() =
+        map {
+            StatsIntervalUiModel(
+                it.interval,
+                it.subtotals?.ordersCount,
+                it.subtotals?.totalSales
+            )
+        }
+
+    private fun List<TopPerformerProduct>.toTopPerformersUiList() = map { it.toTopPerformersUiModel() }
+
+    private fun TopPerformerProduct.toTopPerformersUiModel() =
+        TopPerformerProductUiModel(
+            productId = productId,
+            name = StringEscapeUtils.unescapeHtml4(name),
+            timesOrdered = FormatUtils.formatDecimal(quantity),
+            netSales = resourceProvider.getString(
+                R.string.dashboard_top_performers_net_sales,
+                getTotalSpendFormatted(total.toBigDecimal(), currency)
+            ),
+            imageUrl = imageUrl?.toImageUrl(),
+            onClick = ::onTopPerformerSelected
+        )
+
+    private fun getTotalSpendFormatted(totalSpend: BigDecimal, currency: String) =
+        currencyFormatter.formatCurrency(
+            totalSpend,
+            wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode ?: currency
+        )
+
+    private fun String.toImageUrl() =
+        PhotonUtils.getPhotonImageUrl(
+            this,
+            resourceProvider.getDimensionPixelSize(R.dimen.image_minor_100),
+            0
+        )
+
+    private fun getSelectedRangeTypeIfAny(): SelectionType {
+        val previouslySelectedTab = appPrefsWrapper.getActiveStatsTab()
+        return runCatching {
+            SelectionType.valueOf(previouslySelectedTab)
+        }.getOrDefault(SelectionType.TODAY)
+    }
+
+    fun onCustomRangeSelected(range: StatsTimeRange) {
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_CONFIRMED,
+            mapOf(
+                AnalyticsTracker.KEY_IS_EDITING to (_customRange.value != null),
+            )
+        )
+
+        if (_selectedRangeType.value != SelectionType.CUSTOM) {
+            onTabSelected(SelectionType.CUSTOM)
+        }
+        viewModelScope.launch {
+            customDateRangeDataStore.updateDateRange(range)
+        }
+    }
+
+    fun onAddCustomRangeClicked() {
+        triggerEvent(
+            OpenDatePicker(
+                fromDate = _customRange.value?.start ?: Date(),
+                toDate = _customRange.value?.end ?: Date()
+            )
+        )
+
+        val event = if (_customRange.value == null) {
+            AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_ADD_BUTTON_TAPPED
+        } else {
+            AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_EDIT_BUTTON_TAPPED
+        }
+        analyticsTrackerWrapper.track(event)
+    }
+
+    sealed class RevenueStatsViewState {
+        data object Loading : RevenueStatsViewState()
+        data object GenericError : RevenueStatsViewState()
+        data object PluginNotActiveError : RevenueStatsViewState()
+        data class Content(
+            val revenueStats: RevenueStatsUiModel?,
+            val statsRangeSelection: StatsTimeRangeSelection
+        ) : RevenueStatsViewState()
+    }
+
+    sealed class VisitorStatsViewState {
+        data object Error : VisitorStatsViewState()
+        data class Unavailable(
+            val benefitsBanner: JetpackBenefitsBannerUiModel
+        ) : VisitorStatsViewState()
+
+        data class Content(
+            val stats: Map<String, Int>
+        ) : VisitorStatsViewState()
+    }
+
+    data class TopPerformersState(
+        val isLoading: Boolean = false,
+        val isError: Boolean = false,
+        val topPerformers: List<TopPerformerProductUiModel> = emptyList(),
+    )
+
+    sealed class OrderState {
+        data object Empty : OrderState()
+        data object AtLeastOne : OrderState()
+    }
+
+    data class AppbarState(
+        val showShareStoreButton: Boolean = false,
+    )
+
+    sealed class DashboardEvent : MultiLiveEvent.Event() {
+        data class OpenTopPerformer(
+            val productId: Long
+        ) : DashboardEvent()
+
+        data class OpenAnalytics(val analyticsPeriod: StatsTimeRangeSelection) : DashboardEvent()
+
+        data object ShowPrivacyBanner : DashboardEvent()
+
+        data object ShowAIProductDescriptionDialog : DashboardEvent()
+
+        data class ShareStore(val storeUrl: String) : DashboardEvent()
+
+        data class OpenDatePicker(val fromDate: Date, val toDate: Date) : DashboardEvent()
+    }
+
+    data class RefreshState(private val isForced: Boolean = false) {
+        /**
+         * [shouldRefresh] will be true only the first time the refresh event is consulted and when
+         * isForced is initialized on true. Once the event is handled the property will change its value to false
+         */
+        var shouldRefresh: Boolean = isForced
+            private set
+            get(): Boolean {
+                val result = field
+                if (field) {
+                    field = false
+                }
+                return result
+            }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/NotificationsPermissionBar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/NotificationsPermissionBar.kt
@@ -1,0 +1,90 @@
+package com.woocommerce.android.ui.dashboard
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.woocommerce.android.R
+import com.woocommerce.android.R.color
+import com.woocommerce.android.R.dimen
+import com.woocommerce.android.R.drawable
+import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.main.MainActivityViewModel
+
+@Composable
+fun NotificationsPermissionCard(viewModel: MainActivityViewModel = viewModel()) {
+    Column(
+        modifier = Modifier
+            .background(colorResource(id = color.color_surface))
+            .fillMaxWidth()
+    ) {
+        Divider(
+            color = colorResource(id = color.divider_color),
+            thickness = dimensionResource(id = dimen.minor_10)
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(dimensionResource(id = dimen.major_100))
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = dimensionResource(id = dimen.minor_100))
+            ) {
+                Image(
+                    modifier = Modifier.padding(end = dimensionResource(id = dimen.minor_100)),
+                    painter = painterResource(drawable.ic_megaphone),
+                    contentDescription = "",
+                )
+                Text(
+                    text = stringResource(id = R.string.notifications_permission_title),
+                    style = MaterialTheme.typography.subtitle1,
+                    fontWeight = FontWeight.Bold,
+                    color = colorResource(id = color.color_on_surface),
+                )
+            }
+            Text(
+                text = stringResource(id = R.string.notifications_permission_description),
+                style = MaterialTheme.typography.body1,
+                color = colorResource(id = color.color_on_surface),
+                modifier = Modifier.padding(bottom = dimensionResource(id = dimen.major_100))
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                WCTextButton(
+                    modifier = Modifier.padding(end = dimensionResource(id = dimen.major_100)),
+                    text = stringResource(id = R.string.dismiss),
+                    onClick = viewModel::onNotificationsPermissionBarDismissButtonTapped,
+                )
+                WCTextButton(
+                    text = stringResource(id = R.string.allow),
+                    onClick = viewModel::onNotificationsPermissionBarAllowButtonTapped,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun NotificationsPermissionCardPreview() {
+    NotificationsPermissionCard()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/StatsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/StatsRepository.kt
@@ -1,0 +1,339 @@
+package com.woocommerce.android.ui.dashboard.data
+
+import com.woocommerce.android.AppConstants
+import com.woocommerce.android.WooException
+import com.woocommerce.android.extensions.formatToYYYYmmDD
+import com.woocommerce.android.extensions.formatToYYYYmmDDhhmmss
+import com.woocommerce.android.extensions.semverCompareTo
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T.DASHBOARD
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCRevenueStatsModel
+import org.wordpress.android.fluxc.persistence.entity.TopPerformerProductEntity
+import org.wordpress.android.fluxc.store.WCLeaderboardsStore
+import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCStatsStore
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchNewVisitorStatsPayload
+import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsPayload
+import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsError
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.utils.DateUtils
+import java.util.Date
+import javax.inject.Inject
+
+@Suppress("TooManyFunctions")
+class StatsRepository @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val wcStatsStore: WCStatsStore,
+    @Suppress("UnusedPrivateMember", "Required to ensure the WCOrderStore is initialized!")
+    private val wcOrderStore: WCOrderStore,
+    private val wcLeaderboardsStore: WCLeaderboardsStore,
+    private val wooCommerceStore: WooCommerceStore,
+    private val dispatchers: CoroutineDispatchers
+) {
+    companion object {
+        private val TAG = StatsRepository::class.java
+
+        // Minimum supported version to use /wc-analytics/leaderboards/products instead of slower endpoint
+        // /wc-analytics/leaderboards. More info https://github.com/woocommerce/woocommerce-android/issues/6688
+        private const val PRODUCT_ONLY_LEADERBOARD_REPORT_MIN_WC_VERSION = "6.7.0"
+        private const val AN_HOUR_IN_MILLIS = 3600000
+    }
+
+    suspend fun fetchRevenueStats(
+        range: StatsTimeRange,
+        granularity: StatsGranularity,
+        forced: Boolean,
+        revenueRangeId: String = ""
+    ): Result<WCRevenueStatsModel?> = fetchRevenueStats(
+        range = range,
+        granularity = granularity,
+        forced = forced,
+        revenueRangeId = revenueRangeId,
+        site = selectedSite.get()
+    )
+
+    private suspend fun fetchRevenueStats(
+        range: StatsTimeRange,
+        granularity: StatsGranularity,
+        forced: Boolean,
+        revenueRangeId: String = "",
+        site: SiteModel
+    ): Result<WCRevenueStatsModel?> {
+        val result = wcStatsStore.fetchRevenueStats(
+            FetchRevenueStatsPayload(
+                site = site,
+                granularity = granularity,
+                startDate = range.start.formatToYYYYmmDDhhmmss(),
+                endDate = range.end.formatToYYYYmmDDhhmmss(),
+                forced = forced,
+                revenueRangeId = revenueRangeId
+            )
+        )
+
+        return if (!result.isError) {
+            val revenueStatsModel = withContext(dispatchers.io) {
+                wcStatsStore.getRawRevenueStats(
+                    site,
+                    result.granularity,
+                    result.startDate!!,
+                    result.endDate!!
+                )
+            }
+            Result.success(revenueStatsModel)
+        } else {
+            val errorMessage = result.error?.message ?: "Timeout"
+            WooLog.e(
+                DASHBOARD,
+                "$TAG - Error fetching revenue stats: $errorMessage"
+            )
+            val exception = StatsException(error = result.error)
+            Result.failure(exception)
+        }
+    }
+
+    suspend fun getRevenueStatsById(
+        revenueRangeId: String
+    ): Result<WCRevenueStatsModel?> = withContext(dispatchers.io) {
+        Result.success(
+            wcStatsStore.getRawRevenueStatsFromRangeId(
+                selectedSite.get(),
+                revenueRangeId
+            )
+        )
+    }
+
+    suspend fun fetchVisitorStats(
+        range: StatsTimeRange,
+        granularity: StatsGranularity,
+        forced: Boolean
+    ): Result<Map<String, Int>> = fetchVisitorStats(
+        range = range,
+        granularity = granularity,
+        forced = forced,
+        site = selectedSite.get()
+    )
+
+    private suspend fun fetchVisitorStats(
+        range: StatsTimeRange,
+        granularity: StatsGranularity,
+        forced: Boolean,
+        site: SiteModel
+    ): Result<Map<String, Int>> {
+        val visitsPayload = FetchNewVisitorStatsPayload(
+            site = site,
+            granularity = granularity,
+            startDate = range.start.formatToYYYYmmDDhhmmss(),
+            endDate = range.end.formatToYYYYmmDDhhmmss(),
+            forced = forced
+        )
+        val result = wcStatsStore.fetchNewVisitorStats(visitsPayload)
+        return if (!result.isError) {
+            val visitorStats = withContext(dispatchers.io) {
+                wcStatsStore.getNewVisitorStats(
+                    site,
+                    result.granularity,
+                    result.quantity,
+                    result.date,
+                    result.isCustomField
+                )
+            }
+            Result.success(visitorStats)
+        } else {
+            val errorMessage = result.error?.message ?: "Timeout"
+            WooLog.e(
+                DASHBOARD,
+                "$TAG - Error fetching visitor stats: $errorMessage"
+            )
+            Result.failure(Exception(errorMessage))
+        }
+    }
+
+    fun observeTopPerformers(
+        range: StatsTimeRange,
+    ): Flow<List<TopPerformerProductEntity>> {
+        val siteModel = selectedSite.get()
+        val datePeriod = DateUtils.getDatePeriod(
+            startDate = range.start.formatToYYYYmmDDhhmmss(),
+            endDate = range.end.formatToYYYYmmDDhhmmss()
+        )
+        return wcLeaderboardsStore
+            .observeTopPerformerProducts(siteModel, datePeriod)
+            .flowOn(Dispatchers.IO)
+    }
+
+    suspend fun getTopPerformers(
+        startDate: String,
+        endDate: String
+    ): List<TopPerformerProductEntity> {
+        val siteModel = selectedSite.get()
+        val datePeriod = DateUtils.getDatePeriod(startDate, endDate)
+        return wcLeaderboardsStore.getCachedTopPerformerProducts(siteModel, datePeriod)
+    }
+
+    suspend fun fetchTopPerformerProducts(
+        forceRefresh: Boolean,
+        range: StatsTimeRange,
+        quantity: Int
+    ): Result<Unit> {
+        return fetchTopPerformerProducts(
+            forceRefresh = forceRefresh,
+            startDate = range.start.formatToYYYYmmDDhhmmss(),
+            endDate = range.end.formatToYYYYmmDDhhmmss(),
+            quantity = quantity
+        )
+    }
+
+    suspend fun fetchTopPerformerProducts(
+        forceRefresh: Boolean,
+        startDate: String,
+        endDate: String,
+        quantity: Int
+    ): Result<Unit> {
+        val siteModel = selectedSite.get()
+        val datePeriod = DateUtils.getDatePeriod(startDate, endDate)
+        val cachedTopPerformers = wcLeaderboardsStore.getCachedTopPerformerProducts(
+            site = siteModel,
+            datePeriod = datePeriod
+        )
+        return if (forceRefresh || cachedTopPerformers.isEmpty() || cachedTopPerformers.expired()) {
+            val supportOnlyLegacyEndpoint = supportsProductOnlyLeaderboardAndReportEndpoint().not()
+            val result = if (supportOnlyLegacyEndpoint) {
+                wcLeaderboardsStore.fetchTopPerformerProductsLegacy(
+                    site = siteModel,
+                    startDate = startDate,
+                    endDate = endDate,
+                    quantity = quantity
+                )
+            } else {
+                wcLeaderboardsStore.fetchTopPerformerProducts(
+                    site = siteModel,
+                    startDate = startDate,
+                    endDate = endDate,
+                    quantity = quantity
+                )
+            }
+            when {
+                result.isError -> Result.failure(WooException(result.error))
+                else -> Result.success(Unit)
+            }
+        } else {
+            Result.success(Unit)
+        }
+    }
+
+    private fun List<TopPerformerProductEntity>.expired(): Boolean =
+        any { topPerformerProductEntity ->
+            System.currentTimeMillis() - topPerformerProductEntity.millisSinceLastUpdated > AN_HOUR_IN_MILLIS
+        }
+
+    suspend fun checkIfStoreHasNoOrders(): Flow<Result<Boolean>> = flow {
+        val result = withTimeoutOrNull(AppConstants.REQUEST_TIMEOUT) {
+            wcOrderStore.hasOrders(selectedSite.get())
+        }
+
+        when (result) {
+            is WCOrderStore.HasOrdersResult.Success -> {
+                emit(Result.success(!result.hasOrders))
+            }
+
+            is WCOrderStore.HasOrdersResult.Failure, null -> {
+                val errorMessage = (result as? WCOrderStore.HasOrdersResult.Failure)?.error?.message ?: "Timeout"
+                WooLog.e(
+                    DASHBOARD,
+                    "$TAG - Error fetching whether orders exist: $errorMessage"
+                )
+                emit(Result.failure(Exception(errorMessage)))
+            }
+        }
+    }
+
+    data class StatsException(val error: OrderStatsError?) : Exception()
+    data class SiteStats(
+        val revenue: WCRevenueStatsModel?,
+        val visitors: Map<String, Int>?,
+        val currencyCode: String
+    )
+
+    /**
+     * This function will return the site stats optional including visitor stats.
+     * Even if the includeVisitorStats flag is set to true, errors fetching visitor
+     * will be handled as null and only errors fetching the revenue stats will be processed.
+     */
+    suspend fun fetchStats(
+        range: StatsTimeRange,
+        revenueStatsGranularity: StatsGranularity,
+        visitorStatsGranularity: StatsGranularity,
+        forced: Boolean,
+        includeVisitorStats: Boolean,
+        site: SiteModel = selectedSite.get()
+    ): Result<SiteStats> = coroutineScope {
+        val fetchVisitorStats = if (includeVisitorStats) {
+            async {
+                fetchVisitorStats(
+                    range = range,
+                    granularity = visitorStatsGranularity,
+                    forced = forced,
+                    site = site
+                )
+            }
+        } else {
+            CompletableDeferred(Result.success(emptyMap()))
+        }
+
+        val fetchRevenueStats = async {
+            fetchRevenueStats(
+                range = range,
+                granularity = revenueStatsGranularity,
+                forced = forced,
+                site = site
+            )
+        }
+        val visitorStats = fetchVisitorStats.await()
+        val revenueStats = fetchRevenueStats.await()
+        val siteCurrencyCode = wooCommerceStore.getSiteSettings(site)?.currencyCode.orEmpty()
+
+        // If there was an error fetching the visitor stats chances are that is because
+        // jetpack is not properly configure to return stats. So we take into account
+        // only revenue stats to return process the error response.
+        return@coroutineScope if (revenueStats.isFailure) {
+            Result.failure(revenueStats.exceptionOrNull()!!)
+        } else {
+            Result.success(
+                SiteStats(
+                    revenue = revenueStats.getOrNull(),
+                    visitors = visitorStats.getOrNull(),
+                    currencyCode = siteCurrencyCode
+                )
+            )
+        }
+    }
+
+    private fun supportsProductOnlyLeaderboardAndReportEndpoint(): Boolean {
+        val currentWooCoreVersion =
+            wooCommerceStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_CORE)?.version ?: "0.0"
+        return currentWooCoreVersion.semverCompareTo(PRODUCT_ONLY_LEADERBOARD_REPORT_MIN_WC_VERSION) >= 0
+    }
+}
+
+fun String.asRevenueRangeId(
+    startDate: Date,
+    endDate: Date
+): String {
+    val startDateString = startDate.formatToYYYYmmDD()
+    val endDateString = endDate.formatToYYYYmmDD()
+    return "$this$startDateString$endDateString"
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/domain/GetStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/domain/GetStats.kt
@@ -1,0 +1,184 @@
+package com.woocommerce.android.ui.dashboard.domain
+
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsUpdateDataStore
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
+import com.woocommerce.android.ui.analytics.ranges.revenueStatsGranularity
+import com.woocommerce.android.ui.analytics.ranges.visitorStatsGranularity
+import com.woocommerce.android.ui.dashboard.data.StatsRepository
+import com.woocommerce.android.ui.dashboard.data.StatsRepository.StatsException
+import com.woocommerce.android.ui.dashboard.data.asRevenueRangeId
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.DateUtils
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.transform
+import org.wordpress.android.fluxc.model.WCRevenueStatsModel
+import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+
+class GetStats @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val statsRepository: StatsRepository,
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val coroutineDispatchers: CoroutineDispatchers,
+    private val analyticsUpdateDataStore: AnalyticsUpdateDataStore,
+) {
+    suspend operator fun invoke(refresh: Boolean, selectedRange: StatsTimeRangeSelection): Flow<LoadStatsResult> {
+        val shouldRefreshRevenue =
+            shouldUpdateStats(selectedRange, refresh, AnalyticsUpdateDataStore.AnalyticData.REVENUE)
+        val shouldRefreshVisitors =
+            shouldUpdateStats(selectedRange, refresh, AnalyticsUpdateDataStore.AnalyticData.VISITORS)
+        return merge(
+            hasOrders(),
+            revenueStats(selectedRange, shouldRefreshRevenue),
+            visitorStats(selectedRange, shouldRefreshRevenue)
+        ).onEach { result ->
+            if (result is LoadStatsResult.RevenueStatsSuccess && shouldRefreshRevenue) {
+                analyticsUpdateDataStore.storeLastAnalyticsUpdate(
+                    rangeSelection = selectedRange,
+                    analyticData = AnalyticsUpdateDataStore.AnalyticData.REVENUE
+                )
+            }
+            if (result is LoadStatsResult.VisitorsStatsSuccess && shouldRefreshVisitors) {
+                analyticsUpdateDataStore.storeLastAnalyticsUpdate(
+                    rangeSelection = selectedRange,
+                    analyticData = AnalyticsUpdateDataStore.AnalyticData.VISITORS
+                )
+            }
+        }.flowOn(coroutineDispatchers.computation)
+    }
+
+    private suspend fun hasOrders(): Flow<LoadStatsResult.HasOrders> =
+        statsRepository.checkIfStoreHasNoOrders()
+            .transform {
+                if (it.getOrNull() == true) {
+                    emit(LoadStatsResult.HasOrders(false))
+                } else {
+                    emit(LoadStatsResult.HasOrders(true))
+                }
+            }
+
+    private suspend fun revenueStats(
+        rangeSelection: StatsTimeRangeSelection,
+        forceRefresh: Boolean
+    ): Flow<LoadStatsResult> {
+        val revenueRangeId = rangeSelection.selectionType.identifier.asRevenueRangeId(
+            startDate = rangeSelection.currentRange.start,
+            endDate = rangeSelection.currentRange.end
+        )
+        if (forceRefresh.not()) {
+            statsRepository.getRevenueStatsById(revenueRangeId)
+                .takeIf { it.isSuccess && it.getOrNull() != null }
+                ?.let { return flowOf(LoadStatsResult.RevenueStatsSuccess(it.getOrNull())) }
+        }
+
+        val revenueStatsResult = statsRepository.fetchRevenueStats(
+            range = rangeSelection.currentRange,
+            granularity = rangeSelection.revenueStatsGranularity,
+            forced = forceRefresh,
+            revenueRangeId = revenueRangeId
+        ).let { result ->
+            result.fold(
+                onSuccess = { stats ->
+                    appPrefsWrapper.setV4StatsSupported(true)
+                    LoadStatsResult.RevenueStatsSuccess(stats)
+                },
+                onFailure = {
+                    if (isPluginNotActiveError(it)) {
+                        appPrefsWrapper.setV4StatsSupported(false)
+                        LoadStatsResult.PluginNotActive
+                    } else {
+                        LoadStatsResult.RevenueStatsError
+                    }
+                }
+            )
+        }
+        return flowOf(revenueStatsResult)
+    }
+
+    private suspend fun visitorStats(
+        rangeSelection: StatsTimeRangeSelection,
+        forceRefresh: Boolean
+    ): Flow<LoadStatsResult> {
+        // Visitor stats are only available for Jetpack connected sites
+        return when (selectedSite.connectionType) {
+            SiteConnectionType.Jetpack -> {
+                val result = statsRepository.fetchVisitorStats(
+                    range = rangeSelection.currentRange,
+                    granularity = rangeSelection.visitorStatsGranularity,
+                    forced = forceRefresh
+                )
+                    .let { result ->
+                        result.fold(
+                            onSuccess = { stats -> LoadStatsResult.VisitorsStatsSuccess(stats) },
+                            onFailure = { LoadStatsResult.VisitorsStatsError }
+                        )
+                    }
+                flowOf(result)
+            }
+
+            else -> selectedSite.connectionType?.let {
+                flowOf(LoadStatsResult.VisitorStatUnavailable(it))
+            } ?: emptyFlow()
+        }
+    }
+
+    private fun isPluginNotActiveError(error: Throwable): Boolean =
+        (error as? StatsException)?.error?.type == OrderStatsErrorType.PLUGIN_NOT_ACTIVE
+
+    private suspend fun shouldUpdateStats(
+        selectionRange: StatsTimeRangeSelection,
+        refresh: Boolean,
+        analyticData: AnalyticsUpdateDataStore.AnalyticData
+    ): Boolean {
+        if (refresh) return true
+        return analyticsUpdateDataStore
+            .shouldUpdateAnalytics(
+                rangeSelection = selectionRange,
+                analyticData = analyticData
+            )
+            .firstOrNull() ?: true
+    }
+
+    sealed class LoadStatsResult {
+        data class RevenueStatsSuccess(
+            val stats: WCRevenueStatsModel?
+        ) : LoadStatsResult()
+
+        data class VisitorsStatsSuccess(
+            val stats: Map<String, Int>
+        ) : LoadStatsResult()
+
+        data class HasOrders(
+            val hasOrder: Boolean
+        ) : LoadStatsResult()
+
+        object RevenueStatsError : LoadStatsResult()
+        object VisitorsStatsError : LoadStatsResult()
+        object PluginNotActive : LoadStatsResult()
+        data class VisitorStatUnavailable(
+            val connectionType: SiteConnectionType
+        ) : LoadStatsResult()
+    }
+}
+
+fun StatsGranularity.asRangeSelection(dateUtils: DateUtils, locale: Locale? = null) =
+    StatsTimeRangeSelection.SelectionType.from(this)
+        .generateSelectionData(
+            calendar = Calendar.getInstance(),
+            locale = locale ?: Locale.getDefault(),
+            referenceStartDate = dateUtils.getCurrentDateInSiteTimeZone() ?: Date(),
+            referenceEndDate = dateUtils.getCurrentDateInSiteTimeZone() ?: Date()
+        )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/domain/GetTopPerformers.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/domain/GetTopPerformers.kt
@@ -1,0 +1,91 @@
+package com.woocommerce.android.ui.dashboard.domain
+
+import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsUpdateDataStore
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
+import com.woocommerce.android.ui.dashboard.data.StatsRepository
+import com.woocommerce.android.util.CoroutineDispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import org.wordpress.android.fluxc.persistence.entity.TopPerformerProductEntity
+import javax.inject.Inject
+
+class GetTopPerformers @Inject constructor(
+    private val statsRepository: StatsRepository,
+    private val coroutineDispatchers: CoroutineDispatchers,
+    private val analyticsUpdateDataStore: AnalyticsUpdateDataStore
+) {
+    private companion object {
+        const val NUM_TOP_PERFORMERS = 5
+    }
+
+    fun observeTopPerformers(selectedRange: StatsTimeRangeSelection): Flow<List<TopPerformerProduct>> {
+        return statsRepository.observeTopPerformers(selectedRange.currentRange)
+            .map { topPerformersProductEntities ->
+                topPerformersProductEntities
+                    .map { it.toTopPerformerProduct() }
+                    .sortDescByQuantityAndTotal()
+            }.flowOn(coroutineDispatchers.computation)
+    }
+
+    suspend fun fetchTopPerformers(
+        selectedRange: StatsTimeRangeSelection,
+        refresh: Boolean = false,
+        topPerformersCount: Int = NUM_TOP_PERFORMERS,
+    ): Result<Unit> {
+        val isForcedRefresh = shouldUpdateStats(selectedRange, refresh)
+        return statsRepository.fetchTopPerformerProducts(
+            forceRefresh = isForcedRefresh,
+            range = selectedRange.currentRange,
+            quantity = topPerformersCount
+        )
+            .let { result ->
+                if (result.isSuccess && isForcedRefresh) {
+                    analyticsUpdateDataStore.storeLastAnalyticsUpdate(
+                        rangeSelection = selectedRange,
+                        analyticData = AnalyticsUpdateDataStore.AnalyticData.TOP_PERFORMERS
+                    )
+                }
+                result
+            }
+    }
+
+    private suspend fun shouldUpdateStats(
+        selectionRange: StatsTimeRangeSelection,
+        refresh: Boolean
+    ): Boolean {
+        if (refresh) return true
+        return analyticsUpdateDataStore
+            .shouldUpdateAnalytics(
+                rangeSelection = selectionRange,
+                analyticData = AnalyticsUpdateDataStore.AnalyticData.TOP_PERFORMERS
+            )
+            .firstOrNull() ?: true
+    }
+
+    private fun List<TopPerformerProduct>.sortDescByQuantityAndTotal() =
+        sortedWith(
+            compareByDescending(TopPerformerProduct::quantity)
+                .thenByDescending(TopPerformerProduct::total)
+        )
+
+    private fun TopPerformerProductEntity.toTopPerformerProduct() =
+        TopPerformerProduct(
+            productId = productId.value,
+            name = name,
+            quantity = quantity,
+            currency = currency,
+            total = total,
+            imageUrl = imageUrl
+        )
+
+    data class TopPerformerProduct(
+        val productId: Long,
+        val name: String,
+        val quantity: Int,
+        val currency: String,
+        val total: Double,
+        val imageUrl: String?
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/domain/ObserveLastUpdate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/domain/ObserveLastUpdate.kt
@@ -1,0 +1,39 @@
+package com.woocommerce.android.ui.dashboard.domain
+
+import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsUpdateDataStore
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class ObserveLastUpdate @Inject constructor(
+    private val analyticsUpdateDataStore: AnalyticsUpdateDataStore
+) {
+    operator fun invoke(
+        selectedRange: StatsTimeRangeSelection,
+        analyticData: List<AnalyticsUpdateDataStore.AnalyticData>
+    ): Flow<Long?> {
+        return analyticsUpdateDataStore.observeLastUpdate(
+            rangeSelection = selectedRange,
+            analyticData = analyticData
+        )
+    }
+
+    operator fun invoke(
+        selectedRange: StatsTimeRangeSelection,
+        analyticData: AnalyticsUpdateDataStore.AnalyticData
+    ): Flow<Long?> {
+        return analyticsUpdateDataStore.observeLastUpdate(
+            rangeSelection = selectedRange,
+            analyticData = analyticData
+        )
+    }
+
+    operator fun invoke(
+        timeRangeSelection: StatsTimeRangeSelection
+    ): Flow<Long?> {
+        return analyticsUpdateDataStore.observeLastUpdate(
+            rangeSelection = timeRangeSelection,
+            analyticData = AnalyticsUpdateDataStore.AnalyticData.ALL
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/BottomNavigationPosition.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/BottomNavigationPosition.kt
@@ -8,7 +8,7 @@ const val PRODUCTS_POSITION = 2
 const val MORE_POSITION = 3
 
 enum class BottomNavigationPosition(val position: Int, val id: Int) {
-    MY_STORE(MY_STORE_POSITION, R.id.dashboard),
+    MY_STORE(MY_STORE_POSITION, R.id.my_store),
     ORDERS(ORDERS_POSITION, R.id.orders),
     PRODUCTS(PRODUCTS_POSITION, R.id.products),
     MORE(MORE_POSITION, R.id.moreMenu)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/BottomNavigationPosition.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/BottomNavigationPosition.kt
@@ -8,7 +8,7 @@ const val PRODUCTS_POSITION = 2
 const val MORE_POSITION = 3
 
 enum class BottomNavigationPosition(val position: Int, val id: Int) {
-    MY_STORE(MY_STORE_POSITION, R.id.my_store),
+    MY_STORE(MY_STORE_POSITION, DashboardDestination.id),
     ORDERS(ORDERS_POSITION, R.id.orders),
     PRODUCTS(PRODUCTS_POSITION, R.id.products),
     MORE(MORE_POSITION, R.id.moreMenu)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/DashboardDestination.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/DashboardDestination.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.main
+
+import com.woocommerce.android.R
+import com.woocommerce.android.util.FeatureFlag
+
+object DashboardDestination {
+    val id = if (FeatureFlag.DYNAMIC_DASHBOARD.isEnabled()) R.id.dashboard else R.id.my_store
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -444,7 +444,7 @@ class MainActivity :
     override fun isAtNavigationRoot(): Boolean {
         return if (::navController.isInitialized) {
             val currentDestinationId = navController.currentDestination?.id
-            currentDestinationId == R.id.dashboard ||
+            currentDestinationId == R.id.my_store ||
                 currentDestinationId == R.id.orders ||
                 currentDestinationId == R.id.products ||
                 currentDestinationId == R.id.moreMenu ||

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -444,7 +444,7 @@ class MainActivity :
     override fun isAtNavigationRoot(): Boolean {
         return if (::navController.isInitialized) {
             val currentDestinationId = navController.currentDestination?.id
-            currentDestinationId == R.id.my_store ||
+            currentDestinationId == DashboardDestination.id ||
                 currentDestinationId == R.id.orders ||
                 currentDestinationId == R.id.products ||
                 currentDestinationId == R.id.moreMenu ||

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -64,7 +64,7 @@ class MainActivityViewModel @Inject constructor(
         }
     }
 
-    val startDestination = if (selectedSite.exists()) R.id.my_store else R.id.nav_graph_site_picker
+    val startDestination = if (selectedSite.exists()) DashboardDestination.id else R.id.nav_graph_site_picker
 
     val moreMenuBadgeState = combine(
         unseenReviewsCountHandler.observeUnseenCount(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -64,7 +64,7 @@ class MainActivityViewModel @Inject constructor(
         }
     }
 
-    val startDestination = if (selectedSite.exists()) R.id.dashboard else R.id.nav_graph_site_picker
+    val startDestination = if (selectedSite.exists()) R.id.my_store else R.id.nav_graph_site_picker
 
     val moreMenuBadgeState = combine(
         unseenReviewsCountHandler.observeUnseenCount(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -17,6 +17,7 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.navigation.NavigationBarView.OnItemReselectedListener
 import com.google.android.material.navigation.NavigationBarView.OnItemSelectedListener
 import com.woocommerce.android.R
+import com.woocommerce.android.util.FeatureFlag
 import java.lang.ref.WeakReference
 
 class MainBottomNavigationView @JvmOverloads constructor(
@@ -44,6 +45,12 @@ class MainBottomNavigationView @JvmOverloads constructor(
     fun init(navController: NavController, listener: MainNavigationListener) {
         this.navController = navController
         this.listener = listener
+
+        if (FeatureFlag.DYNAMIC_DASHBOARD.isEnabled()) {
+            menu.removeItem(R.id.my_store)
+        } else {
+            menu.removeItem(R.id.dashboard)
+        }
 
         addTopDivider()
         createBadges()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductNavigator.kt
@@ -282,7 +282,7 @@ class ProductNavigator @Inject constructor() {
                     navOptions =
                     if (target.source == STORE_ONBOARDING) {
                         NavOptions.Builder()
-                            .setPopUpTo(id.dashboard, false)
+                            .setPopUpTo(id.my_store, false)
                             .build()
                     } else {
                         null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -28,11 +28,10 @@ enum class FeatureFlag {
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
             NEW_SHIPPING_SUPPORT -> PackageUtils.isDebugBuild()
-
+            DYNAMIC_DASHBOARD -> PackageUtils.isDebugBuild() && !PackageUtils.isTesting()
             CONNECTIVITY_TOOL,
             BLAZE_I3,
-            CUSTOM_RANGE_ANALYTICS,
-            DYNAMIC_DASHBOARD -> true
+            CUSTOM_RANGE_ANALYTICS -> true
         }
     }
 }

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/dashboardStats_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/empty_state_bg_color"
+    tools:context="com.woocommerce.android.ui.dashboard.DashboardFragment">
+
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout
+            android:id="@+id/my_store_refresh_layout"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+            <androidx.core.widget.NestedScrollView
+                android:id="@+id/stats_scroll_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:transitionGroup="true">
+
+                <LinearLayout
+                    android:id="@+id/my_store_stats_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:animateLayoutChanges="true"
+                    android:descendantFocusability="blocksDescendants"
+                    android:orientation="vertical">
+
+                    <androidx.fragment.app.FragmentContainerView
+                        android:id="@+id/jitmFragment"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/minor_100" />
+
+                    <androidx.compose.ui.platform.ComposeView
+                        android:id="@+id/store_onboarding_view"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/minor_100"
+                        android:transitionName="@string/store_onboarding_collapsed_transition_name"
+                        android:visibility="gone" />
+
+                    <androidx.compose.ui.platform.ComposeView
+                        android:id="@+id/blaze_banner_view"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/minor_100"
+                        android:visibility="gone" />
+
+                    <!-- Order stats -->
+                    <com.woocommerce.android.ui.dashboard.DashboardStatsView
+                        android:id="@+id/my_store_stats"
+                        style="@style/Woo.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" />
+
+                    <!-- Feedback Request Card -->
+                    <com.woocommerce.android.ui.feedback.FeedbackRequestCard
+                        android:id="@+id/store_feedback_request_card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/minor_100"
+                        android:visibility="gone" />
+
+                    <androidx.compose.ui.platform.ComposeView
+                        android:id="@+id/blaze_campaign_view"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/minor_100"
+                        android:visibility="gone" />
+
+                    <com.woocommerce.android.widgets.WCEmptyView
+                        android:id="@+id/empty_view"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_marginTop="@dimen/major_100"
+                        android:visibility="gone"
+                        tools:visibility="visible" />
+
+                    <!-- Top performer stats -->
+                    <com.woocommerce.android.ui.dashboard.DashboardTopPerformersView
+                        android:id="@+id/my_store_top_performers"
+                        style="@style/Woo.Card"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" />
+
+                </LinearLayout>
+            </androidx.core.widget.NestedScrollView>
+
+        </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>
+
+        <include
+            android:id="@+id/jetpack_benefits_banner"
+            layout="@layout/view_jetpack_benefits_bottom_banner" />
+    </androidx.appcompat.widget.LinearLayoutCompat>
+
+    <ScrollView
+        android:id="@+id/stats_error_scroll_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/empty_state_bg_color"
+        android:visibility="gone">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal|top"
+            android:orientation="vertical"
+            android:padding="@dimen/major_200">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/my_store_stats_availability_title"
+                style="@style/Woo.TextView.Headline6"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:lineSpacingExtra="5sp"
+                android:text="@string/my_store_stats_availability_title"
+                android:textAlignment="center"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageView
+                android:id="@+id/stats_availability_image"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_250"
+                android:importantForAccessibility="no"
+                android:src="@drawable/img_empty_search"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/my_store_stats_availability_title" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/my_store_stats_availability_message"
+                style="@style/Woo.TextView.Body1"
+                android:layout_width="@dimen/minor_00"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/major_150"
+                android:layout_marginTop="@dimen/major_250"
+                android:layout_marginEnd="@dimen/major_150"
+                android:lineSpacingExtra="@dimen/minor_50"
+                android:text="@string/my_store_stats_availability_description"
+                android:textAlignment="center"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/stats_availability_image" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </ScrollView>
+
+</RelativeLayout>

--- a/WooCommerce/src/main/res/menu/menu_bottom_bar.xml
+++ b/WooCommerce/src/main/res/menu/menu_bottom_bar.xml
@@ -7,6 +7,11 @@
         android:title="@string/my_store" />
 
     <item
+        android:id="@+id/dashboard"
+        android:icon="@drawable/as_menu_dashboard"
+        android:title="@string/my_store" />
+
+    <item
         android:id="@+id/orders"
         android:icon="@drawable/as_menu_orders_list"
         android:title="@string/orders" />

--- a/WooCommerce/src/main/res/menu/menu_bottom_bar.xml
+++ b/WooCommerce/src/main/res/menu/menu_bottom_bar.xml
@@ -2,7 +2,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
-        android:id="@+id/dashboard"
+        android:id="@+id/my_store"
         android:icon="@drawable/as_menu_dashboard"
         android:title="@string/my_store" />
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -19,7 +19,7 @@
     <include app:graph="@navigation/nav_graph_order_creations" />
 
     <fragment
-        android:id="@+id/dashboard"
+        android:id="@+id/my_store"
         android:name="com.woocommerce.android.ui.mystore.MyStoreFragment"
         android:label="fragment_my_store"
         tools:layout="@layout/fragment_my_store">
@@ -83,6 +83,73 @@
             app:destination="@id/addProductWithAIBottomSheet" />
         <action
             android:id="@+id/action_myStore_to_blazeCampaignListFragment"
+            app:destination="@id/blazeCampaignListFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/dashboard"
+        android:name="com.woocommerce.android.ui.dashboard.DashboardFragment"
+        android:label="fragment_dashboard"
+        tools:layout="@layout/fragment_my_store">
+        <action
+            android:id="@+id/action_dashboard_to_jetpackBenefitsDialog"
+            app:destination="@id/nav_graph_jetpack_install" />
+        <action
+            android:id="@+id/action_dashboard_to_analytics"
+            app:destination="@id/analytics"
+            app:enterAnim="@anim/activity_fade_in"
+            app:exitAnim="@null"
+            app:popEnterAnim="@null"
+            app:popExitAnim="@anim/activity_fade_out" />
+        <action
+            android:id="@+id/action_dashboard_to_onboardingFragment"
+            app:destination="@id/storeOnboardingFragment" />
+        <action
+            android:id="@+id/action_dashboard_to_launchStoreFragment"
+            app:destination="@id/launchStoreFragment" />
+        <action
+            android:id="@+id/action_dashboard_to_nav_graph_domain_change"
+            app:destination="@id/nav_graph_domain_change">
+            <argument
+                android:name="source"
+                android:defaultValue="STORE_ONBOARDING"
+                app:argType="com.woocommerce.android.ui.prefs.domain.DomainFlowSource" />
+        </action>
+        <action
+            android:id="@+id/action_dashboard_to_productTypesBottomSheet"
+            app:destination="@id/productTypesBottomSheetFragment"
+            app:enterAnim="@anim/activity_fade_in"
+            app:exitAnim="@null"
+            app:popEnterAnim="@null"
+            app:popExitAnim="@anim/activity_fade_out">
+            <argument
+                android:name="isAddProduct"
+                android:defaultValue="true"
+                app:argType="boolean" />
+            <argument
+                android:name="source"
+                android:defaultValue="STORE_ONBOARDING"
+                app:argType="com.woocommerce.android.ui.products.AddProductSource" />
+        </action>
+        <action
+            android:id="@+id/action_dashboard_to_paymentsPreSetupFragment"
+            app:destination="@id/paymentsPreSetupFragment" />
+        <action
+            android:id="@+id/action_dashboard_to_wooPaymentsSetupInstructionsFragment"
+            app:destination="@id/wooPaymentsSetupInstructionsFragment" />
+        <action
+            android:id="@+id/action_dashboard_to_aboutYourStoreFragment"
+            app:destination="@id/aboutYourStoreFragment" />
+        <action
+            android:id="@+id/action_dashboard_to_AIProductDescriptionDialogFragment"
+            app:destination="@id/AIProductDescriptionDialogFragment" />
+        <action
+            android:id="@+id/action_dashboard_to_nameYourStoreDialogFragment"
+            app:destination="@id/nameYourStoreDialogFragment" />
+        <action
+            android:id="@+id/action_dashboard_to_addProductWithAIBottomSheet"
+            app:destination="@id/addProductWithAIBottomSheet" />
+        <action
+            android:id="@+id/action_dashboard_to_blazeCampaignListFragment"
             app:destination="@id/blazeCampaignListFragment" />
     </fragment>
     <fragment


### PR DESCRIPTION
### Description
As agreed on Slack, this PR adds a copy of the my store screen, it's a copy of all of the package, which would make the development on the new screen less disruptive.

I didn't duplicate tests, as I think we'll need new unit tests for most of the changes, and where the old tests are usable, we'll move them when needed before doing any code cleanup at the end of the project.

### Testing instructions
Just a non-regression test, disable the feature flag, and confirm the app behaves correctly (this should be covered by UI tests, but just to be sure).

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
