### PR TITLE
New shipping UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -69,6 +69,9 @@ import com.woocommerce.android.ui.orders.creation.giftcards.OrderCreateEditGiftC
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigator
 import com.woocommerce.android.ui.orders.creation.product.discount.OrderCreateEditProductDiscountFragment.Companion.KEY_PRODUCT_DISCOUNT_RESULT
+import com.woocommerce.android.ui.orders.creation.shipping.OrderShippingFragment.Companion.REMOVE_SHIPPING_RESULT
+import com.woocommerce.android.ui.orders.creation.shipping.OrderShippingFragment.Companion.UPDATE_SHIPPING_RESULT
+import com.woocommerce.android.ui.orders.creation.shipping.ShippingUpdateResult
 import com.woocommerce.android.ui.orders.creation.simplepaymentsmigration.OrderCreateEditSimplePaymentsMigrationBottomSheetFragment
 import com.woocommerce.android.ui.orders.creation.taxes.rates.TaxRate
 import com.woocommerce.android.ui.orders.creation.taxes.rates.TaxRateSelectorFragment.Companion.KEY_SELECTED_TAX_RATE
@@ -1078,6 +1081,12 @@ class OrderCreateEditFormFragment :
         }
         handleResult<Order.Customer>(CustomerListFragment.KEY_CUSTOMER_RESULT) {
             viewModel.onCustomerEdited(it)
+        }
+        handleResult<ShippingUpdateResult>(UPDATE_SHIPPING_RESULT) { result ->
+            viewModel.onUpdatedShipping(result)
+        }
+        handleResult<Long>(REMOVE_SHIPPING_RESULT) { result ->
+            viewModel.onRemoveShipping(result)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -107,6 +107,7 @@ import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavi
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.ShowCreatedOrder
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.TaxRateSelector
 import com.woocommerce.android.ui.orders.creation.product.discount.CurrencySymbolFinder
+import com.woocommerce.android.ui.orders.creation.shipping.ShippingUpdateResult
 import com.woocommerce.android.ui.orders.creation.taxes.GetAddressFromTaxRate
 import com.woocommerce.android.ui.orders.creation.taxes.GetTaxRatesInfoDialogViewState
 import com.woocommerce.android.ui.orders.creation.taxes.TaxBasedOnSetting
@@ -1498,6 +1499,36 @@ class OrderCreateEditViewModel @Inject constructor(
         )
     }
 
