### PR TITLE
[Watch App] Introduce login UI and error handling

### DIFF
--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/phone/PhoneConnectionRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/phone/PhoneConnectionRepository.kt
@@ -5,6 +5,8 @@ import com.google.android.gms.wearable.CapabilityClient
 import com.google.android.gms.wearable.DataItem
 import com.google.android.gms.wearable.DataMapItem
 import com.google.android.gms.wearable.MessageClient
+import com.woocommerce.android.phone.PhoneConnectionRepository.RequestState.Idle
+import com.woocommerce.android.phone.PhoneConnectionRepository.RequestState.Waiting
 import com.woocommerce.android.ui.login.LoginRepository
 import com.woocommerce.commons.wear.DataPath
 import com.woocommerce.commons.wear.MessagePath
@@ -14,13 +16,32 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.update
 
+@OptIn(FlowPreview::class)
 class PhoneConnectionRepository @Inject constructor(
     private val loginRepository: LoginRepository,
     private val capabilityClient: CapabilityClient,
     private val messageClient: MessageClient,
     private val coroutineScope: CoroutineScope
 ) {
+    private val _stateMachine = MutableStateFlow<RequestState>(Idle)
+    val stateMachine = _stateMachine.asStateFlow()
+
+    init {
+        coroutineScope.launch {
+            _stateMachine
+                .filter { it is Waiting }
+                .debounce(20000)
+                .collect { _stateMachine.update { Idle } }
+        }
+    }
+
     fun handleReceivedData(dataItem: DataItem) {
         when (dataItem.uri.path) {
             DataPath.SITE_DATA.value -> handleAuthenticationData(dataItem)
@@ -31,12 +52,15 @@ class PhoneConnectionRepository @Inject constructor(
     suspend fun sendMessage(
         path: MessagePath,
         data: ByteArray = byteArrayOf()
-    ): Result<Unit> = fetchReachableNodes()
-        .takeIf { it.isNotEmpty() }
-        ?.map { coroutineScope.async { messageClient.sendMessage(it.id, path.value, data) } }
-        ?.awaitAll()
-        ?.let { Result.success(Unit) }
-        ?: Result.failure(Exception("No reachable nodes found"))
+    ): Result<Unit> {
+        _stateMachine.update { Waiting(path) }
+        return fetchReachableNodes()
+            .takeIf { it.isNotEmpty() }
+            ?.map { coroutineScope.async { messageClient.sendMessage(it.id, path.value, data) } }
+            ?.awaitAll()
+            ?.let { Result.success(Unit) }
+            ?: Result.failure(Exception(MESSAGE_FAILURE_EXCEPTION))
+    }
 
     private suspend fun fetchReachableNodes() = capabilityClient
         .getAllCapabilities(CapabilityClient.FILTER_REACHABLE)
@@ -52,8 +76,15 @@ class PhoneConnectionRepository @Inject constructor(
         coroutineScope.launch { loginRepository.receiveStoreData(dataMap) }
     }
 
+    sealed class RequestState {
+        data object Idle: RequestState()
+        data class Waiting(val currentPath: MessagePath): RequestState()
+    }
+
     companion object {
         const val TAG = "PhoneConnectionRepository"
         const val WOO_MOBILE_CAPABILITY = "woo_mobile"
+
+        const val MESSAGE_FAILURE_EXCEPTION = "No reachable nodes found"
     }
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/phone/PhoneConnectionRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/phone/PhoneConnectionRepository.kt
@@ -52,16 +52,14 @@ class PhoneConnectionRepository @Inject constructor(
     suspend fun sendMessage(
         path: MessagePath,
         data: ByteArray = byteArrayOf()
-    ): Result<Unit> {
-        return fetchReachableNodes()
-            .takeIf { it.isNotEmpty() }
-            ?.map { coroutineScope.async { messageClient.sendMessage(it.id, path.value, data) } }
-            ?.awaitAll()
-            ?.let {
-                _requestState.update { Waiting(path) }
-                Result.success(Unit)
-            } ?: Result.failure(Exception(MESSAGE_FAILURE_EXCEPTION))
-    }
+    ) = fetchReachableNodes()
+        .takeIf { it.isNotEmpty() }
+        ?.map { coroutineScope.async { messageClient.sendMessage(it.id, path.value, data) } }
+        ?.awaitAll()
+        ?.let {
+            _requestState.update { Waiting(path) }
+            Result.success(Unit)
+        } ?: Result.failure(Exception(MESSAGE_FAILURE_EXCEPTION))
 
     private suspend fun fetchReachableNodes() = capabilityClient
         .getAllCapabilities(CapabilityClient.FILTER_REACHABLE)

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/phone/PhoneConnectionRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/phone/PhoneConnectionRepository.kt
@@ -11,17 +11,17 @@ import com.woocommerce.android.ui.login.LoginRepository
 import com.woocommerce.commons.wear.DataPath
 import com.woocommerce.commons.wear.MessagePath
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
-import javax.inject.Inject
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
 
 @OptIn(FlowPreview::class)
 class PhoneConnectionRepository @Inject constructor(
@@ -78,8 +78,8 @@ class PhoneConnectionRepository @Inject constructor(
     }
 
     sealed class RequestState {
-        data object Idle: RequestState()
-        data class Waiting(val currentPath: MessagePath): RequestState()
+        data object Idle : RequestState()
+        data class Waiting(val currentPath: MessagePath) : RequestState()
     }
 
     companion object {

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -42,6 +43,7 @@ fun LoginScreen(
             contentAlignment = Alignment.Center
         ) {
             if (isLoading) {
+                TimeText()
                 LoadingScreen()
             } else {
                 ErrorScreen(onTryAgainClicked)
@@ -58,12 +60,17 @@ private fun LoadingScreen(
         modifier = modifier
             .fillMaxSize()
             .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp),
+        verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        TimeText()
-        CircularProgressIndicator()
-        Text("Loading")
+        CircularProgressIndicator(
+            modifier = modifier
+                .size(24.dp)
+        )
+        Text(
+            text = "Loading",
+            modifier = modifier.padding(8.dp)
+        )
     }
 }
 

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
@@ -27,14 +27,14 @@ fun LoginScreen(viewModel: LoginViewModel) {
     val viewState by viewModel.viewState.observeAsState()
     LoginScreen(
         isLoading = viewState?.isLoading ?: false,
-        onLoginButtonClicked = viewModel::onLoginButtonClicked
+        onTryAgainClicked = viewModel::onTryAgainClicked
     )
 }
 
 @Composable
 fun LoginScreen(
     isLoading: Boolean,
-    onLoginButtonClicked: () -> Unit
+    onTryAgainClicked: () -> Unit
 ) {
     WooTheme {
         Box(
@@ -44,7 +44,7 @@ fun LoginScreen(
             if (isLoading) {
                 LoadingScreen()
             } else {
-                ErrorScreen(onLoginButtonClicked)
+                ErrorScreen(onTryAgainClicked)
             }
         }
     }
@@ -69,7 +69,7 @@ private fun LoadingScreen(
 
 @Composable
 fun ErrorScreen(
-    onLoginButtonClicked: () -> Unit,
+    onTryAgainClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -93,7 +93,7 @@ fun ErrorScreen(
             style = WooTypography.caption2
         )
         Button(
-            onClick = onLoginButtonClicked,
+            onClick = onTryAgainClicked,
             modifier = modifier.fillMaxWidth()
         ) {
             Text("Try Again")
@@ -107,7 +107,7 @@ fun ErrorScreen(
 fun PreviewError() {
     LoginScreen(
         isLoading = false,
-        onLoginButtonClicked = {}
+        onTryAgainClicked = {}
     )
 }
 
@@ -117,6 +117,6 @@ fun PreviewError() {
 fun PreviewLoading() {
     LoginScreen(
         isLoading = true,
-        onLoginButtonClicked = {}
+        onTryAgainClicked = {}
     )
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.tooling.preview.devices.WearDevices
@@ -43,7 +44,8 @@ fun LoginScreen(
         ) {
             if (isLoading) {
                 TimeText()
-                Text("Loading...")
+                CircularProgressIndicator()
+                Text("Loading")
             } else {
                 SyncScreen(onLoginButtonClicked)
             }
@@ -85,12 +87,22 @@ fun SyncScreen(
     }
 }
 
-@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true)
-@Preview(device = WearDevices.SQUARE, showSystemUi = true)
+@Preview(name = "Error Round", device = WearDevices.LARGE_ROUND, showSystemUi = true)
+@Preview(name = "Error Square", device = WearDevices.SQUARE, showSystemUi = true)
 @Composable
-fun Preview() {
+fun PreviewError() {
     LoginScreen(
         isLoading = false,
+        onLoginButtonClicked = {}
+    )
+}
+
+@Preview(name = "Loading Round", device = WearDevices.LARGE_ROUND, showSystemUi = true)
+@Preview(name = "Loading Square", device = WearDevices.SQUARE, showSystemUi = true)
+@Composable
+fun PreviewLoading() {
+    LoginScreen(
+        isLoading = true,
         onLoginButtonClicked = {}
     )
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.login
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -43,18 +42,33 @@ fun LoginScreen(
             contentAlignment = Alignment.Center
         ) {
             if (isLoading) {
-                TimeText()
-                CircularProgressIndicator()
-                Text("Loading")
+                LoadingScreen()
             } else {
-                SyncScreen(onLoginButtonClicked)
+                ErrorScreen(onLoginButtonClicked)
             }
         }
     }
 }
 
 @Composable
-fun SyncScreen(
+private fun LoadingScreen(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        TimeText()
+        CircularProgressIndicator()
+        Text("Loading")
+    }
+}
+
+@Composable
+fun ErrorScreen(
     onLoginButtonClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.login
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -10,6 +12,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
@@ -17,6 +20,7 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.tooling.preview.devices.WearDevices
 import com.woocommerce.android.presentation.theme.WooTheme
+import com.woocommerce.android.presentation.theme.WooTypography
 
 @Composable
 fun LoginScreen(viewModel: LoginViewModel) {
@@ -37,8 +41,8 @@ fun LoginScreen(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
-            TimeText()
             if (isLoading) {
+                TimeText()
                 Text("Loading...")
             } else {
                 SyncScreen(onLoginButtonClicked)
@@ -49,16 +53,34 @@ fun LoginScreen(
 
 @Composable
 fun SyncScreen(
-    onLoginButtonClicked: () -> Unit
+    onLoginButtonClicked: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = Modifier.padding(16.dp)
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        Text(
+            text = "Log in",
+            style = WooTypography.body1
+        )
+        Text(
+            text = "Something went wrong",
+            style = WooTypography.body2
+        )
+        Text(
+            text = "Make sure your phone is nearby with the Woo app installed and Bluetooth is on.",
+            textAlign = TextAlign.Center,
+            style = WooTypography.caption2
+        )
         Button(
             onClick = onLoginButtonClicked,
-            modifier = Modifier.fillMaxWidth()
+            modifier = modifier.fillMaxWidth()
         ) {
-            Text("Continue on phone")
+            Text("Try Again")
         }
     }
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -21,6 +22,7 @@ import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.tooling.preview.devices.WearDevices
+import com.woocommerce.android.R
 import com.woocommerce.android.presentation.theme.WooTheme
 import com.woocommerce.android.presentation.theme.WooTypography
 
@@ -69,7 +71,7 @@ private fun LoadingScreen(
                 .size(24.dp)
         )
         Text(
-            text = "Registering",
+            text = stringResource(id = R.string.login_screen_loading_text),
             modifier = modifier.padding(8.dp)
         )
     }
@@ -88,12 +90,12 @@ fun ErrorScreen(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            text = "Log in",
+            text = stringResource(id = R.string.login_screen_error_title),
             style = WooTypography.body1,
             modifier = modifier.padding(bottom = 16.dp)
         )
         Text(
-            text = "Open the Woo app on your phone and hold your watch nearby",
+            text = stringResource(id = R.string.login_screen_error_caption),
             textAlign = TextAlign.Center,
             style = WooTypography.caption1
         )
@@ -101,7 +103,7 @@ fun ErrorScreen(
             onClick = onTryAgainClicked,
             modifier = modifier.width(150.dp)
         ) {
-            Text("Try Again")
+            Text(stringResource(id = R.string.login_screen_error_action_button))
         }
     }
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
@@ -96,7 +96,8 @@ fun ErrorScreen(
         Text(
             text = stringResource(id = R.string.login_screen_error_caption),
             textAlign = TextAlign.Center,
-            style = WooTypography.caption1
+            style = WooTypography.caption1,
+            modifier = modifier.padding(bottom = 8.dp)
         )
         Button(
             onClick = onTryAgainClicked,

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -68,7 +69,7 @@ private fun LoadingScreen(
                 .size(24.dp)
         )
         Text(
-            text = "Loading",
+            text = "Registering",
             modifier = modifier.padding(8.dp)
         )
     }
@@ -88,20 +89,17 @@ fun ErrorScreen(
     ) {
         Text(
             text = "Log in",
-            style = WooTypography.body1
+            style = WooTypography.body1,
+            modifier = modifier.padding(bottom = 16.dp)
         )
         Text(
-            text = "Something went wrong",
-            style = WooTypography.body2
-        )
-        Text(
-            text = "Make sure your phone is nearby with the Woo app installed and Bluetooth is on.",
+            text = "Open the Woo app on your phone and hold your watch nearby",
             textAlign = TextAlign.Center,
-            style = WooTypography.caption2
+            style = WooTypography.caption1
         )
         Button(
             onClick = onTryAgainClicked,
-            modifier = modifier.fillMaxWidth()
+            modifier = modifier.width(150.dp)
         ) {
             Text("Try Again")
         }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
@@ -32,7 +32,14 @@ class LoginViewModel @AssistedInject constructor(
     val viewState = _viewState.asLiveData()
 
     init {
-        launch { observeLoginChanges() }
+        _viewState.update { it.copy(isLoading = true) }
+        launch {
+            phoneConnectionRepository.sendMessage(REQUEST_SITE)
+                .fold(
+                    onSuccess = { observeLoginChanges() },
+                    onFailure = { _viewState.update { it.copy(isLoading = false) } }
+                )
+        }
     }
 
     private suspend fun observeLoginChanges() {

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.navigation.NavHostController
 import com.woocommerce.android.phone.PhoneConnectionRepository
+import com.woocommerce.android.ui.NavRoutes
 import com.woocommerce.android.ui.NavRoutes.MY_STORE
 import com.woocommerce.commons.viewmodel.ScopedViewModel
 import com.woocommerce.commons.viewmodel.getStateFlow
@@ -37,7 +38,9 @@ class LoginViewModel @AssistedInject constructor(
     private suspend fun observeLoginChanges() {
         loginRepository.isUserLoggedIn.collect { isLoggedIn ->
             if (isLoggedIn) {
-                navController.navigate(MY_STORE.route)
+                navController.navigate(MY_STORE.route) {
+                    popUpTo(NavRoutes.LOGIN.route) { inclusive = true }
+                }
             } else {
                 _viewState.update { it.copy(isLoading = false) }
             }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
@@ -51,14 +51,14 @@ class LoginViewModel @AssistedInject constructor(
 
     private suspend fun observeLoginChanges() {
         observeLoginRequest().collect { loginState ->
-                when (loginState) {
-                    Logged -> navController.navigate(MY_STORE.route) {
-                        popUpTo(NavRoutes.LOGIN.route) { inclusive = true }
-                    }
-                    Waiting -> _viewState.update { it.copy(isLoading = true) }
-                    Failed -> _viewState.update { it.copy(isLoading = false) }
+            when (loginState) {
+                Logged -> navController.navigate(MY_STORE.route) {
+                    popUpTo(NavRoutes.LOGIN.route) { inclusive = true }
                 }
+                Waiting -> _viewState.update { it.copy(isLoading = true) }
+                Failed -> _viewState.update { it.copy(isLoading = false) }
             }
+        }
     }
 
     @Parcelize

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
@@ -63,8 +63,7 @@ class LoginViewModel @AssistedInject constructor(
 
     @Parcelize
     data class ViewState(
-        val isLoading: Boolean = true,
-        val isSyncButtonVisible: Boolean = false
+        val isLoading: Boolean = true
     ) : Parcelable
 
     @AssistedFactory

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
@@ -31,16 +31,9 @@ class LoginViewModel @AssistedInject constructor(
     )
     val viewState = _viewState.asLiveData()
 
-    init {
-        _viewState.update { it.copy(isLoading = true) }
-        launch {
-            phoneConnectionRepository.sendMessage(REQUEST_SITE)
-                .fold(
-                    onSuccess = { observeLoginChanges() },
-                    onFailure = { _viewState.update { it.copy(isLoading = false) } }
-                )
-        }
-    }
+    init { requestSiteData() }
+
+    fun onTryAgainClicked() { requestSiteData() }
 
     private suspend fun observeLoginChanges() {
         loginRepository.isUserLoggedIn.collect { isLoggedIn ->
@@ -54,10 +47,14 @@ class LoginViewModel @AssistedInject constructor(
         }
     }
 
-    fun onTryAgainClicked() {
+    private fun requestSiteData() {
         _viewState.update { it.copy(isLoading = true) }
         launch {
             phoneConnectionRepository.sendMessage(REQUEST_SITE)
+                .fold(
+                    onSuccess = { observeLoginChanges() },
+                    onFailure = { _viewState.update { it.copy(isLoading = false) } }
+                )
         }
     }
 

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
@@ -44,7 +44,7 @@ class LoginViewModel @AssistedInject constructor(
         }
     }
 
-    fun onLoginButtonClicked() {
+    fun onTryAgainClicked() {
         _viewState.update { it.copy(isLoading = true) }
         launch {
             phoneConnectionRepository.sendMessage(REQUEST_SITE)

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
@@ -15,7 +15,7 @@ class ObserveLoginRequest @Inject constructor(
 ) {
     operator fun invoke() = combine(
         loginRepository.isUserLoggedIn,
-        phoneRepository.stateMachine
+        phoneRepository.requestState
     ) { isUserLoggedIn, requestState ->
         when {
             isUserLoggedIn -> Logged

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
@@ -6,8 +6,8 @@ import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Fa
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Logged
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Waiting
 import com.woocommerce.commons.wear.MessagePath.REQUEST_SITE
-import javax.inject.Inject
 import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
 
 class ObserveLoginRequest @Inject constructor(
     private val loginRepository: LoginRepository,

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.ui.login
+
+import com.woocommerce.android.phone.PhoneConnectionRepository
+import com.woocommerce.android.phone.PhoneConnectionRepository.RequestState.Waiting
+import com.woocommerce.android.ui.login.LoginViewModel.LoginState
+import com.woocommerce.commons.wear.MessagePath.REQUEST_SITE
+import javax.inject.Inject
+import kotlinx.coroutines.flow.combine
+
+class ObserveLoginRequest @Inject constructor(
+    private val loginRepository: LoginRepository,
+    private val phoneRepository: PhoneConnectionRepository,
+) {
+    operator fun invoke() = combine(
+        loginRepository.isUserLoggedIn,
+        phoneRepository.stateMachine
+    ) { isUserLoggedIn, requestState ->
+        when {
+            isUserLoggedIn -> LoginState.Logged
+            requestState == Waiting(REQUEST_SITE) -> LoginState.Waiting
+            else -> LoginState.Failed
+        }
+    }
+
+    enum class LoginRequestState {
+        Logged,
+        Waiting,
+        Failed
+    }
+}

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
@@ -1,8 +1,10 @@
 package com.woocommerce.android.ui.login
 
 import com.woocommerce.android.phone.PhoneConnectionRepository
-import com.woocommerce.android.phone.PhoneConnectionRepository.RequestState.Waiting
-import com.woocommerce.android.ui.login.LoginViewModel.LoginState
+import com.woocommerce.android.phone.PhoneConnectionRepository.RequestState
+import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Failed
+import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Logged
+import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Waiting
 import com.woocommerce.commons.wear.MessagePath.REQUEST_SITE
 import javax.inject.Inject
 import kotlinx.coroutines.flow.combine
@@ -16,9 +18,9 @@ class ObserveLoginRequest @Inject constructor(
         phoneRepository.stateMachine
     ) { isUserLoggedIn, requestState ->
         when {
-            isUserLoggedIn -> LoginState.Logged
-            requestState == Waiting(REQUEST_SITE) -> LoginState.Waiting
-            else -> LoginState.Failed
+            isUserLoggedIn -> Logged
+            requestState == RequestState.Waiting(REQUEST_SITE) -> Waiting
+            else -> Failed
         }
     }
 

--- a/WooCommerce-Wear/src/main/res/values/strings.xml
+++ b/WooCommerce-Wear/src/main/res/values/strings.xml
@@ -1,10 +1,13 @@
 <resources>
     <string name="app_name">WooCommerce</string>
-    <!--
-    This string is used for square devices and overridden by hello_world in
-    values-round/strings.xml for round devices.
-    -->
-    <string name="hello_world">From the Square world,\nHello, %1$s!</string>
+
+    <!-- Login Screen -->
+    <string name="login_screen_loading_text">Registering</string>
+    <string name="login_screen_error_title">Log in</string>
+    <string name="login_screen_error_caption">Open the Woo app on your phone and hold your watch nearby</string>
+    <string name="login_screen_error_action_button">Try Again</string>
+
+    <!-- Tile and Complication -->
     <string name="tile_label">Example tile</string>
     <string name="complication_label">Example complication</string>
 </resources>

--- a/WooCommerce-Wear/src/main/res/values/strings.xml
+++ b/WooCommerce-Wear/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
     <string name="app_name">WooCommerce</string>
 
     <!-- Login Screen -->
-    <string name="login_screen_loading_text">Registering</string>
+    <string name="login_screen_loading_text">Loading</string>
     <string name="login_screen_error_title">Log in</string>
     <string name="login_screen_error_caption">Open the Woo app on your phone and hold your watch nearby</string>
     <string name="login_screen_error_action_button">Try Again</string>

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/LoginViewModelTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/LoginViewModelTest.kt
@@ -71,17 +71,19 @@ class LoginViewModelTest : BaseUnitTest() {
     @Test
     fun `on login button clicked, loading is started`() = testBlocking {
         // Given
-        var isLoading: Boolean? = null
+        val isLoadingEvents = mutableListOf<Boolean>()
         whenever(loginRepository.isUserLoggedIn).thenReturn(flowOf(false))
         createSut()
-        sut.viewState.observeForever { isLoading = it.isLoading }
+        sut.viewState.observeForever { isLoadingEvents.add(it.isLoading) }
 
         // When
         sut.onTryAgainClicked()
 
         // Then
-        assertThat(isLoading).isNotNull()
-        assertThat(isLoading).isTrue
+        assertThat(isLoadingEvents).hasSize(3)
+        assertThat(isLoadingEvents[0]).isFalse
+        assertThat(isLoadingEvents[1]).isTrue
+        assertThat(isLoadingEvents[2]).isFalse
     }
 
     @Test

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/LoginViewModelTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/LoginViewModelTest.kt
@@ -11,8 +11,11 @@ import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.Mockito.never
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -33,7 +36,10 @@ class LoginViewModelTest : BaseUnitTest() {
         createSut()
 
         // Then
-        verify(navController).navigate(NavRoutes.MY_STORE.route)
+        verify(navController).navigate(
+            eq(NavRoutes.MY_STORE.route),
+            builder = any()
+        )
     }
 
     @Test
@@ -59,7 +65,7 @@ class LoginViewModelTest : BaseUnitTest() {
         sut.onTryAgainClicked()
 
         // Then
-        verify(phoneConnectionRepository).sendMessage(REQUEST_SITE)
+        verify(phoneConnectionRepository, times(2)).sendMessage(REQUEST_SITE)
     }
 
     @Test

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/LoginViewModelTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/LoginViewModelTest.kt
@@ -102,15 +102,19 @@ class LoginViewModelTest : BaseUnitTest() {
     @Test
     fun `on viewModel init, then fail REQUEST_SITE message and cancel loading`() = testBlocking {
         // Given
+        var isLoading: Boolean? = null
         whenever(phoneConnectionRepository.sendMessage(REQUEST_SITE))
             .doReturn(Result.failure(Exception("")))
 
         // When
         createSut()
+        sut.viewState.observeForever { isLoading = it.isLoading }
 
         // Then
         verify(phoneConnectionRepository).sendMessage(REQUEST_SITE)
         verify(loginRepository, never()).isUserLoggedIn
+        assertThat(isLoading).isNotNull()
+        assertThat(isLoading).isFalse
     }
 
     private fun createSut() {

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/LoginViewModelTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/LoginViewModelTest.kt
@@ -54,7 +54,7 @@ class LoginViewModelTest : BaseUnitTest() {
         createSut()
 
         // When
-        sut.onLoginButtonClicked()
+        sut.onTryAgainClicked()
 
         // Then
         verify(phoneConnectionRepository).sendMessage(MessagePath.REQUEST_SITE)
@@ -69,7 +69,7 @@ class LoginViewModelTest : BaseUnitTest() {
         sut.viewState.observeForever { isLoading = it.isLoading }
 
         // When
-        sut.onLoginButtonClicked()
+        sut.onTryAgainClicked()
 
         // Then
         assertThat(isLoading).isNotNull()

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/LoginViewModelTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/LoginViewModelTest.kt
@@ -5,11 +5,13 @@ import androidx.navigation.NavHostController
 import com.woocommerce.android.BaseUnitTest
 import com.woocommerce.android.phone.PhoneConnectionRepository
 import com.woocommerce.android.ui.NavRoutes
-import com.woocommerce.commons.wear.MessagePath
+import com.woocommerce.commons.wear.MessagePath.REQUEST_SITE
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.Mockito.never
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -57,7 +59,7 @@ class LoginViewModelTest : BaseUnitTest() {
         sut.onTryAgainClicked()
 
         // Then
-        verify(phoneConnectionRepository).sendMessage(MessagePath.REQUEST_SITE)
+        verify(phoneConnectionRepository).sendMessage(REQUEST_SITE)
     }
 
     @Test
@@ -74,6 +76,35 @@ class LoginViewModelTest : BaseUnitTest() {
         // Then
         assertThat(isLoading).isNotNull()
         assertThat(isLoading).isTrue
+    }
+
+    @Test
+    fun `on viewModel init, then send REQUEST_SITE message and observe the logged in status`() = testBlocking {
+        // Given
+        whenever(loginRepository.isUserLoggedIn).thenReturn(flowOf(false))
+        whenever(phoneConnectionRepository.sendMessage(REQUEST_SITE))
+            .doReturn(Result.success(Unit))
+
+        // When
+        createSut()
+
+        // Then
+        verify(phoneConnectionRepository).sendMessage(REQUEST_SITE)
+        verify(loginRepository).isUserLoggedIn
+    }
+
+    @Test
+    fun `on viewModel init, then fail REQUEST_SITE message and cancel loading`() = testBlocking {
+        // Given
+        whenever(phoneConnectionRepository.sendMessage(REQUEST_SITE))
+            .doReturn(Result.failure(Exception("")))
+
+        // When
+        createSut()
+
+        // Then
+        verify(phoneConnectionRepository).sendMessage(REQUEST_SITE)
+        verify(loginRepository, never()).isUserLoggedIn
     }
 
     private fun createSut() {


### PR DESCRIPTION
Summary
==========
Fix issue #11335, #11337 and #11422 by introducing an integrated way between the Login UI and Login state handling.

This PR introduces the following changes:
- Actual Login UI for when the Watch app starts, including loading feedback and error instructions, alongside a Try again button
- Multiple errors scenario detection to decide when to display the error instructions
- Trigger the subsequence My Store view once the Store is correctly authenticated

Screenshots
==========
| Round  | Square |
| ------------- | ------------- |
| <img width="201" alt="Screenshot 2024-05-01 at 01 50 24" src="https://github.com/woocommerce/woocommerce-android/assets/5920403/668eda4b-c198-46c8-957e-0e3787d2389d"> | <img width="164" alt="Screenshot 2024-05-01 at 01 50 29" src="https://github.com/woocommerce/woocommerce-android/assets/5920403/1d1e11a4-55b6-45e9-828f-8e296457dc4f"> |





Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.