### PR TITLE
[UI Tests] Slowing down search to allow for UI transitions on slower Emulators.

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
@@ -57,6 +57,7 @@ class ProductListScreen : Screen {
 
     fun enterSearchTerm(term: String): ProductListScreen {
         typeTextInto(androidx.appcompat.R.id.search_src_text, term)
+        idleFor(1000) // allow for UI transitions
         waitForAtLeastOneElementToBeDisplayed(R.id.productInfoContainer)
         return this
     }
@@ -96,8 +97,8 @@ class ProductListScreen : Screen {
         if (Screen.isElementDisplayed(androidx.appcompat.R.id.search_src_text)) {
             // Double pressBack is needed because first one only removes the focus
             // from search field, while the second one leaves the search mode.
-            Espresso.pressBack()
-            Espresso.pressBack()
+            pressBack()
+            pressBack()
         }
         return this
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11287
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
In recent days, `e2eRealApiProductsSearchUsual` started demonstrating flakiness on Firebase. The [video](https://console.firebase.google.com/u/1/project/api-project-108380595987/testlab/histories/bh.edfd947f2636efe3/matrices/4721839960542317323/executions/bs.fedb2dcc4cc98b29/testcases/50/video) of the execution showed no signs of something being visually wrong. At some point in the test, after executing several searches, the test finds two elements that are completely the identical, apart from the `has-window-focus` and `root-is-layout-requested` properties. The root of the issue is this ambiguous matcher exception:

```
androidx.test.espresso.AmbiguousViewMatcherException: '(view.getId() is <2131363942> and … and view.getText() with or without transformation to match: is "SKU: CF-CPC")))' matches 2 views in the hierarchy:

- [1] LinearLayout{id=2131363942, res-name=productInfoContainer, visibility=VISIBLE, width=849, height=151, has-focus=false, has-focusable=false, has-window-focus=false, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=androidx.constraintlayout.widget.ConstraintLayout$LayoutParams@YYYYYY, tag=null, root-is-layout-requested=true, has-input-connection=false, x=189.0, y=42.0, child-count=4}

- [2] LinearLayout{id=2131363942, res-name=productInfoContainer, visibility=VISIBLE, width=849, height=151, has-focus=false, has-focusable=false, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=androidx.constraintlayout.widget.ConstraintLayout$LayoutParams@YYYYYY, tag=null, root-is-layout-requested=false, has-input-connection=false, x=189.0, y=42.0, child-count=4}
```

Due to Emulators performance being slower on Firebase than locally, possibly the test captures an in-between state when two same elements exist at the same time, one being on top of another. This is not reproducible locally. Also, the performance on Firebase might fluctuate, I guess, depending on the total load. This is why this test did not fail before, but started doing recently.  More info at p1712695115551579-slack-C5ALGJYEP

### Testing instructions
- All execution in dedicated test PR #11294 are green, there are no reruns
- The execution is this PR is 🟢 too, making the total number of executions 5.