### PR TITLE
Use CallThrottler in NavController extension to prevent crashes.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NavController.kt
@@ -67,3 +67,11 @@ fun NavController.navigateSafely(
         }
     }
 }
+
+fun NavController.popBackStackSafely() {
+    CallThrottler.throttle {
+        if (popBackStack().not()) {
+            WooLog.w(WooLog.T.UTILS, "No back stack entry found to pop.")
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.extensions.WindowSizeClass
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.pinFabAboveBottomNavigationBar
+import com.woocommerce.android.extensions.popBackStackSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.extensions.windowSizeClass
 import com.woocommerce.android.model.FeatureFeedbackSettings
@@ -173,7 +174,7 @@ class OrderListFragment :
                         WooLog.d(WooLog.T.ORDERS, "Before navigating back from OrderList: Location #1")
                         if (!binding.detailPaneContainer.findNavController().popBackStack()) {
                             WooLog.d(WooLog.T.ORDERS, "Before navigating back from OrderList: Location #2")
-                            findNavController().popBackStack()
+                            findNavController().popBackStackSafely()
                         }
                     } else if (isSearching) {
                         WooLog.d(WooLog.T.ORDERS, "Before navigating back from OrderList: Location #3")
@@ -189,9 +190,9 @@ class OrderListFragment :
                             // and now it's a single pane layout (phone), e.g. due to a configuration change.
                             // In this case we need to switch panes – show the list pane instead of details pane.
                             adjustUiForDeviceType(savedInstanceState)
-                        } else {
+                        } else if (findNavController().currentDestination?.id == R.id.orders) {
                             WooLog.d(WooLog.T.ORDERS, "Before navigating back from OrderList: Location #6")
-                            findNavController().popBackStack()
+                            findNavController().popBackStackSafely()
                         }
                     }
                     WooLog.d(WooLog.T.ORDERS, "After navigating back from OrderList: End")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11063

<!-- Id number of the GitHub issue this PR addresses. -->

### Description

To address the issue of the `MainBottomNavigationView` crashing due to rapid double-tapping of the back button on the `OrderListFragment`, several enhancements were made:

1. Throttling Back Navigation: Introduced a `popBackStackSafely` method in the `NavController` extensions. This method uses a throttling mechanism to prevent rapid consecutive calls to `popBackStack`, which can lead to crashes if the back stack is manipulated too quickly.

2. Integration in Fragment: Utilized the new `popBackStackSafely` method within `OrderListFragment` to ensure that back navigation is handled safely. This prevents the fragment from attempting to navigate back when there is no entry in the back stack.

3. Check to ensure navigation entry is still correct before navigating.

### Testing instructions 

**Test on tablet and phones**

1. Navigate to the Order Details on an order.
2. Press back to the Order List.
3. Press back to the My Store.
4. Ensure no crashes take place and navigation works as expected.
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
