### PR TITLE
Add a way to clear parent category

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryFragment.kt
@@ -106,6 +106,10 @@ class AddProductCategoryFragment :
             }
         }
 
+        binding.clearParentCategory.setOnClickListener {
+            viewModel.onClearParentCategoryClicked()
+        }
+
         with(binding.productCategoryParent) {
             viewModel.getSelectedParentCategoryName()?.let { setText(it) }
             setClickListener {
@@ -160,10 +164,17 @@ class AddProductCategoryFragment :
             }
             new.selectedParentId.takeIfNotEqualTo(old?.selectedParentId) {
                 val parentCategoryName = viewModel.getSelectedParentCategoryName()
-                parentCategoryName?.let { binding.productCategoryParent.setHtmlText(it) }
+                if (parentCategoryName != null) {
+                    binding.productCategoryParent.setHtmlText(parentCategoryName)
+                } else {
+                    binding.productCategoryParent.setHtmlText("")
+                }
             }
             new.isEditingMode.takeIfNotEqualTo(old?.isEditingMode) {
                 deleteMenuItem?.isVisible = it
+            }
+            new.selectedParentId.takeIfNotEqualTo(old?.selectedParentId) {
+                binding.clearParentCategory.isEnabled = it != 0L && it != null
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
@@ -84,6 +84,10 @@ class AddProductCategoryViewModel @Inject constructor(
         }
     }
 
+    fun onClearParentCategoryClicked() {
+        addProductCategoryViewState = addProductCategoryViewState.copy(selectedParentId = 0L)
+    }
+
     fun onCategoryNameChanged(categoryName: String) {
         addProductCategoryViewState = if (categoryName.isEmpty()) {
             addProductCategoryViewState.copy(

--- a/WooCommerce/src/main/res/layout/fragment_add_product_category.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_product_category.xml
@@ -20,7 +20,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:paddingBottom="@dimen/major_100"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/toolbar">
@@ -52,6 +51,17 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/product_category_name" />
+
+
+        <com.google.android.material.button.MaterialButton
+            style="@style/Woo.Button.TextButton.TextStart"
+            android:id="@+id/clear_parent_category"
+            android:paddingStart="@dimen/major_100"
+            android:paddingEnd="@dimen/minor_100"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="@string/product_category_clear_parent"/>
 
     </com.woocommerce.android.widgets.WCElevatedLinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2050,6 +2050,7 @@
     <string name="product_variation_no_price_set">No price set</string>
     <string name="product_categories">Categories</string>
     <string name="product_category_empty">Add category</string>
+    <string name="product_category_clear_parent">Clear parent category</string>
     <string name="product_category_list_empty_title">Add your first category</string>
     <string name="product_category_list_empty_message">Organise your products in categories</string>
     <string name="product_add_category">Add category</string>


### PR DESCRIPTION
Implements #11427.

After fixing a parent category crash, I realized there's no way to clear the parent category once it's been set. This PR adds a button to do that.

[Screen_recording_20240501_182608.webm](https://github.com/woocommerce/woocommerce-android/assets/1522856/512e5e67-4b03-4b81-a041-94b721e21502)

**To test:**
1. Make sure you already have a category hierarchy with some categories having a parent
2. Go to Products -> Tap on a product -> Tap on Categories
3. Tap on a category with a parent category
4. Tap on the `Clear parent category` button
5. Notice the parent category is removed and the button is disabled
6. Tap on Save
7. Notice the changed category is not in the top level