### PR TITLE
[Migrate Simple Payments] Fix back navigation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -554,6 +554,8 @@ class OrderListFragment :
                     action = event.action
                 )
                 is OrderListViewModel.OrderListEvent.RetryLoadingOrders -> refreshOrders()
+                is OrderListViewModel.OrderListEvent.OpenOrderCreationWithSimplePaymentsMigration ->
+                    openOrderCreationFragment(indicateSimplePaymentsMigration = true)
                 else -> event.isHandled = false
             }
         }
@@ -701,12 +703,16 @@ class OrderListFragment :
         )
     }
 
-    private fun openOrderCreationFragment(code: String? = null, barcodeFormat: BarcodeFormat? = null) {
+    private fun openOrderCreationFragment(
+        code: String? = null,
+        barcodeFormat: BarcodeFormat? = null,
+        indicateSimplePaymentsMigration: Boolean = false,
+    ) {
         OrderDurationRecorder.startRecording()
         AnalyticsTracker.track(AnalyticsEvent.ORDERS_ADD_NEW)
         findNavController().navigateSafely(
             OrderListFragmentDirections.actionOrderListFragmentToOrderCreationFragment(
-                OrderCreateEditViewModel.Mode.Creation(),
+                OrderCreateEditViewModel.Mode.Creation(indicateSimplePaymentsMigration),
                 code,
                 barcodeFormat,
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -891,4 +891,13 @@ class OrderListViewModel @Inject constructor(
         @IgnoredOnParcel
         val isFilteringActive = filterCount > 0
     }
+
+    @Parcelize
+    sealed class Mode : Parcelable {
+        @Parcelize
+        data class StartOrderCreation(val indicateSimplePaymentsMigration: Boolean = false) : Mode()
+
+        @Parcelize
+        data object Standard : Mode()
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -61,6 +61,7 @@ import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -114,6 +115,8 @@ class OrderListViewModel @Inject constructor(
     private val showTestNotification: ShowTestNotification,
     private val dateUtils: DateUtils
 ) : ScopedViewModel(savedState), LifecycleOwner {
+    private val navArgs: OrderListFragmentArgs by savedState.navArgs()
+
     private val lifecycleRegistry: LifecycleRegistry by lazy {
         LifecycleRegistry(this)
     }
@@ -217,6 +220,15 @@ class OrderListViewModel @Inject constructor(
                 orderListTransactionLauncher.onListFetched()
                 checkChaChingSoundSettings()
             }
+
+        when (navArgs.mode) {
+            Mode.START_ORDER_CREATION_WITH_SIMPLE_PAYMENTS_MIGRATION -> {
+                triggerEvent(OrderListEvent.OpenOrderCreationWithSimplePaymentsMigration)
+            }
+            Mode.STANDARD -> {
+                // stay on the screen
+            }
+        }
     }
 
     fun loadOrders() {
@@ -876,6 +888,8 @@ class OrderListViewModel @Inject constructor(
         data class VMKilledWhenScanningInProgress(@StringRes val message: Int) : Event()
 
         data object RetryLoadingOrders : OrderListEvent()
+
+        data object OpenOrderCreationWithSimplePaymentsMigration : OrderListEvent()
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -892,12 +892,7 @@ class OrderListViewModel @Inject constructor(
         val isFilteringActive = filterCount > 0
     }
 
-    @Parcelize
-    sealed class Mode : Parcelable {
-        @Parcelize
-        data class StartOrderCreation(val indicateSimplePaymentsMigration: Boolean = false) : Mode()
-
-        @Parcelize
-        data object Standard : Mode()
+    enum class Mode {
+        STANDARD, START_ORDER_CREATION_WITH_SIMPLE_PAYMENTS_MIGRATION
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubFragment.kt
@@ -123,9 +123,7 @@ class PaymentsHubFragment : BaseFragment(R.layout.fragment_payments_hub) {
                 is PaymentsHubViewModel.PaymentsHubEvents.NavigateToOrderCreationScreen -> {
                     findNavController().navigate(
                         PaymentsHubFragmentDirections.actionCardReaderHubFragmentToOrderListFragment(
-                            mode = OrderListViewModel.Mode.StartOrderCreation(
-                                indicateSimplePaymentsMigration = true
-                            )
+                            mode = OrderListViewModel.Mode.START_ORDER_CREATION_WITH_SIMPLE_PAYMENTS_MIGRATION
                         )
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubFragment.kt
@@ -23,7 +23,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.main.AppBarStatus
-import com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel
+import com.woocommerce.android.ui.orders.list.OrderListViewModel
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingParams
 import com.woocommerce.android.ui.payments.hub.PaymentsHubViewModel.PaymentsHubEvents.NavigateToTapTooPaySummaryScreen
@@ -122,8 +122,10 @@ class PaymentsHubFragment : BaseFragment(R.layout.fragment_payments_hub) {
                 }
                 is PaymentsHubViewModel.PaymentsHubEvents.NavigateToOrderCreationScreen -> {
                     findNavController().navigate(
-                        PaymentsHubFragmentDirections.actionCardReaderHubFragmentToOrderCreationFragment(
-                            mode = OrderCreateEditViewModel.Mode.Creation(indicateSimplePaymentsMigration = true),
+                        PaymentsHubFragmentDirections.actionCardReaderHubFragmentToOrderListFragment(
+                            mode = OrderListViewModel.Mode.StartOrderCreation(
+                                indicateSimplePaymentsMigration = true
+                            )
                         )
                     )
                 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -163,7 +163,7 @@
             app:argType="long" />
         <argument
             android:name="mode"
-            android:defaultValue="Standard"
+            android:defaultValue="STANDARD"
             app:argType="com.woocommerce.android.ui.orders.list.OrderListViewModel$Mode" />
         <action
             android:id="@+id/action_orderListFragment_to_orderDetailFragment"
@@ -277,7 +277,7 @@
             app:enterAnim="@anim/activity_fade_in"
             app:exitAnim="@null"
             app:popEnterAnim="@null"
-            app:popExitAnim="@anim/activity_fade_out"></action>
+            app:popExitAnim="@anim/activity_fade_out" />
     </fragment>
     <dialog
         android:id="@+id/updateStockStatusFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -161,6 +161,10 @@
             android:name="orderId"
             android:defaultValue="-1L"
             app:argType="long" />
+        <argument
+            android:name="mode"
+            android:defaultValue="Standard"
+            app:argType="com.woocommerce.android.ui.orders.list.OrderListViewModel$Mode" />
         <action
             android:id="@+id/action_orderListFragment_to_orderDetailFragment"
             app:destination="@id/nav_graph_orders">

--- a/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
@@ -154,7 +154,9 @@
             app:popExitAnim="@anim/activity_fade_out" />
         <action
             android:id="@+id/action_cardReaderHubFragment_to_orderListFragment"
-            app:destination="@+id/orders">
+            app:destination="@+id/orders"
+            app:popUpTo="@+id/moreMenu"
+            app:popUpToInclusive="true">
             <argument
                 android:name="mode"
                 app:argType="com.woocommerce.android.ui.orders.list.OrderListViewModel$Mode"/>

--- a/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
@@ -153,11 +153,11 @@
             app:popEnterAnim="@null"
             app:popExitAnim="@anim/activity_fade_out" />
         <action
-            android:id="@+id/action_cardReaderHubFragment_to_orderCreationFragment"
-            app:destination="@id/nav_graph_order_creations">
+            android:id="@+id/action_cardReaderHubFragment_to_orderListFragment"
+            app:destination="@+id/orders">
             <argument
                 android:name="mode"
-                app:argType="com.woocommerce.android.ui.orders.creation.OrderCreateEditViewModel$Mode" />
+                app:argType="com.woocommerce.android.ui.orders.list.OrderListViewModel$Mode"/>
         </action>
     </fragment>
     <fragment


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11225
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds "OrderListFragment" between Payments screen and Order Creation screen. The idea is to:
* Fix navigation after payments is collected for order (it navigates back to Order List screen)
* Make it clear for users that they have to go Orders -> Order creation -> Payments path instead of Payments -> Collect Payment screen

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
* More -> Payments -> Collect payment
* Try to collect payment -> Notice that Order list opened after that the same way as if you would go Orders -> Create order Path
* Navigate Back -> Notice that the Order List opened

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/c63ebf9d-2228-4ccb-a56c-addf35a70f65


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
