### PR TITLE
Release shipping method selection

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 -----
 - [*] Tap To Pay: Changed navigation from Tap To Pay Summary screen to About Tap To Pay [https://github.com/woocommerce/woocommerce-android/pull/11411]
 - [*] Tap To Pay: Change description of how Tap To Pay works, excluding simple payments [https://github.com/woocommerce/woocommerce-android/pull/11411]
-
+- [*] Shipping: A shipping method can now be selected when adding or editing shipping on an order [https://github.com/woocommerce/woocommerce-android/pull/11481]
 
 18.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -29,14 +29,14 @@ enum class FeatureFlag {
             MORE_MENU_INBOX,
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
-            ORDER_CREATION_AUTO_TAX_RATE,
-            EOSL_M1 -> PackageUtils.isDebugBuild()
+            ORDER_CREATION_AUTO_TAX_RATE -> PackageUtils.isDebugBuild()
 
             DYNAMIC_DASHBOARD,
             CONNECTIVITY_TOOL,
             CUSTOM_RANGE_ANALYTICS,
             NEW_SHIPPING_SUPPORT,
-            APP_PASSWORD_TUTORIAL -> true
+            APP_PASSWORD_TUTORIAL,
+            EOSL_M1 -> true
         }
     }
 }


### PR DESCRIPTION
## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR releases the first milestone of the Enhancing Order Shipping Lines project, which adds support for selecting a shipping method when adding/editing shipping on an order.

## Description

This PR enables the Enhancing Order Shipping Lines M1 feature flag and adds the release notes.

## Testing instructions

Basic testing steps:

1. Go to the Orders tab.
2. Create a new order and add a product, or select an existing order and tap "Edit".
3. In the other form, tap "Add Shipping" to add a shipping line to the order, or tap "Shipping" in order totals to edit a shipping line on the order.

Scenarios to test:

* Adding shipping to a new order.
* Editing shipping on an existing order.
* Removing shipping from an order.

Expected functionality:

- The Add shipping screen allows you to select the shipping method, setting the shipping name and the shipping cost.
- The Select shipping method screen displays all configured shipping methods in the store plus the other option
- The Remove shipping from order button is displayed when there is an existing shipping line in the order.
- Editing a shipping line fills the Add shipping screen with the values of the previous shipping set (shipping method, name and cost)
- Track every time the shipping method selection changes
- Track when a shipping line is added to the order
- Track when the add shipping button is pressed


### Images/gif

**Add shipping**

https://github.com/woocommerce/woocommerce-android/assets/18119390/c04ca12a-971f-4839-9ccc-2791d785b1bc

**Edit shipping**

https://github.com/woocommerce/woocommerce-android/assets/18119390/a2f44416-c22f-4ff3-976b-c89dd0e46cd4

**Delete shipping**

https://github.com/woocommerce/woocommerce-android/assets/18119390/c5bf3a7a-39f3-4c1a-8e61-d537f17467d9


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
