### PR TITLE
[Dynamic Dashboard] Replace the edit widgets icon

### DIFF
--- a/WooCommerce/src/main/res/menu/menu_dashboard_fragment.xml
+++ b/WooCommerce/src/main/res/menu/menu_dashboard_fragment.xml
@@ -3,9 +3,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/menu_edit_screen_widgets"
-        android:icon="@drawable/ic_configuration"
+        android:icon="@drawable/ic_edit_pencil"
         android:title="@string/my_store_edit_screen_widgets"
         android:visible="true"
+        app:iconTint="@color/color_primary"
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/menu_share_store"


### PR DESCRIPTION
Implements #11315.

<img src="https://github.com/woocommerce/woocommerce-android/assets/1522856/34ff00bf-466c-40c9-ae4d-d84848b847a2" width=300 />

**To test:**
1. Enable the feature flag
2. Verify the new edit widgets menu icon is the edit pencil