### PR TITLE
Update leak canary o to latest version to avoid potential crashes

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -322,7 +322,7 @@ dependencies {
     }
 
     if (isLeakCanaryEnabled()) {
-        debugImplementation 'com.squareup.leakcanary:leakcanary-android-core:2.9.1'
+        debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.14'
     }
 
     // Dependencies for local unit tests


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
It was reported that there's an issue with Leak Canary versions between `2.8` and `2.13`. This issue will make the app crash at runtime. This PR updates the version to `2.14` where the issue is fixed: 

![IMG_2439](https://github.com/woocommerce/woocommerce-android/assets/2663464/4c7e7096-22ea-4981-9bfa-fe4131f6e002)


### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. There is nothing to test; verifying that all PR checks are green should be fine. 
2. In any case, I've smoke-tested the app until the Leak canary report showed up, and everything looks good. You might want to check that, too, if you want. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
