### PR TITLE
Remove EAH feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 18.2
 -----
-
+- [**] Stats: The Analytics Hub now includes analytics for Product Bundles and Gift Cards, when those extensions are active. [https://github.com/woocommerce/woocommerce-android/pull/11290]
 
 18.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/ObserveAnalyticsCardsConfiguration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/ObserveAnalyticsCardsConfiguration.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.model.AnalyticsCards
 import com.woocommerce.android.ui.analytics.hub.settings.SaveAnalyticsCardsConfiguration
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsSettingsDataStore
 import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsSettingsResourcesRepository
-import com.woocommerce.android.util.FeatureFlag
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -32,7 +31,7 @@ class ObserveAnalyticsCardsConfiguration @Inject constructor(
                 saveAnalyticsCardsConfiguration(configuration)
             }
 
-            if (FeatureFlag.EAH_I3.isEnabled()) configuration else configuration.filter { it.card.isPlugin.not() }
+            configuration
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -17,7 +17,6 @@ enum class FeatureFlag {
     CONNECTIVITY_TOOL,
     NEW_SHIPPING_SUPPORT,
     DYNAMIC_DASHBOARD,
-    EAH_I3,
     APP_PASSWORD_TUTORIAL;
 
     fun isEnabled(context: Context? = null): Boolean {
@@ -32,7 +31,6 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
-            EAH_I3,
             APP_PASSWORD_TUTORIAL -> PackageUtils.isDebugBuild()
 
             DYNAMIC_DASHBOARD -> false


### PR DESCRIPTION
### Description
This PR releases the full support for Product Bundles and Gift Cards extension analytics in the analytics hub.

### Testing instructions
#### On a store with the Product Bundles and Gift Cards extensions active:

1. Confirm the product bundles and gift cards analytics cards are shown by default in the Analytics Hub.
2. Confirm they can be managed (added/removed/reordered) when customizing the Analytics Hub cards.

#### On a store without the Product Bundles and Gift Cards extensions active:

1. Confirm both cards are hidden by default in the Analytics Hub.
2. Confirm both cards are included in the list when customizing the Analytics Hub cards. The cards can't be customized; instead, they have an “Explore” button that opens the corresponding woo.com extension page, so the merchant can learn more about the extension.

### Images/gif

| Product Bundles  | Gift Cards |  Customize  | Customize - extensions not installed | 
| ------------- | ------------- | ------------- | ------------- |
| <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/11adb733-4e8f-4042-89e0-0263a9f52720" />  | <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/a41fac57-7718-46c2-bd25-723819799a9b" />  | <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/135ba646-11fe-4cc6-846d-d845b87e5a16" /> | <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/f4ae3c55-834e-4d82-ba80-6a68f4bb31a0" /> |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
