### PR TITLE
[Dynamic Dashboard] Handle hiding the onboarding card when completed

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -919,10 +919,10 @@ object AppPrefs {
         setBoolean(UndeletablePrefKey.TTP_WAS_USED_AT_LEAST_ONCE, true)
     }
 
-    fun markOnboardingTaskCompletedFor(siteId: Int) {
+    fun updateOnboardingCompletedStatus(siteId: Int, completed: Boolean) {
         setBoolean(
             key = getStoreOnboardingKeyFor(siteId),
-            value = true
+            value = completed
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -326,8 +326,8 @@ class AppPrefsWrapper @Inject constructor() {
         }
     }
 
-    fun markAllOnboardingTasksCompleted(siteId: Int) {
-        AppPrefs.markOnboardingTaskCompletedFor(siteId)
+    fun updateOnboardingCompletedStatus(siteId: Int, completed: Boolean) {
+        AppPrefs.updateOnboardingCompletedStatus(siteId, completed)
     }
 
     fun isOnboardingCompleted(siteId: Int): Boolean = AppPrefs.areOnboardingTaskCompletedFor(siteId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
@@ -9,14 +9,17 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class DashboardWidget(
     val type: Type,
-    val isVisible: Boolean,
+    val isSelected: Boolean,
     val status: Status,
 ) : Parcelable {
     val title: Int
         get() = type.titleResource
 
     val isAvailable: Boolean
-        get() = status is Status.Available
+        get() = status == Status.Available
+
+    val isVisible: Boolean
+        get() = isSelected && isAvailable
 
     enum class Type(@StringRes val titleResource: Int) {
         ONBOARDING(R.string.my_store_widget_onboarding_title),
@@ -40,5 +43,5 @@ data class DashboardWidget(
 fun DashboardWidget.toDataModel(): DashboardWidgetDataModel =
     DashboardWidgetDataModel.newBuilder()
         .setType(type.name)
-        .setIsAdded(isVisible)
+        .setIsAdded(isSelected)
         .build()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -93,7 +93,7 @@ class DashboardViewModel @Inject constructor(
         }.asLiveData()
 
     val dashboardWidgets = dashboardRepository.widgets
-        .map { it.filter { widget -> widget.isVisible && widget.isAvailable } }
+        .map { it.filter { widget -> widget.isVisible } }
         .asLiveData()
 
     init {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
@@ -76,7 +76,7 @@ class DashboardRepository @Inject constructor(
             .apply {
                 val index = indexOfFirst { it.type == type }
                 if (index != -1) {
-                    set(index, get(index).copy(isVisible = isVisible))
+                    set(index, get(index).copy(isSelected = isVisible))
                 }
             }
         updateWidgets(dataStoreWidgets)
@@ -91,7 +91,7 @@ class DashboardRepository @Inject constructor(
             val type = DashboardWidget.Type.valueOf(widget.type)
             DashboardWidget(
                 type = type,
-                isVisible = widget.isAdded,
+                isSelected = widget.isAdded,
                 status = when (type) {
                     DashboardWidget.Type.STATS,
                     DashboardWidget.Type.POPULAR_PRODUCTS -> statsWidgetsStatus
@@ -101,6 +101,6 @@ class DashboardRepository @Inject constructor(
                     DashboardWidget.Type.ONBOARDING -> onboardingWidgetStatus
                 }
             )
-        }.sortedBy { it.isAvailable }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveOnboardingWidgetStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveOnboardingWidgetStatus.kt
@@ -1,0 +1,46 @@
+package com.woocommerce.android.ui.dashboard.data
+
+import com.woocommerce.android.R
+import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.onboarding.ShouldShowOnboarding
+import com.woocommerce.android.ui.onboarding.StoreOnboardingRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import javax.inject.Inject
+
+class ObserveOnboardingWidgetStatus @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val storeOnboardingRepository: StoreOnboardingRepository,
+    private val shouldShowOnboarding: ShouldShowOnboarding
+) {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    operator fun invoke() = selectedSite.observe()
+        .filterNotNull()
+        .flatMapLatest {
+            if (shouldShowOnboarding.isOnboardingMarkedAsCompleted()) {
+                flowOf(
+                    DashboardWidget.Status.Unavailable(R.string.my_store_widget_onboarding_completed)
+                )
+            } else {
+                storeOnboardingRepository.observeOnboardingTasks()
+                    .distinctUntilChanged()
+                    .map { tasks ->
+                        shouldShowOnboarding.showForTasks(tasks)
+                    }
+                    .map { showOnboarding ->
+                        if (showOnboarding) {
+                            DashboardWidget.Status.Available
+                        } else {
+                            DashboardWidget.Status.Unavailable(R.string.my_store_widget_onboarding_completed)
+                        }
+                    }
+                    .onStart { storeOnboardingRepository.fetchOnboardingTasks() }
+            }
+        }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingViewModel.kt
@@ -85,7 +85,11 @@ class DashboardOnboardingViewModel @AssistedInject constructor(
                 .onStart { emit(RefreshEvent()) }
                 .collectLatest {
                     _viewState.value = _viewState.value?.copy(isLoading = true)
-                    onboardingRepository.fetchOnboardingTasks()
+                    if (it.isForced) {
+                        // Fetch only if it's a forced refresh, in the other cases, the DashboardRepository will
+                        // trigger the initial fetch
+                        onboardingRepository.fetchOnboardingTasks()
+                    }
                 }
         }
         launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorScreen.kt
@@ -77,7 +77,7 @@ fun DashboardWidgetEditorScreen(viewModel: DashboardWidgetEditorViewModel) {
                             true -> {
                                 DragAndDropSelectableItem(
                                     item = item,
-                                    isSelected = item in state.orderedWidgetList.filter { it.isVisible },
+                                    isSelected = item in state.orderedWidgetList.filter { it.isSelected },
                                     dragDropState = dragDropState,
                                     onSelectionChange = viewModel::onSelectionChange,
                                     itemKey = { it.type },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
@@ -74,7 +74,7 @@ class DashboardWidgetEditorViewModel @Inject constructor(
     }
 
     fun onSelectionChange(dashboardWidget: DashboardWidget, selected: Boolean) {
-        editedWidgets = editedWidgets.map { if (it == dashboardWidget) it.copy(isVisible = selected) else it }
+        editedWidgets = editedWidgets.map { if (it == dashboardWidget) it.copy(isSelected = selected) else it }
     }
 
     fun onOrderChange(fromIndex: Int, toIndex: Int) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboarding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboarding.kt
@@ -41,7 +41,7 @@ class ShouldShowOnboarding @Inject constructor(
             }
             true
         } else {
-            if(appPrefsWrapper.isOnboardingCompleted(siteId)) {
+            if (appPrefsWrapper.isOnboardingCompleted(siteId)) {
                 // Reset the onboarding completed status if there are still pending tasks
                 appPrefsWrapper.updateOnboardingCompletedStatus(siteId, false)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboarding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboarding.kt
@@ -35,8 +35,8 @@ class ShouldShowOnboarding @Inject constructor(
 
         val siteId = selectedSite.getSelectedSiteId()
         val areAllTaskCompleted = if (tasks.all { it.isComplete }) {
-            appPrefsWrapper.updateOnboardingCompletedStatus(siteId, true)
-            if (appPrefsWrapper.getStoreOnboardingShown(siteId)) {
+            if (appPrefsWrapper.getStoreOnboardingShown(siteId) && !appPrefsWrapper.isOnboardingCompleted(siteId)) {
+                appPrefsWrapper.updateOnboardingCompletedStatus(siteId, true)
                 analyticsTrackerWrapper.track(stat = STORE_ONBOARDING_COMPLETED)
             }
             true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboarding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboarding.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.ui.onboarding.StoreOnboardingRepository.Onboardin
 import com.woocommerce.android.ui.onboarding.StoreOnboardingRepository.OnboardingTaskType.MOBILE_UNSUPPORTED
 import com.woocommerce.android.ui.onboarding.StoreOnboardingRepository.OnboardingTaskType.PAYMENTS
 import com.woocommerce.android.ui.onboarding.StoreOnboardingRepository.OnboardingTaskType.WC_PAYMENTS
+import com.woocommerce.android.util.FeatureFlag
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -44,7 +45,7 @@ class ShouldShowOnboarding @Inject constructor(
         }
 
         return if (!areAllTaskCompleted &&
-            isOnboardingListSettingVisible()
+            (FeatureFlag.DYNAMIC_DASHBOARD.isEnabled() || isOnboardingListSettingVisible())
         ) {
             appPrefsWrapper.setStoreOnboardingShown(siteId)
             true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboarding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboarding.kt
@@ -35,12 +35,16 @@ class ShouldShowOnboarding @Inject constructor(
 
         val siteId = selectedSite.getSelectedSiteId()
         val areAllTaskCompleted = if (tasks.all { it.isComplete }) {
-            appPrefsWrapper.markAllOnboardingTasksCompleted(siteId)
+            appPrefsWrapper.updateOnboardingCompletedStatus(siteId, true)
             if (appPrefsWrapper.getStoreOnboardingShown(siteId)) {
                 analyticsTrackerWrapper.track(stat = STORE_ONBOARDING_COMPLETED)
             }
             true
         } else {
+            if(appPrefsWrapper.isOnboardingCompleted(siteId)) {
+                // Reset the onboarding completed status if there are still pending tasks
+                appPrefsWrapper.updateOnboardingCompletedStatus(siteId, false)
+            }
             false
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingRepository.kt
@@ -26,7 +26,9 @@ class StoreOnboardingRepository @Inject constructor(
     private val siteStore: SiteStore
 ) {
 
-    private val onboardingTasksCacheFlow: MutableSharedFlow<List<OnboardingTask>> = MutableSharedFlow()
+    private val onboardingTasksCacheFlow: MutableSharedFlow<List<OnboardingTask>> = MutableSharedFlow(
+        replay = 1
+    )
 
     fun observeOnboardingTasks(): SharedFlow<List<OnboardingTask>> = onboardingTasksCacheFlow
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.onboarding.ShouldShowOnboarding
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.StringUtils
 import kotlinx.coroutines.launch
@@ -79,7 +80,7 @@ class MainSettingsPresenter @Inject constructor(
     }
 
     override fun setupOnboardingListVisibilitySetting() {
-        if (!shouldShowOnboarding.isOnboardingMarkedAsCompleted()) {
+        if (!FeatureFlag.DYNAMIC_DASHBOARD.isEnabled() && !shouldShowOnboarding.isOnboardingMarkedAsCompleted()) {
             appSettingsFragmentView?.handleStoreSetupListSetting(
                 enabled = shouldShowOnboarding.isOnboardingListSettingVisible(),
                 onToggleChange = { isChecked ->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -417,7 +417,9 @@
     <string name="my_store_widget_stats_title">Performance</string>
     <string name="my_store_widget_top_products_title">Top products</string>
     <string name="my_store_widget_blaze_title">Blaze campaigns</string>
+
     <string name="my_store_widget_unavailable">Unavailable</string>
+    <string name="my_store_widget_onboarding_completed">Completed</string>
 
     <string name="dynamic_dashboard_hide_widget_menu_item">Hide</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboardingTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboardingTest.kt
@@ -100,7 +100,7 @@ internal class ShouldShowOnboardingTest : BaseUnitTest() {
 
         sut.showForTasks(ONBOARDING_TASK_COMPLETED_LIST)
 
-        verify(appPrefsWrapper).markAllOnboardingTasksCompleted(CURRENT_SITE_ID)
+        verify(appPrefsWrapper).updateOnboardingCompletedStatus(CURRENT_SITE_ID, true)
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11359 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds logic to hide the onboarding card when it's completed, the row will be shown with a badge `Completed` when it's.

The last commit 32a57e0f427143f339996d214f439a109b840ad3 is unrelated to the changes of the PR, but it's just something I thought about, after the last PR, the `DashbaordWidget` has now two properties: `isVisible` and `status`, and the `status` could be `Hidden`, so to make things more clear, I renamed `isVisible` to `isSelected`, and made `isVisible` a calculated property that checks the status, this way we see the difference between the two properties more clearly.

### Testing instructions
1. Confirm the FeatureFlag DYNAMIC_DASHBOARD is enabled.
2. Use a site where onboarding is still not completed.
3. Open the app.
4. Confirm the onboarding card is shown.
5. Open the app settings, and confirm the toggle for the onboarding is not shown.
6. Finish the onboarding (or switch to a site with onboarding completed)
7. Confirm the onboarding card is hidden.
8. Open the dashboard settings.
9. Confirm the row is shown with a badge "Completed" and it's unavailable for selection.

### Images/gif
<img width=360 src="https://github.com/woocommerce/woocommerce-android/assets/1657201/d74e800f-097f-46c8-989a-3e327d053c8b" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
