### PR TITLE
Specify a ChatGPT model explicitly

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
@@ -135,7 +135,7 @@ class AIRepository @Inject constructor(
         prompt: String,
         feature: String,
         format: ResponseFormat? = null,
-        model: String? = null
+        model: String? = "gpt-3.5-turbo-1106"
     ): Result<String> = withContext(Dispatchers.IO) {
         jetpackAIStore.fetchJetpackAICompletions(selectedSite.get(), prompt, feature, format, model).run {
             when (this) {


### PR DESCRIPTION
This fixes an issue after the backend model changed a broke the AI product generation.

**To test:**
1. Log in to a store with Business plan (AI is available)
2. Go to products
3. Tap on the Add product button
4. Choose AI product creation
5. Go through the flow
6. Verify product details are generated