### PR TITLE
[Dynamic Dashboard] Extract Blaze Card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -171,9 +171,10 @@ class DashboardFragment :
             setContent {
                 WooThemeWithBackground {
                     DashboardBlazeCard(
+                        blazeCampaignCreationDispatcher = blazeCampaignCreationDispatcher,
                         updateContainerVisibility = { isVisible ->
                             binding.blazeCampaignView.isVisible = isVisible
-                        },
+                        }
                     )
                 }
             }
@@ -205,42 +206,8 @@ class DashboardFragment :
 
         setupStateObservers()
         setupOnboardingView()
-        setUpBlazeCampaignView()
 
         initJitm(savedInstanceState)
-    }
-
-    private fun setUpBlazeCampaignView() {
-//        dashboardBlazeViewModel.event.observe(viewLifecycleOwner) { event ->
-//            when (event) {
-//                is DashboardBlazeViewModel.LaunchBlazeCampaignCreation -> openBlazeCreationFlow(event.productId)
-//
-//                is DashboardBlazeViewModel.ShowAllCampaigns -> {
-//                    findNavController().navigateSafely(
-//                        DashboardFragmentDirections.actionDashboardToBlazeCampaignListFragment()
-//                    )
-//                }
-//
-//                is DashboardBlazeViewModel.ShowCampaignDetails -> {
-//                    findNavController().navigateSafely(
-//                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(
-//                            urlToLoad = event.url,
-//                            urlsToTriggerExit = arrayOf(event.urlToTriggerExit),
-//                            title = getString(R.string.blaze_campaign_details_title)
-//                        )
-//                    )
-//                }
-//            }
-//        }
-    }
-
-    private fun openBlazeCreationFlow(productId: Long?) {
-        lifecycleScope.launch {
-            blazeCampaignCreationDispatcher.startCampaignCreation(
-                source = BlazeFlowSource.MY_STORE_SECTION,
-                productId = productId
-            )
-        }
     }
 
     @Suppress("LongMethod")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -39,9 +39,6 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
-import com.woocommerce.android.ui.blaze.MyStoreBlazeView
-import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel
-import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.MyStoreBlazeCampaignState
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenEditWidgets
@@ -49,6 +46,9 @@ import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.Op
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShareStore
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowAIProductDescriptionDialog
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowPrivacyBanner
+import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeView
+import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel
+import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState
 import com.woocommerce.android.ui.dashboard.stats.DashboardStatsCard
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.jitm.JitmFragment
@@ -92,7 +92,7 @@ class DashboardFragment :
 
     private val dashboardViewModel: DashboardViewModel by viewModels()
     private val storeOnboardingViewModel: StoreOnboardingViewModel by activityViewModels()
-    private val myStoreBlazeViewModel: MyStoreBlazeViewModel by viewModels()
+    private val dashboardBlazeViewModel: DashboardBlazeViewModel by viewModels()
 
     @Inject
     lateinit var selectedSite: SelectedSite
