### PR TITLE
Shipping methods networking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingMethod.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingMethod.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
+import com.woocommerce.android.network.shipping_methods.ShippingMethodsRestClient
+import com.woocommerce.android.ui.orders.creation.shipping.ShippingMethodsRepository
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -8,3 +10,7 @@ data class ShippingMethod(
     val id: String,
     val title: String
 ) : Parcelable
+
+fun ShippingMethodsRestClient.ShippingMethodDto.toAppModel(): ShippingMethod {
+    return ShippingMethod(id = this.id ?: ShippingMethodsRepository.OTHER_ID, title = this.title.orEmpty())
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingMethod.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ShippingMethod.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
-import com.woocommerce.android.network.shipping_methods.ShippingMethodsRestClient
+import com.woocommerce.android.network.shippingmethods.ShippingMethodsRestClient
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingMethodsRepository
 import kotlinx.parcelize.Parcelize
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/shipping_methods/ShippingMethodsRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/shipping_methods/ShippingMethodsRestClient.kt
@@ -1,0 +1,25 @@
+package com.woocommerce.android.network.shipping_methods
+
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.utils.toWooPayload
+import javax.inject.Inject
+
+class ShippingMethodsRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
+    suspend fun fetchShippingMethods(site: SiteModel): WooPayload<List<ShippingMethodDto>> {
+        val url = WOOCOMMERCE.shipping_methods.pathV3
+
+        return wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = Array<ShippingMethodDto>::class.java,
+        ).toWooPayload { methods -> methods.toList() }
+    }
+
+    data class ShippingMethodDto(
+        val id: String? = null,
+        val title: String? = null,
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/shippingmethods/ShippingMethodsRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/shippingmethods/ShippingMethodsRestClient.kt
@@ -18,6 +18,16 @@ class ShippingMethodsRestClient @Inject constructor(private val wooNetwork: WooN
         ).toWooPayload { methods -> methods.toList() }
     }
 
