### PR TITLE
Revert Woo.com domain usages in favor of woocomerce.com

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -25,7 +25,8 @@ A clear and concise description of what you expected to happen.
 
 **Isolating the problem (mark completed items with an [x]):**
 - [ ] I have deactivated other plugins and confirmed this bug occurs when only WooCommerce plugin is active.
-- [ ] This bug happens with a default WordPress theme active, or [Storefront](https://woo.com/products/storefront/).
+- [ ] This bug happens with a default WordPress theme active,
+  or [Storefront](https://woocommerce.com/products/storefront/).
 - [ ] I can reproduce this bug consistently using the steps above.
 
 **Mobile Environment**

--- a/.github/ISSUE_TEMPLATE/Support.md
+++ b/.github/ISSUE_TEMPLATE/Support.md
@@ -11,15 +11,17 @@ assignees: ''
 We don't offer technical support on GitHub so we recommend using the following:
 
 **Reading our documentation**
-Usage docs can be found here: https://woo.com/documentation/woocommerce/
+Usage docs can be found here: https://woocommerce.com/documentation/woocommerce/
 
-If you have a problem, you may want to start with the self help guide here: https://woo.com/document/woocommerce-self-service-guide/
+If you have a problem, you may want to start with the self help guide
+here: https://woocommerce.com/document/woocommerce-self-service-guide/
 
-**Technical support for premium extensions or if you're a Woo.com customer**
+**Technical support for premium extensions or if you're a woocommerce.com customer**
  from a human being - submit a ticket via the helpdesk
-https://woo.com/contact-us/
+https://woocommerce.com/contact-us/
 
 **General usage and development questions**
-- WooCommerce Slack Community: https://woo.com/community-slack/
+
+- WooCommerce Slack Community: https://woocommerce.com/community-slack/
 - WordPress.org Forums: https://wordpress.org/support/plugin/woocommerce
 - The WooCommerce Help and Share Facebook group

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before anything else, please take a moment to read our [Code of Conduct](CODE-OF
 
 * [Report a bug](https://github.com/woocommerce/woocommerce-android/issues/new?template=Bug_report.md)  and prefix the title with "Bug:"
 * [Request a feature](https://github.com/woocommerce/woocommerce-android/issues/new?assignees=&labels=&projects=&template=Feature_request.md)
-* [Chat with us on Slack](https://woo.com/community-slack/): #mobile
+* [Chat with us on Slack](https://woocommerce.com/community-slack/): #mobile
 * Submit a help request from directly within the app
 
 ## Translating
@@ -54,4 +54,5 @@ Have a look at the [Coding Style Guide](https://github.com/woocommerce/woocommer
 
 ## Getting in Touch
 
-If you have questions or just want to say hi, join the [WooCommerce Slack](https://woo.com/community-slack/) and drop a message on the `#mobile-apps` channel.
+If you have questions or just want to say hi, join the [WooCommerce Slack](https://woocommerce.com/community-slack/) and
+drop a message on the `#mobile-apps` channel.

--- a/README.md
+++ b/README.md
@@ -99,11 +99,12 @@ If you happen to find a security vulnerability, we would appreciate you letting 
 
 ## 🦮 Need Help?
 
-You can find the WooCommerce usage docs here: [woo.com/documentation/woocommerce/](https://woo.com/documentation/woocommerce/)
+You can find the WooCommerce usage docs
+here: [woocommerce.com/documentation/woocommerce/](https://woocommerce.com/documentation/woocommerce/)
 
 General usage and development questions:
 
-* [WooCommerce Slack Community](https://woo.com/community-slack/)
+* [WooCommerce Slack Community](https://woocommerce.com/community-slack/)
 * [WordPress.org Forums](https://wordpress.org/support/plugin/woocommerce)
 * [The WooCommerce Help and Share Facebook group](https://www.facebook.com/groups/woohelp/)
 
@@ -124,6 +125,6 @@ In order to offer a great experience to our users, we use some proprietary libra
 
 <p align="center">
     <br/><br/>
-    Made with 💜 by <a href="https://woo.com/">WooCommerce</a>.<br/>
-    <a href="https://woo.com/careers/">We're hiring</a>! Come work with us!
+    Made with 💜 by <a href="https://woocommerce.com/">WooCommerce</a>.<br/>
+    <a href="https://woocommerce.com/careers/">We're hiring</a>! Come work with us!
 </p>

--- a/WooCommerce/src/debug/assets/jitm_testing.json
+++ b/WooCommerce/src/debug/assets/jitm_testing.json
@@ -15,7 +15,7 @@
       "hook": "",
       "newWindow": true,
       "primary": true,
-      "link": "https:\/\/woo.com\/products\/hardware\/US"
+      "link": "https:\/\/woocommerce.com\/products\/hardware\/US"
     },
     "template": "default",
     "ttl": 300,
@@ -46,7 +46,7 @@
       "hook": "",
       "newWindow": true,
       "primary": true,
-      "link": "https:\/\/woo.com\/products\/hardware\/US"
+      "link": "https:\/\/woocommerce.com\/products\/hardware\/US"
     },
     "template": "default",
     "ttl": 300,

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -68,7 +68,6 @@
                 <data android:scheme="https"/>
 
                 <data android:host="woocommerce.com"/>
-                <data android:host="woo.com"/>
 
                 <data android:path="/mobile/orders/details"/>
                 <data android:path="/mobile/payments"/>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -5,7 +5,7 @@ import com.woocommerce.android.support.help.HelpOrigin.LOGIN_SITE_ADDRESS
 import com.woocommerce.android.support.help.HelpOrigin.LOGIN_USERNAME_PASSWORD
 
 object AppUrls {
-    const val APP_HELP_CENTER = "https://woo.com/document/android/"
+    const val APP_HELP_CENTER = "https://woocommerce.com/document/android/"
 
     const val AUTOMATTIC_TOS = "https://wordpress.com/tos/"
     const val AUTOMATTIC_PRIVACY_POLICY = "https://www.automattic.com/privacy"
@@ -14,22 +14,22 @@ object AppUrls {
     const val AUTOMATTIC_HIRING = "https://automattic.com/work-with-us"
     const val AUTOMATTIC_AI_GUIDELINES = "https://automattic.com/ai-guidelines/"
 
-    const val WOOCOMMERCE_UPGRADE = "https://woo.com/document/how-to-update-woocommerce/"
+    const val WOOCOMMERCE_UPGRADE = "https://woocommerce.com/document/how-to-update-woocommerce/"
     const val WOOCOMMERCE_PLUGIN = "https://wordpress.org/plugins/woocommerce/"
-    const val WOOCOMMERCE_WEB_OPTIONS = "https://woo.com/tracking-and-opt-outs/"
-    const val WOOCOMMERCE_USAGE_TRACKER = "https://woo.com/usage-tracking/"
+    const val WOOCOMMERCE_WEB_OPTIONS = "https://woocommerce.com/tracking-and-opt-outs/"
+    const val WOOCOMMERCE_USAGE_TRACKER = "https://woocommerce.com/usage-tracking/"
 
-    const val URL_LEARN_MORE_REVIEWS = "https://woo.com/document/ratings-and-reviews/"
-    const val URL_LEARN_MORE_ORDERS = "https://woo.com/blog/"
+    const val URL_LEARN_MORE_REVIEWS = "https://woocommerce.com/document/ratings-and-reviews/"
+    const val URL_LEARN_MORE_ORDERS = "https://woocommerce.com/blog/"
 
     const val JETPACK_INSTRUCTIONS =
-        "https://woo.com/document/jetpack-setup-instructions-for-the-woocommerce-mobile-app//"
+        "https://woocommerce.com/document/jetpack-setup-instructions-for-the-woocommerce-mobile-app//"
     const val JETPACK_TROUBLESHOOTING =
         "https://jetpack.com/support/getting-started-with-jetpack/troubleshooting-tips/"
     const val PRODUCT_IMAGE_UPLOADS_TROUBLESHOOTING =
-        "https://woo.com/document/troubleshooting-image-upload-issues-in-the-woo-mobile-apps/"
+        "https://woocommerce.com/document/troubleshooting-image-upload-issues-in-the-woo-mobile-apps/"
     const val ORDERS_TROUBLESHOOTING =
-        "https://woo.com/document/android-ios-apps-troubleshooting-error-fetching-orders/"
+        "https://woocommerce.com/document/android-ios-apps-troubleshooting-error-fetching-orders/"
 
     const val CROWDSIGNAL_MAIN_SURVEY = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
     const val CROWDSIGNAL_PRODUCT_SURVEY = "https://automattic.survey.fm/woo-app-feature-feedback-products"
@@ -57,47 +57,47 @@ object AppUrls {
     const val COUPONS_SURVEY = "https://automattic.survey.fm/woo-app-coupon-management-production"
 
     const val WOOCOMMERCE_USER_ROLES =
-        "https://woo.com/posts/a-guide-to-woocommerce-user-roles-permissions-and-security/"
+        "https://woocommerce.com/posts/a-guide-to-woocommerce-user-roles-permissions-and-security/"
     const val SHIPPING_LABEL_CUSTOMS_ITN = "https://pe.usps.com/text/imm/immc5_010.htm"
     const val SHIPPING_LABEL_CUSTOMS_HS_TARIFF_NUMBER =
-        "https://woo.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29"
+        "https://woocommerce.com/document/woocommerce-shipping-and-tax/woocommerce-shipping/#section-29"
 
     const val WPCOM_ADD_PAYMENT_METHOD = "https://wordpress.com/me/purchases/add-payment-method"
     const val FETCH_PAYMENT_METHOD_URL_PATH = "me/payment-methods"
     const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS =
-        "https://woo.com/document/woopayments/in-person-payments/getting-started-with-in-person-payments/"
+        "https://woocommerce.com/document/woopayments/in-person-payments/getting-started-with-in-person-payments/"
     const val STRIPE_LEARN_MORE_ABOUT_PAYMENTS =
-        "https://woo.com/document/stripe/accept-in-person-payments-with-stripe//"
+        "https://woocommerce.com/document/stripe/accept-in-person-payments-with-stripe//"
     const val STRIPE_TAP_TO_PAY_DEVICE_REQUIREMENTS =
         "https://stripe.com/docs/terminal/payments/setup-reader/tap-to-pay?platform=android#supported-devices"
     const val LEARN_MORE_ABOUT_TAP_TO_PAY =
-        "https://woo.com/document/woopayments/in-person-payments/tap-to-pay-android/"
+        "https://woocommerce.com/document/woopayments/in-person-payments/tap-to-pay-android/"
 
     const val WOOCOMMERCE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY =
-        "https://woo.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/" +
+        "https://woocommerce.com/document/getting-started-with-in-person-payments-with-woocommerce-payments/" +
             "#add-cod-payment-method"
     const val STRIPE_LEARN_MORE_ABOUT_PAYMENTS_CASH_ON_DELIVERY =
-        "https://woo.com/document/stripe/accept-in-person-payments-with-stripe/#section-8"
+        "https://woocommerce.com/document/stripe/accept-in-person-payments-with-stripe/#section-8"
 
-    const val WOOCOMMERCE_PURCHASE_CARD_READER_IN_COUNTRY = "https://woo.com/products/hardware/"
+    const val WOOCOMMERCE_PURCHASE_CARD_READER_IN_COUNTRY = "https://woocommerce.com/products/hardware/"
 
     const val BBPOS_MANUAL_CARD_READER =
-        "https://woo.com/wp-content/uploads/2022/12/c2xbt_product_sheet.pdf"
-    const val M2_MANUAL_CARD_READER = "https://woo.com/wp-content/uploads/2022/12/m2_product_sheet.pdf"
-    const val WISEPAD_3_MANUAL_CARD_READER = "https://woo.com/wp-content/uploads/2022/12/wp3_product_sheet.pdf"
+        "https://woocommerce.com/wp-content/uploads/2022/12/c2xbt_product_sheet.pdf"
+    const val M2_MANUAL_CARD_READER = "https://woocommerce.com/wp-content/uploads/2022/12/m2_product_sheet.pdf"
+    const val WISEPAD_3_MANUAL_CARD_READER = "https://woocommerce.com/wp-content/uploads/2022/12/wp3_product_sheet.pdf"
 
     const val PLAY_STORE_APP_PREFIX = "http://play.google.com/store/apps/details?id="
 
     const val LOGIN_WITH_EMAIL_WHAT_IS_WORDPRESS_COM_ACCOUNT =
-        "https://woo.com/document/what-is-a-wordpress-com-account/"
+        "https://woocommerce.com/document/what-is-a-wordpress-com-account/"
 
-    const val NEW_TO_WOO_DOC = "https://woo.com/woocommerce-features/"
-    const val HOSTING_OPTIONS_DOC = "https://woo.com/hosting-solutions/"
+    const val NEW_TO_WOO_DOC = "https://woocommerce.com/woocommerce-features/"
+    const val HOSTING_OPTIONS_DOC = "https://woocommerce.com/hosting-solutions/"
 
     const val WORPRESS_COM_TERMS = "https://wordpress.com/tos"
     const val JETPACK_SYNC_POLICY = "https://jetpack.com/support/what-data-does-jetpack-sync"
 
-    private const val LOGIN_HELP_CENTER = "https://woo.com/document/android-ios-apps-login-help-faq/"
+    private const val LOGIN_HELP_CENTER = "https://woocommerce.com/document/android-ios-apps-login-help-faq/"
     val LOGIN_HELP_CENTER_URLS = mapOf(
         LOGIN_EMAIL to "$LOGIN_HELP_CENTER#enter-wordpress-com-email-address-login-using-store-address-flow",
         LOGIN_SITE_ADDRESS to "$LOGIN_HELP_CENTER#enter-store-address",
@@ -113,12 +113,12 @@ object AppUrls {
             "dangerous-goods-and-prohibited-items.html"
 
     const val STORE_ONBOARDING_WCPAY_INSTRUCTIONS_WPCOM_ACCOUNT =
-        "https://woo.com/document/woopayments/startup-guide/#signing-up"
+        "https://woocommerce.com/document/woopayments/startup-guide/#signing-up"
     const val STORE_ONBOARDING_WCPAY_INSTRUCTIONS_LEARN_MORE =
-        "https://woo.com/document/woopayments/our-policies/know-your-customer/"
-    const val STORE_ONBOARDING_WCPAY_SETUP_GUIDE = "https://woo.com/document/woopayments/startup-guide/"
+        "https://woocommerce.com/document/woopayments/our-policies/know-your-customer/"
+    const val STORE_ONBOARDING_WCPAY_SETUP_GUIDE = "https://woocommerce.com/document/woopayments/startup-guide/"
     const val STORE_ONBOARDING_PAYMENTS_SETUP_GUIDE =
-        "https://woo.com/documentation/woocommerce/getting-started/sell-products/core-payment-options/"
+        "https://woocommerce.com/documentation/woocommerce/getting-started/sell-products/core-payment-options/"
     const val ADVERTISING_POLICY = "https://automattic.com/advertising-policy/"
     const val BLAZE_SUPPORT = "https://wordpress.com/support/promote-a-post/"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/WCSSRModelExt.kt
@@ -247,7 +247,7 @@ private fun formatSettingsData(data: JSONObject): String {
         sb.append(parseFormatTaxonomy(it, "Product Visibility") + "\n")
     }
 
-    sb.append("Connected to Woo.com: ${checkIfTrue(data.optBoolean("woocommerce_com_connected", false))}\n")
+    sb.append("Connected to WooCommerce.com: ${checkIfTrue(data.optBoolean("woocommerce_com_connected", false))}\n")
 
     return sb.toString()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/PluginUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/PluginUrls.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.model
 
 object PluginUrls {
-    const val SUBSCRIPTIONS_URL = "https://woo.com/products/woocommerce-subscriptions/"
-    const val BUNDLES_URL = "https://woo.com/products/product-bundles/"
-    const val COMPOSITE_URL = "https://woo.com/products/composite-products/"
+    const val SUBSCRIPTIONS_URL = "https://woocommerce.com/products/woocommerce-subscriptions/"
+    const val BUNDLES_URL = "https://woocommerce.com/products/product-bundles/"
+    const val COMPOSITE_URL = "https://woocommerce.com/products/composite-products/"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingsViewModel.kt
@@ -32,7 +32,7 @@ class AnalyticsHubSettingsViewModel @Inject constructor(
 
     companion object {
         const val LOADING_DELAY_MS = 500L
-        const val MARKETPLACE = "https://woo.com/products/"
+        const val MARKETPLACE = "https://woocommerce.com/products/"
     }
 
     val viewStateData: LiveDataDelegate<AnalyticsHubSettingsViewState> =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InfoScreenFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/InfoScreenFragment.kt
@@ -57,7 +57,7 @@ class InfoScreenFragment : Fragment(R.layout.fragment_info_screen) {
 
     sealed class InfoScreenLinkAction : Serializable {
         object LearnMoreAboutShippingLabels : InfoScreenLinkAction() {
-            const val LINK: String = "https://woo.com/products/shipping/"
+            const val LINK: String = "https://woocommerce.com/products/shipping/"
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/connectivitytool/OrderConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/connectivitytool/OrderConnectivityToolViewModel.kt
@@ -256,6 +256,6 @@ class OrderConnectivityToolViewModel @Inject constructor(
         const val jetpackTroubleshootingUrl =
             "https://jetpack.com/support/reconnecting-reinstalling-jetpack/"
         const val genericTroubleshootingUrl =
-            "https://woo.com/document/android-ios-apps-troubleshooting-error-fetching-orders/"
+            "https://woocommerce.com/document/android-ios-apps-troubleshooting-error-fetching-orders/"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainPurchaseViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/domain/DomainPurchaseViewModel.kt
@@ -30,7 +30,7 @@ class DomainPurchaseViewModel @Inject constructor(
     companion object {
         const val CART_URL = "https://wordpress.com/checkout"
         const val WEBVIEW_SUCCESS_TRIGGER_KEYWORD = "https://wordpress.com/checkout/thank-you/"
-        const val WEBVIEW_EXIT_TRIGGER_KEYWORD = "https://woo.com/"
+        const val WEBVIEW_EXIT_TRIGGER_KEYWORD = "https://woocommerce.com/"
     }
 
     private val navArgs: DomainPurchaseFragmentArgs by savedStateHandle.navArgs()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shipping/InstallWCShippingViewModel.kt
@@ -26,7 +26,7 @@ class InstallWCShippingViewModel @Inject constructor(
     private val selectedSite: SelectedSite
 ) : ScopedViewModel(savedState) {
     private companion object {
-        private const val WC_SHIPPING_INFO_URL = "https://woo.com/woocommerce-shipping/"
+        private const val WC_SHIPPING_INFO_URL = "https://woocommerce.com/woocommerce-shipping/"
     }
 
     private val step = savedState.getStateFlow<Step>(this, Step.Onboarding)

--- a/WooCommerce/src/main/res/layout/layout_order_creation_customer_info.xml
+++ b/WooCommerce/src/main/res/layout/layout_order_creation_customer_info.xml
@@ -31,7 +31,7 @@
             android:textAppearance="?attr/textAppearanceBody2"
             app:layout_constraintStart_toStartOf="@id/name"
             app:layout_constraintTop_toBottomOf="@id/name"
-            tools:text="george@woo.com" />
+            tools:text="george@woocommerce.com" />
     </androidx.appcompat.widget.LinearLayoutCompat>
 
     <View

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -736,7 +736,7 @@ Language: ar
     <string name="settings_privacy_header">الخصوصية</string>
     <string name="settings_usage_tracking_description">تعرّف على المزيد حول البيانات التي نجمعها حول متجرك وخياراتك للتحكم في مشاركة البيانات هذه.</string>
     <string name="settings_usage_tracking">تعقب الاستخدام</string>
-    <string name="settings_web_options_description">يتوافر مزيد من خيارات الخصوصية لمستخدمي woo.com. تحقق هنا للتعرف على المزيد.</string>
+    <string name="settings_web_options_description">يتوافر مزيد من خيارات الخصوصية لمستخدمي woocommerce.com. تحقق هنا للتعرف على المزيد.</string>
     <string name="settings_web_options">خيارات الويب</string>
     <string name="settings_more_privacy_options_header">مزيد من خيارات الخصوصية</string>
     <string name="settings_tracking_analytics_error_update">كان هناك خطأ في أثناء تحديث إعدادات الخصوصية لديك</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -736,7 +736,7 @@ Language: de
     <string name="settings_privacy_header">Datenschutz</string>
     <string name="settings_usage_tracking_description">Weitere Informationen zu den Daten, die wir über deinen Shop erfassen, sowie deinen Optionen zum Kontrollieren dieser Datenfreigabe.</string>
     <string name="settings_usage_tracking">Nutzungsaufzeichnung</string>
-    <string name="settings_web_options_description">Weitere Datenschutz-Optionen für woo.com-Benutzer verfügbar. Hier erfährst du mehr.</string>
+    <string name="settings_web_options_description">Weitere Datenschutz-Optionen für woocommerce.com-Benutzer verfügbar. Hier erfährst du mehr.</string>
     <string name="settings_web_options">Web-Optionen</string>
     <string name="settings_more_privacy_options_header">Mehr Datenschutz-Optionen</string>
     <string name="settings_tracking_analytics_error_update">Beim Aktualisieren deiner Privatsphäre-Einstellungen ist ein Fehler aufgetreten</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -736,7 +736,7 @@ Language: es
     <string name="settings_privacy_header">Privacidad</string>
     <string name="settings_usage_tracking_description">Obtén más información sobre los datos que recopilamos sobre tu tienda y tus opciones para controlar los datos que compartes.</string>
     <string name="settings_usage_tracking">Seguimiento de uso</string>
-    <string name="settings_web_options_description">Más opciones de privacidad disponibles para los usuarios de woo.com. Consulta aquí para saber más.</string>
+    <string name="settings_web_options_description">Más opciones de privacidad disponibles para los usuarios de woocommerce.com. Consulta aquí para saber más.</string>
     <string name="settings_web_options">Opciones web</string>
     <string name="settings_more_privacy_options_header">Más opciones de privacidad</string>
     <string name="settings_tracking_analytics_error_update">Se ha producido un error al actualizar tu configuración de privacidad</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -736,7 +736,7 @@ Language: fr
     <string name="settings_privacy_header">Confidentialité</string>
     <string name="settings_usage_tracking_description">Apprenez-en davantage sur les données que nous recueillons à propos de votre boutique et sur les options dont vous disposez pour contrôler le partage de ces informations.</string>
     <string name="settings_usage_tracking">Suivi d’utilisation</string>
-    <string name="settings_web_options_description">Plus d’options de confidentialité disponibles pour les utilisateurs de woo.com. Cliquez ici pour en savoir plus.</string>
+    <string name="settings_web_options_description">Plus d’options de confidentialité disponibles pour les utilisateurs de woocommerce.com. Cliquez ici pour en savoir plus.</string>
     <string name="settings_web_options">Options Web</string>
     <string name="settings_more_privacy_options_header">Plus d’options de confidentialité</string>
     <string name="settings_tracking_analytics_error_update">Une erreur est survenue lors de la mise à jour de vos réglages de confidentialité</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -736,7 +736,7 @@ Language: he_IL
     <string name="settings_privacy_header">פרטיות</string>
     <string name="settings_usage_tracking_description">למידע נוסף על הנתונים שאנחנו אוספים לגביך ומאחסנים ועל האפשרויות שיש לך לשלוט בשיתוף הנתונים האלו.</string>
     <string name="settings_usage_tracking">מעקב אחר השימוש</string>
-    <string name="settings_web_options_description">אפשרויות פרטיות נוספות עבור משתמשי woo.com. לרשותך כאן מידע נוסף.</string>
+    <string name="settings_web_options_description">אפשרויות פרטיות נוספות עבור משתמשי woocommerce.com. לרשותך כאן מידע נוסף.</string>
     <string name="settings_web_options">אפשרויות באינטרנט</string>
     <string name="settings_more_privacy_options_header">אפשרויות פרטיות נוספות</string>
     <string name="settings_tracking_analytics_error_update">אירעה שגיאה בעדכון הגדרות הפרטיות שלך</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -736,7 +736,7 @@ Language: id
     <string name="settings_privacy_header">Privasi</string>
     <string name="settings_usage_tracking_description">Pelajari selengkapnya tentang data yang kami kumpulkan seputar toko Anda dan pilihan Anda dalam mengelola pembagian data.</string>
     <string name="settings_usage_tracking">Pelacakan Penggunaan</string>
-    <string name="settings_web_options_description">Tersedia pilihan privasi lainnya untuk pengguna woo.com. Lihat di sini untuk membaca selengkapnya.</string>
+    <string name="settings_web_options_description">Tersedia pilihan privasi lainnya untuk pengguna woocommerce.com. Lihat di sini untuk membaca selengkapnya.</string>
     <string name="settings_web_options">Pilihan Web</string>
     <string name="settings_more_privacy_options_header">Pilihan privasi lainnya</string>
     <string name="settings_tracking_analytics_error_update">Terjadi error saat memperbarui pengaturan privasi Anda</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -736,7 +736,7 @@ Language: it
     <string name="settings_privacy_header">Privacy</string>
     <string name="settings_usage_tracking_description">Scopri di più sui dati che raccogliamo sul tuo negozio e sulle tue opzioni per il controllo di questa condivisione dei dati.</string>
     <string name="settings_usage_tracking">Tracciabilità dell\'utilizzo</string>
-    <string name="settings_web_options_description">Per gli utenti di woo.com sono disponibili ulteriori opzioni per la privacy. Controlla qui per saperne di più.</string>
+    <string name="settings_web_options_description">Per gli utenti di woocommerce.com sono disponibili ulteriori opzioni per la privacy. Controlla qui per saperne di più.</string>
     <string name="settings_web_options">Opinioni del web</string>
     <string name="settings_more_privacy_options_header">Ulteriori opzioni per la privacy</string>
     <string name="settings_tracking_analytics_error_update">Si è verificato un errore durante l\'aggiornamento delle impostazioni sulla privacy</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -748,7 +748,7 @@ Language: ja_JP
     <string name="order_creation_barcode_scanning_unable_to_add_variable_product">直接バリエーション商品を追加できません。 特定のバリエーションを選択してください</string>
     <string name="order_creation_barcode_scanning_scanning_failed">スキャンに失敗しました。 後でもう一度お試しください。</string>
     <string name="order_creation_barcode_scanning_unable_to_add_product">SKU「%s」の商品が見つかりません。 注文に追加できません</string>
-    <string name="settings_web_options_description">woo.com ユーザー向けのその他のプライバシーオプションを利用できます。 こちらをクリックして詳細をご確認ください。</string>
+    <string name="settings_web_options_description">woocommerce.com ユーザー向けのその他のプライバシーオプションを利用できます。 こちらをクリックして詳細をご確認ください。</string>
     <string name="order_list_barcode_scanning_scanning_failed">スキャンに失敗しました。 後でもう一度お試しください</string>
     <string name="scan_barcode">バーコードのスキャン</string>
     <string name="shipping_notice_banner_instructions_content">欧州連合 (EU) の関税法規則に従う国への発送は、すべての品目について明確な説明が求められるようになりました。 たとえば衣類を送る場合、どのようなタイプの衣類であるか (例: 男性用シャツ、女児用ベスト、男児用上着など) を明記しなければ認められません。 これを怠ると、配送が税関で遅延または中断されることがあります。</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -736,7 +736,7 @@ Language: ko_KR
     <string name="settings_privacy_header">개인정보</string>
     <string name="settings_usage_tracking_description">이 데이터 공유를 제어하기 위해 당사에서 수집하는 회원님의 스토어와 옵션에 대한 데이터에 대해 자세히 알아보세요.</string>
     <string name="settings_usage_tracking">사용량 추적</string>
-    <string name="settings_web_options_description">Woo.com 사용자는 추가 개인정보 옵션을 사용할 수 있습니다. 여기에서 자세히 알아보세요.</string>
+    <string name="settings_web_options_description">woocommerce.com 사용자는 추가 개인정보 옵션을 사용할 수 있습니다. 여기에서 자세히 알아보세요.</string>
     <string name="settings_web_options">웹 옵션</string>
     <string name="settings_more_privacy_options_header">추가 개인정보 옵션</string>
     <string name="settings_tracking_analytics_error_update">프라이버시 설정 업데이트 중 오류가 발생했습니다.</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -736,7 +736,7 @@ Language: nl
     <string name="settings_privacy_header">Privacy</string>
     <string name="settings_usage_tracking_description">Lees meer over de gegevens die we verzamelen over je winkel en jouw opties voor het beheren van deze gegevensuitwisseling.</string>
     <string name="settings_usage_tracking">Gebruiksgegevens bijhouden</string>
-    <string name="settings_web_options_description">Meer privacyopties beschikbaar voor gebruikers van woo.com. Kijk hier voor meer informatie.</string>
+    <string name="settings_web_options_description">Meer privacyopties beschikbaar voor gebruikers van woocommerce.com. Kijk hier voor meer informatie.</string>
     <string name="settings_web_options">Webopties</string>
     <string name="settings_more_privacy_options_header">Meer privacyopties</string>
     <string name="settings_tracking_analytics_error_update">Er is een fout opgetreden bij het bijwerken van je privacy-instellingen</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -748,7 +748,7 @@ Language: pt_BR
     <string name="settings_tracking_analytics_error_update">Ocorreu um erro ao atualizar suas configurações de privacidade</string>
     <string name="settings_tracking_analytics_error_fetch">Ocorreu um erro ao obter suas configurações de privacidade</string>
     <string name="order_creation_barcode_scanning_unable_to_add_product">Produto com SKU %s não encontrado. Não foi possível adicionar ao pedido</string>
-    <string name="settings_web_options_description">Mais opções de privacidade disponíveis para usuários do woo.com. Clique aqui para saber mais.</string>
+    <string name="settings_web_options_description">Mais opções de privacidade disponíveis para usuários do woocommerce.com. Clique aqui para saber mais.</string>
     <string name="order_list_barcode_scanning_scanning_failed">Falha ao escanear. Tente novamente mais tarde</string>
     <string name="scan_barcode">Escanear código de barras do produto</string>
     <string name="shipping_notice_banner_instructions_content">O envio para países que seguem as regras alfandegárias da União Europeia (UE) agora exige que você descreva de forma detalhada cada item. Por exemplo, se você está enviando roupas, deve indicar que tipo de roupa (camisas masculinas, colete feminino, jaqueta masculina) para que a descrição seja aceitável. Caso contrário, os envios podem sofrer atrasos ou ficar interditados na alfândega.</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -736,7 +736,7 @@ Language: ru
     <string name="settings_privacy_header">Конфиденциальность</string>
     <string name="settings_usage_tracking_description">Узнайте больше о данных, которые мы собираем в вашем магазине, и о том, как вы можете управлять передачей этих данных.</string>
     <string name="settings_usage_tracking">Отслеживание использования</string>
-    <string name="settings_web_options_description">Для пользователей woo.com доступны дополнительные опции конфиденциальности. Подробности см. здесь.</string>
+    <string name="settings_web_options_description">Для пользователей woocommerce.com доступны дополнительные опции конфиденциальности. Подробности см. здесь.</string>
     <string name="settings_web_options">Интернет-опции</string>
     <string name="settings_more_privacy_options_header">Дополнительные параметры конфиденциальности</string>
     <string name="settings_tracking_analytics_error_update">При обновлении настроек конфиденциальности произошла ошибка</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -748,7 +748,7 @@ Language: sv_SE
     <string name="settings_usage_tracking_description">Läs mer om vilka data vi samlar in om din butik och dina möjligheter att styra vilka data som delas.</string>
     <string name="settings_usage_tracking">Användningsspårning</string>
     <string name="order_creation_barcode_scanning_unable_to_add_product">Produkten med SKU %s hittades inte. Det gick inte att lägga till i beställningen</string>
-    <string name="settings_web_options_description">Fler integritetsalternativ tillgängliga för woo.com-användare. Kolla in här för att lära dig mer.</string>
+    <string name="settings_web_options_description">Fler integritetsalternativ tillgängliga för woocommerce.com-användare. Kolla in här för att lära dig mer.</string>
     <string name="scan_barcode">Skanna streckkod</string>
     <string name="order_list_barcode_scanning_scanning_failed">Skanning misslyckades. Försök igen senare</string>
     <string name="shipping_notice_banner_instructions_content">Leverans till länder som följer EU:s tullregler kräver nu att du tydligt beskriver varje vara. Om du till exempel skickar kläder måste du ange vilken typ av kläder det är (t.ex. herrskjortor, flickvästar, pojkjackor) för att beskrivningen ska vara godtagbar. Annars kan leveranser försenas eller avbrytas i tullen.</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -736,7 +736,7 @@ Language: tr
     <string name="settings_privacy_header">Gizlilik</string>
     <string name="settings_usage_tracking_description">Mağazanız hakkında topladığımız veriler ve bu verilerin paylaşımını kontrol etme seçenekleriniz hakkında daha fazla bilgi edinin.</string>
     <string name="settings_usage_tracking">Kullanım İzleme</string>
-    <string name="settings_web_options_description">woo.com kullanıcıları için daha fazla gizlilik seçeneği mevcut. Daha fazla bilgi edinmek için burayı kontrol edin.</string>
+    <string name="settings_web_options_description">woocommerce.com kullanıcıları için daha fazla gizlilik seçeneği mevcut. Daha fazla bilgi edinmek için burayı kontrol edin.</string>
     <string name="settings_web_options">Web Seçenekleri</string>
     <string name="settings_more_privacy_options_header">Daha fazla gizlilik seçeneği</string>
     <string name="settings_tracking_analytics_error_update">Gizlilik ayarlarınız güncellenirken bir hata oluştu</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -748,7 +748,7 @@ Language: zh_CN
     <string name="settings_tracking_analytics_description">允许我们收集与用户跟我们的移动应用程序互动情况相关的信息，从而优化性能。</string>
     <string name="card_reader_payment_vm_killed_when_tpp_in_foreground">当 Woo 应用程序在后台运行时，系统会将其终止。 您可以尝试再次使用它。</string>
     <string name="order_creation_barcode_scanning_unable_to_add_product">未找到 SKU 为 %s 的产品。 无法添加到订单</string>
-    <string name="settings_web_options_description">为 woo.com 用户提供更多隐私选项。 点击此处了解更多详情。</string>
+    <string name="settings_web_options_description">为 woocommerce.com 用户提供更多隐私选项。 点击此处了解更多详情。</string>
     <string name="order_list_barcode_scanning_scanning_failed">扫描失败。 请稍后再试</string>
     <string name="scan_barcode">扫描条形码</string>
     <string name="shipping_notice_banner_instructions_content">现在，当运输到遵守欧盟 (EU) 海关规定的国家/地区时，您需要清楚地描述每一件商品。 例如，假设您发送衣服，您的描述中需要指出是哪种类型的衣服（例如，男士衬衫、女孩背心、男孩夹克）才可被接受。 否则货物可能会在海关滞留或被扣留。</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -736,7 +736,7 @@ Language: zh_TW
     <string name="settings_privacy_header">隱私權</string>
     <string name="settings_usage_tracking_description">深入瞭解我們針對你的商店收集了哪些資料，以及您可使用的資料分享控制選項。</string>
     <string name="settings_usage_tracking">使用情況追蹤</string>
-    <string name="settings_web_options_description">woo.com 為使用者提供更多隱私權選項。 如要瞭解詳情，請查看此處。</string>
+    <string name="settings_web_options_description">woocommerce.com 為使用者提供更多隱私權選項。 如要瞭解詳情，請查看此處。</string>
     <string name="settings_web_options">網頁選項</string>
     <string name="settings_more_privacy_options_header">其他隱私權選項</string>
     <string name="settings_tracking_analytics_error_update">更新你的隱私權設定時發生錯誤</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2329,7 +2329,7 @@
     <string name="settings_tracking_analytics_error_update">There was an error updating your privacy settings</string>
     <string name="settings_more_privacy_options_header">More privacy options</string>
     <string name="settings_web_options">Web Options</string>
-    <string name="settings_web_options_description">More privacy options available for woo.com users. Check here to learn more.</string>
+    <string name="settings_web_options_description">More privacy options available for woocommerce.com users. Check here to learn more.</string>
     <string name="settings_usage_tracking">Usage Tracking</string>
     <string name="settings_usage_tracking_description">Learn more about the data we collect about your store and your options to control this data sharing.</string>
     <string name="settings_privacy_header">Privacy</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationParametersViewModelTest.kt
@@ -13,7 +13,7 @@ import org.junit.Test
 class BlazeCampaignCreationAdDestinationParametersViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: BlazeCampaignCreationAdDestinationParametersViewModel
 
-    private val targetUrl = "https://woo.com"
+    private val targetUrl = "https://woocommerce.com"
 
     fun setup(params: Map<String, String> = emptyMap()) {
         viewModel = BlazeCampaignCreationAdDestinationParametersViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/destination/BlazeCampaignCreationAdDestinationViewModelTest.kt
@@ -41,14 +41,14 @@ class BlazeCampaignCreationAdDestinationViewModelTest : BaseUnitTest() {
 
     @Before
     fun setupTests() {
-        whenever(product.permalink).thenReturn("https://woo.com")
+        whenever(product.permalink).thenReturn("https://woocommerce.com")
         whenever(selectedSite.get()).thenReturn(SiteModel().apply { url = "https://woo2.com" })
         whenever(productDetailRepository.getProduct(any())).thenReturn(product)
     }
 
     @Test
     fun `given a product id, when back is pressed, then exit with result`() = testBlocking {
-        setup("https://woo.com", productId = 1L)
+        setup("https://woocommerce.com", productId = 1L)
 
         viewModel.onBackPressed()
 
@@ -58,7 +58,7 @@ class BlazeCampaignCreationAdDestinationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when url property is tapped, then url dialog becomes visible`() = testBlocking {
-        setup("https://woo.com", productId = 1L)
+        setup("https://woocommerce.com", productId = 1L)
 
         viewModel.onUrlPropertyTapped()
 
@@ -69,7 +69,7 @@ class BlazeCampaignCreationAdDestinationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when parameter property is tapped, then navigate to parameters screen`() = testBlocking {
-        val url = "https://woo.com"
+        val url = "https://woocommerce.com"
         setup(url, productId = 1L)
 
         viewModel.onParameterPropertyTapped()
@@ -84,7 +84,7 @@ class BlazeCampaignCreationAdDestinationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when target url is updated, then view state is updated`() = testBlocking {
-        val url = "https://woo.com?productId=1"
+        val url = "https://woocommerce.com?productId=1"
         val base = "https://cnn.com"
         val params = mapOf("a" to "b", "c" to "d")
         setup(url, productId = 1L)
@@ -98,7 +98,7 @@ class BlazeCampaignCreationAdDestinationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when destination url is changed, then view state is updated and url dialog is not visible`() = testBlocking {
-        val url = "https://woo.com"
+        val url = "https://woocommerce.com"
         val url2 = "https://cnn.com"
         setup(url, productId = 1L)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
@@ -1404,7 +1404,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
 
             assertThat(viewModel.event.value).isInstanceOf(PurchaseCardReader::class.java)
             assertThat((viewModel.event.value as PurchaseCardReader).url).isEqualTo(
-                "https://woo.com/products/hardware/US"
+                "https://woocommerce.com/products/hardware/US"
             )
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/about/TapToPayAboutViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/about/TapToPayAboutViewModelTest.kt
@@ -117,7 +117,7 @@ class TapToPayAboutViewModelTest : BaseUnitTest() {
         // THEN
         assertThat(viewModel.event.value).isEqualTo(
             NavigateToUrlInGenericWebView(
-                "https://woo.com/products/hardware/CA"
+                "https://woocommerce.com/products/hardware/CA"
             )
         )
     }
@@ -149,7 +149,7 @@ class TapToPayAboutViewModelTest : BaseUnitTest() {
         // THEN
         assertThat(viewModel.event.value).isEqualTo(
             NavigateToUrlInGenericWebView(
-                "https://woo.com/products/hardware/GB"
+                "https://woocommerce.com/products/hardware/GB"
             )
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/summary/TapToPaySummaryViewModelTest.kt
@@ -510,7 +510,7 @@ class TapToPaySummaryViewModelTest : BaseUnitTest() {
         // THEN
         assertThat(viewModel.event.value).isEqualTo(
             TapToPaySummaryViewModel.NavigateToUrlInGenericWebView(
-                "https://woo.com/document/woopayments/in-person-payments/tap-to-pay-android/"
+                "https://woocommerce.com/document/woopayments/in-person-payments/tap-to-pay-android/"
             )
         )
     }

--- a/docs/issue-triage.md
+++ b/docs/issue-triage.md
@@ -56,4 +56,6 @@ In addition to the guidelines above, we have specific criteria for prioritizing 
 
 The matrix and criteria outline above are meant as a guideline, to avoid having to rely solely on "gut instinct" when prioritizing issues. However, there will likely be exceptions or cases that are unclear. Trust your instincts if an issue seems to be higher priority than the matrix gives it!
 
-You can also always reach out for help prioritizing or escalating issues: Contributors are welcome to get in touch in the `#mobile-apps` channel on the [WooCommerce Community Slack](https://woo.com/community-slack/), and WooCommerce team members can reach out to the WooCommerce Mobile lead, team leads, or quality lead for help.
+You can also always reach out for help prioritizing or escalating issues: Contributors are welcome to get in touch in
+the `#mobile-apps` channel on the [WooCommerce Community Slack](https://woocommerce.com/community-slack/), and
+WooCommerce team members can reach out to the WooCommerce Mobile lead, team leads, or quality lead for help.

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -2321,7 +2321,7 @@
     <string name="settings_tracking_analytics_error_update">There was an error updating your privacy settings</string>
     <string name="settings_more_privacy_options_header">More privacy options</string>
     <string name="settings_web_options">Web Options</string>
-    <string name="settings_web_options_description">More privacy options available for woo.com users. Check here to learn more.</string>
+    <string name="settings_web_options_description">More privacy options available for woocommerce.com users. Check here to learn more.</string>
     <string name="settings_usage_tracking">Usage Tracking</string>
     <string name="settings_usage_tracking_description">Learn more about the data we collect about your store and your options to control this data sharing.</string>
     <string name="settings_privacy_header">Privacy</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: https://github.com/woocommerce/woocommerce-android/issues/11234
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR reverts the changes recently added here: https://github.com/woocommerce/woocommerce-android/pull/10177 were we replaced the usages of woocommece.com domain in favor of woo.com

DON'T PANIC about the number of file changes 😅. All are super simple changes and many of them are coming from replacing `Woo.com` from localized strings

### Testing instructions
I'll copy paste the testing instructions from the prior PR as the same apply here

<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
* Valudate that universal links work, both with `woocommerce.com` and `woo.com` domains. E.g.:
```
 adb shell am start -a android.intent.action.VIEW \
   -c android.intent.category.BROWSABLE \
   -d "https://woocommerce.com/mobile/payments/tap-to-pay"
```
<img width="282" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/4923871/c4c76030-e93c-464d-9403-9a9731118265">


* Validate that all links replacements lead to the same page as before

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.