### PR TITLE
Add session as a plugin card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/AnalyticCardConfiguration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/AnalyticCardConfiguration.kt
@@ -12,7 +12,7 @@ enum class AnalyticsCards(val resId: Int, val isPlugin: Boolean = false) {
     Revenue(R.string.analytics_revenue_card_title),
     Orders(R.string.analytics_orders_card_title),
     Products(R.string.analytics_products_card_title),
-    Session(R.string.analytics_session_card_title),
+    Session(R.string.analytics_session_card_title, isPlugin = true),
     Bundles(R.string.analytics_bundles_card_title, isPlugin = true),
     GiftCards(R.string.analytics_gift_cards_card_title, isPlugin = true)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/PluginUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/PluginUrls.kt
@@ -5,4 +5,5 @@ object PluginUrls {
     const val BUNDLES_URL = "https://woo.com/products/product-bundles/"
     const val COMPOSITE_URL = "https://woo.com/products/composite-products/"
     const val GIFT_CARDS_URL = "https://woocommerce.com/products/gift-cards/"
+    const val JETPACK_URL = "https://woocommerce.com/products/jetpack/"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/GetAnalyticPluginsCardActive.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/GetAnalyticPluginsCardActive.kt
@@ -11,7 +11,8 @@ class GetAnalyticPluginsCardActive @Inject constructor(
 ) {
     private val analyticPlugins = listOf(
         WooCommerceStore.WooPlugin.WOO_PRODUCT_BUNDLES,
-        WooCommerceStore.WooPlugin.WOO_GIFT_CARDS
+        WooCommerceStore.WooPlugin.WOO_GIFT_CARDS,
+        WooCommerceStore.WooPlugin.JETPACK
     )
 
     suspend operator fun invoke(): Set<AnalyticsCards> {
@@ -23,6 +24,7 @@ class GetAnalyticPluginsCardActive @Inject constructor(
                 when (pluginModel.name) {
                     WooCommerceStore.WooPlugin.WOO_PRODUCT_BUNDLES.pluginName -> AnalyticsCards.Bundles
                     WooCommerceStore.WooPlugin.WOO_GIFT_CARDS.pluginName -> AnalyticsCards.GiftCards
+                    WooCommerceStore.WooPlugin.JETPACK.pluginName -> AnalyticsCards.Session
                     else -> null
                 }
             }.toSet()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingsViewModel.kt
@@ -217,6 +217,7 @@ fun AnalyticCardConfiguration.toConfigurationUI(activePluginCards: Set<Analytics
         val url = when (this.card) {
             AnalyticsCards.Bundles -> PluginUrls.BUNDLES_URL
             AnalyticsCards.GiftCards -> PluginUrls.GIFT_CARDS_URL
+            AnalyticsCards.Session -> PluginUrls.JETPACK_URL
             else -> MARKETPLACE
         }
         AnalyticCardConfigurationUI.ExploreCardConfigurationUI(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/ObserveAnalyticsCardsConfigurationTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/ObserveAnalyticsCardsConfigurationTest.kt
@@ -46,7 +46,7 @@ class ObserveAnalyticsCardsConfigurationTest : BaseUnitTest() {
 
     @Test
     fun `when there is NO saved configuration, the default configuration is retrieved`() = testBlocking {
-        val defaultPluginCardsActive = setOf(AnalyticsCards.Bundles)
+        val defaultPluginCardsActive = setOf(AnalyticsCards.Bundles, AnalyticsCards.Session)
         whenever(resourcesRepository.getDefaultAnalyticsCardsConfiguration()).thenReturn(defaultConfiguration)
         whenever(settingsDataStore.observeCardsConfiguration()).thenReturn(flowOf(null))
         whenever(getAnalyticPluginsCardActive.invoke()).thenReturn(defaultPluginCardsActive)
@@ -58,7 +58,7 @@ class ObserveAnalyticsCardsConfigurationTest : BaseUnitTest() {
 
     @Test
     fun `when there is a configuration saved, the saved configuration is retrieved`() = testBlocking {
-        val defaultPluginCardsActive = setOf(AnalyticsCards.Bundles)
+        val defaultPluginCardsActive = setOf(AnalyticsCards.Bundles, AnalyticsCards.Session)
 
         whenever(settingsDataStore.observeCardsConfiguration()).thenReturn(flowOf(savedConfiguration))
         whenever(getAnalyticPluginsCardActive.invoke()).thenReturn(defaultPluginCardsActive)
@@ -84,7 +84,7 @@ class ObserveAnalyticsCardsConfigurationTest : BaseUnitTest() {
     @Test
     fun `when the configuration contains plugin card as visible and the plugin is active, then show the card`() =
         testBlocking {
-            val pluginCardsActive = setOf(AnalyticsCards.Bundles)
+            val pluginCardsActive = setOf(AnalyticsCards.Bundles, AnalyticsCards.Session)
             whenever(settingsDataStore.observeCardsConfiguration()).thenReturn(flowOf(defaultConfiguration))
             whenever(getAnalyticPluginsCardActive.invoke()).thenReturn(pluginCardsActive)
 
@@ -96,7 +96,7 @@ class ObserveAnalyticsCardsConfigurationTest : BaseUnitTest() {
     @Test
     fun `when the saved configuration has an outdated cards number, then merge the outdated configuration with the default one`() =
         testBlocking {
-            val pluginCardsActive = setOf(AnalyticsCards.Bundles)
+            val pluginCardsActive = setOf(AnalyticsCards.Bundles, AnalyticsCards.Session)
             val configuration = defaultConfiguration.map { it.copy(isVisible = false) }.dropLast(2)
             whenever(resourcesRepository.getDefaultAnalyticsCardsConfiguration()).thenReturn(defaultConfiguration)
             whenever(settingsDataStore.observeCardsConfiguration()).thenReturn(flowOf(configuration))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/settings/AnalyticsHubSettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/settings/AnalyticsHubSettingsViewModelTest.kt
@@ -45,7 +45,7 @@ class AnalyticsHubSettingsViewModelTest : BaseUnitTest() {
         AnalyticCardConfiguration(AnalyticsCards.Session, "Visitors", false)
     )
 
-    private val defaultPluginCardsActive = setOf(AnalyticsCards.Bundles)
+    private val defaultPluginCardsActive = setOf(AnalyticsCards.Bundles, AnalyticsCards.Session)
 
     private val defaultConfigurationUI = defaultConfiguration.map { it.toConfigurationUI(defaultPluginCardsActive) }
 

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2989-ef06e4ee91cd94da2e227b2e35ada7d1ae64edd8'
+    fluxCVersion = 'trunk-e5d362001b45699162fc191d60c232d6fd35fb5b'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-d92a27b45609ad295d667dda9c5024530035a4df'
+    fluxCVersion = '2989-ef06e4ee91cd94da2e227b2e35ada7d1ae64edd8'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
⚠️ Depends on this FluxC PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2989

### Description
This small PR updates the session card of the Analytic Hub screen to be a plugin card, taking into account that the session card depends on the Jetpack plugin.

### Testing instructions
TC1
1. Activate the Jetpack plugin on wp-admin
2. Open the app
3. Tap on See all store analytics
4. Check that the Session card is displayed depending on the current configuration

TC2
1. Deactivate the Jetpack plugin on wp-admin
2. Open the app
3. Tap on See all store analytics
4. Check that the Session card is NOT displayed
5. Tap on the pencil to navigate to the Customize Analytics screen
6. Check that the Session card appears with the Explore option
7. Tap on Explore and check that the App navigates to the Jetpack plugin page

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/f3221516-b457-4661-9816-1afa22d71557


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
