### PR TITLE
Fix the AI product generation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIPrompts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIPrompts.kt
@@ -116,7 +116,7 @@ object AIPrompts {
             keywords: "$keywords"
             tone: "$tone"
 
-            Expected json response format:
+            Your response should be in JSON format and don't send anything extra. Don't include the word JSON in your response:
             "{
                "name":"The name of the product, in the ISO language code "$languageISOCode"",
                "description":"Product description of around 100 words long in a "$tone" tone, in the ISO language code "$languageISOCode"",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAICompletionsResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.ResponseFormat
 import org.wordpress.android.fluxc.store.jetpackai.JetpackAIStore
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -75,7 +76,7 @@ class AIRepository @Inject constructor(
             languageISOCode
         )
 
-        return fetchJetpackAICompletionsForSite(prompt, PRODUCT_DETAILS_FROM_SCANNED_TEXT_FEATURE)
+        return fetchJetpackAICompletionsForSite(prompt, PRODUCT_DETAILS_FROM_SCANNED_TEXT_FEATURE, ResponseFormat.JSON)
             .mapCatching { json ->
                 Gson().fromJson(json, AIProductDetailsResult::class.java)
             }
@@ -105,7 +106,8 @@ class AIRepository @Inject constructor(
                 existingTags = existingTags.map { it.name },
                 languageISOCode = languageISOCode
             ),
-            feature = PRODUCT_CREATION_FEATURE
+            feature = PRODUCT_CREATION_FEATURE,
+            format = ResponseFormat.JSON
         )
     }
 
@@ -131,9 +133,11 @@ class AIRepository @Inject constructor(
 
     private suspend fun fetchJetpackAICompletionsForSite(
         prompt: String,
-        feature: String
+        feature: String,
+        format: ResponseFormat? = null,
+        model: String? = null
     ): Result<String> = withContext(Dispatchers.IO) {
-        jetpackAIStore.fetchJetpackAICompletions(selectedSite.get(), prompt, feature).run {
+        jetpackAIStore.fetchJetpackAICompletions(selectedSite.get(), prompt, feature, format, model).run {
             when (this) {
                 is JetpackAICompletionsResponse.Success -> {
                     WooLog.d(WooLog.T.AI, "Fetching Jetpack AI completions succeeded")

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2988-76fed8bf191e70f0553d7492c66c961f0becebcc'
+    fluxCVersion = '2.75.0'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.74.0'
+    fluxCVersion = '2988-76fed8bf191e70f0553d7492c66c961f0becebcc'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Fixes #11267. The prompt is now more explicit about the expected response JSON format, which fixes the problem.

**To test:**
1. Start the app 
2. Tap on the Products tab
3. Tap on the Add product CTA
4. Select the AI generation option
5. Enter the name of the product
6. Enter the description
7. Tap on Create product details button
8. Notice the product details are successfully generated

**Edit:**
Please also test the product generation using package photo.

**Note: ** Please don't merge until the FluxC PR is merged.