### PR TITLE
Beta fix: Category parent selection crash fix

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
@@ -268,19 +268,20 @@ class AddProductCategoryViewModel @Inject constructor(
 
     private fun Sequence<ProductCategoryItemUiModel>.filterDescendantsOfCurrent(): List<ProductCategoryItemUiModel> {
         return filterNot {
-            getIneligibleCategories(navArgs.productCategory!!.remoteCategoryId)
-                .contains(it.category.remoteCategoryId)
+            getIneligibleCategories(navArgs.productCategory?.remoteCategoryId).contains(it.category.remoteCategoryId)
         }.toList()
     }
 
-    private fun Sequence<ProductCategoryItemUiModel>.getIneligibleCategories(currentId: Long): Set<Long> {
-        val ineligibleCategories = mutableSetOf(currentId)
-        this.filter { it.category.parentId == currentId }
-            .map { it.category.remoteCategoryId }
-            .forEach {
-                ineligibleCategories += getIneligibleCategories(it)
-            }
-        return ineligibleCategories
+    private fun Sequence<ProductCategoryItemUiModel>.getIneligibleCategories(currentId: Long?): Set<Long> {
+        return currentId?.let {
+            val ineligibleCategories = mutableSetOf(currentId)
+            this.filter { it.category.parentId == currentId }
+                .map { it.category.remoteCategoryId }
+                .forEach {
+                    ineligibleCategories += getIneligibleCategories(it)
+                }
+            ineligibleCategories
+        } ?: emptySet()
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
@@ -251,7 +251,8 @@ class AddProductCategoryViewModel @Inject constructor(
                 } else {
                     _parentCategories.value = productsInDb
                         .sortCategories(resourceProvider)
-                        .filter { parentCategoryIsElegible(it) }
+                        .asSequence()
+                        .filterDescendantsOfCurrent()
                     showSkeleton = false
                 }
             }
@@ -265,9 +266,22 @@ class AddProductCategoryViewModel @Inject constructor(
         }
     }
 
-    private fun parentCategoryIsElegible(it: ProductCategoryItemUiModel) =
-        it.category.remoteCategoryId != navArgs.productCategory?.remoteCategoryId &&
-            it.category.parentId != navArgs.productCategory?.remoteCategoryId
+    private fun Sequence<ProductCategoryItemUiModel>.filterDescendantsOfCurrent(): List<ProductCategoryItemUiModel> {
+        return filterNot {
+            getIneligibleCategories(navArgs.productCategory!!.remoteCategoryId)
+                .contains(it.category.remoteCategoryId)
+        }.toList()
+    }
+
+    private fun Sequence<ProductCategoryItemUiModel>.getIneligibleCategories(currentId: Long): Set<Long> {
+        val ineligibleCategories = mutableSetOf(currentId)
+        this.filter { it.category.parentId == currentId }
+            .map { it.category.remoteCategoryId }
+            .forEach {
+                ineligibleCategories += getIneligibleCategories(it)
+            }
+        return ineligibleCategories
+    }
 
     /**
      * Triggered when the user scrolls past the point of loaded categories
@@ -292,7 +306,8 @@ class AddProductCategoryViewModel @Inject constructor(
                     productCategoriesRepository.getProductCategoriesList()
                 }
                 .sortCategories(resourceProvider)
-                .filter { parentCategoryIsElegible(it) }
+                .asSequence()
+                .filterDescendantsOfCurrent()
 
             parentCategoryListViewState = parentCategoryListViewState.copy(
                 isLoading = true,


### PR DESCRIPTION
Fixes #11210. The previous fix (#11228) addressed the case when the selected category or a direct child was selected. However, the further descendants were not filtered out and when they are selected as a parent, the app will crash.

| Categories | Parent options (selecting `B`) |
|--------|--------|
| ![image](https://github.com/woocommerce/woocommerce-android/assets/1522856/64aa7566-83bd-4d5d-9150-4cb525d63168) | ![image](https://github.com/woocommerce/woocommerce-android/assets/1522856/026e3e61-f020-46a4-b4ba-baeb0849d9e7) | 

**To test:**
1. Make sure your store has categories with a hierarchy a couple of levels deep
2. Go to Products -> Select a product -> Tap on Categories
3. Tap on a hierarchy that has children/grandchildren
4. Tap on Parent category
5. Notice that the parent options exclude the selected category and all descendants