### PR TITLE
Integer overflow crash fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/budget/BlazeCampaignBudgetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/budget/BlazeCampaignBudgetViewModel.kt
@@ -238,8 +238,8 @@ class BlazeCampaignBudgetViewModel @Inject constructor(
     @Parcelize
     data class ForecastUi(
         val isLoading: Boolean,
-        val impressionsMin: Int,
-        val impressionsMax: Int,
+        val impressionsMin: Long,
+        val impressionsMax: Long,
         val isError: Boolean
     ) : Parcelable
 }

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-0e8dda940d40d875e52256555706c2fde382d0c4'
+    fluxCVersion = 'trunk-f154a1ace883ee3e0f4b1308a76c9316109b6b03'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Fixes #11230, a crash that occurs because a Blaze API response value contains a parameter that can be larger that 32-bit integer. This PR updates the FluxC reference and changes the type of the affected parameters.

**To test:**
There's not much to test, a simple smoke test of ad forecasting is sufficient.