### PR TITLE
Record precise time in encrypted logs

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/RollingLogEntries.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/RollingLogEntries.kt
@@ -45,7 +45,7 @@ class RollingLogEntries(private val limit: Int) : LinkedList<LogEntry>() {
 
         override fun toString(): String {
             val logText = if (text.isNullOrEmpty()) "null" else text
-            val logDateStr = SimpleDateFormat("MMM-dd kk:mm", Locale.US).format(logDate)
+            val logDateStr = SimpleDateFormat("MMM-dd kk:mm:ss:SS", Locale.US).format(logDate)
             return "[$logDateStr ${tag.name} ${level.name}] $logText"
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/RollingLogEntries.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/RollingLogEntries.kt
@@ -45,7 +45,7 @@ class RollingLogEntries(private val limit: Int) : LinkedList<LogEntry>() {
 
         override fun toString(): String {
             val logText = if (text.isNullOrEmpty()) "null" else text
-            val logDateStr = SimpleDateFormat("MMM-dd kk:mm:ss:SS", Locale.US).format(logDate)
+            val logDateStr = SimpleDateFormat("MMM-dd kk:mm:ss:SSS", Locale.US).format(logDate)
             return "[$logDateStr ${tag.name} ${level.name}] $logText"
         }
     }


### PR DESCRIPTION
### Description
This PR updates time format used in encrypted logs to ensure we record seconds and milliseconds on every line. This will help us during investigation of tricky crashes - race conditions and such.

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
I just put a debugger on [this line](https://github.com/woocommerce/woocommerce-android/blob/2a57d6ffec6b879dd2c44bc68dac928556440e03/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooLog.kt#L175) and invoked `entry.toString()` to double-check the format looks as expected.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No UI or user facing changes


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
