### PR TITLE
[Dynamic Dashboard] Update stats card on pull-to-refresh

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/ViewModelFactory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/ViewModelFactory.kt
@@ -1,0 +1,35 @@
+package com.woocommerce.android.ui.compose
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.HasDefaultViewModelProviderFactory
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.viewModel
+import dagger.hilt.android.lifecycle.withCreationCallback
+
+/**
+ * Based on the androidx "hiltViewModel" implementation:
+ * hilt/hilt-navigation-compose/src/main/java/androidx/hilt/navigation/compose/HiltViewModel.kt
+ */
+@Composable
+inline fun <reified VM : ViewModel, reified VMF> viewModelWithFactory(
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    },
+    key: String? = null,
+    noinline creationCallback: (VMF) -> VM
+): VM {
+    return viewModel(
+        viewModelStoreOwner = viewModelStoreOwner,
+        key = key,
+        extras = viewModelStoreOwner.run {
+            if (this is HasDefaultViewModelProviderFactory) {
+                this.defaultViewModelCreationExtras.withCreationCallback(creationCallback)
+            } else {
+                CreationExtras.Empty.withCreationCallback(creationCallback)
+            }
+        }
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -163,7 +163,8 @@ class DashboardFragment :
                     onStatsError = { showErrorSnack() },
                     openDatePicker = { start, end, callback ->
                         showDateRangePicker(start, end, callback)
-                    }
+                    },
+                    parentViewModel = dashboardViewModel
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -173,8 +173,6 @@ class DashboardFragment :
             binding.myStoreRefreshLayout.isRefreshing = false
             dashboardViewModel.onPullToRefresh()
             storeOnboardingViewModel.onPullToRefresh()
-//            binding.myStoreStats.clearStatsHeaderValues()
-//            binding.myStoreStats.clearChartData()
             refreshJitm()
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -49,6 +49,7 @@ import org.wordpress.android.util.PhotonUtils
 import java.math.BigDecimal
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class DashboardViewModel @Inject constructor(
     savedState: SavedStateHandle,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -92,7 +93,7 @@ class DashboardViewModel @Inject constructor(
     val appbarState: LiveData<AppbarState> = _appbarState
 
     private val _refreshTrigger = MutableSharedFlow<RefreshEvent>(extraBufferCapacity = 1)
-    val refreshTrigger = _refreshTrigger.asSharedFlow()
+    val refreshTrigger: Flow<RefreshEvent> = _refreshTrigger.asSharedFlow()
 
     private val _selectedDateRange = getSelectedDateRange()
     val selectedDateRange: LiveData<StatsTimeRangeSelection> = _selectedDateRange.asLiveData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -18,8 +18,10 @@ import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
 import com.woocommerce.android.ui.compose.rememberNavController
+import com.woocommerce.android.ui.compose.viewModelWithFactory
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardStatsUsageTracksEventEmitter
+import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.JetpackBenefitsBannerUiModel
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateUtils
@@ -37,7 +39,12 @@ fun DashboardStatsCard(
     reportJetpackPluginStatus: (JetpackBenefitsBannerUiModel?) -> Unit,
     onStatsError: () -> Unit,
     openDatePicker: (Long, Long, (Long, Long) -> Unit) -> Unit,
-    viewModel: DashboardStatsViewModel = androidx.lifecycle.viewmodel.compose.viewModel(),
+    parentViewModel: DashboardViewModel,
+    viewModel: DashboardStatsViewModel = viewModelWithFactory<DashboardStatsViewModel, DashboardStatsViewModel.Factory>(
+        creationCallback = {
+            it.create(parentViewModel)
+        }
+    )
 ) {
     val customRange by viewModel.customRange.observeAsState()
     val selectedDateRange by viewModel.selectedDateRange.observeAsState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -183,9 +183,13 @@ fun DashboardStatsCard(
                 statsView.showSkeleton(false)
             }
 
-            DashboardStatsViewModel.RevenueStatsViewState.Loading -> {
+            is DashboardStatsViewModel.RevenueStatsViewState.Loading -> {
                 statsView.showErrorView(false)
                 statsView.showSkeleton(true)
+                if (revenueStatsState.isForced) {
+                    statsView.clearStatsHeaderValues()
+                    statsView.clearChartData()
+                }
             }
 
             else -> Unit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
@@ -38,6 +38,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.flatMapLatest
@@ -50,6 +51,7 @@ import org.wordpress.android.fluxc.utils.putIfNotNull
 import java.util.Date
 import java.util.concurrent.TimeUnit
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel(assistedFactory = DashboardStatsViewModel.Factory::class)
 @Suppress("LongParameterList")
 class DashboardStatsViewModel @AssistedInject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
@@ -51,6 +51,7 @@ import java.util.Date
 import java.util.concurrent.TimeUnit
 
 @HiltViewModel(assistedFactory = DashboardStatsViewModel.Factory::class)
+@Suppress("LongParameterList")
 class DashboardStatsViewModel @AssistedInject constructor(
     savedStateHandle: SavedStateHandle,
     @Assisted private val parentViewModel: DashboardViewModel,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
@@ -156,7 +156,10 @@ class DashboardStatsViewModel @AssistedInject constructor(
             _visitorStatsState.value = VisitorStatsViewState.NotLoaded
             return@coroutineScope
         }
-        _revenueStatsState.value = RevenueStatsViewState.Loading
+        _revenueStatsState.value = RevenueStatsViewState.Loading(isForced = forceRefresh)
+        if (forceRefresh) {
+            _visitorStatsState.value = VisitorStatsViewState.NotLoaded
+        }
         getStats(forceRefresh, selectedRange)
             .collect {
                 when (it) {
@@ -276,7 +279,7 @@ class DashboardStatsViewModel @AssistedInject constructor(
         }
 
     sealed class RevenueStatsViewState {
-        data object Loading : RevenueStatsViewState()
+        data class Loading(val isForced: Boolean) : RevenueStatsViewState()
         data object GenericError : RevenueStatsViewState()
         data object PluginNotActiveError : RevenueStatsViewState()
         data class Content(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11219 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds logic to allow refreshing the stats card on pull-to-refresh, and it's also an **RFC** for a common approach that we can use in all cards:
- It uses Hilt's assisted injection to inject the parent ViewModel in the card's ViewModel.
- The parent ViewModel exposes a `SharedFlow` called `refreshTrigger`.
- The cards' ViewModels will observe the `refreshTrigger` Flow and trigger a refresh during a pull-to-refresh.

Using the injection will also allow easier communication between the parent ViewModel and the card ViewModel when needed.
@0nko @JorgeMucientes please share your thoughts on this approach.

### Testing instructions
1. Enable the feature flag `DYNAMIC_DASHBOARD`
2. Open the app.
3. Pull-to-refresh and confirm the stats card is refreshed.
4. Confirm the "update date" is updated.

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/1657201/7dc39caa-5f1b-47fe-b1a9-d02c66a97d0c


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
