### PR TITLE
Image upload error fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -22,6 +22,8 @@ object AppUrls {
     const val URL_LEARN_MORE_REVIEWS = "https://woocommerce.com/document/ratings-and-reviews/"
     const val URL_LEARN_MORE_ORDERS = "https://woocommerce.com/blog/"
 
+    const val WORDPRESS_PRIVACY_SETTINGS = "https://wordpress.com/support/settings/privacy-settings/"
+
     const val JETPACK_INSTRUCTIONS =
         "https://woocommerce.com/document/jetpack-setup-instructions-for-the-woocommerce-mobile-app//"
     const val JETPACK_TROUBLESHOOTING =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
@@ -4,6 +4,7 @@ import android.text.TextUtils
 import com.woocommerce.android.ui.plans.domain.FREE_TRIAL_PLAN_ID
 import com.woocommerce.android.util.WooLog
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.PUBLIC
 import org.wordpress.android.fluxc.utils.SiteUtils.getNormalizedTimezone
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
@@ -66,6 +67,9 @@ val SiteModel?.isFreeTrial: Boolean
 
 val SiteModel?.isSitePublic: Boolean
     get() = this?.publishedStatus == PUBLIC.value()
+
+val SiteModel?.isSitePrivate: Boolean
+    get() = this?.publishedStatus == SiteVisibility.PRIVATE.value()
 
 val SiteModel.isEligibleForAI: Boolean
     get() = isWPComAtomic || planActiveFeatures.orEmpty().contains("ai-assistant")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.getList
 import com.woocommerce.android.extensions.isEligibleForAI
 import com.woocommerce.android.extensions.isEmpty
+import com.woocommerce.android.extensions.isSitePrivate
 import com.woocommerce.android.extensions.isSitePublic
 import com.woocommerce.android.extensions.orNullIfEmpty
 import com.woocommerce.android.extensions.removeItem
@@ -170,7 +171,7 @@ class ProductDetailViewModel @Inject constructor(
     // view state for the product detail screen
     val productDetailViewStateData = LiveDataDelegate(
         savedState = savedState,
-        initialValue = ProductDetailViewState(areImagesAvailable = selectedSite.get().isSitePublic)
+        initialValue = ProductDetailViewState(areImagesAvailable = !selectedSite.get().isSitePrivate)
     ) { old, new ->
         if (old?.productDraft != new.productDraft || old?.draftPassword != new.draftPassword) {
             new.productDraft?.let {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -168,7 +168,10 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     // view state for the product detail screen
-    val productDetailViewStateData = LiveDataDelegate(savedState, ProductDetailViewState()) { old, new ->
+    val productDetailViewStateData = LiveDataDelegate(
+        savedState = savedState,
+        initialValue = ProductDetailViewState(areImagesAvailable = selectedSite.get().isSitePublic)
+    ) { old, new ->
         if (old?.productDraft != new.productDraft || old?.draftPassword != new.draftPassword) {
             new.productDraft?.let {
                 updateCards(it)
@@ -2578,6 +2581,7 @@ class ProductDetailViewModel @Inject constructor(
         val isConfirmingTrash: Boolean = false,
         val isUploadingDownloadableFile: Boolean? = null,
         val isVariationListEmpty: Boolean? = null,
+        val areImagesAvailable: Boolean
     ) : Parcelable {
         val isPasswordChanged: Boolean
             get() = storedPassword != draftPassword

--- a/WooCommerce/src/main/res/layout/fragment_product_detail.xml
+++ b/WooCommerce/src/main/res/layout/fragment_product_detail.xml
@@ -81,6 +81,28 @@
 
                     </FrameLayout>
 
+                    <FrameLayout
+                        android:id="@+id/imagesUnavailableNotice"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@color/warning_banner_background_color">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            style="@style/Woo.TextView.Subtitle1.OnPrimary.Icon"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_margin="0dp"
+                            android:layout_gravity="center"
+                            android:padding="@dimen/major_100"
+                            android:text="@string/images_unavailable_notice"
+                            android:textColor="@color/color_on_surface"
+                            android:drawablePadding="@dimen/major_100"
+                            app:drawableTint="@color/color_on_surface"
+                            app:drawableStartCompat="@drawable/ic_info_outline_20dp" />
+
+                    </FrameLayout>
+
+
                     <View
                         style="@style/Woo.Divider"
                         android:layout_gravity="bottom" />

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -181,6 +181,7 @@
     <string name="date_timeframe_older_month">Older than a month</string>
     <string name="date_at_time">%1$s at %2$s</string>
     <string name="date_compared_to">Compared to</string>
+    <string name="images_unavailable_notice">The images are unavailable because your site is marked Private. You change this by switching to Coming Soon mode. <a href="">Tap to learn more.</a></string>
     <!--
         Error Strings
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -181,7 +181,7 @@
     <string name="date_timeframe_older_month">Older than a month</string>
     <string name="date_at_time">%1$s at %2$s</string>
     <string name="date_compared_to">Compared to</string>
-    <string name="images_unavailable_notice">The images are unavailable because your site is marked Private. You can change this by switching to Coming Soon mode. <a href="">Tap to learn more.</a></string>
+    <string name="images_unavailable_notice">The images are unavailable because your site is marked Private. You can change this by switching to Coming Soon mode.\n<a href="">Tap to learn more.</a></string>
     <!--
         Error Strings
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -181,7 +181,7 @@
     <string name="date_timeframe_older_month">Older than a month</string>
     <string name="date_at_time">%1$s at %2$s</string>
     <string name="date_compared_to">Compared to</string>
-    <string name="images_unavailable_notice">The images are unavailable because your site is marked Private. You change this by switching to Coming Soon mode. <a href="">Tap to learn more.</a></string>
+    <string name="images_unavailable_notice">The images are unavailable because your site is marked Private. You can change this by switching to Coming Soon mode. <a href="">Tap to learn more.</a></string>
     <!--
         Error Strings
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -1083,7 +1083,8 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         selectedSite = mock {
             on { get() } doReturn SiteModel().apply { publishedStatus = SiteVisibility.COMING_SOON.value() }
         }
-        savedState = ProductDetailFragmentArgs(ProductDetailFragment.Mode.ShowProduct(PRODUCT_REMOTE_ID)).toSavedStateHandle()
+        savedState = ProductDetailFragmentArgs(ProductDetailFragment.Mode.ShowProduct(PRODUCT_REMOTE_ID))
+            .toSavedStateHandle()
         viewModel = spy(
             ProductDetailViewModel(
                 savedState = savedState,
@@ -1128,7 +1129,8 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         selectedSite = mock {
             on { get() } doReturn SiteModel().apply { publishedStatus = SiteVisibility.COMING_SOON.value() }
         }
-        savedState = ProductDetailFragmentArgs(ProductDetailFragment.Mode.ShowProduct(PRODUCT_REMOTE_ID)).toSavedStateHandle()
+        savedState = ProductDetailFragmentArgs(ProductDetailFragment.Mode.ShowProduct(PRODUCT_REMOTE_ID))
+            .toSavedStateHandle()
         viewModel = spy(
             ProductDetailViewModel(
                 savedState = savedState,


### PR DESCRIPTION
Fixes #10329. The PR adds a notice when a site is in Private mode that the images are not accessible. Users were reporting that they can't upload images but it's not due to a bug in the app.

| Light | Dark |
|--------|--------|
| ![image](https://github.com/woocommerce/woocommerce-android/assets/1522856/8422840c-e5e5-40e9-bbd1-9f7716038b27) | ![image](https://github.com/woocommerce/woocommerce-android/assets/1522856/e5d83731-5f63-4314-b0cb-7c94a45e6d58) | 

**To test:**
1. Log in to a site that is `Public`
2. Go to Products -> Tap on some product
3. Verify the images are available (either existing images or button to add one)
4. In `wp-admin` set the site to `Private` mode in the Settings
5. In the app, switch to a different site and switch back (or re-login)
6. Go to Products -> Tap on some product
7. Verify a notice is displayed instead of an image gallery
8. Tap on the notice
9. Verify a privacy settings website is opened
10. Go back
11. In `wp-admin` set the site to `Coming soon` mode in the Settings
12. In the app, switch to a different site and switch back (or re-login)
13. Go to Products -> Tap on some product
14. Verify the images are available (either existing images or button to add one)