### PR TITLE
Use items for delta calculation in bundles

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsRepository.kt
@@ -345,8 +345,8 @@ class AnalyticsRepository @Inject constructor(
             BundlesResult.BundlesError
         } else {
             val delta = calculateDeltaPercentage(
-                previousVal = previousBundleStats.netRevenue,
-                currentVal = currentBundleStats.netRevenue,
+                previousVal = previousBundleStats.itemsSold.toDouble(),
+                currentVal = currentBundleStats.itemsSold.toDouble(),
             )
             val bundles = bundlesReport.map { item ->
                 BundleItem(


### PR DESCRIPTION
### Description
A quick fix to use items sold instead of the net revenue in the analytics bundles card to match the iOS behavior.

### Testing instructions
No need 

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
