### PR TITLE
Fix/blaze image errors

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -100,7 +100,6 @@ class MediaFilesRepository @Inject constructor(
                     parcelFileDescriptor.close()
                 }
                 return@withContext ImageDimensions(options.outWidth, options.outHeight)
-
             } catch (e: IOException) {
                 e.printStackTrace()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/MediaFilesRepository.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.media
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.net.Uri
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.R
@@ -36,6 +38,8 @@ import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded
 import org.wordpress.android.mediapicker.MediaPickerUtils
 import org.wordpress.android.util.MediaUtils
 import java.io.File
+import java.io.FileDescriptor
+import java.io.IOException
 import javax.inject.Inject
 
 class MediaFilesRepository @Inject constructor(
@@ -79,6 +83,19 @@ class MediaFilesRepository @Inject constructor(
             }
             return@withContext mediaModel
         }
+    }
+
+    fun getBitmapFromUri(uri: String): Bitmap? {
+        try {
+            val parcelFileDescriptor = context.contentResolver.openFileDescriptor(Uri.parse(uri), "r")
+            val fileDescriptor: FileDescriptor = parcelFileDescriptor!!.fileDescriptor
+            val bitmap = BitmapFactory.decodeFileDescriptor(fileDescriptor)
+            parcelFileDescriptor.close()
+            return bitmap
+        } catch (e: IOException) {
+            e.printStackTrace()
+        }
+        return null
     }
 
     @OptIn(DelicateCoroutinesApi::class)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -152,7 +152,7 @@ class BlazeRepository @Inject constructor(
             tagLine = "",
             description = "",
             campaignImage = product.images.firstOrNull().let {
-                if (it != null) {
+                if (it != null && isValidAdImage(it.source)) {
                     BlazeCampaignImage.RemoteImage(it.id, it.source)
                 } else {
                     BlazeCampaignImage.None

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -328,15 +328,14 @@ class BlazeRepository @Inject constructor(
     }
 
     suspend fun isValidAdImage(uri: String): Boolean {
-        val bitmap = mediaFilesRepository.getBitmapFromUri(uri)
+        val (width, height) = mediaFilesRepository.getImageDimensions(uri)
         return when {
-            bitmap == null -> {
-                WooLog.w(WooLog.T.BLAZE, "isValidAdImage: Failed to convert uri: $uri to bitmap")
+            width == 0 || height == 0 -> {
+                WooLog.w(WooLog.T.BLAZE, "isValidAdImage uri: Failed to get image dimens from uri: $uri")
                 false
             }
 
-            bitmap.width < BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS -> false
-            bitmap.height < BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS -> false
+            width < BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS || height < BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS -> false
             else -> true
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -329,7 +329,6 @@ class BlazeRepository @Inject constructor(
 
     fun isValidAdImage(uri: String): Boolean {
         val bitmap = mediaFilesRepository.getBitmapFromUri(uri)
-        WooLog.w(WooLog.T.BLAZE, "MediaFilesRepository width: ${bitmap?.width}, height: ${bitmap?.height}")
         return when {
             bitmap == null -> {
                 WooLog.w(WooLog.T.BLAZE, "isValidAdImage: Failed to convert uri: $uri to bitmap")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -327,7 +327,7 @@ class BlazeRepository @Inject constructor(
         }
     }
 
-    fun isValidAdImage(uri: String): Boolean {
+    suspend fun isValidAdImage(uri: String): Boolean {
         val bitmap = mediaFilesRepository.getBitmapFromUri(uri)
         return when {
             bitmap == null -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -45,6 +45,7 @@ class BlazeRepository @Inject constructor(
         const val CAMPAIGN_MAXIMUM_DAILY_SPEND = 50f // USD
         const val CAMPAIGN_MAX_DURATION = 28 // Days
         const val DEFAULT_CAMPAIGN_BUDGET_MODE = "total" // "total" or "daily" for campaigns that run without end date
+        const val BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS = 500 // Must be at least 500 x 500 pixels
     }
 
     fun observeLanguages() = blazeCampaignsStore.observeBlazeTargetingLanguages()
@@ -323,6 +324,21 @@ class BlazeRepository @Inject constructor(
 
         return result.onFailure {
             WooLog.w(WooLog.T.BLAZE, "Failed to prepare campaign image: ${it.message}")
+        }
+    }
+
+    fun isValidAdImage(uri: String): Boolean {
+        val bitmap = mediaFilesRepository.getBitmapFromUri(uri)
+        WooLog.w(WooLog.T.BLAZE, "MediaFilesRepository width: ${bitmap?.width}, height: ${bitmap?.height}")
+        return when {
+            bitmap == null -> {
+                WooLog.w(WooLog.T.BLAZE, "isValidAdImage: Failed to convert uri: $uri to bitmap")
+                false
+            }
+
+            bitmap.width < BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS -> false
+            bitmap.height < BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS -> false
+            else -> true
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -45,7 +45,7 @@ class BlazeRepository @Inject constructor(
         const val CAMPAIGN_MAXIMUM_DAILY_SPEND = 50f // USD
         const val CAMPAIGN_MAX_DURATION = 28 // Days
         const val DEFAULT_CAMPAIGN_BUDGET_MODE = "total" // "total" or "daily" for campaigns that run without end date
-        const val BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS = 500 // Must be at least 500 x 500 pixels
+        const val BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS = 600 // Must be at least 600 x 600 pixels
     }
 
     fun observeLanguages() = blazeCampaignsStore.observeBlazeTargetingLanguages()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdFragment.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -46,6 +47,7 @@ class BlazeCampaignCreationEditAdFragment : BaseFragment(), MediaPickerResultHan
             when (event) {
                 is Exit -> findNavController().popBackStack()
                 is ShowMediaLibrary -> mediaPickerHelper.showMediaPicker(event.source)
+                is ShowDialog -> event.showDialog()
                 is ExitWithResult<*> -> {
                     navigateBackWithResult(EDIT_AD_RESULT, event.data as EditAdResult)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
@@ -120,7 +120,9 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
                 _viewState.update {
                     it.copy(adImage = BlazeRepository.BlazeCampaignImage.LocalImage(uri))
                 }
-            } else showInvalidIMageDialog()
+            } else {
+                showInvalidIMageDialog()
+            }
         }
     }
 
@@ -135,7 +137,9 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
                         )
                     )
                 }
-            } else showInvalidIMageDialog()
+            } else {
+                showInvalidIMageDialog()
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CREATION_EDIT_AD_AI_SUGGESTION_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CREATION_EDIT_AD_SAVE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -118,7 +119,7 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
             _viewState.update {
                 it.copy(adImage = BlazeRepository.BlazeCampaignImage.LocalImage(uri))
             }
-        }
+        } else showInvalidIMageDialog()
     }
 
     fun onWPMediaSelected(image: Product.Image) {
@@ -131,7 +132,20 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
                     )
                 )
             }
-        }
+        } else showInvalidIMageDialog()
+    }
+
+    private fun showInvalidIMageDialog() {
+        triggerEvent(
+            Event.ShowDialog(
+                titleId = R.string.blaze_campaign_edit_ad_invalid_image_title,
+                messageId = R.string.blaze_campaign_edit_ad_invalid_image_description,
+                positiveButtonId = R.string.dialog_ok,
+                positiveBtnAction = { dialog, _ ->
+                    dialog.dismiss()
+                },
+            )
+        )
     }
 
     private fun updateSuggestion(suggestion: AiSuggestionForAd) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
@@ -27,6 +27,7 @@ import javax.inject.Inject
 class BlazeCampaignCreationEditAdViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val blazeRepository: BlazeRepository
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         private const val TAGLINE_MAX_LENGTH = 32
@@ -113,19 +114,23 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
     }
 
     fun onLocalImageSelected(uri: String) {
-        _viewState.update {
-            it.copy(adImage = BlazeRepository.BlazeCampaignImage.LocalImage(uri))
+        if (blazeRepository.isValidAdImage(uri)) {
+            _viewState.update {
+                it.copy(adImage = BlazeRepository.BlazeCampaignImage.LocalImage(uri))
+            }
         }
     }
 
     fun onWPMediaSelected(image: Product.Image) {
-        _viewState.update {
-            it.copy(
-                adImage = BlazeRepository.BlazeCampaignImage.RemoteImage(
-                    mediaId = image.id,
-                    uri = image.source
+        if (blazeRepository.isValidAdImage(image.source)) {
+            _viewState.update {
+                it.copy(
+                    adImage = BlazeRepository.BlazeCampaignImage.RemoteImage(
+                        mediaId = image.id,
+                        uri = image.source
+                    )
                 )
-            )
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
@@ -115,24 +115,28 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
     }
 
     fun onLocalImageSelected(uri: String) {
-        if (blazeRepository.isValidAdImage(uri)) {
-            _viewState.update {
-                it.copy(adImage = BlazeRepository.BlazeCampaignImage.LocalImage(uri))
-            }
-        } else showInvalidIMageDialog()
+        launch {
+            if (blazeRepository.isValidAdImage(uri)) {
+                _viewState.update {
+                    it.copy(adImage = BlazeRepository.BlazeCampaignImage.LocalImage(uri))
+                }
+            } else showInvalidIMageDialog()
+        }
     }
 
     fun onWPMediaSelected(image: Product.Image) {
-        if (blazeRepository.isValidAdImage(image.source)) {
-            _viewState.update {
-                it.copy(
-                    adImage = BlazeRepository.BlazeCampaignImage.RemoteImage(
-                        mediaId = image.id,
-                        uri = image.source
+        launch {
+            if (blazeRepository.isValidAdImage(image.source)) {
+                _viewState.update {
+                    it.copy(
+                        adImage = BlazeRepository.BlazeCampaignImage.RemoteImage(
+                            mediaId = image.id,
+                            uri = image.source
+                        )
                     )
-                )
-            }
-        } else showInvalidIMageDialog()
+                }
+            } else showInvalidIMageDialog()
+        }
     }
 
     private fun showInvalidIMageDialog() {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3814,6 +3814,8 @@
     <string name="blaze_campaign_edit_ad_change_description_title">Description</string>
     <string name="blaze_campaign_edit_ad_characters_remaining">%d characters remaining</string>
     <string name="blaze_campaign_edit_ad_suggested_by_ai">Suggested by AI</string>
+    <string name="blaze_campaign_edit_ad_invalid_image_title">Invalid image</string>
+    <string name="blaze_campaign_edit_ad_invalid_image_description">Please select and image with a minimum dimension of 500x500 pixels</string>
 
     <!--
     Blaze campaign payment


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11275
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Blaze required the ad images to be at least 600x600px. In the current native flow we are not explicit about this anywhere. If the user attempts to create a campaign with an image smaller than 600x600, then campaign creation will fail, but we won't tell the user why. This results in a very bad UX.

The PR fixes that. We now validate the image as soon as the user adds one, and provide a comprehensive message if the image doesn't meet the 600x600px requirement. 


https://github.com/woocommerce/woocommerce-android/assets/2663464/d7c1180f-41d6-4c7b-b109-4e2e2d7e22b3

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Esentially follow the steps from the screen recording. 
1. Trigger Blaze creation flow for a product using an image smaller than 600x600. You can download any image smaller than 600 by searching in google for images using `400x400 image` for example
2. The product image won't be displayed and you'd be forced to add an image
3. Add a valid image from either local storage or WP library
4. Now attempt to add the invalid image again and check a dialog is shown saying the image is not at least 600x600px
5. Validate that the dialog message is comprehensive enough. 

