### PR TITLE
Add EOSL_M1 feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -16,7 +16,8 @@ enum class FeatureFlag {
     CONNECTIVITY_TOOL,
     NEW_SHIPPING_SUPPORT,
     DYNAMIC_DASHBOARD,
-    APP_PASSWORD_TUTORIAL;
+    APP_PASSWORD_TUTORIAL,
+    EOSL_M1;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -28,7 +29,8 @@ enum class FeatureFlag {
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
-            ORDER_CREATION_AUTO_TAX_RATE -> PackageUtils.isDebugBuild()
+            ORDER_CREATION_AUTO_TAX_RATE,
+            EOSL_M1 -> PackageUtils.isDebugBuild()
 
             DYNAMIC_DASHBOARD -> false
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11389 

### Description
This PR adds a feature flag to hide EOSL features until ready for release.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
