### PR TITLE
Update image minimum size restrictions from 600x600 to 400x400

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 18.4
 -----
+- [internal] Blaze: Change campaign image minimum expected dimensions. [https://github.com/woocommerce/woocommerce-android/pull/11368]
 
 
 18.3

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -45,7 +45,7 @@ class BlazeRepository @Inject constructor(
         const val CAMPAIGN_MAXIMUM_DAILY_SPEND = 50f // USD
         const val CAMPAIGN_MAX_DURATION = 28 // Days
         const val DEFAULT_CAMPAIGN_BUDGET_MODE = "total" // "total" or "daily" for campaigns that run without end date
-        const val BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS = 600 // Must be at least 600 x 600 pixels
+        const val BLAZE_IMAGE_MINIMUM_SIZE_IN_PIXELS = 400 // Must be at least 400 x 400 pixels
     }
 
     fun observeLanguages() = blazeCampaignsStore.observeBlazeTargetingLanguages()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/ad/BlazeCampaignCreationEditAdViewModel.kt
@@ -121,7 +121,7 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
                     it.copy(adImage = BlazeRepository.BlazeCampaignImage.LocalImage(uri))
                 }
             } else {
-                showInvalidIMageDialog()
+                showInvalidImageSizeDialog()
             }
         }
     }
@@ -138,16 +138,16 @@ class BlazeCampaignCreationEditAdViewModel @Inject constructor(
                     )
                 }
             } else {
-                showInvalidIMageDialog()
+                showInvalidImageSizeDialog()
             }
         }
     }
 
-    private fun showInvalidIMageDialog() {
+    private fun showInvalidImageSizeDialog() {
         triggerEvent(
             Event.ShowDialog(
                 titleId = R.string.blaze_campaign_edit_ad_invalid_image_title,
-                messageId = R.string.blaze_campaign_edit_ad_invalid_image_size_description,
+                messageId = R.string.blaze_campaign_edit_ad_invalid_image_description,
                 positiveButtonId = R.string.dialog_ok,
                 positiveBtnAction = { dialog, _ ->
                     dialog.dismiss()

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3834,7 +3834,7 @@
     <string name="blaze_campaign_edit_ad_characters_remaining">%d characters remaining</string>
     <string name="blaze_campaign_edit_ad_suggested_by_ai">Suggested by AI</string>
     <string name="blaze_campaign_edit_ad_invalid_image_title">Invalid image</string>
-    <string name="blaze_campaign_edit_ad_invalid_image_size_description">Please select and image with a minimum dimension of 600x600 pixels</string>
+    <string name="blaze_campaign_edit_ad_invalid_image_description">Please select an image with a minimum size of 400x400 pixels</string>
 
     <!--
     Blaze campaign payment


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11367 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Reduce the minimum ad image size restriction from 600x600 to 400x400px

The API will now handle upscaling the image when needed if the uploaded image is smaller than 600x600px but larger than 400x400px.

The goal is to unblock users when creating Blaze ads, that have smaller product images. Full context here: p1713450773231259/1712831081.385859-slack-C069RG07W6S

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Start Blaze campaign creation flow
2. Click on `Edit ad` button
3. Attempt adding an image under 400x400px and check dialog is displayed showing invalid image message
4. Attempt to add an image over 400x400px and check is added correctly

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/e8f695d9-98e8-4099-9d76-03a5425e1be9

