### PR TITLE
[Dynamic Dashboard] Introduce Site Dagger component

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DashboardDataStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DashboardDataStoreModule.kt
@@ -1,0 +1,35 @@
+package com.woocommerce.android.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.dataStoreFile
+import com.woocommerce.android.di.SiteComponent
+import com.woocommerce.android.di.SiteCoroutineScope
+import com.woocommerce.android.di.SiteScope
+import com.woocommerce.android.ui.dashboard.data.DashboardSerializer
+import com.woocommerce.android.ui.mystore.data.DashboardDataModel
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.wordpress.android.fluxc.model.SiteModel
+
+@Module
+@InstallIn(SiteComponent::class)
+object DashboardDataStoreModule {
+    @Provides
+    @SiteScope
+    fun provideDashboardDataStore(
+        appContext: Context,
+        @SiteCoroutineScope siteCoroutineScope: CoroutineScope,
+        site: SiteModel
+    ): DataStore<DashboardDataModel> = DataStoreFactory.create(
+        produceFile = {
+            appContext.dataStoreFile("dashboard_configuration_${site.id}")
+        },
+        scope = CoroutineScope(siteCoroutineScope.coroutineContext + Dispatchers.IO),
+        serializer = DashboardSerializer
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.datastore
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
-import androidx.datastore.dataStoreFile
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
@@ -11,11 +10,8 @@ import com.woocommerce.android.datastore.DataStoreType.ANALYTICS_CONFIGURATION
 import com.woocommerce.android.datastore.DataStoreType.ANALYTICS_UI_CACHE
 import com.woocommerce.android.datastore.DataStoreType.TRACKER
 import com.woocommerce.android.di.AppCoroutineScope
-import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.dashboard.data.DashboardSerializer
 import com.woocommerce.android.ui.mystore.data.CustomDateRange
 import com.woocommerce.android.ui.mystore.data.CustomDateRangeSerializer
-import com.woocommerce.android.ui.mystore.data.DashboardDataModel
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -77,18 +73,5 @@ class DataStoreModule {
         },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO),
         serializer = CustomDateRangeSerializer
-    )
-
-    @Provides
-    fun provideDashboardDataStore(
-        appContext: Context,
-        @AppCoroutineScope appCoroutineScope: CoroutineScope,
-        site: SelectedSite
-    ): DataStore<DashboardDataModel> = DataStoreFactory.create(
-        produceFile = {
-            appContext.dataStoreFile("dashboard_configuration_${site.get().id}")
-        },
-        scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO),
-        serializer = DashboardSerializer
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/SiteComponent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/SiteComponent.kt
@@ -1,0 +1,41 @@
+package com.woocommerce.android.di
+
+import androidx.datastore.core.DataStore
+import com.woocommerce.android.ui.mystore.data.DashboardDataModel
+import dagger.BindsInstance
+import dagger.hilt.DefineComponent
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import org.wordpress.android.fluxc.model.SiteModel
+import javax.inject.Qualifier
+import javax.inject.Scope
+import kotlin.annotation.AnnotationRetention.RUNTIME
+
+@Scope
+@MustBeDocumented
+@Retention(value = RUNTIME)
+annotation class SiteScope
+
+@SiteScope
+@DefineComponent(parent = SingletonComponent::class)
+interface SiteComponent {
+    @DefineComponent.Builder
+    interface Builder {
+        fun setSite(@BindsInstance site: SiteModel): Builder
+        fun setCoroutineScope(@BindsInstance @SiteCoroutineScope scope: CoroutineScope): Builder
+        fun build(): SiteComponent
+    }
+}
+
+@InstallIn(SiteComponent::class)
+@EntryPoint
+interface SiteComponentEntryPoint {
+    fun dashboardDataStore(): DataStore<DashboardDataModel>
+}
+
+@Qualifier
+@MustBeDocumented
+@Retention(RUNTIME)
+annotation class SiteCoroutineScope

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/MediaPickerModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/mediapicker/MediaPickerModule.kt
@@ -7,15 +7,17 @@ import dagger.Provides
 import dagger.android.AndroidInjectionModule
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import org.wordpress.android.fluxc.model.SiteModel
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.login.di.LoginServiceModule
 import org.wordpress.android.mediapicker.api.Log
 import org.wordpress.android.mediapicker.api.MediaPickerSetup
 import org.wordpress.android.mediapicker.api.MimeTypeProvider
 import org.wordpress.android.mediapicker.api.Tracker
 import org.wordpress.android.mediapicker.loader.MediaLoaderFactory
