### PR TITLE
Explore plugins analytic hub

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/PluginUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/PluginUrls.kt
@@ -1,9 +1,7 @@
 package com.woocommerce.android.model
 
-class PluginUrls {
-    companion object{
-        const val SUBSCRIPTIONS_URL = "https://woo.com/products/woocommerce-subscriptions/"
-        const val BUNDLES_URL = "https://woo.com/products/product-bundles/"
-        const val COMPOSITE_URL = "https://woo.com/products/composite-products/"
-    }
+object PluginUrls {
+    const val SUBSCRIPTIONS_URL = "https://woo.com/products/woocommerce-subscriptions/"
+    const val BUNDLES_URL = "https://woo.com/products/product-bundles/"
+    const val COMPOSITE_URL = "https://woo.com/products/composite-products/"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/PluginUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/PluginUrls.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.model
+
+class PluginUrls {
+    companion object{
+        const val SUBSCRIPTIONS_URL = "https://woo.com/products/woocommerce-subscriptions/"
+        const val BUNDLES_URL = "https://woo.com/products/product-bundles/"
+        const val COMPOSITE_URL = "https://woo.com/products/composite-products/"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingFragment.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -44,6 +45,9 @@ class AnalyticsHubSettingFragment : BaseFragment() {
     private fun handleEvent(event: MultiLiveEvent.Event) {
         when (event) {
             is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
+            is MultiLiveEvent.Event.LaunchUrlInChromeTab -> {
+                ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingScreen.kt
@@ -29,7 +29,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.AnalyticsCards
 import com.woocommerce.android.ui.compose.component.DiscardChangesDialog
 import com.woocommerce.android.ui.compose.component.DragAndDropItem
-import com.woocommerce.android.ui.compose.component.DragAndDropSelectableItemsList
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
@@ -62,11 +61,12 @@ fun AnalyticsHubSettingScreen(viewModel: AnalyticsHubSettingsViewModel) {
         }) { padding ->
             when (state) {
                 is AnalyticsHubSettingsViewState.CardsConfiguration -> {
-                    DragAndDropSelectableItemsList(
+                    HubSettingsCardItemsList(
                         items = state.cardsConfiguration,
                         selectedItems = state.cardsConfiguration.filter { it.isVisible },
                         onSelectionChange = viewModel::onSelectionChange,
                         onOrderChange = viewModel::onOrderChange,
+                        onExplorePlugin = viewModel::onExploreUrl,
                         itemFormatter = { title },
                         itemKey = { _, card -> card.card },
                         modifier = Modifier.padding(padding)
@@ -105,15 +105,17 @@ fun LoadWidgetsConfiguration(modifier: Modifier = Modifier) {
 @Preview(name = "Screen", device = Devices.PIXEL_4)
 fun AnalyticsHubSettingScreenPreview() {
     val items = listOf(
-        AnalyticCardConfigurationUI(AnalyticsCards.Revenue, "Revenue", true),
-        AnalyticCardConfigurationUI(AnalyticsCards.Orders, "Orders", true),
-        AnalyticCardConfigurationUI(AnalyticsCards.Session, "Session", false)
+        AnalyticCardConfigurationUI.SelectableCardConfigurationUI(AnalyticsCards.Revenue, "Revenue", true),
+        AnalyticCardConfigurationUI.SelectableCardConfigurationUI(AnalyticsCards.Orders, "Orders", true),
+        AnalyticCardConfigurationUI.SelectableCardConfigurationUI(AnalyticsCards.Session, "Session", false),
+        AnalyticCardConfigurationUI.ExploreCardConfigurationUI(AnalyticsCards.Bundles, "Bundles", "")
     )
-    DragAndDropSelectableItemsList(
+    HubSettingsCardItemsList(
         items = items,
         selectedItems = items.filter { it.isVisible },
         onSelectionChange = { _, _ -> },
         onOrderChange = { _, _ -> },
+        onExplorePlugin = {},
         itemFormatter = { title },
         itemKey = { _, card -> card.card }
     )
@@ -124,7 +126,7 @@ fun AnalyticsHubSettingScreenPreview() {
 fun AnalyticCardItemPreview() {
     WooThemeWithBackground {
         DragAndDropItem(
-            item = AnalyticCardConfigurationUI(AnalyticsCards.Revenue, "Revenue", true),
+            item = AnalyticCardConfigurationUI.SelectableCardConfigurationUI(AnalyticsCards.Revenue, "Revenue", true),
             title = "Revenue",
             isSelected = true,
             onSelectionChange = { _, _ -> }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingsViewModel.kt
@@ -7,8 +7,10 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.AnalyticCardConfiguration
 import com.woocommerce.android.model.AnalyticsCards
+import com.woocommerce.android.model.PluginUrls
 import com.woocommerce.android.ui.analytics.hub.GetAnalyticPluginsCardActive
 import com.woocommerce.android.ui.analytics.hub.ObserveAnalyticsCardsConfiguration
+import com.woocommerce.android.ui.analytics.hub.settings.AnalyticsHubSettingsViewModel.Companion.MARKETPLACE
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -30,6 +32,7 @@ class AnalyticsHubSettingsViewModel @Inject constructor(
 
     companion object {
         const val LOADING_DELAY_MS = 500L
+        const val MARKETPLACE = "https://woo.com/products/"
     }
 
     val viewStateData: LiveDataDelegate<AnalyticsHubSettingsViewState> =
@@ -46,7 +49,9 @@ class AnalyticsHubSettingsViewModel @Inject constructor(
         launch {
             activePluginCards = getAnalyticPluginsCardActive()
             observeAnalyticsCardsConfiguration().first().let { configuration ->
-                currentConfiguration = configuration.map { it.toConfigurationUI(activePluginCards) }
+                currentConfiguration = configuration
+                    .map { it.toConfigurationUI(activePluginCards) }
+                    .sortedByDescending { it is AnalyticCardConfigurationUI.SelectableCardConfigurationUI }
                 draftConfiguration = currentConfiguration
                 checkVisibleCards()
                 viewState = AnalyticsHubSettingsViewState.CardsConfiguration(
@@ -127,23 +132,35 @@ class AnalyticsHubSettingsViewModel @Inject constructor(
 
     private fun updateSelection(card: AnalyticsCards, isSelected: Boolean) {
         draftConfiguration = draftConfiguration.map { cardConfiguration ->
-            if (cardConfiguration.card == card) {
-                cardConfiguration.copy(isVisible = isSelected)
-            } else {
-                cardConfiguration
+            when {
+                cardConfiguration.card == card &&
+                    cardConfiguration is AnalyticCardConfigurationUI.SelectableCardConfigurationUI -> {
+                    cardConfiguration.copy(isVisible = isSelected)
+                }
+
+                else -> {
+                    cardConfiguration
+                }
             }
         }
     }
 
+    fun onExploreUrl(url: String) {
+        triggerEvent(MultiLiveEvent.Event.LaunchUrlInChromeTab(url))
+    }
+
     private fun checkVisibleCards() {
         val visibleCards = draftConfiguration.count { card -> card.isVisible }
-        draftConfiguration = draftConfiguration.map { card ->
-            if (visibleCards == 1 && card.isVisible) {
-                card.copy(isEnabled = false)
-            } else {
-                card.copy(isEnabled = card.card.isPlugin.not() || card.card in activePluginCards)
+        draftConfiguration =
+            draftConfiguration.map { card ->
+                when {
+                    card is AnalyticCardConfigurationUI.SelectableCardConfigurationUI &&
+                        visibleCards == 1 &&
+                        card.isVisible -> card.copy(isEnabled = false)
+                    card is AnalyticCardConfigurationUI.SelectableCardConfigurationUI -> card.copy(isEnabled = true)
+                    else -> card
+                }
             }
-        }
     }
 
     fun onOrderChange(fromIndex: Int, toIndex: Int) {
@@ -168,20 +185,45 @@ sealed class AnalyticsHubSettingsViewState : Parcelable {
 }
 
 @Parcelize
-data class AnalyticCardConfigurationUI(
-    val card: AnalyticsCards,
-    val title: String,
-    val isVisible: Boolean = true,
-    val isEnabled: Boolean = true
-) : Parcelable
+sealed class AnalyticCardConfigurationUI(
+    open val card: AnalyticsCards,
+    open val title: String,
+    open val isVisible: Boolean,
+) : Parcelable {
+
+    data class SelectableCardConfigurationUI(
+        override val card: AnalyticsCards,
+        override val title: String,
+        override val isVisible: Boolean = true,
+        val isEnabled: Boolean = true
+    ) : AnalyticCardConfigurationUI(card, title, isVisible)
+
+    data class ExploreCardConfigurationUI(
+        override val card: AnalyticsCards,
+        override val title: String,
+        val url: String,
+    ) : AnalyticCardConfigurationUI(card, title, false)
+}
 
 fun AnalyticCardConfiguration.toConfigurationUI(activePluginCards: Set<AnalyticsCards>): AnalyticCardConfigurationUI {
-    return AnalyticCardConfigurationUI(
-        card = this.card,
-        title = this.title,
-        isVisible = this.isVisible,
-        isEnabled = this.card.isPlugin.not() || this.card in activePluginCards
-    )
+    return if (this.card.isPlugin.not() || this.card in activePluginCards) {
+        AnalyticCardConfigurationUI.SelectableCardConfigurationUI(
+            card = this.card,
+            title = this.title,
+            isVisible = this.isVisible,
+            isEnabled = true
+        )
+    } else {
+        val url = when (this.card) {
+            AnalyticsCards.Bundles -> PluginUrls.BUNDLES_URL
+            else -> MARKETPLACE
+        }
+        AnalyticCardConfigurationUI.ExploreCardConfigurationUI(
+            card = this.card,
+            title = this.title,
+            url = url
+        )
+    }
 }
 
 fun AnalyticCardConfigurationUI.toConfigurationModel(): AnalyticCardConfiguration {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/HubSettingsCardItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/HubSettingsCardItemsList.kt
@@ -1,0 +1,153 @@
+package com.woocommerce.android.ui.analytics.hub.settings
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.DraggableItem
+import com.woocommerce.android.ui.compose.component.DragAndDropItem
+import com.woocommerce.android.ui.compose.component.ShowDividers
+import com.woocommerce.android.ui.compose.dragContainerForDragHandle
+import com.woocommerce.android.ui.compose.rememberDragDropState
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun HubSettingsCardItemsList(
+    items: List<AnalyticCardConfigurationUI>,
+    selectedItems: List<AnalyticCardConfigurationUI>,
+    onSelectionChange: (AnalyticCardConfigurationUI, Boolean) -> Unit,
+    onOrderChange: (fromIndex: Int, toIndex: Int) -> Unit,
+    onExplorePlugin: (url: String) -> Unit,
+    itemFormatter: AnalyticCardConfigurationUI.() -> String = { toString() },
+    itemKey: ((index: Int, item: AnalyticCardConfigurationUI) -> Any),
+    modifier: Modifier = Modifier
+) {
+    val listState = rememberLazyListState()
+    val dragDropState = rememberDragDropState(listState) { fromIndex, toIndex -> onOrderChange(fromIndex, toIndex) }
+
+    LazyColumn(
+        state = listState,
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colors.surface)
+    ) {
+        itemsIndexed(items = items, key = itemKey) { i, item ->
+            when (item) {
+                is AnalyticCardConfigurationUI.SelectableCardConfigurationUI -> {
+                    DraggableItem(dragDropState, i) { isDragging ->
+                        val elevation by animateDpAsState(if (isDragging) 4.dp else 1.dp, label = "card_elevation")
+                        val showDividers = when {
+                            isDragging -> ShowDividers.None
+                            i == 0 -> ShowDividers.All
+                            else -> ShowDividers.Bottom
+                        }
+                        DragAndDropItem(
+                            showDividers = showDividers,
+                            item = item,
+                            title = itemFormatter(item),
+                            isSelected = item in selectedItems,
+                            onSelectionChange = onSelectionChange,
+                            elevation = elevation,
+                            isEnabled = item.isEnabled
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.DragHandle,
+                                contentDescription = stringResource(id = R.string.drag_handle),
+                                modifier = Modifier
+                                    .dragContainerForDragHandle(
+                                        dragDropState = dragDropState,
+                                        key = itemKey(i, item),
+                                    )
+                                    .clickable(
+                                        onClick = {},
+                                        indication = null,
+                                        interactionSource = remember { MutableInteractionSource() }
+                                    )
+                            )
+                        }
+                    }
+                }
+
+                is AnalyticCardConfigurationUI.ExploreCardConfigurationUI -> {
+                    ExplorePluginItem(
+                        item = item,
+                        onExplorePlugin = onExplorePlugin,
+                        pos = i
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ExplorePluginItem(
+    item: AnalyticCardConfigurationUI.ExploreCardConfigurationUI,
+    onExplorePlugin: (url: String) -> Unit,
+    pos: Int,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        elevation = 2.dp,
+        shape = RoundedCornerShape(0.dp)
+    ) {
+        Column {
+            if (pos == 0) Divider()
+            Box(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .clickable { onExplorePlugin(item.url) }
+                    .padding(horizontal = 16.dp, vertical = 4.dp)
+            ) {
+                Text(
+                    item.title,
+                    Modifier
+                        .padding(start = 40.dp)
+                        .align(Alignment.CenterStart)
+                )
+                Card(
+                    elevation = 1.dp,
+                    shape = RoundedCornerShape(4.dp),
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .padding(vertical = 8.dp)
+                ) {
+                    Box(
+
+                        modifier = Modifier
+                            .background(MaterialTheme.colors.primary)
+                            .padding(vertical = 6.dp, horizontal = 12.dp)
+                    ) {
+                        Text("Explore!", color = MaterialTheme.colors.onPrimary)
+                    }
+                }
+            }
+            Divider()
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DragAndDropSelectableItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DragAndDropSelectableItemsList.kt
@@ -113,24 +113,32 @@ fun <T> DragAndDropItem(
     modifier: Modifier = Modifier,
     showDividers: ShowDividers = ShowDividers.Bottom,
     elevation: Dp = 1.dp,
-    dragHandle: (@Composable () -> Unit)? = null
+    isEnabled: Boolean = true,
+    dragHandle: (@Composable () -> Unit)? = null,
 ) {
     Card(
         modifier = modifier,
         elevation = elevation,
         shape = RoundedCornerShape(0.dp)
     ) {
+        val itemModifier = if (isEnabled) {
+            Modifier
+                .clickable { onSelectionChange(item, !isSelected) }
+                .padding(16.dp)
+        } else {
+            Modifier
+                .padding(16.dp)
+        }
         Column {
             if (showDividers == All) Divider()
             Row(
-                modifier = Modifier
-                    .clickable { onSelectionChange(item, !isSelected) }
-                    .padding(16.dp),
+                modifier = itemModifier,
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 SelectionCheck(
                     isSelected = isSelected,
-                    onSelectionChange = { onSelectionChange(item, !isSelected) }
+                    onSelectionChange = { onSelectionChange(item, !isSelected) },
+                    isEnabled = isEnabled
                 )
                 Text(
                     text = title,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -9,9 +9,9 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.model.PluginUrls.Companion.BUNDLES_URL
-import com.woocommerce.android.model.PluginUrls.Companion.COMPOSITE_URL
-import com.woocommerce.android.model.PluginUrls.Companion.SUBSCRIPTIONS_URL
+import com.woocommerce.android.model.PluginUrls.BUNDLES_URL
+import com.woocommerce.android.model.PluginUrls.COMPOSITE_URL
+import com.woocommerce.android.model.PluginUrls.SUBSCRIPTIONS_URL
 import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.model.sortCategories

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModel.kt
@@ -9,6 +9,9 @@ import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.PluginUrls.Companion.BUNDLES_URL
+import com.woocommerce.android.model.PluginUrls.Companion.COMPOSITE_URL
+import com.woocommerce.android.model.PluginUrls.Companion.SUBSCRIPTIONS_URL
 import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.model.sortCategories
@@ -57,9 +60,6 @@ class ProductFilterListViewModel @Inject constructor(
     companion object {
         private const val KEY_PRODUCT_FILTER_OPTIONS = "key_product_filter_options"
         private const val KEY_PRODUCT_FILTER_SELECTED_CATEGORY_NAME = "key_product_filter_selected_category_name"
-        const val SUBSCRIPTIONS_URL = "https://woo.com/products/woocommerce-subscriptions/"
-        const val BUNDLES_URL = "https://woo.com/products/product-bundles/"
-        const val COMPOSITE_URL = "https://woo.com/products/composite-products/"
     }
 
     private val arguments: ProductFilterListFragmentArgs by savedState.navArgs()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/settings/AnalyticsHubSettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/settings/AnalyticsHubSettingsViewModelTest.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.analytics.hub.settings.AnalyticsHubSettingsVie
 import com.woocommerce.android.ui.analytics.hub.settings.AnalyticsHubSettingsViewState
 import com.woocommerce.android.ui.analytics.hub.settings.AnalyticsHubSettingsViewState.CardsConfiguration
 import com.woocommerce.android.ui.analytics.hub.settings.SaveAnalyticsCardsConfiguration
+import com.woocommerce.android.ui.analytics.hub.settings.toConfigurationUI
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -44,6 +45,8 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
     )
 
     private val defaultPluginCardsActive = setOf(AnalyticsCards.Bundles)
+
+    private val defaultConfigurationUI = defaultConfiguration.map { it.toConfigurationUI(defaultPluginCardsActive) }
 
     fun setup() {
         sut = AnalyticsHubSettingsViewModel(
@@ -90,7 +93,7 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
 
         advanceTimeBy(501)
 
-        sut.onSelectionChange(AnalyticsCards.Session, true)
+        sut.onSelectionChange(defaultConfigurationUI.last(), true)
         sut.onBackPressed()
 
         // The exit event is NOT triggered
@@ -127,7 +130,7 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
 
         advanceTimeBy(501)
 
-        sut.onSelectionChange(AnalyticsCards.Session, true)
+        sut.onSelectionChange(defaultConfigurationUI.last(), true)
 
         // The save button is disabled when the configuration doesn't have any change
         assertThat(viewState).isInstanceOf(CardsConfiguration::class.java)
@@ -141,9 +144,10 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
             whenever(getAnalyticPluginsCardActive.invoke()).thenReturn(defaultPluginCardsActive)
             setup()
 
-            val itemsToChange = listOf(AnalyticsCards.Revenue, AnalyticsCards.Orders, AnalyticsCards.Session)
+            val itemsToChange = defaultConfigurationUI.take(3)
+            val itemsToChangeCards = itemsToChange.map { it.card }.toSet()
             val expectedConfiguration = defaultConfiguration.map {
-                if (it.card in itemsToChange) {
+                if (it.card in itemsToChangeCards) {
                     it.copy(isVisible = false)
                 } else {
                     it
@@ -210,7 +214,10 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
 
             advanceTimeBy(501)
 
-            sut.onSelectionChange(AnalyticsCards.Orders, true)
+            sut.onSelectionChange(
+                AnalyticCardConfigurationUI(AnalyticsCards.Orders, "Orders", false, isEnabled = true),
+                true
+            )
 
             // The save button is disabled when the configuration doesn't have any change
             assertThat(viewState).isInstanceOf(CardsConfiguration::class.java)
@@ -239,7 +246,10 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
 
             advanceTimeBy(501)
 
-            sut.onSelectionChange(AnalyticsCards.Orders, false)
+            sut.onSelectionChange(
+                AnalyticCardConfigurationUI(AnalyticsCards.Orders, "Orders", true, isEnabled = true),
+                false
+            )
 
             // The save button is disabled when the configuration doesn't have any change
             assertThat(viewState).isInstanceOf(CardsConfiguration::class.java)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/settings/AnalyticsHubSettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/settings/AnalyticsHubSettingsViewModelTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.AnalyticCardConfiguration
 import com.woocommerce.android.model.AnalyticsCards
+import com.woocommerce.android.model.PluginUrls
 import com.woocommerce.android.ui.analytics.hub.GetAnalyticPluginsCardActive
 import com.woocommerce.android.ui.analytics.hub.ObserveAnalyticsCardsConfiguration
 import com.woocommerce.android.ui.analytics.hub.settings.AnalyticCardConfigurationUI
@@ -174,9 +175,24 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
                 AnalyticCardConfiguration(AnalyticsCards.Session, "Stats", false)
             )
             val expected = listOf(
-                AnalyticCardConfigurationUI(AnalyticsCards.Revenue, "Revenue", true, isEnabled = false),
-                AnalyticCardConfigurationUI(AnalyticsCards.Orders, "Orders", false, isEnabled = true),
-                AnalyticCardConfigurationUI(AnalyticsCards.Session, "Stats", false, isEnabled = true)
+                AnalyticCardConfigurationUI.SelectableCardConfigurationUI(
+                    AnalyticsCards.Revenue,
+                    "Revenue",
+                    true,
+                    isEnabled = false
+                ),
+                AnalyticCardConfigurationUI.SelectableCardConfigurationUI(
+                    AnalyticsCards.Orders,
+                    "Orders",
+                    false,
+                    isEnabled = true
+                ),
+                AnalyticCardConfigurationUI.SelectableCardConfigurationUI(
+                    AnalyticsCards.Session,
+                    "Stats",
+                    false,
+                    isEnabled = true
+                )
             )
             whenever(getAnalyticPluginsCardActive.invoke()).thenReturn(defaultPluginCardsActive)
             whenever(observeAnalyticsCardsConfiguration.invoke()).thenReturn(flowOf(configuration))
@@ -201,9 +217,24 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
                 AnalyticCardConfiguration(AnalyticsCards.Session, "Stats", false)
             )
             val expected = listOf(
-                AnalyticCardConfigurationUI(AnalyticsCards.Revenue, "Revenue", true, isEnabled = true),
-                AnalyticCardConfigurationUI(AnalyticsCards.Orders, "Orders", true, isEnabled = true),
-                AnalyticCardConfigurationUI(AnalyticsCards.Session, "Stats", false, isEnabled = true)
+                AnalyticCardConfigurationUI.SelectableCardConfigurationUI(
+                    AnalyticsCards.Revenue,
+                    "Revenue",
+                    true,
+                    isEnabled = true
+                ),
+                AnalyticCardConfigurationUI.SelectableCardConfigurationUI(
+                    AnalyticsCards.Orders,
+                    "Orders",
+                    true,
+                    isEnabled = true
+                ),
+                AnalyticCardConfigurationUI.SelectableCardConfigurationUI(
+                    AnalyticsCards.Session,
+                    "Stats",
+                    false,
+                    isEnabled = true
+                )
             )
             whenever(getAnalyticPluginsCardActive.invoke()).thenReturn(defaultPluginCardsActive)
             whenever(observeAnalyticsCardsConfiguration.invoke()).thenReturn(flowOf(configuration))
@@ -215,7 +246,12 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
             advanceTimeBy(501)
 
             sut.onSelectionChange(
-                AnalyticCardConfigurationUI(AnalyticsCards.Orders, "Orders", false, isEnabled = true),
+                AnalyticCardConfigurationUI.SelectableCardConfigurationUI(
+                    AnalyticsCards.Orders,
+                    "Orders",
+                    false,
+                    isEnabled = true
+                ),
                 true
             )
 
@@ -233,9 +269,24 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
                 AnalyticCardConfiguration(AnalyticsCards.Session, "Stats", false)
             )
             val expected = listOf(
-                AnalyticCardConfigurationUI(AnalyticsCards.Revenue, "Revenue", true, isEnabled = false),
-                AnalyticCardConfigurationUI(AnalyticsCards.Orders, "Orders", false, isEnabled = true),
-                AnalyticCardConfigurationUI(AnalyticsCards.Session, "Stats", false, isEnabled = true)
+                AnalyticCardConfigurationUI.SelectableCardConfigurationUI(
+                    AnalyticsCards.Revenue,
+                    "Revenue",
+                    true,
+                    isEnabled = false
+                ),
+                AnalyticCardConfigurationUI.SelectableCardConfigurationUI(
+                    AnalyticsCards.Orders,
+                    "Orders",
+                    false,
+                    isEnabled = true
+                ),
+                AnalyticCardConfigurationUI.SelectableCardConfigurationUI(
+                    AnalyticsCards.Session,
+                    "Stats",
+                    false,
+                    isEnabled = true
+                )
             )
             whenever(getAnalyticPluginsCardActive.invoke()).thenReturn(defaultPluginCardsActive)
             whenever(observeAnalyticsCardsConfiguration.invoke()).thenReturn(flowOf(configuration))
@@ -247,7 +298,12 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
             advanceTimeBy(501)
 
             sut.onSelectionChange(
-                AnalyticCardConfigurationUI(AnalyticsCards.Orders, "Orders", true, isEnabled = true),
+                AnalyticCardConfigurationUI.SelectableCardConfigurationUI(
+                    AnalyticsCards.Orders,
+                    "Orders",
+                    true,
+                    isEnabled = true
+                ),
                 false
             )
 
@@ -264,9 +320,9 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
             AnalyticCardConfiguration(AnalyticsCards.Session, "Stats", false)
         )
         val expected = listOf(
-            AnalyticCardConfigurationUI(AnalyticsCards.Orders, "Orders", true),
-            AnalyticCardConfigurationUI(AnalyticsCards.Session, "Stats", false),
-            AnalyticCardConfigurationUI(AnalyticsCards.Revenue, "Revenue", true),
+            AnalyticCardConfigurationUI.SelectableCardConfigurationUI(AnalyticsCards.Orders, "Orders", true),
+            AnalyticCardConfigurationUI.SelectableCardConfigurationUI(AnalyticsCards.Session, "Stats", false),
+            AnalyticCardConfigurationUI.SelectableCardConfigurationUI(AnalyticsCards.Revenue, "Revenue", true),
         )
         whenever(getAnalyticPluginsCardActive.invoke()).thenReturn(defaultPluginCardsActive)
         whenever(observeAnalyticsCardsConfiguration.invoke()).thenReturn(flowOf(configuration))
@@ -313,7 +369,7 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when a plugin is not active, then the plugin card is disabled`() = testBlocking {
+    fun `when a plugin is not active, then the plugin card is explore option`() = testBlocking {
         whenever(observeAnalyticsCardsConfiguration.invoke()).thenReturn(flowOf(defaultConfiguration))
         whenever(getAnalyticPluginsCardActive.invoke()).thenReturn(emptySet())
         setup()
@@ -323,11 +379,10 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
 
         assertThat(viewState).isInstanceOf(CardsConfiguration::class.java)
         assertThat((viewState as CardsConfiguration).cardsConfiguration).contains(
-            AnalyticCardConfigurationUI(
+            AnalyticCardConfigurationUI.ExploreCardConfigurationUI(
                 card = AnalyticsCards.Bundles,
                 title = AnalyticsCards.Bundles.name,
-                isVisible = true,
-                isEnabled = false
+                url = PluginUrls.BUNDLES_URL
             )
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductFilterListViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.products
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.PluginUrls
 import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
@@ -149,7 +150,7 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
         // Size equals 2 Subscription & Variable Subscriptions
         assertThat(exploreOptions.size).isEqualTo(2)
         exploreOptions.forEach { option ->
-            assertThat(option.url).isEqualTo(ProductFilterListViewModel.SUBSCRIPTIONS_URL)
+            assertThat(option.url).isEqualTo(PluginUrls.SUBSCRIPTIONS_URL)
         }
     }
 
@@ -177,7 +178,7 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
         // Only one explore option for bundles
         assertThat(exploreOptions.size).isEqualTo(1)
         exploreOptions.forEach { option ->
-            assertThat(option.url).isEqualTo(ProductFilterListViewModel.BUNDLES_URL)
+            assertThat(option.url).isEqualTo(PluginUrls.BUNDLES_URL)
         }
     }
 
@@ -205,7 +206,7 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
         // Only one explore option for composite
         assertThat(exploreOptions.size).isEqualTo(1)
         exploreOptions.forEach { option ->
-            assertThat(option.url).isEqualTo(ProductFilterListViewModel.COMPOSITE_URL)
+            assertThat(option.url).isEqualTo(PluginUrls.COMPOSITE_URL)
         }
     }
 
@@ -239,7 +240,7 @@ class ProductFilterListViewModelTest : BaseUnitTest() {
         val exploreOption = ProductFilterListViewModel.FilterListOptionItemUiModel.ExploreOptionItemUiModel(
             filterOptionItemName = ProductType.COMPOSITE.value,
             filterOptionItemValue = ProductType.COMPOSITE.value,
-            url = ProductFilterListViewModel.COMPOSITE_URL
+            url = PluginUrls.COMPOSITE_URL
         )
 
         productFilterListViewModel.loadFilters()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10968

### Why 
When a supported extension is not active, the Analytics Hub customize view now includes its analytics card in the list. It can't be selected, and it shows an "Explore" button with a link to the extension details.

### Description
This PR adds support for the Explore cards when a supported extension is not active. It does that by adding the new `ExploreCardConfigurationUI` class. Because this new list will need to handle two different types of items (selectable and explore), I created a new list class inspired by the `DragAndDropSelectableItemsList` but with support for Explore items.

### Testing instructions
#### Prerequisites
1. Need a store with the product bundles extension installed

#### Testing
TC1 (With the product bundles extension installed and disabled)
1. Open the app
2. Tap on See all store analytics
3. Tap on the pencil at the top of the Analytics Hub screen
4. Check that the product bundles extension is displayed with the Explore message
5. Tap on the extensions
6. Check that the app navigates to the product bundles extension page
7. Check that disabling all selectable items left disables the last selectable item

TC2 (With the product bundles extension installed and enabled)
1. Open the app
2. Tap on See all store analytics
3. Tap on the pencil at the top of the Analytics Hub screen
4. Check that the product bundles extension is displayed and is selectable
5. Save a configuration with the product bundles card selected
6. Check that the product bundles card is included in the list of analytics cards and that displays the expected information

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/642458e1-5db9-4ffe-abee-c265731494f2


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
