### PR TITLE
Fix/align tracking with ios for custom range

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/ranges/StatsTimeRangeGranularities.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/ranges/StatsTimeRangeGranularities.kt
@@ -54,3 +54,6 @@ val StatsTimeRangeSelection.visitorSummaryStatsGranularity: StatsGranularity
             }
         }
     }
+
+val StatsTimeRangeSelection.myStoreTrackingGranularityString: String
+    get() = selectionType.toDashBoardTrackingGranularityString()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/ranges/StatsTimeRangeSelection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/ranges/StatsTimeRangeSelection.kt
@@ -188,5 +188,5 @@ fun SelectionType.toDashBoardTrackingGranularityString(): String {
         YEAR_TO_DATE -> StatsGranularity.YEARS.name
         CUSTOM -> this.identifier
         else -> error("My Store tracking granularity unsupported range")
-    }
+    }.lowercase()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/ranges/StatsTimeRangeSelection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/ranges/StatsTimeRangeSelection.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.analytics.ranges
 
 import android.os.Parcelable
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.CUSTOM
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.LAST_MONTH
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.LAST_QUARTER
@@ -176,5 +177,16 @@ class StatsTimeRangeSelection private constructor(
             val names: Array<String>
                 get() = values().map { it.name }.toTypedArray()
         }
