### PR TITLE
[Dynamic Dashboard] Widget editor persistence

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
@@ -30,7 +30,6 @@ class DashboardWidgetEditorViewModel @Inject constructor(
             isLoading = state.widgetList.isEmpty(),
             isSaveButtonEnabled = state.widgetList.map { DashboardWidget(it.type, it.isSelected) } != widgets,
         )
-
     }.asLiveData()
 
     private var editedWidgets: List<DashboardWidgetUi>
@@ -68,12 +67,14 @@ class DashboardWidgetEditorViewModel @Inject constructor(
 
     fun onSaveClicked() {
         viewModelScope.launch {
-            dashboardRepository.updateWidgets(editedWidgets.map { widget ->
-                DashboardWidget(
-                    type = widget.type,
-                    isAdded = widget.isSelected
-                )
-            })
+            dashboardRepository.updateWidgets(
+                editedWidgets.map { widget ->
+                    DashboardWidget(
+                        type = widget.type,
+                        isAdded = widget.isSelected
+                    )
+                }
+            )
         }
         triggerEvent(Exit)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
@@ -4,92 +4,86 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.R
-import com.woocommerce.android.ui.dashboard.widgeteditor.DashboardWidgetEditorViewModel.WidgetType.BlazeCampaigns
-import com.woocommerce.android.ui.dashboard.widgeteditor.DashboardWidgetEditorViewModel.WidgetType.StoreOnboarding
-import com.woocommerce.android.ui.dashboard.widgeteditor.DashboardWidgetEditorViewModel.WidgetType.StoreStats
-import com.woocommerce.android.ui.dashboard.widgeteditor.DashboardWidgetEditorViewModel.WidgetType.TopProducts
+import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.ui.dashboard.data.DashboardRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
 class DashboardWidgetEditorViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
+    private val dashboardRepository: DashboardRepository,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
-    private val widgetEditorState: MutableStateFlow<WidgetEditorState> = savedState.getStateFlow(
-        viewModelScope,
-        WidgetEditorState(
-            widgetList = getWidgetsCurrentSelection(),
-            showDiscardDialog = false,
-            isLoading = false,
+    private val widgetEditorState = savedState.getStateFlow(viewModelScope, WidgetEditorState())
+    val viewState = combine(widgetEditorState, dashboardRepository.widgets) { state, widgets ->
+        state.copy(
+            isLoading = state.widgetList.isEmpty(),
+            isSaveButtonEnabled = state.widgetList.map { DashboardWidget(it.type, it.isSelected) } != widgets,
         )
-    )
 
-    private fun getWidgetsCurrentSelection() = listOf(
-        DashboardWidget(
-            title = resourceProvider.getString(R.string.my_store_edit_screen_widget_stats),
-            isSelected = true,
-            StoreStats
-        ),
-        DashboardWidget(
-            title = resourceProvider.getString(R.string.my_store_edit_screen_widget_top_performers),
-            isSelected = true,
-            TopProducts
-        ),
-        DashboardWidget(
-            title = resourceProvider.getString(R.string.my_store_edit_screen_widget_blaze_campaigns),
-            isSelected = true,
-            BlazeCampaigns
-        ),
-        DashboardWidget(
-            title = resourceProvider.getString(R.string.my_store_edit_screen_widget_onboarding_list),
-            isSelected = false,
-            StoreOnboarding
-        ),
-    )
+    }.asLiveData()
 
-    val viewState = widgetEditorState.asLiveData()
+    private var editedWidgets: List<DashboardWidgetUi>
+        get() = widgetEditorState.value.widgetList
+        set(value) {
+            widgetEditorState.update { it.copy(widgetList = value) }
+        }
 
-    private val existingWidgetConfiguration = widgetEditorState.value.widgetList
-    private var editedWidgets = widgetEditorState.value.widgetList
+    private val hasChanges
+        get() = viewState.value?.isSaveButtonEnabled == true
+
+    init {
+        loadWidgets()
+    }
+
+    private fun loadWidgets() {
+        viewModelScope.launch {
+            editedWidgets = dashboardRepository.widgets.first()
+                .map { widget ->
+                    DashboardWidgetUi(
+                        title = resourceProvider.getString(widget.type.titleResource),
+                        isSelected = widget.isAdded,
+                        type = widget.type
+                    )
+                }
+        }
+    }
 
     fun onBackPressed() {
         when {
-            hasChanges(editedWidgets) -> widgetEditorState.update { it.copy(showDiscardDialog = true) }
+            hasChanges -> widgetEditorState.update { it.copy(showDiscardDialog = true) }
             else -> triggerEvent(Exit)
         }
     }
 
     fun onSaveClicked() {
-        TODO("Saving selected widgets is not yet implemented")
+        viewModelScope.launch {
+            dashboardRepository.updateWidgets(editedWidgets.map { widget ->
+                DashboardWidget(
+                    type = widget.type,
+                    isAdded = widget.isSelected
+                )
+            })
+        }
+        triggerEvent(Exit)
     }
 
-    fun onSelectionChange(dashboardWidget: DashboardWidget, selected: Boolean) {
-        editedWidgets = editedWidgets
-            .map { if (it == dashboardWidget) it.copy(isSelected = selected) else it }
-        updateWidgetStateWith(editedWidgets)
+    fun onSelectionChange(dashboardWidget: DashboardWidgetUi, selected: Boolean) {
+        editedWidgets = editedWidgets.map { if (it == dashboardWidget) it.copy(isSelected = selected) else it }
     }
 
     fun onOrderChange(fromIndex: Int, toIndex: Int) {
         editedWidgets = editedWidgets.toMutableList().apply { add(toIndex, removeAt(fromIndex)) }
-        updateWidgetStateWith(editedWidgets)
-    }
-
-    private fun updateWidgetStateWith(editedWidgets: List<DashboardWidget>) {
-        widgetEditorState.update {
-            it.copy(
-                widgetList = editedWidgets,
-                isSaveButtonEnabled = hasChanges(editedWidgets)
-            )
-        }
     }
 
     fun onDismissDiscardDialog() {
@@ -100,27 +94,18 @@ class DashboardWidgetEditorViewModel @Inject constructor(
         triggerEvent(Exit)
     }
 
-    private fun hasChanges(editedWidgets: List<DashboardWidget>) = editedWidgets != existingWidgetConfiguration
-
     @Parcelize
     data class WidgetEditorState(
-        val widgetList: List<DashboardWidget>,
+        val widgetList: List<DashboardWidgetUi> = emptyList(),
         val showDiscardDialog: Boolean = false,
         val isSaveButtonEnabled: Boolean = false,
-        val isLoading: Boolean = false
+        val isLoading: Boolean = true
     ) : Parcelable
 
     @Parcelize
-    data class DashboardWidget(
+    data class DashboardWidgetUi(
         val title: String,
         val isSelected: Boolean,
-        val type: WidgetType,
+        val type: DashboardWidget.Type
     ) : Parcelable
-
-    enum class WidgetType {
-        StoreStats,
-        TopProducts,
-        BlazeCampaigns,
-        StoreOnboarding,
-    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/depositsummary/PaymentsHubDepositSummaryRepositoryTest.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.payments.hub.depositsummary
 
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -20,12 +22,18 @@ import org.wordpress.android.fluxc.store.WCWooPaymentsStore
 @OptIn(ExperimentalCoroutinesApi::class)
 class PaymentsHubDepositSummaryRepositoryTest : BaseUnitTest() {
     private val store: WCWooPaymentsStore = mock()
-    private val site: SiteModel = mock()
+    private val selectedSite: SelectedSite = mock()
+    private val site = SiteModel()
 
     private val repo = PaymentsHubDepositSummaryRepository(
         store = store,
-        site = site,
+        site = selectedSite,
     )
+
+    @Before
+    fun setup() {
+        whenever(selectedSite.get()).thenReturn(site)
+    }
 
     @Test
     fun `given store has cache, when retrieveDepositOverview, then cache firstly returned`() = testBlocking {


### PR DESCRIPTION
Implements #11261. The PR add persistence to widget editor screen, which saves any changes for each site individually.

[Screen_recording_20240409_102619.webm](https://github.com/woocommerce/woocommerce-android/assets/1522856/754cfea6-0c3f-4eb0-bfe6-39259ad3fcee)

**To test:**
1. Make sure you enabe `DYNAMIC_DASHBOARD` flag
2. Log in and tap on the My Store settings button
3. Try to rearrange the items and change selection
4. Tap on Save
5. Go back to the settings
6. Notice the previous configuration is restored
7. Switch sites and go to the My Store settings
8. Notice the default configuration for the new site
9. Make some changes and save them
10. Switch to the original site
11. Go to My Store settings
12. Notice the correct widget configuration is restored

**Note:** Please merge #11262 first.