### PR TITLE
[18.5 release] Rename string resource's key

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardUiHelpers.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardUiHelpers.kt
@@ -8,7 +8,7 @@ import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAc
 fun DashboardWidget.Type.defaultHideMenuEntry(onHideClicked: () -> Unit): DashboardWidgetAction {
     return DashboardWidgetAction(
         title = UiStringRes(
-            R.string.dynamic_dashboard_hide_widget_menu_item,
+            R.string.dynamic_dashboard_widget_menu_item_hide,
             params = listOf(UiStringRes(titleResource))
         ),
         action = onHideClicked

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -10,7 +10,6 @@ Language: ar
     <string name="store_onboarding_task_view_all_tasks">عرض جميع المهام</string>
     <string name="analytics_session_no_available_description">تعتمد تحليلات الجلسة على أعداد الزائرين الفريدة غير المتاحة لنطاقات التواريخ المخصصة</string>
     <string name="analytics_session_no_available">بيانات الجلسة غير متاحة</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">إخفاء</string>
     <string name="my_store_widget_unavailable">غير متاح</string>
     <string name="my_store_widget_stats_title">الأداء</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">مشاهدة كل تحليلات المتجر</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -10,7 +10,6 @@ Language: de
     <string name="store_onboarding_task_view_all_tasks">Alle Aufgaben anzeigen</string>
     <string name="analytics_session_no_available_description">Analysedaten für Sitzungen basieren auf Besucherzahlen, die für individuelle Zeiträume nicht verfügbar sind</string>
     <string name="analytics_session_no_available">Sitzungsdaten nicht verfügbar</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">Ausblenden</string>
     <string name="my_store_widget_unavailable">Nicht verfügbar</string>
     <string name="my_store_widget_stats_title">Performance</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">Alle Shop-Analysen anzeigen</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -10,7 +10,6 @@ Language: es
     <string name="store_onboarding_task_view_all_tasks">Ver todas las tareas</string>
     <string name="analytics_session_no_available_description">Los análisis de sesiones se basan en los recuentos de visitantes únicos, que no están disponibles para rangos de fechas personalizados</string>
     <string name="analytics_session_no_available">Datos de la sesión no disponibles</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">Ocultar</string>
     <string name="my_store_widget_unavailable">No disponible</string>
     <string name="my_store_widget_stats_title">Rendimiento</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">Ver todos los análisis de la tienda</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -10,7 +10,6 @@ Language: fr
     <string name="store_onboarding_task_view_all_tasks">Voir toutes les tâches</string>
     <string name="analytics_session_no_available_description">Les analyses de session se basent sur le nombre de visites uniques indisponibles pour les plages de dates personnalisées</string>
     <string name="analytics_session_no_available">Données de session indisponibles</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">Masquer</string>
     <string name="my_store_widget_unavailable">Indisponible</string>
     <string name="my_store_widget_stats_title">Performances</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">Voir toutes les statistiques de la boutique</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -10,7 +10,6 @@ Language: he_IL
     <string name="store_onboarding_task_view_all_tasks">להציג את כל המשימות</string>
     <string name="analytics_session_no_available_description">נתונים אנליטיים של הפעלות מסתמכים על מספר המבקרים הייחודיים, והם לא זמינים בטווח תאריכים מותאם אישית</string>
     <string name="analytics_session_no_available">הנתונים של ההפעלה לא זמינים</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">להסתיר</string>
     <string name="my_store_widget_unavailable">לא זמין</string>
     <string name="my_store_widget_stats_title">ביצועים</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">להציג את כל הנתונים האנליטיים של החנות</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -10,7 +10,6 @@ Language: id
     <string name="store_onboarding_task_view_all_tasks">Lihat semua tugas</string>
     <string name="analytics_session_no_available_description">Analitik sesi bergantung pada jumlah pengunjung unik yang tidak tersedia untuk rentang tanggal kustom</string>
     <string name="analytics_session_no_available">Data sesi tidak tersedia</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">Sembunyikan</string>
     <string name="my_store_widget_unavailable">Tidak tersedia</string>
     <string name="my_store_widget_stats_title">Performa</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">Lihat semua analitik toko</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -10,7 +10,6 @@ Language: it
     <string name="store_onboarding_task_view_all_tasks">Visualizza tutte le attività</string>
     <string name="analytics_session_no_available_description">L\'analisi delle sessioni si basa su un numero unico di visitatori non disponibile per intervalli di date personalizzati</string>
     <string name="analytics_session_no_available">Dati della sessione non disponibili</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">Nascondi</string>
     <string name="my_store_widget_unavailable">Non disponibile</string>
     <string name="my_store_widget_stats_title">Prestazioni</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">Visualizza tutte le analisi del negozio</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -10,7 +10,6 @@ Language: ja_JP
     <string name="store_onboarding_task_view_all_tasks">すべてのタスクを表示</string>
     <string name="analytics_session_no_available_description">セッション分析はカスタムの日付範囲で利用できないユニーク訪問者数に基づいています</string>
     <string name="analytics_session_no_available">セッションデータを利用できません</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">非表示</string>
     <string name="my_store_widget_unavailable">利用できません</string>
     <string name="my_store_widget_stats_title">パフォーマンス</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">すべてのストアアナリティクスを表示</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -10,7 +10,6 @@ Language: ko_KR
     <string name="store_onboarding_task_view_all_tasks">모든 작업 보기</string>
     <string name="analytics_session_no_available_description">세션 분석에서는 사용자 정의 범위에 사용할 수 없는 고유 방문자 수를 이용합니다</string>
     <string name="analytics_session_no_available">세션 데이터 사용 불가</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">숨기기</string>
     <string name="my_store_widget_unavailable">사용할 수 없음</string>
     <string name="my_store_widget_stats_title">성과</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">모든 스토어 분석 보기</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -10,7 +10,6 @@ Language: nl
     <string name="store_onboarding_task_view_all_tasks">Alle taken bekijken</string>
     <string name="analytics_session_no_available_description">Sessie-analyses gebruiken tellingen van unieke bezoekers, die niet beschikbaar zijn voor aangepaste datumbereiken</string>
     <string name="analytics_session_no_available">Sessiegegevens niet beschikbaar</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">Verbergen</string>
     <string name="my_store_widget_unavailable">Niet beschikbaar</string>
     <string name="my_store_widget_stats_title">Prestaties</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">Alle winkelanalyses bekijken</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -10,7 +10,6 @@ Language: pt_BR
     <string name="store_onboarding_task_view_all_tasks">Visualizar todas as tarefas</string>
     <string name="analytics_session_no_available_description">A análise da sessão depende da contagem de visitantes diferentes, não disponíveis para datas personalizadas</string>
     <string name="analytics_session_no_available">Dados da sessão indisponíveis</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">Ocultar</string>
     <string name="my_store_widget_unavailable">Indisponível</string>
     <string name="my_store_widget_stats_title">Desempenho</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">Ver todos os dados analíticos da loja</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -10,7 +10,6 @@ Language: ru
     <string name="store_onboarding_task_view_all_tasks">Посмотреть все задачи</string>
     <string name="analytics_session_no_available_description">Аналитические данные сеанса основываются на количестве уникальных посетителей, которое невозможно определить для произвольных временных промежутков.</string>
     <string name="analytics_session_no_available">Данные сеанса недоступны</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">Скрыть</string>
     <string name="my_store_widget_unavailable">Недоступно</string>
     <string name="my_store_widget_stats_title">Производительность</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">Просмотреть всю аналитику магазина</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -10,7 +10,6 @@ Language: sv_SE
     <string name="store_onboarding_task_view_all_tasks">Visa alla uppgifter</string>
     <string name="analytics_session_no_available_description">Sessionsanalysen bygger på antalet unika besökare, vilket inte är tillgängligt för anpassade datumintervall</string>
     <string name="analytics_session_no_available">Sessionsdata ej tillgänglig</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">Dölj</string>
     <string name="my_store_widget_unavailable">Inte tillgänglig</string>
     <string name="my_store_widget_stats_title">Prestanda</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">Visa alla butiksanalyser</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -10,7 +10,6 @@ Language: tr
     <string name="store_onboarding_task_view_all_tasks">Tüm görevleri görüntüle</string>
     <string name="analytics_session_no_available_description">Oturum analizleri, özel tarih aralıklarında kullanılamayan benzersiz ziyaretçi sayılarına dayanır</string>
     <string name="analytics_session_no_available">Oturum verileri kullanılamıyor</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">Gizle</string>
     <string name="my_store_widget_unavailable">Kullanılamıyor</string>
     <string name="my_store_widget_stats_title">Performans</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">Tüm mağaza analizlerini görüntüle</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -10,7 +10,6 @@ Language: zh_CN
     <string name="store_onboarding_task_view_all_tasks">查看所有任务</string>
     <string name="analytics_session_no_available_description">会话分析依赖于独立访客数，但不适用于自定义日期范围</string>
     <string name="analytics_session_no_available">会话数据不可用</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">隐藏</string>
     <string name="my_store_widget_unavailable">不可用</string>
     <string name="my_store_widget_stats_title">业绩</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">查看所有商店分析数据</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -10,7 +10,6 @@ Language: zh_TW
     <string name="store_onboarding_task_view_all_tasks">檢視所有工作項目</string>
     <string name="analytics_session_no_available_description">自訂日期範圍無法提供工作階段分析所仰賴的不重複訪客數</string>
     <string name="analytics_session_no_available">無法提供工作階段資料</string>
-    <string name="dynamic_dashboard_hide_widget_menu_item">隱藏</string>
     <string name="my_store_widget_unavailable">無法使用</string>
     <string name="my_store_widget_stats_title">績效</string>
     <string name="dashboard_top_performers_main_cta_view_all_analytics">檢視所有商店分析資料</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -426,6 +426,7 @@
     <string name="my_store_widget_onboarding_completed">Completed</string>
 
     <string name="dynamic_dashboard_hide_widget_menu_item">Hide %s</string>
+    <string name="dynamic_dashboard_widget_menu_item_hide">Hide %s</string>
     <string name="dynamic_dashboard_widget_error_title">Unable to load data</string>
     <string name="dynamic_dashboard_widget_error_description"><![CDATA[Try reloading this card. If the issue persists, please <a href="support">contact support</a>.]]></string>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -425,7 +425,7 @@
     <string name="my_store_widget_unavailable">Unavailable</string>
     <string name="my_store_widget_onboarding_completed">Completed</string>
 
-    <string name="dynamic_dashboard_hide_widget_menu_item">Hide %s</string>
+    <string name="dynamic_dashboard_hide_widget_menu_item">Hide</string>
     <string name="dynamic_dashboard_widget_menu_item_hide">Hide %s</string>
     <string name="dynamic_dashboard_widget_error_title">Unable to load data</string>
     <string name="dynamic_dashboard_widget_error_description"><![CDATA[Try reloading this card. If the issue persists, please <a href="support">contact support</a>.]]></string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -425,7 +425,6 @@
     <string name="my_store_widget_unavailable">Unavailable</string>
     <string name="my_store_widget_onboarding_completed">Completed</string>
 
-    <string name="dynamic_dashboard_hide_widget_menu_item">Hide</string>
     <string name="dynamic_dashboard_widget_menu_item_hide">Hide %s</string>
     <string name="dynamic_dashboard_widget_error_title">Unable to load data</string>
     <string name="dynamic_dashboard_widget_error_description"><![CDATA[Try reloading this card. If the issue persists, please <a href="support">contact support</a>.]]></string>


### PR DESCRIPTION
This PR renames the key of the string that we want to trigger translation updates for. 
Reason: the value under `dynamic_dashboard_hide_widget_menu_item` key was updated but the translations were not resulting in a failing lint check.

Context: p1714744086590719-slack-C6H8C3G23