### PR TITLE
Pass the isEnabled state to draggable item

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingScreen.kt
@@ -107,7 +107,8 @@ fun AnalyticsHubSettingScreen(
                                 dragDropState = dragDropState,
                                 onSelectionChange = onSelectionChange,
                                 itemKey = { it.card },
-                                itemFormatter = { title }
+                                itemFormatter = { title },
+                                isEnabled = item.isEnabled
                             )
                         }
 


### PR DESCRIPTION
### Description
This tiny PR passes the isEnabled state to the `DragAndDropSelectableItem`  so we can disable the draggable card item when there is only one item selected.

### Testing instructions

1. Open the App
2. Tap on See all store analytics
3. Tap on the pencil icon in the menu to navigate to the Customize Analytics screen.
4. Unmark All the cards and check that the last one is disabled


### Images/gif
https://github.com/woocommerce/woocommerce-android/assets/18119390/8fdacf5d-086e-47f1-b8fe-6928fa4f150d

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
