### PR TITLE
Dynamic dashboard/UI tests

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/InitializationRule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/InitializationRule.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.test.platform.app.InstrumentationRegistry
 import com.woocommerce.android.AppInitializer
 import com.woocommerce.android.di.AppCoroutineScope
+import com.woocommerce.android.di.SiteComponentEntryPoint
 import com.woocommerce.android.tools.SelectedSite
 import dagger.hilt.EntryPoint
 import dagger.hilt.EntryPoints
@@ -43,8 +44,10 @@ class InitializationRule : TestRule {
                     base.evaluate()
                 } finally {
                     entryPoint.appCoroutineScope().cancel()
-                    // Reset the selected site to make sure its CoroutineScope is cancelled
-                    entryPoint.selectedSite().reset()
+                    // Cancel site coroutine scope
+                    entryPoint.selectedSite().siteComponent?.let {
+                        EntryPoints.get(it, SiteComponentEntryPoint::class.java)
+                    }?.siteCoroutineScope()?.cancel()
                 }
             }
         }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/InitializationRule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/InitializationRule.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.test.platform.app.InstrumentationRegistry
 import com.woocommerce.android.AppInitializer
 import com.woocommerce.android.di.AppCoroutineScope
+import com.woocommerce.android.tools.SelectedSite
 import dagger.hilt.EntryPoint
 import dagger.hilt.EntryPoints
 import dagger.hilt.InstallIn
@@ -21,6 +22,7 @@ class InitializationRule : TestRule {
         fun initializer(): AppInitializer
 
         @AppCoroutineScope fun appCoroutineScope(): CoroutineScope
+        fun selectedSite(): SelectedSite
     }
 
     private val instrumentation
@@ -41,6 +43,8 @@ class InitializationRule : TestRule {
                     base.evaluate()
                 } finally {
                     entryPoint.appCoroutineScope().cancel()
+                    // Reset the selected site to make sure its CoroutineScope is cancelled
+                    entryPoint.selectedSite().reset()
                 }
             }
         }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
@@ -5,6 +5,7 @@ import android.content.res.Configuration
 import android.view.View
 import androidx.annotation.StringRes
 import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onChildren
