### PR TITLE
Fix/blaze fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
@@ -147,7 +147,7 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
         triggerEvent(
             Event.ShowDialog(
                 titleId = R.string.blaze_campaign_edit_ad_invalid_image_title,
-                messageId = R.string.blaze_campaign_edit_ad_invalid_image_description,
+                messageId = R.string.blaze_campaign_edit_ad_invalid_image_size_description,
                 positiveButtonId = R.string.dialog_ok,
                 positiveBtnAction = { dialog, _ ->
                     dialog.dismiss()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -26,7 +27,8 @@ class BlazeCampaignPaymentSummaryViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val blazeRepository: BlazeRepository,
     currencyFormatter: CurrencyFormatter,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val prefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs = BlazeCampaignPaymentSummaryFragmentArgs.fromSavedStateHandle(savedStateHandle)
     private val budgetFormatted = currencyFormatter.formatCurrency(
@@ -122,6 +124,7 @@ class BlazeCampaignPaymentSummaryViewModel @Inject constructor(
                 onSuccess = {
                     campaignCreationState.value = null
                     analyticsTrackerWrapper.track(stat = AnalyticsEvent.BLAZE_CREATION_PAYMENT_SUBMIT_CAMPAIGN_TAPPED)
+                    prefsWrapper.isMyStoreBlazeViewDismissed = false
                     triggerEvent(NavigateToStartingScreenWithSuccessBottomSheet)
                 },
                 onFailure = {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3824,7 +3824,7 @@
     <string name="blaze_campaign_edit_ad_characters_remaining">%d characters remaining</string>
     <string name="blaze_campaign_edit_ad_suggested_by_ai">Suggested by AI</string>
     <string name="blaze_campaign_edit_ad_invalid_image_title">Invalid image</string>
-    <string name="blaze_campaign_edit_ad_invalid_image_description">Please select and image with a minimum dimension of 500x500 pixels</string>
+    <string name="blaze_campaign_edit_ad_invalid_image_size_description">Please select and image with a minimum dimension of 600x600 pixels</string>
 
     <!--
     Blaze campaign payment

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModelTests.kt
@@ -60,7 +60,8 @@ class BlazeCampaignPaymentSummaryViewModelTests : BaseUnitTest() {
             ).toSavedStateHandle(),
             blazeRepository = blazeRepository,
             currencyFormatter = currencyFormatter,
-            analyticsTrackerWrapper = mock()
+            analyticsTrackerWrapper = mock(),
+            prefsWrapper = mock()
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Adds a number of small fixes for Blaze
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- Fixes wrong image size error description. It turned out in the end the backend min size requirement was 600x600
- Enhancement: When the user creates a new Blaze campaign successfully, if my store Blaze view had been dismissed we restore it. 

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
**Wrong image size**

- Open Blaze campaign creation flow
- Click on `Edit ad` and select and image that is smaller than 600x600 
- Check the dialog is shown warning the user that the image is smaller than 600x600


https://github.com/woocommerce/woocommerce-android/assets/2663464/d7159984-0922-4c27-aebb-78e4e062a61b


**Restore Blase view on My Store screen**

- Dismiss Blaze view from My store screen
- Create a Blaze campaign successfully
- Navigate back to My store screen and check that Blaze view is displayed
