### PR TITLE
[Watch App] Introduce Site handling and changes event

### DIFF
--- a/WooCommerce-Wear/build.gradle
+++ b/WooCommerce-Wear/build.gradle
@@ -132,6 +132,7 @@ dependencies {
     implementation "androidx.preference:preference-ktx:1.2.1"
     implementation "androidx.datastore:datastore-preferences:1.1.0"
     implementation "androidx.datastore:datastore:1.1.0"
+    implementation 'com.google.code.gson:gson:2.10.1'
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"

--- a/WooCommerce-Wear/build.gradle
+++ b/WooCommerce-Wear/build.gradle
@@ -6,6 +6,25 @@ plugins {
     id 'com.google.devtools.ksp'
 }
 
+repositories {
+    maven {
+        url 'https://a8c-libs.s3.amazonaws.com/android'
+        content {
+            includeGroup "org.wordpress"
+            includeGroup "org.wordpress.fluxc"
+            includeGroup "org.wordpress.fluxc.plugins"
+            includeGroup "org.wordpress.wellsql"
+        }
+    }
+    mavenCentral()
+    maven {
+        url "https://a8c-libs.s3.amazonaws.com/android/jcenter-mirror"
+        content {
+            includeVersion "com.android.volley", "volley", "1.1.1"
+        }
+    }
+}
+
 def versionProperties = loadPropertiesFromFile(file("${rootDir}/version.properties"))
 
 android {
@@ -72,6 +91,14 @@ android {
 dependencies {
     // Project
     implementation project(":libs:commons")
+    implementation("${gradle.ext.fluxCBinaryPath}:$fluxCVersion") {
+        exclude group: "com.android.support"
+        exclude group: "org.wordpress", module: "utils"
+    }
+    implementation("${gradle.ext.fluxCWooCommercePluginBinaryPath}:$fluxCVersion") {
+        exclude group: "com.android.support"
+        exclude group: "org.wordpress", module: "utils"
+    }
 
     // WearOS
     implementation "com.google.android.gms:play-services-wearable:$googlePlayWearableVersion"

--- a/WooCommerce-Wear/src/main/AndroidManifest.xml
+++ b/WooCommerce-Wear/src/main/AndroidManifest.xml
@@ -32,16 +32,6 @@
             android:name=".phone.PhoneConnectionService"
             android:exported="true">
             <intent-filter>
-                <!-- listeners receive events that match the action and data filters -->
-                <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
-                <data
-                    android:host="*"
-                    android:pathPrefix="/token-data"
-                    android:scheme="wear" />
-            </intent-filter>
-
-            <intent-filter>
-                <!-- listeners receive events that match the action and data filters -->
                 <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
                 <data
                     android:host="*"

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/phone/PhoneConnectionRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/phone/PhoneConnectionRepository.kt
@@ -23,12 +23,12 @@ class PhoneConnectionRepository @Inject constructor(
 ) {
     fun handleReceivedData(dataItem: DataItem) {
         when (dataItem.uri.path) {
-            DataPath.TOKEN_DATA.value -> handleAuthenticationData(dataItem)
+            DataPath.SITE_DATA.value -> handleAuthenticationData(dataItem)
             else -> Log.d(TAG, "Unknown path data received")
         }
     }
 
-    suspend fun sendMessageToAllNodes(
+    suspend fun sendMessage(
         path: MessagePath,
         data: ByteArray = byteArrayOf()
     ): Result<Unit> = fetchReachableNodes()

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/phone/PhoneConnectionService.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/phone/PhoneConnectionService.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.phone
 import android.util.Log
 import com.google.android.gms.wearable.DataEvent
 import com.google.android.gms.wearable.DataEventBuffer
-import com.google.android.gms.wearable.MessageEvent
 import com.google.android.gms.wearable.WearableListenerService
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -11,18 +10,13 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class PhoneConnectionService : WearableListenerService() {
 
-    @Inject lateinit var connRepository: PhoneConnectionRepository
+    @Inject lateinit var phoneConnectionRepository: PhoneConnectionRepository
 
     override fun onDataChanged(dataEvents: DataEventBuffer) {
         super.onDataChanged(dataEvents)
         Log.d("DATA RECEIVED", "onDataChanged")
         dataEvents
             .filter { it.type == DataEvent.TYPE_CHANGED }
-            .forEach { connRepository.handleReceivedData(it.dataItem) }
-    }
-
-    override fun onMessageReceived(message: MessageEvent) {
-        super.onMessageReceived(message)
-        Log.d("MESSAGE RECEIVED", "onMessageReceived")
+            .forEach { phoneConnectionRepository.handleReceivedData(it.dataItem) }
     }
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/Navigation.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/Navigation.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.ui.NavRoutes.MY_STORE
 import com.woocommerce.android.ui.login.LoginScreen
 import com.woocommerce.android.ui.login.LoginViewModel
 import com.woocommerce.android.ui.mystore.MyStoreScreen
+import com.woocommerce.android.ui.mystore.MyStoreViewModel
 
 @Composable
 fun WooWearNavHost(
@@ -28,7 +29,10 @@ fun WooWearNavHost(
             LoginScreen(viewModel)
         }
         composable(MY_STORE.route) {
-            MyStoreScreen()
+            val viewModel: MyStoreViewModel = hiltViewModel<MyStoreViewModel, MyStoreViewModel.Factory> {
+                it.create(navController)
+            }
+            MyStoreScreen(viewModel)
         }
     }
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
@@ -13,6 +13,7 @@ import com.woocommerce.commons.wear.DataParameters.TOKEN
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import org.wordpress.android.fluxc.model.SiteModel
 
 class LoginRepository @Inject constructor(
@@ -25,13 +26,11 @@ class LoginRepository @Inject constructor(
             .map { it[stringPreferencesKey(CURRENT_SITE_KEY)] }
             .distinctUntilChanged()
             .map { it?.let { gson.fromJson(it, SiteModel::class.java) } }
+            .filterNotNull()
 
     val isUserLoggedIn
         get() = loginDataStore.data
-            .map { prefs ->
-                searchToken(prefs)?.isNotEmpty()
-                    ?: false
-            }
+            .map { searchToken(it)?.isNotEmpty() ?: false }
 
     suspend fun receiveStoreData(data: DataMap) {
         val siteJSON = data.getString(SITE_JSON.value)

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
@@ -8,7 +8,7 @@ import com.google.android.gms.wearable.DataMap
 import com.google.gson.Gson
 import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType
-import com.woocommerce.commons.wear.DataParameters.SITE_DATA
+import com.woocommerce.commons.wear.DataParameters.SITE_JSON
 import com.woocommerce.commons.wear.DataParameters.TOKEN
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -23,7 +23,7 @@ class LoginRepository @Inject constructor(
         .map { it[stringPreferencesKey(STORE_CONFIG_KEY)].isNullOrEmpty().not() }
 
     suspend fun receiveStoreData(data: DataMap) {
-        val site = data.getString(SITE_DATA.value)
+        val site = data.getString(SITE_JSON.value)
             ?.let { gson.fromJson(it, SiteModel::class.java) }
 
         data.getString(TOKEN.value)?.let { token ->

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
@@ -10,11 +10,11 @@ import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType
 import com.woocommerce.commons.wear.DataParameters.SITE_JSON
 import com.woocommerce.commons.wear.DataParameters.TOKEN
-import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
 import org.wordpress.android.fluxc.model.SiteModel
+import javax.inject.Inject
 
 class LoginRepository @Inject constructor(
     @DataStoreQualifier(DataStoreType.LOGIN) private val loginDataStore: DataStore<Preferences>,

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
@@ -21,15 +21,18 @@ class LoginRepository @Inject constructor(
 ) {
     private val gson by lazy { Gson() }
 
-    val currentSite
+    private val storedSiteData
         get() = loginDataStore.data
             .map { it[stringPreferencesKey(CURRENT_SITE_KEY)] }
-            .distinctUntilChanged()
             .map { it?.let { gson.fromJson(it, SiteModel::class.java) } }
+
+    val currentSite
+        get() = storedSiteData
+            .distinctUntilChanged()
             .filterNotNull()
 
     val isUserLoggedIn
-        get() = currentSite.map { it.siteId > 0 }
+        get() = storedSiteData.map { it != null && it.siteId > 0 }
 
     suspend fun receiveStoreData(data: DataMap) {
         val siteJSON = data.getString(SITE_JSON.value)

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
@@ -5,19 +5,28 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.google.android.gms.wearable.DataMap
+import com.google.gson.Gson
 import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType
+import com.woocommerce.commons.wear.DataParameters.SITE_DATA
+import com.woocommerce.commons.wear.DataParameters.TOKEN
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
+import org.wordpress.android.fluxc.model.SiteModel
 
 class LoginRepository @Inject constructor(
     @DataStoreQualifier(DataStoreType.LOGIN) private val loginDataStore: DataStore<Preferences>,
 ) {
+    private val gson by lazy { Gson() }
+
     fun isUserLoggedIn() = loginDataStore.data
         .map { it[stringPreferencesKey(STORE_CONFIG_KEY)].isNullOrEmpty().not() }
 
     suspend fun receiveStoreData(data: DataMap) {
-        data.getString("token")?.let { token ->
+        val site = data.getString(SITE_DATA.value)
+            ?.let { gson.fromJson(it, SiteModel::class.java) }
+
+        data.getString(TOKEN.value)?.let { token ->
             loginDataStore.edit { prefs ->
                 prefs[stringPreferencesKey(STORE_CONFIG_KEY)] = token
             }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
@@ -12,7 +12,7 @@ import com.woocommerce.commons.wear.DataParameters.SITE_JSON
 import com.woocommerce.commons.wear.DataParameters.TOKEN
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import org.wordpress.android.fluxc.model.SiteModel
 
 class LoginRepository @Inject constructor(
@@ -23,15 +23,15 @@ class LoginRepository @Inject constructor(
     val currentSite
         get() = loginDataStore.data
             .map { it[stringPreferencesKey(CURRENT_SITE_KEY)] }
+            .distinctUntilChanged()
             .map { it?.let { gson.fromJson(it, SiteModel::class.java) } }
 
     val isUserLoggedIn
-        get() = combine(loginDataStore.data, currentSite) { prefs, site ->
-            site?.takeIf { it.siteId > 0 }
-                ?.let { prefs[stringPreferencesKey(generateTokenKey(it.siteId))] }
-                ?.isNotEmpty()
-                ?: false
-        }
+        get() = loginDataStore.data
+            .map { prefs ->
+                searchToken(prefs)?.isNotEmpty()
+                    ?: false
+            }
 
     suspend fun receiveStoreData(data: DataMap) {
         val siteJSON = data.getString(SITE_JSON.value)
@@ -46,6 +46,12 @@ class LoginRepository @Inject constructor(
             }
         }
     }
+
+    private fun searchToken(prefs: Preferences) =
+        prefs[stringPreferencesKey(CURRENT_SITE_KEY)]
+            ?.let { gson.fromJson(it, SiteModel::class.java) }
+            ?.takeIf { it.siteId > 0 }
+            ?.let { prefs[stringPreferencesKey(generateTokenKey(it.siteId))] }
 
     private fun generateTokenKey(siteId: Long) = "$TOKEN_KEY:$siteId"
 

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
@@ -12,6 +12,7 @@ import com.woocommerce.commons.wear.DataParameters.SITE_JSON
 import com.woocommerce.commons.wear.DataParameters.TOKEN
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
+import kotlinx.coroutines.flow.combine
 import org.wordpress.android.fluxc.model.SiteModel
 
 class LoginRepository @Inject constructor(
@@ -19,8 +20,18 @@ class LoginRepository @Inject constructor(
 ) {
     private val gson by lazy { Gson() }
 
-    fun isUserLoggedIn() = loginDataStore.data
-        .map { it[stringPreferencesKey(CURRENT_SITE_KEY)] }
+    val currentSite
+        get() = loginDataStore.data
+            .map { it[stringPreferencesKey(CURRENT_SITE_KEY)] }
+            .map { it?.let { gson.fromJson(it, SiteModel::class.java) } }
+
+    val isUserLoggedIn
+        get() = combine(loginDataStore.data, currentSite) { prefs, site ->
+            site?.takeIf { it.siteId > 0 }
+                ?.let { prefs[stringPreferencesKey(generateTokenKey(it.siteId))] }
+                ?.isNotEmpty()
+                ?: false
+        }
 
     suspend fun receiveStoreData(data: DataMap) {
         val siteJSON = data.getString(SITE_JSON.value)

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginRepository.kt
@@ -29,8 +29,7 @@ class LoginRepository @Inject constructor(
             .filterNotNull()
 
     val isUserLoggedIn
-        get() = loginDataStore.data
-            .map { searchToken(it)?.isNotEmpty() ?: false }
+        get() = currentSite.map { it.siteId > 0 }
 
     suspend fun receiveStoreData(data: DataMap) {
         val siteJSON = data.getString(SITE_JSON.value)
@@ -45,12 +44,6 @@ class LoginRepository @Inject constructor(
             }
         }
     }
-
-    private fun searchToken(prefs: Preferences) =
-        prefs[stringPreferencesKey(CURRENT_SITE_KEY)]
-            ?.let { gson.fromJson(it, SiteModel::class.java) }
-            ?.takeIf { it.siteId > 0 }
-            ?.let { prefs[stringPreferencesKey(generateTokenKey(it.siteId))] }
 
     private fun generateTokenKey(siteId: Long) = "$TOKEN_KEY:$siteId"
 

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
@@ -8,7 +8,7 @@ import com.woocommerce.android.phone.PhoneConnectionRepository
 import com.woocommerce.android.ui.NavRoutes.MY_STORE
 import com.woocommerce.commons.viewmodel.ScopedViewModel
 import com.woocommerce.commons.viewmodel.getStateFlow
-import com.woocommerce.commons.wear.MessagePath.REQUEST_TOKEN
+import com.woocommerce.commons.wear.MessagePath.REQUEST_SITE
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -20,7 +20,7 @@ import kotlinx.parcelize.Parcelize
 @HiltViewModel(assistedFactory = LoginViewModel.Factory::class)
 class LoginViewModel @AssistedInject constructor(
     private val loginRepository: LoginRepository,
-    private val connRepository: PhoneConnectionRepository,
+    private val phoneConnectionRepository: PhoneConnectionRepository,
     @Assisted private val navController: NavHostController,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
@@ -47,7 +47,7 @@ class LoginViewModel @AssistedInject constructor(
     fun onLoginButtonClicked() {
         _viewState.update { it.copy(isLoading = true) }
         launch {
-            connRepository.sendMessageToAllNodes(REQUEST_TOKEN)
+            phoneConnectionRepository.sendMessage(REQUEST_SITE)
             _viewState.update { it.copy(isLoading = false) }
         }
     }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
@@ -35,7 +35,7 @@ class LoginViewModel @AssistedInject constructor(
     }
 
     private suspend fun observeLoginChanges() {
-        loginRepository.isUserLoggedIn().collect { isLoggedIn ->
+        loginRepository.isUserLoggedIn.collect { isLoggedIn ->
             if (isLoggedIn) {
                 navController.navigate(MY_STORE.route)
             } else {

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/mystore/MyStoreScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/mystore/MyStoreScreen.kt
@@ -21,7 +21,7 @@ fun MyStoreScreen(viewModel: MyStoreViewModel) {
     val viewState by viewModel.viewState.observeAsState()
     MyStoreScreen(
         currentSiteId = viewState?.currentSiteId.orEmpty(),
-        currentSiteName =  viewState?.currentSiteName.orEmpty()
+        currentSiteName = viewState?.currentSiteName.orEmpty()
     )
 }
 

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/mystore/MyStoreScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/mystore/MyStoreScreen.kt
@@ -1,50 +1,57 @@
 package com.woocommerce.android.ui.mystore
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.wear.compose.material.MaterialTheme
+import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.tooling.preview.devices.WearDevices
-import com.woocommerce.android.R
 import com.woocommerce.android.presentation.theme.WooTheme
 
 @Composable
-fun MyStoreScreen() {
-    WooTheme {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colors.background),
-            contentAlignment = Alignment.Center
-        ) {
-            TimeText()
-            Greeting(greetingName = "Woo")
-        }
-    }
+fun MyStoreScreen(viewModel: MyStoreViewModel) {
+    val viewState by viewModel.viewState.observeAsState()
+    MyStoreScreen(
+        currentSiteId = viewState?.currentSiteId.orEmpty(),
+        currentSiteName =  viewState?.currentSiteName.orEmpty()
+    )
 }
 
 @Composable
-fun Greeting(greetingName: String) {
-    Text(
-        modifier = Modifier.fillMaxWidth(),
-        textAlign = TextAlign.Center,
-        color = MaterialTheme.colors.primary,
-        text = stringResource(R.string.hello_world, greetingName)
-    )
+fun MyStoreScreen(
+    currentSiteId: String?,
+    currentSiteName: String?
+) {
+    WooTheme {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            TimeText()
+            Column(
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Text(text = currentSiteId ?: "No site selected")
+                Text(text = currentSiteName ?: "No site selected")
+            }
+        }
+    }
 }
 
 @Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true)
 @Preview(device = WearDevices.SQUARE, showSystemUi = true)
 @Composable
 fun DefaultPreview() {
-    MyStoreScreen()
+    MyStoreScreen(
+        currentSiteId = "1",
+        currentSiteName = "My Store"
+    )
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -41,7 +41,7 @@ class MyStoreViewModel @AssistedInject constructor(
         _viewState.update {
             it.copy(
                 currentSiteId = site.siteId.toString(),
-                currentSiteName = site.displayName
+                currentSiteName = site.name
             )
         }
     }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -40,7 +40,7 @@ class MyStoreViewModel @AssistedInject constructor(
     private fun updateSiteData(site: SiteModel) {
         _viewState.update {
             it.copy(
-                currentSiteId = site.siteId,
+                currentSiteId = site.siteId.toString(),
                 currentSiteName = site.displayName
             )
         }
@@ -48,7 +48,7 @@ class MyStoreViewModel @AssistedInject constructor(
 
     @Parcelize
     data class ViewState(
-        val currentSiteId: Long? = null,
+        val currentSiteId: String? = null,
         val currentSiteName: String? = null
     ) : Parcelable
 

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.ui.mystore
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.NavHostController
+import com.woocommerce.android.ui.login.LoginRepository
+import com.woocommerce.commons.viewmodel.ScopedViewModel
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+
+@HiltViewModel(assistedFactory = MyStoreViewModel.Factory::class)
+class MyStoreViewModel @AssistedInject constructor(
+    private val loginRepository: LoginRepository,
+    @Assisted private val navController: NavHostController,
+    savedState: SavedStateHandle
+) : ScopedViewModel(savedState) {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(navController: NavHostController): MyStoreViewModel
+    }
+}

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -1,13 +1,21 @@
 package com.woocommerce.android.ui.mystore
 
+import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
 import androidx.navigation.NavHostController
 import com.woocommerce.android.ui.login.LoginRepository
 import com.woocommerce.commons.viewmodel.ScopedViewModel
+import com.woocommerce.commons.viewmodel.getStateFlow
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.model.SiteModel
 
 @HiltViewModel(assistedFactory = MyStoreViewModel.Factory::class)
 class MyStoreViewModel @AssistedInject constructor(
@@ -15,6 +23,34 @@ class MyStoreViewModel @AssistedInject constructor(
     @Assisted private val navController: NavHostController,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
+    private val _viewState = savedState.getStateFlow(
+        scope = this,
+        initialValue = ViewState()
+    )
+    val viewState = _viewState.asLiveData()
+
+    init { observeLoginChanges() }
+
+    private fun observeLoginChanges() {
+        loginRepository.currentSite
+            .onEach { updateSiteData(it) }
+            .launchIn(this)
+    }
+
+    private fun updateSiteData(site: SiteModel) {
+        _viewState.update {
+            it.copy(
+                currentSiteId = site.siteId,
+                currentSiteName = site.displayName
+            )
+        }
+    }
+
+    @Parcelize
+    data class ViewState(
+        val currentSiteId: Long? = null,
+        val currentSiteName: String? = null
+    ) : Parcelable
 
     @AssistedFactory
     interface Factory {

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/mystore/MyStoreViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.SiteModel
 
+@Suppress("UnusedPrivateProperty")
 @HiltViewModel(assistedFactory = MyStoreViewModel.Factory::class)
 class MyStoreViewModel @AssistedInject constructor(
     private val loginRepository: LoginRepository,

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -249,14 +249,6 @@
                 <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />
                 <data
                     android:host="*"
-                    android:pathPrefix="/request-token"
-                    android:scheme="wear" />
-            </intent-filter>
-
-            <intent-filter>
-                <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />
-                <data
-                    android:host="*"
                     android:pathPrefix="/request-site"
                     android:scheme="wear" />
             </intent-filter>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/SiteObserver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/SiteObserver.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.environment.EnvironmentRepository
 import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.wear.WearableConnectionRepository
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -18,7 +19,8 @@ import javax.inject.Inject
 class SiteObserver @Inject constructor(
     private val selectedSite: SelectedSite,
     private val wooCommerceStore: WooCommerceStore,
-    private val environmentRepository: EnvironmentRepository
+    private val environmentRepository: EnvironmentRepository,
+    private val connRepository: WearableConnectionRepository
 ) {
     suspend fun observeAndUpdateSelectedSiteData() {
         selectedSite.observe()
@@ -34,6 +36,8 @@ class SiteObserver @Inject constructor(
                     ?.model?.let { storeID ->
                         WooLog.d(WooLog.T.UTILS, "Fetched StoreID $storeID for site ${site.name}")
                     }
+
+                connRepository.sendTokenData()
             }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/SiteObserver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/SiteObserver.kt
@@ -20,7 +20,7 @@ class SiteObserver @Inject constructor(
     private val selectedSite: SelectedSite,
     private val wooCommerceStore: WooCommerceStore,
     private val environmentRepository: EnvironmentRepository,
-    private val connRepository: WearableConnectionRepository
+    private val wearableConnectionRepository: WearableConnectionRepository
 ) {
     suspend fun observeAndUpdateSelectedSiteData() {
         selectedSite.observe()
@@ -37,7 +37,7 @@ class SiteObserver @Inject constructor(
                         WooLog.d(WooLog.T.UTILS, "Fetched StoreID $storeID for site ${site.name}")
                     }
 
-                connRepository.sendTokenData()
+                wearableConnectionRepository.sendSiteData()
             }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionRepository.kt
@@ -5,7 +5,9 @@ import com.google.android.gms.wearable.DataMap
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.gson.Gson
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.commons.wear.DataParameters
 import com.woocommerce.commons.wear.DataParameters.SITE_ID
+import com.woocommerce.commons.wear.DataParameters.SITE_JSON
 import com.woocommerce.commons.wear.DataParameters.TIMESTAMP
 import com.woocommerce.commons.wear.DataParameters.TOKEN
 import com.woocommerce.commons.wear.DataPath
@@ -27,7 +29,7 @@ class WearableConnectionRepository @Inject constructor(
             TOKEN_DATA,
             DataMap().apply {
                 val siteJSON = gson.toJson(selectedSite.get())
-                putString(SITE_DATA.value, siteJSON)
+                putString(SITE_JSON.value, siteJSON)
                 putString(SITE_ID.value, selectedSite.get().id.toString())
                 putString(TOKEN.value, accountStore.accessToken.orEmpty())
                 putLong(TIMESTAMP.value, Instant.now().epochSecond)
@@ -40,7 +42,7 @@ class WearableConnectionRepository @Inject constructor(
             SITE_DATA,
             DataMap().apply {
                 val siteJSON = gson.toJson(selectedSite.get())
-                putString(SITE_DATA.value, siteJSON)
+                putString(SITE_JSON.value, siteJSON)
                 putLong(TIMESTAMP.value, Instant.now().epochSecond)
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionRepository.kt
@@ -5,7 +5,6 @@ import com.google.android.gms.wearable.DataMap
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.gson.Gson
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.commons.wear.DataParameters
 import com.woocommerce.commons.wear.DataParameters.SITE_ID
 import com.woocommerce.commons.wear.DataParameters.SITE_JSON
 import com.woocommerce.commons.wear.DataParameters.TIMESTAMP

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionRepository.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.wear
 import com.google.android.gms.wearable.DataClient
 import com.google.android.gms.wearable.DataMap
 import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.gson.Gson
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.commons.wear.DataParameters.SITE_ID
 import com.woocommerce.commons.wear.DataParameters.TIMESTAMP
@@ -19,10 +20,15 @@ class WearableConnectionRepository @Inject constructor(
     private val accountStore: AccountStore,
     private val selectedSite: SelectedSite
 ) {
+    private val gson by lazy { Gson() }
+
     fun sendTokenData() {
         sendData(
             TOKEN_DATA,
             DataMap().apply {
+                val siteJSON = gson.toJson(selectedSite.get())
+                putString(SITE_DATA.value, siteJSON)
+                putString(SITE_ID.value, selectedSite.get().id.toString())
                 putString(TOKEN.value, accountStore.accessToken.orEmpty())
                 putLong(TIMESTAMP.value, Instant.now().epochSecond)
             }
@@ -33,7 +39,8 @@ class WearableConnectionRepository @Inject constructor(
         sendData(
             SITE_DATA,
             DataMap().apply {
-                putString(SITE_ID.value, selectedSite.get().id.toString())
+                val siteJSON = gson.toJson(selectedSite.get())
+                putString(SITE_DATA.value, siteJSON)
                 putLong(TIMESTAMP.value, Instant.now().epochSecond)
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionRepository.kt
@@ -5,13 +5,11 @@ import com.google.android.gms.wearable.DataMap
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.gson.Gson
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.commons.wear.DataParameters.SITE_ID
 import com.woocommerce.commons.wear.DataParameters.SITE_JSON
 import com.woocommerce.commons.wear.DataParameters.TIMESTAMP
 import com.woocommerce.commons.wear.DataParameters.TOKEN
 import com.woocommerce.commons.wear.DataPath
 import com.woocommerce.commons.wear.DataPath.SITE_DATA
-import com.woocommerce.commons.wear.DataPath.TOKEN_DATA
 import org.wordpress.android.fluxc.store.AccountStore
 import java.time.Instant
 import javax.inject.Inject
@@ -23,25 +21,13 @@ class WearableConnectionRepository @Inject constructor(
 ) {
     private val gson by lazy { Gson() }
 
-    fun sendTokenData() {
-        sendData(
-            TOKEN_DATA,
-            DataMap().apply {
-                val siteJSON = gson.toJson(selectedSite.get())
-                putString(SITE_JSON.value, siteJSON)
-                putString(SITE_ID.value, selectedSite.get().id.toString())
-                putString(TOKEN.value, accountStore.accessToken.orEmpty())
-                putLong(TIMESTAMP.value, Instant.now().epochSecond)
-            }
-        )
-    }
-
     fun sendSiteData() {
         sendData(
             SITE_DATA,
             DataMap().apply {
                 val siteJSON = gson.toJson(selectedSite.get())
                 putString(SITE_JSON.value, siteJSON)
+                putString(TOKEN.value, accountStore.accessToken.orEmpty())
                 putLong(TIMESTAMP.value, Instant.now().epochSecond)
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionService.kt
@@ -4,16 +4,34 @@ import android.util.Log
 import com.google.android.gms.wearable.DataEventBuffer
 import com.google.android.gms.wearable.MessageEvent
 import com.google.android.gms.wearable.WearableListenerService
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.commons.wear.MessagePath.REQUEST_SITE
 import com.woocommerce.commons.wear.MessagePath.REQUEST_TOKEN
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class WearableConnectionService : WearableListenerService() {
 
     @Inject
     lateinit var connRepository: WearableConnectionRepository
+
+    @Inject
+    lateinit var coroutineScope: CoroutineScope
+
+    @Inject
+    lateinit var selectedSite: SelectedSite
+
+    override fun onCreate() {
+        super.onCreate()
+        coroutineScope.launch {
+            selectedSite.observe().collect {
+                connRepository.sendTokenData()
+            }
+        }
+    }
 
     override fun onDataChanged(dataEvents: DataEventBuffer) {
         super.onDataChanged(dataEvents)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionService.kt
@@ -1,21 +1,11 @@
 package com.woocommerce.android.wear
 
-import android.util.Log
-import com.google.android.gms.wearable.DataEventBuffer
 import com.google.android.gms.wearable.MessageEvent
 import com.google.android.gms.wearable.WearableListenerService
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.commons.wear.MessagePath.REQUEST_SITE
 import com.woocommerce.commons.wear.MessagePath.REQUEST_TOKEN
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class WearableConnectionService : WearableListenerService() {
@@ -23,43 +13,11 @@ class WearableConnectionService : WearableListenerService() {
     @Inject
     lateinit var connRepository: WearableConnectionRepository
 
-    @Inject
-    lateinit var coroutineScope: CoroutineScope
-
-    @Inject
-    lateinit var selectedSite: SelectedSite
-
-    private var siteObservationJob: Job? = null
-
-    override fun onCreate() {
-        super.onCreate()
-        siteObservationJob = selectedSite.observe()
-            .filterNotNull()
-            .distinctUntilChanged()
-            .onEach { connRepository.sendSiteData() }
-            .launchIn(coroutineScope)
-    }
-
-    override fun onDataChanged(dataEvents: DataEventBuffer) {
-        super.onDataChanged(dataEvents)
-        Log.d(TAG, "onDataChanged")
-    }
-
     override fun onMessageReceived(message: MessageEvent) {
         super.onMessageReceived(message)
         when (message.path) {
             REQUEST_TOKEN.value -> connRepository.sendTokenData()
             REQUEST_SITE.value -> connRepository.sendSiteData()
         }
-    }
-
-    override fun onDestroy() {
-        siteObservationJob?.cancel()
-        siteObservationJob = null
-        super.onDestroy()
-    }
-
-    companion object {
-        private const val TAG = "WearableConnectionService"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionService.kt
@@ -10,6 +10,10 @@ import com.woocommerce.commons.wear.MessagePath.REQUEST_TOKEN
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -26,11 +30,11 @@ class WearableConnectionService : WearableListenerService() {
 
     override fun onCreate() {
         super.onCreate()
-        coroutineScope.launch {
-            selectedSite.observe().collect {
-                connRepository.sendTokenData()
-            }
-        }
+        selectedSite.observe()
+            .filterNotNull()
+            .distinctUntilChanged()
+            .onEach { connRepository.sendSiteData() }
+            .launchIn(coroutineScope)
     }
 
     override fun onDataChanged(dataEvents: DataEventBuffer) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionService.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.wear
 import com.google.android.gms.wearable.MessageEvent
 import com.google.android.gms.wearable.WearableListenerService
 import com.woocommerce.commons.wear.MessagePath.REQUEST_SITE
-import com.woocommerce.commons.wear.MessagePath.REQUEST_TOKEN
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -11,13 +10,12 @@ import javax.inject.Inject
 class WearableConnectionService : WearableListenerService() {
 
     @Inject
-    lateinit var connRepository: WearableConnectionRepository
+    lateinit var wearableConnectionRepository: WearableConnectionRepository
 
     override fun onMessageReceived(message: MessageEvent) {
         super.onMessageReceived(message)
         when (message.path) {
-            REQUEST_TOKEN.value -> connRepository.sendTokenData()
-            REQUEST_SITE.value -> connRepository.sendSiteData()
+            REQUEST_SITE.value -> wearableConnectionRepository.sendSiteData()
         }
     }
 }

--- a/libs/commons/src/main/java/com/woocommerce/commons/wear/Paths.kt
+++ b/libs/commons/src/main/java/com/woocommerce/commons/wear/Paths.kt
@@ -1,18 +1,15 @@
 package com.woocommerce.commons.wear
 
 enum class MessagePath(val value: String) {
-    REQUEST_TOKEN("/request-token"),
     REQUEST_SITE("/request-site")
 }
 
 enum class DataPath(val value: String) {
-    TOKEN_DATA("/token-data"),
     SITE_DATA("/site-data")
 }
 
 enum class DataParameters(val value: String) {
     TOKEN("token"),
-    SITE_ID("site-id"),
     SITE_JSON("site-json"),
     TIMESTAMP("timestamp")
 }

--- a/libs/commons/src/main/java/com/woocommerce/commons/wear/Paths.kt
+++ b/libs/commons/src/main/java/com/woocommerce/commons/wear/Paths.kt
@@ -13,6 +13,6 @@ enum class DataPath(val value: String) {
 enum class DataParameters(val value: String) {
     TOKEN("token"),
     SITE_ID("site-id"),
-    SITE_DATA("site-data"),
+    SITE_JSON("site-json"),
     TIMESTAMP("timestamp")
 }

--- a/libs/commons/src/main/java/com/woocommerce/commons/wear/Paths.kt
+++ b/libs/commons/src/main/java/com/woocommerce/commons/wear/Paths.kt
@@ -13,5 +13,6 @@ enum class DataPath(val value: String) {
 enum class DataParameters(val value: String) {
     TOKEN("token"),
     SITE_ID("site-id"),
+    SITE_DATA("site-data"),
     TIMESTAMP("timestamp")
 }


### PR DESCRIPTION
Summary
==========
Fix issue #11344 by introducing the following changes:

-  Unifying the site and token paths to a single one
- Introducing the FluxC library to the Wear app
- Introducing reactive mechanisms to observe, notify and update the wear app when the store changes in the phone

Screen Capture
==========
https://github.com/woocommerce/woocommerce-android/assets/5920403/bb25f945-7d49-43ac-87e3-35d2d6cf2641

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.