### PR TITLE
Select shipping method UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingMethod.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingMethod.kt
@@ -1,0 +1,10 @@
+package com.woocommerce.android.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class ShippingMethod(
+    val id: String,
+    val title: String
+) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingFragment.kt
@@ -12,9 +12,12 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.model.ShippingMethod
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.orders.creation.shipping.OrderShippingMethodsFragment.Companion.SELECTED_METHOD_RESULT
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -42,7 +45,15 @@ class OrderShippingFragment : BaseFragment() {
                 is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
                 is UpdateShipping -> navigateBackWithResult(UPDATE_SHIPPING_RESULT, event.shippingUpdate)
                 is RemoveShipping -> navigateBackWithResult(REMOVE_SHIPPING_RESULT, event.id)
+                is SelectShippingMethod -> {
+                    val action = OrderShippingFragmentDirections
+                        .actionOrderShippingFragmentToOrderShippingMethodsFragment(event.currentMethodId)
+                    findNavController().navigate(action)
+                }
             }
+        }
+        handleResult<ShippingMethod>(SELECTED_METHOD_RESULT) { selected ->
+            viewModel.onMethodSelected(selected)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsFragment.kt
@@ -1,0 +1,52 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Surface
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.navigateBackWithResult
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class OrderShippingMethodsFragment : BaseFragment() {
+
+    val viewModel: OrderShippingMethodsViewModel by viewModels()
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                WooThemeWithBackground {
+                    Surface {
+                        OrderShippingMethodsScreen(viewModel = viewModel, modifier = Modifier.fillMaxSize())
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.Exit -> findNavController().popBackStack()
+                is ShippingMethodSelected -> navigateBackWithResult(SELECTED_METHOD_RESULT, event.selected)
+            }
+        }
+    }
+
+    companion object {
+        const val SELECTED_METHOD_RESULT = "selected_method_result"
+    }
+
+    override fun getFragmentTitle() = getString(R.string.order_creation_shipping_methods_title)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsScreen.kt
@@ -1,0 +1,231 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.model.ShippingMethod
+import com.woocommerce.android.ui.compose.animations.SkeletonView
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun OrderShippingMethodsScreen(
+    viewModel: OrderShippingMethodsViewModel,
+    modifier: Modifier = Modifier
+) {
+    val viewState by viewModel.viewState.collectAsState()
+    OrderShippingMethodsScreen(
+        viewState = viewState,
+        onMethodSelected = viewModel::onMethodSelected,
+        onRetry = viewModel::retry,
+        modifier = modifier
+    )
+}
+
+@Composable
+fun OrderShippingMethodsScreen(
+    viewState: OrderShippingMethodsViewModel.ViewState,
+    onMethodSelected: (method: OrderShippingMethodsViewModel.ShippingMethodUI) -> Unit,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    when (viewState) {
+        OrderShippingMethodsViewModel.ViewState.Error -> {
+            ErrorMessage(
+                onRetry = onRetry,
+                modifier = modifier.padding(16.dp)
+            )
+        }
+
+        OrderShippingMethodsViewModel.ViewState.Loading -> {
+            OrderShippingMethodsListSkeleton(modifier = modifier.padding(16.dp))
+        }
+
+        is OrderShippingMethodsViewModel.ViewState.ShippingMethodsState -> {
+            OrderShippingMethodsList(
+                methods = viewState.methods,
+                onMethodSelected = onMethodSelected,
+                modifier = modifier
+            )
+        }
+    }
+}
+
+@Composable
+fun OrderShippingMethodsList(
+    methods: List<OrderShippingMethodsViewModel.ShippingMethodUI>,
+    onMethodSelected: (method: OrderShippingMethodsViewModel.ShippingMethodUI) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(modifier = modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp)) {
+        items(methods, key = { item -> item.method.id }) { method ->
+            SelectableShippingMethod(
+                method = method,
+                modifier = Modifier.clickable { onMethodSelected(method) }
+            )
+        }
+    }
+}
+
+@Composable
+fun SelectableShippingMethod(
+    method: OrderShippingMethodsViewModel.ShippingMethodUI,
+    modifier: Modifier = Modifier
+) {
+    Column {
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp, bottom = 16.dp, end = 8.dp)
+        ) {
+            Text(
+                text = method.method.title,
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+                    .weight(2f, fill = true)
+            )
+            AnimatedVisibility(visible = method.isSelected) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_done_secondary),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .align(Alignment.CenterVertically)
+
+                )
+            }
+        }
+        Divider()
+    }
+}
+
+@Preview
+@Composable
+fun SelectableShippingMethodPreview(@PreviewParameter(IsSelectedProvider::class) isSelected: Boolean) {
+    val method = OrderShippingMethodsViewModel.ShippingMethodUI(
+        method = ShippingMethod(
+            id = "other",
+            title = "Other"
+        ),
+        isSelected = isSelected
+    )
+    WooThemeWithBackground {
+        SelectableShippingMethod(method = method)
+    }
+}
+
+class IsSelectedProvider : PreviewParameterProvider<Boolean> {
+    override val values = sequenceOf(true, false)
+}
+
+@Composable
+fun OrderShippingMethodsListSkeleton(modifier: Modifier) {
+    val numberOfInboxSkeletonRows = 5
+    LazyColumn(modifier) {
+        repeat(numberOfInboxSkeletonRows) {
+            item {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_50)),
+                    modifier = Modifier.padding(top = 16.dp, bottom = 16.dp, end = 8.dp)
+                ) {
+                    SkeletonView(
+                        dimensionResource(id = R.dimen.skeleton_text_large_width),
+                        dimensionResource(id = R.dimen.major_100)
+                    )
+                }
+                Divider()
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun OrderShippingMethodsSkeletonPreview() {
+    WooThemeWithBackground {
+        OrderShippingMethodsListSkeleton(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        )
+    }
+}
+
+@Composable
+private fun ErrorMessage(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(dimensionResource(id = R.dimen.major_200)),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.weight(1f))
+        Image(
+            painter = painterResource(id = R.drawable.img_woo_generic_error),
+            contentDescription = null,
+        )
+        Spacer(Modifier.size(dimensionResource(id = R.dimen.major_200)))
+        Text(
+            text = stringResource(id = R.string.order_creation_shipping_methods_error),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.subtitle1,
+            modifier = Modifier.padding(
+                start = dimensionResource(id = R.dimen.major_150),
+                end = dimensionResource(id = R.dimen.major_150)
+            )
+        )
+
+        Spacer(Modifier.size(dimensionResource(id = R.dimen.minor_100)))
+        WCColoredButton(onClick = { onRetry() }) {
+            Text(text = stringResource(id = R.string.retry))
+        }
+
+        Spacer(Modifier.weight(1f))
+    }
+}
+
+@Preview
+@Composable
+fun ErrorMessagePreview() {
+    WooThemeWithBackground {
+        ErrorMessage(
+            onRetry = {},
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsViewModel.kt
@@ -1,0 +1,95 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.model.ShippingMethod
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class OrderShippingMethodsViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedStateHandle) {
+    private val navArgs: OrderShippingMethodsFragmentArgs by savedState.navArgs()
+    val viewState: MutableStateFlow<ViewState>
+
+    init {
+        viewState = MutableStateFlow(ViewState.Loading)
+        launch {
+            getShippingMethods()
+        }
+    }
+
+    fun retry() {
+        launch {
+            getShippingMethods()
+        }
+    }
+
+    private suspend fun getShippingMethods() {
+        viewState.value = ViewState.Loading
+        delay(1000)
+        val fetchedShippingMethods = listOf(
+            ShippingMethod(
+                id = "flat_rate",
+                title = "Flat Rate"
+            ),
+            ShippingMethod(
+                id = "free_shipping",
+                title = "Free shipping"
+            ),
+            ShippingMethod(
+                id = "local_pickup",
+                title = "Local pickup"
+            ),
+            ShippingMethod(
+                id = "other",
+                title = "Other"
+            )
+        )
+
+        var methodsUIList = fetchedShippingMethods.map { ShippingMethodUI(it) }
+
+        methodsUIList = navArgs.selectedMethodId?.let { selectedId ->
+            updateSelection(selectedId, fetchedShippingMethods.map { ShippingMethodUI(it) })
+        } ?: methodsUIList
+
+        viewState.value = ViewState.ShippingMethodsState(methods = methodsUIList)
+    }
+
+    fun onMethodSelected(selected: ShippingMethodUI) {
+        val currentState = viewState.value as? ViewState.ShippingMethodsState ?: return
+        viewState.value = currentState.copy(methods = updateSelection(selected.method.id, currentState.methods))
+        triggerEvent(ShippingMethodSelected(selected.method))
+    }
+
+    private fun updateSelection(selectedId: String, methods: List<ShippingMethodUI>): List<ShippingMethodUI> {
+        return methods.map { shippingMethod ->
+            if (shippingMethod.method.id == selectedId) {
+                shippingMethod.copy(isSelected = true)
+            } else {
+                shippingMethod.copy(isSelected = false)
+            }
+        }
+    }
+
+    sealed class ViewState {
+        data object Error : ViewState()
+        data object Loading : ViewState()
+        data class ShippingMethodsState(
+            val methods: List<ShippingMethodUI>
+        ) : ViewState()
+    }
+
+    data class ShippingMethodUI(
+        val method: ShippingMethod,
+        val isSelected: Boolean = false
+    )
+}
+
+data class ShippingMethodSelected(val selected: ShippingMethod) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsViewModel.kt
@@ -31,6 +31,7 @@ class OrderShippingMethodsViewModel @Inject constructor(
         }
     }
 
+    @Suppress("MagicNumber")
     private suspend fun getShippingMethods() {
         viewState.value = ViewState.Loading
         delay(1000)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
@@ -59,7 +59,7 @@ fun UpdateShippingScreen(
                 isSaveChangesEnabled = currentState.isSaveChangesEnabled,
                 onNameChanged = { name -> viewModel.onNameChanged(name) },
                 onAmountChanged = { amount -> viewModel.onAmountChanged(amount) },
-                onMethodSelected = { viewModel.onMethodSelected() },
+                onSelectMethod = { viewModel.onSelectMethod() },
                 onRemove = { viewModel.onRemove() },
                 onSaveChanges = { viewModel.onSaveChanges() },
                 modifier = modifier
@@ -81,7 +81,7 @@ fun UpdateShippingScreen(
     amount: BigDecimal,
     onAmountChanged: (BigDecimal) -> Unit,
     method: String?,
-    onMethodSelected: () -> Unit,
+    onSelectMethod: () -> Unit,
     isSaveChangesEnabled: Boolean,
     onSaveChanges: () -> Unit,
     isEditFlow: Boolean,
@@ -101,7 +101,7 @@ fun UpdateShippingScreen(
             FieldSelectValue(
                 text = method,
                 hint = stringResource(id = R.string.order_creation_add_shipping_method_select_hint),
-                onSelect = onMethodSelected,
+                onSelect = onSelectMethod,
                 modifier = Modifier.fillMaxWidth()
             )
             Divider(modifier = Modifier.padding(horizontal = 16.dp))
@@ -247,7 +247,7 @@ fun UpdateShippingScreenPreview() {
             isEditFlow = false,
             onAmountChanged = {},
             onNameChanged = {},
-            onMethodSelected = {},
+            onSelectMethod = {},
             onSaveChanges = {},
             onRemove = {}
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
@@ -68,7 +69,11 @@ fun UpdateShippingScreen(
 
         is OrderShippingViewModel.ViewState.Loading -> {
             Box(modifier = Modifier.fillMaxSize()) {
-                Text(text = "loading", modifier = Modifier.align(Alignment.Center))
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .align(Alignment.Center),
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.capitalize
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.ShippingMethod
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -53,16 +54,14 @@ class OrderShippingViewModel @Inject constructor(
     }
 
     @Suppress("MagicNumber")
-    private suspend fun getShippingMethod(shippingLine: Order.ShippingLine): Order.ShippingMethod? {
+    private suspend fun getShippingMethod(shippingLine: Order.ShippingLine): ShippingMethod? {
         return if (shippingLine.methodId == null) {
             null
         } else {
             delay(1000)
-            Order.ShippingMethod(
+            ShippingMethod(
                 id = shippingLine.methodId,
-                title = shippingLine.methodId.capitalize(),
-                total = BigDecimal.ZERO,
-                tax = BigDecimal.ZERO
+                title = shippingLine.methodId.capitalize()
             )
         }
     }
@@ -134,7 +133,7 @@ class OrderShippingViewModel @Inject constructor(
     sealed class ViewState {
         data object Loading : ViewState()
         data class ShippingState(
-            val method: Order.ShippingMethod?,
+            val method: ShippingMethod?,
             val name: String?,
             val amount: BigDecimal,
             val isEditFlow: Boolean,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
@@ -101,8 +101,17 @@ class OrderShippingViewModel @Inject constructor(
         return canEditValues
     }
 
-    fun onMethodSelected() {
-        /*TODO*/
+    fun onSelectMethod() {
+        triggerEvent(SelectShippingMethod((viewState.value as? ViewState.ShippingState)?.method?.id))
+    }
+
+    fun onMethodSelected(selected: ShippingMethod) {
+        (viewState.value as? ViewState.ShippingState)?.let {
+            viewState.value = it.copy(
+                method = selected,
+                isSaveChangesEnabled = isSaveChangesEnabled(newMethodId = selected.id)
+            )
+        }
     }
 
     fun onSaveChanges() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
@@ -161,3 +161,4 @@ data class ShippingUpdateResult(
 
 data class UpdateShipping(val shippingUpdate: ShippingUpdateResult) : MultiLiveEvent.Event()
 data class RemoveShipping(val id: Long) : MultiLiveEvent.Event()
+data class SelectShippingMethod(val currentMethodId: String?) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_order_creations.xml
@@ -441,5 +441,17 @@
             android:name="currentShippingLine"
             app:argType="com.woocommerce.android.model.Order$ShippingLine"
             app:nullable="true" />
+        <action
+            android:id="@+id/action_orderShippingFragment_to_orderShippingMethodsFragment"
+            app:destination="@id/orderShippingMethodsFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/orderShippingMethodsFragment"
+        android:name="com.woocommerce.android.ui.orders.creation.shipping.OrderShippingMethodsFragment"
+        android:label="OrderShippingMethodsFragment" >
+        <argument
+            android:name="selectedMethodId"
+            app:argType="string"
+            app:nullable="true" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -668,6 +668,8 @@
     <string name="order_creation_payment_tax_label">Taxes</string>
     <string name="order_creation_shipping_name">Name</string>
     <string name="order_creation_shipping_title_add">Add Shipping</string>
+    <string name="order_creation_shipping_methods_title">Method</string>
+    <string name="order_creation_shipping_methods_error">Error while fetching your shipping methods. Please try again</string>
     <string name="order_creation_shipping_add">Add Shipping</string>
     <string name="order_creation_add_shipping">Add shipping</string>
     <string name="order_creation_add_shipping_method">Method</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsViewModelTest.kt
@@ -1,0 +1,67 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+
+import com.woocommerce.android.model.ShippingMethod
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceTimeBy
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OrderShippingMethodsViewModelTest : BaseUnitTest() {
+    private lateinit var viewModel: OrderShippingMethodsViewModel
+    private val noSelectedArgs
+        get() = OrderShippingMethodsFragmentArgs(null)
+
+    private val selectedArgs
+        get() = OrderShippingMethodsFragmentArgs("other")
+
+    fun setup(args: OrderShippingMethodsFragmentArgs) {
+        viewModel = OrderShippingMethodsViewModel(
+            savedStateHandle = args.toSavedStateHandle()
+        )
+    }
+
+    @Test
+    fun `given there is no shipping method selected, make sure selection is empty`() = testBlocking {
+        setup(noSelectedArgs)
+        advanceTimeBy(1001)
+        val viewState = viewModel.viewState.first()
+        assertThat(viewState).isNotNull
+        assertThat(viewState).isInstanceOf(OrderShippingMethodsViewModel.ViewState.ShippingMethodsState::class.java)
+        val selectedItems = (viewState as OrderShippingMethodsViewModel.ViewState.ShippingMethodsState)
+            .methods.filter { it.isSelected }
+        assertThat(selectedItems.size).isEqualTo(0)
+    }
+    @Test
+    fun `given there is a shipping method selected, make sure the item is marked as selected`() = testBlocking {
+        setup(selectedArgs)
+        advanceTimeBy(1001)
+        val viewState = viewModel.viewState.first()
+        assertThat(viewState).isNotNull
+        assertThat(viewState).isInstanceOf(OrderShippingMethodsViewModel.ViewState.ShippingMethodsState::class.java)
+        val selectedItems = (viewState as OrderShippingMethodsViewModel.ViewState.ShippingMethodsState)
+            .methods.filter { it.isSelected }
+        assertThat(selectedItems.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `given there is no shipping method selected, if the selection changes, the the item is marked as selected`() = testBlocking {
+        setup(noSelectedArgs)
+        val selected = OrderShippingMethodsViewModel.ShippingMethodUI(
+            ShippingMethod("other","Other"),
+            isSelected = false
+        )
+
+        advanceTimeBy(1001)
+        viewModel.onMethodSelected(selected)
+        val viewState = viewModel.viewState.first()
+        assertThat(viewState).isNotNull
+        assertThat(viewState).isInstanceOf(OrderShippingMethodsViewModel.ViewState.ShippingMethodsState::class.java)
+        val selectedItem = (viewState as OrderShippingMethodsViewModel.ViewState.ShippingMethodsState)
+            .methods.firstOrNull { it.method.id ==  selected.method.id && it.isSelected}
+        assertThat(selectedItem).isNotNull
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.creation.shipping
 
-
 import com.woocommerce.android.model.ShippingMethod
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -35,6 +34,7 @@ class OrderShippingMethodsViewModelTest : BaseUnitTest() {
             .methods.filter { it.isSelected }
         assertThat(selectedItems.size).isEqualTo(0)
     }
+
     @Test
     fun `given there is a shipping method selected, make sure the item is marked as selected`() = testBlocking {
         setup(selectedArgs)
@@ -51,7 +51,7 @@ class OrderShippingMethodsViewModelTest : BaseUnitTest() {
     fun `given there is no shipping method selected, if the selection changes, the the item is marked as selected`() = testBlocking {
         setup(noSelectedArgs)
         val selected = OrderShippingMethodsViewModel.ShippingMethodUI(
-            ShippingMethod("other","Other"),
+            ShippingMethod("other", "Other"),
             isSelected = false
         )
 
@@ -61,7 +61,7 @@ class OrderShippingMethodsViewModelTest : BaseUnitTest() {
         assertThat(viewState).isNotNull
         assertThat(viewState).isInstanceOf(OrderShippingMethodsViewModel.ViewState.ShippingMethodsState::class.java)
         val selectedItem = (viewState as OrderShippingMethodsViewModel.ViewState.ShippingMethodsState)
-            .methods.firstOrNull { it.method.id ==  selected.method.id && it.isSelected}
+            .methods.firstOrNull { it.method.id == selected.method.id && it.isSelected }
         assertThat(selectedItem).isNotNull
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11390

### Description
This PR adds the select shipping method screen and the new screen navigation and sends the selected shipping method back to the Add Shipping screen. Additionally, this PR adds two extra states to the screen: The `Loading` state that will be shown when the screen is fetching the shipping methods and the `Error` state that will be shown if the app fails to load the shipping methods.

### Testing instructions
TC1
1. Open the app
2. Go to orders
3. Tap on add new order (+)
4. Tap on Add products and add a product, so the Add shipping button is enabled
5. Tap on Add shipping
6. Tap on select shipping method
7. Check that the shipping methods are displayed
8. Check that no shipping method is selected
9. Select a shipping method
10. Check that the app navigates back to the Add Shipping screen and the selected method is displayed on the Method section

TC2
1. After running the TC1 tap on the Method section
2. Check that the shipping methods are displayed
3. Check that the expected shipping method is selected

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/7617d309-6098-4bb9-95dd-f7b261836440


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
