### PR TITLE
Disable the dynamic dashboard feature flag temporarily

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -30,7 +30,7 @@ enum class FeatureFlag {
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE -> PackageUtils.isDebugBuild()
 
-            DYNAMIC_DASHBOARD -> PackageUtils.isDebugBuild() && !PackageUtils.isTesting()
+            DYNAMIC_DASHBOARD -> false
 
             CONNECTIVITY_TOOL,
             BLAZE_I3,


### PR DESCRIPTION
### Description
This PR simply disables the dynamic dashboard flag temporarily to avoid disrupting the development flow of other teams.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
