### PR TITLE
Clear runnable on destroy

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
@@ -47,7 +47,7 @@ class ProductTagsFragment :
         super.onViewCreated(view, savedInstanceState)
 
         _binding = FragmentProductTagsBinding.bind(view)
-
+        initializeView()
         setupObservers(viewModel)
         viewModel.loadProductTags()
 
@@ -73,12 +73,8 @@ class ProductTagsFragment :
         AnalyticsTracker.trackViewShown(this)
     }
 
-    @Suppress("DEPRECATION")
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-
+    private fun initializeView() {
         val activity = requireActivity()
-
         productTagsAdapter = ProductTagsAdapter(this, this)
         with(binding.productTagsRecycler) {
             layoutManager = LinearLayoutManager(activity)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/tags/ProductTagsFragment.kt
@@ -39,6 +39,7 @@ class ProductTagsFragment :
     private val skeletonView = SkeletonView()
     private var progressDialog: CustomProgressDialog? = null
     private val searchHandler = Handler(Looper.getMainLooper())
+    private var searchRunnable: Runnable? = null
 
     private var _binding: FragmentProductTagsBinding? = null
     private val binding get() = _binding!!
@@ -63,10 +64,14 @@ class ProductTagsFragment :
     }
 
     override fun onDestroyView() {
+        clearSearchRunnable()
         skeletonView.hide()
         super.onDestroyView()
+        searchRunnable = null
         _binding = null
     }
+
+    private fun clearSearchRunnable() = searchRunnable?.let { searchHandler.removeCallbacks(it) }
 
     override fun onResume() {
         super.onResume()
@@ -114,14 +119,13 @@ class ProductTagsFragment :
      * perform a search while the user is typing
      */
     private fun setProductTagsFilterDelayed(filter: String) {
-        searchHandler.postDelayed(
-            {
-                if (filter == binding.addProductTagView.getEnteredTag()) {
-                    viewModel.setProductTagsFilter(filter)
-                }
-            },
-            AppConstants.SEARCH_TYPING_DELAY_MS
-        )
+        clearSearchRunnable()
+        searchRunnable = Runnable {
+            if (filter == binding.addProductTagView.getEnteredTag()) {
+                viewModel.setProductTagsFilter(filter)
+            }
+        }
+        searchHandler.postDelayed(searchRunnable!!, AppConstants.SEARCH_TYPING_DELAY_MS)
     }
 
     private fun setupObservers(viewModel: ProductDetailViewModel) {


### PR DESCRIPTION
Closes: #11305

### Description
This PR fixes the `NullPointerException` when leaving the `ProductTagsFragment` before the `searchHandler` completes the current search execution. It does that by cleaning the `searchHandler` on the `onDestroy` method call.
Additionaly, his PR also moved all the view initialization logic from the deprecated `onActivityCreated`  to an `initializeView` function that is going to be called on the `onViewCreated` method.

Shout out to @malinajirka for noticing the handler issue. peaMlT-xV-p2#comment-1262

### Testing instructions
You can reproduce the `NullPointerException` by running this Patch 

<details>
  <summary>Patch</summary>

```
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/AppConstants.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppConstants.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppConstants.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppConstants.kt	(revision ffe19e15c46b70e318a95065b421f7adf5b889d6)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppConstants.kt	(date 1713402424520)
@@ -5,7 +5,7 @@
  */
 object AppConstants {
     const val REQUEST_TIMEOUT = 40L * 1000
-    const val SEARCH_TYPING_DELAY_MS = 500L
+    const val SEARCH_TYPING_DELAY_MS = 5000L
     const val TWITTER_USERNAME = "woocommerce"
     const val INSTAGRAM_USERNAME = "woocommerce"
     const val FADE_ANIMATION_DELAY_MS = 1000
```
</details>

Then:
1. Open the app
2. Tap on Products
3. Select a product and enter the product details
4. Tap on Add more details
5. Select the Tag option
6. Start typing a tag name and leave the screen before the filter operation completes (the patch will give you 5 secs)
7. Wait until 5 sec and check that the app does not crash

You can apply the same Patch to trunk and check that the app crashes after running the same steps above ☝️ 

### Images

https://github.com/woocommerce/woocommerce-android/assets/18119390/ab3eb4a2-d48b-4e34-8b0d-fb364b96a152




- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->