### PR TITLE
[Better Errors] Tweak incorrect connectivity tool UI elements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/connectivitytool/OrderConnectivityToolScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/connectivitytool/OrderConnectivityToolScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.connectivitytool
 
 import androidx.annotation.ColorRes
+import androidx.annotation.DimenRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
@@ -24,6 +25,8 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowOutward
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -31,6 +34,7 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -185,12 +189,14 @@ fun ConnectivityCheckCard(
                     modifier = modifier.size(dimensionResource(id = R.dimen.major_150))
                 )
                 is Success -> ResultIcon(
-                    icon = R.drawable.ic_rounded_chcekbox_checked,
-                    color = R.color.woo_green_50
+                    icon = Icons.Default.CheckCircle,
+                    color = R.color.woo_green_50,
+                    size = R.dimen.major_150
                 )
                 is Failure -> ResultIcon(
-                    icon = R.drawable.ic_rounded_chcekbox_partially_checked,
-                    color = R.color.woo_red_50
+                    icon = Icons.Default.Error,
+                    color = R.color.woo_red_50,
+                    size = R.dimen.major_175
                 )
                 is NotStarted -> { /* Do nothing */ }
             }
@@ -281,11 +287,12 @@ fun ConnectivitySummary(
 
 @Composable
 fun ResultIcon(
-    @DrawableRes icon: Int,
-    @ColorRes color: Int
+    icon: ImageVector,
+    @ColorRes color: Int,
+    @DimenRes size: Int
 ) {
     Image(
-        painter = painterResource(id = icon),
+        imageVector = icon,
         colorFilter = ColorFilter.tint(colorResource(id = color)),
         contentDescription = null
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/connectivitytool/OrderConnectivityToolScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/connectivitytool/OrderConnectivityToolScreen.kt
@@ -252,30 +252,36 @@ fun ConnectivitySummary(
         Column(
             verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
             modifier = modifier
-                .padding(dimensionResource(id = R.dimen.major_100))
+                .padding(vertical = dimensionResource(id = R.dimen.major_100))
+                .padding(start = dimensionResource(id = R.dimen.major_100))
         ) {
-            Text(
-                text = stringResource(id = R.string.orderlist_connectivity_tool_summary_title),
-                fontWeight = FontWeight.Bold,
+            Column(
                 modifier = modifier
-                    .fillMaxHeight()
-            )
-
-            Text(
-                text = stringResource(id = R.string.orderlist_connectivity_tool_summary_suggestion),
-                style = MaterialTheme.typography.body2
-            )
-
-            WCTextButton(
-                allCaps = false,
-                onClick = onReturnClick,
-                text = stringResource(id = R.string.orderlist_connectivity_tool_return_action),
-                icon = Icons.Default.ArrowBack,
-                contentPadding = PaddingValues(
-                    vertical = dimensionResource(id = R.dimen.minor_100),
-                    horizontal = dimensionResource(id = R.dimen.minor_00)
+                    .padding(end = dimensionResource(id = R.dimen.major_100))
+            ) {
+                Text(
+                    text = stringResource(id = R.string.orderlist_connectivity_tool_summary_title),
+                    fontWeight = FontWeight.Bold,
+                    modifier = modifier
+                        .fillMaxHeight()
                 )
-            )
+
+                Text(
+                    text = stringResource(id = R.string.orderlist_connectivity_tool_summary_suggestion),
+                    style = MaterialTheme.typography.body2
+                )
+
+                WCTextButton(
+                    allCaps = false,
+                    onClick = onReturnClick,
+                    text = stringResource(id = R.string.orderlist_connectivity_tool_return_action),
+                    icon = Icons.Default.ArrowBack,
+                    contentPadding = PaddingValues(
+                        vertical = dimensionResource(id = R.dimen.minor_100),
+                        horizontal = dimensionResource(id = R.dimen.minor_00)
+                    )
+                )
+            }
 
             Divider()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/connectivitytool/OrderConnectivityToolScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/connectivitytool/OrderConnectivityToolScreen.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.orders.connectivitytool
 
 import androidx.annotation.ColorRes
-import androidx.annotation.DimenRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
@@ -190,13 +189,11 @@ fun ConnectivityCheckCard(
                 )
                 is Success -> ResultIcon(
                     icon = Icons.Default.CheckCircle,
-                    color = R.color.woo_green_50,
-                    size = R.dimen.major_150
+                    color = R.color.woo_green_50
                 )
                 is Failure -> ResultIcon(
                     icon = Icons.Default.Error,
-                    color = R.color.woo_red_50,
-                    size = R.dimen.major_175
+                    color = R.color.woo_red_50
                 )
                 is NotStarted -> { /* Do nothing */ }
             }
@@ -288,8 +285,7 @@ fun ConnectivitySummary(
 @Composable
 fun ResultIcon(
     icon: ImageVector,
-    @ColorRes color: Int,
-    @DimenRes size: Int
+    @ColorRes color: Int
 ) {
     Image(
         imageVector = icon,


### PR DESCRIPTION
Summary
==========
Fix two issues with the Connectivity Tool UI after the design review:

- Replace the previous Success and Error icons with the Material ones defined in the designs
- Fix some incorrect padding with the UI dividers

Screenshots
==========
| Before  | After |
| ------------- | ------------- |
| <img width="424" alt="Screenshot 2024-04-10 at 17 08 42" src="https://github.com/woocommerce/woocommerce-android/assets/5920403/4b91bd1d-ca4f-4618-a8e2-98334465b30c"> | <img width="413" alt="Screenshot 2024-04-10 at 17 08 21" src="https://github.com/woocommerce/woocommerce-android/assets/5920403/3bcf6828-7204-48b1-848a-4d06f7052a1e"> |

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.