### PR TITLE
Update release notes for 18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
 
-## 18.1
+## 18.2
+In our latest update, we're enhancing your WooCommerce experience! We're transitioning from simple payments to a more customizable order creation flow, enabling you to set the desired amount with ease. Plus, our improved Analytics Hub now provides insights into Product Bundles and Gift Cards, offering a more comprehensive view of your business stats, given those extensions are active. Enjoy the upgrade!
 
-Introducing refined features in our WooCommerce mobile app! We've enhanced the accuracy of visitor stats to offer you
-more precise insights. Enjoy a better understanding of your customer interactions, further helping you optimize your
-strategies. Update now for a superior user experience.
+## 18.1
+Introducing refined features in our WooCommerce mobile app! We've enhanced the accuracy of visitor stats to offer you more precise insights. Enjoy a better understanding of your customer interactions, further helping you optimize your strategies. Update now for a superior user experience.
 
 ## 18.0
 Discover a smoother shopping experience in our latest update! We've squashed some pesky bugs in the products section for a flawless selection and viewing, especially in 2-pane mode. Photos now shine brighter with our enhanced screens. Transitioning between panes? We've polished that too, ensuring seamless shifts. Plus, we're introducing a helpful confirmation dialog for unsaved changes. Most excitingly, dive into your store's performance with custom date ranges in the My Store tab. Update now for these improvements and more!

--- a/WooCommerce/metadata/release_notes.txt
+++ b/WooCommerce/metadata/release_notes.txt
@@ -1,3 +1,1 @@
-- [**] Payments: We are sunsetting simple payments in favour of the order creation flow with custom amount set [https://github.com/woocommerce/woocommerce-android/pull/11274]
-- [**] Stats: The Analytics Hub now includes analytics for Product Bundles and Gift Cards, when those extensions are active. [https://github.com/woocommerce/woocommerce-android/pull/11290]
-
+In our latest update, we're enhancing your WooCommerce experience! We're transitioning from simple payments to a more customizable order creation flow, enabling you to set the desired amount with ease. Plus, our improved Analytics Hub now provides insights into Product Bundles and Gift Cards, offering a more comprehensive view of your business stats, given those extensions are active. Enjoy the upgrade!


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Prepares release notes for version `18.2`. The content of the release notes was generated using ChatGPT prompt: 

> Act like a mobile app marketer that wants to prepare a release notes for Google Play and App Store. I want to write effective app store release notes that help users understand the changes in our WooCommerce mobile app. Prepare it based on this list. Do not write it point by point and keep it under 350 characters. It should be a unique paragraph: {paste bullet points from WooCommerce/metadata/release_notes.txt here}

Unsing as input the existing `RELEASE-NOTES.txt` for `18.2`: 
```
- [**] Payments: We are sunsetting simple payments in favour of the order creation flow with custom amount set [https://github.com/woocommerce/woocommerce-android/pull/11274]
- [**] Stats: The Analytics Hub now includes analytics for Product Bundles and Gift Cards, when those extensions are active. [https://github.com/woocommerce/woocommerce-android/pull/11290]
```
