### PR TITLE
[Watch App] Introduce orders list

### DIFF
--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/presentation/theme/WooColors.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/presentation/theme/WooColors.kt
@@ -15,7 +15,7 @@ object WooColors {
     val md_theme_dark_onError = Color(0xFF000000)
     val md_theme_dark_background = Color(0xFF121212)
     val md_theme_dark_onBackground = Color(0xFFFFFFFF)
-    val md_theme_dark_surface = Color(0xFF121212)
+    val md_theme_dark_surface = Color(0xFF000000)
     val md_theme_dark_onSurface = Color(0xFFFFFFFF)
     val purple_surface = Color(0xBB533582)
     val woo_purple_5 = Color(0xFFDFD1FB)

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/presentation/theme/WooColors.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/presentation/theme/WooColors.kt
@@ -17,9 +17,12 @@ object WooColors {
     val md_theme_dark_onBackground = Color(0xFFFFFFFF)
     val md_theme_dark_surface = Color(0xFF000000)
     val md_theme_dark_onSurface = Color(0xFFFFFFFF)
-    val purple_surface = Color(0xBB533582)
+    val woo_purple_surface = Color(0xBB533582)
+    val woo_gray_surface = Color(0xFFBDC1C6)
     val woo_purple_5 = Color(0xFFDFD1FB)
     val woo_purple_10 = Color(0xFFCFB9F6)
+    val woo_purple_20 = Color(0xFFBEA0F2)
+    val woo_gray_alpha = Color(0x80FFFFFF)
 }
 
 val WooWearColors = Colors(

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/Navigation.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/Navigation.kt
@@ -30,9 +30,7 @@ fun WooWearNavHost(
             LoginScreen(viewModel)
         }
         composable(MY_STORE.route) {
-            val storeStatsViewModel = hiltViewModel<StoreStatsViewModel, StoreStatsViewModel.Factory> {
-                it.create(navController)
-            }
+            val storeStatsViewModel = hiltViewModel<StoreStatsViewModel>()
             val ordersListViewModel = hiltViewModel<OrdersListViewModel, OrdersListViewModel.Factory> {
                 it.create(navController)
             }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -25,8 +26,8 @@ import androidx.wear.compose.foundation.lazy.AutoCenteringParams
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
-import androidx.wear.compose.material.TimeText
 import androidx.wear.tooling.preview.devices.WearDevices
+import com.woocommerce.android.R
 import com.woocommerce.android.presentation.theme.WooColors
 import com.woocommerce.android.presentation.theme.WooTheme
 import com.woocommerce.android.presentation.theme.WooTypography
@@ -55,7 +56,7 @@ fun OrdersListScreen(
                     .fillMaxSize()
             ) {
                 Text(
-                    text = "Orders",
+                    text = stringResource(id = R.string.orders_list_screen_title),
                     style = WooTypography.body1,
                     color = WooColors.woo_gray_alpha,
                     textAlign = TextAlign.Center,

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
@@ -50,18 +50,32 @@ fun OrdersListScreen(
             modifier = modifier.fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
-            TimeText()
-            val listState = rememberScalingLazyListState()
-            ScalingLazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                autoCentering = AutoCenteringParams(itemIndex = 0),
-                state = listState
+            Column(
+                modifier = modifier
+                    .fillMaxSize()
             ) {
-                items(orders) {
-                    OrderListItem(
-                        modifier = modifier,
-                        order = it
+                Text(
+                    text = "Orders",
+                    style = WooTypography.body1,
+                    color = WooColors.woo_gray_alpha,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 6.dp)
+                )
+                ScalingLazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    autoCentering = AutoCenteringParams(itemIndex = 0),
+                    state = rememberScalingLazyListState(
+                        initialCenterItemIndex = 0
                     )
+                ) {
+                    items(orders) {
+                        OrderListItem(
+                            modifier = modifier,
+                            order = it
+                        )
+                    }
                 }
             }
         }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.ui.orders
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Text
@@ -11,6 +9,10 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.wear.compose.foundation.lazy.AutoCenteringParams
+import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
 import androidx.wear.tooling.preview.devices.WearDevices
 import com.woocommerce.android.presentation.theme.WooTheme
 
@@ -27,13 +29,15 @@ fun OrdersListScreen(
     orders: List<String>
 ) {
     WooTheme {
-        Column(
-            verticalArrangement = Arrangement.Center,
-            modifier = Modifier.fillMaxSize()
+        val listState = rememberScalingLazyListState()
+        ScalingLazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            autoCentering = AutoCenteringParams(itemIndex = 0),
+            state = listState
         ) {
-            orders.forEach {
+            items(orders) { order ->
                 Text(
-                    text = it,
+                    text = order,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.fillMaxWidth()
                 )

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Text
@@ -15,7 +16,7 @@ import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
 import androidx.wear.tooling.preview.devices.WearDevices
 import com.woocommerce.android.presentation.theme.WooTheme
-import com.woocommerce.android.ui.orders.OrdersListViewModel.OrderListItem
+import com.woocommerce.android.ui.orders.OrdersListViewModel.OrderItem
 
 @Composable
 fun OrdersListScreen(viewModel: OrdersListViewModel) {
@@ -27,7 +28,8 @@ fun OrdersListScreen(viewModel: OrdersListViewModel) {
 
 @Composable
 fun OrdersListScreen(
-    orders: List<OrderListItem>
+    orders: List<OrderItem>,
+    modifier: Modifier = Modifier
 ) {
     WooTheme {
         val listState = rememberScalingLazyListState()
@@ -36,14 +38,27 @@ fun OrdersListScreen(
             autoCentering = AutoCenteringParams(itemIndex = 0),
             state = listState
         ) {
-            items(orders) { order ->
-                Text(
-                    text = order.customerName,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth()
+            items(orders) {
+                OrderListItem(
+                    modifier = modifier,
+                    order = it
                 )
             }
         }
+    }
+}
+
+@Composable
+fun OrderListItem(
+    modifier: Modifier,
+    order: OrderItem
+) {
+    Box(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = order.customerName,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }
 
@@ -55,21 +70,21 @@ fun OrdersListScreen(
 fun Preview() {
     OrdersListScreen(
         orders = listOf(
-            OrderListItem(
+            OrderItem(
                 date = "2021-09-01",
                 number = "123",
                 customerName = "John Doe",
                 total = "$100.00",
                 status = "Processing"
             ),
-            OrderListItem(
+            OrderItem(
                 date = "2021-09-02",
                 number = "124",
                 customerName = "Jane Doe",
                 total = "$200.00",
                 status = "Completed"
             ),
-            OrderListItem(
+            OrderItem(
                 date = "2021-09-03",
                 number = "125",
                 customerName = "John Smith",

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
@@ -15,6 +15,7 @@ import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
 import androidx.wear.tooling.preview.devices.WearDevices
 import com.woocommerce.android.presentation.theme.WooTheme
+import com.woocommerce.android.ui.orders.OrdersListViewModel.OrderListItem
 
 @Composable
 fun OrdersListScreen(viewModel: OrdersListViewModel) {
@@ -26,7 +27,7 @@ fun OrdersListScreen(viewModel: OrdersListViewModel) {
 
 @Composable
 fun OrdersListScreen(
-    orders: List<String>
+    orders: List<OrderListItem>
 ) {
     WooTheme {
         val listState = rememberScalingLazyListState()
@@ -37,7 +38,7 @@ fun OrdersListScreen(
         ) {
             items(orders) { order ->
                 Text(
-                    text = order,
+                    text = order.customerName,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.fillMaxWidth()
                 )
@@ -52,5 +53,29 @@ fun OrdersListScreen(
 @Preview(device = WearDevices.RECT, showSystemUi = true)
 @Composable
 fun Preview() {
-    OrdersListScreen(orders = listOf("Order 1", "Order 2", "Order 3"))
+    OrdersListScreen(
+        orders = listOf(
+            OrderListItem(
+                date = "2021-09-01",
+                number = "123",
+                customerName = "John Doe",
+                total = "$100.00",
+                status = "Processing"
+            ),
+            OrderListItem(
+                date = "2021-09-02",
+                number = "124",
+                customerName = "Jane Doe",
+                total = "$200.00",
+                status = "Completed"
+            ),
+            OrderListItem(
+                date = "2021-09-03",
+                number = "125",
+                customerName = "John Smith",
+                total = "$300.00",
+                status = "Pending"
+            )
+        )
+    )
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
@@ -6,23 +6,47 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.wear.tooling.preview.devices.WearDevices
 import com.woocommerce.android.presentation.theme.WooTheme
 
 @Composable
 fun OrdersListScreen(viewModel: OrdersListViewModel) {
-    viewModel.apply { }
+    val viewState by viewModel.viewState.observeAsState()
+    OrdersListScreen(
+        orders = viewState?.orders.orEmpty()
+    )
+}
+
+@Composable
+fun OrdersListScreen(
+    orders: List<String>
+) {
     WooTheme {
         Column(
             verticalArrangement = Arrangement.Center,
             modifier = Modifier.fillMaxSize()
         ) {
-            Text(
-                text = "Orders List",
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth()
-            )
+            orders.forEach {
+                Text(
+                    text = it,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
     }
+}
+
+@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true)
+@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
+@Preview(device = WearDevices.SQUARE, showSystemUi = true)
+@Preview(device = WearDevices.RECT, showSystemUi = true)
+@Composable
+fun Preview() {
+    OrdersListScreen(orders = listOf("Order 1", "Order 2", "Order 3"))
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
@@ -7,14 +7,17 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -22,8 +25,11 @@ import androidx.wear.compose.foundation.lazy.AutoCenteringParams
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
+import androidx.wear.compose.material.TimeText
 import androidx.wear.tooling.preview.devices.WearDevices
+import com.woocommerce.android.presentation.theme.WooColors
 import com.woocommerce.android.presentation.theme.WooTheme
+import com.woocommerce.android.presentation.theme.WooTypography
 import com.woocommerce.android.ui.orders.OrdersListViewModel.OrderItem
 
 @Composable
@@ -40,17 +46,23 @@ fun OrdersListScreen(
     modifier: Modifier = Modifier
 ) {
     WooTheme {
-        val listState = rememberScalingLazyListState()
-        ScalingLazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            autoCentering = AutoCenteringParams(itemIndex = 0),
-            state = listState
+        Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
         ) {
-            items(orders) {
-                OrderListItem(
-                    modifier = modifier,
-                    order = it
-                )
+            TimeText()
+            val listState = rememberScalingLazyListState()
+            ScalingLazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                autoCentering = AutoCenteringParams(itemIndex = 0),
+                state = listState
+            ) {
+                items(orders) {
+                    OrderListItem(
+                        modifier = modifier,
+                        order = it
+                    )
+                }
             }
         }
     }
@@ -64,33 +76,43 @@ fun OrderListItem(
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(15.dp))
-            .background(Color.White)
+            .background(Color.DarkGray)
+            .padding(10.dp)
             .fillMaxWidth()
     ) {
-        Column {
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Row(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text(
                     text = order.date,
+                    color = WooColors.woo_purple_20
                 )
                 Text(
-                    text = order.number
+                    text = order.number,
+                    color = WooColors.woo_gray_alpha
                 )
             }
             Text(
                 text = order.customerName,
+                style = WooTypography.body1,
+                color = Color.White,
                 textAlign = TextAlign.Start,
                 modifier = Modifier.fillMaxWidth()
             )
             Text(
                 text = order.total,
+                style = WooTypography.body1,
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Start,
                 modifier = Modifier.fillMaxWidth()
             )
             Text(
                 text = order.status,
+                style = WooTypography.caption1,
+                color = WooColors.woo_gray_alpha,
                 textAlign = TextAlign.Start,
                 modifier = Modifier.fillMaxWidth()
             )

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListScreen.kt
@@ -1,15 +1,23 @@
 package com.woocommerce.android.ui.orders
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.AutoCenteringParams
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.items
@@ -53,12 +61,40 @@ fun OrderListItem(
     modifier: Modifier,
     order: OrderItem
 ) {
-    Box(modifier = modifier.fillMaxWidth()) {
-        Text(
-            text = order.customerName,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth()
-        )
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(15.dp))
+            .background(Color.White)
+            .fillMaxWidth()
+    ) {
+        Column {
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = order.date,
+                )
+                Text(
+                    text = order.number
+                )
+            }
+            Text(
+                text = order.customerName,
+                textAlign = TextAlign.Start,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Text(
+                text = order.total,
+                textAlign = TextAlign.Start,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Text(
+                text = order.status,
+                textAlign = TextAlign.Start,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
     }
 }
 
@@ -71,22 +107,22 @@ fun Preview() {
     OrdersListScreen(
         orders = listOf(
             OrderItem(
-                date = "2021-09-01",
-                number = "123",
+                date = "25 Feb",
+                number = "#125",
                 customerName = "John Doe",
                 total = "$100.00",
                 status = "Processing"
             ),
             OrderItem(
-                date = "2021-09-02",
-                number = "124",
+                date = "31 Dec",
+                number = "#124",
                 customerName = "Jane Doe",
                 total = "$200.00",
                 status = "Completed"
             ),
             OrderItem(
-                date = "2021-09-03",
-                number = "125",
+                date = "4 Oct",
+                number = "#123",
                 customerName = "John Smith",
                 total = "$300.00",
                 status = "Pending"

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListViewModel.kt
@@ -40,6 +40,7 @@ class OrdersListViewModel @AssistedInject constructor(
     }
 
     private fun requestOrdersData(selectedSite: SiteModel) {
+        selectedSite.apply {  }
         // TODO: Introduce actual request
         _viewState.update {
             it.copy(orders = listOf("Order 1", "Order 2", "Order 3"))

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListViewModel.kt
@@ -40,32 +40,34 @@ class OrdersListViewModel @AssistedInject constructor(
     }
 
     private fun requestOrdersData(selectedSite: SiteModel) {
-        selectedSite.apply {  }
-        // TODO: Introduce actual request
+        selectedSite.apply { }
+        // Introduce actual request
         _viewState.update {
-            it.copy(orders = listOf(
-                OrderItem(
-                    date = "25 Feb",
-                    number = "#125",
-                    customerName = "John Doe",
-                    total = "$100.00",
-                    status = "Processing"
-                ),
-                OrderItem(
-                    date = "31 Dec",
-                    number = "#124",
-                    customerName = "Jane Doe",
-                    total = "$200.00",
-                    status = "Completed"
-                ),
-                OrderItem(
-                    date = "4 Oct",
-                    number = "#123",
-                    customerName = "John Smith",
-                    total = "$300.00",
-                    status = "Pending"
+            it.copy(
+                orders = listOf(
+                    OrderItem(
+                        date = "25 Feb",
+                        number = "#125",
+                        customerName = "John Doe",
+                        total = "$100.00",
+                        status = "Processing"
+                    ),
+                    OrderItem(
+                        date = "31 Dec",
+                        number = "#124",
+                        customerName = "Jane Doe",
+                        total = "$200.00",
+                        status = "Completed"
+                    ),
+                    OrderItem(
+                        date = "4 Oct",
+                        number = "#123",
+                        customerName = "John Smith",
+                        total = "$300.00",
+                        status = "Pending"
+                    )
                 )
-            ))
+            )
         }
     }
 

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListViewModel.kt
@@ -44,21 +44,21 @@ class OrdersListViewModel @AssistedInject constructor(
         // TODO: Introduce actual request
         _viewState.update {
             it.copy(orders = listOf(
-                OrderListItem(
+                OrderItem(
                     date = "2021-09-01",
                     number = "123",
                     customerName = "John Doe",
                     total = "$100.00",
                     status = "Processing"
                 ),
-                OrderListItem(
+                OrderItem(
                     date = "2021-09-02",
                     number = "124",
                     customerName = "Jane Doe",
                     total = "$200.00",
                     status = "Completed"
                 ),
-                OrderListItem(
+                OrderItem(
                     date = "2021-09-03",
                     number = "125",
                     customerName = "John Smith",
@@ -71,11 +71,11 @@ class OrdersListViewModel @AssistedInject constructor(
 
     @Parcelize
     data class ViewState(
-        val orders: List<OrderListItem> = emptyList()
+        val orders: List<OrderItem> = emptyList()
     ) : Parcelable
 
     @Parcelize
-    data class OrderListItem(
+    data class OrderItem(
         val date: String,
         val number: String,
         val customerName: String,

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListViewModel.kt
@@ -43,13 +43,44 @@ class OrdersListViewModel @AssistedInject constructor(
         selectedSite.apply {  }
         // TODO: Introduce actual request
         _viewState.update {
-            it.copy(orders = listOf("Order 1", "Order 2", "Order 3"))
+            it.copy(orders = listOf(
+                OrderListItem(
+                    date = "2021-09-01",
+                    number = "123",
+                    customerName = "John Doe",
+                    total = "$100.00",
+                    status = "Processing"
+                ),
+                OrderListItem(
+                    date = "2021-09-02",
+                    number = "124",
+                    customerName = "Jane Doe",
+                    total = "$200.00",
+                    status = "Completed"
+                ),
+                OrderListItem(
+                    date = "2021-09-03",
+                    number = "125",
+                    customerName = "John Smith",
+                    total = "$300.00",
+                    status = "Pending"
+                )
+            ))
         }
     }
 
     @Parcelize
     data class ViewState(
-        val orders: List<String> = emptyList()
+        val orders: List<OrderListItem> = emptyList()
+    ) : Parcelable
+
+    @Parcelize
+    data class OrderListItem(
+        val date: String,
+        val number: String,
+        val customerName: String,
+        val total: String,
+        val status: String
     ) : Parcelable
 
     @AssistedFactory

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListViewModel.kt
@@ -45,22 +45,22 @@ class OrdersListViewModel @AssistedInject constructor(
         _viewState.update {
             it.copy(orders = listOf(
                 OrderItem(
-                    date = "2021-09-01",
-                    number = "123",
+                    date = "25 Feb",
+                    number = "#125",
                     customerName = "John Doe",
                     total = "$100.00",
                     status = "Processing"
                 ),
                 OrderItem(
-                    date = "2021-09-02",
-                    number = "124",
+                    date = "31 Dec",
+                    number = "#124",
                     customerName = "Jane Doe",
                     total = "$200.00",
                     status = "Completed"
                 ),
                 OrderItem(
-                    date = "2021-09-03",
-                    number = "125",
+                    date = "4 Oct",
+                    number = "#123",
                     customerName = "John Smith",
                     total = "$300.00",
                     status = "Pending"

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersListViewModel.kt
@@ -1,19 +1,56 @@
 package com.woocommerce.android.ui.orders
 
+import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
 import androidx.navigation.NavHostController
+import com.woocommerce.android.ui.login.LoginRepository
 import com.woocommerce.commons.viewmodel.ScopedViewModel
+import com.woocommerce.commons.viewmodel.getStateFlow
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.model.SiteModel
 
 @Suppress("UnusedPrivateProperty")
 @HiltViewModel(assistedFactory = OrdersListViewModel.Factory::class)
 class OrdersListViewModel @AssistedInject constructor(
     @Assisted private val navController: NavHostController,
+    loginRepository: LoginRepository,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState) {
+    private val _viewState = savedState.getStateFlow(
+        scope = this,
+        initialValue = ViewState()
+    )
+    val viewState = _viewState.asLiveData()
+
+    init {
+        loginRepository.selectedSiteFlow
+            .filterNotNull()
+            .onEach {
+                requestOrdersData(it)
+            }.launchIn(this)
+    }
+
+    private fun requestOrdersData(selectedSite: SiteModel) {
+        // TODO: Introduce actual request
+        _viewState.update {
+            it.copy(orders = listOf("Order 1", "Order 2", "Order 3"))
+        }
+    }
+
+    @Parcelize
+    data class ViewState(
+        val orders: List<String> = emptyList()
+    ) : Parcelable
+
     @AssistedFactory
     interface Factory {
         fun create(navController: NavHostController): OrdersListViewModel

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/StoreStatsScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/StoreStatsScreen.kt
@@ -95,7 +95,7 @@ fun StoreStatsScreen(
                 if (isLoading) {
                     LoadingScreen()
                 } else {
-                    MyStoreView(
+                    StatsContentScreen(
                         modifier,
                         totalRevenue,
                         visitorsCount,
@@ -110,7 +110,7 @@ fun StoreStatsScreen(
 }
 
 @Composable
-private fun MyStoreView(
+private fun StatsContentScreen(
     modifier: Modifier,
     totalRevenue: String,
     visitorsCount: String,
@@ -144,15 +144,15 @@ private fun MyStoreView(
                     .fillMaxWidth()
                     .padding(top = 4.dp)
             ) {
-                StoreDataItem(
+                IconStats(
                     icon = Icons.Filled.Description,
                     value = ordersCount,
                 )
-                StoreDataItem(
+                IconStats(
                     icon = Icons.Filled.Group,
                     value = visitorsCount,
                 )
-                StoreDataItem(
+                IconStats(
                     icon = Icons.Filled.Timeline,
                     value = conversionRate,
                 )
@@ -172,7 +172,7 @@ private fun MyStoreView(
 }
 
 @Composable
-fun StoreDataItem(
+private fun IconStats(
     modifier: Modifier = Modifier,
     icon: ImageVector,
     value: String

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/StoreStatsScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/StoreStatsScreen.kt
@@ -67,7 +67,7 @@ fun StoreStatsScreen(
         ) {
             val brush = Brush.verticalGradient(
                 listOf(
-                    WooColors.purple_surface,
+                    WooColors.woo_purple_surface,
                     Color.Black
                 )
             )

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/StoreStatsScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/StoreStatsScreen.kt
@@ -121,7 +121,7 @@ private fun StatsContentScreen(
     Box(modifier = modifier.fillMaxSize()) {
         Column {
             Text(
-                text = stringResource(id = R.string.my_store_screen_revenue_title),
+                text = stringResource(id = R.string.stats_screen_revenue_title),
                 textAlign = TextAlign.Center,
                 color = WooColors.woo_purple_5,
                 style = WooTypography.body2,
@@ -160,7 +160,7 @@ private fun StatsContentScreen(
         }
 
         Text(
-            text = stringResource(id = R.string.my_store_screen_time_description, timestamp),
+            text = stringResource(id = R.string.stats_screen_time_description, timestamp),
             style = WooTypography.caption2,
             textAlign = TextAlign.Center,
             modifier = modifier

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/StoreStatsViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/StoreStatsViewModel.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.stats
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
-import androidx.navigation.NavHostController
 import com.woocommerce.android.phone.PhoneConnectionRepository
 import com.woocommerce.android.system.NetworkStatus
 import com.woocommerce.android.ui.login.LoginRepository
@@ -12,9 +11,6 @@ import com.woocommerce.android.ui.stats.datasource.FetchStatsFromStore
 import com.woocommerce.android.ui.stats.datasource.MyStoreStatsRequest
 import com.woocommerce.commons.viewmodel.ScopedViewModel
 import com.woocommerce.commons.viewmodel.getStateFlow
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
@@ -26,11 +22,10 @@ import org.wordpress.android.fluxc.model.SiteModel
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import javax.inject.Inject
 
-@Suppress("UnusedPrivateProperty", "LongParameterList")
-@HiltViewModel(assistedFactory = StoreStatsViewModel.Factory::class)
-class StoreStatsViewModel @AssistedInject constructor(
-    @Assisted private val navController: NavHostController,
+@HiltViewModel
+class StoreStatsViewModel @Inject constructor(
     private val phoneRepository: PhoneConnectionRepository,
     private val fetchStatsFromStore: FetchStatsFromStore,
     private val fetchStatsFromPhone: FetchStatsFromPhone,
@@ -111,9 +106,4 @@ class StoreStatsViewModel @AssistedInject constructor(
         val title: String,
         val value: String,
     ) : Parcelable
-
-    @AssistedFactory
-    interface Factory {
-        fun create(navController: NavHostController): StoreStatsViewModel
-    }
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/StoreStatsViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/StoreStatsViewModel.kt
@@ -8,7 +8,7 @@ import com.woocommerce.android.system.NetworkStatus
 import com.woocommerce.android.ui.login.LoginRepository
 import com.woocommerce.android.ui.stats.datasource.FetchStatsFromPhone
 import com.woocommerce.android.ui.stats.datasource.FetchStatsFromStore
-import com.woocommerce.android.ui.stats.datasource.MyStoreStatsRequest
+import com.woocommerce.android.ui.stats.datasource.StoreStatsRequest
 import com.woocommerce.commons.viewmodel.ScopedViewModel
 import com.woocommerce.commons.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -67,9 +67,9 @@ class StoreStatsViewModel @Inject constructor(
         }
     }
 
-    private fun handleStatsDataChange(statsData: MyStoreStatsRequest?) {
+    private fun handleStatsDataChange(statsData: StoreStatsRequest?) {
         when (statsData) {
-            is MyStoreStatsRequest.Data -> {
+            is StoreStatsRequest.Data -> {
                 _viewState.update {
                     it.copy(
                         isLoading = false,

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/datasource/FetchStatsFromPhone.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/datasource/FetchStatsFromPhone.kt
@@ -14,12 +14,12 @@ class FetchStatsFromPhone @Inject constructor(
     private val phoneRepository: PhoneConnectionRepository,
     private val statsRepository: StatsRepository
 ) {
-    suspend operator fun invoke(): Flow<MyStoreStatsRequest?> {
+    suspend operator fun invoke(): Flow<StoreStatsRequest?> {
         phoneRepository.sendMessage(REQUEST_STATS)
         return combine(statsRepository.observeStatsDataChanges(), timeoutFlow) { statsData, isTimeout ->
             when {
                 statsData?.isFinished == true -> statsData
-                isTimeout -> MyStoreStatsRequest.Error
+                isTimeout -> StoreStatsRequest.Error
                 else -> null
             }
         }.filterNotNull()

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/datasource/FetchStatsFromStore.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/datasource/FetchStatsFromStore.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.stats.datasource
 
-import com.woocommerce.android.ui.stats.datasource.MyStoreStatsRequest.Data.RevenueData
+import com.woocommerce.android.ui.stats.datasource.StoreStatsRequest.Data.RevenueData
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
@@ -18,7 +18,7 @@ class FetchStatsFromStore @Inject constructor(
 
     suspend operator fun invoke(
         selectedSite: SiteModel
-    ): Flow<MyStoreStatsRequest> {
+    ): Flow<StoreStatsRequest> {
         fetchRevenueStats(selectedSite)
         fetchVisitorsStats(selectedSite)
 
@@ -26,7 +26,7 @@ class FetchStatsFromStore @Inject constructor(
             revenueStats,
             visitorStats
         ) { revenueStats, visitorStats ->
-            MyStoreStatsRequest.Data(
+            StoreStatsRequest.Data(
                 revenueData = revenueStats,
                 visitorData = visitorStats,
             )

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/datasource/StatsRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/datasource/StatsRepository.kt
@@ -9,7 +9,7 @@ import com.google.gson.Gson
 import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType
 import com.woocommerce.android.ui.login.LoginRepository
-import com.woocommerce.android.ui.stats.datasource.MyStoreStatsRequest.Data.RevenueData
+import com.woocommerce.android.ui.stats.datasource.StoreStatsRequest.Data.RevenueData
 import com.woocommerce.android.ui.stats.range.TodayRangeData
 import com.woocommerce.commons.extensions.formatToYYYYmmDDhhmmss
 import com.woocommerce.commons.wear.DataParameters.ORDERS_COUNT
@@ -94,7 +94,7 @@ class StatsRepository @Inject constructor(
     }
 
     suspend fun receiveStatsDataFromPhone(data: DataMap) {
-        val statsJson = MyStoreStatsRequest.Data(
+        val statsJson = StoreStatsRequest.Data(
             revenueData = RevenueData(
                 totalRevenue = data.getString(TOTAL_REVENUE.value, ""),
                 orderCount = data.getInt(ORDERS_COUNT.value, 0)
@@ -109,7 +109,7 @@ class StatsRepository @Inject constructor(
 
     fun observeStatsDataChanges() = statsDataStore.data
         .map { it[stringPreferencesKey(generateStatsKey())] }
-        .map { it?.let { gson.fromJson(it, MyStoreStatsRequest.Data::class.java) } }
+        .map { it?.let { gson.fromJson(it, StoreStatsRequest.Data::class.java) } }
 
     private fun generateStatsKey(): String {
         val siteId = loginRepository.selectedSite?.siteId ?: 0

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/datasource/StoreStatsRequest.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/stats/datasource/StoreStatsRequest.kt
@@ -2,23 +2,14 @@ package com.woocommerce.android.ui.stats.datasource
 
 import com.woocommerce.commons.extensions.convertedFrom
 
-sealed class MyStoreStatsRequest {
+sealed class StoreStatsRequest {
     data class Data(
         private val revenueData: RevenueData?,
         private val visitorData: Int?
-    ) : MyStoreStatsRequest() {
-        val isFinished
-            get() = revenueData != null &&
-                visitorData != null
-        val revenue
-            get() = revenueData?.totalRevenue.orEmpty()
-
-        val ordersCount
-            get() = revenueData?.orderCount ?: 0
-
-        val visitorsCount
-            get() = visitorData ?: 0
-
+    ) : StoreStatsRequest() {
+        val revenue get() = revenueData?.totalRevenue.orEmpty()
+        val ordersCount get() = revenueData?.orderCount ?: 0
+        val visitorsCount get() = visitorData ?: 0
         val conversionRate: String
             get() {
                 val ordersCount = revenueData?.orderCount ?: 0
@@ -26,11 +17,15 @@ sealed class MyStoreStatsRequest {
                 return ordersCount convertedFrom visitorsCount
             }
 
+        val isFinished
+            get() = revenueData != null &&
+                visitorData != null
+
         data class RevenueData(
             val totalRevenue: String,
             val orderCount: Int
         )
     }
 
-    data object Error : MyStoreStatsRequest()
+    data object Error : StoreStatsRequest()
 }

--- a/WooCommerce-Wear/src/main/res/values/strings.xml
+++ b/WooCommerce-Wear/src/main/res/values/strings.xml
@@ -7,9 +7,12 @@
     <string name="login_screen_error_caption">Open the Woo app on your phone and hold your watch nearby</string>
     <string name="login_screen_error_action_button">Try Again</string>
 
-    <!-- My Store Screen -->
-    <string name="my_store_screen_revenue_title">Revenue</string>
-    <string name="my_store_screen_time_description">Today • As of %1$s</string>
+    <!-- Stats Screen -->
+    <string name="stats_screen_revenue_title">Revenue</string>
+    <string name="stats_screen_time_description">Today • As of %1$s</string>
+
+    <!-- Orders List Screen -->
+    <string name="orders_list_screen_title">Orders</string>
 
     <!-- Tile and Complication -->
     <string name="tile_label">Example tile</string>


### PR DESCRIPTION
Summary
==========
Fix issue #11340 by introducing the `OrdersListScreen` compose file with the expected designs from Figma.

Screen Capture
==========
https://github.com/woocommerce/woocommerce-android/assets/5920403/4b032919-1476-4e1e-9b9d-4070d5bf3de4

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.