### PR TITLE
Fix crash when updating a product category

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
@@ -247,7 +247,9 @@ class AddProductCategoryViewModel @Inject constructor(
                 if (productsInDb.isEmpty()) {
                     showSkeleton = true
                 } else {
-                    _parentCategories.value = productsInDb.sortCategories(resourceProvider)
+                    _parentCategories.value = productsInDb
+                        .sortCategories(resourceProvider)
+                        .filter { parentCategoryIsElegible(it) }
                     showSkeleton = false
                 }
             }
@@ -260,6 +262,10 @@ class AddProductCategoryViewModel @Inject constructor(
             fetchParentCategories(loadMore = loadMore)
         }
     }
+
+    private fun parentCategoryIsElegible(it: ProductCategoryItemUiModel) =
+        it.category.remoteCategoryId != navArgs.productCategory?.remoteCategoryId &&
+            it.category.parentId != navArgs.productCategory?.remoteCategoryId
 
     /**
      * Triggered when the user scrolls past the point of loaded categories
@@ -284,6 +290,7 @@ class AddProductCategoryViewModel @Inject constructor(
                     productCategoriesRepository.getProductCategoriesList()
                 }
                 .sortCategories(resourceProvider)
+                .filter { parentCategoryIsElegible(it) }
 
             parentCategoryListViewState = parentCategoryListViewState.copy(
                 isLoading = true,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
@@ -63,7 +63,9 @@ class AddProductCategoryViewModel @Inject constructor(
     }
 
     fun onBackButtonClicked(categoryName: String, parentId: String): Boolean {
-        val hasChanges = categoryName.isNotEmpty() || parentId.isNotEmpty()
+        val hasChanges = (categoryName.isNotEmpty() || parentId.isNotEmpty()) &&
+            navArgs.productCategory?.name != addProductCategoryViewState.categoryName ||
+            navArgs.productCategory?.parentId != addProductCategoryViewState.selectedParentId
         return if (hasChanges && addProductCategoryViewState.shouldShowDiscardDialog) {
             triggerEvent(
                 ShowDialog.buildDiscardDialogEvent(


### PR DESCRIPTION
⚠️ Do not merge yet. We need to discuss if this needs to be a beta fix. 

<!-- Remember about a good descriptive title. -->

Closes: #11210 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
When updating an existing product category, if the user selects as the parent category: 
- The category that is being edited itself
- OR a child category of the category that is being edited

The app will crash. This bug is caused by an API flaw. The API will return `200 success`, but the category won't be updated, and the `parentId` will be set to 0, which leads to the null pointer exception. 

Follow these steps to reproduce the null pointer crash:

https://github.com/woocommerce/woocommerce-android/assets/2663464/998963fa-e544-40e5-a4c4-21c1ca595237

To fix this, we need to ensure that when editing an existing category and opening the parent categories screen, the following categories are excluded from the list: 
- The category that is currently being edited
- Any child category of the category being edited


NOTE: There's a bug I just noticed while testing this, unrelated to the changes or the feature. But when opening the parent category selector, you'll see the 2 toolbars are shown. Should be fixed in a different PR IMHO. 

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Navigate to the product detail screen
2. Open categories screen
3. Click on an existing category
4. Check that the parent category selector doesn't show any child categories or the category itself

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/e67d4ae7-58a3-404a-b2c1-8be541769fff