@@ -187,15 +188,16 @@ open class Screen {
         matcher: SemanticsMatcher,
         requireFullVisibility: Boolean = true
     ) {
+        fun SemanticsNodeInteraction.isFullyDisplayed(): Boolean {
+            return onChildren().onLast().isDisplayed() && onChildren().onFirst().isDisplayed()
+        }
+
         val device = UiDevice.getInstance(getInstrumentation())
         var scrollUp = true
         var numberOfScrolls = 0
         while (true) {
             val node = onNode(matcher)
-            if (node.isDisplayed() &&
-                (!requireFullVisibility ||
-                    (node.onChildren().onLast().isDisplayed() && node.onChildren().onFirst().isDisplayed()))
-            ) return
+            if (node.isDisplayed() && (!requireFullVisibility || node.isFullyDisplayed())) return
 
             val parentBounds = node.onParent().fetchSemanticsNode().touchBoundsInRoot
             device.swipe(

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
@@ -4,6 +4,13 @@ import android.app.Activity
 import android.content.res.Configuration
 import android.view.View
 import androidx.annotation.StringRes
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onChildren
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onParent
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.closeSoftKeyboard
@@ -32,6 +39,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
 import androidx.test.runner.lifecycle.Stage.RESUMED
+import androidx.test.uiautomator.UiDevice
 import com.google.android.material.tabs.TabLayout
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
@@ -164,6 +172,51 @@ open class Screen {
         // Need to use the NestedScrollViewExtension because Espresso doesn't natively support it:
         // https://medium.com/@devasierra/espresso-nestedscrollview-scrolling-via-kotlin-delegation-5e7f0aa64c09
         onView(withId(elementID)).perform(NestedScrollViewExtension())
+    }
+
+    /**
+     * Performs a swipe gesture to scroll to top until the node that matches the given matcher is displayed.
+     *
+     * This is needed until https://issuetracker.google.com/issues/232625918 is fixed.
+     *
+     * @param matcher The matcher to find the node to scroll to.
+     * @param requireFullVisibility Whether the node must be fully visible to consider it as displayed,
+     *      if this is true, and the node is larger than the screen, the condition will never succeed.
+     */
+    fun ComposeTestRule.scrollToNodeThatMatches(
+        matcher: SemanticsMatcher,
+        requireFullVisibility: Boolean = true
+    ) {
+        val device = UiDevice.getInstance(getInstrumentation())
+        var scrollUp = true
+        var numberOfScrolls = 0
+        while (true) {
+            val node = onNode(matcher)
+            if (node.isDisplayed() &&
+                (!requireFullVisibility ||
+                    (node.onChildren().onLast().isDisplayed() && node.onChildren().onFirst().isDisplayed()))
+            ) return
+
+            val parentBounds = node.onParent().fetchSemanticsNode().touchBoundsInRoot
+            device.swipe(
+                parentBounds.center.x.toInt(),
+                parentBounds.center.y.toInt(),
+                parentBounds.center.x.toInt(),
+                parentBounds.center.y.toInt() + if (scrollUp) -100 else 100,
+                10
+            )
+            numberOfScrolls++
+            if (numberOfScrolls * 100 > device.displayHeight) {
+                if (scrollUp) {
+                    // We scrolled up and still didn't find the node, change direction
+                    numberOfScrolls = 0
+                    scrollUp = false
+                } else {
+                    // We scrolled up and down and still didn't find the node
+                    throw IllegalStateException("Couldn't find the node that matches the given matcher.")
+                }
+            }
+        }
     }
 
     fun scrollToListItem(itemTitle: String, listID: Int) {
@@ -437,7 +490,7 @@ open class Screen {
         return mCurrentActivity
     }
 
-    protected fun getTranslatedString(resourceID: Int): String {
+    fun getTranslatedString(resourceID: Int): String {
         return getCurrentActivity()!!.resources.getString(resourceID)
     }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
@@ -215,7 +215,7 @@ open class Screen {
                     scrollUp = false
                 } else {
                     // We scrolled up and down and still didn't find the node
-                    throw IllegalStateException("Couldn't find the node that matches the given matcher.")
+                    error("Couldn't find the node that matches the given matcher.")
                 }
             }
         }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/TabNavComponent.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/TabNavComponent.kt
@@ -3,14 +3,14 @@ package com.woocommerce.android.e2e.screens
 import com.woocommerce.android.R
 import com.woocommerce.android.e2e.helpers.util.Screen
 import com.woocommerce.android.e2e.screens.moremenu.MoreMenuScreen
-import com.woocommerce.android.e2e.screens.mystore.MyStoreScreen
+import com.woocommerce.android.e2e.screens.mystore.DashboardScreen
 import com.woocommerce.android.e2e.screens.orders.OrderListScreen
 import com.woocommerce.android.e2e.screens.products.ProductListScreen
 
 class TabNavComponent : Screen(R.id.dashboard) {
-    fun gotoMyStoreScreen(): MyStoreScreen {
+    fun gotoMyStoreScreen(): DashboardScreen {
         clickOn(R.id.dashboard)
-        return MyStoreScreen()
+        return DashboardScreen()
     }
 
     fun gotoOrdersScreen(): OrderListScreen {

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/TabNavComponent.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/TabNavComponent.kt
@@ -7,9 +7,9 @@ import com.woocommerce.android.e2e.screens.mystore.MyStoreScreen
 import com.woocommerce.android.e2e.screens.orders.OrderListScreen
 import com.woocommerce.android.e2e.screens.products.ProductListScreen
 
-class TabNavComponent : Screen(R.id.my_store) {
+class TabNavComponent : Screen(R.id.dashboard) {
     fun gotoMyStoreScreen(): MyStoreScreen {
-        clickOn(R.id.my_store)
+        clickOn(R.id.dashboard)
         return MyStoreScreen()
     }
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/login/PasswordScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/login/PasswordScreen.kt
@@ -2,15 +2,15 @@ package com.woocommerce.android.e2e.screens.login
 
 import com.woocommerce.android.R
 import com.woocommerce.android.e2e.helpers.util.Screen
-import com.woocommerce.android.e2e.screens.mystore.MyStoreScreen
+import com.woocommerce.android.e2e.screens.mystore.DashboardScreen
 
 class PasswordScreen : Screen {
     constructor() : super(org.wordpress.android.login.R.id.input)
 
-    fun proceedWith(password: String): MyStoreScreen {
+    fun proceedWith(password: String): DashboardScreen {
         typeTextInto(org.wordpress.android.login.R.id.input, password)
         clickOn(R.id.bottom_button)
 
-        return MyStoreScreen()
+        return DashboardScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/login/WelcomeScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/login/WelcomeScreen.kt
@@ -8,7 +8,7 @@ import com.woocommerce.android.e2e.screens.TabNavComponent
 class WelcomeScreen : Screen {
     companion object {
         fun logoutIfNeeded(composeTestRule: ComposeContentTestRule): WelcomeScreen {
-            if (isElementDisplayed(R.id.my_store)) {
+            if (isElementDisplayed(R.id.dashboard)) {
                 TabNavComponent()
                     .gotoMoreMenuScreen()
                     .openSettings(composeTestRule)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/DashboardScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/DashboardScreen.kt
@@ -14,17 +14,17 @@ import com.woocommerce.android.ui.dashboard.stats.DashboardStatsTestTags
 import org.hamcrest.Matchers
 import org.json.JSONArray
 
-class MyStoreScreen : Screen(R.id.my_store_refresh_layout) {
+class DashboardScreen : Screen(R.id.my_store_refresh_layout) {
     val stats = StatsComponent()
     val topPerformers = TopPerformersComponent()
 
-    fun tapChartMiddle(): MyStoreScreen {
+    fun tapChartMiddle(): DashboardScreen {
         scrollTo(R.id.chart)
         clickOn(R.id.chart)
         return this
     }
 
-    fun assertStatsSummary(summary: StatsSummaryData): MyStoreScreen {
+    fun assertStatsSummary(summary: StatsSummaryData): DashboardScreen {
         Espresso.onView(
             Matchers.allOf(
                 // Assert there's a Stats container element
@@ -96,7 +96,7 @@ class MyStoreScreen : Screen(R.id.my_store_refresh_layout) {
     fun assertTopPerformers(
         topPerformersJSONArray: JSONArray,
         composeTestRule: ComposeTestRule
-    ): MyStoreScreen {
+    ): DashboardScreen {
         composeTestRule.onNodeWithTag(DashboardStatsTestTags.DASHBOARD_TOP_PERFORMERS_CARD)
             .assertIsDisplayed()
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/MyStoreScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/MyStoreScreen.kt
@@ -86,8 +86,7 @@ class MyStoreScreen : Screen(R.id.my_store_refresh_layout) {
                         )
                     )
                 ),
-
-                )
+            )
         )
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
 
@@ -110,7 +109,6 @@ class MyStoreScreen : Screen(R.id.my_store_refresh_layout) {
                 .assertIsDisplayed()
             composeTestRule.onNodeWithText("Net sales: $$topPerformerSales.00")
                 .assertIsDisplayed()
-
         }
 
         return this

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/MyStoreScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/MyStoreScreen.kt
@@ -1,16 +1,22 @@
 package com.woocommerce.android.e2e.screens.mystore
 
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
 import com.woocommerce.android.R
 import com.woocommerce.android.e2e.helpers.util.Screen
 import com.woocommerce.android.e2e.helpers.util.StatsSummaryData
+import com.woocommerce.android.ui.dashboard.stats.DashboardStatsTestTags
 import org.hamcrest.Matchers
 import org.json.JSONArray
 
 class MyStoreScreen : Screen(R.id.my_store_refresh_layout) {
     val stats = StatsComponent()
+    val topPerformers = TopPerformersComponent()
 
     fun tapChartMiddle(): MyStoreScreen {
         scrollTo(R.id.chart)
@@ -81,52 +87,32 @@ class MyStoreScreen : Screen(R.id.my_store_refresh_layout) {
                     )
                 ),
 
-            )
+                )
         )
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
 
         return this
     }
 
-    fun assertTopPerformers(topPerformersJSONArray: JSONArray): MyStoreScreen {
-        scrollTo(R.id.topPerformers_recycler)
+    fun assertTopPerformers(
+        topPerformersJSONArray: JSONArray,
+        composeTestRule: ComposeTestRule
+    ): MyStoreScreen {
+        composeTestRule.onNodeWithTag(DashboardStatsTestTags.DASHBOARD_TOP_PERFORMERS_CARD)
+            .assertIsDisplayed()
 
         for (i in 0 until topPerformersJSONArray.length()) {
             val innerArray = topPerformersJSONArray.getJSONArray(i)
             val topPerformerName = innerArray.getJSONObject(0).getString("value")
             val topPerformerSales = innerArray.getJSONObject(2).getString("value")
 
-            Espresso.onView(
-                Matchers.allOf(
-                    // Assert there's a Top Performers container element
-                    ViewMatchers.withId(R.id.topPerformers_recycler),
+            composeTestRule.onNodeWithText(topPerformerName)
+                .assertIsDisplayed()
+            composeTestRule.onNodeWithText("Net sales: $$topPerformerSales.00")
+                .assertIsDisplayed()
 
-                    ViewMatchers.hasDescendant(
-                        Matchers.allOf(
-                            // Which has a product container
-                            ViewMatchers.withId(R.id.product_container),
-                            ViewMatchers.withChild(
-                                Matchers.allOf(
-                                    // With expected product name value as a child
-                                    ViewMatchers.withId(R.id.text_ProductName),
-                                    ViewMatchers.withText(topPerformerName)
-                                )
-                            ),
-                            ViewMatchers.withChild(
-                                Matchers.allOf(
-                                    // And with expected product net sales value as a child
-                                    ViewMatchers.withId(R.id.netSalesTextView),
-                                    ViewMatchers.withText("Net sales: $$topPerformerSales.00")
-                                )
-                            )
-                        )
-                    ),
-                )
-            )
-                .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
         }
 
-        scrollTo(R.id.stats_view_row)
         return this
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/StatsComponent.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/StatsComponent.kt
@@ -31,23 +31,23 @@ class StatsComponent : Screen(R.id.dashboardStats_root) {
         }
     }
 
-    fun switchToStatsDashboardTodayTab(composeTestRule: ComposeTestRule): MyStoreScreen {
+    fun switchToStatsDashboardTodayTab(composeTestRule: ComposeTestRule): DashboardScreen {
         return switchToStatsDashboardTab(R.string.today, composeTestRule)
     }
 
-    fun switchToStatsDashboardWeekTab(composeTestRule: ComposeTestRule): MyStoreScreen {
+    fun switchToStatsDashboardWeekTab(composeTestRule: ComposeTestRule): DashboardScreen {
         return switchToStatsDashboardTab(R.string.this_week, composeTestRule)
     }
 
-    fun switchToStatsDashboardMonthTab(composeTestRule: ComposeTestRule): MyStoreScreen {
+    fun switchToStatsDashboardMonthTab(composeTestRule: ComposeTestRule): DashboardScreen {
         return switchToStatsDashboardTab(R.string.this_month, composeTestRule)
     }
 
-    fun switchToStatsDashboardYearTab(composeTestRule: ComposeTestRule): MyStoreScreen {
+    fun switchToStatsDashboardYearTab(composeTestRule: ComposeTestRule): DashboardScreen {
         return switchToStatsDashboardTab(R.string.this_year, composeTestRule)
     }
 
-    private fun switchToStatsDashboardTab(tabName: Int, composeTestRule: ComposeTestRule): MyStoreScreen {
+    private fun switchToStatsDashboardTab(tabName: Int, composeTestRule: ComposeTestRule): DashboardScreen {
         composeTestRule.scrollToNodeThatMatches(
             hasTestTag(DashboardStatsTestTags.DASHBOARD_STATS_CARD)
         )
@@ -60,6 +60,6 @@ class StatsComponent : Screen(R.id.dashboardStats_root) {
 
         waitForGraphToLoad()
 
-        return MyStoreScreen()
+        return DashboardScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/StatsComponent.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/StatsComponent.kt
@@ -1,12 +1,21 @@
 package com.woocommerce.android.e2e.screens.mystore
 
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onChildren
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import com.woocommerce.android.R
 import com.woocommerce.android.e2e.helpers.util.Screen
+import com.woocommerce.android.ui.dashboard.stats.DashboardStatsTestTags
 
 class StatsComponent : Screen(R.id.dashboardStats_root) {
     override fun recover() {
         super.recover()
-        clickOn(R.id.my_store)
+        clickOn(R.id.dashboard)
     }
 
     private fun waitForGraphToLoad() {
@@ -29,25 +38,47 @@ class StatsComponent : Screen(R.id.dashboardStats_root) {
         }
     }
 
-    fun switchToStatsDashboardTodayTab(): MyStoreScreen {
-        return switchToStatsDashboardTab(R.string.today)
+    fun switchToStatsDashboardTodayTab(composeTestRule: ComposeTestRule): MyStoreScreen {
+        return composeTestRule.switchToStatsDashboardTab(R.string.today)
     }
 
-    fun switchToStatsDashboardWeekTab(): MyStoreScreen {
-        return switchToStatsDashboardTab(R.string.this_week)
+    fun switchToStatsDashboardWeekTab(composeTestRule: ComposeTestRule): MyStoreScreen {
+        return composeTestRule.switchToStatsDashboardTab(R.string.this_week)
     }
 
-    fun switchToStatsDashboardMonthTab(): MyStoreScreen {
-        return switchToStatsDashboardTab(R.string.this_month)
+    fun switchToStatsDashboardMonthTab(composeTestRule: ComposeTestRule): MyStoreScreen {
+        return composeTestRule.switchToStatsDashboardTab(R.string.this_month)
     }
 
-    fun switchToStatsDashboardYearTab(): MyStoreScreen {
-        return switchToStatsDashboardTab(R.string.this_year)
+    fun switchToStatsDashboardYearTab(composeTestRule: ComposeTestRule): MyStoreScreen {
+        return composeTestRule.switchToStatsDashboardTab(R.string.this_year)
     }
 
-    private fun switchToStatsDashboardTab(tabName: Int): MyStoreScreen {
-        selectItemWithTitleInTabLayout(tabName, R.id.my_store_stats_container)
+    private fun ComposeTestRule.switchToStatsDashboardTab(tabName: Int): MyStoreScreen {
+        onNodeWithTag(DashboardStatsTestTags.DASHBOARD_STATS_CARD)
+            .onChildren()
+            .filterToOne(
+                hasTestTag(DashboardStatsTestTags.STATS_RANGE_DROPDOWN_BUTTON)
+            )
+            .performClick()
+
+        waitUntil(
+            timeoutMillis = 1000,
+            condition = {
+                onNodeWithTag(DashboardStatsTestTags.STATS_RANGE_DROPDOWN_MENU)
+                    .isDisplayed()
+            }
+        )
+
+        onNodeWithTag(DashboardStatsTestTags.STATS_RANGE_DROPDOWN_MENU)
+            .onChildren()
+            .filterToOne(
+                hasText(getTranslatedString(tabName))
+            )
+            .performClick()
+
         waitForGraphToLoad()
+
         return MyStoreScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/StatsComponent.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/StatsComponent.kt
@@ -1,13 +1,7 @@
 package com.woocommerce.android.e2e.screens.mystore
 
-import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.onChildren
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
 import com.woocommerce.android.R
 import com.woocommerce.android.e2e.helpers.util.Screen
 import com.woocommerce.android.ui.dashboard.stats.DashboardStatsTestTags
@@ -28,7 +22,6 @@ class StatsComponent : Screen(R.id.dashboardStats_root) {
         // idleFor(1000)
         if (!waitForElementToBeDisplayedWithoutFailure(R.id.conversionValueTextView)) {
             recover()
-            scrollTo(R.id.stats_view_row)
             waitForElementToBeDisplayed(R.id.conversionValueTextView)
             // idle for a bit in order to load labels as well
             idleFor(3000)
@@ -39,43 +32,31 @@ class StatsComponent : Screen(R.id.dashboardStats_root) {
     }
 
     fun switchToStatsDashboardTodayTab(composeTestRule: ComposeTestRule): MyStoreScreen {
-        return composeTestRule.switchToStatsDashboardTab(R.string.today)
+        return switchToStatsDashboardTab(R.string.today, composeTestRule)
     }
 
     fun switchToStatsDashboardWeekTab(composeTestRule: ComposeTestRule): MyStoreScreen {
-        return composeTestRule.switchToStatsDashboardTab(R.string.this_week)
+        return switchToStatsDashboardTab(R.string.this_week, composeTestRule)
     }
 
     fun switchToStatsDashboardMonthTab(composeTestRule: ComposeTestRule): MyStoreScreen {
-        return composeTestRule.switchToStatsDashboardTab(R.string.this_month)
+        return switchToStatsDashboardTab(R.string.this_month, composeTestRule)
     }
 
     fun switchToStatsDashboardYearTab(composeTestRule: ComposeTestRule): MyStoreScreen {
-        return composeTestRule.switchToStatsDashboardTab(R.string.this_year)
+        return switchToStatsDashboardTab(R.string.this_year, composeTestRule)
     }
 
-    private fun ComposeTestRule.switchToStatsDashboardTab(tabName: Int): MyStoreScreen {
-        onNodeWithTag(DashboardStatsTestTags.DASHBOARD_STATS_CARD)
-            .onChildren()
-            .filterToOne(
-                hasTestTag(DashboardStatsTestTags.STATS_RANGE_DROPDOWN_BUTTON)
-            )
-            .performClick()
-
-        waitUntil(
-            timeoutMillis = 1000,
-            condition = {
-                onNodeWithTag(DashboardStatsTestTags.STATS_RANGE_DROPDOWN_MENU)
-                    .isDisplayed()
-            }
+    private fun switchToStatsDashboardTab(tabName: Int, composeTestRule: ComposeTestRule): MyStoreScreen {
+        composeTestRule.scrollToNodeThatMatches(
+            hasTestTag(DashboardStatsTestTags.DASHBOARD_STATS_CARD)
         )
 
-        onNodeWithTag(DashboardStatsTestTags.STATS_RANGE_DROPDOWN_MENU)
-            .onChildren()
-            .filterToOne(
-                hasText(getTranslatedString(tabName))
-            )
-            .performClick()
+        switchToStatsDateRange(
+            rootTag = DashboardStatsTestTags.DASHBOARD_STATS_CARD,
+            dateRangeName = tabName,
+            composeTestRule = composeTestRule
+        )
 
         waitForGraphToLoad()
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/StatsHeaderExt.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/StatsHeaderExt.kt
@@ -1,0 +1,40 @@
+package com.woocommerce.android.e2e.screens.mystore
+
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onChildren
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.woocommerce.android.e2e.helpers.util.Screen
+import com.woocommerce.android.ui.dashboard.stats.DashboardStatsTestTags
+
+fun Screen.switchToStatsDateRange(
+    rootTag: String,
+    dateRangeName: Int,
+    composeTestRule: ComposeTestRule
+) {
+    composeTestRule.onNodeWithTag(rootTag)
+        .onChildren()
+        .filterToOne(
+            hasTestTag(DashboardStatsTestTags.STATS_RANGE_DROPDOWN_BUTTON)
+        )
+        .performClick()
+
+    composeTestRule.waitUntil(
+        timeoutMillis = 1000,
+        condition = {
+            composeTestRule.onNodeWithTag(DashboardStatsTestTags.STATS_RANGE_DROPDOWN_MENU)
+                .isDisplayed()
+        }
+    )
+
+    composeTestRule.onNodeWithTag(DashboardStatsTestTags.STATS_RANGE_DROPDOWN_MENU)
+        .onChildren()
+        .filterToOne(
+            hasText(getTranslatedString(dateRangeName))
+        )
+        .performClick()
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/TopPerformersComponent.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/TopPerformersComponent.kt
@@ -12,7 +12,7 @@ class TopPerformersComponent : Screen(R.id.dashboardStats_root) {
         clickOn(R.id.dashboard)
     }
 
-    fun switchToStatsDashboardTodayTab(composeTestRule: ComposeTestRule): MyStoreScreen {
+    fun switchToStatsDashboardTodayTab(composeTestRule: ComposeTestRule): DashboardScreen {
         composeTestRule.scrollToNodeThatMatches(
             hasTestTag(DashboardStatsTestTags.DASHBOARD_TOP_PERFORMERS_CARD)
         )
@@ -23,6 +23,6 @@ class TopPerformersComponent : Screen(R.id.dashboardStats_root) {
             composeTestRule = composeTestRule
         )
 
-        return MyStoreScreen()
+        return DashboardScreen()
     }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/TopPerformersComponent.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/mystore/TopPerformersComponent.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.e2e.screens.mystore
+
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.woocommerce.android.R
+import com.woocommerce.android.e2e.helpers.util.Screen
+import com.woocommerce.android.ui.dashboard.stats.DashboardStatsTestTags
+
+class TopPerformersComponent : Screen(R.id.dashboardStats_root) {
+    override fun recover() {
+        super.recover()
+        clickOn(R.id.dashboard)
+    }
+
+    fun switchToStatsDashboardTodayTab(composeTestRule: ComposeTestRule): MyStoreScreen {
+        composeTestRule.scrollToNodeThatMatches(
+            hasTestTag(DashboardStatsTestTags.DASHBOARD_TOP_PERFORMERS_CARD)
+        )
+
+        switchToStatsDateRange(
+            rootTag = DashboardStatsTestTags.DASHBOARD_TOP_PERFORMERS_CARD,
+            dateRangeName = R.string.today,
+            composeTestRule = composeTestRule
+        )
+
+        return MyStoreScreen()
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/screenshot/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/screenshot/ScreenshotTest.kt
@@ -10,7 +10,7 @@ import com.woocommerce.android.e2e.helpers.InitializationRule
 import com.woocommerce.android.e2e.helpers.TestBase
 import com.woocommerce.android.e2e.screens.TabNavComponent
 import com.woocommerce.android.e2e.screens.login.WelcomeScreen
-import com.woocommerce.android.e2e.screens.mystore.MyStoreScreen
+import com.woocommerce.android.e2e.screens.mystore.DashboardScreen
 import com.woocommerce.android.e2e.screens.notifications.NotificationsScreen
 import com.woocommerce.android.e2e.screens.orders.CardReaderPaymentScreen
 import com.woocommerce.android.e2e.screens.orders.UnifiedOrderScreen
@@ -90,9 +90,9 @@ class ScreenshotTest : TestBase(failOnUnmatchedWireMockRequests = false) {
         }
 
         // My Store
-        MyStoreScreen()
+        DashboardScreen()
             .stats.switchToStatsDashboardMonthTab(composeTestRule)
-            .thenTakeScreenshot<MyStoreScreen>("order-dashboard")
+            .thenTakeScreenshot<DashboardScreen>("order-dashboard")
 
         // Create Orders
         TabNavComponent()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/screenshot/ScreenshotTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/screenshot/ScreenshotTest.kt
@@ -91,7 +91,7 @@ class ScreenshotTest : TestBase(failOnUnmatchedWireMockRequests = false) {
 
         // My Store
         MyStoreScreen()
-            .stats.switchToStatsDashboardMonthTab()
+            .stats.switchToStatsDashboardMonthTab(composeTestRule)
             .thenTakeScreenshot<MyStoreScreen>("order-dashboard")
 
         // Create Orders

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/StatsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/StatsUITest.kt
@@ -7,6 +7,7 @@ import androidx.test.rule.ActivityTestRule
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.e2e.helpers.InitializationRule
 import com.woocommerce.android.e2e.helpers.TestBase
+import com.woocommerce.android.e2e.helpers.util.MocksReader
 import com.woocommerce.android.e2e.helpers.util.StatsSummaryData
 import com.woocommerce.android.e2e.rules.Retry
 import com.woocommerce.android.e2e.rules.RetryTestRule
@@ -85,16 +86,16 @@ class StatsUITest : TestBase() {
             .stats.switchToStatsDashboardYearTab(composeTestRule)
             .assertStatsSummary(yearStats)
     }
-//
-//    @Retry(numberOfTimes = 1)
-//    @Test
-//    fun e2eStatsTopPerformers() {
-//        val topPerformersJSONArray = MocksReader().readStatsTopPerformersToArray()
-//
-//        MyStoreScreen()
-//            .stats.switchToStatsDashboardTodayTab(composeTestRule)
-//            .assertTopPerformers(topPerformersJSONArray)
-//    }
+
+    @Retry(numberOfTimes = 1)
+    @Test
+    fun e2eStatsTopPerformers() {
+        val topPerformersJSONArray = MocksReader().readStatsTopPerformersToArray()
+
+        MyStoreScreen()
+            .topPerformers.switchToStatsDashboardTodayTab(composeTestRule)
+            .assertTopPerformers(topPerformersJSONArray, composeTestRule)
+    }
 
     @Retry(numberOfTimes = 1)
     @Test

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/StatsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/StatsUITest.kt
@@ -7,7 +7,6 @@ import androidx.test.rule.ActivityTestRule
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.e2e.helpers.InitializationRule
 import com.woocommerce.android.e2e.helpers.TestBase
-import com.woocommerce.android.e2e.helpers.util.MocksReader
 import com.woocommerce.android.e2e.helpers.util.StatsSummaryData
 import com.woocommerce.android.e2e.rules.Retry
 import com.woocommerce.android.e2e.rules.RetryTestRule
@@ -79,29 +78,29 @@ class StatsUITest : TestBase() {
     @Test
     fun e2eStatsSummary() {
         MyStoreScreen()
-            .stats.switchToStatsDashboardTodayTab()
+            .stats.switchToStatsDashboardTodayTab(composeTestRule)
             .assertStatsSummary(todayStats)
-            .stats.switchToStatsDashboardWeekTab()
+            .stats.switchToStatsDashboardWeekTab(composeTestRule)
             .assertStatsSummary(weekStats)
-            .stats.switchToStatsDashboardYearTab()
+            .stats.switchToStatsDashboardYearTab(composeTestRule)
             .assertStatsSummary(yearStats)
     }
-
-    @Retry(numberOfTimes = 1)
-    @Test
-    fun e2eStatsTopPerformers() {
-        val topPerformersJSONArray = MocksReader().readStatsTopPerformersToArray()
-
-        MyStoreScreen()
-            .stats.switchToStatsDashboardTodayTab()
-            .assertTopPerformers(topPerformersJSONArray)
-    }
+//
+//    @Retry(numberOfTimes = 1)
+//    @Test
+//    fun e2eStatsTopPerformers() {
+//        val topPerformersJSONArray = MocksReader().readStatsTopPerformersToArray()
+//
+//        MyStoreScreen()
+//            .stats.switchToStatsDashboardTodayTab(composeTestRule)
+//            .assertTopPerformers(topPerformersJSONArray)
+//    }
 
     @Retry(numberOfTimes = 1)
     @Test
     fun e2eStatsTapChart() {
         MyStoreScreen()
-            .stats.switchToStatsDashboardWeekTab()
+            .stats.switchToStatsDashboardWeekTab(composeTestRule)
             .assertStatsSummary(weekStats)
             .tapChartMiddle()
             .assertStatsSummary(weekMiddleStats)

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/StatsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/StatsUITest.kt
@@ -13,7 +13,7 @@ import com.woocommerce.android.e2e.rules.Retry
 import com.woocommerce.android.e2e.rules.RetryTestRule
 import com.woocommerce.android.e2e.screens.TabNavComponent
 import com.woocommerce.android.e2e.screens.login.WelcomeScreen
-import com.woocommerce.android.e2e.screens.mystore.MyStoreScreen
+import com.woocommerce.android.e2e.screens.mystore.DashboardScreen
 import com.woocommerce.android.ui.login.LoginActivity
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -78,7 +78,7 @@ class StatsUITest : TestBase() {
     @Retry(numberOfTimes = 1)
     @Test
     fun e2eStatsSummary() {
-        MyStoreScreen()
+        DashboardScreen()
             .stats.switchToStatsDashboardTodayTab(composeTestRule)
             .assertStatsSummary(todayStats)
             .stats.switchToStatsDashboardWeekTab(composeTestRule)
@@ -92,7 +92,7 @@ class StatsUITest : TestBase() {
     fun e2eStatsTopPerformers() {
         val topPerformersJSONArray = MocksReader().readStatsTopPerformersToArray()
 
-        MyStoreScreen()
+        DashboardScreen()
             .topPerformers.switchToStatsDashboardTodayTab(composeTestRule)
             .assertTopPerformers(topPerformersJSONArray, composeTestRule)
     }
@@ -100,7 +100,7 @@ class StatsUITest : TestBase() {
     @Retry(numberOfTimes = 1)
     @Test
     fun e2eStatsTapChart() {
-        MyStoreScreen()
+        DashboardScreen()
             .stats.switchToStatsDashboardWeekTab(composeTestRule)
             .assertStatsSummary(weekStats)
             .tapChartMiddle()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -86,7 +87,7 @@ fun DashboardStatsCard(
         ),
         isError = revenueStatsState is DashboardStatsViewModel.RevenueStatsViewState.PluginNotActiveError ||
             revenueStatsState == DashboardStatsViewModel.RevenueStatsViewState.GenericError,
-        modifier = modifier
+        modifier = modifier.testTag(DashboardStatsTestTags.DASHBOARD_STATS_CARD)
     ) {
         when (revenueStatsState) {
             is DashboardStatsViewModel.RevenueStatsViewState.GenericError -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -212,7 +212,7 @@ private fun StatsChart(
         statsView.showLastUpdate(lastUpdateState)
     }
 
-    LaunchedEffect(revenueStatsState) {
+    LaunchedEffect(dateRange, revenueStatsState) {
         when (revenueStatsState) {
             is DashboardStatsViewModel.RevenueStatsViewState.Content -> {
                 statsView.showErrorView(false)
@@ -238,7 +238,7 @@ private fun StatsChart(
         }
     }
 
-    LaunchedEffect(visitorsStatsState) {
+    LaunchedEffect(dateRange, visitorsStatsState) {
         visitorsStatsState?.let {
             statsView.showVisitorStats(it)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -213,7 +213,7 @@ private fun StatsChart(
         statsView.showLastUpdate(lastUpdateState)
     }
 
-    LaunchedEffect(dateRange, revenueStatsState) {
+    LaunchedEffect(dateRange?.rangeSelection, revenueStatsState) {
         when (revenueStatsState) {
             is DashboardStatsViewModel.RevenueStatsViewState.Content -> {
                 statsView.showErrorView(false)
@@ -239,7 +239,7 @@ private fun StatsChart(
         }
     }
 
-    LaunchedEffect(dateRange, visitorsStatsState) {
+    LaunchedEffect(dateRange?.rangeSelection, visitorsStatsState) {
         visitorsStatsState?.let {
             statsView.showVisitorStats(it)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsHeader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsHeader.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -87,7 +88,10 @@ fun DashboardStatsHeader(
 
         Box {
             var isMenuExpanded by remember { mutableStateOf(false) }
-            IconButton(onClick = { isMenuExpanded = true }) {
+            IconButton(
+                onClick = { isMenuExpanded = true },
+                modifier = Modifier.testTag(DashboardStatsTestTags.STATS_RANGE_DROPDOWN_BUTTON)
+            ) {
                 Icon(
                     imageVector = Icons.Default.DateRange,
                     contentDescription = stringResource(
@@ -101,6 +105,7 @@ fun DashboardStatsHeader(
                 expanded = isMenuExpanded,
                 onDismissRequest = { isMenuExpanded = false },
                 modifier = Modifier.defaultMinSize(minWidth = 250.dp)
+                    .testTag(DashboardStatsTestTags.STATS_RANGE_DROPDOWN_MENU)
             ) {
                 DashboardViewModel.SUPPORTED_RANGES_ON_MY_STORE_TAB.forEach {
                     DropdownMenuItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsTestTags.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsTestTags.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.ui.dashboard.stats
+
+object DashboardStatsTestTags {
+    const val DASHBOARD_STATS_CARD = "dashboard_stats_card"
+    const val STATS_RANGE_DROPDOWN_BUTTON = "stats_range_dropdown_button"
+    const val STATS_RANGE_DROPDOWN_MENU = "stats_range_dropdown_menu"
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsTestTags.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsTestTags.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.dashboard.stats
 
 object DashboardStatsTestTags {
     const val DASHBOARD_STATS_CARD = "dashboard_stats_card"
+    const val DASHBOARD_TOP_PERFORMERS_CARD = "dashboard_top_performers_card"
     const val STATS_RANGE_DROPDOWN_BUTTON = "stats_range_dropdown_button"
     const val STATS_RANGE_DROPDOWN_MENU = "stats_range_dropdown_menu"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -50,6 +51,7 @@ import com.woocommerce.android.ui.dashboard.TopPerformerProductUiModel
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.stats.DashboardStatsHeader
+import com.woocommerce.android.ui.dashboard.stats.DashboardStatsTestTags
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenAnalytics
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenDatePicker
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersViewModel.OpenTopPerformer
@@ -78,7 +80,7 @@ fun DashboardTopPerformersWidgetCard(
             titleResource = topPerformersState.titleStringRes,
             menu = topPerformersState.menu,
             button = topPerformersState.onOpenAnalyticsTapped,
-            modifier = modifier,
+            modifier = modifier.testTag(DashboardStatsTestTags.DASHBOARD_TOP_PERFORMERS_CARD),
             isError = topPerformersState.isError
         ) {
             when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -32,9 +32,7 @@ enum class FeatureFlag {
             ORDER_CREATION_AUTO_TAX_RATE,
             EOSL_M1 -> PackageUtils.isDebugBuild()
 
-            // Keep dynamic dashboard disabled when running in tests until we update the UI tests
-            DYNAMIC_DASHBOARD -> !PackageUtils.isTesting()
-
+            DYNAMIC_DASHBOARD,
             CONNECTIVITY_TOOL,
             CUSTOM_RANGE_ANALYTICS,
             NEW_SHIPPING_SUPPORT,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboardingTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboardingTest.kt
@@ -105,8 +105,6 @@ internal class ShouldShowOnboardingTest : BaseUnitTest() {
 
     @Test
     fun `given onboarding is enabled from settings, when at least one task is incomplete, then return true`() {
-        givenOnboardingIsEnabledFromSettings(enabled = true)
-
         val show = sut.showForTasks(ONBOARDING_TASK_INCOMPLETED_LIST)
 
         assertTrue(show)
@@ -114,8 +112,6 @@ internal class ShouldShowOnboardingTest : BaseUnitTest() {
 
     @Test
     fun `given onboarding is enabled from settings, when at least one task is incomplete, then mark onboarding shown`() {
-        givenOnboardingIsEnabledFromSettings(enabled = true)
-
         sut.showForTasks(ONBOARDING_TASK_INCOMPLETED_LIST)
 
         verify(appPrefsWrapper).setStoreOnboardingShown(CURRENT_SITE_ID)
@@ -155,9 +151,5 @@ internal class ShouldShowOnboardingTest : BaseUnitTest() {
 
     private fun givenStoreOnboardingHasBeenShownAtLeastOnce(shown: Boolean) {
         whenever(appPrefsWrapper.getStoreOnboardingShown(CURRENT_SITE_ID)).thenReturn(shown)
-    }
-
-    private fun givenOnboardingIsEnabledFromSettings(enabled: Boolean) {
-        whenever(appPrefsWrapper.getOnboardingSettingVisibility(CURRENT_SITE_ID)).thenReturn(enabled)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11453 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates the UI tests to align with the dynamic dashboard changes.

Please feel free to share any np comments in the review, I don't have a lot of experience with UI tests especially ones that involve Compose, and if we can improve anything it would be great.

### Testing instructions
Just green CI.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
