### PR TITLE
Issue/11443 onboarding blaze error handling

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/ObserveMostRecentBlazeCampaign.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/ObserveMostRecentBlazeCampaign.kt
@@ -1,9 +1,11 @@
 package com.woocommerce.android.ui.blaze
 
+import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import org.wordpress.android.fluxc.model.blaze.BlazeCampaignModel
 import org.wordpress.android.fluxc.store.blaze.BlazeCampaignsStore
@@ -13,12 +15,17 @@ class ObserveMostRecentBlazeCampaign @Inject constructor(
     private val selectedSite: SelectedSite,
     private val blazeCampaignsStore: BlazeCampaignsStore
 ) {
-    operator fun invoke(forceRefresh: Boolean): Flow<BlazeCampaignModel?> = flow {
+    operator fun invoke(forceRefresh: Boolean): Flow<Result<BlazeCampaignModel?>> = flow {
         if (forceRefresh) {
-            blazeCampaignsStore.fetchBlazeCampaigns(selectedSite.get())
+            blazeCampaignsStore.fetchBlazeCampaigns(selectedSite.get()).let {
+                if (it.isError) {
+                    emit(Result.failure(OnChangedException(it.error)))
+                    return@flow
+                }
+            }
         }
 
-        emitAll(blazeCampaignsStore.observeMostRecentBlazeCampaign(selectedSite.get()))
+        emitAll(blazeCampaignsStore.observeMostRecentBlazeCampaign(selectedSite.get()).map { Result.success(it) })
     }.onStart {
         if (!forceRefresh) {
             // When not forcing a refresh, we'll start by emitting the cached value, and here we'll refresh

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -8,7 +8,6 @@ import android.view.View
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
-import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -47,7 +46,6 @@ import com.woocommerce.android.ui.jitm.JitmMessagePathsProvider
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.main.MainNavigationRouter
-import com.woocommerce.android.ui.onboarding.StoreOnboardingViewModel
 import com.woocommerce.android.ui.prefs.privacy.banner.PrivacyBannerFragmentDirections
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.WooLog
@@ -69,7 +67,6 @@ class DashboardFragment :
     }
 
     private val dashboardViewModel: DashboardViewModel by viewModels()
-    private val storeOnboardingViewModel: StoreOnboardingViewModel by activityViewModels()
 
     @Inject
     lateinit var selectedSite: SelectedSite
@@ -99,7 +96,6 @@ class DashboardFragment :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         lifecycle.addObserver(dashboardViewModel.performanceObserver)
-        lifecycle.addObserver(storeOnboardingViewModel)
         super.onCreate(savedInstanceState)
     }
 
@@ -125,7 +121,6 @@ class DashboardFragment :
         binding.myStoreRefreshLayout.setOnRefreshListener {
             binding.myStoreRefreshLayout.isRefreshing = false
             dashboardViewModel.onPullToRefresh()
-            storeOnboardingViewModel.onPullToRefresh()
             refreshJitm()
         }
 
@@ -259,11 +254,6 @@ class DashboardFragment :
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
-    }
-
-    override fun onDestroy() {
-        lifecycle.removeObserver(storeOnboardingViewModel)
-        super.onDestroy()
     }
 
     private fun initJitm() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
@@ -206,9 +206,11 @@ class DashboardBlazeViewModel @AssistedInject constructor(
 
     private fun getProductsFlow(forceRefresh: Boolean): Flow<Result<List<Product>>> {
         return flow {
-            if (forceRefresh) refreshProducts().onFailure {
-                emit(Result.failure(it))
-                return@flow
+            if (forceRefresh) {
+                refreshProducts().onFailure {
+                    emit(Result.failure(it))
+                    return@flow
+                }
             }
 
             emitAll(
@@ -227,9 +229,9 @@ class DashboardBlazeViewModel @AssistedInject constructor(
     }
 
     private suspend fun refreshProducts() = productListRepository.fetchProductList(
-            productFilterOptions = mapOf(ProductFilterOption.STATUS to ProductStatus.PUBLISH.value),
-            sortType = ProductSorting.DATE_DESC,
-        )
+        productFilterOptions = mapOf(ProductFilterOption.STATUS to ProductStatus.PUBLISH.value),
+        sortType = ProductSorting.DATE_DESC,
+    )
 
     private fun launchCampaignCreation(productId: Long?) {
         triggerEvent(LaunchBlazeCampaignCreation(productId))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveBlazeWidgetStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveBlazeWidgetStatus.kt
@@ -37,8 +37,7 @@ class ObserveBlazeWidgetStatus @Inject constructor(
         .withIndex()
         .map { (index, productsCount) ->
             if (productsCount == 0L && index == 0) {
-                productListRepository.fetchProductList()
-                false
+                productListRepository.fetchProductList().getOrNull()?.size != 0
             } else {
                 productsCount > 0
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingCard.kt
@@ -224,7 +224,7 @@ fun OnboardingCardProgressHeader(
 ) {
     val completedTasks = tasks.count { it.isCompleted }
     val totalTasks = tasks.count()
-    val progress by remember { mutableFloatStateOf(completedTasks / totalTasks.toFloat()) }
+    val progress by remember { mutableFloatStateOf(if (totalTasks == 0) 0f else completedTasks / totalTasks.toFloat()) }
     val animatedProgress = animateFloatAsState(
         targetValue = progress,
         animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/OnboardingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/OnboardingScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -295,7 +296,7 @@ fun OnboardingTaskCollapsedProgressHeader(
 ) {
     val completedTasks = tasks.count { it.isCompleted }
     val totalTasks = tasks.count()
-    val progress by remember { mutableStateOf(completedTasks / totalTasks.toFloat()) }
+    val progress by remember { mutableFloatStateOf(if (totalTasks == 0) 0f else completedTasks / totalTasks.toFloat()) }
     val animatedProgress = animateFloatAsState(
         targetValue = progress,
         animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec
@@ -324,7 +325,7 @@ fun OnboardingTaskProgressHeader(
 ) {
     val completedTasks = tasks.count { it.isCompleted }
     val totalTasks = tasks.count()
-    val progress by remember { mutableStateOf(completedTasks / totalTasks.toFloat()) }
+    val progress by remember { mutableFloatStateOf(if (totalTasks == 0) 0f else completedTasks / totalTasks.toFloat()) }
     val animatedProgress = animateFloatAsState(
         targetValue = progress,
         animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingFragment.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.transition.MaterialContainerTransform
 import com.woocommerce.android.R
@@ -18,13 +19,18 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.products.AddProductNavigator
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class StoreOnboardingFragment : BaseFragment() {
-    private val viewModel: StoreOnboardingViewModel by activityViewModels()
+    private val viewModel: StoreOnboardingViewModel by if (FeatureFlag.DYNAMIC_DASHBOARD.isEnabled()) {
+        viewModels()
+    } else {
+        activityViewModels()
+    }
 
     @Inject
     lateinit var addProductNavigator: AddProductNavigator

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingRepository.kt
@@ -33,12 +33,14 @@ class StoreOnboardingRepository @Inject constructor(
         .filter { it.siteId == selectedSite.get().id }
         .map { it.tasks }
 
-    suspend fun fetchOnboardingTasks() {
+    suspend fun fetchOnboardingTasks(): Result<Unit> {
         WooLog.d(WooLog.T.ONBOARDING, "Fetching onboarding tasks")
         val result = onboardingStore.fetchOnboardingTasks(selectedSite.get())
-        when {
-            result.isError ->
+        return when {
+            result.isError -> {
                 WooLog.i(WooLog.T.ONBOARDING, "Error fetching onboarding tasks: ${result.error}")
+                Result.failure(WooException(result.error))
+            }
 
             else -> {
                 WooLog.d(WooLog.T.ONBOARDING, "Success fetching onboarding tasks")
@@ -56,6 +58,7 @@ class StoreOnboardingRepository @Inject constructor(
                     ?: emptyList()
 
                 onboardingTasksCacheFlow.emit(OnboardingTasksEvent(selectedSite.get().id, mobileSupportedTasks))
+                Result.success(Unit)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingRepository.kt
@@ -28,6 +28,9 @@ class StoreOnboardingRepository @Inject constructor(
     private val siteStore: SiteStore
 ) {
     private val onboardingTasksCacheFlow: MutableSharedFlow<OnboardingTasksEvent> = MutableSharedFlow(replay = 1)
+    val hasCachedTasks
+        get() = onboardingTasksCacheFlow.replayCache.firstOrNull()
+            ?.takeIf { it.siteId == selectedSite.getSelectedSiteId() } != null
 
     fun observeOnboardingTasks(): Flow<List<OnboardingTask>> = onboardingTasksCacheFlow
         .filter { it.siteId == selectedSite.get().id }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/ShouldShowCreateTestOrderScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/ShouldShowCreateTestOrderScreen.kt
@@ -27,7 +27,7 @@ class ShouldShowCreateTestOrderScreen @Inject constructor(
 
         val productList = localProductList.ifEmpty {
             withContext(Dispatchers.IO) {
-                productListRepository.fetchProductList()
+                productListRepository.fetchProductList().getOrNull() ?: productListRepository.getProductList()
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppConstants
+import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.tools.NetworkStatus
@@ -190,10 +191,14 @@ class ProductSelectionListViewModel @Inject constructor(
     ) {
         if (networkStatus.isConnected()) {
             if (searchQuery.isNullOrEmpty()) {
-                _productList.value = productRepository.fetchProductList(
+                productRepository.fetchProductList(
                     loadMore,
                     excludedProductIds = excludedProductIds
-                )
+                ).onFailure {
+                    triggerEvent(ShowSnackbar(R.string.product_list_fetch_error))
+                }.getOrNull()?.let {
+                    _productList.value = it
+                }
             } else {
                 productRepository.searchProductList(
                     searchQuery = searchQuery,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.WooException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.RequestResult
 import com.woocommerce.android.model.toAppModel
@@ -19,7 +18,6 @@ import com.woocommerce.android.ui.subscriptions.IsEligibleForSubscriptions
 import com.woocommerce.android.util.ContinuationWrapper
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -38,8 +36,7 @@ class ProductListRepository @Inject constructor(
     private val productStore: WCProductStore,
     private val selectedSite: SelectedSite,
     private val dispatchers: CoroutineDispatchers,
-    private val isEligibleForSubscriptions: IsEligibleForSubscriptions,
-    @AppCoroutineScope private val scope: CoroutineScope
+    private val isEligibleForSubscriptions: IsEligibleForSubscriptions
 ) {
     companion object {
         private const val PRODUCT_PAGE_SIZE = WCProductStore.DEFAULT_PRODUCT_PAGE_SIZE

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
@@ -524,12 +524,14 @@ class ProductListViewModel @Inject constructor(
         scrollToTop: Boolean = false
     ) {
         if (!isSearching()) {
-            val products = productRepository.fetchProductList(loadMore, productFilterOptions)
+            val productList = productRepository.fetchProductList(loadMore, productFilterOptions).onFailure {
+                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.product_list_fetch_error))
+            }.getOrNull()
             // don't update the product list if a search was initiated while fetching
             if (isSearching()) {
                 WooLog.i(WooLog.T.PRODUCTS, "Search initiated while fetching products")
             } else {
-                _productList.value = products
+                productList?.let { _productList.value = it }
             }
         } else if (searchQuery?.isNotEmpty() == true) {
             productRepository.searchProductList(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1968,6 +1968,7 @@
     <string name="product_list_filters_list_item">Selected filter option</string>
     <string name="product_list_unsaved_product_unselected_title">You about to discard changes to %s</string>
     <string name="product_list_unsaved_product_unselected_message">Are you sure you want to discard the changes you made to this product?</string>
+    <string name="product_list_fetch_error">Error fetching products!</string>
     <string name="product_search_hint">Search products</string>
     <string name="product_search_hint_active_filters">Search filtered products</string>
     <string name="product_search_all">All products</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModelTest.kt
@@ -58,7 +58,7 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
                 this.removeIf { it.remoteId == excludedIds }
             }
         }
-        doReturn(expectedProductList).whenever(productRepository).fetchProductList(
+        doReturn(Result.success(expectedProductList)).whenever(productRepository).fetchProductList(
             excludedProductIds = excludedProductIds
         )
 
@@ -97,7 +97,7 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
         doReturn(emptyList<Product>()).whenever(productRepository).getProductList(
             excludedProductIds = excludedProductIds
         )
-        doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList(
+        doReturn(Result.success(emptyList<Product>())).whenever(productRepository).fetchProductList(
             excludedProductIds = excludedProductIds
         )
 
@@ -115,7 +115,7 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
     fun `Shows and hides product list load more progress correctly`() =
         testBlocking {
             doReturn(true).whenever(productRepository).canLoadMoreProducts
-            doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList(
+            doReturn(Result.success(emptyList<Product>())).whenever(productRepository).fetchProductList(
                 excludedProductIds = excludedProductIds
             )
 
@@ -153,7 +153,7 @@ class ProductSelectionListViewModelTest : BaseUnitTest() {
                 }
             }
 
-            doReturn(expectedProductList).whenever(productRepository).fetchProductList(
+            doReturn(Result.success(expectedProductList)).whenever(productRepository).fetchProductList(
                 excludedProductIds = excludedProductIds
             )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
@@ -74,7 +74,8 @@ class ProductListViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Displays the product list view correctly`() = testBlocking {
-        doReturn(productList).whenever(productRepository).fetchProductList(productFilterOptions = emptyMap())
+        doReturn(Result.success(productList))
+            .whenever(productRepository).fetchProductList(productFilterOptions = emptyMap())
 
         createViewModel()
 
@@ -106,7 +107,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     @Test
     fun `Shows and hides product list skeleton correctly`() = testBlocking {
         doReturn(emptyList<Product>()).whenever(productRepository).getProductList()
-        doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
+        doReturn(Result.success(emptyList<Product>())).whenever(productRepository).fetchProductList()
 
         createViewModel()
 
@@ -124,7 +125,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     fun `Shows and hides product list load more progress correctly`() =
         testBlocking {
             doReturn(true).whenever(productRepository).canLoadMoreProducts
-            doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
+            doReturn(Result.success(emptyList<Product>())).whenever(productRepository).fetchProductList()
 
             createViewModel()
 
@@ -141,7 +142,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     fun `Shows and hides add product button correctly when loading list of products`() =
         testBlocking {
             // when
-            doReturn(productList).whenever(productRepository).fetchProductList()
+            doReturn(Result.success(productList)).whenever(productRepository).fetchProductList()
 
             createViewModel()
 
@@ -162,7 +163,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     fun `Hides add product button when list of products is empty`() =
         testBlocking {
             // when
-            doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
+            doReturn(Result.success(emptyList<Product>())).whenever(productRepository).fetchProductList()
 
             createViewModel()
 
@@ -183,7 +184,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     fun `Hides add product button when searching`() =
         testBlocking {
             // when
-            doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
+            doReturn(Result.success(emptyList<Product>())).whenever(productRepository).fetchProductList()
 
             createViewModel()
 
@@ -206,7 +207,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     fun `Shows add product button after opening and closing search`() =
         testBlocking {
             // when
-            doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
+            doReturn(Result.success(emptyList<Product>())).whenever(productRepository).fetchProductList()
 
             createViewModel()
 
@@ -230,7 +231,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     fun `Hides filters buttons when searching`() =
         testBlocking {
             // when
-            doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
+            doReturn(Result.success(emptyList<Product>())).whenever(productRepository).fetchProductList()
 
             createViewModel()
 
@@ -252,7 +253,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     fun `Shows filters buttons after opening and closing search`() =
         testBlocking {
             // when
-            doReturn(emptyList<Product>()).whenever(productRepository).fetchProductList()
+            doReturn(Result.success(emptyList<Product>())).whenever(productRepository).fetchProductList()
 
             createViewModel()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11443 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR improves error handling in the Onboarding and Blaze cards.

### Testing instructions
1. Apply the following patch
<details>
<summary>Patch</summary>

```Patch
Subject: [PATCH] add
---
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt	(revision 28530588579adf71d6151cee9e4b29cab28e8237)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt	(date 1714822175705)
@@ -20,6 +20,7 @@
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -31,6 +32,7 @@
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.store.WCProductStore
 import javax.inject.Inject
+import kotlin.random.Random
 
 class ProductListRepository @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
@@ -87,6 +89,10 @@
         excludedProductIds: List<Long>? = null,
         sortType: WCProductStore.ProductSorting? = null
     ): Result<List<Product>> {
+        if (Random.nextBoolean()) {
+            delay(300)
+            return Result.failure(Exception())
+        }
         offset = if (loadMore) offset + PRODUCT_PAGE_SIZE else 0
         lastSearchQuery = null
         lastIsSkuSearch = WCProductStore.SkuSearchOptions.Disabled
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingRepository.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingRepository.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingRepository.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingRepository.kt	(revision 28530588579adf71d6151cee9e4b29cab28e8237)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingRepository.kt	(date 1714822175707)
@@ -20,6 +20,7 @@
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility.PUBLIC
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.random.Random
 
 @Singleton
 class StoreOnboardingRepository @Inject constructor(
@@ -39,6 +40,7 @@
     suspend fun fetchOnboardingTasks(): Result<Unit> {
         WooLog.d(WooLog.T.ONBOARDING, "Fetching onboarding tasks")
         val result = onboardingStore.fetchOnboardingTasks(selectedSite.get())
+        if (Random.nextBoolean()) return Result.failure(Exception())
         return when {
             result.isError -> {
                 WooLog.i(WooLog.T.ONBOARDING, "Error fetching onboarding tasks: ${result.error}")
Index: build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/build.gradle b/build.gradle
--- a/build.gradle	(revision 28530588579adf71d6151cee9e4b29cab28e8237)
+++ b/build.gradle	(date 1714822175709)
@@ -30,7 +30,7 @@
     tasks.withType(KotlinCompile).all {
         kotlinOptions {
             jvmTarget = JavaVersion.VERSION_1_8
-            allWarningsAsErrors = true
+            allWarningsAsErrors = false
             freeCompilerArgs += [
                     "-opt-in=kotlin.RequiresOptIn",
                     "-Xjvm-default=all-compatibility",
```

</details>

2. Open the app.
3. Refresh the Blaze and Onboarding cards, they will fail randomly.
4. Confirm retrying will reload the cards

### Images/gif
[Screen_recording_20240505_170129.webm](https://github.com/woocommerce/woocommerce-android/assets/1657201/875a1382-37ca-47c5-a7ce-d1446158ef5a)


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