+    }
+}
+
+fun SelectionType.toDashBoardTrackingGranularityString(): String {
+    return when (this) {
+        TODAY -> StatsGranularity.DAYS.name
+        WEEK_TO_DATE -> StatsGranularity.WEEKS.name
+        MONTH_TO_DATE -> StatsGranularity.MONTHS.name
+        YEAR_TO_DATE -> StatsGranularity.YEARS.name
+        CUSTOM -> this.identifier
+        else -> error("My Store tracking granularity unsupported range")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardStatsView.kt
@@ -41,6 +41,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.analytics.ranges.myStoreTrackingGranularityString
 import com.woocommerce.android.ui.analytics.ranges.revenueStatsGranularity
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.Companion.SUPPORTED_RANGES_ON_MY_STORE_TAB
 import com.woocommerce.android.util.CurrencyFormatter
@@ -213,7 +214,7 @@ class DashboardStatsView @JvmOverloads constructor(
         // Track range change
         AnalyticsTracker.track(
             AnalyticsEvent.DASHBOARD_MAIN_STATS_DATE,
-            mapOf(KEY_RANGE to selectedTimeRange.selectionType.toString().lowercase())
+            mapOf(KEY_RANGE to selectedTimeRange.myStoreTrackingGranularityString)
         )
         isRequestingStats = true
         applyCustomRange(statsTimeRangeSelection)
@@ -806,7 +807,7 @@ class DashboardStatsView @JvmOverloads constructor(
                 AnalyticsEvent.STATS_UNEXPECTED_FORMAT,
                 mapOf(
                     KEY_DATE to dateString,
-                    KEY_GRANULARITY to statsTimeRangeSelection.selectionType.identifier,
+                    KEY_GRANULARITY to statsTimeRangeSelection.myStoreTrackingGranularityString,
                     KEY_RANGE to revenueStatsModel?.rangeId
                 )
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopPerformersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardTopPerformersView.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.databinding.MyStoreTopPerformersBinding
 import com.woocommerce.android.databinding.TopPerformersListItemBinding
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.analytics.ranges.toDashBoardTrackingGranularityString
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.widgets.SkeletonView
 import java.util.Locale
@@ -58,7 +59,7 @@ class DashboardTopPerformersView @JvmOverloads constructor(
     fun onDateGranularityChanged(selectionType: SelectionType) {
         AnalyticsTracker.track(
             AnalyticsEvent.DASHBOARD_TOP_PERFORMERS_DATE,
-            mapOf(AnalyticsTracker.KEY_RANGE to selectionType.identifier)
+            mapOf(AnalyticsTracker.KEY_RANGE to selectionType.toDashBoardTrackingGranularityString())
         )
         binding.topPerformersRecycler.adapter = TopPerformersAdapter()
         showEmptyView(false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsUpdateDataStore
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.analytics.ranges.myStoreTrackingGranularityString
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenDatePicker
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowAIProductDescriptionDialog
 import com.woocommerce.android.ui.dashboard.domain.GetStats
@@ -307,7 +308,7 @@ class DashboardViewModel @Inject constructor(
         analyticsTrackerWrapper.track(
             AnalyticsEvent.DASHBOARD_MAIN_STATS_LOADED,
             buildMap {
-                put(AnalyticsTracker.KEY_RANGE, selectedRange.selectionType.identifier)
+                put(AnalyticsTracker.KEY_RANGE, selectedRange.myStoreTrackingGranularityString)
                 putIfNotNull(AnalyticsTracker.KEY_ID to result.stats?.rangeId)
             }
         )
@@ -345,7 +346,7 @@ class DashboardViewModel @Inject constructor(
             onSuccess = {
                 analyticsTrackerWrapper.track(
                     AnalyticsEvent.DASHBOARD_TOP_PERFORMERS_LOADED,
-                    mapOf(AnalyticsTracker.KEY_RANGE to selectedRange.selectionType.identifier)
+                    mapOf(AnalyticsTracker.KEY_RANGE to selectedRange.myStoreTrackingGranularityString)
                 )
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -41,6 +41,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.analytics.ranges.myStoreTrackingGranularityString
 import com.woocommerce.android.ui.analytics.ranges.revenueStatsGranularity
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.Companion.SUPPORTED_RANGES_ON_MY_STORE_TAB
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.VisitorStatsViewState
@@ -210,7 +211,7 @@ class MyStoreStatsView @JvmOverloads constructor(
         // Track range change
         AnalyticsTracker.track(
             AnalyticsEvent.DASHBOARD_MAIN_STATS_DATE,
-            mapOf(KEY_RANGE to selectedTimeRange.selectionType.toString().lowercase())
+            mapOf(KEY_RANGE to selectedTimeRange.myStoreTrackingGranularityString)
         )
         isRequestingStats = true
         applyCustomRange(statsTimeRangeSelection)
@@ -820,7 +821,7 @@ class MyStoreStatsView @JvmOverloads constructor(
                 AnalyticsEvent.STATS_UNEXPECTED_FORMAT,
                 mapOf(
                     KEY_DATE to dateString,
-                    KEY_GRANULARITY to statsTimeRangeSelection.selectionType.identifier,
+                    KEY_GRANULARITY to statsTimeRangeSelection.myStoreTrackingGranularityString,
                     KEY_RANGE to revenueStatsModel?.rangeId
                 )
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopPerformersView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreTopPerformersView.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.databinding.MyStoreTopPerformersBinding
 import com.woocommerce.android.databinding.TopPerformersListItemBinding
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.analytics.ranges.toDashBoardTrackingGranularityString
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.widgets.SkeletonView
 import java.util.Locale
@@ -58,7 +59,7 @@ class MyStoreTopPerformersView @JvmOverloads constructor(
     fun onDateGranularityChanged(selectionType: SelectionType) {
         AnalyticsTracker.track(
             AnalyticsEvent.DASHBOARD_TOP_PERFORMERS_DATE,
-            mapOf(AnalyticsTracker.KEY_RANGE to selectionType.identifier)
+            mapOf(AnalyticsTracker.KEY_RANGE to selectionType.toDashBoardTrackingGranularityString())
         )
         binding.topPerformersRecycler.adapter = TopPerformersAdapter()
         showEmptyView(false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -25,6 +25,8 @@ import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsUpdateDataStore
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.analytics.ranges.myStoreTrackingGranularityString
+import com.woocommerce.android.ui.analytics.ranges.revenueStatsGranularity
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.MyStoreEvent.OpenDatePicker
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.MyStoreEvent.ShowAIProductDescriptionDialog
 import com.woocommerce.android.ui.mystore.data.CustomDateRangeDataStore
@@ -307,10 +309,11 @@ class MyStoreViewModel @Inject constructor(
             result.stats?.toStoreStatsUiModel(),
             selectedRange
         )
+        selectedRange.revenueStatsGranularity
         analyticsTrackerWrapper.track(
             AnalyticsEvent.DASHBOARD_MAIN_STATS_LOADED,
             buildMap {
-                put(AnalyticsTracker.KEY_RANGE, selectedRange.selectionType.identifier)
+                put(AnalyticsTracker.KEY_RANGE, selectedRange.myStoreTrackingGranularityString)
                 putIfNotNull(AnalyticsTracker.KEY_ID to result.stats?.rangeId)
             }
         )
@@ -348,7 +351,7 @@ class MyStoreViewModel @Inject constructor(
             onSuccess = {
                 analyticsTrackerWrapper.track(
                     AnalyticsEvent.DASHBOARD_TOP_PERFORMERS_LOADED,
-                    mapOf(AnalyticsTracker.KEY_RANGE to selectedRange.selectionType.identifier)
+                    mapOf(AnalyticsTracker.KEY_RANGE to selectedRange.myStoreTrackingGranularityString)
                 )
             }
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/MyStoreViewModelTest.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsUpdateDataStore
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
+import com.woocommerce.android.ui.analytics.ranges.toDashBoardTrackingGranularityString
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.RevenueStatsViewState.Content
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.RevenueStatsViewState.GenericError
 import com.woocommerce.android.ui.mystore.MyStoreViewModel.RevenueStatsViewState.PluginNotActiveError
@@ -216,7 +217,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
             verify(analyticsTrackerWrapper).track(
                 AnalyticsEvent.DASHBOARD_MAIN_STATS_LOADED,
-                mapOf(AnalyticsTracker.KEY_RANGE to ANY_SELECTION_TYPE.identifier)
+                mapOf(AnalyticsTracker.KEY_RANGE to ANY_SELECTION_TYPE.toDashBoardTrackingGranularityString())
             )
         }
 
@@ -371,7 +372,7 @@ class MyStoreViewModelTest : BaseUnitTest() {
 
             verify(analyticsTrackerWrapper).track(
                 AnalyticsEvent.DASHBOARD_TOP_PERFORMERS_LOADED,
-                mapOf(AnalyticsTracker.KEY_RANGE to ANY_SELECTION_TYPE.identifier)
+                mapOf(AnalyticsTracker.KEY_RANGE to ANY_SELECTION_TYPE.toDashBoardTrackingGranularityString())
             )
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
While working on the Custom Range tab project I refactored the tracking values for the property `range` to match the values used in Analytics Hub. That is the `SelectionType.identifier` value. However, after some discussion with iOS folks p1711098837458129-slack-C03L1NF1EA3, it was decided to revert this change back and use `StatsGranularity.name.lowercase()` for tracking `range` property values. 

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Smoke test tracking for My Store tab and check  that any event tracked with the `range` property has the following values: 
- `days`
- `weeks`
- `months`
- `years`
- `custom`