+    fun onUpdatedShipping(shippingUpdateResult: ShippingUpdateResult) {
+        tracker.track(
+            ORDER_SHIPPING_METHOD_ADD,
+            mapOf(KEY_FLOW to flow)
+        )
+        _orderDraft.update { draft ->
+            val shipping: List<ShippingLine> = draft.shippingLines.map { shippingLine ->
+                if (shippingLine.itemId == shippingUpdateResult.id) {
+                    shippingLine.copy(
+                        methodId = shippingUpdateResult.methodId ?: "other",
+                        total = shippingUpdateResult.amount,
+                        methodTitle = shippingUpdateResult.name
+                    )
+                } else {
+                    shippingLine
+                }
+            }.ifEmpty {
+                listOf(
+                    ShippingLine(
+                        methodId = shippingUpdateResult.methodId ?: "other",
+                        total = shippingUpdateResult.amount,
+                        methodTitle = shippingUpdateResult.name
+                    )
+                )
+            }
+
+            draft.copy(shippingLines = shipping)
+        }
+    }
+
     fun onShippingEdited(amount: BigDecimal, name: String) {
         tracker.track(
             ORDER_SHIPPING_METHOD_ADD,
@@ -1516,6 +1547,28 @@ class OrderCreateEditViewModel @Inject constructor(
             }
 
             draft.copy(shippingLines = shipping)
+        }
+    }
+
+    fun onRemoveShipping(itemId: Long) {
+        tracker.track(
+            ORDER_SHIPPING_METHOD_REMOVE,
+            mapOf(
+                KEY_FLOW to flow,
+                KEY_HORIZONTAL_SIZE_CLASS to getScreenSizeClassNameForAnalytics(viewState.windowSizeClass)
+            )
+        )
+        _orderDraft.update { draft ->
+            draft.copy(
+                shippingLines = draft.shippingLines.map { shippingLine ->
+                    if (itemId == shippingLine.itemId) {
+                        // Setting methodId to null will remove the shipping line in core
+                        shippingLine.copy(methodId = null)
+                    } else {
+                        shippingLine
+                    }
+                }
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/navigation/OrderCreateEditNavigator.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavi
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.SelectItems
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.ShowCreatedOrder
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
+import com.woocommerce.android.util.FeatureFlag
 
 object OrderCreateEditNavigator {
     @Suppress("LongMethod", "ComplexMethod")
@@ -57,9 +58,17 @@ object OrderCreateEditNavigator {
                     .actionOrderCreationFragmentToOrderDetailFragment(target.orderId, target.startPaymentFlow)
             }
 
-            is EditShipping ->
-                OrderCreateEditFormFragmentDirections
-                    .actionOrderCreationFragmentToOrderCreationShippingFragment(target.currentShippingLine)
+            is EditShipping -> {
+                if (FeatureFlag.EOSL_M1.isEnabled()) {
+                    OrderCreateEditFormFragmentDirections
+                        .actionOrderCreationFragmentToOrderCreateEditUpdateShippingFragment(
+                            target.currentShippingLine
+                        )
+                } else {
+                    OrderCreateEditFormFragmentDirections
+                        .actionOrderCreationFragmentToOrderCreationShippingFragment(target.currentShippingLine)
+                }
+            }
 
             is EditCoupon ->
                 OrderCreateEditFormFragmentDirections.actionOrderCreationFragmentToOrderCreationCouponEditFragment(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/AmountBigDecimalTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/AmountBigDecimalTextField.kt
@@ -1,0 +1,52 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+import android.util.TypedValue
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.viewinterop.AndroidView
+import com.google.android.material.textfield.TextInputLayout
+import com.woocommerce.android.extensions.filterNotNull
+import com.woocommerce.android.widgets.WCMaterialOutlinedCurrencyEditTextView
+import java.math.BigDecimal
+
+@Composable
+fun AmountBigDecimalTextField(
+    value: BigDecimal,
+    onValueChange: (BigDecimal) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val owner = LocalLifecycleOwner.current
+    AndroidView(
+        modifier = modifier,
+        factory = { context ->
+            // Creates view
+            WCMaterialOutlinedCurrencyEditTextView(context).apply {
+                // Sets up listeners for View -> Compose communication
+                supportsEmptyState = false
+                supportsNegativeValues = false
+                this.value.filterNotNull().observe(owner) {
+                    onValueChange(it)
+                }
+                boxBackgroundMode = TextInputLayout.BOX_BACKGROUND_NONE
+                val textSize = 24f
+                editText.apply {
+                    background = null
+                    setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize)
+                }
+                prefixTextView.apply {
+                    setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize)
+                }
+                suffixTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize)
+            }
+        },
+        update = { view ->
+            // View's been inflated or state read in this block has been updated
+            // Add logic here if necessary
+
+            // As selectedItem is read here, AndroidView will recompose
+            // whenever the state changes
+            // Example of Compose -> View communication
+            view.setValueIfDifferent(value)
+        }
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingFragment.kt
@@ -1,0 +1,53 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Surface
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class OrderShippingFragment : BaseFragment() {
+    val viewModel: OrderShippingViewModel by viewModels()
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                WooThemeWithBackground {
+                    Surface {
+                        UpdateShippingScreen(viewModel = viewModel, modifier = Modifier.fillMaxSize())
+                    }
+                }
+            }
+        }
+    }
+
+    override fun getFragmentTitle() = getString(R.string.order_creation_shipping_title_add)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
+                is UpdateShipping -> navigateBackWithResult(UPDATE_SHIPPING_RESULT, event.shippingUpdate)
+                is RemoveShipping -> navigateBackWithResult(REMOVE_SHIPPING_RESULT, event.id)
+            }
+        }
+    }
+
+    companion object {
+        const val UPDATE_SHIPPING_RESULT = "update_shipping-result"
+        const val REMOVE_SHIPPING_RESULT = "remove_shipping-result"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
@@ -1,0 +1,255 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldColors
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import java.math.BigDecimal
+
+@Composable
+fun UpdateShippingScreen(
+    viewModel: OrderShippingViewModel,
+    modifier: Modifier = Modifier
+) {
+    val viewState by viewModel.viewState.collectAsState()
+    when (val currentState = viewState) {
+        is OrderShippingViewModel.ViewState.ShippingState -> {
+            UpdateShippingScreen(
+                name = currentState.name,
+                amount = currentState.amount,
+                method = currentState.method?.title,
+                isEditFlow = currentState.isEditFlow,
+                isSaveChangesEnabled = currentState.isSaveChangesEnabled,
+                onNameChanged = { name -> viewModel.onNameChanged(name) },
+                onAmountChanged = { amount -> viewModel.onAmountChanged(amount) },
+                onMethodSelected = { viewModel.onMethodSelected() },
+                onRemove = { viewModel.onRemove() },
+                onSaveChanges = { viewModel.onSaveChanges() },
+                modifier = modifier
+            )
+        }
+
+        is OrderShippingViewModel.ViewState.Loading -> {
+            Box(modifier = Modifier.fillMaxSize()) {
+                Text(text = "loading", modifier = Modifier.align(Alignment.Center))
+            }
+        }
+    }
+}
+
+@Composable
+fun UpdateShippingScreen(
+    name: String?,
+    onNameChanged: (String) -> Unit,
+    amount: BigDecimal,
+    onAmountChanged: (BigDecimal) -> Unit,
+    method: String?,
+    onMethodSelected: () -> Unit,
+    isSaveChangesEnabled: Boolean,
+    onSaveChanges: () -> Unit,
+    isEditFlow: Boolean,
+    onRemove: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .verticalScroll(state = rememberScrollState())
+                .padding(bottom = 200.dp)
+        ) {
+            FieldCaption(
+                text = stringResource(id = R.string.order_creation_add_shipping_method),
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+            FieldSelectValue(
+                text = method,
+                hint = stringResource(id = R.string.order_creation_add_shipping_method_select_hint),
+                onSelect = onMethodSelected,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            Box {
+                FieldCaption(
+                    text = stringResource(id = R.string.order_creation_add_shipping_amount),
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+                AmountBigDecimalTextField(
+                    value = amount,
+                    onValueChange = { amount -> onAmountChanged(amount) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 32.dp)
+                )
+            }
+            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            FieldCaption(
+                text = stringResource(id = R.string.order_creation_add_shipping_name),
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+            FieldEditValue(
+                name.orEmpty(),
+                { name -> onNameChanged(name) },
+                Modifier.fillMaxWidth()
+            )
+        }
+        Column(
+            modifier = Modifier
+                .background(color = MaterialTheme.colors.surface)
+                .fillMaxWidth()
+                .padding(16.dp)
+                .align(Alignment.BottomCenter)
+        ) {
+            WCColoredButton(
+                enabled = isSaveChangesEnabled,
+                onClick = { onSaveChanges() },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(stringResource(id = R.string.order_creation_shipping_add))
+            }
+            if (isEditFlow) {
+                WCOutlinedButton(
+                    onClick = { onRemove() },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(id = R.string.order_creation_remove_shipping))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun FieldCaption(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(text = text, fontSize = 16.sp, modifier = modifier.padding(top = 16.dp))
+}
+
+@Composable
+fun FieldSelectValue(
+    text: String?,
+    hint: String?,
+    onSelect: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val display = text ?: hint.orEmpty()
+    val alpha = if (text == null) 0.6f else 1f
+    Box(
+        modifier = modifier
+            .padding(8.dp)
+            .clickable { onSelect() }
+            .padding(8.dp)
+            .fillMaxWidth()
+    ) {
+        Text(
+            text = display,
+            fontSize = 24.sp,
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .alpha(alpha)
+        )
+        Icon(
+            painter = painterResource(id = R.drawable.ic_arrow_right),
+            contentDescription = null,
+            modifier = Modifier
+                .size(dimensionResource(id = R.dimen.major_250))
+                .align(Alignment.CenterEnd)
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun FieldEditValue(
+    text: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    colors: TextFieldColors = TextFieldDefaults.textFieldColors(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    BasicTextField(
+        value = text,
+        onValueChange = onValueChange,
+        textStyle = TextStyle(
+            fontSize = 24.sp,
+            color = MaterialTheme.colors.onSurface
+        ),
+        cursorBrush = SolidColor(colors.cursorColor(false).value),
+        modifier = modifier,
+        decorationBox = @Composable { innerTextField ->
+            // places leading icon, text field with label and placeholder, trailing icon
+            TextFieldDefaults.TextFieldDecorationBox(
+                value = text,
+                innerTextField = innerTextField,
+                interactionSource = interactionSource,
+                placeholder = @Composable {
+                    Text(
+                        text = stringResource(id = R.string.order_creation_add_shipping_name_hint),
+                        fontSize = 24.sp,
+                    )
+                },
+                enabled = true,
+                singleLine = true,
+                visualTransformation = VisualTransformation.None
+            )
+        }
+    )
+}
+
+@Composable
+@Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO, device = Devices.PIXEL_4)
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES, device = Devices.PIXEL_4)
+fun UpdateShippingScreenPreview() {
+    WooThemeWithBackground {
+        UpdateShippingScreen(
+            name = "Flat Rate",
+            method = "Flat Rate",
+            amount = "10.00".toBigDecimal(),
+            isSaveChangesEnabled = true,
+            isEditFlow = false,
+            onAmountChanged = {},
+            onNameChanged = {},
+            onMethodSelected = {},
+            onSaveChanges = {},
+            onRemove = {}
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
@@ -103,7 +103,7 @@ class OrderShippingViewModel @Inject constructor(
     }
 
     fun onMethodSelected() {
-        triggerEvent(MultiLiveEvent.Event.Exit)
+        /*TODO*/
     }
 
     fun onSaveChanges() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
@@ -24,7 +24,7 @@ class OrderShippingViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
 
     private val navArgs: OrderShippingFragmentArgs by savedState.navArgs()
-    var viewState: MutableStateFlow<ViewState>
+    val viewState: MutableStateFlow<ViewState>
 
     init {
         val state = if (navArgs.currentShippingLine == null) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
@@ -1,0 +1,155 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+import android.os.Parcelable
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.capitalize
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+import javax.inject.Inject
+
+@HiltViewModel
+class OrderShippingViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val resourceProvider: ResourceProvider
+) : ScopedViewModel(savedStateHandle) {
+
+    private val navArgs: OrderShippingFragmentArgs by savedState.navArgs()
+    var viewState: MutableStateFlow<ViewState>
+
+    init {
+        val state = if (navArgs.currentShippingLine == null) {
+            ViewState.ShippingState(
+                method = null,
+                name = null,
+                amount = BigDecimal.ZERO,
+                isEditFlow = false,
+                isSaveChangesEnabled = false
+            )
+        } else {
+            ViewState.Loading
+        }
+        viewState = MutableStateFlow(state)
+        navArgs.currentShippingLine?.let { shippingLine: Order.ShippingLine ->
+            launch {
+                viewState.value = ViewState.ShippingState(
+                    method = getShippingMethod(shippingLine),
+                    name = shippingLine.methodTitle,
+                    amount = shippingLine.total,
+                    isEditFlow = true,
+                    isSaveChangesEnabled = false
+                )
+            }
+        }
+    }
+
+    @Suppress("MagicNumber")
+    private suspend fun getShippingMethod(shippingLine: Order.ShippingLine): Order.ShippingMethod? {
+        return if (shippingLine.methodId == null) {
+            null
+        } else {
+            delay(1000)
+            Order.ShippingMethod(
+                id = shippingLine.methodId,
+                title = shippingLine.methodId.capitalize(),
+                total = BigDecimal.ZERO,
+                tax = BigDecimal.ZERO
+            )
+        }
+    }
+
+    fun onNameChanged(name: String) {
+        (viewState.value as? ViewState.ShippingState)?.let {
+            viewState.value = it.copy(
+                name = name,
+                isSaveChangesEnabled = isSaveChangesEnabled(newName = name)
+            )
+        }
+    }
+
+    fun onAmountChanged(amount: BigDecimal) {
+        (viewState.value as? ViewState.ShippingState)?.let {
+            viewState.value = it.copy(
+                amount = amount,
+                isSaveChangesEnabled = isSaveChangesEnabled(newAmount = amount)
+            )
+        }
+    }
+
+    private fun isSaveChangesEnabled(
+        newName: String? = null,
+        newAmount: BigDecimal? = null,
+        newMethodId: String? = null
+    ): Boolean {
+        val state = viewState.value as? ViewState.ShippingState ?: return false
+        val name = newName ?: state.name
+        val amount = newAmount ?: state.amount
+        val methodId = newMethodId ?: state.method?.id
+        val canEditValues = navArgs.currentShippingLine?.let { shippingLine: Order.ShippingLine ->
+            shippingLine.methodId != methodId ||
+                shippingLine.methodTitle != name ||
+                shippingLine.total != amount
+        } ?: true
+        return canEditValues
+    }
+
+    fun onMethodSelected() {
+        triggerEvent(MultiLiveEvent.Event.Exit)
+    }
+
+    fun onSaveChanges() {
+        val state = viewState.value as? ViewState.ShippingState ?: return
+        val id = navArgs.currentShippingLine?.itemId
+        val name = if (state.name.isNullOrEmpty()) {
+            resourceProvider.getString(R.string.order_creation_add_shipping_name_hint)
+        } else {
+            state.name
+        }
+        val event = UpdateShipping(
+            ShippingUpdateResult(
+                id = id,
+                amount = state.amount,
+                name = name,
+                methodId = state.method?.id
+            )
+        )
+        triggerEvent(event)
+    }
+
+    fun onRemove() {
+        navArgs.currentShippingLine?.let { shippingLine: Order.ShippingLine ->
+            triggerEvent(RemoveShipping(shippingLine.itemId))
+        }
+    }
+
+    sealed class ViewState {
+        data object Loading : ViewState()
+        data class ShippingState(
+            val method: Order.ShippingMethod?,
+            val name: String?,
+            val amount: BigDecimal,
+            val isEditFlow: Boolean,
+            val isSaveChangesEnabled: Boolean
+        ) : ViewState()
+    }
+}
+
+@Parcelize
+data class ShippingUpdateResult(
+    val id: Long?,
+    val amount: BigDecimal,
+    val name: String,
+    val methodId: String?
+) : Parcelable
+
+data class UpdateShipping(val shippingUpdate: ShippingUpdateResult) : MultiLiveEvent.Event()
+data class RemoveShipping(val id: Long) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -179,6 +179,13 @@
         <action
             android:id="@+id/action_orderCreationFragment_to_giftCardFragment"
             app:destination="@id/giftCardFragment" />
+        <action
+            android:id="@+id/action_orderCreationFragment_to_orderCreateEditUpdateShippingFragment"
+            app:destination="@id/orderShippingFragment"
+            app:enterAnim="@anim/default_enter_anim"
+            app:exitAnim="@anim/default_exit_anim"
+            app:popEnterAnim="@anim/default_pop_enter_anim"
+            app:popExitAnim="@anim/default_pop_exit_anim" />
     </fragment>
     <fragment
         android:id="@+id/barcodeScanningFragment"
@@ -424,6 +431,15 @@
             android:name="giftCard"
             android:defaultValue="@null"
             app:argType="string"
+            app:nullable="true" />
+    </fragment>
+    <fragment
+        android:id="@+id/orderShippingFragment"
+        android:name="com.woocommerce.android.ui.orders.creation.shipping.OrderShippingFragment"
+        android:label="OrderCreateEditUpdateShippingFragment" >
+        <argument
+            android:name="currentShippingLine"
+            app:argType="com.woocommerce.android.model.Order$ShippingLine"
             app:nullable="true" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -668,7 +668,13 @@
     <string name="order_creation_payment_tax_label">Taxes</string>
     <string name="order_creation_shipping_name">Name</string>
     <string name="order_creation_shipping_title_add">Add Shipping</string>
+    <string name="order_creation_shipping_add">Add Shipping</string>
     <string name="order_creation_add_shipping">Add shipping</string>
+    <string name="order_creation_add_shipping_method">Method</string>
+    <string name="order_creation_add_shipping_amount">Amount</string>
+    <string name="order_creation_add_shipping_name">Name</string>
+    <string name="order_creation_add_shipping_name_hint">Shipping</string>
+    <string name="order_creation_add_shipping_method_select_hint">Select a shipping method</string>
     <string name="order_creation_edit_shipping">Shipping</string>
     <string name="order_creation_remove_shipping">Remove shipping from order</string>
     <string name="order_creation_add_fee_removal_hint">Remove fee from order</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModelTest.kt
@@ -1,0 +1,114 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceTimeBy
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import java.math.BigDecimal
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OrderShippingViewModelTest : BaseUnitTest() {
+    lateinit var viewModel: OrderShippingViewModel
+
+    private val creationArgs
+        get() = OrderShippingFragmentArgs(null)
+
+    private val editArgs
+        get() = OrderShippingFragmentArgs(
+            Order.ShippingLine(
+                methodId = "other",
+                total = BigDecimal.TEN,
+                methodTitle = "Shipping"
+            )
+        )
+
+    fun setup(args: OrderShippingFragmentArgs) {
+        viewModel = OrderShippingViewModel(
+            savedStateHandle = args.toSavedStateHandle(),
+            resourceProvider = mock()
+        )
+    }
+
+    @Test
+    fun `given this is creation flow, when the screen loads, make sure data is empty`() = testBlocking {
+        setup(creationArgs)
+        val viewState = viewModel.viewState.first()
+        assertThat(viewState).isNotNull
+        assertThat(viewState).isInstanceOf(OrderShippingViewModel.ViewState.ShippingState::class.java)
+        assertThat((viewState as OrderShippingViewModel.ViewState.ShippingState).name).isNull()
+        assertThat(viewState.method).isNull()
+        assertThat(viewState.amount).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(viewState.isEditFlow).isFalse
+    }
+
+    @Test
+    fun `given this is edit flow, when the screen loads, make sure data matches the current shipping line`() = testBlocking {
+        setup(editArgs)
+
+        advanceTimeBy(1001)
+        // When the screen load and
+        val viewState = viewModel.viewState.value
+
+        assertThat(viewState).isNotNull
+        assertThat(viewState).isInstanceOf(OrderShippingViewModel.ViewState.ShippingState::class.java)
+        assertThat((viewState as OrderShippingViewModel.ViewState.ShippingState).name)
+            .isEqualTo(editArgs.currentShippingLine?.methodTitle)
+        assertThat(viewState.amount).isEqualByComparingTo(editArgs.currentShippingLine?.total)
+        assertThat(viewState.isEditFlow).isTrue
+    }
+
+    @Test
+    fun `when editing the amount, then update the state`() {
+        setup(creationArgs)
+        viewModel.onAmountChanged(BigDecimal.TEN)
+
+        val viewState = viewModel.viewState.value
+        assertThat((viewState as OrderShippingViewModel.ViewState.ShippingState).amount)
+            .isEqualByComparingTo(BigDecimal.TEN)
+    }
+
+    @Test
+    fun `when editing name, then update the state`() {
+        setup(creationArgs)
+        val name = "shipping name"
+
+        viewModel.onNameChanged(name)
+
+        val viewState = viewModel.viewState.value
+        assertThat((viewState as OrderShippingViewModel.ViewState.ShippingState).name)
+            .isEqualTo(name)
+    }
+
+    @Test
+    fun `when done button is clicked, then update shipping line data`() {
+        setup(creationArgs)
+        val amount = BigDecimal.TEN
+        val name = "Shipping name"
+
+        viewModel.onAmountChanged(amount)
+        viewModel.onNameChanged(name)
+        viewModel.onSaveChanges()
+
+        val lastEvent = viewModel.event.getOrAwaitValue()
+        assertThat(lastEvent).isInstanceOf(UpdateShipping::class.java)
+        (lastEvent as UpdateShipping).let {
+            assertThat(it.shippingUpdate.name).isEqualTo(name)
+            assertThat(it.shippingUpdate.amount).isEqualByComparingTo(amount)
+        }
+    }
+
+    @Test
+    fun `when clicking on remove, then remove the shipping line`() {
+        setup(editArgs)
+        viewModel.onRemove()
+
+        val lastEvent = viewModel.event.getOrAwaitValue()
+        assertThat(lastEvent).isInstanceOf(RemoveShipping::class.java)
+        assertThat((lastEvent as RemoveShipping).id).isEqualTo(editArgs.currentShippingLine?.itemId)
+    }
+}


### PR DESCRIPTION
Part of: #11390

### Description
This PR primarily focuses on adding support for the new shipping UI, which is designed to facilitate the process of adding the shipping method. Although the current version doesn't allow for method selection, it does update the screen to include the new method selection control. In addition to these UI changes, I've also incorporated the basic logic to save the shipping line changes (create/edit flows).

### Testing instructions
TC1
1. Open the app
2. Go to orders
3. Tap on add new order (+)
4. Tap on Add products and add a product, so the Add shipping button is enabled
5. Tap on Add shipping
6. Add an amount
7. Add a name
8. Tap on Add Shipping and check that the shipping is added to the order

TC2
1. On the recently updated order expand the Order Total section
2. Tap on Shipping
3. Check that the shipping line displays the values from TC1
4. Edit any value 
5. Check that the Add shipping button is enabled
6. Tap on Add shipping and that the shipping value is updated

TC3
1. On the recently updated order expand the Order Total section
2. Tap on Shipping
3. Check that the shipping line displays the values from TC2
4. Tap on Remove shipping from order
5. Check that the shipping line is removed from the order

### Images/gif

| Before | After |
| ------------- | ------------- |
| <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/26a621e0-5f4d-422b-abf2-d14b59e423a7" /> | <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/c2454be0-7a83-4395-867b-d77f932d41f6" />  |





- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
