### PR TITLE
[Dynamic Dashboard] Share Your Store card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
@@ -65,8 +65,14 @@ val SiteModel.clock: Clock
 val SiteModel?.isFreeTrial: Boolean
     get() = this?.planId == FREE_TRIAL_PLAN_ID
 
+/**
+ * Returns true if the site is public, this means:
+ * - Either the site is a WPCom store that's public.
+ * - Or the site is a self-hosted site, self-hosted sites doesn't have a public/private status, so we consider
+ *   them public.
+ */
 val SiteModel?.isSitePublic: Boolean
-    get() = this?.publishedStatus == PUBLIC.value()
+    get() = this?.let { !isWPComAtomic || publishedStatus == PUBLIC.value() } ?: false
 
 val SiteModel?.isSitePrivate: Boolean
     get() = this?.publishedStatus == SiteVisibility.PRIVATE.value()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -61,6 +62,9 @@ private fun WidgetList(
             .background(MaterialTheme.colors.surface)
             .padding(vertical = dimensionResource(id = R.dimen.major_100))
     ) {
+        val widgetModifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
         widgetUiModels.forEach {
             AnimatedVisibility(it.isVisible) {
                 when (it) {
@@ -68,13 +72,15 @@ private fun WidgetList(
                         ConfigurableWidgetCard(
                             widgetUiModel = it,
                             dashboardViewModel = dashboardViewModel,
-                            blazeCampaignCreationDispatcher = blazeCampaignCreationDispatcher
+                            blazeCampaignCreationDispatcher = blazeCampaignCreationDispatcher,
+                            modifier = widgetModifier
                         )
                     }
 
                     is DashboardViewModel.DashboardWidgetUiModel.ShareStoreWidget -> {
                         ShareStoreCard(
-                            onShareClicked = dashboardViewModel::onShareStoreClicked
+                            onShareClicked = dashboardViewModel::onShareStoreClicked,
+                            modifier = widgetModifier
                         )
                     }
                 }
@@ -87,7 +93,8 @@ private fun WidgetList(
 private fun ConfigurableWidgetCard(
     widgetUiModel: DashboardViewModel.DashboardWidgetUiModel.ConfigurableWidget,
     dashboardViewModel: DashboardViewModel,
-    blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher
+    blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher,
+    modifier: Modifier
 ) {
     when (widgetUiModel.widget.type) {
         DashboardWidget.Type.STATS -> {
@@ -98,30 +105,37 @@ private fun ConfigurableWidgetCard(
                 openDatePicker = { start, end, callback ->
                     dashboardViewModel.onDashboardWidgetEvent(OpenRangePicker(start, end, callback))
                 },
-                parentViewModel = dashboardViewModel
+                parentViewModel = dashboardViewModel,
+                modifier = modifier
             )
         }
 
-        DashboardWidget.Type.POPULAR_PRODUCTS -> DashboardTopPerformersWidgetCard(dashboardViewModel)
+        DashboardWidget.Type.POPULAR_PRODUCTS -> DashboardTopPerformersWidgetCard(
+            parentViewModel = dashboardViewModel,
+            modifier = modifier
+        )
 
         DashboardWidget.Type.BLAZE -> DashboardBlazeCard(
             blazeCampaignCreationDispatcher = blazeCampaignCreationDispatcher,
-            parentViewModel = dashboardViewModel
+            parentViewModel = dashboardViewModel,
+            modifier = modifier
         )
 
-        DashboardWidget.Type.ONBOARDING -> DashboardOnboardingCard(parentViewModel = dashboardViewModel)
+        DashboardWidget.Type.ONBOARDING -> DashboardOnboardingCard(
+            parentViewModel = dashboardViewModel,
+            modifier = modifier
+        )
     }
 }
 
 @Composable
 private fun ShareStoreCard(
     onShareClicked: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
-            .padding(horizontal = 16.dp)
             .border(
                 width = 1.dp,
                 color = colorResource(id = R.color.woo_gray_5),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -1,22 +1,32 @@
 package com.woocommerce.android.ui.dashboard
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
-import com.woocommerce.android.model.DashboardWidget.Type.BLAZE
-import com.woocommerce.android.model.DashboardWidget.Type.ONBOARDING
-import com.woocommerce.android.model.DashboardWidget.Type.POPULAR_PRODUCTS
-import com.woocommerce.android.model.DashboardWidget.Type.STATS
+import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
+import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowStatsError
 import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeCard
@@ -55,14 +65,18 @@ private fun WidgetList(
             AnimatedVisibility(it.isVisible) {
                 when (it) {
                     is DashboardViewModel.DashboardWidgetUiModel.ConfigurableWidget -> {
-                        ConfigurableWidgetContent(
+                        ConfigurableWidgetCard(
                             widgetUiModel = it,
                             dashboardViewModel = dashboardViewModel,
                             blazeCampaignCreationDispatcher = blazeCampaignCreationDispatcher
                         )
                     }
 
-                    is DashboardViewModel.DashboardWidgetUiModel.ShareStoreWidget -> {}
+                    is DashboardViewModel.DashboardWidgetUiModel.ShareStoreWidget -> {
+                        ShareStoreCard(
+                            onShareClicked = dashboardViewModel::onShareStoreClicked
+                        )
+                    }
                 }
             }
         }
@@ -70,13 +84,13 @@ private fun WidgetList(
 }
 
 @Composable
-private fun ConfigurableWidgetContent(
+private fun ConfigurableWidgetCard(
     widgetUiModel: DashboardViewModel.DashboardWidgetUiModel.ConfigurableWidget,
     dashboardViewModel: DashboardViewModel,
     blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher
 ) {
     when (widgetUiModel.widget.type) {
-        STATS -> {
+        DashboardWidget.Type.STATS -> {
             DashboardStatsCard(
                 onStatsError = {
                     dashboardViewModel.onDashboardWidgetEvent(ShowStatsError)
@@ -88,13 +102,52 @@ private fun ConfigurableWidgetContent(
             )
         }
 
-        POPULAR_PRODUCTS -> DashboardTopPerformersWidgetCard(dashboardViewModel)
+        DashboardWidget.Type.POPULAR_PRODUCTS -> DashboardTopPerformersWidgetCard(dashboardViewModel)
 
-        BLAZE -> DashboardBlazeCard(
+        DashboardWidget.Type.BLAZE -> DashboardBlazeCard(
             blazeCampaignCreationDispatcher = blazeCampaignCreationDispatcher,
             parentViewModel = dashboardViewModel
         )
 
-        ONBOARDING -> DashboardOnboardingCard(parentViewModel = dashboardViewModel)
+        DashboardWidget.Type.ONBOARDING -> DashboardOnboardingCard(parentViewModel = dashboardViewModel)
+    }
+}
+
+@Composable
+private fun ShareStoreCard(
+    onShareClicked: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .padding(horizontal = 16.dp)
+            .border(
+                width = 1.dp,
+                color = colorResource(id = R.color.woo_gray_5),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .padding(16.dp)
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.blaze_campaign_created_success),
+            contentDescription = null
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = stringResource(id = R.string.get_the_word_out),
+            style = MaterialTheme.typography.h6,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(id = R.string.share_your_store_message),
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        WCColoredButton(
+            onClick = onShareClicked,
+            text = stringResource(id = R.string.share_store_button)
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -79,7 +79,7 @@ private fun WidgetList(
 
                     is DashboardViewModel.DashboardWidgetUiModel.ShareStoreWidget -> {
                         ShareStoreCard(
-                            onShareClicked = dashboardViewModel::onShareStoreClicked,
+                            onShareClicked = it.onShareClicked,
                             modifier = widgetModifier
                         )
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -43,6 +43,7 @@ import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.Sh
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowAIProductDescriptionDialog
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowPrivacyBanner
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowStatsError
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel
 import com.woocommerce.android.ui.jitm.JitmFragment
 import com.woocommerce.android.ui.jitm.JitmMessagePathsProvider
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -190,7 +191,11 @@ class DashboardFragment :
         }
         dashboardViewModel.dashboardWidgets.observe(viewLifecycleOwner) { widgets ->
             // Show banners only if onboarding list is NOT displayed
-            if (widgets.any { it.type == DashboardWidget.Type.ONBOARDING }.not()) {
+            if (
+                widgets.none {
+                    (it as? DashboardWidgetUiModel.ConfigurableWidget)?.widget?.type == DashboardWidget.Type.ONBOARDING
+                }
+            ) {
                 initJitm()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -52,7 +52,6 @@ import com.woocommerce.android.ui.onboarding.StoreOnboardingViewModel
 import com.woocommerce.android.ui.prefs.privacy.banner.PrivacyBannerFragmentDirections
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.WooLog
-import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -107,7 +106,6 @@ class DashboardFragment :
             hasShadow = true,
         )
 
-    private var isEmptyViewVisible: Boolean = false
     private var wasPreviouslyStopped = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -155,12 +153,6 @@ class DashboardFragment :
     private fun setupStateObservers() {
         dashboardViewModel.appbarState.observe(viewLifecycleOwner) { requireActivity().invalidateOptionsMenu() }
 
-        dashboardViewModel.hasOrders.observe(viewLifecycleOwner) { newValue ->
-            when (newValue) {
-                DashboardViewModel.OrderState.Empty -> showEmptyView(true)
-                DashboardViewModel.OrderState.AtLeastOne -> showEmptyView(false)
-            }
-        }
         dashboardViewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is ShowPrivacyBanner ->
@@ -366,21 +358,6 @@ class DashboardFragment :
                 )
             }
         }
-    }
-
-    private fun showEmptyView(show: Boolean) {
-        val dashboardVisibility: Int
-        if (show) {
-            dashboardVisibility = View.GONE
-            binding.emptyView.show(EmptyViewType.DASHBOARD) {
-                dashboardViewModel.onShareStoreClicked()
-            }
-        } else {
-            binding.emptyView.hide()
-            dashboardVisibility = View.VISIBLE
-        }
-        binding.dashboardContainer.visibility = dashboardVisibility
-        isEmptyViewVisible = show
     }
 
     override fun shouldExpandToolbar() = binding.statsScrollView.scrollY == 0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -72,9 +72,6 @@ class DashboardViewModel @Inject constructor(
 
     val performanceObserver: LifecycleObserver = dashboardTransactionLauncher
 
-    private var _hasOrders = MutableLiveData<OrderState>()
-    val hasOrders: LiveData<OrderState> = _hasOrders
-
     private var _appbarState = MutableLiveData<AppbarState>()
     val appbarState: LiveData<AppbarState> = _appbarState
 
@@ -195,11 +192,6 @@ class DashboardViewModel @Inject constructor(
                     }
                 )
             }
-    }
-
-    sealed class OrderState {
-        data object Empty : OrderState()
-        data object AtLeastOne : OrderState()
     }
 
     data class AppbarState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -179,7 +179,7 @@ class DashboardViewModel @Inject constructor(
             selectedSite.get().isSitePublic &&
             selectedSite.get().url != null
         ) {
-            add(DashboardWidgetUiModel.ShareStoreWidget)
+            add(DashboardWidgetUiModel.ShareStoreWidget(::onShareStoreClicked))
         }
     }
 
@@ -222,7 +222,9 @@ class DashboardViewModel @Inject constructor(
                 get() = widget.isVisible
         }
 
-        data object ShareStoreWidget : DashboardWidgetUiModel
+        data class ShareStoreWidget(
+            val onShareClicked: () -> Unit
+        ) : DashboardWidgetUiModel
     }
 
     data class AppbarState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -93,7 +93,7 @@ class DashboardViewModel @Inject constructor(
         }.asLiveData()
 
     val dashboardWidgets = dashboardRepository.widgets
-        .map { it.filter { widget -> widget.isVisible } }
+        .map { widgets -> mapWidgetsToUiModels(widgets) }
         .asLiveData()
 
     init {
@@ -166,6 +166,12 @@ class DashboardViewModel @Inject constructor(
         triggerEvent(DashboardEvent.ContactSupport)
     }
 
+    private fun mapWidgetsToUiModels(widgets: List<DashboardWidget>): List<DashboardWidgetUiModel> = buildList {
+        addAll(
+            widgets.map { DashboardWidgetUiModel.ConfigurableWidget(it) }
+        )
+    }
+
     private fun jetpackBenefitsBannerState(
         connectionType: SiteConnectionType
     ): Flow<JetpackBenefitsBannerUiModel?> {
@@ -192,6 +198,19 @@ class DashboardViewModel @Inject constructor(
                     }
                 )
             }
+    }
+
+    sealed interface DashboardWidgetUiModel {
+        val isVisible: Boolean
+            get() = true
+        data class ConfigurableWidget(
+            val widget: DashboardWidget,
+        ) : DashboardWidgetUiModel {
+            override val isVisible: Boolean
+                get() = widget.isVisible
+        }
+
+        data object ShareStoreWidget : DashboardWidgetUiModel
     }
 
     data class AppbarState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -118,7 +118,11 @@ class DashboardViewModel @Inject constructor(
     }
 
     private fun updateShareStoreButtonVisibility() {
-        _appbarState.value = AppbarState(showShareStoreButton = selectedSite.get().isSitePublic)
+        _appbarState.value = AppbarState(
+            showShareStoreButton = selectedSite.get().let {
+                it.isSitePublic && it.url != null
+            }
+        )
     }
 
     override fun onCleared() {
@@ -170,6 +174,13 @@ class DashboardViewModel @Inject constructor(
         addAll(
             widgets.map { DashboardWidgetUiModel.ConfigurableWidget(it) }
         )
+
+        if (!widgets.first { it.type == DashboardWidget.Type.STATS }.isAvailable &&
+            selectedSite.get().isSitePublic &&
+            selectedSite.get().url != null
+        ) {
+            add(DashboardWidgetUiModel.ShareStoreWidget)
+        }
     }
 
     private fun jetpackBenefitsBannerState(
@@ -203,6 +214,7 @@ class DashboardViewModel @Inject constructor(
     sealed interface DashboardWidgetUiModel {
         val isVisible: Boolean
             get() = true
+
         data class ConfigurableWidget(
             val widget: DashboardWidget,
         ) : DashboardWidgetUiModel {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WidgetCard.kt
@@ -42,7 +42,6 @@ fun WidgetCard(
     val roundedShape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
     Column(
         modifier = modifier
-            .padding(horizontal = dimensionResource(id = R.dimen.major_100))
             .border(
                 width = dimensionResource(id = R.dimen.minor_10),
                 color = colorResource(id = R.color.woo_gray_5),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
@@ -68,9 +68,9 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun DashboardBlazeCard(
-    modifier: Modifier = Modifier,
     blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher,
     parentViewModel: DashboardViewModel,
+    modifier: Modifier = Modifier,
     viewModel: DashboardBlazeViewModel = viewModelWithFactory { factory: DashboardBlazeViewModel.Factory ->
         factory.create(parentViewModel)
     }
@@ -146,7 +146,7 @@ private fun BlazeFrame(
 ) {
     if (FeatureFlag.DYNAMIC_DASHBOARD.isEnabled()) {
         WidgetCard(
-            modifier = modifier.fillMaxWidth(),
+            modifier = modifier,
             titleResource = DashboardWidget.Type.BLAZE.titleResource,
             iconResource = R.drawable.ic_blaze,
             menu = state.menu,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
@@ -45,7 +45,6 @@ import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAc
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.onboarding.DashboardOnboardingViewModel.Companion.MAX_NUMBER_OF_TASK_TO_DISPLAY_IN_CARD
-import com.woocommerce.android.ui.dashboard.onboarding.DashboardOnboardingViewModel.Factory
 import com.woocommerce.android.ui.dashboard.onboarding.DashboardOnboardingViewModel.OnboardingDashBoardState
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.onboarding.AboutYourStoreTaskRes
@@ -66,18 +65,19 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 @Composable
 fun DashboardOnboardingCard(
     parentViewModel: DashboardViewModel,
-    onboardingViewModel: DashboardOnboardingViewModel =
-        viewModelWithFactory<DashboardOnboardingViewModel, Factory>(
-            creationCallback = {
-                it.create(parentViewModel)
-            }
-        )
+    modifier: Modifier = Modifier,
+    onboardingViewModel: DashboardOnboardingViewModel = viewModelWithFactory(
+        creationCallback = { factory: DashboardOnboardingViewModel.Factory ->
+            factory.create(parentViewModel)
+        }
+    )
 ) {
     onboardingViewModel.viewState.observeAsState().value?.let { onboardingState ->
         WidgetCard(
             titleResource = onboardingState.title,
             menu = onboardingState.menu,
             button = onboardingState.onViewAllTapped,
+            modifier = modifier,
         ) {
             when {
                 onboardingState.isLoading -> StoreOnboardingLoading()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -66,9 +66,10 @@ fun DashboardStatsCard(
     onStatsError: () -> Unit,
     openDatePicker: (Long, Long, (Long, Long) -> Unit) -> Unit,
     parentViewModel: DashboardViewModel,
-    viewModel: DashboardStatsViewModel = viewModelWithFactory<DashboardStatsViewModel, DashboardStatsViewModel.Factory>(
-        creationCallback = {
-            it.create(parentViewModel)
+    modifier: Modifier = Modifier,
+    viewModel: DashboardStatsViewModel = viewModelWithFactory(
+        creationCallback = { factory: DashboardStatsViewModel.Factory ->
+            factory.create(parentViewModel)
         }
     )
 ) {
@@ -109,7 +110,8 @@ fun DashboardStatsCard(
             )
         } else {
             null
-        }
+        },
+        modifier = modifier
     ) {
         if (revenueStatsState !is DashboardStatsViewModel.RevenueStatsViewState.PluginNotActiveError) {
             DashboardStatsContent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -63,7 +63,6 @@ import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAc
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.TopPerformerProductUiModel
 import com.woocommerce.android.ui.dashboard.WidgetCard
-import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.Factory
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenAnalytics
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenDatePicker
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenTopPerformer
@@ -77,12 +76,12 @@ import java.util.Locale
 @Composable
 fun DashboardTopPerformersWidgetCard(
     parentViewModel: DashboardViewModel,
-    topPerformersViewModel: DashboardTopPerformersViewModel =
-        viewModelWithFactory<DashboardTopPerformersViewModel, Factory>(
-            creationCallback = {
-                it.create(parentViewModel)
-            }
-        )
+    modifier: Modifier = Modifier,
+    topPerformersViewModel: DashboardTopPerformersViewModel = viewModelWithFactory(
+        creationCallback = { factory: DashboardTopPerformersViewModel.Factory ->
+            factory.create(parentViewModel)
+        }
+    )
 ) {
     topPerformersViewModel.topPerformersState.observeAsState().value?.let { topPerformersState ->
         val lastUpdateState by topPerformersViewModel.lastUpdateTopPerformers.observeAsState()
@@ -91,6 +90,7 @@ fun DashboardTopPerformersWidgetCard(
             titleResource = topPerformersState.titleStringRes,
             menu = topPerformersState.menu,
             button = topPerformersState.onOpenAnalyticsTapped,
+            modifier = modifier
         ) {
             DashboardTopPerformersContent(
                 topPerformersState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -288,10 +288,7 @@ class ProductDetailViewModel @Inject constructor(
             val showPublishOption = !isProductPublishedOrPrivate || isProductUnderCreation
 
             // Show sharing option only if the product isn't being created.
-            // Additionally, for WPCom atomic sites, ensure the site is public.
-            // (`isSitePublic` applies only to WordPress.com sites, not self-hosted ones).
-            val showShareOption = !isProductUnderCreation &&
-                (!selectedSite.get().isWPComAtomic || selectedSite.get().isSitePublic)
+            val showShareOption = !isProductUnderCreation && selectedSite.get().isSitePublic
 
             // Show "Share" as action with text only if "Save" or "Publish" is not currently shown as action with text.
             val showShareOptionAsActionWithText =

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -53,15 +53,6 @@
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="@dimen/minor_100"
                         android:visibility="gone" />
-
-                    <com.woocommerce.android.widgets.WCEmptyView
-                        android:id="@+id/empty_view"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:layout_marginTop="@dimen/major_100"
-                        android:visibility="gone"
-                        tools:visibility="visible" />
-
                 </LinearLayout>
             </androidx.core.widget.NestedScrollView>
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11406 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds the "Share your store" card to the dashboard, it will be shown when the site doesn't have any orders.

The last commit 8138fd8cf3e9eeac4d70e5864f39b80a415fb28a is not directly related to the share card, but it's a change to improve the consistency by requiring passing a modifier to all the cards, since now we can have different types of cards.

### Testing instructions
1. Make sure the dynamic dashboard feature flag is enabled.
2. Create a store that doesn't have any orders.
3. Open the app.
4. Confirm the "share your store" card is visible below the other cards.
5. Click on "Share your store" button.
6. Confirm it works as expected.
7. Add some orders to the store.
8. Go back to the dashboard, and confirm the share card was removed.

### Images/gif
<img src="https://github.com/woocommerce/woocommerce-android/assets/1657201/d2f82f3e-4ddf-4a14-8cd4-f4e8be90edb3" width=400 />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
