### PR TITLE
[Beta fix] Fix crash with Composable DatePickerDialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DialogButtonsRowLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DialogButtonsRowLayout.kt
@@ -58,18 +58,24 @@ fun DialogButtonsRowLayout(
                     placeables.maxOf { it.height }
                 }
 
-                return layout(constraints.maxWidth, height) {
+                val width = if (constraints.maxWidth != Constraints.Infinity) {
+                    constraints.maxWidth
+                } else {
+                    placeables.sumOf { it.width }
+                }
+
+                return layout(width, height) {
                     if (!shouldStackItems) {
                         neutralPlaceable?.placeRelative(
                             x = 0,
                             y = (height - neutralPlaceable.height) / 2
                         )
                         confirmPlaceable.placeRelative(
-                            x = constraints.maxWidth - confirmPlaceable.width,
+                            x = width - confirmPlaceable.width,
                             y = (height - confirmPlaceable.height) / 2
                         )
                         dismissPlaceable.placeRelative(
-                            x = constraints.maxWidth - confirmPlaceable.width - dismissPlaceable.width,
+                            x = width - confirmPlaceable.width - dismissPlaceable.width,
                             y = (height - dismissPlaceable.height) / 2
                         )
                     } else {
@@ -77,7 +83,7 @@ fun DialogButtonsRowLayout(
 
                         placeables.forEach { placeable ->
                             placeable.placeRelative(
-                                x = constraints.maxWidth - placeable.width,
+                                x = width - placeable.width,
                                 y = yPosition
                             )
                             yPosition += placeable.height

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DialogButtonsRowLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/DialogButtonsRowLayout.kt
@@ -107,6 +107,24 @@ fun DialogButtonsRowLayout(
                     measurables.maxOf { it.maxIntrinsicHeight(width) }
                 }
             }
+
+            override fun IntrinsicMeasureScope.maxIntrinsicWidth(
+                measurables: List<IntrinsicMeasurable>,
+                height: Int
+            ): Int {
+                return measurables.sumOf {
+                    it.maxIntrinsicWidth(height)
+                }
+            }
+
+            override fun IntrinsicMeasureScope.minIntrinsicWidth(
+                measurables: List<IntrinsicMeasurable>,
+                height: Int
+            ): Int {
+                return measurables.sumOf {
+                    it.minIntrinsicWidth(height)
+                }
+            }
         }
     }
     Layout(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11425 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
We recently updated Compose version (https://github.com/woocommerce/woocommerce-android/pull/11330), and this update included a new [change](https://android-review.googlesource.com/c/platform/frameworks/support/+/2946951) to check the dimensions we pass during the layout, this change caused the app to crash when trying to use the `DatePickerDialog`.
The cause is that for the `DatePickerDialog` we use `DialogButtonsRowLayout` to lay the buttons as a stack when needed, and we use [Intrinsic measurements](https://developer.android.com/develop/ui/compose/layouts/intrinsic-measurements) to make sure the dialog's header can match the size of the dialog without going more than needed. In `DialogButtonsRowLayout` we were handling the intrinsic measurements of the `height`, but not the `width`, which meant that we got a `Constraint.Infinity` when trying to lay it out.

### Testing instructions
TC 1:
1. Open the app.
2. Open the coupons screen.
3. Click on ➕ to add a new coupon.
4. Click on "Expiry date".
5. Confirm the app doesn't crash.
6. Rotate your phone, and confirm the dialog layout is updated accordingly.

TC 2:
Check the previews of `DialogButtonsRowLayout` and confirm there is no regression.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->