### PR TITLE
Fix/11270 errors generating weekly strings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -237,9 +237,11 @@ class MyStoreStatsView @JvmOverloads constructor(
             customRangeGranularityLabel.isVisible = true
             customRangeLabel.text = selectedTimeRange.currentRangeDescription
             customRangeGranularityLabel.text = getStringForGranularity(selectedTimeRange.revenueStatsGranularity)
+            statsDateValue.isVisible = false
         } else {
             customRangeLabel.isVisible = false
             customRangeGranularityLabel.isVisible = false
+            statsDateValue.isVisible = true
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreStatsView.kt
@@ -419,7 +419,7 @@ class MyStoreStatsView @JvmOverloads constructor(
         return when (activeGranularity) {
             StatsGranularity.HOURS -> dateUtils.getFriendlyDayHourString(dateString).orEmpty()
             StatsGranularity.DAYS -> dateUtils.getDayMonthDateString(dateString).orEmpty()
-            StatsGranularity.WEEKS -> dateUtils.getShortMonthDayString(dateString).orEmpty()
+            StatsGranularity.WEEKS -> dateUtils.getShortMonthDayStringForWeek(dateString).orEmpty()
             StatsGranularity.MONTHS -> dateUtils.getMonthString(dateString).orEmpty()
             StatsGranularity.YEARS -> dateString
         }.also { result -> trackUnexpectedFormat(result, dateString) }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes: #11270
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Extra context: peaMlT-xx-p2
Fixes an error happening when trying to parse dates in my store stats with a custom range selected were the granularity for the provided range is `WEEKS`

The error didn't generate a crash but prevented the UI from showing the date value when tapping on a specific date in the line chart

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Select the custom range tab on my store screen
2. Pick a custom date range between < 28 days and > 90 days to get a weekly granularity
4. Check no `java.lang.IndexOutOfBoundsException:` happens in the logcat when stats are loaded for the provided range