### PR TITLE
[Better Errors] Fix troubleshooting banner visibility control

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -997,8 +997,12 @@ class OrderListFragment :
                 show = show,
                 title = getString(R.string.orderlist_timeout_error_title),
                 message = getString(R.string.orderlist_timeout_error_message),
-                supportContactClick = { openSupportRequestScreen() },
+                supportContactClick = {
+                    viewModel.changeTroubleshootingBannerVisibility(show = false)
+                    openSupportRequestScreen()
+                },
                 troubleshootingClick = {
+                    viewModel.changeTroubleshootingBannerVisibility(show = false)
                     viewModel.trackConnectivityTroubleshootClicked()
                     openConnectivityTool()
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -185,7 +185,8 @@ class OrderListViewModel @Inject constructor(
         get() {
             val simplePaymentsAndOrderFeedbackDismissed =
                 simplePaymentsAndOrderCreationFeedbackState == FeatureFeedbackSettings.FeedbackState.DISMISSED
-            return !simplePaymentsAndOrderFeedbackDismissed
+            val isTroubleshootingBannerVisible = viewState.shouldDisplayTroubleshootingBanner
+            return !simplePaymentsAndOrderFeedbackDismissed && !isTroubleshootingBannerVisible
         }
 
     init {
@@ -254,6 +255,13 @@ class OrderListViewModel @Inject constructor(
         activeWCOrderListDescriptor = listDescriptor
         val pagedListWrapper = listStore.getList(listDescriptor, dataSource, lifecycle)
         activatePagedListWrapper(pagedListWrapper, isFirstInit = true)
+    }
+
+    fun changeTroubleshootingBannerVisibility(show: Boolean) {
+        viewState = viewState.copy(
+            shouldDisplayTroubleshootingBanner = show,
+            isSimplePaymentsAndOrderCreationFeedbackVisible = !show
+        )
     }
 
     /**
@@ -449,9 +457,7 @@ class OrderListViewModel @Inject constructor(
                                 triggerEvent(RetryLoadingOrders)
                             }
 
-                            else -> viewState = viewState.copy(
-                                shouldDisplayTroubleshootingBanner = true
-                            )
+                            else -> changeTroubleshootingBannerVisibility(show = true)
                         }
                         noTimeoutHappened = false
                     }


### PR DESCRIPTION
Summary
==========
Introduces a fix for the inconsistent state between displaying the Troubleshooting banner that leads to the Connectivity Tool and the other banners, e.g. the Feature announcement banner and JITM banner.

Screen Capture
==========
https://github.com/woocommerce/woocommerce-android/assets/5920403/659bf33a-fa45-46be-a053-92d5c57c1745



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.