### PR TITLE
[Better Errors] Handle password tutorial corner cases

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsFragment.kt
@@ -112,6 +112,7 @@ class LoginSiteCredentialsFragment : Fragment() {
         ) { _, result ->
             result.getString(ApplicationPasswordTutorialFragment.URL_KEY)
                 ?.let { viewModel.onWebAuthorizationUrlLoaded(it) }
+                ?: viewModel.onPasswordTutorialAborted()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -139,6 +139,10 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         triggerEvent(ShowResetPasswordScreen(siteAddress))
     }
 
+    fun onPasswordTutorialAborted() {
+        fetchedSiteId.value = -1
+    }
+
     fun onBackClick() {
         if (state.value == State.WebAuthorization) {
             fetchedSiteId.value = -1

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialFragment.kt
@@ -10,11 +10,15 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.os.bundleOf
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
+import com.woocommerce.android.R
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.support.requests.SupportRequestFormActivity
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.login.sitecredentials.applicationpassword.ApplicationPasswordTutorialViewModel.OnContactSupport
+import com.woocommerce.android.ui.login.sitecredentials.applicationpassword.ApplicationPasswordTutorialViewModel.ShowConfirmationDialog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -52,8 +56,19 @@ class ApplicationPasswordTutorialFragment : BaseFragment() {
                     )
                     parentFragmentManager.popBackStack()
                 }
+                is ShowConfirmationDialog -> showConfirmationDialog()
             }
         }
+    }
+
+    private fun showConfirmationDialog() {
+        WooDialog.showDialog(
+            activity = requireActivity(),
+            messageId = R.string.coupon_details_delete_confirmation,
+            positiveButtonId = R.string.apply,
+            negativeButtonId = R.string.cancel,
+            posBtnAction = { _, _ -> parentFragmentManager.popBackStack() }
+        )
     }
 
     override fun onAttach(context: Context) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialFragment.kt
@@ -49,26 +49,10 @@ class ApplicationPasswordTutorialFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) {
             when (it) {
                 is OnContactSupport -> openSupportRequestScreen()
-                is ExitWithResult<*> -> {
-                    setFragmentResult(
-                        requestKey = WEB_NAVIGATION_RESULT,
-                        result = bundleOf(URL_KEY to it.data)
-                    )
-                    parentFragmentManager.popBackStack()
-                }
+                is ExitWithResult<*> -> exitWithResult(it.data as String)
                 is ShowConfirmationDialog -> showConfirmationDialog()
             }
         }
