### PR TITLE
Prepare release notes for 18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 <!--
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
+
+## 18.1
+
+Introducing refined features in our WooCommerce mobile app! We've enhanced the accuracy of visitor stats to offer you
+more precise insights. Enjoy a better understanding of your customer interactions, further helping you optimize your
+strategies. Update now for a superior user experience.
+
 ## 18.0
 Discover a smoother shopping experience in our latest update! We've squashed some pesky bugs in the products section for a flawless selection and viewing, especially in 2-pane mode. Photos now shine brighter with our enhanced screens. Transitioning between panes? We've polished that too, ensuring seamless shifts. Plus, we're introducing a helpful confirmation dialog for unsaved changes. Most excitingly, dive into your store's performance with custom date ranges in the My Store tab. Update now for these improvements and more!
 

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,2 +1,1 @@
-- [*] Stats: Improved the accuracy of visitor stats [https://github.com/woocommerce/woocommerce-android/pull/11191]
-
+Introducing refined features in our WooCommerce mobile app! We've enhanced the accuracy of visitor stats to offer you more precise insights. Enjoy a better understanding of your customer interactions, further helping you optimize your strategies. Update now for a superior user experience.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Prepares release notes for version `18.1`. The content of the release notes was generated using ChatGPT prompt: 

> Act like a mobile app marketer that wants to prepare a release notes for Google Play and App Store. I want to write effective app store release notes that help users understand the changes in our WooCommerce mobile app. Prepare it based on this list. Do not write it point by point and keep it under 350 characters. It should be a unique paragraph: {paste bullet points from WooCommerce/metadata/release_notes.txt here}

Unsing as input the existing `RELEASE-NOTES.txt` for `18.1`: 
```
- [*] Stats: Improved the accuracy of visitor stats [https://github.com/woocommerce/woocommerce-android/pull/11191]
```