+    suspend fun fetchShippingMethodsById(site: SiteModel, methodId: String): WooPayload<ShippingMethodDto> {
+        val url = WOOCOMMERCE.shipping_methods.id(methodId).pathV3
+
+        return wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = ShippingMethodDto::class.java,
+        ).toWooPayload()
+    }
+
     data class ShippingMethodDto(
         val id: String? = null,
         val title: String? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/shippingmethods/ShippingMethodsRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/shippingmethods/ShippingMethodsRestClient.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.network.shipping_methods
+package com.woocommerce.android.network.shippingmethods
 
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodById.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodById.kt
@@ -11,7 +11,7 @@ class GetShippingMethodById @Inject constructor(
         if (shippingMethodId == ShippingMethodsRepository.OTHER_ID || shippingMethodId == null) {
             return other
         }
-        val result = shippingMethodsRepository.fetchShippingMethods()
-        return result.model?.firstOrNull { shippingMethod -> shippingMethod.id == shippingMethodId } ?: other
+        val result = shippingMethodsRepository.fetchShippingMethodById(shippingMethodId)
+        return result.model ?: other
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodById.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodById.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+import com.woocommerce.android.model.ShippingMethod
+import javax.inject.Inject
+
+class GetShippingMethodById @Inject constructor(
+    private val shippingMethodsRepository: ShippingMethodsRepository
+) {
+    suspend operator fun invoke(shippingMethodId: String?): ShippingMethod {
+        val other = shippingMethodsRepository.getOtherShippingMethod()
+        if (shippingMethodId == ShippingMethodsRepository.OTHER_ID || shippingMethodId == null) {
+            return other
+        }
+        val result = shippingMethodsRepository.fetchShippingMethods()
+        return result.model?.firstOrNull { shippingMethod -> shippingMethod.id == shippingMethodId } ?: other
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodsWithOtherValue.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodsWithOtherValue.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+import com.woocommerce.android.model.ShippingMethod
+import javax.inject.Inject
+
+class GetShippingMethodsWithOtherValue @Inject constructor(
+    private val shippingMethodsRepository: ShippingMethodsRepository
+) {
+    suspend operator fun invoke(): Result<List<ShippingMethod>> {
+        val result = shippingMethodsRepository.fetchShippingMethods()
+        return when {
+            result.model != null -> {
+                val shippingMethodsWithOtherValue = result.model!!.toMutableList().also {
+                    it.add(shippingMethodsRepository.getOtherShippingMethod())
+                }
+
+                Result.success(shippingMethodsWithOtherValue)
+            }
+
+            else -> {
+                val message = result.error.message ?: "error fetching shipping methods"
+                Result.failure(Exception(message))
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsViewModel.kt
@@ -6,14 +6,14 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class OrderShippingMethodsViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val getShippingMethodsWithOtherValue: GetShippingMethodsWithOtherValue
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: OrderShippingMethodsFragmentArgs by savedState.navArgs()
     val viewState: MutableStateFlow<ViewState>
@@ -33,33 +33,20 @@ class OrderShippingMethodsViewModel @Inject constructor(
 
     private suspend fun getShippingMethods() {
         viewState.value = ViewState.Loading
-        delay(1000)
-        val fetchedShippingMethods = listOf(
-            ShippingMethod(
-                id = "flat_rate",
-                title = "Flat Rate"
-            ),
-            ShippingMethod(
-                id = "free_shipping",
-                title = "Free shipping"
-            ),
-            ShippingMethod(
-                id = "local_pickup",
-                title = "Local pickup"
-            ),
-            ShippingMethod(
-                id = "other",
-                title = "Other"
-            )
+        getShippingMethodsWithOtherValue().fold(
+            onSuccess = { fetchedShippingMethods ->
+                var methodsUIList = fetchedShippingMethods.map { ShippingMethodUI(it) }
+
+                methodsUIList = navArgs.selectedMethodId?.let { selectedId ->
+                    updateSelection(selectedId, fetchedShippingMethods.map { ShippingMethodUI(it) })
+                } ?: methodsUIList
+
+                viewState.value = ViewState.ShippingMethodsState(methods = methodsUIList)
+            },
+            onFailure = {
+                viewState.value = ViewState.Error
+            }
         )
-
-        var methodsUIList = fetchedShippingMethods.map { ShippingMethodUI(it) }
-
-        methodsUIList = navArgs.selectedMethodId?.let { selectedId ->
-            updateSelection(selectedId, fetchedShippingMethods.map { ShippingMethodUI(it) })
-        } ?: methodsUIList
-
-        viewState.value = ViewState.ShippingMethodsState(methods = methodsUIList)
     }
 
     fun onMethodSelected(selected: ShippingMethodUI) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.orders.creation.shipping
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.capitalize
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.ShippingMethod
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -11,7 +10,6 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -21,7 +19,8 @@ import javax.inject.Inject
 @HiltViewModel
 class OrderShippingViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val getShippingMethodById: GetShippingMethodById
 ) : ScopedViewModel(savedStateHandle) {
 
     private val navArgs: OrderShippingFragmentArgs by savedState.navArgs()
@@ -43,26 +42,13 @@ class OrderShippingViewModel @Inject constructor(
         navArgs.currentShippingLine?.let { shippingLine: Order.ShippingLine ->
             launch {
                 viewState.value = ViewState.ShippingState(
-                    method = getShippingMethod(shippingLine),
+                    method = getShippingMethodById(shippingLine.methodId),
                     name = shippingLine.methodTitle,
                     amount = shippingLine.total,
                     isEditFlow = true,
                     isSaveChangesEnabled = false
                 )
             }
-        }
-    }
-
-    @Suppress("MagicNumber")
-    private suspend fun getShippingMethod(shippingLine: Order.ShippingLine): ShippingMethod? {
-        return if (shippingLine.methodId == null) {
-            null
-        } else {
-            delay(1000)
-            ShippingMethod(
-                id = shippingLine.methodId,
-                title = shippingLine.methodId.capitalize()
-            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingMethodsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingMethodsRepository.kt
@@ -43,6 +43,26 @@ class ShippingMethodsRepository @Inject constructor(
         }
     }
 
+    suspend fun fetchShippingMethodById(
+        methodId: String,
+        site: SiteModel = selectedSite.get()
+    ): WooResult<ShippingMethod> {
+        return withContext(dispatchers.io) {
+            val response = shippingMethodsRestClient.fetchShippingMethodsById(site, methodId)
+            when {
+                response.isError -> {
+                    WooResult(response.error)
+                }
+
+                response.result != null -> {
+                    WooResult(response.result!!.toAppModel())
+                }
+
+                else -> WooResult(WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN))
+            }
+        }
+    }
+
     fun getOtherShippingMethod(): ShippingMethod {
         return ShippingMethod(
             id = OTHER_ID,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingMethodsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingMethodsRepository.kt
@@ -1,0 +1,52 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+import com.woocommerce.android.R
+import com.woocommerce.android.model.ShippingMethod
+import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.network.shipping_methods.ShippingMethodsRestClient
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import javax.inject.Inject
+
+class ShippingMethodsRepository @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val shippingMethodsRestClient: ShippingMethodsRestClient,
+    private val resourceProvider: ResourceProvider,
+    private val dispatchers: CoroutineDispatchers
+) {
+    companion object {
+        const val OTHER_ID = "other"
+    }
+
+    suspend fun fetchShippingMethods(site: SiteModel = selectedSite.get()): WooResult<List<ShippingMethod>> {
+        return withContext(dispatchers.io) {
+            val response = shippingMethodsRestClient.fetchShippingMethods(site)
+            when {
+                response.isError -> {
+                    WooResult(response.error)
+                }
+
+                response.result != null -> {
+                    val shippingMethods = response.result!!.map { dto -> dto.toAppModel() }
+                    WooResult(shippingMethods)
+                }
+
+                else -> WooResult(WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN))
+            }
+        }
+    }
+
+    fun getOtherShippingMethod(): ShippingMethod {
+        return ShippingMethod(
+            id = OTHER_ID,
+            title = resourceProvider.getString(R.string.other)
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingMethodsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingMethodsRepository.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.ui.orders.creation.shipping
 import com.woocommerce.android.R
 import com.woocommerce.android.model.ShippingMethod
 import com.woocommerce.android.model.toAppModel
-import com.woocommerce.android.network.shipping_methods.ShippingMethodsRestClient
+import com.woocommerce.android.network.shippingmethods.ShippingMethodsRestClient
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.ResourceProvider

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodByIdTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodByIdTest.kt
@@ -82,7 +82,7 @@ class GetShippingMethodByIdTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when fetching ship´ping methods fail, then return other`() = testBlocking {
+    fun `when fetching shipping methods fail, then return other`() = testBlocking {
         val fetchResult = WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN)
         whenever(shippingMethodsRestClient.fetchShippingMethods(siteModel)).doReturn(WooPayload(fetchResult))
         whenever(resourceProvider.getString(any())).doReturn("Other")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodByIdTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodByIdTest.kt
@@ -1,0 +1,94 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+import com.woocommerce.android.network.shipping_methods.ShippingMethodsRestClient
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetShippingMethodByIdTest : BaseUnitTest() {
+    private val siteModel = SiteModel()
+    private val selectedSite: SelectedSite = mock {
+        on { get() } doReturn siteModel
+    }
+    private val resourceProvider: ResourceProvider = mock()
+    private val shippingMethodsRestClient: ShippingMethodsRestClient = mock()
+
+    private val shippingMethodsRepository = ShippingMethodsRepository(
+        selectedSite = selectedSite,
+        dispatchers = coroutinesTestRule.testDispatchers,
+        resourceProvider = resourceProvider,
+        shippingMethodsRestClient = shippingMethodsRestClient
+    )
+
+    val sut = GetShippingMethodById(shippingMethodsRepository)
+
+    @Test
+    fun `when the method is in the result, then return is the expected`() = testBlocking {
+        val fetchResult = List(3) { i ->
+            ShippingMethodsRestClient.ShippingMethodDto(
+                id = "id$i",
+                title = "title$i",
+            )
+        }
+        whenever(shippingMethodsRestClient.fetchShippingMethods(siteModel)).doReturn(WooPayload(fetchResult))
+        whenever(resourceProvider.getString(any())).doReturn("Other")
+
+        val result = sut.invoke("id1")
+        assertThat(result).isNotNull
+        assertThat(result.id).isEqualTo("id1")
+    }
+
+    @Test
+    fun `when the method id is other, then return is the expected`() = testBlocking {
+        whenever(resourceProvider.getString(any())).doReturn("Other")
+
+        val result = sut.invoke(ShippingMethodsRepository.OTHER_ID)
+
+        // If is other doesn't need to fetch the values from the API
+        verify(shippingMethodsRestClient, never()).fetchShippingMethods(siteModel)
+        assertThat(result).isNotNull
+        assertThat(result.id).isEqualTo(ShippingMethodsRepository.OTHER_ID)
+    }
+
+    @Test
+    fun `when the method is NOT in the result, then return other`() = testBlocking {
+        val fetchResult = List(3) { i ->
+            ShippingMethodsRestClient.ShippingMethodDto(
+                id = "id$i",
+                title = "title$i",
+            )
+        }
+        whenever(shippingMethodsRestClient.fetchShippingMethods(siteModel)).doReturn(WooPayload(fetchResult))
+        whenever(resourceProvider.getString(any())).doReturn("Other")
+
+        val result = sut.invoke("id8")
+        assertThat(result).isNotNull
+        assertThat(result.id).isEqualTo(ShippingMethodsRepository.OTHER_ID)
+    }
+
+    @Test
+    fun `when fetching ship´ping methods fail, then return other`() = testBlocking {
+        val fetchResult = WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN)
+        whenever(shippingMethodsRestClient.fetchShippingMethods(siteModel)).doReturn(WooPayload(fetchResult))
+        whenever(resourceProvider.getString(any())).doReturn("Other")
+
+        val result = sut.invoke("id8")
+        assertThat(result).isNotNull
+        assertThat(result.id).isEqualTo(ShippingMethodsRepository.OTHER_ID)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodByIdTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodByIdTest.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.orders.creation.shipping
 
-import com.woocommerce.android.network.shipping_methods.ShippingMethodsRestClient
+import com.woocommerce.android.network.shippingmethods.ShippingMethodsRestClient
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodByIdTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodByIdTest.kt
@@ -39,18 +39,20 @@ class GetShippingMethodByIdTest : BaseUnitTest() {
 
     @Test
     fun `when the method is in the result, then return is the expected`() = testBlocking {
-        val fetchResult = List(3) { i ->
-            ShippingMethodsRestClient.ShippingMethodDto(
-                id = "id$i",
-                title = "title$i",
-            )
-        }
-        whenever(shippingMethodsRestClient.fetchShippingMethods(siteModel)).doReturn(WooPayload(fetchResult))
+        val methodId = "id1"
+        val fetchResult = ShippingMethodsRestClient.ShippingMethodDto(
+            id = methodId,
+            title = "title1",
+        )
+
+        whenever(shippingMethodsRestClient.fetchShippingMethodsById(siteModel, methodId)).doReturn(
+            WooPayload(fetchResult)
+        )
         whenever(resourceProvider.getString(any())).doReturn("Other")
 
-        val result = sut.invoke("id1")
+        val result = sut.invoke(methodId)
         assertThat(result).isNotNull
-        assertThat(result.id).isEqualTo("id1")
+        assertThat(result.id).isEqualTo(methodId)
     }
 
     @Test
@@ -60,34 +62,23 @@ class GetShippingMethodByIdTest : BaseUnitTest() {
         val result = sut.invoke(ShippingMethodsRepository.OTHER_ID)
 
         // If is other doesn't need to fetch the values from the API
-        verify(shippingMethodsRestClient, never()).fetchShippingMethods(siteModel)
-        assertThat(result).isNotNull
-        assertThat(result.id).isEqualTo(ShippingMethodsRepository.OTHER_ID)
-    }
-
-    @Test
-    fun `when the method is NOT in the result, then return other`() = testBlocking {
-        val fetchResult = List(3) { i ->
-            ShippingMethodsRestClient.ShippingMethodDto(
-                id = "id$i",
-                title = "title$i",
-            )
-        }
-        whenever(shippingMethodsRestClient.fetchShippingMethods(siteModel)).doReturn(WooPayload(fetchResult))
-        whenever(resourceProvider.getString(any())).doReturn("Other")
-
-        val result = sut.invoke("id8")
+        verify(shippingMethodsRestClient, never()).fetchShippingMethodsById(
+            siteModel,
+            ShippingMethodsRepository.OTHER_ID
+        )
         assertThat(result).isNotNull
         assertThat(result.id).isEqualTo(ShippingMethodsRepository.OTHER_ID)
     }
 
     @Test
     fun `when fetching shipping methods fail, then return other`() = testBlocking {
+        val methodId = "id8"
         val fetchResult = WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN)
-        whenever(shippingMethodsRestClient.fetchShippingMethods(siteModel)).doReturn(WooPayload(fetchResult))
+        whenever(shippingMethodsRestClient.fetchShippingMethodsById(siteModel, methodId))
+            .doReturn(WooPayload(fetchResult))
         whenever(resourceProvider.getString(any())).doReturn("Other")
 
-        val result = sut.invoke("id8")
+        val result = sut.invoke(methodId)
         assertThat(result).isNotNull
         assertThat(result.id).isEqualTo(ShippingMethodsRepository.OTHER_ID)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodsWithOtherValueTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodsWithOtherValueTest.kt
@@ -1,0 +1,80 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+import com.woocommerce.android.network.shipping_methods.ShippingMethodsRestClient
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetShippingMethodsWithOtherValueTest : BaseUnitTest() {
+
+    private val siteModel = SiteModel()
+    private val selectedSite: SelectedSite = mock {
+        on { get() } doReturn siteModel
+    }
+    private val resourceProvider: ResourceProvider = mock()
+    private val shippingMethodsRestClient: ShippingMethodsRestClient = mock()
+
+    private val shippingMethodsRepository = ShippingMethodsRepository(
+        selectedSite = selectedSite,
+        dispatchers = coroutinesTestRule.testDispatchers,
+        resourceProvider = resourceProvider,
+        shippingMethodsRestClient = shippingMethodsRestClient
+    )
+
+    val sut = GetShippingMethodsWithOtherValue(shippingMethodsRepository)
+
+    @Test
+    fun `when  get shipping succeed then a success response is returned including other`() = testBlocking {
+        val fetchResult = List(3) { i ->
+            ShippingMethodsRestClient.ShippingMethodDto(
+                id = "id$i",
+                title = "title$i",
+            )
+        }
+        whenever(shippingMethodsRestClient.fetchShippingMethods(siteModel)).doReturn(WooPayload(fetchResult))
+        whenever(resourceProvider.getString(any())).doReturn("Other")
+
+        val result = sut.invoke()
+        assertThat(result).isNotNull
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.isFailure).isFalse()
+        assertThat(result.getOrNull()!!.size).isEqualTo(4) // List + Other
+        val other = result.getOrNull()!!.firstOrNull { it.id == ShippingMethodsRepository.OTHER_ID }
+        assertThat(other).isNotNull
+    }
+
+    @Test
+    fun `when  get shipping fails then an error response is returned`() = testBlocking {
+        val fetchResult = WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN)
+        whenever(shippingMethodsRestClient.fetchShippingMethods(siteModel)).doReturn(WooPayload(fetchResult))
+
+        val result = sut.invoke()
+        assertThat(result).isNotNull
+        assertThat(result.isSuccess).isFalse()
+        assertThat(result.isFailure).isTrue()
+    }
+
+    @Test
+    fun `when get shipping succeed but is null then an error response is returned`() = testBlocking {
+        val fetchResult = null
+        whenever(shippingMethodsRestClient.fetchShippingMethods(siteModel)).doReturn(WooPayload(fetchResult))
+
+        val result = sut.invoke()
+        assertThat(result).isNotNull
+        assertThat(result.isSuccess).isFalse()
+        assertThat(result.isFailure).isTrue()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodsWithOtherValueTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodsWithOtherValueTest.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.orders.creation.shipping
 
-import com.woocommerce.android.network.shipping_methods.ShippingMethodsRestClient
+import com.woocommerce.android.network.shippingmethods.ShippingMethodsRestClient
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsViewModelTest.kt
@@ -4,9 +4,11 @@ import com.woocommerce.android.model.ShippingMethod
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.advanceTimeBy
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class OrderShippingMethodsViewModelTest : BaseUnitTest() {
@@ -17,16 +19,25 @@ class OrderShippingMethodsViewModelTest : BaseUnitTest() {
     private val selectedArgs
         get() = OrderShippingMethodsFragmentArgs("other")
 
+    private val getShippingMethodsWithOtherValue: GetShippingMethodsWithOtherValue = mock()
+
+    private val defaultShippingMethods = listOf(
+        ShippingMethod(id = "free_shipping", "Free Shipping"),
+        ShippingMethod(id = ShippingMethodsRepository.OTHER_ID, "Other"),
+        ShippingMethod(id = "local_pickup", "Local Pick Up"),
+    )
+
     fun setup(args: OrderShippingMethodsFragmentArgs) {
         viewModel = OrderShippingMethodsViewModel(
-            savedStateHandle = args.toSavedStateHandle()
+            savedStateHandle = args.toSavedStateHandle(),
+            getShippingMethodsWithOtherValue = getShippingMethodsWithOtherValue
         )
     }
 
     @Test
     fun `given there is no shipping method selected, make sure selection is empty`() = testBlocking {
+        whenever(getShippingMethodsWithOtherValue.invoke()).doReturn(Result.success(defaultShippingMethods))
         setup(noSelectedArgs)
-        advanceTimeBy(1001)
         val viewState = viewModel.viewState.first()
         assertThat(viewState).isNotNull
         assertThat(viewState).isInstanceOf(OrderShippingMethodsViewModel.ViewState.ShippingMethodsState::class.java)
@@ -37,8 +48,8 @@ class OrderShippingMethodsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given there is a shipping method selected, make sure the item is marked as selected`() = testBlocking {
+        whenever(getShippingMethodsWithOtherValue.invoke()).doReturn(Result.success(defaultShippingMethods))
         setup(selectedArgs)
-        advanceTimeBy(1001)
         val viewState = viewModel.viewState.first()
         assertThat(viewState).isNotNull
         assertThat(viewState).isInstanceOf(OrderShippingMethodsViewModel.ViewState.ShippingMethodsState::class.java)
@@ -48,20 +59,22 @@ class OrderShippingMethodsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given there is no shipping method selected, if the selection changes, the the item is marked as selected`() = testBlocking {
-        setup(noSelectedArgs)
-        val selected = OrderShippingMethodsViewModel.ShippingMethodUI(
-            ShippingMethod("other", "Other"),
-            isSelected = false
-        )
+    fun `given there is no shipping method selected, if the selection changes, the the item is marked as selected`() =
+        testBlocking {
+            whenever(getShippingMethodsWithOtherValue.invoke()).doReturn(Result.success(defaultShippingMethods))
 
-        advanceTimeBy(1001)
-        viewModel.onMethodSelected(selected)
-        val viewState = viewModel.viewState.first()
-        assertThat(viewState).isNotNull
-        assertThat(viewState).isInstanceOf(OrderShippingMethodsViewModel.ViewState.ShippingMethodsState::class.java)
-        val selectedItem = (viewState as OrderShippingMethodsViewModel.ViewState.ShippingMethodsState)
-            .methods.firstOrNull { it.method.id == selected.method.id && it.isSelected }
-        assertThat(selectedItem).isNotNull
-    }
+            setup(noSelectedArgs)
+
+            val selected = OrderShippingMethodsViewModel.ShippingMethodUI(
+                ShippingMethod("other", "Other"),
+                isSelected = false
+            )
+            viewModel.onMethodSelected(selected)
+            val viewState = viewModel.viewState.first()
+            assertThat(viewState).isNotNull
+            assertThat(viewState).isInstanceOf(OrderShippingMethodsViewModel.ViewState.ShippingMethodsState::class.java)
+            val selectedItem = (viewState as OrderShippingMethodsViewModel.ViewState.ShippingMethodsState)
+                .methods.firstOrNull { it.method.id == selected.method.id && it.isSelected }
+            assertThat(selectedItem).isNotNull
+        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModelTest.kt
@@ -27,10 +27,13 @@ class OrderShippingViewModelTest : BaseUnitTest() {
             )
         )
 
+    private val getShippingMethodById: GetShippingMethodById = mock()
+
     fun setup(args: OrderShippingFragmentArgs) {
         viewModel = OrderShippingViewModel(
             savedStateHandle = args.toSavedStateHandle(),
-            resourceProvider = mock()
+            resourceProvider = mock(),
+            getShippingMethodById = getShippingMethodById
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingMethodsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingMethodsRepositoryTest.kt
@@ -1,0 +1,71 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+import com.woocommerce.android.network.shipping_methods.ShippingMethodsRestClient
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ShippingMethodsRepositoryTest : BaseUnitTest() {
+
+    private val selectedSite: SelectedSite = mock()
+    private val resourceProvider: ResourceProvider = mock()
+    private val shippingMethodsRestClient: ShippingMethodsRestClient = mock()
+
+    private val sut = ShippingMethodsRepository(
+        selectedSite = selectedSite,
+        dispatchers = coroutinesTestRule.testDispatchers,
+        resourceProvider = resourceProvider,
+        shippingMethodsRestClient = shippingMethodsRestClient
+    )
+
+    @Test
+    fun `when shipping requests succeed then a success response is returned`() = testBlocking {
+        val siteModel = SiteModel()
+        val fetchResult = List(3) { i ->
+            ShippingMethodsRestClient.ShippingMethodDto(
+                id = "id$i",
+                title = "title$i",
+            )
+        }
+        whenever(shippingMethodsRestClient.fetchShippingMethods(siteModel)).doReturn(WooPayload(fetchResult))
+
+        val result = sut.fetchShippingMethods(siteModel)
+        assertThat(result.isError).isFalse()
+        assertThat(result.model).isNotNull
+        assertThat(result.model?.size).isEqualTo(fetchResult.size)
+    }
+
+    @Test
+    fun `when shipping requests succeed but model is null then an error response is returned`() = testBlocking {
+        val siteModel = SiteModel()
+        val fetchResult = null
+        whenever(shippingMethodsRestClient.fetchShippingMethods(siteModel)).doReturn(WooPayload(fetchResult))
+
+        val result = sut.fetchShippingMethods(siteModel)
+        assertThat(result.isError).isTrue()
+        assertThat(result.model).isNull()
+    }
+
+    @Test
+    fun `when shipping requests fails then an error response is returned`() = testBlocking {
+        val siteModel = SiteModel()
+        val fetchResult = WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN)
+        whenever(shippingMethodsRestClient.fetchShippingMethods(siteModel)).doReturn(WooPayload(fetchResult))
+
+        val result = sut.fetchShippingMethods(siteModel)
+        assertThat(result.isError).isTrue()
+        assertThat(result.model).isNull()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingMethodsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingMethodsRepositoryTest.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.orders.creation.shipping
 
-import com.woocommerce.android.network.shipping_methods.ShippingMethodsRestClient
+import com.woocommerce.android.network.shippingmethods.ShippingMethodsRestClient
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.78.0'
+    fluxCVersion = '3007-91f0df49fcdbdb8ce4e48c3da05a2ba4aeaf0ca1'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '3007-91f0df49fcdbdb8ce4e48c3da05a2ba4aeaf0ca1'
+    fluxCVersion = 'trunk-cfe34975d20df76a2b7b4522dccd2faf53ef0f7c'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
⚠️ This PR depends on [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3007)
Closes: #11391

### Why 
As a crucial part of the Enhancing Order Shipping Lines pffQ75-m4-p2, we are proposing to implement the shipping method selection feature, which is essential for our project's success.

### Description
This PR adds the necessary logic to fetch the shipping methods from the API. The PR introduces the uses cases `GetShippingMethodById` which will return the shipping method using the method ID, and the `GetShippingMethodsWithOtherValue` which will return the list of shipping methods from the API and it will including the `other` shipping method. With the changes introduced here, the new UI finally connects with the data from the API.

### Testing instructions
TC1
1. Open the app
2. Go to orders
3. Tap on add new order (+)
4. Tap on Add products and add a product, so the Add shipping button is enabled
5. Tap on Add shipping
6. Tap on select shipping method
7. Check that the shipping methods are displayed
8. Check that no shipping method is selected
9. Select a shipping method
10. Check that the app navigates back to the Add Shipping screen and the selected method is displayed on the Method section

TC2
1. After running the TC1 tap on the Method section
2. Check that the shipping methods are displayed
3. Check that the expected shipping method is selected


### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/46f1d7ed-5a37-48ab-88cc-2d6a91bb25d2


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->