### PR TITLE
[Dynamic Dashboard] Update Blaze card UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
@@ -49,6 +49,7 @@ import com.woocommerce.android.ui.blaze.campaigs.BlazeCampaignItem
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.ProductThumbnail
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCOverflowMenu
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
@@ -150,7 +151,7 @@ private fun BlazeFrame(
             titleResource = DashboardWidget.Type.BLAZE.titleResource,
             iconResource = R.drawable.ic_blaze,
             menu = state.menu,
-            button = state.createCampaignButton,
+            button = state.mainButton,
         ) {
             content()
         }
@@ -194,6 +195,17 @@ fun DashboardBlazeView(
                         campaign = state.campaign,
                         onCampaignClicked = state.onCampaignClicked,
                     )
+
+                    if (FeatureFlag.DYNAMIC_DASHBOARD.isEnabled()) {
+                        WCOutlinedButton(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = dimensionResource(id = R.dimen.minor_100)),
+                            onClick = state.onCreateCampaignClicked,
+                        ) {
+                            Text(stringResource(R.string.blaze_campaign_create_campaign_button))
+                        }
+                    }
                 }
 
                 is DashboardBlazeCampaignState.NoCampaign -> {
@@ -209,6 +221,20 @@ fun DashboardBlazeView(
                         onProductSelected = state.onProductClicked,
                         modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100))
                     )
+
+                    if (FeatureFlag.DYNAMIC_DASHBOARD.isEnabled()) {
+                        WCOutlinedButton(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(
+                                    top = dimensionResource(id = R.dimen.minor_100),
+                                    bottom = dimensionResource(id = R.dimen.major_100)
+                                ),
+                            onClick = state.onCreateCampaignClicked,
+                        ) {
+                            Text(stringResource(R.string.blaze_campaign_create_campaign_button))
+                        }
+                    }
                 }
 
                 else -> error("Invalid state")
@@ -227,20 +253,20 @@ private fun BlazeCampaignFooter(state: DashboardBlazeCampaignState) {
 
             is DashboardBlazeCampaignState.Campaign -> {
                 ShowAllOrCreateCampaignFooter(
-                    onShowAllClicked = state.onViewAllCampaignsClicked,
-                    onCreateCampaignClicked = state.createCampaignButton.action
+                    onShowAllClicked = state.showAllCampaignsButton.action,
+                    onCreateCampaignClicked = state.onCreateCampaignClicked
                 )
             }
 
             is DashboardBlazeCampaignState.NoCampaign -> {
                 WCTextButton(
-                    onClick = state.createCampaignButton.action,
+                    onClick = state.onCreateCampaignClicked,
                     contentPadding = PaddingValues(
                         top = ButtonDefaults.TextButtonContentPadding.calculateTopPadding(),
                         bottom = ButtonDefaults.TextButtonContentPadding.calculateBottomPadding(),
                     )
                 ) {
-                    Text(stringResource(id = R.string.blaze_campaign_promote_button))
+                    Text(stringResource(id = R.string.blaze_campaign_create_campaign_button))
                 }
             }
 
@@ -264,7 +290,7 @@ private fun ShowAllOrCreateCampaignFooter(
             modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_100)),
             onClick = onCreateCampaignClicked
         ) {
-            Text(stringResource(id = R.string.blaze_campaign_promote_button))
+            Text(stringResource(id = R.string.blaze_campaign_create_campaign_button))
         }
     }
 }
@@ -311,14 +337,22 @@ fun BlazeProductItem(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             ProductThumbnail(imageUrl = product.imgUrl)
-            Text(
+            Column(
                 modifier = Modifier
                     .padding(start = dimensionResource(id = R.dimen.major_100))
-                    .weight(1f),
-                text = product.name,
-                style = MaterialTheme.typography.subtitle1,
-                fontWeight = FontWeight.Bold
-            )
+                    .weight(1f)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.blaze_campaign_suggested_product_caption),
+                    style = MaterialTheme.typography.caption,
+                    color = colorResource(R.color.color_on_surface_medium)
+                )
+                Text(
+                    text = product.name,
+                    style = MaterialTheme.typography.subtitle1,
+                    fontWeight = FontWeight.Bold
+                )
+            }
             Icon(
                 painter = painterResource(id = R.drawable.ic_arrow_right),
                 contentDescription = null
@@ -425,7 +459,7 @@ fun MyStoreBlazeViewCampaignPreview() {
                 ),
             ),
             onCampaignClicked = {},
-            onViewAllCampaignsClicked = {},
+            onCreateCampaignClicked = {},
             menu = DashboardWidgetMenu(
                 items = listOf(
                     DashboardWidget.Type.BLAZE.defaultHideMenuEntry(
@@ -433,10 +467,10 @@ fun MyStoreBlazeViewCampaignPreview() {
                     )
                 )
             ),
-            createCampaignButton = DashboardWidgetAction(
-                titleResource = R.string.blaze_campaign_promote_button,
+            showAllCampaignsButton = DashboardWidgetAction(
+                titleResource = R.string.blaze_campaign_show_all_button,
                 action = {}
-            )
+            ),
         ),
         onDismissBlazeView = {}
     )
@@ -459,10 +493,7 @@ fun MyStoreBlazeViewNoCampaignPreview() {
                     )
                 )
             ),
