### PR TITLE
Add a check to avoid app crash when the products list is empty

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
@@ -82,6 +82,12 @@ class DashboardBlazeViewModel @AssistedInject constructor(
                     val products = productsResult.getOrThrow()
                     val blazeCampaignModel = blazeCampaignResult.getOrThrow()
 
+                    if (products.isEmpty()) {
+                        // When the products is empty, the card will be hidden by the parent view model
+                        // so we don't need to show any UI
+                        return@combine null
+                    }
+
                     when {
                         blazeCampaignModel == null -> showUiForNoCampaign(products)
                         else -> showUiForCampaign(blazeCampaignModel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveBlazeWidgetStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveBlazeWidgetStatus.kt
@@ -37,7 +37,12 @@ class ObserveBlazeWidgetStatus @Inject constructor(
         .withIndex()
         .map { (index, productsCount) ->
             if (productsCount == 0L && index == 0) {
-                productListRepository.fetchProductList().getOrNull()?.size != 0
+                productListRepository
+                    .fetchProductList(
+                        productFilterOptions = mapOf(ProductFilterOption.STATUS to ProductStatus.PUBLISH.value)
+                    ).getOrNull()
+                    ?.filterNot { it.isSampleProduct }
+                    ?.size != 0
             } else {
                 productsCount > 0
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11489 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
During the code cleanup after enabling Dynamic Dashboard feature, I removed the status `Hidden` from the Blaze card as it wasn't relevant anymore (the card visibility is handled by the parent ViewModel), but this has caused a crash in some cases, the testing instructions will explain those cases.

### Testing instructions
1. Using the branch `release/18.6`.
2. Use a site with a single product.
3. Open the app.
4. Make sure the Blaze card is enabled.
5. Go to the Products list, and trash the published product.
6. Go back to the MyStore screen.
7. Pull the screen to refresh it.
8. Notice the crash.
9. Now switch to the branch `issue/11489-fix-blaze-card-crash`
10. Repeat 2 - 7
11. Confirm the app doesn't crash, and the Blaze card is hidden as expected.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
