### PR TITLE
Bump Tracks to `5.0.0`

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -248,6 +248,7 @@ dependencies {
         exclude group: "org.wordpress", module: "fluxc"
     }
     implementation "com.automattic:Automattic-Tracks-Android:$automatticTracksVersion"
+    implementation "com.automattic.tracks:crashlogging:$automatticTracksVersion"
 
     implementation("${gradle.ext.fluxCBinaryPath}:$fluxCVersion") {
         exclude group: "com.android.support"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -179,6 +179,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     fun init(application: Application) {
         this.application = application
 
+        crashLogging.initialize()
         Thread.setDefaultUncaughtExceptionHandler(
             UncaughtErrorsHandler(
                 context = application,

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ ext {
     mediapickerVersion = '0.3.0'
     wordPressLoginVersion = '1.15.0'
     aboutAutomatticVersion = '0.0.6'
-    automatticTracksVersion = '4.0.2'
+    automatticTracksVersion = '5.0.0'
     workManagerVersion = '2.7.1'
     billingVersion = '5.0.0'
     stripeTerminalVersion = '3.1.1'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR bumps Tracks to `5.0.0` and addresses breaking changes: introduces `crashlogging` library (extracted from Tracks) and initializes SDK via `initialize` method.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Please use `CrashLogging#sendReport` method somewhere in the code, run build in release variant and verify that the event was sent to the Sentry instance


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