-    }
-
-    private fun showConfirmationDialog() {
-        WooDialog.showDialog(
-            activity = requireActivity(),
-            messageId = R.string.login_app_password_exit_dialog_message,
-            positiveButtonId = R.string.login_app_password_exit_dialog_confirmation,
-            negativeButtonId = R.string.login_app_password_exit_dialog_cancel,
-            posBtnAction = { _, _ -> parentFragmentManager.popBackStack() }
-        )
     }
 
     override fun onAttach(context: Context) {
@@ -77,6 +61,24 @@ class ApplicationPasswordTutorialFragment : BaseFragment() {
             authorizationUrl = url,
             errorMessage = errorMessageRes
         )
+    }
+
+    private fun showConfirmationDialog() {
+        WooDialog.showDialog(
+            activity = requireActivity(),
+            messageId = R.string.login_app_password_exit_dialog_message,
+            positiveButtonId = R.string.login_app_password_exit_dialog_confirmation,
+            negativeButtonId = R.string.login_app_password_exit_dialog_cancel,
+            posBtnAction = { _, _ -> exitWithResult() }
+        )
+    }
+
+    private fun exitWithResult(url: String? = null) {
+        setFragmentResult(
+            requestKey = WEB_NAVIGATION_RESULT,
+            result = bundleOf(URL_KEY to url)
+        )
+        parentFragmentManager.popBackStack()
     }
 
     private fun openSupportRequestScreen() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialFragment.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.dialog.WooDialog
 import com.woocommerce.android.ui.login.sitecredentials.applicationpassword.ApplicationPasswordTutorialViewModel.OnContactSupport
 import com.woocommerce.android.ui.login.sitecredentials.applicationpassword.ApplicationPasswordTutorialViewModel.ShowConfirmationDialog
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialFragment.kt
@@ -64,9 +64,9 @@ class ApplicationPasswordTutorialFragment : BaseFragment() {
     private fun showConfirmationDialog() {
         WooDialog.showDialog(
             activity = requireActivity(),
-            messageId = R.string.coupon_details_delete_confirmation,
-            positiveButtonId = R.string.apply,
-            negativeButtonId = R.string.cancel,
+            messageId = R.string.login_app_password_exit_dialog_message,
+            positiveButtonId = R.string.login_app_password_exit_dialog_confirmation,
+            negativeButtonId = R.string.login_app_password_exit_dialog_cancel,
             posBtnAction = { _, _ -> parentFragmentManager.popBackStack() }
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialScreen.kt
@@ -38,7 +38,7 @@ import org.wordpress.android.fluxc.network.UserAgent
 fun ApplicationPasswordTutorialScreen(viewModel: ApplicationPasswordTutorialViewModel) {
     val viewState = viewModel.viewState.observeAsState()
     ApplicationPasswordTutorialScreen(
-        shouldDisplayWebView = viewState.value?.shouldDisplayWebView ?: false,
+        authorizationStarted = viewState.value?.authorizationStarted ?: false,
         errorMessageRes = viewState.value?.errorMessage,
         webViewUrl = viewState.value?.authorizationUrl.orEmpty(),
         webViewUserAgent = viewModel.userAgent,
@@ -52,7 +52,7 @@ fun ApplicationPasswordTutorialScreen(viewModel: ApplicationPasswordTutorialView
 @Composable
 fun ApplicationPasswordTutorialScreen(
     modifier: Modifier = Modifier,
-    shouldDisplayWebView: Boolean,
+    authorizationStarted: Boolean,
     webViewUrl: String,
     webViewUserAgent: UserAgent?,
     @StringRes errorMessageRes: Int?,
@@ -70,7 +70,7 @@ fun ApplicationPasswordTutorialScreen(
             )
         }
     ) { paddingValues ->
-        if (shouldDisplayWebView && webViewUserAgent != null) {
+        if (authorizationStarted && webViewUserAgent != null) {
             WCWebView(
                 url = webViewUrl,
                 userAgent = webViewUserAgent,
@@ -174,7 +174,7 @@ private fun TutorialContentScreen(
 fun ApplicationPasswordTutorialScreenPreview() {
     WooThemeWithBackground {
         ApplicationPasswordTutorialScreen(
-            shouldDisplayWebView = false,
+            authorizationStarted = false,
             errorMessageRes = R.string.login_app_password_subtitle,
             webViewUrl = "",
             webViewUserAgent = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
@@ -66,7 +67,10 @@ fun ApplicationPasswordTutorialScreen(
             Toolbar(
                 title = stringResource(id = R.string.log_in),
                 onNavigationButtonClick = onNavigationButtonClicked,
-                navigationIcon = Icons.Filled.ArrowBack
+                navigationIcon = when {
+                    authorizationStarted -> Icons.Filled.Close
+                    else -> Icons.Filled.ArrowBack
+                }
             )
         }
     ) { paddingValues ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialScreen.kt
@@ -44,7 +44,8 @@ fun ApplicationPasswordTutorialScreen(viewModel: ApplicationPasswordTutorialView
         webViewUserAgent = viewModel.userAgent,
         onContinueClicked = viewModel::onContinueClicked,
         onContactSupportClicked = viewModel::onContactSupportClicked,
-        onPageLoaded = viewModel::onWebPageLoaded
+        onPageLoaded = viewModel::onWebPageLoaded,
+        onNavigationButtonClicked = viewModel::onNavigationButtonClicked
     )
 }
 
@@ -57,13 +58,14 @@ fun ApplicationPasswordTutorialScreen(
     @StringRes errorMessageRes: Int?,
     onPageLoaded: (String) -> Unit,
     onContinueClicked: () -> Unit,
-    onContactSupportClicked: () -> Unit
+    onContactSupportClicked: () -> Unit,
+    onNavigationButtonClicked: () -> Unit
 ) {
     Scaffold(
         topBar = {
             Toolbar(
                 title = stringResource(id = R.string.log_in),
-                onNavigationButtonClick = { /*TODO*/ },
+                onNavigationButtonClick = onNavigationButtonClicked,
                 navigationIcon = Icons.Filled.ArrowBack
             )
         }
@@ -178,7 +180,8 @@ fun ApplicationPasswordTutorialScreenPreview() {
             webViewUserAgent = null,
             onContinueClicked = { },
             onContactSupportClicked = { },
-            onPageLoaded = { }
+            onPageLoaded = { },
+            onNavigationButtonClicked = { }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialViewModel.kt
@@ -28,7 +28,7 @@ class ApplicationPasswordTutorialViewModel @Inject constructor(
     val viewState = _viewState.asLiveData()
 
     fun onContinueClicked() {
-        _viewState.update { it.copy(shouldDisplayWebView = true) }
+        _viewState.update { it.copy(authorizationStarted = true) }
     }
 
     fun onContactSupportClicked() {
@@ -59,7 +59,7 @@ class ApplicationPasswordTutorialViewModel @Inject constructor(
 
     @Parcelize
     data class ViewState(
-        val shouldDisplayWebView: Boolean = false,
+        val authorizationStarted: Boolean = false,
         val authorizationUrl: String? = null,
         @StringRes val errorMessage: Int? = null,
     ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialViewModel.kt
@@ -5,9 +5,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -39,6 +40,8 @@ class ApplicationPasswordTutorialViewModel @Inject constructor(
             triggerEvent(ExitWithResult(url))
         }
     }
+
+    fun onNavigationButtonClicked() { triggerEvent(Exit) }
 
     fun onWebViewDataAvailable(
         authorizationUrl: String?,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -41,7 +42,7 @@ class ApplicationPasswordTutorialViewModel @Inject constructor(
         }
     }
 
-    fun onNavigationButtonClicked() { triggerEvent(Exit) }
+    fun onNavigationButtonClicked() { triggerEvent(ShowConfirmationDialog) }
 
     fun onWebViewDataAvailable(
         authorizationUrl: String?,
@@ -55,7 +56,8 @@ class ApplicationPasswordTutorialViewModel @Inject constructor(
         }
     }
 
-    object OnContactSupport : MultiLiveEvent.Event()
+    object OnContactSupport : Event()
+    object ShowConfirmationDialog : Event()
 
     @Parcelize
     data class ViewState(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4028,4 +4028,7 @@
     <string name="login_app_password_instructions_footer">If you run into any issues, please contact our support team.</string>
     <string name="login_app_password_continue_button">Continue</string>
     <string name="login_app_password_support_button">Contact Support</string>
+    <string name="login_app_password_exit_dialog_message">It seems that you have not approved the app connection yet. Are you sure you want to exit?</string>
+    <string name="login_app_password_exit_dialog_confirmation">Exit Anyway</string>
+    <string name="login_app_password_exit_dialog_cancel">Cancel</string>
 </resources>


### PR DESCRIPTION
Summary
==========
Fix issue #10804 by introducing screen navigation warnings and handling once the Application Password Tutorial is started. One solution is to present a simple confirmation dialog before exiting the tutorial, and the other solution is to allow the user to reenter the Tutorial if they try to authenticate once again.

Screen Capture
==========
https://github.com/woocommerce/woocommerce-android/assets/5920403/e0af5caa-0916-4efa-b0b0-a92dbf6aa770

How to Test
==========
### Scenario 1 - Back during Tutorial
1. Make sure you have a store configured with something that can get in the way of the login, like the reCAPTCHA plugin.
2. Start the store login flow using the store address and direct user credentials.
3. Hit the back button and verify that an alert dialog is displayed before exiting the view.
4. Verify that it is still possible to trigger the Tutorial once again.
7. 
### Scenario 2 - Back during Authorization
1. Make sure you have a store configured with something that can get in the way of the login, like the reCAPTCHA plugin.
2. Start the store login flow using the store address and direct user credentials.
3. Verify that the Username/Password screen redirects to the Application Password Tutorial screen.
4. Once in the tutorial, hit the `Continue` button and proceed to the Application Password authorization web view.
5. Hit the `X` button and verify that an alert dialog is displayed before exiting the view.
6. Verify that it is still possible to trigger the Tutorial once again.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
