### PR TITLE
Address SQLiteBlobTooBigException crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -70,5 +70,6 @@ class WooWellSqlConfig(context: Context) : WellSqlConfig(context, ADDON_WOOCOMME
      * number of SQLiteBlobTooBigExceptions. Note that this is only called on API 28 and
      * above since earlier versions don't allow adjusting the cursor window size.
      */
+    @Suppress("MagicNumber")
     override fun getCursorWindowSize() = (1024L * 1024L * 10L)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooWellSqlConfig.kt
@@ -66,9 +66,9 @@ class WooWellSqlConfig(context: Context) : WellSqlConfig(context, ADDON_WOOCOMME
     }
 
     /**
-     * Increase the cursor window size to 5MB for devices running API 28 and above. This should reduce the
+     * Increase the cursor window size to 10MB for devices running API 28 and above. This should reduce the
      * number of SQLiteBlobTooBigExceptions. Note that this is only called on API 28 and
      * above since earlier versions don't allow adjusting the cursor window size.
      */
-    override fun getCursorWindowSize() = (1024L * 1024L * 5L)
+    override fun getCursorWindowSize() = (1024L * 1024L * 10L)
 }


### PR DESCRIPTION
This is an attempt to address some of the crash events reported in #11309. The PR doubles the size of the cursor window of the database for devices running API 28 and higher. While it probably won't fix all crashes (there can always be larger data) and it won't work for older Android versions, it should have an impact. At the same time, we don't want to make the cursor window size too big to avoid OOM errors, so 10MB seemed like a reasonable compromise.

**To test:**
There isn't much to test. I did verify that the fix worked for an absurdly large product description that was causing the app to crash previously.