### PR TITLE
[Dynamic Dashboard] Feedback card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -23,18 +23,16 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.model.DashboardWidget
-import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowStatsError
-import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
-import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeCard
 import com.woocommerce.android.ui.dashboard.onboarding.DashboardOnboardingCard
 import com.woocommerce.android.ui.dashboard.stats.DashboardStatsCard
@@ -179,49 +177,41 @@ private fun ShareStoreCard(
 }
 
 @Composable
-fun FeedbackCard(
+private fun FeedbackCard(
     widget: DashboardViewModel.DashboardWidgetUiModel.FeedbackWidget,
     modifier: Modifier
 ) {
-    WidgetCard(
-        titleResource = R.string.my_store_widget_feedback_title,
-        menu = DashboardWidgetMenu(
-            items = listOf(
-                DashboardWidgetAction(
-                    title = UiStringRes(
-                        stringRes = R.string.dynamic_dashboard_hide_widget_menu_item,
-                        listOf(UiStringRes(stringRes = R.string.my_store_widget_feedback_title)),
-                    ),
-                    action = widget.onDismiss
-                )
-            ),
-        ),
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.padding(16.dp)
-        ) {
-            Text(
-                text = stringResource(id = R.string.feedback_request_title),
-                style = MaterialTheme.typography.body1
+            .border(
+                width = 1.dp,
+                color = colorResource(id = R.color.woo_gray_5),
+                shape = RoundedCornerShape(8.dp)
             )
-            Spacer(modifier = Modifier.height(16.dp))
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                WCOutlinedButton(
-                    onClick = widget.onNegativeClick,
-                    text = stringResource(id = R.string.feedback_request_make_better),
-                    modifier = Modifier.weight(1f)
-                )
-                WCColoredButton(
-                    onClick = widget.onPositiveClick,
-                    text = stringResource(id = R.string.feedback_request_like_it),
-                    modifier = Modifier.weight(1f)
-                )
-            }
+            .padding(16.dp)
+    ) {
+        Text(
+            text = stringResource(id = R.string.feedback_request_title),
+            style = MaterialTheme.typography.body1,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(top = 8.dp)
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            WCOutlinedButton(
+                onClick = widget.onNegativeClick,
+                text = stringResource(id = R.string.feedback_request_make_better),
+                modifier = Modifier.weight(1f)
+            )
+            WCColoredButton(
+                onClick = widget.onPositiveClick,
+                text = stringResource(id = R.string.feedback_request_like_it),
+                modifier = Modifier.weight(1f)
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -178,7 +178,6 @@ private fun ShareStoreCard(
     }
 }
 
-
 @Composable
 fun FeedbackCard(
     widget: DashboardViewModel.DashboardWidgetUiModel.FeedbackWidget,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -181,6 +182,10 @@ private fun FeedbackCard(
     widget: DashboardViewModel.DashboardWidgetUiModel.FeedbackWidget,
     modifier: Modifier
 ) {
+    LaunchedEffect(Unit) {
+        widget.onShown()
+    }
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -28,8 +29,10 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
 import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowStatsError
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeCard
 import com.woocommerce.android.ui.dashboard.onboarding.DashboardOnboardingCard
 import com.woocommerce.android.ui.dashboard.stats.DashboardStatsCard
@@ -80,6 +83,13 @@ private fun WidgetList(
                     is DashboardViewModel.DashboardWidgetUiModel.ShareStoreWidget -> {
                         ShareStoreCard(
                             onShareClicked = it.onShareClicked,
+                            modifier = widgetModifier
+                        )
+                    }
+
+                    is DashboardViewModel.DashboardWidgetUiModel.FeedbackWidget -> {
+                        FeedbackCard(
+                            widget = it,
                             modifier = widgetModifier
                         )
                     }
@@ -163,5 +173,46 @@ private fun ShareStoreCard(
             onClick = onShareClicked,
             text = stringResource(id = R.string.share_store_button)
         )
+    }
+}
+
+
+@Composable
+fun FeedbackCard(
+    widget: DashboardViewModel.DashboardWidgetUiModel.FeedbackWidget,
+    modifier: Modifier
+) {
+    WidgetCard(
+        titleResource = R.string.my_store_widget_feedback_title,
+        menu = DashboardWidgetMenu(
+            items = emptyList()
+        ),
+        modifier = modifier
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.feedback_request_title),
+                style = MaterialTheme.typography.body1
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                WCOutlinedButton(
+                    onClick = widget.onNegativeClick,
+                    text = stringResource(id = R.string.feedback_request_make_better),
+                    modifier = Modifier.weight(1f)
+                )
+                WCColoredButton(
+                    onClick = widget.onPositiveClick,
+                    text = stringResource(id = R.string.feedback_request_like_it),
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -27,11 +27,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowStatsError
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeCard
 import com.woocommerce.android.ui.dashboard.onboarding.DashboardOnboardingCard
@@ -185,7 +187,15 @@ fun FeedbackCard(
     WidgetCard(
         titleResource = R.string.my_store_widget_feedback_title,
         menu = DashboardWidgetMenu(
-            items = emptyList()
+            items = listOf(
+                DashboardWidgetAction(
+                    title = UiStringRes(
+                        stringRes = R.string.dynamic_dashboard_hide_widget_menu_item,
+                        listOf(UiStringRes(stringRes = R.string.my_store_widget_feedback_title)),
+                    ),
+                    action = widget.onDismiss
+                )
+            ),
         ),
         modifier = modifier
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -18,7 +18,6 @@ import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.play.core.review.ReviewManagerFactory
 import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -60,7 +59,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.wordpress.android.util.NetworkUtils
-import java.util.Calendar
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -88,9 +86,6 @@ class DashboardFragment :
 
     @Inject
     lateinit var appPrefsWrapper: AppPrefsWrapper
-
-    @Inject
-    lateinit var feedbackPrefs: FeedbackPrefs
 
     @Inject
     lateinit var blazeCampaignCreationDispatcher: BlazeCampaignCreationDispatcher
@@ -315,10 +310,6 @@ class DashboardFragment :
     }
 
     private fun handleFeedbackRequestPositiveClick() {
-        // set last feedback date to now and hide the card
-        feedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
-        binding.storeFeedbackRequestCard.visibility = View.GONE
-
         // Request a ReviewInfo object from the Google Reviews API. If this fails
         // we just move on as there isn't anything we can do.
         val manager = ReviewManagerFactory.create(requireContext())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -37,6 +37,8 @@ import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ContactSupport
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.FeedbackNegativeAction
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.FeedbackPositiveAction
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenEditWidgets
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShareStore
@@ -180,6 +182,10 @@ class DashboardFragment :
 
                 is ContactSupport -> activity?.startHelpActivity(HelpOrigin.MY_STORE)
 
+                is FeedbackPositiveAction -> handleFeedbackRequestPositiveClick()
+
+                is FeedbackNegativeAction -> mainNavigationRouter?.showFeedbackSurvey()
+
                 else -> event.isHandled = false
             }
         }
@@ -253,7 +259,6 @@ class DashboardFragment :
 
     override fun onResume() {
         super.onResume()
-        handleFeedbackRequestCardState()
         AnalyticsTracker.trackViewShown(this)
         // Avoid executing interacted() on first load. Only when the user navigated away from the fragment.
         if (wasPreviouslyStopped) {
@@ -307,31 +312,6 @@ class DashboardFragment :
 
     override fun scrollToTop() {
         binding.statsScrollView.smoothScrollTo(0, 0)
-    }
-
-    /**
-     * This method verifies if the feedback card should be visible.
-     *
-     * If it should but it's not, the feedback card is reconfigured and presented
-     * If should not and it's visible, the card visibility is changed to gone
-     * If should be and it's already visible, nothing happens
-     */
-    private fun handleFeedbackRequestCardState() = with(binding.storeFeedbackRequestCard) {
-        if (feedbackPrefs.userFeedbackIsDue && visibility == View.GONE) {
-            setupFeedbackRequestCard()
-        } else if (feedbackPrefs.userFeedbackIsDue.not() && visibility == View.VISIBLE) {
-            visibility = View.GONE
-        }
-    }
-
-    private fun setupFeedbackRequestCard() {
-        binding.storeFeedbackRequestCard.visibility = View.VISIBLE
-        val negativeCallback = {
-            mainNavigationRouter?.showFeedbackSurvey()
-            binding.storeFeedbackRequestCard.visibility = View.GONE
-            feedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
-        }
-        binding.storeFeedbackRequestCard.initView(negativeCallback, ::handleFeedbackRequestPositiveClick)
     }
 
     private fun handleFeedbackRequestPositiveClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -205,8 +205,7 @@ class DashboardViewModel @Inject constructor(
                 onNegativeClick = {
                     feedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
                     triggerEvent(DashboardEvent.FeedbackNegativeAction)
-                },
-                onDismiss = { feedbackPrefs.lastFeedbackDate = Calendar.getInstance().time }
+                }
             )
         )
     }
@@ -257,8 +256,7 @@ class DashboardViewModel @Inject constructor(
         data class FeedbackWidget(
             override val isVisible: Boolean,
             val onPositiveClick: () -> Unit,
-            val onNegativeClick: () -> Unit,
-            val onDismiss: () -> Unit
+            val onNegativeClick: () -> Unit
         ) : DashboardWidgetUiModel
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -195,7 +195,8 @@ class DashboardViewModel @Inject constructor(
         add(DashboardWidgetUiModel.ShareStoreWidget(shouldShowShareCard, ::onShareStoreClicked))
 
         add(
-            1,
+            // Show at the second row
+            (indexOfFirst { it.isVisible } + 1).coerceIn(0..<size),
             DashboardWidgetUiModel.FeedbackWidget(
                 isVisible = userFeedbackIsDue,
                 onPositiveClick = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -199,11 +199,25 @@ class DashboardViewModel @Inject constructor(
             (indexOfFirst { it.isVisible } + 1).coerceIn(0..<size),
             DashboardWidgetUiModel.FeedbackWidget(
                 isVisible = userFeedbackIsDue,
+                onShown = {
+                    analyticsTrackerWrapper.track(
+                        AnalyticsEvent.APP_FEEDBACK_PROMPT,
+                        mapOf(AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_SHOWN)
+                    )
+                },
                 onPositiveClick = {
+                    analyticsTrackerWrapper.track(
+                        AnalyticsEvent.APP_FEEDBACK_PROMPT,
+                        mapOf(AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_LIKED)
+                    )
                     feedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
                     triggerEvent(DashboardEvent.FeedbackPositiveAction)
                 },
                 onNegativeClick = {
+                    analyticsTrackerWrapper.track(
+                        AnalyticsEvent.APP_FEEDBACK_PROMPT,
+                        mapOf(AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_NOT_LIKED)
+                    )
                     feedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
                     triggerEvent(DashboardEvent.FeedbackNegativeAction)
                 }
@@ -256,6 +270,7 @@ class DashboardViewModel @Inject constructor(
 
         data class FeedbackWidget(
             override val isVisible: Boolean,
+            val onShown: () -> Unit,
             val onPositiveClick: () -> Unit,
             val onNegativeClick: () -> Unit
         ) : DashboardWidgetUiModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -195,7 +195,7 @@ class DashboardViewModel @Inject constructor(
 
         if (userFeedbackIsDue) {
             add(
-                2,
+                1,
                 DashboardWidgetUiModel.FeedbackWidget(
                     onPositiveClick = {
                         feedbackPrefs.lastFeedbackDate = Calendar.getInstance().time

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -225,6 +225,12 @@ class DashboardViewModel @Inject constructor(
         data class ShareStoreWidget(
             val onShareClicked: () -> Unit
         ) : DashboardWidgetUiModel
+
+        data class FeedbackWidget(
+            val onPositiveClick: () -> Unit,
+            val onNegativeClick: () -> Unit,
+            val onDismiss: () -> Unit
+        ) : DashboardWidgetUiModel
     }
 
     data class AppbarState(

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -45,14 +45,6 @@
                         android:id="@+id/dashboard_container"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content" />
-
-                    <!-- Feedback Request Card -->
-                    <com.woocommerce.android.ui.feedback.FeedbackRequestCard
-                        android:id="@+id/store_feedback_request_card"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/minor_100"
-                        android:visibility="gone" />
                 </LinearLayout>
             </androidx.core.widget.NestedScrollView>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -420,6 +420,7 @@
     <string name="my_store_widget_stats_title">Performance</string>
     <string name="my_store_widget_top_products_title">Top products</string>
     <string name="my_store_widget_blaze_title">Blaze campaigns</string>
+    <string name="my_store_widget_feedback_title">Feedback</string>
 
     <string name="my_store_widget_unavailable">Unavailable</string>
     <string name="my_store_widget_onboarding_completed">Completed</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -222,7 +222,8 @@ class DashboardViewModelTest : BaseUnitTest() {
 
         val widgets = viewModel.dashboardWidgets.captureValues().last()
 
-        val feedbackCard = widgets.first { it is DashboardViewModel.DashboardWidgetUiModel.FeedbackWidget }
+        val feedbackCard = widgets.filter { it.isVisible }[1]
+        assertThat(feedbackCard).isInstanceOf(DashboardViewModel.DashboardWidgetUiModel.FeedbackWidget::class.java)
         assertThat(feedbackCard.isVisible).isTrue()
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -273,19 +273,4 @@ class DashboardViewModelTest : BaseUnitTest() {
         verify(feedbackPrefs).lastFeedbackDate = any()
         assertThat(event).isEqualTo(DashboardViewModel.DashboardEvent.FeedbackNegativeAction)
     }
-
-    @Test
-    fun `given feedback card is shown, when dismiss button is tapped, then handle click`() = testBlocking {
-        setup {
-            whenever(feedbackPrefs.userFeedbackIsDueObservable).thenReturn(flowOf(true))
-        }
-
-        val widgets = viewModel.dashboardWidgets.captureValues().last()
-        val feedbackCard = widgets.filterIsInstance(
-            DashboardViewModel.DashboardWidgetUiModel.FeedbackWidget::class.java
-        ).first()
-        feedbackCard.onDismiss.invoke()
-
-        verify(feedbackPrefs).lastFeedbackDate = any()
-    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.dashboard
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.FeedbackPrefs
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.tools.SelectedSite
@@ -255,6 +257,10 @@ class DashboardViewModelTest : BaseUnitTest() {
 
         verify(feedbackPrefs).lastFeedbackDate = any()
         assertThat(event).isEqualTo(DashboardViewModel.DashboardEvent.FeedbackPositiveAction)
+        verify(analyticsTrackerWrapper).track(
+            AnalyticsEvent.APP_FEEDBACK_PROMPT,
+            mapOf(AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_LIKED)
+        )
     }
 
     @Test
@@ -273,5 +279,9 @@ class DashboardViewModelTest : BaseUnitTest() {
 
         verify(feedbackPrefs).lastFeedbackDate = any()
         assertThat(event).isEqualTo(DashboardViewModel.DashboardEvent.FeedbackNegativeAction)
+        verify(analyticsTrackerWrapper).track(
+            AnalyticsEvent.APP_FEEDBACK_PROMPT,
+            mapOf(AnalyticsTracker.KEY_FEEDBACK_ACTION to AnalyticsTracker.VALUE_FEEDBACK_NOT_LIKED)
+        )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11407 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds logic to show the feedback card in the dashboard when it's needed.

There is still an ongoing discussion about the position of the card p1714639095329519/1714486421.996339-slack-C0354HSNUJH, I'll update it if needed on a separate PR.

### Testing instructions
1. Apply the following patch to force showing the feedback card
<details>
<summary>Patch</summary>

```patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt	(revision 342fc01f601b4ae1d67eeec1627f1d10c0472ce9)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/FeedbackPrefs.kt	(date 1714410744001)
@@ -20,6 +20,9 @@
 class FeedbackPrefs(
     private val context: Context
 ) {
+    init {
+        setString(LAST_FEEDBACK_DATE, Date(0).time.toString())
+    }
     private val gson by lazy { Gson() }
     private val featureMapTypeToken by lazy { object : TypeToken<Map<String, String>>() {}.type }
     private val sharedPreferences get() = PreferenceManager.getDefaultSharedPreferences(context)
@@ -32,7 +35,7 @@
             } ?: mapOf()
 
     val userFeedbackIsDue: Boolean
-        get() = AppPrefs.installationDate?.pastTimeDeltaFromNowInDays greaterThan THREE_MONTHS_IN_DAYS &&
+        get() = Date(0).pastTimeDeltaFromNowInDays greaterThan THREE_MONTHS_IN_DAYS &&
             lastFeedbackDate?.pastTimeDeltaFromNowInDays greaterThan SIX_MONTHS_IN_DAYS
 
     val userFeedbackIsDueObservable: Flow<Boolean> = callbackFlow {
```
</details>

2. Make sure the dynamic dashboard feature flag is enabled.
3. Open the app.
4. Confirm the feedback card is shown.
5. Click on one of the feedback card buttons.
6. Confirm the action works, and the card is hidden.
7. Close the app.
8. Repeat 3 to 7 with a different action (Positive, negative and dismiss), and confirm all work.

NB: The positive action won't do anything, as the debug app is not available in Google Play.

### Images/gif
<img width=360 src="https://github.com/woocommerce/woocommerce-android/assets/1657201/2d18372f-d6c2-456f-9ac6-96e85af9c94c" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->