### PR TITLE
Track WC core version in every track event

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -39,6 +39,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboa
 import com.woocommerce.android.util.AppThemeUtils
 import com.woocommerce.android.util.ApplicationLifecycleMonitor
 import com.woocommerce.android.util.ApplicationLifecycleMonitor.ApplicationLifecycleListener
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.REGEX_API_JETPACK_TUNNEL_METHOD
 import com.woocommerce.android.util.REGEX_API_NUMERIC_PARAM
@@ -133,6 +134,8 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     @Inject lateinit var connectionReceiver: ConnectionChangeReceiver
 
     @Inject lateinit var prefs: AppPrefs
+
+    @Inject lateinit var getWooVersion: GetWooCorePluginCachedVersion
 
     @Inject @AppCoroutineScope
     lateinit var appCoroutineScope: CoroutineScope
@@ -350,7 +353,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     }
 
     private fun initAnalytics() {
-        AnalyticsTracker.init(application, selectedSite, prefs)
+        AnalyticsTracker.init(application, selectedSite, prefs, getWooVersion)
 
         AnalyticsTracker.refreshMetadata(accountStore.account?.userName)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -94,6 +94,8 @@ class AnalyticsTracker private constructor(
         finalProperties[IS_DEBUG] = BuildConfig.DEBUG
         selectedSiteModel?.url?.let { finalProperties[KEY_SITE_URL] = it }
 
+        getWooVersion()?.let { finalProperties[KEY_CACHED_WOO_VERSION] = it }
+
         val propertiesJson = JSONObject(finalProperties)
         tracksClient?.track(EVENTS_PREFIX + eventName, propertiesJson, user, userType)
 
@@ -300,6 +302,7 @@ class AnalyticsTracker private constructor(
 
         const val KEY_WAS_ECOMMERCE_TRIAL = "was_ecommerce_trial"
         const val KEY_PLAN_PRODUCT_SLUG = "plan_product_slug"
+        const val KEY_CACHED_WOO_VERSION = "cached_woo_core_version"
 
         const val KEY_PERIOD = "period"
         const val KEY_REPORT = "report"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.analytics.AnalyticsEvent.BACK_PRESSED
 import com.woocommerce.android.analytics.AnalyticsEvent.VIEW_SHOWN
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
@@ -20,6 +21,7 @@ class AnalyticsTracker private constructor(
     private val context: Context,
     private val selectedSite: SelectedSite,
     private val appPrefs: AppPrefs,
+    private val getWooVersion: GetWooCorePluginCachedVersion,
 ) {
     private var tracksClient: TracksClient? = TracksClient.getClient(context)
     private var username: String? = null
@@ -655,8 +657,13 @@ class AnalyticsTracker private constructor(
                 }
             }
 
-        fun init(context: Context, selectedSite: SelectedSite, appPrefs: AppPrefs) {
-            instance = AnalyticsTracker(context.applicationContext, selectedSite, appPrefs)
+        fun init(
+            context: Context,
+            selectedSite: SelectedSite,
+            appPrefs: AppPrefs,
+            getWooVersion: GetWooCorePluginCachedVersion,
+        ) {
+            instance = AnalyticsTracker(context.applicationContext, selectedSite, appPrefs, getWooVersion)
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
             sendUsageStats = prefs.getBoolean(PREFKEY_SEND_USAGE_STATS, true)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -206,16 +206,11 @@ class AnalyticsTracker private constructor(
         const val KEY_CUSTOM_FIELDS_SIZE = "custom_fields_size"
         const val KEY_WAITING_TIME = "waiting_time"
         const val KEY_IS_NON_ATOMIC = "is_non_atomic"
-        const val KEY_INDUSTRY_SLUG = "industry_slug"
-        const val KEY_USER_COMMERCE_JOURNEY = "user_commerce_journey"
-        const val KEY_ECOMMERCE_PLATFORMS = "ecommerce_platforms"
-        const val KEY_COUNTRY_CODE = "country_code"
         const val KEY_CAUSE = "cause"
         const val KEY_SCENARIO = "scenario"
         const val KEY_REASON = "reason"
         const val KEY_TAP = "tap"
         const val KEY_FAILURE = "failure"
-        const val KEY_IS_FREE_TRIAL = "is_free_trial"
         const val KEY_SCANNING_SOURCE = "source"
         const val KEY_SCANNING_BARCODE_FORMAT = "barcode_format"
         const val KEY_PRODUCT_ADDED_VIA = "added_via"
@@ -261,7 +256,6 @@ class AnalyticsTracker private constructor(
         const val VALUE_SEARCH_SKU = "sku"
         const val VALUE_SUBMIT = "submit"
         const val VALUE_DISMISS = "dismiss"
-        const val VALUE_SUPPORT = "support"
         const val VALUE_WP_COM = "wp_com"
         const val VALUE_NO_WP_COM = "no_wp_com"
         const val VALUE_PREVIOUS_PERIOD = "previous_period"
@@ -314,7 +308,6 @@ class AnalyticsTracker private constructor(
         enum class OrderNoteType(val value: String) {
             CUSTOMER("customer"),
             PRIVATE("private"),
-            SYSTEM("system")
         }
 
         const val KEY_FEEDBACK_ACTION = "action"
@@ -404,7 +397,6 @@ class AnalyticsTracker private constructor(
         enum class ConnectedProductsListAction(val value: String) {
             ADD_TAPPED("add_tapped"),
             ADDED("added"),
-            DONE_TAPPED("done_tapped"),
             DELETE_TAPPED("delete_tapped")
         }
 
@@ -491,7 +483,6 @@ class AnalyticsTracker private constructor(
 
         // -- Jetpack Installation
         const val VALUE_JETPACK_INSTALLATION_SOURCE_WEB = "web"
-        const val VALUE_JETPACK_INSTALLATION_SOURCE_NATIVE = "native"
 
         // -- Jetpack Setup
         const val KEY_JETPACK_SETUP_IS_ALREADY_CONNECTED = "is_already_connected"
@@ -545,7 +536,6 @@ class AnalyticsTracker private constructor(
         const val IPP_LEARN_MORE_SOURCE = "source"
 
         // -- Domain change
-        const val VALUE_SETTINGS = "settings"
         const val VALUE_STEP_DASHBOARD = "dashboard"
         const val VALUE_STEP_PICKER = "picker"
         const val VALUE_STEP_CONTACT_INFO = "contact_info"
@@ -553,12 +543,8 @@ class AnalyticsTracker private constructor(
         const val KEY_USE_DOMAIN_CREDIT = "use_domain_credit"
 
         // -- Free Trial
-        const val KEY_FREE_TRIAL_SOURCE = "source"
-        const val KEY_SURVEY_OPTION = "survey_option"
-        const val KEY_SURVEY_FREE_TEXT = "free_text"
         const val VALUE_BANNER = "banner"
         const val VALUE_UPGRADES_SCREEN = "upgrades_screen"
-        const val VALUE_NOTIFICATION = "notification"
 
         // -- Store Onboarding
         const val ONBOARDING_TASK_KEY = "task"
@@ -581,7 +567,6 @@ class AnalyticsTracker private constructor(
         const val KEY_IS_RETRY = "is_retry"
         const val KEY_WITH_MESSAGE = "with_message"
         const val VALUE_PRODUCT_SHARING = "product_sharing"
-        const val VALUE_PRODUCT_SHARING_MESSAGE = "product_sharing_message"
 
         // -- AI product description
         const val VALUE_AZTEC_EDITOR = "aztec_editor"
@@ -597,7 +582,6 @@ class AnalyticsTracker private constructor(
 
         // -- Blaze
         const val KEY_BLAZE_SOURCE = "source"
-        const val KEY_BLAZE_STEP = "step"
         const val KEY_BLAZE_DURATION = "duration"
         const val KEY_BLAZE_TOTAL_BUDGET = "total_budget"
         const val KEY_BLAZE_IS_AI_CONTENT = "is_ai_suggested_ad_content"
@@ -636,7 +620,6 @@ class AnalyticsTracker private constructor(
 
         // Theme picker
         const val KEY_THEME_PICKER_SOURCE = "source"
-        const val VALUE_THEME_PICKER_SOURCE_STORE_CREATION = "store_creation"
         const val VALUE_THEME_PICKER_SOURCE_SETTINGS = "settings"
         const val KEY_THEME_PICKER_THEME = "theme"
         const val KEY_THEME_PICKER_LAYOUT_PREVIEW = "layout"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/StatsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/StatsRepository.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.DASHBOARD
 import kotlinx.coroutines.CompletableDeferred
@@ -42,7 +43,8 @@ class StatsRepository @Inject constructor(
     private val wcOrderStore: WCOrderStore,
     private val wcLeaderboardsStore: WCLeaderboardsStore,
     private val wooCommerceStore: WooCommerceStore,
-    private val dispatchers: CoroutineDispatchers
+    private val dispatchers: CoroutineDispatchers,
+    private val getWooVersion: GetWooCorePluginCachedVersion,
 ) {
     companion object {
         private val TAG = StatsRepository::class.java
@@ -358,8 +360,7 @@ class StatsRepository @Inject constructor(
     }
 
     private fun supportsProductOnlyLeaderboardAndReportEndpoint(): Boolean {
-        val currentWooCoreVersion =
-            wooCommerceStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_CORE)?.version ?: "0.0"
+        val currentWooCoreVersion = getWooVersion() ?: return false
         return currentWooCoreVersion.semverCompareTo(PRODUCT_ONLY_LEADERBOARD_REPORT_MIN_WC_VERSION) >= 0
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepository.kt
@@ -4,15 +4,14 @@ import com.woocommerce.android.extensions.isFreeTrial
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.store.WooCommerceStore
-import org.wordpress.android.fluxc.store.WooCommerceStore.WooPlugin.WOO_CORE
 import javax.inject.Inject
 
 class MoreMenuRepository @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val wooCommerceStore: WooCommerceStore,
+    private val getWooVersion: GetWooCorePluginCachedVersion
 ) {
     companion object {
         private const val INBOX_MINIMUM_SUPPORTED_VERSION = "6.4.0"
@@ -22,8 +21,7 @@ class MoreMenuRepository @Inject constructor(
         withContext(Dispatchers.IO) {
             if (!selectedSite.exists() || !FeatureFlag.MORE_MENU_INBOX.isEnabled()) return@withContext false
 
-            val currentWooCoreVersion =
-                wooCommerceStore.getSitePlugin(selectedSite.get(), WOO_CORE)?.version ?: "0.0"
+            val currentWooCoreVersion = getWooVersion() ?: return@withContext false
             currentWooCoreVersion.semverCompareTo(INBOX_MINIMUM_SUPPORTED_VERSION) >= 0
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/data/StatsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/data/StatsRepository.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.DASHBOARD
 import kotlinx.coroutines.CompletableDeferred
@@ -45,6 +46,7 @@ class StatsRepository @Inject constructor(
     private val wcOrderStore: WCOrderStore,
     private val wcLeaderboardsStore: WCLeaderboardsStore,
     private val wooCommerceStore: WooCommerceStore,
+    private val getWooVersion: GetWooCorePluginCachedVersion,
     private val dispatchers: CoroutineDispatchers
 ) {
     companion object {
@@ -361,8 +363,7 @@ class StatsRepository @Inject constructor(
     }
 
     private fun supportsProductOnlyLeaderboardAndReportEndpoint(): Boolean {
-        val currentWooCoreVersion =
-            wooCommerceStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_CORE)?.version ?: "0.0"
+        val currentWooCoreVersion = getWooVersion() ?: return false
         return currentWooCoreVersion.semverCompareTo(PRODUCT_ONLY_LEADERBOARD_REPORT_MIN_WC_VERSION) >= 0
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepository.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.ui.orders.creation.taxes.TaxBasedOnSetting.Billin
 import com.woocommerce.android.ui.orders.creation.taxes.TaxBasedOnSetting.ShippingAddress
 import com.woocommerce.android.ui.orders.creation.taxes.TaxBasedOnSetting.StoreAddress
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import kotlinx.coroutines.NonCancellable
@@ -45,7 +46,8 @@ class OrderCreateEditRepository @Inject constructor(
     private val dispatchers: CoroutineDispatchers,
     private val wooCommerceStore: WooCommerceStore,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val listItemMapper: ListItemMapper
+    private val listItemMapper: ListItemMapper,
+    private val getWooVersion: GetWooCorePluginCachedVersion,
 ) {
     suspend fun createOrUpdateOrder(order: Order, giftCard: String = ""): Result<Order> {
         val request = UpdateOrderRequest(
@@ -169,13 +171,7 @@ class OrderCreateEditRepository @Inject constructor(
     private var isAutoDraftSupported: Boolean? = null
     private suspend fun isAutoDraftSupported(): Boolean {
         isAutoDraftSupported?.let { return it }
-        val version = withContext(dispatchers.io) {
-            wooCommerceStore.getSitePlugin(
-                selectedSite.get(),
-                WooCommerceStore.WooPlugin.WOO_CORE
-            )?.version
-                ?: "0.0"
-        }
+        val version = withContext(dispatchers.io) { getWooVersion() ?: "0.0" }
         val isSupported = version.semverCompareTo(AUTO_DRAFT_SUPPORTED_VERSION) >= 0
         isAutoDraftSupported = isSupported
         return isSupported

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListIsAdvancedSearchSupported.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListIsAdvancedSearchSupported.kt
@@ -1,20 +1,17 @@
 package com.woocommerce.android.ui.orders.creation.customerlist
 
 import com.woocommerce.android.extensions.semverCompareTo
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
 class CustomerListIsAdvancedSearchSupported @Inject constructor(
-    private val wooCommerceStore: WooCommerceStore,
     private val dispatchers: CoroutineDispatchers,
-    private val selectedSite: SelectedSite,
+    private val getWooVersion: GetWooCorePluginCachedVersion,
 ) {
     suspend operator fun invoke() = withContext(dispatchers.io) {
-        val version = wooCommerceStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_CORE)?.version
-            ?: return@withContext false
+        val version = getWooVersion() ?: return@withContext false
         version.semverCompareTo(WOO_CORE_SUPPORTS_SEARCH_BY_ALL_CUSTOMERS_VERSION) >= 0
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptHelper.kt
@@ -4,16 +4,16 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCOrderStore
-import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
 class PaymentReceiptHelper @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val wooCommerceStore: WooCommerceStore,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val orderStore: WCOrderStore,
+    private val getWooVersion: GetWooCorePluginCachedVersion,
 ) {
     fun storeReceiptUrl(orderId: Long, receiptUrl: String) {
         selectedSite.get().let {
@@ -76,15 +76,10 @@ class PaymentReceiptHelper @Inject constructor(
     }
 
     fun isWCCanGenerateReceipts(): Boolean {
-        val currentWooCoreVersion = getWoocommerceCorePluginVersion()
+        val currentWooCoreVersion = getWooVersion() ?: return false
 
         return currentWooCoreVersion.semverCompareTo(WC_CAN_GENERATE_RECEIPTS_VERSION) >= 0
     }
-
-    private fun getWoocommerceCorePluginVersion() = wooCommerceStore.getSitePlugin(
-        selectedSite.get(),
-        WooCommerceStore.WooPlugin.WOO_CORE
-    )?.version ?: ""
 
     private companion object {
         const val WCPAY_RECEIPTS_SENDING_SUPPORT_VERSION = "4.0.0"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -10,11 +10,11 @@ import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.onboarding.ShouldShowOnboarding
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.StringUtils
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
-import org.wordpress.android.fluxc.store.WooCommerceStore.WooPlugin.WOO_CORE
 import javax.inject.Inject
 
 class MainSettingsPresenter @Inject constructor(
@@ -26,7 +26,8 @@ class MainSettingsPresenter @Inject constructor(
     private val shouldShowOnboarding: ShouldShowOnboarding,
     private val accountRepository: AccountRepository,
     private val notificationChannelsHandler: NotificationChannelsHandler,
-    private val analyticsTracker: AnalyticsTrackerWrapper
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val getWooVersion: GetWooCorePluginCachedVersion,
 ) : MainSettingsContract.Presenter {
     private var appSettingsFragmentView: MainSettingsContract.View? = null
 
@@ -111,5 +112,5 @@ class MainSettingsPresenter @Inject constructor(
         get() = selectedSite.get().isWPComAtomic
 
     override val wooPluginVersion: String
-        get() = wooCommerceStore.getSitePlugin(selectedSite.get(), WOO_CORE)?.version ?: ""
+        get() = getWooVersion() ?: ""
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/GetWooCorePluginCachedVersion.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/GetWooCorePluginCachedVersion.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.util
+
+import com.woocommerce.android.tools.SelectedSite
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+class GetWooCorePluginCachedVersion @Inject constructor(
+    private val wooCommerceStore: WooCommerceStore,
+    private val selectedSite: SelectedSite,
+) {
+    operator fun invoke(): String? = wooCommerceStore.getSitePlugin(
+        selectedSite.get(),
+        WooCommerceStore.WooPlugin.WOO_CORE
+    )?.version
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/GetWooCorePluginCachedVersion.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/GetWooCorePluginCachedVersion.kt
@@ -8,8 +8,11 @@ class GetWooCorePluginCachedVersion @Inject constructor(
     private val wooCommerceStore: WooCommerceStore,
     private val selectedSite: SelectedSite,
 ) {
-    operator fun invoke(): String? = wooCommerceStore.getSitePlugin(
-        selectedSite.get(),
-        WooCommerceStore.WooPlugin.WOO_CORE
-    )?.version
+    operator fun invoke(): String? =
+        selectedSite.getOrNull()?.let { selectedSite ->
+            wooCommerceStore.getSitePlugin(
+                selectedSite,
+                WooCommerceStore.WooPlugin.WOO_CORE
+            )?.version
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/StatsRepositoryTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/mystore/StatsRepositoryTests.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.mystore
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
 import com.woocommerce.android.ui.mystore.data.StatsRepository
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -37,6 +38,7 @@ class StatsRepositoryTests : BaseUnitTest() {
     private val wcOrderStore: WCOrderStore = mock()
     private val wcLeaderboardsStore: WCLeaderboardsStore = mock()
     private val wooCommerceStore: WooCommerceStore = mock()
+    private val getWooVersion: GetWooCorePluginCachedVersion = mock()
 
     private lateinit var sut: StatsRepository
 
@@ -56,6 +58,7 @@ class StatsRepositoryTests : BaseUnitTest() {
             wcOrderStore = wcOrderStore,
             wcLeaderboardsStore = wcLeaderboardsStore,
             wooCommerceStore = wooCommerceStore,
+            getWooVersion = getWooVersion,
             dispatchers = coroutinesTestRule.testDispatchers
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.orders.creation.taxes.TaxBasedOnSetting
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -49,6 +50,7 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
     private lateinit var orderUpdateStore: OrderUpdateStore
     private lateinit var selectedSite: SelectedSite
     private lateinit var wooCommerceStore: WooCommerceStore
+    private val getWooVersion: GetWooCorePluginCachedVersion = mock()
 
     private val defaultSiteModel = SiteModel()
 
@@ -77,7 +79,8 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
             dispatchers = coroutinesTestRule.testDispatchers,
             wooCommerceStore = wooCommerceStore,
             analyticsTrackerWrapper = trackerWrapper,
-            listItemMapper = mock()
+            listItemMapper = mock(),
+            getWooVersion = getWooVersion,
         )
     }
 
@@ -125,8 +128,7 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
     @Test
     fun `when AUTO_DRAFT is not supported then status is changed to PENDING`() = testBlocking {
         // Given a site using a version that doesn't support AUTO_DRAFT
-        whenever(wooCommerceStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_CORE))
-            .thenReturn(SitePluginModel().apply { version = "6.2.0" })
+        whenever(getWooVersion()).thenReturn("6.2.0")
         whenever(orderUpdateStore.createOrder(any(), any(), anyOrNull()))
             .thenReturn(WooResult(OrderTestUtils.generateOrder()))
 
@@ -156,8 +158,7 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
     @Test
     fun `when AUTO_DRAFT is supported then status is keep as AUTO_DRAFT`() = testBlocking {
         // Given a site using a version that support AUTO_DRAFT
-        whenever(wooCommerceStore.getSitePlugin(selectedSite.get(), WooCommerceStore.WooPlugin.WOO_CORE))
-            .thenReturn(SitePluginModel().apply { version = OrderCreateEditRepository.AUTO_DRAFT_SUPPORTED_VERSION })
+        whenever(getWooVersion()).thenReturn(OrderCreateEditRepository.AUTO_DRAFT_SUPPORTED_VERSION)
         whenever(orderUpdateStore.createOrder(any(), any(), anyOrNull()))
             .thenReturn(WooResult(OrderTestUtils.generateOrder()))
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListIsAdvancedSearchSupportedTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListIsAdvancedSearchSupportedTest.kt
@@ -1,39 +1,27 @@
 package com.woocommerce.android.ui.orders.creation.customerlist
 
-import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.plugin.SitePluginModel
-import org.wordpress.android.fluxc.store.WooCommerceStore
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CustomerListIsAdvancedSearchSupportedTest : BaseUnitTest() {
-    private val wooCommerceStore: WooCommerceStore = mock()
-    private val selectedSiteModel: SiteModel = mock()
-    private val selectedSite: SelectedSite = mock {
-        on { get() }.thenReturn(selectedSiteModel)
-    }
+    private val getWooVersion: GetWooCorePluginCachedVersion = mock()
 
     private val action = CustomerListIsAdvancedSearchSupported(
-        wooCommerceStore = wooCommerceStore,
         dispatchers = coroutinesTestRule.testDispatchers,
-        selectedSite = selectedSite,
+        getWooVersion = getWooVersion,
     )
 
     @Test
     fun `given version lower than 8, when action invoked, then false returned`() = testBlocking {
         // GIVEN
         val version = "7.9.9"
-        val sitePluginModel = mock<SitePluginModel> {
-            on { this.version }.thenReturn(version)
-        }
-        whenever(wooCommerceStore.getSitePlugin(selectedSiteModel, WooCommerceStore.WooPlugin.WOO_CORE))
-            .thenReturn(sitePluginModel)
+        whenever(getWooVersion()).thenReturn(version)
 
         // WHEN
         val result = action()
@@ -46,11 +34,7 @@ class CustomerListIsAdvancedSearchSupportedTest : BaseUnitTest() {
     fun `given version null, when action invoked, then false returned`() = testBlocking {
         // GIVEN
         val version = null
-        val sitePluginModel = mock<SitePluginModel> {
-            on { this.version }.thenReturn(version)
-        }
-        whenever(wooCommerceStore.getSitePlugin(selectedSiteModel, WooCommerceStore.WooPlugin.WOO_CORE))
-            .thenReturn(sitePluginModel)
+        whenever(getWooVersion()).thenReturn(version)
 
         // WHEN
         val result = action()
@@ -63,11 +47,7 @@ class CustomerListIsAdvancedSearchSupportedTest : BaseUnitTest() {
     fun `given version 8, when action invoked, then true returned`() = testBlocking {
         // GIVEN
         val version = "8.0.0"
-        val sitePluginModel = mock<SitePluginModel> {
-            on { this.version }.thenReturn(version)
-        }
-        whenever(wooCommerceStore.getSitePlugin(selectedSiteModel, WooCommerceStore.WooPlugin.WOO_CORE))
-            .thenReturn(sitePluginModel)
+        whenever(getWooVersion()).thenReturn(version)
 
         // WHEN
         val result = action()
@@ -80,11 +60,7 @@ class CustomerListIsAdvancedSearchSupportedTest : BaseUnitTest() {
     fun `given version more than 8, when action invoked, then true returned`() = testBlocking {
         // GIVEN
         val version = "8.0.1"
-        val sitePluginModel = mock<SitePluginModel> {
-            on { this.version }.thenReturn(version)
-        }
-        whenever(wooCommerceStore.getSitePlugin(selectedSiteModel, WooCommerceStore.WooPlugin.WOO_CORE))
-            .thenReturn(sitePluginModel)
+        whenever(getWooVersion()).thenReturn(version)
 
         // WHEN
         val result = action()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptHelperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptHelperTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.payments.receipt
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -11,14 +12,12 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.plugin.SitePluginModel
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.OrderReceiptResponse
 import org.wordpress.android.fluxc.store.WCOrderStore
-import org.wordpress.android.fluxc.store.WooCommerceStore
 
 @ExperimentalCoroutinesApi
 class PaymentReceiptHelperTest : BaseUnitTest() {
@@ -26,10 +25,10 @@ class PaymentReceiptHelperTest : BaseUnitTest() {
         on { get() }.thenReturn(mock())
     }
     private val appPrefsWrapper: AppPrefsWrapper = mock()
-    private val wooCommerceStore: WooCommerceStore = mock()
+    private val getWooVersion: GetWooCorePluginCachedVersion = mock()
     private val orderStore: WCOrderStore = mock()
 
-    private val helper = PaymentReceiptHelper(selectedSite, wooCommerceStore, appPrefsWrapper, orderStore)
+    private val helper = PaymentReceiptHelper(selectedSite, appPrefsWrapper, orderStore, getWooVersion)
 
     @Test
     fun `given selected site, when storeReceiptUrl, then url is stored`() {
@@ -48,15 +47,7 @@ class PaymentReceiptHelperTest : BaseUnitTest() {
         // GIVEN
         val site = selectedSite.get()
         whenever(appPrefsWrapper.getReceiptUrl(site.id, site.siteId, site.selfHostedSiteId, 1)).thenReturn("")
-        val plugin = mock<SitePluginModel> {
-            on { version }.thenReturn("3.9.9")
-        }
-        whenever(
-            wooCommerceStore.getSitePlugin(
-                selectedSite.get(),
-                WooCommerceStore.WooPlugin.WOO_CORE
-            )
-        ).thenReturn(plugin)
+        whenever(getWooVersion()).thenReturn("3.9.9")
 
         // WHEN
         val result = helper.getReceiptUrl(1)
@@ -70,15 +61,7 @@ class PaymentReceiptHelperTest : BaseUnitTest() {
         // GIVEN
         val site = selectedSite.get()
         whenever(appPrefsWrapper.getReceiptUrl(site.id, site.siteId, site.selfHostedSiteId, 1)).thenReturn("url")
-        val plugin = mock<SitePluginModel> {
-            on { version }.thenReturn("3.9.9")
-        }
-        whenever(
-            wooCommerceStore.getSitePlugin(
-                selectedSite.get(),
-                WooCommerceStore.WooPlugin.WOO_CORE
-            )
-        ).thenReturn(plugin)
+        whenever(getWooVersion()).thenReturn("3.9.9")
 
         // WHEN
         val result = helper.getReceiptUrl(1)
@@ -91,15 +74,8 @@ class PaymentReceiptHelperTest : BaseUnitTest() {
     fun `given version 8_7_0 site and remote call success, when getReceiptUrl, then url returned`() = testBlocking {
         // GIVEN
         val site = selectedSite.get()
-        val plugin = mock<SitePluginModel> {
-            on { version }.thenReturn("8.7.0")
-        }
-        whenever(
-            wooCommerceStore.getSitePlugin(
-                selectedSite.get(),
-                WooCommerceStore.WooPlugin.WOO_CORE
-            )
-        ).thenReturn(plugin)
+        whenever(getWooVersion()).thenReturn("8.7.0")
+
         whenever(orderStore.fetchOrdersReceipt(site, 1, expirationDays = 2)).thenReturn(
             WooPayload(OrderReceiptResponse("url", "date"))
         )
@@ -115,15 +91,7 @@ class PaymentReceiptHelperTest : BaseUnitTest() {
     fun `given version 8_7_0_10 site and saved url, when getReceiptUrl, then url returned`() = testBlocking {
         // GIVEN
         val site = selectedSite.get()
-        val plugin = mock<SitePluginModel> {
-            on { version }.thenReturn("8.7.0.10")
-        }
-        whenever(
-            wooCommerceStore.getSitePlugin(
-                selectedSite.get(),
-                WooCommerceStore.WooPlugin.WOO_CORE
-            )
-        ).thenReturn(plugin)
+        whenever(getWooVersion()).thenReturn("8.7.0.10")
         whenever(orderStore.fetchOrdersReceipt(site, 1, expirationDays = 2)).thenReturn(
             WooPayload(OrderReceiptResponse("url", "date"))
         )
@@ -139,15 +107,7 @@ class PaymentReceiptHelperTest : BaseUnitTest() {
     fun `given version 8_7_0 site and remote call fails, when getReceiptUrl, then failure returned`() = testBlocking {
         // GIVEN
         val site = selectedSite.get()
-        val plugin = mock<SitePluginModel> {
-            on { version }.thenReturn("8.7.0")
-        }
-        whenever(
-            wooCommerceStore.getSitePlugin(
-                selectedSite.get(),
-                WooCommerceStore.WooPlugin.WOO_CORE
-            )
-        ).thenReturn(plugin)
+        whenever(getWooVersion()).thenReturn("8.7.0.10")
         whenever(orderStore.fetchOrdersReceipt(site, 1, expirationDays = 2)).thenReturn(
             WooPayload(
                 WooError(
@@ -228,15 +188,7 @@ class PaymentReceiptHelperTest : BaseUnitTest() {
     @Test
     fun `given version 8_7_0, when isReceiptAvailable, then true returned`() = testBlocking {
         // GIVEN
-        val plugin = mock<SitePluginModel> {
-            on { version }.thenReturn("8.7.0")
-        }
-        whenever(
-            wooCommerceStore.getSitePlugin(
-                selectedSite.get(),
-                WooCommerceStore.WooPlugin.WOO_CORE
-            )
-        ).thenReturn(plugin)
+        whenever(getWooVersion()).thenReturn("8.7.0")
 
         // WHEN
         val result = helper.isReceiptAvailable(1)
@@ -248,15 +200,7 @@ class PaymentReceiptHelperTest : BaseUnitTest() {
     @Test
     fun `given version empty and empty local storage, when isReceiptAvailable, then false returned`() = testBlocking {
         // GIVEN
-        val plugin = mock<SitePluginModel> {
-            on { version }.thenReturn("")
-        }
-        whenever(
-            wooCommerceStore.getSitePlugin(
-                selectedSite.get(),
-                WooCommerceStore.WooPlugin.WOO_CORE
-            )
-        ).thenReturn(plugin)
+        whenever(getWooVersion()).thenReturn("")
         whenever(appPrefsWrapper.getReceiptUrl(any(), any(), any(), any())).thenReturn("")
 
         // WHEN
@@ -269,15 +213,7 @@ class PaymentReceiptHelperTest : BaseUnitTest() {
     @Test
     fun `given version empty string and empty local storage, when isReceiptAvailable, then false returned`() = testBlocking {
         // GIVEN
-        val plugin = mock<SitePluginModel> {
-            on { version }.thenReturn("")
-        }
-        whenever(
-            wooCommerceStore.getSitePlugin(
-                selectedSite.get(),
-                WooCommerceStore.WooPlugin.WOO_CORE
-            )
-        ).thenReturn(plugin)
+        whenever(getWooVersion()).thenReturn("")
         whenever(appPrefsWrapper.getReceiptUrl(any(), any(), any(), any())).thenReturn("")
 
         // WHEN
@@ -290,15 +226,7 @@ class PaymentReceiptHelperTest : BaseUnitTest() {
     @Test
     fun `given version empty 6_3_9 and non empty local storage, when isReceiptAvailable, then true returned`() = testBlocking {
         // GIVEN
-        val plugin = mock<SitePluginModel> {
-            on { version }.thenReturn("")
-        }
-        whenever(
-            wooCommerceStore.getSitePlugin(
-                selectedSite.get(),
-                WooCommerceStore.WooPlugin.WOO_CORE
-            )
-        ).thenReturn(plugin)
+        whenever(getWooVersion()).thenReturn("")
         whenever(appPrefsWrapper.getReceiptUrl(any(), any(), any(), any())).thenReturn("url")
 
         // WHEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.onboarding.ShouldShowOnboarding
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
@@ -29,6 +30,7 @@ class MainSettingsPresenterTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock()
     private val notificationChannelsHandler: NotificationChannelsHandler = mock()
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
+    private val getWooVersion: GetWooCorePluginCachedVersion = mock()
 
     private val view: MainSettingsContract.View = mock()
     private lateinit var presenter: MainSettingsPresenter
@@ -44,7 +46,8 @@ class MainSettingsPresenterTest : BaseUnitTest() {
             shouldShowOnboarding = shouldShowOnboarding,
             accountRepository = accountRepository,
             notificationChannelsHandler = notificationChannelsHandler,
-            analyticsTracker = analyticsTracker
+            analyticsTracker = analyticsTracker,
+            getWooVersion = getWooVersion,
         )
         presenter.takeView(view)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/GetWooCorePluginCachedVersionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/GetWooCorePluginCachedVersionTest.kt
@@ -1,0 +1,76 @@
+package com.woocommerce.android.util
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.plugin.SitePluginModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetWooCorePluginCachedVersionTest : BaseUnitTest() {
+    private val wooCommerceStore: WooCommerceStore = mock()
+    private val selectedSite: SelectedSite = mock()
+    private val getWooCorePluginCachedVersion = GetWooCorePluginCachedVersion(
+        wooCommerceStore = wooCommerceStore,
+        selectedSite = selectedSite
+    )
+
+    @Test
+    fun `given selected site is null, when invoke is called, then return null`() {
+        // GIVEN
+        whenever(selectedSite.getOrNull()).thenReturn(null)
+
+        // WHEN
+        val result = getWooCorePluginCachedVersion()
+
+        // THEN
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `given selected site is not null and store returns null, when invoke is called, then return null`() {
+        // GIVEN
+        val siteModel = mock<SiteModel>()
+        whenever(selectedSite.getOrNull()).thenReturn(siteModel)
+        whenever(
+            wooCommerceStore.getSitePlugin(
+                siteModel,
+                WooCommerceStore.WooPlugin.WOO_CORE
+            )
+        ).thenReturn(null)
+
+        // WHEN
+        val result = getWooCorePluginCachedVersion()
+
+        // THEN
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `given selected site is not null and store returns not null, when invoke is called, then return store response`() {
+        // GIVEN
+        val siteModel = mock<SiteModel>()
+        val version = "1.0.0"
+        whenever(selectedSite.getOrNull()).thenReturn(siteModel)
+        val sitePluginModel = mock<SitePluginModel> {
+            on { this.version }.thenReturn(version)
+        }
+        whenever(
+            wooCommerceStore.getSitePlugin(
+                siteModel,
+                WooCommerceStore.WooPlugin.WOO_CORE
+            )
+        ).thenReturn(sitePluginModel)
+
+        // WHEN
+        val result = getWooCorePluginCachedVersion()
+
+        // THEN
+        assertThat(result).isEqualTo(version)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11264
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR:
* Extracts retrieving woo core version from the cache into `GetWooCorePluginCacheVersion`
* Using that class adds `cached_woo_core_version` to every tracks event
* Removes unused keys from `AnalyticsTracker` class

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Using logcat and "track" filtering notice `"cached_woo_core_version":"8.8.0-rc.1"` in tracked every event


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
