### PR TITLE
[Dynamic dashboard] Update Blaze eligibility check

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.blaze
 
-import com.woocommerce.android.extensions.isSitePublic
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.util.RemoteFeatureFlag.WOO_BLAZE
@@ -12,6 +11,5 @@ class IsBlazeEnabled @Inject constructor(
 ) {
     suspend operator fun invoke(): Boolean = selectedSite.getIfExists()?.isAdmin ?: false &&
         selectedSite.getIfExists()?.canBlaze ?: false &&
-        selectedSite.getIfExists()?.isSitePublic ?: false &&
         isRemoteFeatureFlagEnabled(WOO_BLAZE)
 }


### PR DESCRIPTION
Fixes #11377. The PR removes the check for site status (`blog_public`) when determining Blaze eligibility, which was a redundant constraint.

**To test:**
The functionality hasn't changed, the Blaze card is still unavailable when a site is not public. You can try and verify this.