### PR TITLE
EAH design feedback M2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
@@ -24,7 +24,7 @@ import com.woocommerce.android.ui.analytics.hub.RefreshIndicator.ShowIndicator
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.CUSTOM
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.common.MarginTopItemDecoration
+import com.woocommerce.android.ui.common.MarginBottomItemDecoration
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -136,7 +136,7 @@ class AnalyticsHubFragment : BaseFragment(R.layout.fragment_analytics) {
             layoutManager = LinearLayoutManager(context)
             adapter = cardsAdapter
             isNestedScrollingEnabled = false
-            addItemDecoration(MarginTopItemDecoration(R.dimen.major_100, requireContext()))
+            addItemDecoration(MarginBottomItemDecoration(R.dimen.major_100, requireContext()))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/MarginBottomItemDecoration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/MarginBottomItemDecoration.kt
@@ -5,7 +5,7 @@ import android.graphics.Rect
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 
-class MarginTopItemDecoration(
+class MarginBottomItemDecoration(
     marginTopResId: Int,
     context: Context
 ) : RecyclerView.ItemDecoration() {
@@ -19,6 +19,6 @@ class MarginTopItemDecoration(
         state: RecyclerView.State
     ) {
         super.getItemOffsets(outRect, view, parent, state)
-        outRect.top = margin
+        outRect.bottom = margin
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DragAndDropSelectableItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DragAndDropSelectableItemsList.kt
@@ -137,7 +137,7 @@ fun <T> DragAndDropItem(
             ) {
                 SelectionCheck(
                     isSelected = isSelected,
-                    onSelectionChange = { onSelectionChange(item, !isSelected) },
+                    onSelectionChange = null,
                     isEnabled = isEnabled
                 )
                 Text(
@@ -156,7 +156,7 @@ fun <T> DragAndDropItem(
 @Composable
 fun SelectionCheck(
     isSelected: Boolean,
-    onSelectionChange: (Boolean) -> Unit,
+    onSelectionChange: ((Boolean) -> Unit)?,
     modifier: Modifier = Modifier,
     isEnabled: Boolean = true
 ) {
@@ -168,10 +168,10 @@ fun SelectionCheck(
 
     val colorFilter = if (isEnabled) null else ColorFilter.tint(Color.Gray)
 
-    val description = stringResource(id = R.string.order_configuration_product_selection_control)
+    val description = stringResource(id = R.string.card_selection_control)
     val state = if (!isEnabled) stringResource(id = R.string.disabled) else ""
 
-    val controlModifier = if (isEnabled) {
+    val controlModifier = if (isEnabled && onSelectionChange != null) {
         modifier.clickable { onSelectionChange(!isSelected) }
     } else {
         modifier

--- a/WooCommerce/src/main/res/drawable/ic_analytics_calendar.xml
+++ b/WooCommerce/src/main/res/drawable/ic_analytics_calendar.xml
@@ -1,7 +1,5 @@
-<vector android:height="24dp" android:viewportHeight="25"
-    android:viewportWidth="24" android:width="23.04dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <group>
-        <clip-path android:fillType="evenOdd" android:pathData="M19,22.5C20.1,22.5 21,21.6 21,20.5V6.5C21,5.4 20.1,4.5 19,4.5H18V2.5H16V4.5H8V2.5H6V4.5H5C3.89,4.5 3.01,5.4 3.01,6.5L3,20.5C3,21.6 3.89,22.5 5,22.5H19ZM9,13.5V11.5H7V13.5H9ZM5,8.5H19V6.5H5V8.5ZM19,10.5V20.5H5V10.5H19ZM17,13.5V11.5H15V13.5H17ZM13,13.5H11V11.5H13V13.5Z"/>
-        <path android:fillColor="@color/color_secondary" android:pathData="M0,0.5h24v24h-24z"/>
-    </group>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M19,4h-1V2h-2v2H8V2H6v2H5C3.89,4 3.01,4.9 3.01,6L3,20c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V6C21,4.9 20.1,4 19,4zM19,20H5V10h14V20zM19,8H5V6h14V8zM9,14H7v-2h2V14zM13,14h-2v-2h2V14zM17,14h-2v-2h2V14zM9,18H7v-2h2V18zM13,18h-2v-2h2V18zM17,18h-2v-2h2V18z"/>
+    
 </vector>

--- a/WooCommerce/src/main/res/drawable/ic_edit_pencil.xml
+++ b/WooCommerce/src/main/res/drawable/ic_edit_pencil.xml
@@ -1,9 +1,5 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
-    <path
-        android:fillColor="@color/color_icon_primary"
-        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M14.06,9.02l0.92,0.92L5.92,19L5,19v-0.92l9.06,-9.06M17.66,3c-0.25,0 -0.51,0.1 -0.7,0.29l-1.83,1.83 3.75,3.75 1.83,-1.83c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.2,-0.2 -0.45,-0.29 -0.71,-0.29zM14.06,6.19L3,17.25L3,21h3.75L17.81,9.94l-3.75,-3.75z"/>
+    
 </vector>

--- a/WooCommerce/src/main/res/layout/fragment_analytics.xml
+++ b/WooCommerce/src/main/res/layout/fragment_analytics.xml
@@ -56,7 +56,8 @@
                 android:layout_height="wrap_content"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/analyticsDateSelectorCard" />
+                app:layout_constraintTop_toBottomOf="@+id/analyticsDateSelectorCard"
+                android:layout_marginTop="@dimen/major_100"/>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>
 </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4003,6 +4003,7 @@
 
     <string name="order_configuration_product_selection">Select product %s</string>
     <string name="order_configuration_product_selection_control">Product selection</string>
+    <string name="card_selection_control">Analytic card selection</string>
     <string name="disabled">Disabled</string>
     <string name="see_report">See Report</string>
 


### PR DESCRIPTION
Closes: #11151

### Description
This PR addresses the design changes proposed after the design review of M2

- [x] Occasionally after rearranging the cards, the shadow on the last card doesn’t load.
- [x] Make sure that tapping on the checkbox highlights the entire row background. (Tapping on the row checks and unchecks the checkbox, and highlights the row background on tap. Tapping on the checkbox, though, works just fine, but only highlights the checkbox background.)
- [x] Update the pencil icon to a Google Material icon instead of gridicon.

![image](https://github.com/woocommerce/woocommerce-android/assets/18119390/7e62ed2a-ff80-4cf8-9b1c-6ed44f9314fe)
![image](https://github.com/woocommerce/woocommerce-android/assets/18119390/73b91d1e-79cc-4762-8fb8-986055cf8e63)
![image](https://github.com/woocommerce/woocommerce-android/assets/18119390/9f0b7e2e-2cb6-4906-825f-f34ac99f2096)


### Testing instructions
TC1
1. Open the app
2. Tap on the See all store analytics
3. Check that the screen is using the new material icons (pencil and calendar)
4. Check that the last displayed card has a shadow
5. Tap on the pencil to enter the Customize Analytics screen
6. Check that tapping on a checkbox selects the whole row instead of selecting only the control


### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/d8bb7e16-815c-476b-92c7-bcc0a872236f

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