@@ -200,16 +200,16 @@ class DashboardFragment :
     }
 
     private fun setUpBlazeCampaignView() {
-        myStoreBlazeViewModel.blazeViewState.observe(viewLifecycleOwner) { blazeCampaignState ->
-            if (blazeCampaignState is MyStoreBlazeCampaignState.Hidden) {
+        dashboardBlazeViewModel.blazeViewState.observe(viewLifecycleOwner) { blazeCampaignState ->
+            if (blazeCampaignState is DashboardBlazeCampaignState.Hidden) {
                 binding.blazeCampaignView.hide()
             } else {
                 binding.blazeCampaignView.apply {
                     setContent {
                         WooThemeWithBackground {
-                            MyStoreBlazeView(
+                            DashboardBlazeView(
                                 state = blazeCampaignState,
-                                onDismissBlazeView = myStoreBlazeViewModel::onBlazeViewDismissed,
+                                onDismissBlazeView = dashboardBlazeViewModel::onBlazeViewDismissed,
                             )
                         }
                     }
@@ -217,17 +217,17 @@ class DashboardFragment :
                 }
             }
         }
-        myStoreBlazeViewModel.event.observe(viewLifecycleOwner) { event ->
+        dashboardBlazeViewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is MyStoreBlazeViewModel.LaunchBlazeCampaignCreation -> openBlazeCreationFlow(event.productId)
+                is DashboardBlazeViewModel.LaunchBlazeCampaignCreation -> openBlazeCreationFlow(event.productId)
 
-                is MyStoreBlazeViewModel.ShowAllCampaigns -> {
+                is DashboardBlazeViewModel.ShowAllCampaigns -> {
                     findNavController().navigateSafely(
                         DashboardFragmentDirections.actionDashboardToBlazeCampaignListFragment()
                     )
                 }
 
-                is MyStoreBlazeViewModel.ShowCampaignDetails -> {
+                is DashboardBlazeViewModel.ShowCampaignDetails -> {
                     findNavController().navigateSafely(
                         NavGraphMainDirections.actionGlobalWPComWebViewFragment(
                             urlToLoad = event.url,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -46,9 +46,7 @@ import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.Op
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShareStore
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowAIProductDescriptionDialog
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowPrivacyBanner
-import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeView
-import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel
-import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState
+import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeCard
 import com.woocommerce.android.ui.dashboard.stats.DashboardStatsCard
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.jitm.JitmFragment
@@ -92,7 +90,6 @@ class DashboardFragment :
 
     private val dashboardViewModel: DashboardViewModel by viewModels()
     private val storeOnboardingViewModel: StoreOnboardingViewModel by activityViewModels()
-    private val dashboardBlazeViewModel: DashboardBlazeViewModel by viewModels()
 
     @Inject
     lateinit var selectedSite: SelectedSite
@@ -168,6 +165,20 @@ class DashboardFragment :
             }
         }
 
+        binding.blazeCampaignView.apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                WooThemeWithBackground {
+                    DashboardBlazeCard(
+                        updateContainerVisibility = { isVisible ->
+                            binding.blazeCampaignView.isVisible = isVisible
+                        },
+                    )
+                }
+            }
+        }
+
         binding.myStoreRefreshLayout.setOnRefreshListener {
             binding.myStoreRefreshLayout.isRefreshing = false
             dashboardViewModel.onPullToRefresh()
@@ -200,44 +211,27 @@ class DashboardFragment :
     }
 
     private fun setUpBlazeCampaignView() {
-        dashboardBlazeViewModel.blazeViewState.observe(viewLifecycleOwner) { blazeCampaignState ->
-            if (blazeCampaignState is DashboardBlazeCampaignState.Hidden) {
-                binding.blazeCampaignView.hide()
-            } else {
-                binding.blazeCampaignView.apply {
-                    setContent {
-                        WooThemeWithBackground {
-                            DashboardBlazeView(
-                                state = blazeCampaignState,
-                                onDismissBlazeView = dashboardBlazeViewModel::onBlazeViewDismissed,
-                            )
-                        }
-                    }
-                    show()
-                }
-            }
-        }
-        dashboardBlazeViewModel.event.observe(viewLifecycleOwner) { event ->
-            when (event) {
-                is DashboardBlazeViewModel.LaunchBlazeCampaignCreation -> openBlazeCreationFlow(event.productId)
-
-                is DashboardBlazeViewModel.ShowAllCampaigns -> {
-                    findNavController().navigateSafely(
-                        DashboardFragmentDirections.actionDashboardToBlazeCampaignListFragment()
-                    )
-                }
-
-                is DashboardBlazeViewModel.ShowCampaignDetails -> {
-                    findNavController().navigateSafely(
-                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(
-                            urlToLoad = event.url,
-                            urlsToTriggerExit = arrayOf(event.urlToTriggerExit),
-                            title = getString(R.string.blaze_campaign_details_title)
-                        )
-                    )
-                }
-            }
-        }
+//        dashboardBlazeViewModel.event.observe(viewLifecycleOwner) { event ->
+//            when (event) {
+//                is DashboardBlazeViewModel.LaunchBlazeCampaignCreation -> openBlazeCreationFlow(event.productId)
+//
+//                is DashboardBlazeViewModel.ShowAllCampaigns -> {
+//                    findNavController().navigateSafely(
+//                        DashboardFragmentDirections.actionDashboardToBlazeCampaignListFragment()
+//                    )
+//                }
+//
+//                is DashboardBlazeViewModel.ShowCampaignDetails -> {
+//                    findNavController().navigateSafely(
+//                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+//                            urlToLoad = event.url,
+//                            urlsToTriggerExit = arrayOf(event.urlToTriggerExit),
+//                            title = getString(R.string.blaze_campaign_details_title)
+//                        )
+//                    )
+//                }
+//            }
+//        }
     }
 
     private fun openBlazeCreationFlow(productId: Long?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
@@ -41,8 +41,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
-import com.woocommerce.android.R.dimen
-import com.woocommerce.android.R.string
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.blaze.BlazeCampaignStat
 import com.woocommerce.android.ui.blaze.BlazeCampaignUi
@@ -58,7 +56,6 @@ import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState
 import com.woocommerce.android.viewmodel.MultiLiveEvent
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import kotlinx.coroutines.launch
 
 @Composable
@@ -90,7 +87,7 @@ fun DashboardBlazeCard(
 
 @Composable
 private fun HandleEvents(
-    event: LiveData<Event>,
+    event: LiveData<MultiLiveEvent.Event>,
     blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher
 ) {
     val navController = rememberNavController()
@@ -174,7 +171,7 @@ fun DashboardBlazeView(
                             BlazeProductItem(
                                 product = state.product,
                                 onProductSelected = state.onProductClicked,
-                                modifier = Modifier.padding(top = dimensionResource(id = dimen.major_100))
+                                modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100))
                             )
                         }
 
@@ -189,7 +186,7 @@ fun DashboardBlazeView(
 
                     is DashboardBlazeCampaignState.NoCampaign -> CreateCampaignFooter(
                         onCreateCampaignClicked = state.onCreateCampaignClicked,
-                        modifier = Modifier.padding(top = dimensionResource(id = dimen.major_100))
+                        modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100))
                     )
 
                     else -> error("Invalid state")
@@ -318,15 +315,15 @@ fun MyStoreBlazeViewCampaignPreview() {
                 status = Active,
                 stats = listOf(
                     BlazeCampaignStat(
-                        name = string.blaze_campaign_status_impressions,
+                        name = R.string.blaze_campaign_status_impressions,
                         value = 100.toString()
                     ),
                     BlazeCampaignStat(
-                        name = string.blaze_campaign_status_clicks,
+                        name = R.string.blaze_campaign_status_clicks,
                         value = 10.toString()
                     ),
                     BlazeCampaignStat(
-                        name = string.blaze_campaign_status_budget,
+                        name = R.string.blaze_campaign_status_budget,
                         value = 1000.toString()
                     ),
                 ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
@@ -21,6 +21,8 @@ import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -44,6 +46,27 @@ import com.woocommerce.android.ui.compose.component.ProductThumbnail
 import com.woocommerce.android.ui.compose.component.WCOverflowMenu
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState
+
+@Composable
+fun DashboardBlazeCard(
+    // This is a temporary solution until we introduce a dynamic container where we will communicate the event
+    // to the parent ViewModel directly
+    updateContainerVisibility: (Boolean) -> Unit,
+    viewModel: DashboardBlazeViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
+) {
+    viewModel.blazeViewState.observeAsState().value?.let { state ->
+        LaunchedEffect(state) {
+            updateContainerVisibility(state != DashboardBlazeCampaignState.Hidden)
+        }
+
+        if (state != DashboardBlazeCampaignState.Hidden) {
+            DashboardBlazeView(
+                state = state,
+                onDismissBlazeView = viewModel::onBlazeViewDismissed
+            )
+        }
+    }
+}
 
 @Composable
 fun DashboardBlazeView(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.blaze
+package com.woocommerce.android.ui.dashboard.blaze
 
 import android.content.res.Configuration
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -33,15 +33,21 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.MyStoreBlazeCampaignState
+import com.woocommerce.android.R.dimen
+import com.woocommerce.android.R.string
+import com.woocommerce.android.ui.blaze.BlazeCampaignStat
+import com.woocommerce.android.ui.blaze.BlazeCampaignUi
+import com.woocommerce.android.ui.blaze.BlazeProductUi
+import com.woocommerce.android.ui.blaze.CampaignStatusUi.Active
 import com.woocommerce.android.ui.blaze.campaigs.BlazeCampaignItem
 import com.woocommerce.android.ui.compose.component.ProductThumbnail
 import com.woocommerce.android.ui.compose.component.WCOverflowMenu
 import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState
 
 @Composable
-fun MyStoreBlazeView(
-    state: MyStoreBlazeCampaignState,
+fun DashboardBlazeView(
+    state: DashboardBlazeCampaignState,
     onDismissBlazeView: () -> Unit,
 ) {
     Card(
@@ -61,13 +67,13 @@ fun MyStoreBlazeView(
                 ) {
                     BlazeCampaignHeader()
                     when (state) {
-                        is MyStoreBlazeCampaignState.Campaign -> BlazeCampaignItem(
+                        is DashboardBlazeCampaignState.Campaign -> BlazeCampaignItem(
                             campaign = state.campaign,
                             onCampaignClicked = state.onCampaignClicked,
                             modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100))
                         )
 
-                        is MyStoreBlazeCampaignState.NoCampaign -> {
+                        is DashboardBlazeCampaignState.NoCampaign -> {
                             Text(
                                 modifier = Modifier.padding(
                                     top = dimensionResource(id = R.dimen.major_100),
@@ -79,7 +85,7 @@ fun MyStoreBlazeView(
                             BlazeProductItem(
                                 product = state.product,
                                 onProductSelected = state.onProductClicked,
-                                modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100))
+                                modifier = Modifier.padding(top = dimensionResource(id = dimen.major_100))
                             )
                         }
 
@@ -87,14 +93,14 @@ fun MyStoreBlazeView(
                     }
                 }
                 when (state) {
-                    is MyStoreBlazeCampaignState.Campaign -> ShowAllOrCreateCampaignFooter(
+                    is DashboardBlazeCampaignState.Campaign -> ShowAllOrCreateCampaignFooter(
                         onShowAllClicked = state.onViewAllCampaignsClicked,
                         onCreateCampaignClicked = state.onCreateCampaignClicked
                     )
 
-                    is MyStoreBlazeCampaignState.NoCampaign -> CreateCampaignFooter(
+                    is DashboardBlazeCampaignState.NoCampaign -> CreateCampaignFooter(
                         onCreateCampaignClicked = state.onCreateCampaignClicked,
-                        modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100))
+                        modifier = Modifier.padding(top = dimensionResource(id = dimen.major_100))
                     )
 
                     else -> error("Invalid state")
@@ -216,22 +222,22 @@ fun MyStoreBlazeViewCampaignPreview() {
         name = "Product name",
         imgUrl = "",
     )
-    MyStoreBlazeView(
-        state = MyStoreBlazeCampaignState.Campaign(
+    DashboardBlazeView(
+        state = DashboardBlazeCampaignState.Campaign(
             campaign = BlazeCampaignUi(
                 product = product,
-                status = CampaignStatusUi.Active,
+                status = Active,
                 stats = listOf(
                     BlazeCampaignStat(
-                        name = R.string.blaze_campaign_status_impressions,
+                        name = string.blaze_campaign_status_impressions,
                         value = 100.toString()
                     ),
                     BlazeCampaignStat(
-                        name = R.string.blaze_campaign_status_clicks,
+                        name = string.blaze_campaign_status_clicks,
                         value = 10.toString()
                     ),
                     BlazeCampaignStat(
-                        name = R.string.blaze_campaign_status_budget,
+                        name = string.blaze_campaign_status_budget,
                         value = 1000.toString()
                     ),
                 ),
@@ -252,8 +258,8 @@ fun MyStoreBlazeViewCampaignPreview() {
 @Preview(name = "large screen", device = Devices.NEXUS_10)
 @Composable
 fun MyStoreBlazeViewNoCampaignPreview() {
-    MyStoreBlazeView(
-        state = MyStoreBlazeCampaignState.NoCampaign(
+    DashboardBlazeView(
+        state = DashboardBlazeCampaignState.NoCampaign(
             product = BlazeProductUi(
                 name = "Product name",
                 imgUrl = "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
@@ -21,11 +21,14 @@ import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -34,21 +37,33 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.string
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.blaze.BlazeCampaignStat
 import com.woocommerce.android.ui.blaze.BlazeCampaignUi
 import com.woocommerce.android.ui.blaze.BlazeProductUi
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.CampaignStatusUi.Active
 import com.woocommerce.android.ui.blaze.campaigs.BlazeCampaignItem
+import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
 import com.woocommerce.android.ui.compose.component.ProductThumbnail
 import com.woocommerce.android.ui.compose.component.WCOverflowMenu
 import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.rememberNavController
+import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import kotlinx.coroutines.launch
 
 @Composable
 fun DashboardBlazeCard(
+    blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher,
     // This is a temporary solution until we introduce a dynamic container where we will communicate the event
     // to the parent ViewModel directly
     updateContainerVisibility: (Boolean) -> Unit,
@@ -64,6 +79,57 @@ fun DashboardBlazeCard(
                 state = state,
                 onDismissBlazeView = viewModel::onBlazeViewDismissed
             )
+        }
+    }
+
+    HandleEvents(
+        viewModel.event,
+        blazeCampaignCreationDispatcher
+    )
+}
+
+@Composable
+private fun HandleEvents(
+    event: LiveData<Event>,
+    blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher
+) {
+    val navController = rememberNavController()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val coroutineScope = rememberCoroutineScope()
+    val campaignDetailsTitle = stringResource(id = R.string.blaze_campaign_details_title)
+
+    DisposableEffect(event, navController, lifecycleOwner) {
+        val observer = Observer { event: MultiLiveEvent.Event ->
+            when (event) {
+                is DashboardBlazeViewModel.LaunchBlazeCampaignCreation -> coroutineScope.launch {
+                    blazeCampaignCreationDispatcher.startCampaignCreation(
+                        source = BlazeFlowSource.MY_STORE_SECTION,
+                        productId = event.productId
+                    )
+                }
+
+                is DashboardBlazeViewModel.ShowAllCampaigns -> {
+                    navController.navigateSafely(
+                        DashboardFragmentDirections.actionDashboardToBlazeCampaignListFragment()
+                    )
+                }
+
+                is DashboardBlazeViewModel.ShowCampaignDetails -> {
+                    navController.navigateSafely(
+                        NavGraphMainDirections.actionGlobalWPComWebViewFragment(
+                            urlToLoad = event.url,
+                            urlsToTriggerExit = arrayOf(event.urlToTriggerExit),
+                            title = campaignDetailsTitle
+                        )
+                    )
+                }
+            }
+        }
+
+        event.observe(lifecycleOwner, observer)
+
+        onDispose {
+            event.removeObserver(observer)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
@@ -1,9 +1,9 @@
-package com.woocommerce.android.ui.blaze
+package com.woocommerce.android.ui.dashboard.blaze
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.R
+import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CAMPAIGN_DETAIL_SELECTED
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CAMPAIGN_LIST_ENTRY_POINT_SELECTED
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_ENTRY_POINT_DISPLAYED
@@ -11,8 +11,17 @@ import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_VIEW_DISMISSED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.blaze.BlazeCampaignStat
+import com.woocommerce.android.ui.blaze.BlazeCampaignUi
+import com.woocommerce.android.ui.blaze.BlazeProductUi
+import com.woocommerce.android.ui.blaze.BlazeUrlsHelper
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
-import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.MyStoreBlazeCampaignState.Hidden
+import com.woocommerce.android.ui.blaze.CampaignStatusUi
+import com.woocommerce.android.ui.blaze.IsBlazeEnabled
+import com.woocommerce.android.ui.blaze.ObserveMostRecentBlazeCampaign
+import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState.Campaign
+import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState.Hidden
+import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState.NoCampaign
 import com.woocommerce.android.ui.products.ProductListRepository
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -30,7 +39,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 import javax.inject.Inject
 
 @HiltViewModel
-class MyStoreBlazeViewModel @Inject constructor(
+class DashboardBlazeViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     observeMostRecentBlazeCampaign: ObserveMostRecentBlazeCampaign,
     private val productListRepository: ProductListRepository,
@@ -39,7 +48,7 @@ class MyStoreBlazeViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val prefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
-    private val blazeCampaignState: Flow<MyStoreBlazeCampaignState> = flow {
+    private val blazeCampaignState: Flow<DashboardBlazeCampaignState> = flow {
         if (!isBlazeEnabled()) {
             emit(Hidden)
         } else {
@@ -76,9 +85,9 @@ class MyStoreBlazeViewModel @Inject constructor(
         if (isBlazeDismissed) Hidden else blazeViewState
     }.asLiveData()
 
-    private fun showUiForNoCampaign(products: List<Product>): MyStoreBlazeCampaignState {
+    private fun showUiForNoCampaign(products: List<Product>): DashboardBlazeCampaignState {
         val product = products.first()
-        return MyStoreBlazeCampaignState.NoCampaign(
+        return NoCampaign(
             product = BlazeProductUi(
                 name = product.name,
                 imgUrl = product.firstImageUrl.orEmpty(),
@@ -92,8 +101,8 @@ class MyStoreBlazeViewModel @Inject constructor(
         )
     }
 
-    private fun showUiForCampaign(campaign: BlazeCampaignModel): MyStoreBlazeCampaignState {
-        return MyStoreBlazeCampaignState.Campaign(
+    private fun showUiForCampaign(campaign: BlazeCampaignModel): DashboardBlazeCampaignState {
+        return Campaign(
             campaign = BlazeCampaignUi(
                 product = BlazeProductUi(
                     name = campaign.title,
@@ -102,11 +111,11 @@ class MyStoreBlazeViewModel @Inject constructor(
                 status = CampaignStatusUi.fromString(campaign.uiStatus),
                 stats = listOf(
                     BlazeCampaignStat(
-                        name = R.string.blaze_campaign_status_impressions,
+                        name = string.blaze_campaign_status_impressions,
                         value = campaign.impressions.toString()
                     ),
                     BlazeCampaignStat(
-                        name = R.string.blaze_campaign_status_clicks,
+                        name = string.blaze_campaign_status_clicks,
                         value = campaign.clicks.toString()
                     )
                 )
@@ -173,20 +182,20 @@ class MyStoreBlazeViewModel @Inject constructor(
         )
     }
 
-    sealed interface MyStoreBlazeCampaignState {
-        object Hidden : MyStoreBlazeCampaignState
+    sealed interface DashboardBlazeCampaignState {
+        object Hidden : DashboardBlazeCampaignState
         data class NoCampaign(
             val product: BlazeProductUi,
             val onProductClicked: () -> Unit,
             val onCreateCampaignClicked: () -> Unit,
-        ) : MyStoreBlazeCampaignState
+        ) : DashboardBlazeCampaignState
 
         data class Campaign(
             val campaign: BlazeCampaignUi,
             val onCampaignClicked: () -> Unit,
             val onViewAllCampaignsClicked: () -> Unit,
             val onCreateCampaignClicked: () -> Unit,
-        ) : MyStoreBlazeCampaignState
+        ) : DashboardBlazeCampaignState
     }
 
     data class LaunchBlazeCampaignCreation(val productId: Long?) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
@@ -29,6 +29,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -77,6 +78,7 @@ class DashboardBlazeViewModel @Inject constructor(
     private val isBlazeDismissed = prefsWrapper.observePrefs()
         .onStart { emit(Unit) }
         .map { prefsWrapper.isMyStoreBlazeViewDismissed }
+        .distinctUntilChanged()
 
     val blazeViewState = combine(
         blazeCampaignState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.dashboard.stats
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -10,6 +11,7 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.isVisible
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.tabs.TabLayout
 import com.woocommerce.android.AppPrefs
@@ -23,7 +25,7 @@ import com.woocommerce.android.ui.dashboard.DashboardStatsUsageTracksEventEmitte
 import com.woocommerce.android.ui.dashboard.JetpackBenefitsBannerUiModel
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateUtils
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.Date
@@ -194,14 +196,14 @@ fun DashboardStatsCard(
 
 @Composable
 private fun HandleEvents(
-    event: LiveData<Event>,
+    event: LiveData<MultiLiveEvent.Event>,
     openDatePicker: (Long, Long) -> Unit,
 ) {
     val navController = rememberNavController()
     val lifecycleOwner = LocalLifecycleOwner.current
 
-    LaunchedEffect(event, navController, lifecycleOwner) {
-        event.observe(lifecycleOwner) { event ->
+    DisposableEffect(event, navController, lifecycleOwner) {
+        val observer = Observer { event: MultiLiveEvent.Event ->
             when (event) {
                 is DashboardStatsViewModel.OpenDatePicker -> {
                     openDatePicker(event.fromDate.time, event.toDate.time)
@@ -213,6 +215,12 @@ private fun HandleEvents(
                     )
                 }
             }
+        }
+
+        event.observe(lifecycleOwner, observer)
+
+        onDispose {
+            event.removeObserver(observer)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -45,11 +45,11 @@ import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.Selec
 import com.woocommerce.android.ui.base.TopLevelFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
-import com.woocommerce.android.ui.blaze.MyStoreBlazeView
-import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel
-import com.woocommerce.android.ui.blaze.MyStoreBlazeViewModel.MyStoreBlazeCampaignState
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeView
+import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel
+import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.jitm.JitmFragment
 import com.woocommerce.android.ui.jitm.JitmMessagePathsProvider
@@ -104,7 +104,7 @@ class MyStoreFragment :
 
     private val myStoreViewModel: MyStoreViewModel by viewModels()
     private val storeOnboardingViewModel: StoreOnboardingViewModel by activityViewModels()
-    private val myStoreBlazeViewModel: MyStoreBlazeViewModel by viewModels()
+    private val myStoreBlazeViewModel: DashboardBlazeViewModel by viewModels()
 
     @Inject
     lateinit var selectedSite: SelectedSite
@@ -227,13 +227,13 @@ class MyStoreFragment :
 
     private fun setUpBlazeCampaignView() {
         myStoreBlazeViewModel.blazeViewState.observe(viewLifecycleOwner) { blazeCampaignState ->
-            if (blazeCampaignState is MyStoreBlazeCampaignState.Hidden) {
+            if (blazeCampaignState is DashboardBlazeCampaignState.Hidden) {
                 binding.blazeCampaignView.hide()
             } else {
                 binding.blazeCampaignView.apply {
                     setContent {
                         WooThemeWithBackground {
-                            MyStoreBlazeView(
+                            DashboardBlazeView(
                                 state = blazeCampaignState,
                                 onDismissBlazeView = myStoreBlazeViewModel::onBlazeViewDismissed,
                             )
@@ -245,15 +245,15 @@ class MyStoreFragment :
         }
         myStoreBlazeViewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is MyStoreBlazeViewModel.LaunchBlazeCampaignCreation -> openBlazeCreationFlow(event.productId)
+                is DashboardBlazeViewModel.LaunchBlazeCampaignCreation -> openBlazeCreationFlow(event.productId)
 
-                is MyStoreBlazeViewModel.ShowAllCampaigns -> {
+                is DashboardBlazeViewModel.ShowAllCampaigns -> {
                     findNavController().navigateSafely(
                         MyStoreFragmentDirections.actionMyStoreToBlazeCampaignListFragment()
                     )
                 }
 
-                is MyStoreBlazeViewModel.ShowCampaignDetails -> {
+                is DashboardBlazeViewModel.ShowCampaignDetails -> {
                     findNavController().navigateSafely(
                         NavGraphMainDirections.actionGlobalWPComWebViewFragment(
                             urlToLoad = event.url,

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -48,13 +48,6 @@
                         android:transitionName="@string/store_onboarding_collapsed_transition_name"
                         android:visibility="gone" />
 
-                    <androidx.compose.ui.platform.ComposeView
-                        android:id="@+id/blaze_banner_view"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/minor_100"
-                        android:visibility="gone" />
-
                     <!-- Order stats -->
                     <androidx.compose.ui.platform.ComposeView
                         android:id="@+id/my_store_stats"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11250 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR just extracts all logic of Blaze card to the Composable function to be ready for the dynamic dashboard.

### Testing instructions
1. Using a Jetpack or WPCom website, open the app.
2. Confirm the Blaze card is shown (assuming it was not dismissed before).
3. Launch campaign creation, and confirm navigation works.
4. Dismiss the card.
5. Confirm the view gets hidden.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
