### PR TITLE
[Dynamic Dashboard] Prevent unselecting the last selected item

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorScreen.kt
@@ -75,13 +75,15 @@ fun DashboardWidgetEditorScreen(viewModel: DashboardWidgetEditorViewModel) {
                     ) { item, dragDropState ->
                         when (item.isAvailable) {
                             true -> {
+                                val selectedItems = state.orderedWidgetList.filter { it.isVisible }
                                 DragAndDropSelectableItem(
                                     item = item,
-                                    isSelected = item in state.orderedWidgetList.filter { it.isSelected },
+                                    isSelected = item.isSelected,
                                     dragDropState = dragDropState,
                                     onSelectionChange = viewModel::onSelectionChange,
                                     itemKey = { it.type },
-                                    itemFormatter = { stringResource(id = item.title) }
+                                    itemFormatter = { stringResource(id = item.title) },
+                                    isEnabled = !item.isSelected || selectedItems.size > 1
                                 )
                             }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11405 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds logic that prevents deselecting the last selected item in the widget editor.

### Testing instructions
1. Make sure that the dynamic dashboard feature flag is enabled.
2. Open the app.
3. Open the widget editor screen.
4. Confirm that you can deselect all items.

### Images/gif
[Screen_recording_20240430_170804.webm](https://github.com/woocommerce/woocommerce-android/assets/1657201/526cc19f-b145-4ff0-9843-545687c2c155)


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