-import javax.inject.Qualifier
-import kotlin.annotation.AnnotationRetention.RUNTIME
+import org.wordpress.android.mediapicker.source.wordpress.MediaLibrarySource
+import org.wordpress.android.mediapicker.source.wordpress.util.NetworkUtilsWrapper
 
 @InstallIn(SingletonComponent::class)
 @Module(
@@ -27,8 +29,20 @@ import kotlin.annotation.AnnotationRetention.RUNTIME
 abstract class MediaPickerModule {
     companion object {
         @Provides
-        fun provideSelectedSite(selectedSite: SelectedSite): SiteModel {
-            return selectedSite.get()
+        fun provideMediaLibrarySourceFactory(
+            mediaStore: MediaStore,
+            dispatcher: Dispatcher,
+            bgDispatcher: CoroutineDispatcher,
+            networkUtilsWrapper: NetworkUtilsWrapper,
+            site: SelectedSite
+        ): MediaLibrarySource.Factory {
+            return MediaLibrarySource.Factory(
+                mediaStore,
+                dispatcher,
+                bgDispatcher,
+                networkUtilsWrapper,
+                site.get()
+            )
         }
     }
 
@@ -51,8 +65,3 @@ abstract class MediaPickerModule {
         factory: MediaPickerSetupFactory
     ): MediaPickerSetup.Factory
 }
-
-@Qualifier
-@MustBeDocumented
-@Retention(RUNTIME)
-annotation class AppCoroutineScope

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
@@ -1,9 +1,12 @@
 package com.woocommerce.android.ui.dashboard.data
 
 import androidx.datastore.core.DataStore
+import com.woocommerce.android.di.SiteComponentEntryPoint
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.mystore.data.DashboardDataModel
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
+import dagger.hilt.EntryPoints
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
@@ -11,8 +14,13 @@ import java.io.IOException
 import javax.inject.Inject
 
 class DashboardDataStore @Inject constructor(
-    private val dataStore: DataStore<DashboardDataModel>
+    selectedSite: SelectedSite
 ) {
+    private val dataStore: DataStore<DashboardDataModel> = EntryPoints.get(
+        selectedSite.siteComponent!!,
+        SiteComponentEntryPoint::class.java
+    ).dashboardDataStore()
+
     val dashboard: Flow<DashboardDataModel?> = dataStore.data
         .catch { exception ->
             // dataStore.data throws an IOException when an error is encountered when reading data

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryRepository.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.payments.hub.depositsummary
 
+import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.flow.flow
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.payments.woo.WooPaymentsDepositsOverview
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.store.WCWooPaymentsStore
@@ -9,22 +9,22 @@ import javax.inject.Inject
 
 class PaymentsHubDepositSummaryRepository @Inject constructor(
     private val store: WCWooPaymentsStore,
-    private val site: SiteModel,
+    private val site: SelectedSite,
 ) {
     suspend fun retrieveDepositOverview() =
         flow {
-            val cachedData = store.getDepositsOverviewAll(site)
+            val cachedData = store.getDepositsOverviewAll(site.get())
             if (cachedData != null) {
                 emit(RetrieveDepositOverviewResult.Cache(cachedData))
             }
 
-            val fetchedData = store.fetchDepositsOverview(site)
+            val fetchedData = store.fetchDepositsOverview(site.get())
             val data = fetchedData.result
             if (fetchedData.isError || data == null) {
-                store.deleteDepositsOverview(site)
+                store.deleteDepositsOverview(site.get())
                 emit(RetrieveDepositOverviewResult.Error(fetchedData.error))
             } else {
-                store.insertDepositsOverview(site, data)
+                store.insertDepositsOverview(site.get(), data)
                 emit(RetrieveDepositOverviewResult.Remote(data))
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductsMapper.kt
@@ -2,14 +2,15 @@ package com.woocommerce.android.ui.products.selector
 
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.tools.SelectedSite
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.persistence.ProductSqlUtils
 import javax.inject.Inject
 
-class ProductsMapper @Inject constructor(private val site: SiteModel) {
+class ProductsMapper @Inject constructor(private val site: SelectedSite) {
     fun mapProductIdsToProduct(productIds: List<Long>): List<Product> {
-        return productIds.asProductList(site).map { product ->
+        return productIds.asProductList(site.get()).map { product ->
             product.toAppModel()
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryRepositoryTest.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.payments.hub.depositsummary
 
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -20,12 +22,18 @@ import org.wordpress.android.fluxc.store.WCWooPaymentsStore
 @OptIn(ExperimentalCoroutinesApi::class)
 class PaymentsHubDepositSummaryRepositoryTest : BaseUnitTest() {
     private val store: WCWooPaymentsStore = mock()
-    private val site: SiteModel = mock()
+    private val selectedSite: SelectedSite = mock()
+    private val site = SiteModel()
 
     private val repo = PaymentsHubDepositSummaryRepository(
         store = store,
-        site = site,
+        site = selectedSite,
     )
+
+    @Before
+    fun setup() {
+        whenever(selectedSite.get()).thenReturn(site)
+    }
 
     @Test
     fun `given store has cache, when retrieveDepositOverview, then cache firstly returned`() = testBlocking {

--- a/settings.gradle
+++ b/settings.gradle
@@ -62,6 +62,7 @@ gradle.ext.loginFlowBinaryPath = "org.wordpress:login"
 gradle.ext.mediaPickerBinaryPath = "org.wordpress:mediapicker"
 gradle.ext.mediaPickerDomainBinaryPath = "org.wordpress.mediapicker:domain"
 gradle.ext.mediaPickerSourceCameraBinaryPath = "org.wordpress.mediapicker:source-camera"
+gradle.ext.mediaPickerSourceDeviceBinaryPath = "org.wordpress.mediapicker:source-device"
 gradle.ext.mediaPickerSourceGifBinaryPath = "org.wordpress.mediapicker:source-gif"
 gradle.ext.mediaPickerSourceWordPressBinaryPath = "org.wordpress.mediapicker:source-wordpress"
 


### PR DESCRIPTION
Implements #11260. This PR introduces a new Dagger component, whose lifecycle is tied to the currently selected site. This is necessary for the DashboardDataStore, which uses the Site ID to create and read the `DataStore` file. When a different site is selected, the `CoroutineScope` used in the `DataStore` must be cancelled (otherwise the app crashes), hence the necessity for the custom component that controls the lifecycle of the `CoroutineScope`.

Note that this component doesn't replace the `SelectedSite` class that we use throughout the app to inject the current site because only classes scoped under the `SiteComponent` would have access the the current `SiteModel`.

**To test:**
A smoke test of the app (especially changing of sites) should be OK to make sure nothing got broken.