### PR TITLE
[Dynamic dashboard] Improve "has orders" logic

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/SiteObserver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/SiteObserver.kt
@@ -3,8 +3,18 @@ package com.woocommerce.android
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.common.environment.EnvironmentRepository
 import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T.UTILS
+import com.woocommerce.android.util.dispatchAndAwait
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderStatusOptionsChanged
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
@@ -18,22 +28,44 @@ import javax.inject.Inject
 class SiteObserver @Inject constructor(
     private val selectedSite: SelectedSite,
     private val wooCommerceStore: WooCommerceStore,
-    private val environmentRepository: EnvironmentRepository
+    private val environmentRepository: EnvironmentRepository,
+    private val dispatcher: Dispatcher
 ) {
     suspend fun observeAndUpdateSelectedSiteData() {
         selectedSite.observe()
             .filterNotNull()
             .distinctUntilChanged { old, new -> new.id == old.id }
-            .collect { site ->
-                WooLog.d(WooLog.T.UTILS, "Fetch plugins for site ${site.name}")
-                wooCommerceStore.fetchSitePlugins(site)
+            .collectLatest { site ->
+                coroutineScope {
+                    launch { fetchPlugins(site) }
 
-                // Makes sure the store ID is fetched for the site.
-                environmentRepository.fetchOrGetStoreID(site)
-                    .takeIf { result -> result.isError.not() }
-                    ?.model?.let { storeID ->
-                        WooLog.d(WooLog.T.UTILS, "Fetched StoreID $storeID for site ${site.name}")
-                    }
+                    launch { fetchStoreId(site) }
+
+                    launch { fetchOrderStatusOptions(site) }
+                }
             }
+    }
+
+    private suspend fun fetchPlugins(site: SiteModel) {
+        WooLog.d(WooLog.T.UTILS, "Fetch plugins for site ${site.name}")
+        wooCommerceStore.fetchSitePlugins(site)
+    }
+
+    private suspend fun fetchStoreId(site: SiteModel) {
+        // Makes sure the store ID is fetched for the site.
+        environmentRepository.fetchOrGetStoreID(site)
+            .takeIf { result -> result.isError.not() }
+            ?.model?.let { storeID ->
+                WooLog.d(UTILS, "Fetched StoreID $storeID for site ${site.name}")
+            }
+    }
+
+    private suspend fun fetchOrderStatusOptions(site: SiteModel) {
+        WooLog.d(WooLog.T.UTILS, "Fetch status options for site ${site.name}")
+        dispatcher.dispatchAndAwait<FetchOrderStatusOptionsPayload, OnOrderStatusOptionsChanged>(
+            WCOrderActionBuilder.newFetchOrderStatusOptionsAction(
+                FetchOrderStatusOptionsPayload(site)
+            )
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveStatsWidgetsStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveStatsWidgetsStatus.kt
@@ -3,12 +3,14 @@ package com.woocommerce.android.ui.dashboard.data
 import com.woocommerce.android.R
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.flow.transformLatest
+import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.HasOrdersResult
 import javax.inject.Inject
@@ -16,23 +18,19 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 class ObserveStatsWidgetsStatus @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val orderStore: WCOrderStore
+    private val orderStore: WCOrderStore,
+    private val coroutineDispatchers: CoroutineDispatchers
 ) {
     operator fun invoke() = selectedSite.observe()
         .filterNotNull()
         .flatMapLatest { orderStore.observeOrderCountForSite(it) }
         .map { count -> count != 0 }
         .distinctUntilChanged()
-        .transform { hasOrders ->
+        .transformLatest { hasOrders ->
             if (!hasOrders) {
-                val fetchResult = orderStore.fetchHasOrders(selectedSite.get(), null).let {
-                    when (it) {
-                        is HasOrdersResult.Success -> it.hasOrders
-                        // Default to true if we can't determine if there are orders
-                        is HasOrdersResult.Failure -> true
-                    }
-                }
-                emit(fetchResult)
+                // This means either the store doesn't have orders, or no orders are cached yet
+                // Use other approaches to determine if the store has orders
+                emit(getHasOrdersFromOrderStatusOptions() ?: fetchHasOrdersFromApi())
             } else {
                 emit(true)
             }
@@ -45,4 +43,22 @@ class ObserveStatsWidgetsStatus @Inject constructor(
                 )
             }
         }
+
+    private suspend fun getHasOrdersFromOrderStatusOptions() = withContext(coroutineDispatchers.io) {
+        orderStore.getOrderStatusOptionsForSite(selectedSite.get())
+            .filter { it.statusKey != "checkout-draft" }
+            .takeIf { it.isNotEmpty() }
+            ?.sumOf { it.statusCount }
+            ?.let { it != 0 }
+    }
+
+    private suspend fun fetchHasOrdersFromApi(): Boolean {
+        return orderStore.fetchHasOrders(selectedSite.get(), null).let {
+            when (it) {
+                is HasOrdersResult.Success -> it.hasOrders
+                // Default to true if we can't determine if there are orders
+                is HasOrdersResult.Failure -> true
+            }
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainPresenter.kt
@@ -21,13 +21,11 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
-import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged
 import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload
-import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderStatusOptionsPayload
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
@@ -82,11 +80,6 @@ class MainPresenter @Inject constructor(
     override fun selectedSiteChanged(site: SiteModel) {
         productImageMap.reset()
 
-        // Fetch a fresh list of order status options
-        dispatcher.dispatch(
-            WCOrderActionBuilder
-                .newFetchOrderStatusOptionsAction(FetchOrderStatusOptionsPayload(site))
-        )
         coroutineScope.launch { clearCardReaderDataAction() }
 
         updateStatsWidgets()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboarding.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboarding.kt
@@ -38,13 +38,8 @@ class ShouldShowOnboarding @Inject constructor(
             if (appPrefsWrapper.getStoreOnboardingShown(siteId) && !appPrefsWrapper.isOnboardingCompleted(siteId)) {
                 analyticsTrackerWrapper.track(stat = STORE_ONBOARDING_COMPLETED)
             }
-            appPrefsWrapper.updateOnboardingCompletedStatus(siteId, true)
             true
         } else {
-            if (appPrefsWrapper.isOnboardingCompleted(siteId)) {
-                // Reset the onboarding completed status if there are still pending tasks
-                appPrefsWrapper.updateOnboardingCompletedStatus(siteId, false)
-            }
             false
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingRepository.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.onboarding
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.WooException
 import com.woocommerce.android.extensions.isFreeTrial
 import com.woocommerce.android.tools.SelectedSite
@@ -25,7 +26,8 @@ import javax.inject.Singleton
 class StoreOnboardingRepository @Inject constructor(
     private val onboardingStore: OnboardingStore,
     private val selectedSite: SelectedSite,
-    private val siteStore: SiteStore
+    private val siteStore: SiteStore,
+    private val appPrefs: AppPrefsWrapper
 ) {
     private val onboardingTasksCacheFlow: MutableSharedFlow<OnboardingTasksEvent> = MutableSharedFlow(replay = 1)
     val hasCachedTasks
@@ -59,6 +61,13 @@ class StoreOnboardingRepository @Inject constructor(
                     ?.sortedBy { it.type.order }
                     ?.sortedBy { it.isComplete }
                     ?: emptyList()
+
+                // Update onboarding completed status based on the tasks completion status
+                if (mobileSupportedTasks.all { it.isComplete }) {
+                    appPrefs.updateOnboardingCompletedStatus(selectedSite.getSelectedSiteId(), true)
+                } else if (appPrefs.isOnboardingCompleted(selectedSite.getSelectedSiteId())) {
+                    appPrefs.updateOnboardingCompletedStatus(selectedSite.getSelectedSiteId(), false)
+                }
 
                 onboardingTasksCacheFlow.emit(OnboardingTasksEvent(selectedSite.get().id, mobileSupportedTasks))
                 Result.success(Unit)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboardingTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/onboarding/ShouldShowOnboardingTest.kt
@@ -95,15 +95,6 @@ internal class ShouldShowOnboardingTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when all tasks are completed and onboarding, then mark onboarding completed locally`() {
-        givenStoreOnboardingHasBeenShownAtLeastOnce(shown = true)
-
-        sut.showForTasks(ONBOARDING_TASK_COMPLETED_LIST)
-
-        verify(appPrefsWrapper).updateOnboardingCompletedStatus(CURRENT_SITE_ID, true)
-    }
-
-    @Test
     fun `given onboarding is enabled from settings, when at least one task is incomplete, then return true`() {
         val show = sut.showForTasks(ONBOARDING_TASK_INCOMPLETED_LIST)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
This PR updates the logic of deciding on the availability of the stats cards, for more information check p1715164179010139-slack-C03L1NF1EA3 

### Testing instructions
1. Using a store that has orders.
2. Clear the app's data (the important tables to clear are `OrderEntity` and `WCOrderStatusOption` if you want to do it manually)
3. Login.
4. Confirm the stats card are shown
5. Close and reopen the app
6. Confirm the stats cards are shown directly without any flicker.

### Images/gif
| Before | After |
| --- | --- |
| <video src="https://github.com/woocommerce/woocommerce-android/assets/1657201/bd74b415-b0c2-4670-b129-9dc41391a2d7" /> | <video src="https://github.com/woocommerce/woocommerce-android/assets/1657201/b3839202-3cfe-42df-8ae4-0b1965d31c17" /> |

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->