### PR TITLE
Fix crash in MyStoreFragment due to accessing the view binding when it's null

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -495,7 +495,6 @@ class MyStoreFragment :
         binding.myStoreTopPerformers.showSkeleton(true)
     }
 
-    @Suppress("ForbiddenComment")
     private fun prepareJetpackBenefitsBanner() {
         appPrefsWrapper.setJetpackInstallationIsFromBanner(false)
         binding.jetpackBenefitsBanner.root.isVisible = false
@@ -512,7 +511,7 @@ class MyStoreFragment :
             // Due to this issue https://issuetracker.google.com/issues/181325977, we need to make sure
             // we are using `withCreated` here, since if this view doesn't reach the created state,
             // the scope will not get cancelled.
-            // TODO: revisit this once https://issuetracker.google.com/issues/127528777 is implemented
+            // TODO revisit this once https://issuetracker.google.com/issues/127528777 is implemented
             // (no update as of Oct 2023)
             val appBarLayout = requireActivity().findViewById<View>(R.id.app_bar_layout) as? AppBarLayout
             viewLifecycleOwner.withCreated {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
@@ -515,7 +515,7 @@ class MyStoreFragment :
             // TODO: revisit this once https://issuetracker.google.com/issues/127528777 is implemented
             // (no update as of Oct 2023)
             val appBarLayout = requireActivity().findViewById<View>(R.id.app_bar_layout) as? AppBarLayout
-            withCreated {
+            viewLifecycleOwner.withCreated {
                 appBarLayout?.verticalOffsetChanges()
                     ?.onEach { verticalOffset ->
                         binding.jetpackBenefitsBanner.root.translationY =


### PR DESCRIPTION
The fix is to use the correct lifecycleOwner when calling withCreated to wait for the view to be created.

<!-- Remember about a good descriptive title. -->

Closes: #11358 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
#### How to reproduce
Apply this patch on `trunk` then launch the app.
<details>
<summary> Patch </summary>

```patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt	(revision 1ce30c28be7ad26089c603314eae7da208295a15)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/mystore/MyStoreFragment.kt	(date 1713952494723)
@@ -172,6 +172,8 @@
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        findNavController().navigate(MyStoreFragmentDirections.actionMyStoreToOnboardingFragment())
+
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         blazeCampaignCreationDispatcher.attachFragment(this, BlazeFlowSource.MY_STORE_SECTION)
 
```

</details>

##### Explanation
This crash started happening after we replaced the usage of `launchWhenCreated` with the `withCreated` function in https://github.com/woocommerce/woocommerce-android/pull/9998, the issue here is that we added `withCreated` with the implicit receiver `this` that points to the Fragment itself, and not the view's LifecycleOwner, which meant that the code was executed before the View's `LifecycleOwner` gets to the `CREATED` state.

Having the code executed before reaching the `CREATED` state brings us back to the original issue that was fixed with `launchWhenCreated` which that the LifecycleScope won't get canceled (check the comment on the code and the Google [issue](https://issuetracker.google.com/issues/181325977)).

The fix is to explicitly set the `withCreated`'s receiver to the view's LifecycleOwner.


### Testing instructions
1. Check out this branch.
2. Apply the same patch from above.
3. Launch the app and confirm it doesn't crash.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
