### PR TITLE
[Dynamic Dashboard] Add widget error view

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -29,7 +29,6 @@ import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.blaze.creation.BlazeCampaignCreationDispatcher
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
-import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowStatsError
 import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeCard
 import com.woocommerce.android.ui.dashboard.onboarding.DashboardOnboardingCard
 import com.woocommerce.android.ui.dashboard.stats.DashboardStatsCard
@@ -99,9 +98,6 @@ private fun ConfigurableWidgetCard(
     when (widgetUiModel.widget.type) {
         DashboardWidget.Type.STATS -> {
             DashboardStatsCard(
-                onStatsError = {
-                    dashboardViewModel.onDashboardWidgetEvent(ShowStatsError)
-                },
                 openDatePicker = { start, end, callback ->
                     dashboardViewModel.onDashboardWidgetEvent(OpenRangePicker(start, end, callback))
                 },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -42,7 +42,6 @@ import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.Op
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShareStore
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowAIProductDescriptionDialog
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowPrivacyBanner
-import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowStatsError
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel
 import com.woocommerce.android.ui.jitm.JitmFragment
 import com.woocommerce.android.ui.jitm.JitmMessagePathsProvider
@@ -57,7 +56,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import org.wordpress.android.util.NetworkUtils
 import java.util.Calendar
 import javax.inject.Inject
 import kotlin.math.abs
@@ -174,8 +172,6 @@ class DashboardFragment :
                     )
                 }
 
-                is ShowStatsError -> showErrorSnack()
-
                 is OpenRangePicker -> showDateRangePicker(event.start, event.end, event.callback)
 
                 is ContactSupport -> activity?.startHelpActivity(HelpOrigin.MY_STORE)
@@ -276,13 +272,6 @@ class DashboardFragment :
     override fun onDestroy() {
         lifecycle.removeObserver(storeOnboardingViewModel)
         super.onDestroy()
-    }
-
-    private fun showErrorSnack() {
-        if (errorSnackbar?.isShownOrQueued == false || NetworkUtils.isNetworkAvailable(context)) {
-            errorSnackbar = uiMessageResolver.getSnack(R.string.dashboard_stats_error)
-            errorSnackbar?.show()
-        }
     }
 
     private fun initJitm() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -144,10 +144,6 @@ class DashboardViewModel @Inject constructor(
         _refreshTrigger.tryEmit(RefreshEvent(isForced = true))
     }
 
-    fun onRetryOnErrorButtonClicked() {
-        _refreshTrigger.tryEmit(RefreshEvent(isForced = true))
-    }
-
     fun onShareStoreClicked() {
         AnalyticsTracker.track(AnalyticsEvent.DASHBOARD_SHARE_YOUR_STORE_BUTTON_TAPPED)
         triggerEvent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -245,8 +245,6 @@ class DashboardViewModel @Inject constructor(
 
         data object OpenEditWidgets : DashboardEvent()
 
-        data object ShowStatsError : DashboardEvent()
-
         data class OpenRangePicker(
             val start: Long,
             val end: Long,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -144,6 +144,10 @@ class DashboardViewModel @Inject constructor(
         _refreshTrigger.tryEmit(RefreshEvent(isForced = true))
     }
 
+    fun onRetryOnErrorButtonClicked() {
+        _refreshTrigger.tryEmit(RefreshEvent(isForced = true))
+    }
+
     fun onShareStoreClicked() {
         AnalyticsTracker.track(AnalyticsEvent.DASHBOARD_SHARE_YOUR_STORE_BUTTON_TAPPED)
         triggerEvent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WidgetCard.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -37,6 +38,7 @@ fun WidgetCard(
     menu: DashboardWidgetMenu,
     @DrawableRes iconResource: Int? = null,
     button: DashboardWidgetAction? = null,
+    isError: Boolean,
     content: @Composable () -> Unit
 ) {
     val roundedShape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
@@ -51,7 +53,16 @@ fun WidgetCard(
             .background(MaterialTheme.colors.surface)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            if (iconResource != null) {
+            if (isError) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_tintable_info_outline_24dp),
+                    contentDescription = "",
+                    modifier = Modifier
+                        .padding(start = dimensionResource(id = R.dimen.major_100))
+                        .size(dimensionResource(id = R.dimen.major_125)),
+                    tint = colorResource(id = R.color.color_icon)
+                )
+            } else if (iconResource != null) {
                 Image(
                     painter = painterResource(id = iconResource),
                     contentDescription = "",
@@ -80,7 +91,7 @@ fun WidgetCard(
 
         content()
 
-        if (button != null) {
+        if (button != null && !isError) {
             WCTextButton(
                 modifier = Modifier
                     .padding(
@@ -120,7 +131,8 @@ fun PreviewWidgetCard() {
             button = DashboardWidgetAction(
                 titleResource = R.string.blaze_campaign_show_all_button,
                 action = {}
-            )
+            ),
+            isError = false
         ) {
             Text(
                 modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100)),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WidgetError.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WidgetError.kt
@@ -1,0 +1,84 @@
+package com.woocommerce.android.ui.dashboard
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.URL_ANNOTATION_TAG
+import com.woocommerce.android.ui.compose.annotatedStringRes
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+
+@Composable
+fun WidgetError(
+    onContactSupportClicked: () -> Unit,
+    onRetryClicked: () -> Unit
+) {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Image(
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally),
+            contentDescription = null,
+            painter = painterResource(id = R.drawable.img_widget_error)
+        )
+
+        Text(
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+            text = stringResource(id = R.string.dynamic_dashboard_widget_error_title),
+            style = MaterialTheme.typography.h6
+        )
+
+        val errorMessage = annotatedStringRes(R.string.dynamic_dashboard_widget_error_description)
+
+        ClickableText(
+            modifier = Modifier.padding(horizontal = 32.dp),
+            text = errorMessage,
+            style = TextStyle(
+                textAlign = TextAlign.Center,
+                fontSize = 18.sp
+            ),
+            onClick = { offset ->
+                errorMessage.getStringAnnotations(tag = URL_ANNOTATION_TAG, start = offset, end = offset)
+                    .firstOrNull()
+                    ?.let { annotation ->
+                        when (annotation.item) {
+                            "support" -> onContactSupportClicked()
+                        }
+                    }
+            },
+        )
+
+        WCOutlinedButton(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = onRetryClicked
+        ) {
+            Text(text = stringResource(id = R.string.retry))
+        }
+    }
+}
+
+@Composable
+@Preview
+fun WidgetErrorPreview() {
+    WidgetError(
+        onContactSupportClicked = {},
+        onRetryClicked = {}
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
@@ -63,13 +63,8 @@ import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMe
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState
-import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState.Campaign
-import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState.Error
-import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState.Loading
-import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeViewModel.DashboardBlazeCampaignState.NoCampaign
 import com.woocommerce.android.ui.dashboard.defaultHideMenuEntry
 import com.woocommerce.android.util.FeatureFlag
-import com.woocommerce.android.util.FeatureFlag.DYNAMIC_DASHBOARD
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.launch
 
@@ -196,17 +191,17 @@ fun DashboardBlazeView(
                 )
         ) {
             when (state) {
-                is Loading -> BlazeCampaignLoading(
+                is DashboardBlazeCampaignState.Loading -> BlazeCampaignLoading(
                     modifier = Modifier.padding(bottom = dimensionResource(id = R.dimen.major_100))
                 )
 
-                is Campaign -> {
+                is DashboardBlazeCampaignState.Campaign -> {
                     BlazeCampaignItem(
                         campaign = state.campaign,
                         onCampaignClicked = state.onCampaignClicked,
                     )
 
-                    if (DYNAMIC_DASHBOARD.isEnabled()) {
+                    if (FeatureFlag.DYNAMIC_DASHBOARD.isEnabled()) {
                         WCOutlinedButton(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -218,7 +213,7 @@ fun DashboardBlazeView(
                     }
                 }
 
-                is NoCampaign -> {
+                is DashboardBlazeCampaignState.NoCampaign -> {
                     Text(
                         modifier = Modifier.padding(
                             end = dimensionResource(id = R.dimen.major_300)
@@ -232,7 +227,7 @@ fun DashboardBlazeView(
                         modifier = Modifier.padding(top = dimensionResource(id = R.dimen.major_100))
                     )
 
-                    if (DYNAMIC_DASHBOARD.isEnabled()) {
+                    if (FeatureFlag.DYNAMIC_DASHBOARD.isEnabled()) {
                         WCOutlinedButton(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -247,8 +242,8 @@ fun DashboardBlazeView(
                     }
                 }
 
-                Error -> {
-                    if (DYNAMIC_DASHBOARD.isEnabled()) {
+                DashboardBlazeCampaignState.Error -> {
+                    if (FeatureFlag.DYNAMIC_DASHBOARD.isEnabled()) {
                         WidgetError(
                             onContactSupportClicked = onContactSupportClicked,
                             onRetryClicked = onRetryOnErrorButtonClicked

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
@@ -155,6 +155,7 @@ private fun BlazeFrame(
             iconResource = R.drawable.ic_blaze,
             menu = state.menu,
             button = state.mainButton,
+            isError = state is DashboardBlazeCampaignState.Error
         ) {
             content()
         }
@@ -242,7 +243,7 @@ fun DashboardBlazeView(
                     }
                 }
 
-                DashboardBlazeCampaignState.Error -> {
+                is DashboardBlazeCampaignState.Error -> {
                     if (FeatureFlag.DYNAMIC_DASHBOARD.isEnabled()) {
                         WidgetError(
                             onContactSupportClicked = onContactSupportClicked,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
@@ -247,7 +247,7 @@ fun DashboardBlazeView(
                     }
                 }
 
-                Error ->  {
+                Error -> {
                     if (DYNAMIC_DASHBOARD.isEnabled()) {
                         WidgetError(
                             onContactSupportClicked = onContactSupportClicked,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
@@ -84,7 +84,7 @@ fun DashboardBlazeCard(
                 onDismissBlazeView = viewModel::onBlazeViewDismissed,
                 modifier = modifier,
                 onContactSupportClicked = parentViewModel::onContactSupportClicked,
-                onRetryOnErrorButtonClicked = parentViewModel::onRetryOnErrorButtonClicked
+                onRetryOnErrorButtonClicked = viewModel::onRefresh
             )
         }
     }
@@ -146,6 +146,8 @@ private fun BlazeFrame(
     modifier: Modifier,
     state: DashboardBlazeCampaignState,
     onDismissBlazeView: () -> Unit,
+    onContactSupportClicked: () -> Unit,
+    onRetryOnErrorButtonClicked: () -> Unit,
     content: @Composable () -> Unit
 ) {
     if (FeatureFlag.DYNAMIC_DASHBOARD.isEnabled()) {
@@ -157,7 +159,14 @@ private fun BlazeFrame(
             button = state.mainButton,
             isError = state is DashboardBlazeCampaignState.Error
         ) {
-            content()
+            if (state is DashboardBlazeCampaignState.Error) {
+                WidgetError(
+                    onContactSupportClicked = onContactSupportClicked,
+                    onRetryClicked = onRetryOnErrorButtonClicked
+                )
+            } else {
+                content()
+            }
         }
     } else {
         Card(
@@ -183,7 +192,7 @@ fun DashboardBlazeView(
     onContactSupportClicked: () -> Unit = {},
     onRetryOnErrorButtonClicked: () -> Unit = {}
 ) {
-    BlazeFrame(modifier, state, onDismissBlazeView) {
+    BlazeFrame(modifier, state, onDismissBlazeView, onContactSupportClicked, onRetryOnErrorButtonClicked) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -240,15 +249,6 @@ fun DashboardBlazeView(
                         ) {
                             Text(stringResource(string.blaze_campaign_create_campaign_button))
                         }
-                    }
-                }
-
-                is DashboardBlazeCampaignState.Error -> {
-                    if (FeatureFlag.DYNAMIC_DASHBOARD.isEnabled()) {
-                        WidgetError(
-                            onContactSupportClicked = onContactSupportClicked,
-                            onRetryClicked = onRetryOnErrorButtonClicked
-                        )
                     }
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.blaze.BlazeCampaignStat
 import com.woocommerce.android.ui.blaze.BlazeCampaignUi
 import com.woocommerce.android.ui.blaze.BlazeProductUi
@@ -63,6 +64,7 @@ class DashboardBlazeViewModel @AssistedInject constructor(
     private val isBlazeEnabled: IsBlazeEnabled,
     private val blazeUrlsHelper: BlazeUrlsHelper,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val networkStatus: NetworkStatus,
     private val prefsWrapper: AppPrefsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val refreshTrigger = (parentViewModel?.refreshTrigger ?: emptyFlow())
@@ -87,6 +89,7 @@ class DashboardBlazeViewModel @AssistedInject constructor(
                         getProductsFlow(forceRefresh = refreshEvent.isForced)
                     ) { blazeCampaignModel, products ->
                         when {
+                            !networkStatus.isConnected() -> DashboardBlazeCampaignState.Error
                             products.isEmpty() -> Hidden
                             blazeCampaignModel == null -> showUiForNoCampaign(products)
                             else -> showUiForCampaign(blazeCampaignModel)
@@ -237,6 +240,7 @@ class DashboardBlazeViewModel @AssistedInject constructor(
         // TODO remove this state when enabling [FeatureFlag.DYNAMIC_DASHBOARD] and clean up the code
         data object Hidden : DashboardBlazeCampaignState(DashboardWidgetMenu(emptyList()))
         data object Loading : DashboardBlazeCampaignState(DashboardWidgetMenu(emptyList()))
+        data object Error : DashboardBlazeCampaignState(DashboardWidgetMenu(emptyList()))
         data class NoCampaign(
             val product: BlazeProductUi,
             val onProductClicked: () -> Unit,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
@@ -41,9 +41,9 @@ import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.compose.viewModelWithFactory
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
-import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.WidgetCard
+import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.onboarding.DashboardOnboardingViewModel.Companion.MAX_NUMBER_OF_TASK_TO_DISPLAY_IN_CARD
 import com.woocommerce.android.ui.dashboard.onboarding.DashboardOnboardingViewModel.OnboardingDashBoardState
 import com.woocommerce.android.ui.feedback.SurveyType
@@ -80,6 +80,12 @@ fun DashboardOnboardingCard(
             modifier = modifier,
         ) {
             when {
+                onboardingState.isError -> {
+                    WidgetError(
+                        onContactSupportClicked = parentViewModel::onContactSupportClicked,
+                        onRetryClicked = parentViewModel::onRetryOnErrorButtonClicked
+                    )
+                }
                 onboardingState.isLoading -> StoreOnboardingLoading()
                 else ->
                     StoreOnboardingCardContent(
@@ -304,10 +310,6 @@ private fun OnboardingPreview() {
         OnboardingDashBoardState(
             title = R.string.store_onboarding_title,
             menu = DashboardWidgetMenu(emptyList()),
-            onViewAllTapped = DashboardWidgetAction(
-                titleResource = R.string.store_onboarding_task_view_all,
-                action = {}
-            ),
             tasks = listOf(
                 OnboardingTaskUi(
                     taskUiResources = AboutYourStoreTaskRes,
@@ -321,7 +323,8 @@ private fun OnboardingPreview() {
                     taskUiResources = AboutYourStoreTaskRes,
                     isCompleted = false,
                 )
-            )
+            ),
+            onViewAllClicked = {},
         ),
         onTaskClicked = {}
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
@@ -85,7 +85,7 @@ fun DashboardOnboardingCard(
                 onboardingState.isError -> {
                     WidgetError(
                         onContactSupportClicked = parentViewModel::onContactSupportClicked,
-                        onRetryClicked = parentViewModel::onRetryOnErrorButtonClicked
+                        onRetryClicked = onboardingViewModel::onRefresh
                     )
                 }
                 onboardingState.isLoading -> StoreOnboardingLoading()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
@@ -41,6 +41,7 @@ import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.compose.viewModelWithFactory
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
@@ -78,6 +79,7 @@ fun DashboardOnboardingCard(
             menu = onboardingState.menu,
             button = onboardingState.onViewAllTapped,
             modifier = modifier,
+            isError = onboardingState.isError
         ) {
             when {
                 onboardingState.isError -> {
@@ -324,7 +326,10 @@ private fun OnboardingPreview() {
                     isCompleted = false,
                 )
             ),
-            onViewAllClicked = {},
+            onViewAllTapped = DashboardWidgetAction(
+                titleResource = R.string.store_onboarding_task_view_all_tasks,
+                action = {}
+            )
         ),
         onTaskClicked = {}
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingViewModel.kt
@@ -72,7 +72,10 @@ class DashboardOnboardingViewModel @AssistedInject constructor(
                     }
                 )
             ),
-            onViewAllClicked = ::viewAllClicked
+            onViewAllTapped = DashboardWidgetAction(
+                titleResource = R.string.store_onboarding_task_view_all_tasks,
+                action = ::viewAllClicked
+            )
         )
     )
     val viewState = _viewState
@@ -136,17 +139,8 @@ class DashboardOnboardingViewModel @AssistedInject constructor(
         val menu: DashboardWidgetMenu,
         val isLoading: Boolean = false,
         val isError: Boolean = false,
-        val onViewAllClicked: () -> Unit
-    ) {
-        val onViewAllTapped: DashboardWidgetAction? = if (!isError) {
-            DashboardWidgetAction(
-                titleResource = R.string.store_onboarding_task_view_all_tasks,
-                action = onViewAllClicked
-            )
-        } else {
-            null
-        }
-    }
+        val onViewAllTapped: DashboardWidgetAction
+    )
 
     @AssistedFactory
     interface Factory {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -65,7 +65,6 @@ import java.util.Date
 
 @Composable
 fun DashboardStatsCard(
-    onStatsError: () -> Unit,
     openDatePicker: (Long, Long, (Long, Long) -> Unit) -> Unit,
     parentViewModel: DashboardViewModel,
     modifier: Modifier = Modifier,
@@ -79,13 +78,6 @@ fun DashboardStatsCard(
     val revenueStatsState by viewModel.revenueStatsState.observeAsState()
     val visitorsStatsState by viewModel.visitorStatsState.observeAsState()
     val lastUpdateState by viewModel.lastUpdateStats.observeAsState()
-
-    LaunchedEffect(revenueStatsState) {
-        when (revenueStatsState) {
-            is DashboardStatsViewModel.RevenueStatsViewState.GenericError -> onStatsError()
-            else -> Unit
-        }
-    }
 
     HandleEvents(
         event = viewModel.event,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -105,17 +105,12 @@ fun DashboardStatsCard(
                 }
             )
         ),
-        button = if (
-            revenueStatsState !is DashboardStatsViewModel.RevenueStatsViewState.PluginNotActiveError &&
-            revenueStatsState != DashboardStatsViewModel.RevenueStatsViewState.GenericError
-        ) {
-            DashboardViewModel.DashboardWidgetAction(
-                titleResource = R.string.analytics_section_see_all,
-                action = viewModel::onViewAnalyticsClicked
-            )
-        } else {
-            null
-        },
+        button = DashboardViewModel.DashboardWidgetAction(
+            titleResource = R.string.analytics_section_see_all,
+            action = viewModel::onViewAnalyticsClicked
+        ),
+        isError = revenueStatsState is DashboardStatsViewModel.RevenueStatsViewState.PluginNotActiveError ||
+            revenueStatsState == DashboardStatsViewModel.RevenueStatsViewState.GenericError,
         modifier = modifier
     ) {
         when (revenueStatsState) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -105,8 +105,10 @@ fun DashboardStatsCard(
                 }
             )
         ),
-        button = if (revenueStatsState !is DashboardStatsViewModel.RevenueStatsViewState.PluginNotActiveError
-            && revenueStatsState != DashboardStatsViewModel.RevenueStatsViewState.GenericError) {
+        button = if (
+            revenueStatsState !is DashboardStatsViewModel.RevenueStatsViewState.PluginNotActiveError &&
+            revenueStatsState != DashboardStatsViewModel.RevenueStatsViewState.GenericError
+        ) {
             DashboardViewModel.DashboardWidgetAction(
                 titleResource = R.string.analytics_section_see_all,
                 action = viewModel::onViewAnalyticsClicked

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.LiveData
@@ -55,6 +56,7 @@ import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardStatsUsageTracksEventEmitter
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.WidgetCard
+import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.defaultHideMenuEntry
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateUtils
@@ -103,7 +105,8 @@ fun DashboardStatsCard(
                 }
             )
         ),
-        button = if (revenueStatsState !is DashboardStatsViewModel.RevenueStatsViewState.PluginNotActiveError) {
+        button = if (revenueStatsState !is DashboardStatsViewModel.RevenueStatsViewState.PluginNotActiveError
+            && revenueStatsState != DashboardStatsViewModel.RevenueStatsViewState.GenericError) {
             DashboardViewModel.DashboardWidgetAction(
                 titleResource = R.string.analytics_section_see_all,
                 action = viewModel::onViewAnalyticsClicked
@@ -113,23 +116,34 @@ fun DashboardStatsCard(
         },
         modifier = modifier
     ) {
-        if (revenueStatsState !is DashboardStatsViewModel.RevenueStatsViewState.PluginNotActiveError) {
-            DashboardStatsContent(
-                dateRange = dateRange,
-                revenueStatsState = revenueStatsState,
-                visitorsStatsState = visitorsStatsState,
-                lastUpdateState = lastUpdateState,
-                dateUtils = viewModel.dateUtils,
-                currencyFormatter = viewModel.currencyFormatter,
-                usageTracksEventEmitter = viewModel.usageTracksEventEmitter,
-                onAddCustomRangeClick = viewModel::onAddCustomRangeClicked,
-                onTabSelected = viewModel::onTabSelected,
-                onChartDateSelected = viewModel::onChartDateSelected
-            )
-        } else {
-            PluginNotAvailableError(
-                onContactSupportClick = parentViewModel::onContactSupportClicked
-            )
+        when (revenueStatsState) {
+            is DashboardStatsViewModel.RevenueStatsViewState.GenericError -> {
+                WidgetError(
+                    onContactSupportClicked = parentViewModel::onContactSupportClicked,
+                    onRetryClicked = parentViewModel::onRetryOnErrorButtonClicked
+                )
+            }
+
+            !is DashboardStatsViewModel.RevenueStatsViewState.PluginNotActiveError -> {
+                DashboardStatsContent(
+                    dateRange = dateRange,
+                    revenueStatsState = revenueStatsState,
+                    visitorsStatsState = visitorsStatsState,
+                    lastUpdateState = lastUpdateState,
+                    dateUtils = viewModel.dateUtils,
+                    currencyFormatter = viewModel.currencyFormatter,
+                    usageTracksEventEmitter = viewModel.usageTracksEventEmitter,
+                    onAddCustomRangeClick = viewModel::onAddCustomRangeClicked,
+                    onTabSelected = viewModel::onTabSelected,
+                    onChartDateSelected = viewModel::onChartDateSelected
+                )
+            }
+
+            else -> {
+                PluginNotAvailableError(
+                    onContactSupportClick = parentViewModel::onContactSupportClicked
+                )
+            }
         }
     }
 }
@@ -431,3 +445,9 @@ private val SelectionType.title: String
         SelectionType.CUSTOM -> stringResource(id = R.string.date_timeframe_custom)
         else -> error("Invalid selection type")
     }
+
+@Composable
+@Preview
+fun PluginNotAvailableErrorPreview() {
+    PluginNotAvailableError(onContactSupportClick = {})
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -109,7 +109,7 @@ fun DashboardStatsCard(
             is DashboardStatsViewModel.RevenueStatsViewState.GenericError -> {
                 WidgetError(
                     onContactSupportClicked = parentViewModel::onContactSupportClicked,
-                    onRetryClicked = parentViewModel::onRetryOnErrorButtonClicked
+                    onRetryClicked = viewModel::onRefresh
                 )
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
@@ -168,7 +168,7 @@ class DashboardStatsViewModel @AssistedInject constructor(
 
     private suspend fun loadStoreStats(selectedRange: StatsTimeRangeSelection, forceRefresh: Boolean) = coroutineScope {
         if (!networkStatus.isConnected()) {
-            _revenueStatsState.value = RevenueStatsViewState.Content(null, selectedRange)
+            _revenueStatsState.value = RevenueStatsViewState.GenericError
             _visitorStatsState.value = VisitorStatsViewState.NotLoaded
             return@coroutineScope
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/GetStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/GetStats.kt
@@ -196,9 +196,9 @@ class GetStats @Inject constructor(
             val totalVisitorCount: Int?
         ) : LoadStatsResult()
 
-        object RevenueStatsError : LoadStatsResult()
-        object VisitorsStatsError : LoadStatsResult()
-        object PluginNotActive : LoadStatsResult()
+        data object RevenueStatsError : LoadStatsResult()
+        data object VisitorsStatsError : LoadStatsResult()
+        data object PluginNotActive : LoadStatsResult()
         data object VisitorStatUnavailable : LoadStatsResult()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
@@ -106,7 +106,10 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
                     }
                 )
             ),
-            onViewAllAnalyticsTapped = ::onViewAllAnalyticsTapped
+            onOpenAnalyticsTapped =  DashboardWidgetAction(
+                titleResource = R.string.dashboard_top_performers_main_cta_view_all_analytics,
+                action = ::onViewAllAnalyticsTapped
+            )
         )
 
         viewModelScope.launch {
@@ -244,17 +247,8 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
         @StringRes val titleStringRes: Int,
         val topPerformers: List<TopPerformerProductUiModel> = emptyList(),
         val menu: DashboardWidgetMenu,
-        val onViewAllAnalyticsTapped: () -> Unit
-    ) {
-        val onOpenAnalyticsTapped = if (!isError) {
-            DashboardWidgetAction(
-                titleResource = R.string.dashboard_top_performers_main_cta_view_all_analytics,
-                action = onViewAllAnalyticsTapped
-            )
-        } else {
-            null
-        }
-    }
+        val onOpenAnalyticsTapped: DashboardWidgetAction
+    )
 
     data class OpenTopPerformer(
         val productId: Long

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
@@ -106,10 +106,7 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
                     }
                 )
             ),
-            onOpenAnalyticsTapped = DashboardWidgetAction(
-                titleResource = R.string.dashboard_top_performers_main_cta_view_all_analytics,
-                action = ::onViewAllAnalyticsTapped
-            )
+            onViewAllAnalyticsTapped = ::onViewAllAnalyticsTapped
         )
 
         viewModelScope.launch {
@@ -168,7 +165,10 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
 
     private suspend fun loadTopPerformersStats(selectedRange: StatsTimeRangeSelection, forceRefresh: Boolean) =
         coroutineScope {
-            if (!networkStatus.isConnected()) return@coroutineScope
+            if (!networkStatus.isConnected()) {
+                _topPerformersState.value = _topPerformersState.value?.copy(isError = true)
+                return@coroutineScope
+            }
 
             _topPerformersState.value = _topPerformersState.value?.copy(isLoading = true, isError = false)
             val result = getTopPerformers.fetchTopPerformers(selectedRange, forceRefresh)
@@ -244,8 +244,17 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
         @StringRes val titleStringRes: Int,
         val topPerformers: List<TopPerformerProductUiModel> = emptyList(),
         val menu: DashboardWidgetMenu,
-        val onOpenAnalyticsTapped: DashboardWidgetAction
-    )
+        val onViewAllAnalyticsTapped: () -> Unit
+    ) {
+        val onOpenAnalyticsTapped = if (!isError) {
+            DashboardWidgetAction(
+                titleResource = R.string.dashboard_top_performers_main_cta_view_all_analytics,
+                action = onViewAllAnalyticsTapped
+            )
+        } else {
+            null
+        }
+    }
 
     data class OpenTopPerformer(
         val productId: Long

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -59,6 +59,7 @@ import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.Companion.SUPPORTED_RANGES_ON_MY_STORE_TAB
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.TopPerformerProductUiModel
 import com.woocommerce.android.ui.dashboard.WidgetCard
@@ -90,7 +91,8 @@ fun DashboardTopPerformersWidgetCard(
             titleResource = topPerformersState.titleStringRes,
             menu = topPerformersState.menu,
             button = topPerformersState.onOpenAnalyticsTapped,
-            modifier = modifier
+            modifier = modifier,
+            isError = topPerformersState.isError
         ) {
             when {
                 topPerformersState.isError -> TopPerformersErrorView(
@@ -536,7 +538,10 @@ private fun TopPerformersWidgetCardPreview() {
         isLoading = false,
         titleStringRes = DashboardWidget.Type.POPULAR_PRODUCTS.titleResource,
         menu = DashboardWidgetMenu(emptyList()),
-        onViewAllAnalyticsTapped = {}
+        onOpenAnalyticsTapped = DashboardWidgetAction(
+            titleResource = R.string.dashboard_top_performers_main_cta_view_all_analytics,
+            action = {}
+        )
     )
     Column {
         TopPerformersContent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -92,7 +92,6 @@ fun DashboardTopPerformersWidgetCard(
             button = topPerformersState.onOpenAnalyticsTapped,
             modifier = modifier
         ) {
-
             when {
                 topPerformersState.isError -> TopPerformersErrorView(
                     onContactSupportClicked = parentViewModel::onContactSupportClicked,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -97,7 +97,7 @@ fun DashboardTopPerformersWidgetCard(
             when {
                 topPerformersState.isError -> TopPerformersErrorView(
                     onContactSupportClicked = parentViewModel::onContactSupportClicked,
-                    onRetryClicked = parentViewModel::onRetryOnErrorButtonClicked
+                    onRetryClicked = topPerformersViewModel::onRefresh
                 )
                 else -> DashboardTopPerformersContent(
                     topPerformersState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -59,10 +59,10 @@ import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.Companion.SUPPORTED_RANGES_ON_MY_STORE_TAB
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
-import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.TopPerformerProductUiModel
 import com.woocommerce.android.ui.dashboard.WidgetCard
+import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenAnalytics
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenDatePicker
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenTopPerformer
@@ -92,13 +92,20 @@ fun DashboardTopPerformersWidgetCard(
             button = topPerformersState.onOpenAnalyticsTapped,
             modifier = modifier
         ) {
-            DashboardTopPerformersContent(
-                topPerformersState,
-                selectedDateRange,
-                lastUpdateState,
-                topPerformersViewModel::onGranularityChanged,
-                topPerformersViewModel::onEditCustomRangeTapped
-            )
+
+            when {
+                topPerformersState.isError -> TopPerformersErrorView(
+                    onContactSupportClicked = parentViewModel::onContactSupportClicked,
+                    onRetryClicked = parentViewModel::onRetryOnErrorButtonClicked
+                )
+                else -> DashboardTopPerformersContent(
+                    topPerformersState,
+                    selectedDateRange,
+                    lastUpdateState,
+                    topPerformersViewModel::onGranularityChanged,
+                    topPerformersViewModel::onEditCustomRangeTapped
+                )
+            }
         }
     }
 
@@ -205,7 +212,6 @@ private fun TopPerformersContent(
             )
         }
         when {
-            topPerformersState?.isError == true -> TopPerformersErrorView()
             topPerformersState?.topPerformers.isNullOrEmpty() -> TopPerformersEmptyView()
             else -> TopPerformerProductList(
                 topPerformers = topPerformersState?.topPerformers!!,
@@ -481,22 +487,14 @@ private fun TopPerformersEmptyView(modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun TopPerformersErrorView() {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Image(
-            painter = painterResource(id = R.drawable.img_top_performers_empty),
-            contentDescription = "",
-        )
-        Text(
-            modifier = Modifier.padding(top = 16.dp),
-            text = stringResource(id = R.string.dashboard_top_performers_empty),
-            style = MaterialTheme.typography.body2,
-        )
-    }
+private fun TopPerformersErrorView(
+    onContactSupportClicked: () -> Unit,
+    onRetryClicked: () -> Unit
+) {
+    WidgetError(
+        onContactSupportClicked = onContactSupportClicked,
+        onRetryClicked = onRetryClicked
+    )
 }
 
 @LightDarkThemePreviews
@@ -539,10 +537,7 @@ private fun TopPerformersWidgetCardPreview() {
         isLoading = false,
         titleStringRes = DashboardWidget.Type.POPULAR_PRODUCTS.titleResource,
         menu = DashboardWidgetMenu(emptyList()),
-        onOpenAnalyticsTapped = DashboardWidgetAction(
-            titleResource = R.string.dashboard_top_performers_main_cta_view_all_analytics,
-            action = {}
-        )
+        onViewAllAnalyticsTapped = {}
     )
     Column {
         TopPerformersContent(

--- a/WooCommerce/src/main/res/drawable/img_widget_error.xml
+++ b/WooCommerce/src/main/res/drawable/img_widget_error.xml
@@ -1,0 +1,31 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="43dp"
+    android:height="64dp"
+    android:viewportWidth="43"
+    android:viewportHeight="64">
+  <group>
+    <clip-path
+        android:pathData="M0.167,0h42.667v64h-42.667z"/>
+    <path
+        android:pathData="M18.86,64H24.14V37.527L18.86,40.228V64Z"
+        android:fillColor="#BEA0F2"/>
+    <path
+        android:pathData="M16.167,13.34H10.833V24.012H16.167V13.34Z"
+        android:fillColor="#BEA0F2"/>
+    <path
+        android:pathData="M32.167,13.34H26.833V24.012H32.167V13.34Z"
+        android:fillColor="#BEA0F2"/>
+    <path
+        android:pathData="M42.833,24.012H0.167V29.348H42.833V24.012Z"
+        android:fillColor="#674399"/>
+    <path
+        android:pathData="M37.417,29.239L21.5,29.348L5.583,29.239C5.577,29.431 5.583,39.677 5.583,45.517C5.583,54.117 14.777,56.174 21.5,56.174C28.223,56.174 37.417,54.117 37.417,45.517C37.417,40.77 37.423,29.431 37.417,29.239Z"
+        android:fillColor="#674399"/>
+    <path
+        android:pathData="M25.524,7.906H21.642L22.828,0C22.828,0 17.29,7.106 16.457,8.467C15.776,9.581 16.315,10.601 17.473,10.601H21.355L20.17,18.507C20.17,18.507 25.708,11.401 26.54,10.041C27.222,8.926 26.682,7.906 25.524,7.906Z"
+        android:fillColor="#674399"/>
+    <path
+        android:pathData="M5.583,44.888L21.5,29.348L5.583,29.239C5.577,29.425 5.583,38.971 5.583,44.888Z"
+        android:fillColor="#3C2861"/>
+  </group>
+</vector>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -425,6 +425,8 @@
     <string name="my_store_widget_onboarding_completed">Completed</string>
 
     <string name="dynamic_dashboard_hide_widget_menu_item">Hide %s</string>
+    <string name="dynamic_dashboard_widget_error_title">Unable to load data</string>
+    <string name="dynamic_dashboard_widget_error_description"><![CDATA[Try reloading this card. If the issue persists, please <a href="support">contact support</a>.]]></string>
 
     <!--
         Sign Up Flow


### PR DESCRIPTION
Implements #11370.

[Screen_recording_20240502_161221.webm](https://github.com/woocommerce/woocommerce-android/assets/1522856/339f2eb9-b517-49f0-b0b8-55a7dc2ce0f7)

**To test:**
1. Turn on the flight mode
2. Start the app
3. Notice all cards show the error view
4. Try tapping on the contact support link
5. Verify the support screen is opened
6. Tap on Retry (useful when an actual error happens)
7. Notice the My store screen is refreshed