### PR TITLE
Validate percentage amount and catch error

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragment.kt
@@ -252,7 +252,14 @@ class CustomAmountsFragment : BaseFragment(R.layout.dialog_custom_amounts) {
             binding.editPercentage.addTextChangedListener {
                 if (it != null && it.toString().isNotEmpty()) {
                     if (it.toString() != viewModel.currentPercentage.toString()) {
-                        viewModel.currentPercentage = BigDecimal(it.toString())
+                        try {
+                            val newPercentage = BigDecimal(it.toString())
+                            viewModel.currentPercentage = newPercentage
+                            binding.editPercentage.error = null
+                        } catch (e: NumberFormatException) {
+                            binding.editPercentage.error =
+                                getString(R.string.custom_amounts_percentage_invalid_value)
+                        }
                     }
                     binding.updatedAmount.show()
                 } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
@@ -50,6 +50,7 @@ class CustomAmountsViewModel @Inject constructor(
         }
         set(value) {
             val totalAmount = BigDecimal(args.orderTotal ?: "0")
+
             if (totalAmount > BigDecimal.ZERO) {
                 val percentage = value.toString().toDouble().roundToInt()
                 val updatedAmount = (

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -592,6 +592,7 @@
     <string name="custom_amounts_bottom_sheet_percentage_amount_option">A percentage of the order total</string>
     <string name="custom_amounts_percentage_hint">0</string>
     <string name="custom_amounts_percentage_symbol">%</string>
+    <string name="custom_amounts_percentage_invalid_value">Invalid value</string>
 
     <!--
          Taxes


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11452
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
A `NumberFormatException` was thrown when trying to parse a character that is not a number in the CustomAmountsFragment.

Context: peaMlT-zJ-p2

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Steps to reproduce the crash on `trunk`:

1. Open the app
2. Tap on Orders
3. Add a new Order by tapping the (+) button
4. Tap on Add products and add a new product
5. Tap on Add custom amounts
6. Tap on a percentage of the order total
7. Type `.` and see that the app crashes

Verify it's fixed with this PR.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->