-            createCampaignButton = DashboardWidgetAction(
-                titleResource = R.string.blaze_campaign_promote_button,
-                action = {}
-            )
+            onCreateCampaignClicked = {},
         ),
         onDismissBlazeView = {}
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
@@ -343,6 +343,8 @@ fun BlazeProductItem(
                     .weight(1f)
             ) {
                 Text(
+                    modifier = Modifier
+                        .padding(bottom = dimensionResource(id = R.dimen.minor_50)),
                     text = stringResource(id = R.string.blaze_campaign_suggested_product_caption),
                     style = MaterialTheme.typography.caption,
                     color = colorResource(R.color.color_on_surface_medium)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
@@ -129,14 +129,11 @@ class DashboardBlazeViewModel @AssistedInject constructor(
             onProductClicked = {
                 launchCampaignCreation(product.remoteId)
             },
+            onCreateCampaignClicked = {
+                launchCampaignCreation(if (products.size == 1) product.remoteId else null)
+            },
             menu = DashboardWidgetMenu(
                 items = listOf(hideWidgetAction)
-            ),
-            createCampaignButton = DashboardWidgetAction(
-                titleResource = string.blaze_campaign_promote_button,
-                action = {
-                    launchCampaignCreation(if (products.size == 1) product.remoteId else null)
-                }
             )
         )
     }
@@ -174,24 +171,14 @@ class DashboardBlazeViewModel @AssistedInject constructor(
                     )
                 )
             },
-            onViewAllCampaignsClicked = {
-                viewAllCampaigns()
+            onCreateCampaignClicked = {
+                launchCampaignCreation(productId = null)
             },
-            menu = DashboardWidgetMenu(
-                items = listOf(
-                    DashboardWidgetAction(
-                        titleResource = string.blaze_campaign_show_all_button,
-                        action = { triggerEvent(ShowAllCampaigns) }
-                    ),
-                    hideWidgetAction
-                )
+            menu = DashboardWidgetMenu(items = listOf(hideWidgetAction)),
+            showAllCampaignsButton = DashboardWidgetAction(
+                titleResource = string.blaze_campaign_show_all_button,
+                action = { viewAllCampaigns() }
             ),
-            createCampaignButton = DashboardWidgetAction(
-                titleResource = string.blaze_campaign_promote_button,
-                action = {
-                    launchCampaignCreation(productId = null)
-                }
-            )
         )
     }
 
@@ -245,7 +232,7 @@ class DashboardBlazeViewModel @AssistedInject constructor(
 
     sealed class DashboardBlazeCampaignState(
         open val menu: DashboardWidgetMenu,
-        open val createCampaignButton: DashboardWidgetAction? = null
+        val mainButton: DashboardWidgetAction? = null
     ) {
         // TODO remove this state when enabling [FeatureFlag.DYNAMIC_DASHBOARD] and clean up the code
         data object Hidden : DashboardBlazeCampaignState(DashboardWidgetMenu(emptyList()))
@@ -253,17 +240,17 @@ class DashboardBlazeViewModel @AssistedInject constructor(
         data class NoCampaign(
             val product: BlazeProductUi,
             val onProductClicked: () -> Unit,
+            val onCreateCampaignClicked: () -> Unit,
             override val menu: DashboardWidgetMenu,
-            override val createCampaignButton: DashboardWidgetAction
-        ) : DashboardBlazeCampaignState(menu, createCampaignButton)
+        ) : DashboardBlazeCampaignState(menu)
 
         data class Campaign(
             val campaign: BlazeCampaignUi,
             val onCampaignClicked: () -> Unit,
-            val onViewAllCampaignsClicked: () -> Unit,
-            override val menu: DashboardWidgetMenu,
-            override val createCampaignButton: DashboardWidgetAction
-        ) : DashboardBlazeCampaignState(menu, createCampaignButton)
+            val onCreateCampaignClicked: () -> Unit,
+            val showAllCampaignsButton: DashboardWidgetAction,
+            override val menu: DashboardWidgetMenu
+        ) : DashboardBlazeCampaignState(menu, showAllCampaignsButton)
     }
 
     data class LaunchBlazeCampaignCreation(val productId: Long?) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3750,8 +3750,9 @@
     -->
     <string name="blaze_campaign_title">Blaze campaign</string>
     <string name="blaze_campaign_subtitle">Increase visibility and get your products sold quickly.</string>
-    <string name="blaze_campaign_promote_button">Promote</string>
-    <string name="blaze_campaign_show_all_button">Show all</string>
+    <string name="blaze_campaign_create_campaign_button">Create campaign</string>
+    <string name="blaze_campaign_suggested_product_caption">Suggested product</string>
+    <string name="blaze_campaign_show_all_button">View all campaigns</string>
     <string name="blaze_campaign_status_in_moderation">In moderation</string>
     <string name="blaze_campaign_status_active">Active</string>
     <string name="blaze_campaign_status_completed">Completed</string>


### PR DESCRIPTION
Implements #11412 and updates the UI of the Blaze card by moving the `View all campaigns` button from the menu to the bottom of the card and making `Create campaign` button a secondary button inside the card content.

| Campaign | No campaign |
|--------|--------|
| ![image](https://github.com/woocommerce/woocommerce-android/assets/1522856/7877ec02-b12c-4b72-850f-dd23c06477ff) | ![image](https://github.com/woocommerce/woocommerce-android/assets/1522856/ed0dc23e-9093-40ba-a51b-0ea6210e9eb0) | 

**To test:**
1. Enable the dynamic dashboard feature flag
2. Log in to a store with no Blaze campaigns
3. Verify the new Create campaign button is visible and working as expected
4. Log in to a store with existing campaigns
5. Verify the new Create campaign button is visible and working as expected