### PR TITLE
[Watch App] Improve wear login timeout logic

### DIFF
--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/phone/PhoneConnectionRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/phone/PhoneConnectionRepository.kt
@@ -56,6 +56,5 @@ class PhoneConnectionRepository @Inject constructor(
         const val WOO_MOBILE_CAPABILITY = "woo_mobile"
 
         const val MESSAGE_FAILURE_EXCEPTION = "No reachable nodes found"
-        const val REQUEST_TIMEOUT = 20000L
     }
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/phone/PhoneConnectionRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/phone/PhoneConnectionRepository.kt
@@ -5,43 +5,22 @@ import com.google.android.gms.wearable.CapabilityClient
 import com.google.android.gms.wearable.DataItem
 import com.google.android.gms.wearable.DataMapItem
 import com.google.android.gms.wearable.MessageClient
-import com.woocommerce.android.phone.PhoneConnectionRepository.RequestState.Idle
-import com.woocommerce.android.phone.PhoneConnectionRepository.RequestState.Waiting
 import com.woocommerce.android.ui.login.LoginRepository
 import com.woocommerce.commons.wear.DataPath
 import com.woocommerce.commons.wear.MessagePath
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
-@OptIn(FlowPreview::class)
 class PhoneConnectionRepository @Inject constructor(
     private val loginRepository: LoginRepository,
     private val capabilityClient: CapabilityClient,
     private val messageClient: MessageClient,
     private val coroutineScope: CoroutineScope
 ) {
-    private val _requestState = MutableStateFlow<RequestState>(Idle)
-    val requestState = _requestState.asStateFlow()
-
-    init {
-        coroutineScope.launch {
-            _requestState
-                .filter { it is Waiting }
-                .debounce(REQUEST_TIMEOUT)
-                .collect { _requestState.update { Idle } }
-        }
-    }
-
     fun handleReceivedData(dataItem: DataItem) {
         when (dataItem.uri.path) {
             DataPath.SITE_DATA.value -> handleAuthenticationData(dataItem)
@@ -56,10 +35,8 @@ class PhoneConnectionRepository @Inject constructor(
         .takeIf { it.isNotEmpty() }
         ?.map { coroutineScope.async { messageClient.sendMessage(it.id, path.value, data) } }
         ?.awaitAll()
-        ?.let {
-            _requestState.update { Waiting(path) }
-            Result.success(Unit)
-        } ?: Result.failure(Exception(MESSAGE_FAILURE_EXCEPTION))
+        ?.let { Result.success(Unit) }
+        ?: Result.failure(Exception(MESSAGE_FAILURE_EXCEPTION))
 
     private suspend fun fetchReachableNodes() = capabilityClient
         .getAllCapabilities(CapabilityClient.FILTER_REACHABLE)
@@ -74,12 +51,6 @@ class PhoneConnectionRepository @Inject constructor(
         val dataMap = DataMapItem.fromDataItem(dataItem).dataMap
         coroutineScope.launch { loginRepository.receiveStoreData(dataMap) }
     }
-
-    sealed class RequestState {
-        data object Idle : RequestState()
-        data class Waiting(val currentPath: MessagePath) : RequestState()
-    }
-
     companion object {
         const val TAG = "PhoneConnectionRepository"
         const val WOO_MOBILE_CAPABILITY = "woo_mobile"

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
@@ -7,8 +7,8 @@ import androidx.navigation.NavHostController
 import com.woocommerce.android.phone.PhoneConnectionRepository
 import com.woocommerce.android.ui.NavRoutes
 import com.woocommerce.android.ui.NavRoutes.MY_STORE
-import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Timeout
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Logged
+import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Timeout
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Waiting
 import com.woocommerce.commons.viewmodel.ScopedViewModel
 import com.woocommerce.commons.viewmodel.getStateFlow

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/LoginViewModel.kt
@@ -7,7 +7,7 @@ import androidx.navigation.NavHostController
 import com.woocommerce.android.phone.PhoneConnectionRepository
 import com.woocommerce.android.ui.NavRoutes
 import com.woocommerce.android.ui.NavRoutes.MY_STORE
-import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Failed
+import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Timeout
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Logged
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Waiting
 import com.woocommerce.commons.viewmodel.ScopedViewModel
@@ -56,7 +56,7 @@ class LoginViewModel @AssistedInject constructor(
                     popUpTo(NavRoutes.LOGIN.route) { inclusive = true }
                 }
                 Waiting -> _viewState.update { it.copy(isLoading = true) }
-                Failed -> _viewState.update { it.copy(isLoading = false) }
+                Timeout -> _viewState.update { it.copy(isLoading = false) }
             }
         }
     }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.login
 
-import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Failed
+import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Timeout
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Logged
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Waiting
 import kotlinx.coroutines.delay
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
+import kotlinx.coroutines.flow.onEach
 
 class ObserveLoginRequest @Inject constructor(
     private val loginRepository: LoginRepository
@@ -19,7 +20,7 @@ class ObserveLoginRequest @Inject constructor(
         when {
             isUserLoggedIn -> Logged
             isWaiting -> Waiting
-            else -> Failed
+            else -> Timeout
         }
     }
 
@@ -33,7 +34,7 @@ class ObserveLoginRequest @Inject constructor(
     enum class LoginRequestState {
         Logged,
         Waiting,
-        Failed
+        Timeout
     }
 
     companion object {

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
@@ -3,11 +3,11 @@ package com.woocommerce.android.ui.login
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Failed
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Logged
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Waiting
-import kotlinx.coroutines.flow.combine
-import javax.inject.Inject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
 
 class ObserveLoginRequest @Inject constructor(
     private val loginRepository: LoginRepository

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
@@ -1,32 +1,47 @@
 package com.woocommerce.android.ui.login
 
-import com.woocommerce.android.phone.PhoneConnectionRepository
-import com.woocommerce.android.phone.PhoneConnectionRepository.RequestState
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Failed
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Logged
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Waiting
-import com.woocommerce.commons.wear.MessagePath.REQUEST_SITE
 import kotlinx.coroutines.flow.combine
 import javax.inject.Inject
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 class ObserveLoginRequest @Inject constructor(
-    private val loginRepository: LoginRepository,
-    private val phoneRepository: PhoneConnectionRepository,
+    private val loginRepository: LoginRepository
 ) {
     operator fun invoke() = combine(
         loginRepository.isUserLoggedIn,
-        phoneRepository.requestState
-    ) { isUserLoggedIn, requestState ->
+        timeoutFlow
+    ) { isUserLoggedIn, timeoutState ->
         when {
             isUserLoggedIn -> Logged
-            requestState == RequestState.Waiting(REQUEST_SITE) -> Waiting
+            timeoutState == LoginTimeoutState.Waiting -> Waiting
             else -> Failed
         }
     }
+
+    private val timeoutFlow: Flow<LoginTimeoutState>
+        get() = flow {
+            emit(LoginTimeoutState.Waiting)
+            delay(TIMEOUT_MILLIS)
+            emit(LoginTimeoutState.Timeout)
+        }
 
     enum class LoginRequestState {
         Logged,
         Waiting,
         Failed
+    }
+
+    enum class LoginTimeoutState {
+        Waiting,
+        Timeout
+    }
+
+    companion object {
+        const val TIMEOUT_MILLIS = 20000L
     }
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
@@ -1,14 +1,13 @@
 package com.woocommerce.android.ui.login
 
-import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Timeout
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Logged
+import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Timeout
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Waiting
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
-import kotlinx.coroutines.flow.onEach
 
 class ObserveLoginRequest @Inject constructor(
     private val loginRepository: LoginRepository

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/login/ObserveLoginRequest.kt
@@ -14,31 +14,26 @@ class ObserveLoginRequest @Inject constructor(
 ) {
     operator fun invoke() = combine(
         loginRepository.isUserLoggedIn,
-        timeoutFlow
-    ) { isUserLoggedIn, timeoutState ->
+        timeoutWaitingFlow
+    ) { isUserLoggedIn, isWaiting ->
         when {
             isUserLoggedIn -> Logged
-            timeoutState == LoginTimeoutState.Waiting -> Waiting
+            isWaiting -> Waiting
             else -> Failed
         }
     }
 
-    private val timeoutFlow: Flow<LoginTimeoutState>
+    private val timeoutWaitingFlow: Flow<Boolean>
         get() = flow {
-            emit(LoginTimeoutState.Waiting)
+            emit(true)
             delay(TIMEOUT_MILLIS)
-            emit(LoginTimeoutState.Timeout)
+            emit(false)
         }
 
     enum class LoginRequestState {
         Logged,
         Waiting,
         Failed
-    }
-
-    enum class LoginTimeoutState {
-        Waiting,
-        Timeout
     }
 
     companion object {

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/LoginViewModelTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/LoginViewModelTest.kt
@@ -5,7 +5,7 @@ import androidx.navigation.NavHostController
 import com.woocommerce.android.BaseUnitTest
 import com.woocommerce.android.phone.PhoneConnectionRepository
 import com.woocommerce.android.ui.NavRoutes
-import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Failed
+import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Timeout
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Logged
 import com.woocommerce.commons.wear.MessagePath.REQUEST_SITE
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -48,7 +48,7 @@ class LoginViewModelTest : BaseUnitTest() {
     fun `when user is not logged in, loading is stopped`() = testBlocking {
         // Given
         var isLoading: Boolean? = null
-        whenever(observeLoginRequest.invoke()).thenReturn(flowOf(Failed))
+        whenever(observeLoginRequest.invoke()).thenReturn(flowOf(Timeout))
         createSut()
         sut.viewState.observeForever { isLoading = it.isLoading }
 

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/LoginViewModelTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/LoginViewModelTest.kt
@@ -5,8 +5,8 @@ import androidx.navigation.NavHostController
 import com.woocommerce.android.BaseUnitTest
 import com.woocommerce.android.phone.PhoneConnectionRepository
 import com.woocommerce.android.ui.NavRoutes
-import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Timeout
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Logged
+import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Timeout
 import com.woocommerce.commons.wear.MessagePath.REQUEST_SITE
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/ObserveLoginRequestTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/ObserveLoginRequestTest.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android.ui.login
 
 import com.woocommerce.android.BaseUnitTest
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState
-import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Failed
+import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Timeout
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Logged
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Waiting
 import kotlin.test.Test
@@ -36,7 +36,7 @@ class ObserveLoginRequestTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when user is not logged in and waiting timeout, return Failed state`() = testBlocking {
+    fun `when user is not logged in and waiting timeout, return Timeout state`() = testBlocking {
         // Given
         val events = mutableListOf<LoginRequestState>()
         whenever(loginRepository.isUserLoggedIn).thenReturn(flowOf(false))
@@ -48,7 +48,7 @@ class ObserveLoginRequestTest : BaseUnitTest() {
 
         // Then
         advanceUntilIdle()
-        assertThat(events).isEqualTo(listOf(Waiting, Failed))
+        assertThat(events).isEqualTo(listOf(Waiting, Timeout))
     }
 
     @Test

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/ObserveLoginRequestTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/ObserveLoginRequestTest.kt
@@ -2,10 +2,9 @@ package com.woocommerce.android.ui.login
 
 import com.woocommerce.android.BaseUnitTest
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState
-import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Timeout
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Logged
+import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Timeout
 import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Waiting
-import kotlin.test.Test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
@@ -14,6 +13,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import kotlin.test.Test
 
 @ExperimentalCoroutinesApi
 class ObserveLoginRequestTest : BaseUnitTest() {

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/ObserveLoginRequestTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/login/ObserveLoginRequestTest.kt
@@ -1,0 +1,63 @@
+package com.woocommerce.android.ui.login
+
+import com.woocommerce.android.BaseUnitTest
+import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Failed
+import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Logged
+import com.woocommerce.android.ui.login.ObserveLoginRequest.LoginRequestState.Waiting
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.assertj.core.api.Assertions.assertThat
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class ObserveLoginRequestTest : BaseUnitTest() {
+
+    private lateinit var sut: ObserveLoginRequest
+    private val loginRepository: LoginRepository = mock()
+
+    @Test
+    fun `when user is logged in, return Logged state`() = testBlocking {
+        // Given
+        whenever(loginRepository.isUserLoggedIn).thenReturn(flowOf(true))
+
+        // When
+        sut = ObserveLoginRequest(loginRepository)
+
+        // Then
+        assertThat(sut.invoke().first()).isEqualTo(Logged)
+    }
+
+    @Test
+    fun `when user is not logged in and not waiting, return Failed state`() = testBlocking {
+        // Given
+        val events = mutableListOf<ObserveLoginRequest.LoginRequestState>()
+        whenever(loginRepository.isUserLoggedIn).thenReturn(flowOf(false))
+
+        // When
+        ObserveLoginRequest(loginRepository).invoke()
+            .onEach { events.add(it) }
+            .launchIn(this)
+
+        // Then
+        advanceUntilIdle()
+        assertThat(events).isEqualTo(listOf(Waiting, Failed))
+    }
+
+    @Test
+    fun `when user is not logged in and waiting, return Waiting state`() = testBlocking {
+        // Given
+        whenever(loginRepository.isUserLoggedIn).thenReturn(flowOf(false))
+
+        // When
+        sut = ObserveLoginRequest(loginRepository)
+
+        // Then
+        assertThat(sut.invoke().first()).isEqualTo(Waiting)
+    }
+}


### PR DESCRIPTION
Summary
==========
Adds a simplified way to handle the Login timeout event during the Android Wear Store credentials acquisition from the phone.

Introduces a `ObserveLoginRequest` use case, capable of handling the Timeout timer instead of delegating it to the `PhoneConnectionRepository`. Also, adds proper unit test coverage to the new use case.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
