### PR TITLE
EAH M1 design review

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -157,7 +157,7 @@ fun Date.formatAsRangeWith(other: Date, locale: Locale, calendar: Calendar): Str
         other.formatToMMMddYYYY(locale)
     }
 
-    return "$formattedStartDate - $formattedEndDate"
+    return "$formattedStartDate – $formattedEndDate"
 }
 
 private const val THREE_MONTHS = 3

--- a/WooCommerce/src/main/res/layout/analytics_information_card_view.xml
+++ b/WooCommerce/src/main/res/layout/analytics_information_card_view.xml
@@ -74,12 +74,12 @@
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/reportText"
-            style="@style/Woo.Card.Title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="0dp"
             android:textSize="@dimen/text_minor_125"
             android:textStyle="bold"
+            android:textColor="@color/color_on_surface"
             android:text="@string/see_report"
             tools:visibility="visible"
             app:layout_constraintTop_toBottomOf="@+id/reportDivider"

--- a/WooCommerce/src/main/res/layout/analytics_information_card_view.xml
+++ b/WooCommerce/src/main/res/layout/analytics_information_card_view.xml
@@ -89,8 +89,8 @@
             />
         <ImageView
             android:id="@+id/reportIcon"
-            android:layout_width="@dimen/major_200"
-            android:layout_height="@dimen/major_200"
+            android:layout_width="@dimen/image_minor_50"
+            android:layout_height="@dimen/image_minor_50"
             android:src="@drawable/ic_arrow_right"
             app:layout_constraintTop_toTopOf="@+id/reportText"
             app:layout_constraintBottom_toBottomOf="@+id/reportText"

--- a/WooCommerce/src/main/res/layout/analytics_list_card_view.xml
+++ b/WooCommerce/src/main/res/layout/analytics_list_card_view.xml
@@ -142,13 +142,13 @@
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/reportText"
-            style="@style/Woo.Card.Title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="0dp"
             android:textSize="@dimen/text_minor_125"
             android:textStyle="bold"
             android:text="@string/see_report"
+            android:textColor="@color/color_on_surface"
             tools:visibility="visible"
             app:layout_constraintTop_toBottomOf="@+id/reportDivider"
             app:layout_constraintStart_toStartOf="parent"

--- a/WooCommerce/src/main/res/layout/analytics_list_card_view.xml
+++ b/WooCommerce/src/main/res/layout/analytics_list_card_view.xml
@@ -157,8 +157,8 @@
             />
         <ImageView
             android:id="@+id/reportIcon"
-            android:layout_width="@dimen/major_200"
-            android:layout_height="@dimen/major_200"
+            android:layout_width="@dimen/image_minor_50"
+            android:layout_height="@dimen/image_minor_50"
             android:src="@drawable/ic_arrow_right"
             app:layout_constraintTop_toTopOf="@+id/reportText"
             app:layout_constraintBottom_toBottomOf="@+id/reportText"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4004,7 +4004,7 @@
     <string name="order_configuration_product_selection">Select product %s</string>
     <string name="order_configuration_product_selection_control">Product selection</string>
     <string name="disabled">Disabled</string>
-    <string name="see_report">See Report</string>
+    <string name="see_report">See report</string>
 
     <string name="product_update_stock_status_title">Update Stock Status</string>
     <string name="product_update_stock_status_done">DONE</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/ranges/StatsTimeRangeSelectionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/ranges/StatsTimeRangeSelectionTest.kt
@@ -356,8 +356,8 @@ internal class StatsTimeRangeSelectionTest {
         val previousRangeDescription = sut.previousRangeDescription
 
         // Then
-        assertThat(currentRangeDescription).isEqualTo("Jan 1 - Jul 1, 2022")
-        assertThat(previousRangeDescription).isEqualTo("Jan 1 - Jul 1, 2021")
+        assertThat(currentRangeDescription).isEqualTo("Jan 1 – Jul 1, 2022")
+        assertThat(previousRangeDescription).isEqualTo("Jan 1 – Jul 1, 2021")
     }
 
     @Test
@@ -376,8 +376,8 @@ internal class StatsTimeRangeSelectionTest {
         val previousRangeDescription = sut.previousRangeDescription
 
         // Then
-        assertThat(currentRangeDescription).isEqualTo("Jan 1 - Dec 31, 2021")
-        assertThat(previousRangeDescription).isEqualTo("Jan 1 - Dec 31, 2020")
+        assertThat(currentRangeDescription).isEqualTo("Jan 1 – Dec 31, 2021")
+        assertThat(previousRangeDescription).isEqualTo("Jan 1 – Dec 31, 2020")
     }
 
     @Test
@@ -396,8 +396,8 @@ internal class StatsTimeRangeSelectionTest {
         val previousRangeDescription = sut.previousRangeDescription
 
         // Then
-        assertThat(currentRangeDescription).isEqualTo("Jan 1 - Feb 15, 2022")
-        assertThat(previousRangeDescription).isEqualTo("Oct 1 - Nov 15, 2021")
+        assertThat(currentRangeDescription).isEqualTo("Jan 1 – Feb 15, 2022")
+        assertThat(previousRangeDescription).isEqualTo("Oct 1 – Nov 15, 2021")
     }
 
     @Test
@@ -416,8 +416,8 @@ internal class StatsTimeRangeSelectionTest {
         val previousRangeDescription = sut.previousRangeDescription
 
         // Then
-        assertThat(currentRangeDescription).isEqualTo("Jan 1 - Mar 31, 2022")
-        assertThat(previousRangeDescription).isEqualTo("Oct 1 - Dec 31, 2021")
+        assertThat(currentRangeDescription).isEqualTo("Jan 1 – Mar 31, 2022")
+        assertThat(previousRangeDescription).isEqualTo("Oct 1 – Dec 31, 2021")
     }
 
     @Test
