### PR TITLE
[Beta 18.4] Fix for on-back-press NPE in OrderListFragment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -166,6 +166,12 @@ class OrderListFragment :
             this,
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
+                    // We discovered cases where the callback was being invoked multiple times.
+                    // Most likely due to lagging fragment transition, it was not removed from the
+                    // onBackPressedDispatcher before next back press event.
+                    // The check below ensures that the callback is only called once to prevent crashes.
+                    if (findNavController().currentDestination?.id != R.id.orders) return
+
                     orderNavigationLogger.logBackStack(findNavController(), "Before navigating back from OrderList")
                     WooLog.d(WooLog.T.ORDERS, "Before navigating back from OrderList: Start")
                     selectedOrder.selectOrder(-1L)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11063 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We discovered a crash happening on the back-press navigation from the Orders screen.
The suspicious behavior discovered in logs seems to be due to the `onBackPressCallback` being called twice, resulting in popping the back stack multiple times instead of once, and abusing the nav graph's state.

Discussion and details: p1714512654623349-slack-CGPNUU63E

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
We were not able to reproduce the original problem. However, it's important to check if this PR doesn't introduce any regression. The app should navigate back from the Orders screen correctly (in both landscape/tablet, and portrait modes) to My Store, and the bottom navigation should work.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->