### PR TITLE
[Dynamic Dashboard] Update stats card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -18,6 +18,11 @@ fun Date.formatToYYYYmm(locale: Locale = Locale.getDefault()): String = SimpleDa
     locale
 ).format(this)
 
+fun Date.formatToMMMMyyyy(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
+    "MMMM yyyy",
+    locale
+).format(this)
+
 fun Date.formatToYYYYmmDD(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
     "yyyy-MM-dd",
     locale

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WidgetCard.kt
@@ -89,7 +89,10 @@ fun WidgetCard(
                     ),
                 onClick = button.action
             ) {
-                Text(stringResource(id = button.titleResource))
+                Text(
+                    text = stringResource(id = button.titleResource),
+                    style = MaterialTheme.typography.body1
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.tabs.TabLayout
 import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
@@ -26,6 +27,7 @@ import com.woocommerce.android.ui.compose.viewModelWithFactory
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardStatsUsageTracksEventEmitter
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
+import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -71,19 +73,31 @@ fun DashboardStatsCard(
         }
     )
 
-    DashboardStatsCard(
-        selectedDateRange = selectedDateRange,
-        customRange = customRange,
-        revenueStatsState = revenueStatsState,
-        visitorsStatsState = visitorsStatsState,
-        lastUpdateState = lastUpdateState,
-        dateUtils = dateUtils,
-        currencyFormatter = currencyFormatter,
-        usageTracksEventEmitter = usageTracksEventEmitter,
-        onViewAnalyticsClick = viewModel::onViewAnalyticsClicked,
-        onAddCustomRangeClick = viewModel::onAddCustomRangeClicked,
-        onTabSelected = viewModel::onTabSelected
-    )
+    WidgetCard(
+        titleResource = R.string.my_store_widget_stats_title,
+        menu = DashboardViewModel.DashboardWidgetMenu(
+            items = listOf(
+                DashboardViewModel.DashboardWidgetAction(
+                    titleResource = R.string.dynamic_dashboard_hide_widget_menu_item,
+                    action = { /* TODO */ }
+                )
+            )
+        )
+    ) {
+        DashboardStatsCard(
+            selectedDateRange = selectedDateRange,
+            customRange = customRange,
+            revenueStatsState = revenueStatsState,
+            visitorsStatsState = visitorsStatsState,
+            lastUpdateState = lastUpdateState,
+            dateUtils = dateUtils,
+            currencyFormatter = currencyFormatter,
+            usageTracksEventEmitter = usageTracksEventEmitter,
+            onViewAnalyticsClick = viewModel::onViewAnalyticsClicked,
+            onAddCustomRangeClick = viewModel::onAddCustomRangeClicked,
+            onTabSelected = viewModel::onTabSelected
+        )
+    }
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -41,6 +41,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
 import com.woocommerce.android.ui.compose.component.WCTextButton
@@ -93,7 +94,7 @@ fun DashboardStatsCard(
     )
 
     WidgetCard(
-        titleResource = R.string.my_store_widget_stats_title,
+        titleResource = DashboardWidget.Type.STATS.titleResource,
         menu = DashboardViewModel.DashboardWidgetMenu(
             items = listOf(
                 DashboardViewModel.DashboardWidgetAction(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -1,20 +1,26 @@
 package com.woocommerce.android.ui.dashboard.stats
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -126,6 +132,7 @@ fun DashboardStatsCard(
     Column {
         StatsHeader(
             dateRange = dateRange,
+            onCustomRangeClick = onAddCustomRangeClick,
             modifier = Modifier.fillMaxWidth()
         )
         Divider()
@@ -149,16 +156,17 @@ fun DashboardStatsCard(
 @Composable
 private fun StatsHeader(
     dateRange: DashboardStatsViewModel.DateRangeState?,
+    onCustomRangeClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     if (dateRange == null) return
 
     Row(
         modifier = modifier.padding(
-            horizontal = dimensionResource(id = R.dimen.major_100),
-            vertical = dimensionResource(id = R.dimen.minor_100)
+            horizontal = dimensionResource(id = R.dimen.major_100)
         ),
-        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100))
+        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
+        verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
             text = stringResource(
@@ -174,11 +182,29 @@ private fun StatsHeader(
             style = MaterialTheme.typography.body2,
             color = MaterialTheme.colors.onSurface
         )
-        Text(
-            text = dateRange.selectedDateFormatted ?: dateRange.rangeFormatted,
-            style = MaterialTheme.typography.body2,
-            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
-        )
+        val isCustomRange = dateRange.rangeSelection.selectionType == SelectionType.CUSTOM
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
+            modifier = Modifier
+                .then(if (isCustomRange) Modifier.clickable(onClick = onCustomRangeClick) else Modifier)
+                .padding(dimensionResource(id = R.dimen.minor_100))
+        ) {
+            Text(
+                text = dateRange.selectedDateFormatted ?: dateRange.rangeFormatted,
+                style = MaterialTheme.typography.body2,
+                color = if (isCustomRange) MaterialTheme.colors.primary
+                else MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+            )
+            if (isCustomRange) {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = null,
+                    tint = MaterialTheme.colors.primary,
+                    modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_40))
+                )
+            }
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -133,7 +133,6 @@ private fun DashboardStatsContent(
     onTabSelected: (SelectionType) -> Unit,
     onChartDateSelected: (String?) -> Unit
 ) {
-
     Column {
         StatsHeader(
             dateRange = dateRange,
@@ -208,8 +207,11 @@ private fun StatsHeader(
             Text(
                 text = dateRange.selectedDateFormatted ?: dateRange.rangeFormatted,
                 style = MaterialTheme.typography.body2,
-                color = if (isCustomRange) MaterialTheme.colors.primary
-                else MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+                color = if (isCustomRange) {
+                    MaterialTheme.colors.primary
+                } else {
+                    MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+                }
             )
             if (isCustomRange) {
                 Icon(
@@ -233,32 +235,30 @@ private fun StatsHeader(
                 )
             }
 
-            if (isMenuExpanded) {
-                DropdownMenu(
-                    expanded = isMenuExpanded,
-                    onDismissRequest = { isMenuExpanded = false }
-                ) {
-                    DashboardViewModel.SUPPORTED_RANGES_ON_MY_STORE_TAB.forEach {
-                        DropdownMenuItem(
-                            onClick = {
-                                onTabSelected(it)
-                                isMenuExpanded = false
-                            }
+            DropdownMenu(
+                expanded = isMenuExpanded,
+                onDismissRequest = { isMenuExpanded = false }
+            ) {
+                DashboardViewModel.SUPPORTED_RANGES_ON_MY_STORE_TAB.forEach {
+                    DropdownMenuItem(
+                        onClick = {
+                            onTabSelected(it)
+                            isMenuExpanded = false
+                        }
+                    ) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.minor_100))
                         ) {
-                            Row(
-                                horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.minor_100))
-                            ) {
-                                Text(text = it.title)
-                                Spacer(modifier = Modifier.weight(1f))
-                                if (dateRange.rangeSelection.selectionType == it) {
-                                    Icon(
-                                        imageVector = Icons.Default.Check,
-                                        contentDescription = stringResource(id = androidx.compose.ui.R.string.selected),
-                                        tint = MaterialTheme.colors.primary
-                                    )
-                                } else {
-                                    Spacer(modifier = Modifier.size(dimensionResource(R.dimen.image_minor_50)))
-                                }
+                            Text(text = it.title)
+                            Spacer(modifier = Modifier.weight(1f))
+                            if (dateRange.rangeSelection.selectionType == it) {
+                                Icon(
+                                    imageVector = Icons.Default.Check,
+                                    contentDescription = stringResource(id = androidx.compose.ui.R.string.selected),
+                                    tint = MaterialTheme.colors.primary
+                                )
+                            } else {
+                                Spacer(modifier = Modifier.size(dimensionResource(R.dimen.image_minor_50)))
                             }
                         }
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -44,7 +44,6 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
-import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.compose.viewModelWithFactory
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
@@ -102,6 +101,10 @@ fun DashboardStatsCard(
                     action = { /* TODO */ }
                 )
             )
+        ),
+        button = DashboardViewModel.DashboardWidgetAction(
+            titleResource = R.string.analytics_section_see_all,
+            action = viewModel::onViewAnalyticsClicked
         )
     ) {
         DashboardStatsContent(
@@ -112,7 +115,6 @@ fun DashboardStatsCard(
             dateUtils = dateUtils,
             currencyFormatter = currencyFormatter,
             usageTracksEventEmitter = usageTracksEventEmitter,
-            onViewAnalyticsClick = viewModel::onViewAnalyticsClicked,
             onAddCustomRangeClick = viewModel::onAddCustomRangeClicked,
             onTabSelected = viewModel::onTabSelected,
             onChartDateSelected = viewModel::onChartDateSelected
@@ -129,7 +131,6 @@ private fun DashboardStatsContent(
     dateUtils: DateUtils,
     currencyFormatter: CurrencyFormatter,
     usageTracksEventEmitter: DashboardStatsUsageTracksEventEmitter,
-    onViewAnalyticsClick: () -> Unit,
     onAddCustomRangeClick: () -> Unit,
     onTabSelected: (SelectionType) -> Unit,
     onChartDateSelected: (String?) -> Unit
@@ -154,16 +155,6 @@ private fun DashboardStatsContent(
             onChartDateSelected = onChartDateSelected,
             modifier = Modifier.fillMaxWidth()
         )
-
-        WCTextButton(
-            onClick = onViewAnalyticsClick,
-            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
-        ) {
-            Text(
-                text = stringResource(id = R.string.analytics_section_see_all),
-                style = MaterialTheme.typography.body1
-            )
-        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
@@ -244,7 +245,21 @@ private fun StatsHeader(
                                 isMenuExpanded = false
                             }
                         ) {
-                            Text(text = it.title)
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.minor_100))
+                            ) {
+                                Text(text = it.title)
+                                Spacer(modifier = Modifier.weight(1f))
+                                if (dateRange.rangeSelection.selectionType == it) {
+                                    Icon(
+                                        imageVector = Icons.Default.Check,
+                                        contentDescription = stringResource(id = androidx.compose.ui.R.string.selected),
+                                        tint = MaterialTheme.colors.primary
+                                    )
+                                } else {
+                                    Spacer(modifier = Modifier.size(dimensionResource(R.dimen.image_minor_50)))
+                                }
+                            }
                         }
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -42,6 +42,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.compose.viewModelWithFactory
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
@@ -101,7 +102,7 @@ fun DashboardStatsCard(
             )
         )
     ) {
-        DashboardStatsCard(
+        DashboardStatsContent(
             dateRange = dateRange,
             revenueStatsState = revenueStatsState,
             visitorsStatsState = visitorsStatsState,
@@ -118,7 +119,7 @@ fun DashboardStatsCard(
 }
 
 @Composable
-fun DashboardStatsCard(
+private fun DashboardStatsContent(
     dateRange: DashboardStatsViewModel.DateRangeState?,
     revenueStatsState: DashboardStatsViewModel.RevenueStatsViewState?,
     visitorsStatsState: DashboardStatsViewModel.VisitorStatsViewState?,
@@ -148,11 +149,20 @@ fun DashboardStatsCard(
             dateUtils = dateUtils,
             currencyFormatter = currencyFormatter,
             usageTracksEventEmitter = usageTracksEventEmitter,
-            onViewAnalyticsClick = onViewAnalyticsClick,
             onAddCustomRangeClick = onAddCustomRangeClick,
             onChartDateSelected = onChartDateSelected,
             modifier = Modifier.fillMaxWidth()
         )
+
+        WCTextButton(
+            onClick = onViewAnalyticsClick,
+            modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
+        ) {
+            Text(
+                text = stringResource(id = R.string.analytics_section_see_all),
+                style = MaterialTheme.typography.body1
+            )
+        }
     }
 }
 
@@ -252,7 +262,6 @@ private fun StatsChart(
     dateUtils: DateUtils,
     currencyFormatter: CurrencyFormatter,
     usageTracksEventEmitter: DashboardStatsUsageTracksEventEmitter,
-    onViewAnalyticsClick: () -> Unit,
     onAddCustomRangeClick: () -> Unit,
     onChartDateSelected: (String?) -> Unit,
     modifier: Modifier = Modifier
@@ -267,7 +276,7 @@ private fun StatsChart(
                 currencyFormatter = currencyFormatter,
                 usageTracksEventEmitter = usageTracksEventEmitter,
                 lifecycleScope = lifecycleScope,
-                onViewAnalyticsClick = onViewAnalyticsClick,
+                onViewAnalyticsClick = {},
                 onDateSelected = onChartDateSelected
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsRangeFormatter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsRangeFormatter.kt
@@ -17,17 +17,18 @@ class DashboardStatsRangeFormatter @Inject constructor(private val dateUtils: Da
         val endDate = rangeSelection.currentRange.end
         val dateFormatter = SimpleDateFormat.getDateInstance()
 
-        return when(rangeSelection.selectionType) {
+        return when (rangeSelection.selectionType) {
             SelectionType.TODAY -> dateFormatter.format(startDate)
             SelectionType.MONTH_TO_DATE -> startDate.formatToMMMMyyyy()
             SelectionType.YEAR_TO_DATE -> startDate.formatToYYYY()
             SelectionType.WEEK_TO_DATE, SelectionType.CUSTOM ->
                 "${dateFormatter.format(startDate)} – ${dateFormatter.format(endDate)}"
+
             else -> error("Unsupported range value used in Dashboard performance card: ${rangeSelection.selectionType}")
         }
     }
 
-    fun formatSelectedDate(dateString: String, rangeSelection: StatsTimeRangeSelection) : String? {
+    fun formatSelectedDate(dateString: String, rangeSelection: StatsTimeRangeSelection): String? {
         return when (rangeSelection.selectionType) {
             SelectionType.TODAY -> dateUtils.getFriendlyDayHourString(dateString).orEmpty()
             SelectionType.WEEK_TO_DATE -> dateUtils.getShortMonthDayString(dateString).orEmpty()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsRangeFormatter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsRangeFormatter.kt
@@ -1,0 +1,24 @@
+package com.woocommerce.android.ui.dashboard.stats
+
+import android.icu.text.SimpleDateFormat
+import com.woocommerce.android.extensions.formatToMMMMyyyy
+import com.woocommerce.android.extensions.formatToYYYY
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+
+class DashboardStatsRangeFormatter {
+    fun formatRangeDate(rangeSelection: StatsTimeRangeSelection): String {
+        val startDate = rangeSelection.currentRange.start
+        val endDate = rangeSelection.currentRange.end
+        val dateFormatter = SimpleDateFormat.getDateInstance()
+
+        return when(rangeSelection.selectionType) {
+            SelectionType.TODAY -> dateFormatter.format(startDate)
+            SelectionType.MONTH_TO_DATE -> startDate.formatToMMMMyyyy()
+            SelectionType.YEAR_TO_DATE -> startDate.formatToYYYY()
+            SelectionType.WEEK_TO_DATE, SelectionType.CUSTOM ->
+                "${dateFormatter.format(startDate)} – ${dateFormatter.format(endDate)}"
+            else -> error("Unsupported range value used in Dashboard performance card: ${rangeSelection.selectionType}")
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsRangeFormatter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsRangeFormatter.kt
@@ -7,10 +7,8 @@ import com.woocommerce.android.extensions.formatToMMMMyyyy
 import com.woocommerce.android.extensions.formatToYYYY
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
-import com.woocommerce.android.ui.analytics.ranges.revenueStatsGranularity
 import com.woocommerce.android.ui.dashboard.data.asRevenueRangeId
 import com.woocommerce.android.util.DateUtils
-import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import javax.inject.Inject
 
 class DashboardStatsRangeFormatter @Inject constructor(private val dateUtils: DateUtils) {
@@ -29,29 +27,18 @@ class DashboardStatsRangeFormatter @Inject constructor(private val dateUtils: Da
         }
     }
 
-    fun formatSelectedDate(dateString: String, rangeSelection: StatsTimeRangeSelection) : String {
+    fun formatSelectedDate(dateString: String, rangeSelection: StatsTimeRangeSelection) : String? {
         return when (rangeSelection.selectionType) {
             SelectionType.TODAY -> dateUtils.getFriendlyDayHourString(dateString).orEmpty()
             SelectionType.WEEK_TO_DATE -> dateUtils.getShortMonthDayString(dateString).orEmpty()
             SelectionType.MONTH_TO_DATE -> dateUtils.getLongMonthDayString(dateString).orEmpty()
             SelectionType.YEAR_TO_DATE -> dateUtils.getFriendlyLongMonthYear(dateString).orEmpty()
-            SelectionType.CUSTOM -> getDisplayDateForGranularity(
-                dateString,
-                rangeSelection.revenueStatsGranularity
-            )
+            // For custom ranges, we don't display the selected date
+            SelectionType.CUSTOM -> null
 
             else -> error("Unsupported range value used in dashboard card: ${rangeSelection.selectionType}")
-        }.also { result -> trackUnexpectedFormat(result, dateString, rangeSelection) }
+        }?.also { result -> trackUnexpectedFormat(result, dateString, rangeSelection) }
     }
-
-    private fun getDisplayDateForGranularity(dateString: String, statsGranularity: StatsGranularity): String =
-        when (statsGranularity) {
-            StatsGranularity.HOURS -> dateUtils.getShortHourString(dateString).orEmpty()
-            StatsGranularity.DAYS -> dateUtils.getDayString(dateString).orEmpty()
-            StatsGranularity.WEEKS -> dateUtils.getShortMonthDayStringForWeek(dateString).orEmpty()
-            StatsGranularity.MONTHS -> dateUtils.getShortMonthString(dateString).orEmpty()
-            StatsGranularity.YEARS -> dateString
-        }
 
     private fun trackUnexpectedFormat(result: String, dateString: String, rangeSelection: StatsTimeRangeSelection) {
         if (result.isEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
@@ -144,6 +144,7 @@ class DashboardStatsView @JvmOverloads constructor(
         statsDateValue.isVisible = false
         binding.statsTabLayout.isVisible = false
         customRangeButton.isVisible = false
+        binding.viewAnalyticsButton.isVisible = false
     }
 
     fun initView(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
@@ -28,7 +28,6 @@ import com.github.mikephil.charting.highlight.Highlight
 import com.github.mikephil.charting.listener.ChartTouchListener.ChartGesture
 import com.github.mikephil.charting.listener.OnChartValueSelectedListener
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.google.android.material.tabs.TabLayout.Tab
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -37,19 +36,16 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_GRANULAR
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_RANGE
 import com.woocommerce.android.databinding.MyStoreStatsBinding
 import com.woocommerce.android.extensions.convertedFrom
-import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
 import com.woocommerce.android.ui.analytics.ranges.myStoreTrackingGranularityString
 import com.woocommerce.android.ui.analytics.ranges.revenueStatsGranularity
 import com.woocommerce.android.ui.dashboard.BarChartGestureListener
 import com.woocommerce.android.ui.dashboard.DashboardStatsUsageTracksEventEmitter
-import com.woocommerce.android.ui.dashboard.DashboardViewModel.Companion.SUPPORTED_RANGES_ON_MY_STORE_TAB
 import com.woocommerce.android.ui.dashboard.stats.DashboardStatsViewModel.RevenueStatsUiModel
 import com.woocommerce.android.ui.dashboard.stats.DashboardStatsViewModel.VisitorStatsViewState
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateUtils
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooAnimUtils
 import com.woocommerce.android.util.WooAnimUtils.Duration
 import com.woocommerce.android.util.roundToTheNextPowerOfTen
@@ -135,14 +131,6 @@ class DashboardStatsView @JvmOverloads constructor(
 
     val customRangeButton = binding.customRangeButton
 
-    val tabLayout = binding.statsTabLayout
-    private val customRangeTab: Tab by lazy {
-        tabLayout.newTab().apply {
-            setText(getStringForRangeType(SelectionType.CUSTOM))
-            tag = SelectionType.CUSTOM
-        }
-    }
-
     private lateinit var coroutineScope: CoroutineScope
     private val chartUserInteractions = MutableSharedFlow<Unit>()
     private lateinit var chartUserInteractionsJob: Job
@@ -154,6 +142,8 @@ class DashboardStatsView @JvmOverloads constructor(
         // TODO: Remove those views from the layout when releasing Dynamic Dashboard
         customRangeLabel.isVisible = false
         statsDateValue.isVisible = false
+        binding.statsTabLayout.isVisible = false
+        customRangeButton.isVisible = false
     }
 
     fun initView(
@@ -195,18 +185,6 @@ class DashboardStatsView @JvmOverloads constructor(
                     }
                 }
         }
-
-        customRangeButton.isVisible = FeatureFlag.CUSTOM_RANGE_ANALYTICS.isEnabled()
-        // Create tabs and add to appbar
-        SUPPORTED_RANGES_ON_MY_STORE_TAB
-            .filter { it != SelectionType.CUSTOM }
-            .forEach { rangeType ->
-                val tab = tabLayout.newTab().apply {
-                    setText(getStringForRangeType(rangeType))
-                    tag = rangeType
-                }
-                tabLayout.addTab(tab)
-            }
     }
 
     override fun onDetachedFromWindow() {
@@ -224,20 +202,6 @@ class DashboardStatsView @JvmOverloads constructor(
         )
         isRequestingStats = true
         applyCustomRange(statsTimeRangeSelection)
-    }
-
-    fun handleCustomRangeTab(customRange: StatsTimeRange?) {
-        if (customRange != null) {
-            customRangeButton.isVisible = false
-            if (customRangeTab.view.parent == null) {
-                tabLayout.addTab(customRangeTab)
-            }
-        } else {
-            customRangeButton.isVisible = true
-            if (customRangeTab.view.parent != null) {
-                tabLayout.removeTab(customRangeTab)
-            }
-        }
     }
 
     private fun applyCustomRange(selectedTimeRange: StatsTimeRangeSelection) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
@@ -10,7 +10,6 @@ import android.view.View
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.annotation.ColorRes
-import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import androidx.core.view.doOnDetach
 import androidx.core.view.isVisible
@@ -139,7 +138,7 @@ class DashboardStatsView @JvmOverloads constructor(
     private lateinit var onDateSelected: (String?) -> Unit
 
     init {
-        // TODO: Remove those views from the layout when releasing Dynamic Dashboard
+        // TODO Remove those views from the layout when releasing Dynamic Dashboard
         customRangeLabel.isVisible = false
         statsDateValue.isVisible = false
         binding.statsTabLayout.isVisible = false
@@ -147,6 +146,7 @@ class DashboardStatsView @JvmOverloads constructor(
         binding.viewAnalyticsButton.isVisible = false
     }
 
+    @Suppress("LongParameterList")
     fun initView(
         dateUtils: DateUtils,
         currencyFormatter: CurrencyFormatter,
@@ -653,18 +653,6 @@ class DashboardStatsView @JvmOverloads constructor(
             Entry((index + 1).toFloat(), value.toFloat())
         }
         return LineDataSet(entries, "")
-    }
-
-    @StringRes
-    private fun getStringForRangeType(rangeType: SelectionType): Int {
-        return when (rangeType) {
-            SelectionType.TODAY -> R.string.today
-            SelectionType.WEEK_TO_DATE -> R.string.this_week
-            SelectionType.MONTH_TO_DATE -> R.string.this_month
-            SelectionType.YEAR_TO_DATE -> R.string.this_year
-            SelectionType.CUSTOM -> R.string.orderfilters_date_range_filter_custom_range
-            else -> error("Unsupported range value used in my store tab: $rangeType")
-        }
     }
 
     private fun getStringForGranularity(granularity: StatsGranularity): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
@@ -635,7 +635,7 @@ class DashboardStatsView @JvmOverloads constructor(
         WooAnimUtils.fadeOut(view, duration, View.INVISIBLE)
 
         // fade in the new value after fade out finishes
-        val delay = duration.toMillis(context) + 100
+        val delay = duration.toMillis(context) + 200
         fadeHandler.postDelayed(
             {
                 WooAnimUtils.fadeIn(view, duration)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
@@ -148,18 +148,21 @@ class DashboardStatsView @JvmOverloads constructor(
     private lateinit var chartUserInteractionsJob: Job
 
     private var isChartValueSelected = false
+    private lateinit var onDateSelected: (String?) -> Unit
 
     fun initView(
         dateUtils: DateUtils,
         currencyFormatter: CurrencyFormatter,
         usageTracksEventEmitter: DashboardStatsUsageTracksEventEmitter,
         lifecycleScope: LifecycleCoroutineScope,
-        onViewAnalyticsClick: () -> Unit
+        onViewAnalyticsClick: () -> Unit,
+        onDateSelected: (String?) -> Unit
     ) {
         this.dateUtils = dateUtils
         this.currencyFormatter = currencyFormatter
         this.usageTracksEventEmitter = usageTracksEventEmitter
         this.coroutineScope = lifecycleScope
+        this.onDateSelected = onDateSelected
 
         initChart()
 
@@ -206,6 +209,7 @@ class DashboardStatsView @JvmOverloads constructor(
     }
 
     fun loadDashboardStats(selectedTimeRange: StatsTimeRangeSelection) {
+        onDateSelected(null)
         this.statsTimeRangeSelection = selectedTimeRange
         // Track range change
         AnalyticsTracker.track(
@@ -319,6 +323,7 @@ class DashboardStatsView @JvmOverloads constructor(
      * Called when nothing has been selected or an "un-select" has been made.
      */
     override fun onNothingSelected() {
+        onDateSelected(null)
         // update the total values of the chart here
         binding.chart.highlightValue(null)
         updateChartView()
@@ -435,6 +440,7 @@ class DashboardStatsView @JvmOverloads constructor(
 
         // display the order count for this entry
         val date = getDateFromIndex(entry.x.toInt())
+        onDateSelected(date)
         val orderCount = chartOrderStats[date]?.toInt() ?: 0
         ordersValue.text = orderCount.toString()
         updateVisitorsValue(date)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
@@ -114,9 +114,13 @@ class DashboardStatsViewModel @AssistedInject constructor(
         appPrefsWrapper.setActiveStatsTab(selectionType.name)
 
         if (selectionType == SelectionType.CUSTOM) {
-            analyticsTrackerWrapper.track(
-                AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_TAB_SELECTED
-            )
+            if (dateRangeState.value?.customRange == null) {
+                onAddCustomRangeClicked()
+            } else {
+                analyticsTrackerWrapper.track(
+                    AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_TAB_SELECTED
+                )
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
@@ -67,9 +67,8 @@ class DashboardStatsViewModel @AssistedInject constructor(
     private val wooCommerceStore: WooCommerceStore,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val usageTracksEventEmitter: DashboardStatsUsageTracksEventEmitter,
+    private val dateRangeFormatter: DashboardStatsRangeFormatter
 ) : ScopedViewModel(savedStateHandle) {
-    private val dateRangeFormatter = DashboardStatsRangeFormatter()
-
     private var _hasOrders = MutableLiveData<OrderState>()
 
     private val selectedDateRange = getSelectedDateRange()
@@ -84,7 +83,7 @@ class DashboardStatsViewModel @AssistedInject constructor(
             rangeSelection = selectedRange,
             customRange = custom,
             rangeFormatted = dateRangeFormatter.formatRangeDate(selectedRange),
-            selectedDateFormatted = selectedDate
+            selectedDateFormatted = selectedDate?.let { dateRangeFormatter.formatSelectedDate(it, selectedRange) }
         )
     }.asLiveData()
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -409,7 +409,7 @@
     <string name="my_store_edit_screen_widget_onboarding_list">Store Onboarding</string>
 
     <string name="my_store_widget_onboarding_title">Onboarding</string>
-    <string name="my_store_widget_stats_title">Statistics</string>
+    <string name="my_store_widget_stats_title">Performance</string>
     <string name="my_store_widget_top_products_title">Top products</string>
     <string name="my_store_widget_blaze_title">Blaze campaigns</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModelTest.kt
@@ -96,6 +96,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
             observeLastUpdate = observeLastUpdate,
             timezoneProvider = timezoneProvider,
             wooCommerceStore = wooCommerceStore,
+            dateRangeFormatter = DashboardStatsRangeFormatter(dateUtils)
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11316  Closes: #11317
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR implements the following changes:
- It updates the Stats card to follow the new design.
- Replace the tabs with a drop-down menu.

The hide button is not implemented yet, I'll add it on a separate PR when we have a final decision following: p1713495594539859-slack-C03L1NF1EA3
And the chart doesn't span to the full width as it's in Figma, I tried playing with the library a bit, and this proved harder than anticipated, so I left it to a separate PR, and it's a nice to have IMO, so we should prioritize the other tasks anyway,

### Testing instructions
1. Make sure the feature flag `DYNAMIC_DASHBOARD` is enabled
2. Open the app, and confirm the `Performance` card is enabled.
3. Confirm the card follows the design.
4. Change date ranges, and confirm it behaves as expected.

### Images/gif
<img width=360 src="https://github.com/woocommerce/woocommerce-android/assets/1657201/ef6b3571-3127-4e51-9fc2-a94a6b21cba7" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->