@@ -436,8 +436,8 @@ internal class StatsTimeRangeSelectionTest {
         val previousRangeDescription = sut.previousRangeDescription
 
         // Then
-        assertThat(currentRangeDescription).isEqualTo("Jul 1 - 31, 2022")
-        assertThat(previousRangeDescription).isEqualTo("Jun 1 - 30, 2022")
+        assertThat(currentRangeDescription).isEqualTo("Jul 1 – 31, 2022")
+        assertThat(previousRangeDescription).isEqualTo("Jun 1 – 30, 2022")
     }
 
     @Test
@@ -456,8 +456,8 @@ internal class StatsTimeRangeSelectionTest {
         val previousRangeDescription = sut.previousRangeDescription
 
         // Then
-        assertThat(currentRangeDescription).isEqualTo("Jul 1 - 20, 2022")
-        assertThat(previousRangeDescription).isEqualTo("Jun 1 - 20, 2022")
+        assertThat(currentRangeDescription).isEqualTo("Jul 1 – 20, 2022")
+        assertThat(previousRangeDescription).isEqualTo("Jun 1 – 20, 2022")
     }
 
     @Test
@@ -476,8 +476,8 @@ internal class StatsTimeRangeSelectionTest {
         val previousRangeDescription = sut.previousRangeDescription
 
         // Then
-        assertThat(currentRangeDescription).isEqualTo("Jun 1 - 30, 2022")
-        assertThat(previousRangeDescription).isEqualTo("May 1 - 31, 2022")
+        assertThat(currentRangeDescription).isEqualTo("Jun 1 – 30, 2022")
+        assertThat(previousRangeDescription).isEqualTo("May 1 – 31, 2022")
     }
 
     @Test
@@ -496,8 +496,8 @@ internal class StatsTimeRangeSelectionTest {
         val previousRangeDescription = sut.previousRangeDescription
 
         // Then
-        assertThat(currentRangeDescription).isEqualTo("Jul 25 - 29, 2022")
-        assertThat(previousRangeDescription).isEqualTo("Jul 18 - 22, 2022")
+        assertThat(currentRangeDescription).isEqualTo("Jul 25 – 29, 2022")
+        assertThat(previousRangeDescription).isEqualTo("Jul 18 – 22, 2022")
     }
 
     @Test
@@ -516,8 +516,8 @@ internal class StatsTimeRangeSelectionTest {
         val previousRangeDescription = sut.previousRangeDescription
 
         // Then
-        assertThat(currentRangeDescription).isEqualTo("Jun 27 - Jul 2, 2022")
-        assertThat(previousRangeDescription).isEqualTo("Jun 20 - 25, 2022")
+        assertThat(currentRangeDescription).isEqualTo("Jun 27 – Jul 2, 2022")
+        assertThat(previousRangeDescription).isEqualTo("Jun 20 – 25, 2022")
     }
 
     @Test
@@ -536,8 +536,8 @@ internal class StatsTimeRangeSelectionTest {
         val previousRangeDescription = sut.previousRangeDescription
 
         // Then
-        assertThat(currentRangeDescription).isEqualTo("Jul 18 - 24, 2022")
-        assertThat(previousRangeDescription).isEqualTo("Jul 11 - 17, 2022")
+        assertThat(currentRangeDescription).isEqualTo("Jul 18 – 24, 2022")
+        assertThat(previousRangeDescription).isEqualTo("Jul 11 – 17, 2022")
     }
 
     @Test
@@ -556,8 +556,8 @@ internal class StatsTimeRangeSelectionTest {
         val previousRangeDescription = sut.previousRangeDescription
 
         // Then
-        assertThat(currentRangeDescription).isEqualTo("Jun 27 - Jul 3, 2022")
-        assertThat(previousRangeDescription).isEqualTo("Jun 20 - 26, 2022")
+        assertThat(currentRangeDescription).isEqualTo("Jun 27 – Jul 3, 2022")
+        assertThat(previousRangeDescription).isEqualTo("Jun 20 – 26, 2022")
     }
 
     @Test
@@ -617,8 +617,8 @@ internal class StatsTimeRangeSelectionTest {
         val previousRangeDescription = sut.previousRangeDescription
 
         // Then
-        assertThat(currentRangeDescription).isEqualTo("Dec 5 - 7, 2022")
-        assertThat(previousRangeDescription).isEqualTo("Dec 2 - 4, 2022")
+        assertThat(currentRangeDescription).isEqualTo("Dec 5 – 7, 2022")
+        assertThat(previousRangeDescription).isEqualTo("Dec 2 – 4, 2022")
     }
 
     private fun midDayFrom(date: String): Date {


### PR DESCRIPTION
Closes: #10840

### Description
This PR addresses the design changes proposed after the design review of M1

 - [x] “See report” should be in sentence case.
- [x] The text size of “See report” should be one step smaller (I think it’s “Caption”?). This matches the text size on [similar buttons elsewhere](https://href.li/share.cleanshot.com/fCkT046l).
- [x] The chevron icon should be smaller. Again, to match [similar icons elsewhere](https://href.li/share.cleanshot.com/bPJXm0t5).
- [x] This isn’t part of this project, but the date ranges at the top of the screen should use en-dashes (not hyphens).

![image](https://github.com/woocommerce/woocommerce-android/assets/18119390/25bf839d-e12c-44a9-b597-49429181bb7f)

### Testing instructions
1. Open the app
2. Tap on See all store analytics
3. Check that the current screen style matches the changes proposed

### Images/gif
| Before  | After |
| ------------- | ------------- |
| <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/ddcddb81-e419-40e3-a6d1-305190ba6d38" /> | <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/c06c4722-88ab-4cb5-8a39-197e9788cc14" />  |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
