### PR TITLE
[Dynamic Dashboard] Align top performers and stats cards

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/ranges/StatsTimeRangeSelection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/ranges/StatsTimeRangeSelection.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.analytics.ranges
 
 import android.os.Parcelable
-import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.CUSTOM
@@ -190,16 +189,4 @@ fun SelectionType.toDashBoardTrackingGranularityString(): String {
         CUSTOM -> this.identifier
         else -> error("My Store tracking granularity unsupported range")
     }.lowercase()
-}
-
-@StringRes
-fun SelectionType.toDashboardLocalizedGranularityStringId(): Int {
-    return when (this) {
-        TODAY -> R.string.today
-        WEEK_TO_DATE -> R.string.this_week
-        MONTH_TO_DATE -> R.string.this_month
-        YEAR_TO_DATE -> R.string.this_year
-        CUSTOM -> R.string.dashboard_stats_custom_range_label
-        else -> error("Unsupported range value used in my store tab: $this")
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -1,40 +1,23 @@
 package com.woocommerce.android.ui.dashboard.stats
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.DateRange
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -151,12 +134,16 @@ private fun DashboardStatsContent(
     onChartDateSelected: (String?) -> Unit,
 ) {
     Column {
-        StatsHeader(
-            dateRange = dateRange,
-            onCustomRangeClick = onAddCustomRangeClick,
-            onTabSelected = onTabSelected,
-            modifier = Modifier.fillMaxWidth()
-        )
+        dateRange?.let {
+            DashboardStatsHeader(
+                rangeSelection = it.rangeSelection,
+                dateFormatted = dateRange.selectedDateFormatted ?: dateRange.rangeFormatted,
+                onCustomRangeClick = onAddCustomRangeClick,
+                onTabSelected = onTabSelected,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
         Divider()
         StatsChart(
             dateRange = dateRange,
@@ -170,108 +157,6 @@ private fun DashboardStatsContent(
             onChartDateSelected = onChartDateSelected,
             modifier = Modifier.fillMaxWidth()
         )
-    }
-}
-
-@Composable
-private fun StatsHeader(
-    dateRange: DashboardStatsViewModel.DateRangeState?,
-    onCustomRangeClick: () -> Unit,
-    onTabSelected: (SelectionType) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    if (dateRange == null) return
-
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier.padding(
-            start = dimensionResource(id = R.dimen.major_100)
-        )
-    ) {
-        Text(
-            text = stringResource(
-                id = when (dateRange.rangeSelection.selectionType) {
-                    SelectionType.TODAY -> R.string.today
-                    SelectionType.WEEK_TO_DATE -> R.string.this_week
-                    SelectionType.MONTH_TO_DATE -> R.string.this_month
-                    SelectionType.YEAR_TO_DATE -> R.string.this_year
-                    SelectionType.CUSTOM -> R.string.date_timeframe_custom
-                    else -> error("Invalid selection type")
-                }
-            ),
-            style = MaterialTheme.typography.body2,
-            color = MaterialTheme.colors.onSurface
-        )
-        val isCustomRange = dateRange.rangeSelection.selectionType == SelectionType.CUSTOM
-
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100)),
-            modifier = Modifier
-                .then(if (isCustomRange) Modifier.clickable(onClick = onCustomRangeClick) else Modifier)
-                .padding(dimensionResource(id = R.dimen.minor_100))
-        ) {
-            Text(
-                text = dateRange.selectedDateFormatted ?: dateRange.rangeFormatted,
-                style = MaterialTheme.typography.body2,
-                color = if (isCustomRange) {
-                    MaterialTheme.colors.primary
-                } else {
-                    MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
-                }
-            )
-            if (isCustomRange) {
-                Icon(
-                    imageVector = Icons.Default.Edit,
-                    contentDescription = null,
-                    tint = MaterialTheme.colors.primary,
-                    modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_40))
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.weight(1f))
-
-        Box {
-            var isMenuExpanded by remember { mutableStateOf(false) }
-            IconButton(onClick = { isMenuExpanded = true }) {
-                Icon(
-                    imageVector = Icons.Default.DateRange,
-                    contentDescription = null,
-                    tint = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
-                )
-            }
-
-            DropdownMenu(
-                expanded = isMenuExpanded,
-                onDismissRequest = { isMenuExpanded = false }
-            ) {
-                DashboardViewModel.SUPPORTED_RANGES_ON_MY_STORE_TAB.forEach {
-                    DropdownMenuItem(
-                        onClick = {
-                            onTabSelected(it)
-                            isMenuExpanded = false
-                        }
-                    ) {
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.minor_100))
-                        ) {
-                            Text(text = it.title)
-                            Spacer(modifier = Modifier.weight(1f))
-                            if (dateRange.rangeSelection.selectionType == it) {
-                                Icon(
-                                    imageVector = Icons.Default.Check,
-                                    contentDescription = stringResource(id = androidx.compose.ui.R.string.selected),
-                                    tint = MaterialTheme.colors.primary
-                                )
-                            } else {
-                                Spacer(modifier = Modifier.size(dimensionResource(R.dimen.image_minor_50)))
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 }
 
@@ -423,17 +308,6 @@ private fun HandleEvents(
         }
     }
 }
-
-private val SelectionType.title: String
-    @Composable
-    get() = when (this) {
-        SelectionType.TODAY -> stringResource(id = R.string.today)
-        SelectionType.WEEK_TO_DATE -> stringResource(id = R.string.this_week)
-        SelectionType.MONTH_TO_DATE -> stringResource(id = R.string.this_month)
-        SelectionType.YEAR_TO_DATE -> stringResource(id = R.string.this_year)
-        SelectionType.CUSTOM -> stringResource(id = R.string.date_timeframe_custom)
-        else -> error("Invalid selection type")
-    }
 
 @Composable
 @Preview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsHeader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsHeader.kt
@@ -60,6 +60,7 @@ fun DashboardStatsHeader(
 
         Row(
             horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = dimen.minor_100)),
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .then(if (isCustomRange) Modifier.clickable(onClick = onCustomRangeClick) else Modifier)
                 .padding(dimensionResource(id = dimen.minor_100))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsHeader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsHeader.kt
@@ -88,7 +88,9 @@ fun DashboardStatsHeader(
             IconButton(onClick = { isMenuExpanded = true }) {
                 Icon(
                     imageVector = Icons.Default.DateRange,
-                    contentDescription = stringResource(id = R.string.dashboard_stats_edit_granularity_content_description),
+                    contentDescription = stringResource(
+                        id = R.string.dashboard_stats_edit_granularity_content_description
+                    ),
                     tint = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsHeader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsHeader.kt
@@ -1,0 +1,138 @@
+package com.woocommerce.android.ui.dashboard.stats
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.R
+import com.woocommerce.android.R.dimen
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.CUSTOM
+import com.woocommerce.android.ui.dashboard.DashboardViewModel
+
+@Composable
+fun DashboardStatsHeader(
+    rangeSelection: StatsTimeRangeSelection,
+    dateFormatted: String,
+    onCustomRangeClick: () -> Unit,
+    onTabSelected: (SelectionType) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = dimen.minor_100)),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.padding(
+            start = dimensionResource(id = dimen.major_100)
+        )
+    ) {
+        Text(
+            text = rangeSelection.selectionType.title,
+            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.onSurface
+        )
+        val isCustomRange = rangeSelection.selectionType == CUSTOM
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = dimen.minor_100)),
+            modifier = Modifier
+                .then(if (isCustomRange) Modifier.clickable(onClick = onCustomRangeClick) else Modifier)
+                .padding(dimensionResource(id = dimen.minor_100))
+        ) {
+            Text(
+                text = dateFormatted,
+                style = MaterialTheme.typography.body2,
+                color = if (isCustomRange) {
+                    MaterialTheme.colors.primary
+                } else {
+                    MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+                }
+            )
+            if (isCustomRange) {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = null,
+                    tint = MaterialTheme.colors.primary,
+                    modifier = Modifier.size(dimensionResource(id = dimen.image_minor_40))
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Box {
+            var isMenuExpanded by remember { mutableStateOf(false) }
+            IconButton(onClick = { isMenuExpanded = true }) {
+                Icon(
+                    imageVector = Icons.Default.DateRange,
+                    contentDescription = stringResource(id = R.string.dashboard_stats_edit_granularity_content_description),
+                    tint = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+                )
+            }
+
+            DropdownMenu(
+                expanded = isMenuExpanded,
+                onDismissRequest = { isMenuExpanded = false }
+            ) {
+                DashboardViewModel.SUPPORTED_RANGES_ON_MY_STORE_TAB.forEach {
+                    DropdownMenuItem(
+                        onClick = {
+                            onTabSelected(it)
+                            isMenuExpanded = false
+                        }
+                    ) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(dimensionResource(dimen.minor_100))
+                        ) {
+                            Text(text = it.title)
+                            Spacer(modifier = Modifier.weight(1f))
+                            if (rangeSelection.selectionType == it) {
+                                Icon(
+                                    imageVector = Icons.Default.Check,
+                                    contentDescription = stringResource(id = androidx.compose.ui.R.string.selected),
+                                    tint = MaterialTheme.colors.primary
+                                )
+                            } else {
+                                Spacer(modifier = Modifier.size(dimensionResource(dimen.image_minor_50)))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private val SelectionType.title: String
+    @Composable
+    get() = when (this) {
+        SelectionType.TODAY -> stringResource(id = com.woocommerce.android.R.string.today)
+        SelectionType.WEEK_TO_DATE -> stringResource(id = com.woocommerce.android.R.string.this_week)
+        SelectionType.MONTH_TO_DATE -> stringResource(id = com.woocommerce.android.R.string.this_month)
+        SelectionType.YEAR_TO_DATE -> stringResource(id = com.woocommerce.android.R.string.this_year)
+        SelectionType.CUSTOM -> stringResource(id = com.woocommerce.android.R.string.date_timeframe_custom)
+        else -> error("Invalid selection type")
+    }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsHeader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsHeader.kt
@@ -33,7 +33,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
-import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType.CUSTOM
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 
 @Composable
@@ -56,7 +55,7 @@ fun DashboardStatsHeader(
             style = MaterialTheme.typography.body2,
             color = MaterialTheme.colors.onSurface
         )
-        val isCustomRange = rangeSelection.selectionType == CUSTOM
+        val isCustomRange = rangeSelection.selectionType == SelectionType.CUSTOM
 
         Row(
             horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = dimen.minor_100)),
@@ -135,10 +134,10 @@ fun DashboardStatsHeader(
 private val SelectionType.title: String
     @Composable
     get() = when (this) {
-        SelectionType.TODAY -> stringResource(id = com.woocommerce.android.R.string.today)
-        SelectionType.WEEK_TO_DATE -> stringResource(id = com.woocommerce.android.R.string.this_week)
-        SelectionType.MONTH_TO_DATE -> stringResource(id = com.woocommerce.android.R.string.this_month)
-        SelectionType.YEAR_TO_DATE -> stringResource(id = com.woocommerce.android.R.string.this_year)
-        SelectionType.CUSTOM -> stringResource(id = com.woocommerce.android.R.string.date_timeframe_custom)
+        SelectionType.TODAY -> stringResource(id = R.string.today)
+        SelectionType.WEEK_TO_DATE -> stringResource(id = R.string.this_week)
+        SelectionType.MONTH_TO_DATE -> stringResource(id = R.string.this_month)
+        SelectionType.YEAR_TO_DATE -> stringResource(id = R.string.this_year)
+        SelectionType.CUSTOM -> stringResource(id = R.string.date_timeframe_custom)
         else -> error("Invalid selection type")
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsHeader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsHeader.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.ContentAlpha
@@ -27,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
@@ -97,7 +99,8 @@ fun DashboardStatsHeader(
 
             DropdownMenu(
                 expanded = isMenuExpanded,
-                onDismissRequest = { isMenuExpanded = false }
+                onDismissRequest = { isMenuExpanded = false },
+                modifier = Modifier.defaultMinSize(minWidth = 250.dp)
             ) {
                 DashboardViewModel.SUPPORTED_RANGES_ON_MY_STORE_TAB.forEach {
                     DropdownMenuItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
@@ -29,6 +29,7 @@ import com.woocommerce.android.ui.dashboard.defaultHideMenuEntry
 import com.woocommerce.android.ui.dashboard.domain.GetTopPerformers
 import com.woocommerce.android.ui.dashboard.domain.GetTopPerformers.TopPerformerProduct
 import com.woocommerce.android.ui.dashboard.domain.ObserveLastUpdate
+import com.woocommerce.android.ui.dashboard.stats.DashboardStatsRangeFormatter
 import com.woocommerce.android.ui.dashboard.stats.GetSelectedRangeForTopPerformers
 import com.woocommerce.android.ui.mystore.data.TopPerformersCustomDateRangeDataStore
 import com.woocommerce.android.util.CurrencyFormatter
@@ -76,10 +77,16 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
     private val dateUtils: DateUtils,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val customDateRangeDataStore: TopPerformersCustomDateRangeDataStore,
+    private val dateFormatter: DashboardStatsRangeFormatter,
     getSelectedDateRange: GetSelectedRangeForTopPerformers,
 ) : ScopedViewModel(savedState) {
     private val _selectedDateRange = getSelectedDateRange()
-    val selectedDateRange: LiveData<StatsTimeRangeSelection> = _selectedDateRange.asLiveData()
+    val selectedDateRange: LiveData<TopPerformersDateRange> = _selectedDateRange.map {
+        TopPerformersDateRange(
+            rangeSelection = it,
+            dateFormatted = dateFormatter.formatRangeDate(it)
+        )
+    }.asLiveData()
 
     private var _topPerformersState = MutableLiveData<TopPerformersState>()
     val topPerformersState: LiveData<TopPerformersState> = _topPerformersState
@@ -251,9 +258,14 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
     private fun onViewAllAnalyticsTapped() {
         AnalyticsTracker.track(AnalyticsEvent.DASHBOARD_SEE_MORE_ANALYTICS_TAPPED)
         selectedDateRange.value?.let {
-            triggerEvent(OpenAnalytics(it))
+            triggerEvent(OpenAnalytics(it.rangeSelection))
         }
     }
+
+    data class TopPerformersDateRange(
+        val rangeSelection: StatsTimeRangeSelection,
+        val dateFormatted: String
+    )
 
     data class TopPerformersState(
         val isLoading: Boolean = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -121,16 +121,28 @@ fun DashboardTopPerformersContent(
     onGranularityChanged: (SelectionType) -> Unit,
     onEditCustomRangeTapped: () -> Unit,
 ) {
-    when {
-        topPerformersState?.isLoading == true -> TopPerformersLoading(modifier = Modifier.padding(16.dp))
-        else -> {
-            TopPerformersContent(
-                topPerformersState,
-                lastUpdateState,
-                selectedDateRange,
-                onGranularityChanged,
-                onEditCustomRangeTapped
+    Column {
+        selectedDateRange?.let {
+            DashboardStatsHeader(
+                rangeSelection = it.rangeSelection,
+                dateFormatted = it.dateFormatted,
+                onCustomRangeClick = onEditCustomRangeTapped,
+                onTabSelected = onGranularityChanged
             )
+        }
+        Divider(modifier = Modifier.padding(bottom = 16.dp))
+
+        when {
+            topPerformersState?.isLoading == true -> TopPerformersLoading(
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+
+            else -> {
+                TopPerformersContent(
+                    topPerformersState = topPerformersState,
+                    lastUpdateState = lastUpdateState
+                )
+            }
         }
     }
 }
@@ -172,20 +184,8 @@ private fun HandleEvents(
 private fun TopPerformersContent(
     topPerformersState: TopPerformersState?,
     lastUpdateState: String?,
-    selectedDateRange: TopPerformersDateRange?,
-    onGranularityChanged: (SelectionType) -> Unit,
-    onEditCustomRangeTapped: () -> Unit,
 ) {
     Column {
-        selectedDateRange?.let {
-            DashboardStatsHeader(
-                rangeSelection = it.rangeSelection,
-                dateFormatted = it.dateFormatted,
-                onCustomRangeClick = onEditCustomRangeTapped,
-                onTabSelected = onGranularityChanged
-            )
-        }
-        Divider(modifier = Modifier.padding(bottom = 16.dp))
         Row(
             modifier = Modifier.padding(horizontal = 16.dp)
         ) {
@@ -245,28 +245,6 @@ private fun TopPerformerProductList(
 @Composable
 private fun TopPerformersLoading(modifier: Modifier = Modifier) {
     Column(modifier = modifier.fillMaxWidth()) {
-        SkeletonView(
-            modifier = Modifier
-                .height(18.dp)
-                .width(200.dp)
-        )
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp, bottom = 16.dp)
-        ) {
-            SkeletonView(
-                modifier = Modifier
-                    .height(16.dp)
-                    .width(80.dp)
-            )
-            Spacer(modifier = Modifier.weight(1f))
-            SkeletonView(
-                modifier = Modifier
-                    .height(16.dp)
-                    .width(50.dp)
-            )
-        }
         repeat(5) {
             TopPerformerSkeletonItem()
             Divider()
@@ -436,28 +414,28 @@ private fun TopPerformersWidgetCardPreview() {
         )
     )
     Column {
-        TopPerformersContent(
+        DashboardTopPerformersContent(
             topPerformersState = topPerformersState,
             lastUpdateState = "Last update: 8:52 AM",
             selectedDateRange = selectedDateRange,
             onGranularityChanged = {},
             onEditCustomRangeTapped = {}
         )
-        TopPerformersContent(
+        DashboardTopPerformersContent(
             topPerformersState = topPerformersState.copy(isLoading = true),
             lastUpdateState = "Last update: 8:52 AM",
             selectedDateRange = selectedDateRange,
             onGranularityChanged = {},
             onEditCustomRangeTapped = {}
         )
-        TopPerformersContent(
+        DashboardTopPerformersContent(
             topPerformersState = topPerformersState.copy(isError = true),
             lastUpdateState = "Last update: 8:52 AM",
             selectedDateRange = selectedDateRange,
             onGranularityChanged = {},
             onEditCustomRangeTapped = {}
         )
-        TopPerformersContent(
+        DashboardTopPerformersContent(
             topPerformersState = topPerformersState.copy(topPerformers = emptyList()),
             lastUpdateState = "Last update: 8:52 AM",
             selectedDateRange = selectedDateRange,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -2,23 +2,16 @@ package com.woocommerce.android.ui.dashboard.topperformers
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
@@ -27,21 +20,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
@@ -52,7 +40,6 @@ import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
-import com.woocommerce.android.ui.analytics.ranges.toDashboardLocalizedGranularityStringId
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.ProductThumbnail
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
@@ -60,13 +47,13 @@ import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.compose.viewModelWithFactory
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
-import com.woocommerce.android.ui.dashboard.DashboardViewModel.Companion.SUPPORTED_RANGES_ON_MY_STORE_TAB
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.TopPerformerProductUiModel
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
+import com.woocommerce.android.ui.dashboard.stats.DashboardStatsHeader
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenAnalytics
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenDatePicker
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenTopPerformer
@@ -192,11 +179,14 @@ private fun TopPerformersContent(
     onEditCustomRangeTapped: () -> Unit,
 ) {
     Column {
-        TopPerformersDatePicker(
-            selectedDateRange,
-            onGranularityChanged,
-            onEditCustomRangeTapped,
-        )
+        selectedDateRange?.let {
+            DashboardStatsHeader(
+                rangeSelection = it,
+                dateFormatted = it.currentRangeDescription,
+                onCustomRangeClick = onEditCustomRangeTapped,
+                onTabSelected = onGranularityChanged
+            )
+        }
         Divider(modifier = Modifier.padding(bottom = 16.dp))
         Row(
             modifier = Modifier.padding(horizontal = 16.dp)
@@ -234,108 +224,6 @@ private fun TopPerformersContent(
                 color = colorResource(id = R.color.color_on_surface_medium_selector),
                 textAlign = TextAlign.Center
             )
-        }
-    }
-}
-
-@Composable
-private fun TopPerformersDatePicker(
-    selectedDateRange: StatsTimeRangeSelection?,
-    onGranularityChanged: (SelectionType) -> Unit,
-    onCustomRangeClicked: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val isCustomRange = selectedDateRange?.selectionType == StatsTimeRangeSelection.SelectionType.CUSTOM
-    Row(
-        modifier = modifier.padding(start = 16.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        Text(
-            text = stringResource(
-                id = selectedDateRange?.selectionType?.toDashboardLocalizedGranularityStringId() ?: 0
-            ),
-            style = MaterialTheme.typography.body2,
-        )
-        Row(
-            modifier = Modifier
-                .clickable(enabled = isCustomRange) { onCustomRangeClicked() }
-                .weight(1f)
-        ) {
-            Text(
-                text = selectedDateRange?.currentRangeDescription ?: "",
-                style = MaterialTheme.typography.body2,
-                color = if (isCustomRange) {
-                    colorResource(id = R.color.color_primary)
-                } else {
-                    colorResource(id = R.color.color_on_surface_medium_selector)
-                }
-            )
-            if (isCustomRange) {
-                Icon(
-                    modifier = Modifier
-                        .padding(start = 8.dp)
-                        .size(16.dp),
-                    painter = painterResource(id = R.drawable.ic_edit_pencil),
-                    contentDescription = "",
-                    tint = colorResource(id = R.color.color_primary)
-                )
-            }
-        }
-        TopPerformersDateGranularityDropDown(
-            selectedDateRange = selectedDateRange,
-            dateGranularityOptions = SUPPORTED_RANGES_ON_MY_STORE_TAB,
-            onGranularityChanged = onGranularityChanged
-        )
-    }
-}
-
-@Composable
-private fun TopPerformersDateGranularityDropDown(
-    selectedDateRange: StatsTimeRangeSelection?,
-    dateGranularityOptions: List<SelectionType>,
-    onGranularityChanged: (SelectionType) -> Unit
-) {
-    var showDropDown by remember { mutableStateOf(false) }
-    Box {
-        IconButton(onClick = { showDropDown = !showDropDown }) {
-            Icon(
-                imageVector = Icons.Default.DateRange,
-                tint = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
-                contentDescription = stringResource(R.string.dashboard_stats_edit_granularity_content_description),
-            )
-        }
-        DropdownMenu(
-            modifier = Modifier.width(250.dp),
-            offset = DpOffset(
-                x = dimensionResource(id = R.dimen.major_100),
-                y = 0.dp
-            ),
-            expanded = showDropDown,
-            onDismissRequest = { showDropDown = false }
-        ) {
-            dateGranularityOptions.forEach { granularity ->
-                DropdownMenuItem(
-                    modifier = Modifier.height(40.dp),
-                    onClick = {
-                        onGranularityChanged(granularity)
-                        showDropDown = false
-                    }
-                ) {
-                    Text(
-                        modifier = Modifier.weight(1f),
-                        text = stringResource(id = granularity.toDashboardLocalizedGranularityStringId())
-                    )
-                    if (selectedDateRange?.selectionType == granularity) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_menu_check),
-                            contentDescription = stringResource(
-                                id = R.string.dashboard_stats_edit_granularity_selected_content_description
-                            )
-                        )
-                    }
-                }
-            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -10,12 +10,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -38,7 +35,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
-import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.ProductThumbnail
@@ -57,6 +53,7 @@ import com.woocommerce.android.ui.dashboard.stats.DashboardStatsHeader
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenAnalytics
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenDatePicker
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenTopPerformer
+import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.TopPerformersDateRange
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.TopPerformersState
 import com.woocommerce.android.ui.products.details.ProductDetailFragment.Mode.ShowProduct
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -89,6 +86,7 @@ fun DashboardTopPerformersWidgetCard(
                     onContactSupportClicked = parentViewModel::onContactSupportClicked,
                     onRetryClicked = topPerformersViewModel::onRefresh
                 )
+
                 else -> DashboardTopPerformersContent(
                     topPerformersState,
                     selectedDateRange,
@@ -118,7 +116,7 @@ fun DashboardTopPerformersWidgetCard(
 @Composable
 fun DashboardTopPerformersContent(
     topPerformersState: TopPerformersState?,
-    selectedDateRange: StatsTimeRangeSelection?,
+    selectedDateRange: TopPerformersDateRange?,
     lastUpdateState: String?,
     onGranularityChanged: (SelectionType) -> Unit,
     onEditCustomRangeTapped: () -> Unit,
@@ -174,15 +172,15 @@ private fun HandleEvents(
 private fun TopPerformersContent(
     topPerformersState: TopPerformersState?,
     lastUpdateState: String?,
-    selectedDateRange: StatsTimeRangeSelection?,
+    selectedDateRange: TopPerformersDateRange?,
     onGranularityChanged: (SelectionType) -> Unit,
     onEditCustomRangeTapped: () -> Unit,
 ) {
     Column {
         selectedDateRange?.let {
             DashboardStatsHeader(
-                rangeSelection = it,
-                dateFormatted = it.currentRangeDescription,
+                rangeSelection = it.rangeSelection,
+                dateFormatted = it.dateFormatted,
                 onCustomRangeClick = onEditCustomRangeTapped,
                 onTabSelected = onGranularityChanged
             )
@@ -392,11 +390,14 @@ private fun TopPerformersErrorView(
 @LightDarkThemePreviews
 @Composable
 private fun TopPerformersWidgetCardPreview() {
-    val selectedDateRange = SelectionType.TODAY.generateSelectionData(
-        referenceStartDate = Date(),
-        referenceEndDate = Date(),
-        calendar = Calendar.getInstance(),
-        locale = Locale.getDefault()
+    val selectedDateRange = TopPerformersDateRange(
+        SelectionType.TODAY.generateSelectionData(
+            referenceStartDate = Date(),
+            referenceEndDate = Date(),
+            calendar = Calendar.getInstance(),
+            locale = Locale.getDefault(),
+        ),
+        dateFormatted = "Today"
     )
     val topPerformersState = TopPerformersState(
         topPerformers = listOf(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -371,7 +371,6 @@
     <string name="dashboard_stats_granularity_months">Months</string>
     <string name="dashboard_stats_granularity_years">Years</string>
     <string name="dashboard_stats_edit_granularity_content_description">Change date range button</string>
-    <string name="dashboard_stats_edit_granularity_selected_content_description">Item selected</string>
 
     <string name="dashboard_stats_visitors">Visitors</string>
     <string name="dashboard_stats_orders">Orders</string>


### PR DESCRIPTION
### Description
This PR adds two changes:
1. It introduces a common component to be used as the header of the stats and top performers cards, to make sure they stay consistent.
2. It updates the date formatting in the top performer's card to align with the stats and what iOS uses.

### Testing instructions
1. Open the dashboard.
2. Make sure the Performance and Top Performers cards are enabled.
3. Confirm their header look and behave as expected.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
