### PR TITLE
[Dynamic Dashboard] Reviews card UI

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/util/Screen.kt
@@ -199,12 +199,17 @@ open class Screen {
             val node = onNode(matcher)
             if (node.isDisplayed() && (!requireFullVisibility || node.isFullyDisplayed())) return
 
-            val parentBounds = node.onParent().fetchSemanticsNode().touchBoundsInRoot
+            val bounds = node.onParent().fetchSemanticsNode().boundsInWindow.let {
+                it.copy(
+                    top = it.top.coerceIn(0f, device.displayHeight.toFloat()),
+                    bottom = it.bottom.coerceIn(0f, device.displayHeight.toFloat())
+                )
+            }
             device.swipe(
-                parentBounds.center.x.toInt(),
-                parentBounds.center.y.toInt(),
-                parentBounds.center.x.toInt(),
-                parentBounds.center.y.toInt() + if (scrollUp) -100 else 100,
+                bounds.center.x.toInt(),
+                bounds.center.y.toInt(),
+                bounds.center.x.toInt(),
+                bounds.center.y.toInt() + if (scrollUp) -100 else 100,
                 10
             )
             numberOfScrolls++

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/StatsUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/StatsUITest.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.login.LoginActivity
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -97,7 +98,7 @@ class StatsUITest : TestBase() {
             .assertTopPerformers(topPerformersJSONArray, composeTestRule)
     }
 
-    @Retry(numberOfTimes = 1)
+    @Ignore("This became flaky after combining Compose and View on the dashboard")
     @Test
     fun e2eStatsTapChart() {
         DashboardScreen()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
@@ -69,11 +69,19 @@ class DashboardDataStore @Inject constructor(
         }
     }
 
-    private fun getDefaultWidgets() = supportedWidgets.map {
-        DashboardWidgetDataModel.newBuilder()
-            .setType(it.name)
-            .setIsAdded(true)
-            .build()
+    private fun getDefaultWidgets(): List<DashboardWidgetDataModel> {
+        fun DashboardWidget.Type.shouldBeEnabledByDefault() =
+            this == DashboardWidget.Type.STATS ||
+                this == DashboardWidget.Type.POPULAR_PRODUCTS ||
+                this == DashboardWidget.Type.ONBOARDING ||
+                this == DashboardWidget.Type.BLAZE
+
+        return supportedWidgets.map {
+            DashboardWidgetDataModel.newBuilder()
+                .setType(it.name)
+                .setIsAdded(it.shouldBeEnabledByDefault())
+                .build()
+        }
     }
 
     // Use the feature flag [DYNAMIC_DASHBOARD_M2] to filter out unsupported widgets during development

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
@@ -68,6 +68,8 @@ fun DashboardReviewsCard(
             onHideClicked = { parentViewModel.onHideWidgetClicked(DashboardWidget.Type.REVIEWS) },
             onFilterSelected = viewModel::onFilterSelected,
             onViewAllClicked = viewModel::onViewAllClicked,
+            onContactSupportClicked = parentViewModel::onContactSupportClicked,
+            onRetryClicked = viewModel::onRetryClicked,
             modifier = modifier
         )
     }
@@ -101,6 +103,8 @@ private fun DashboardReviewsCard(
     onHideClicked: () -> Unit,
     onFilterSelected: (ProductReviewStatus) -> Unit,
     onViewAllClicked: () -> Unit,
+    onContactSupportClicked: () -> Unit,
+    onRetryClicked: () -> Unit,
     modifier: Modifier
 ) {
     WidgetCard(
@@ -134,8 +138,8 @@ private fun DashboardReviewsCard(
 
             is DashboardReviewsViewModel.ViewState.Error -> {
                 WidgetError(
-                    onContactSupportClicked = { /*TODO*/ },
-                    onRetryClicked = { /*TODO*/ }
+                    onContactSupportClicked = onContactSupportClicked,
+                    onRetryClicked = onRetryClicked
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
@@ -74,7 +74,7 @@ fun DashboardReviewsCard(
 }
 
 @Composable
-fun HandleEvents(event: LiveData<MultiLiveEvent.Event>) {
+private fun HandleEvents(event: LiveData<MultiLiveEvent.Event>) {
     val navController = rememberNavController()
     val lifecycleOwner = LocalLifecycleOwner.current
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
@@ -118,7 +118,7 @@ private fun DashboardReviewsCard(
             titleResource = R.string.dashboard_reviews_card_view_all_button,
             action = onViewAllClicked
         ),
-        isError = false,
+        isError = viewState is DashboardReviewsViewModel.ViewState.Error,
         modifier = modifier
     ) {
         when (viewState) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
@@ -7,13 +7,19 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.compose.viewModelWithFactory
+import com.woocommerce.android.ui.dashboard.DashboardFilterableCardHeader
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.defaultHideMenuEntry
+import com.woocommerce.android.ui.reviews.ProductReviewStatus
 
 @Composable
 fun DashboardReviewsCard(
@@ -23,42 +29,107 @@ fun DashboardReviewsCard(
         factory.create(parentViewModel = parentViewModel)
     }
 ) {
+    viewModel.viewState.observeAsState().value?.let { viewState ->
+        DashboardReviewsCard(
+            viewState = viewState,
+            onHideClicked = { parentViewModel.onHideWidgetClicked(DashboardWidget.Type.REVIEWS) },
+            onFilterSelected = viewModel::onFilterSelected,
+            modifier = modifier
+        )
+    }
+}
+
+@Composable
+private fun DashboardReviewsCard(
+    viewState: DashboardReviewsViewModel.ViewState,
+    onHideClicked: () -> Unit,
+    onFilterSelected: (ProductReviewStatus) -> Unit,
+    modifier: Modifier
+) {
     WidgetCard(
         titleResource = DashboardWidget.Type.REVIEWS.titleResource,
         menu = DashboardWidgetMenu(
             listOf(
-                DashboardWidget.Type.REVIEWS.defaultHideMenuEntry {
-                    parentViewModel.onHideWidgetClicked(
-                        DashboardWidget.Type.REVIEWS
-                    )
-                }
+                DashboardWidget.Type.REVIEWS.defaultHideMenuEntry(onHideClicked)
             )
         ),
         isError = false,
         modifier = modifier
     ) {
-        viewModel.viewState.observeAsState().value?.let { viewState ->
-            when (viewState) {
-                is DashboardReviewsViewModel.ViewState.Loading -> {
-                    CircularProgressIndicator()
-                }
+        when (viewState) {
+            is DashboardReviewsViewModel.ViewState.Loading -> {
+                ReviewsLoading(
+                    selectedFilter = viewState.selectedFilter,
+                    onFilterSelected = onFilterSelected,
+                )
+            }
 
-                is DashboardReviewsViewModel.ViewState.Success -> {
-                    Column {
-                        viewState.reviews.forEach { review ->
-                            Text(text = review.review)
-                            Divider()
-                        }
-                    }
-                }
+            is DashboardReviewsViewModel.ViewState.Success -> {
+                ProductReviewsCardContent(
+                    viewState = viewState,
+                    onFilterSelected = onFilterSelected
+                )
+            }
 
-                is DashboardReviewsViewModel.ViewState.Error -> {
-                    WidgetError(
-                        onContactSupportClicked = { /*TODO*/ },
-                        onRetryClicked = { /*TODO*/ }
-                    )
-                }
+            is DashboardReviewsViewModel.ViewState.Error -> {
+                WidgetError(
+                    onContactSupportClicked = { /*TODO*/ },
+                    onRetryClicked = { /*TODO*/ }
+                )
             }
         }
     }
 }
+
+@Composable
+private fun ProductReviewsCardContent(
+    viewState: DashboardReviewsViewModel.ViewState.Success,
+    onFilterSelected: (ProductReviewStatus) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier) {
+        Header(viewState.selectedFilter, onFilterSelected)
+
+        viewState.reviews.forEach { review ->
+            Text(text = review.review.fastStripHtml())
+        }
+    }
+}
+
+@Composable
+private fun ReviewsLoading(
+    selectedFilter: ProductReviewStatus,
+    onFilterSelected: (ProductReviewStatus) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column {
+        Header(selectedFilter, onFilterSelected)
+        CircularProgressIndicator(modifier = modifier)
+    }
+}
+
+@Composable
+private fun Header(
+    selectedFilter: ProductReviewStatus,
+    onFilterSelected: (ProductReviewStatus) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier) {
+        DashboardFilterableCardHeader(
+            title = stringResource(id = R.string.dashboard_reviews_card_header_title),
+            currentFilter = selectedFilter,
+            filterList = supportedFilters,
+            onFilterSelected = onFilterSelected,
+            mapper = { ProductReviewStatus.getLocalizedLabel(LocalContext.current, it) }
+        )
+
+        Divider()
+    }
+}
+
+private val supportedFilters = listOf(
+    ProductReviewStatus.ALL,
+    ProductReviewStatus.APPROVED,
+    ProductReviewStatus.HOLD,
+    ProductReviewStatus.SPAM
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.dashboard.reviews
 
+import android.widget.RatingBar
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -8,7 +9,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -16,13 +19,19 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.model.ProductReview
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.viewModelWithFactory
 import com.woocommerce.android.ui.dashboard.DashboardFilterableCardHeader
@@ -32,6 +41,7 @@ import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.defaultHideMenuEntry
 import com.woocommerce.android.ui.reviews.ProductReviewStatus
+import com.woocommerce.android.util.StringUtils
 
 @Composable
 fun DashboardReviewsCard(
@@ -105,8 +115,89 @@ private fun ProductReviewsCardContent(
         if (viewState.reviews.isEmpty()) {
             EmptyView(selectedFilter = viewState.selectedFilter)
         } else {
-            viewState.reviews.forEach { review ->
-                Text(text = review.review.fastStripHtml())
+            viewState.reviews.forEachIndexed { index, productReview ->
+                ReviewListItem(
+                    review = productReview,
+                    showDivider = index < viewState.reviews.size - 1
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReviewListItem(
+    review: ProductReview,
+    showDivider: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_comment),
+            contentDescription = null,
+            tint = if (review.read == false) {
+                MaterialTheme.colors.primary
+            } else {
+                MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+            }
+        )
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = if (review.product == null) {
+                    stringResource(
+                        R.string.product_review_list_item_title, review.reviewerName
+                    )
+                } else {
+                    stringResource(
+                        R.string.review_list_item_title,
+                        review.reviewerName,
+                        review.product?.name?.fastStripHtml().orEmpty()
+                    )
+                },
+                style = MaterialTheme.typography.subtitle1,
+                color = MaterialTheme.colors.onSurface
+            )
+
+            val reviewText = buildAnnotatedString {
+                if (review.status == ProductReviewStatus.HOLD.toString()) {
+                    withStyle(SpanStyle(color = colorResource(id = R.color.woo_orange_50))) {
+                        append(stringResource(id = R.string.pending_review_label))
+                    }
+
+                    append(" • ")
+                }
+
+                append(StringUtils.getRawTextFromHtml(review.review))
+            }
+
+            Text(
+                text = reviewText,
+                style = MaterialTheme.typography.body2,
+                color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+            )
+
+            if (review.rating > 0) {
+                AndroidView(
+                    factory = { context ->
+                        RatingBar(context, null, androidx.appcompat.R.attr.ratingBarStyleSmall)
+                    },
+                    update = { ratingBar ->
+                        ratingBar.rating = 100F
+                        ratingBar.numStars = review.rating
+                    }
+                )
+            }
+
+            Spacer(modifier = Modifier)
+
+            if (showDivider) {
+                Divider()
             }
         }
     }
@@ -128,8 +219,7 @@ private fun ReviewsLoading(
                 SkeletonView(width = 24.dp, height = 24.dp)
 
                 Column(
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                    modifier = Modifier
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     SkeletonView(width = 260.dp, height = 16.dp)
                     SkeletonView(width = 120.dp, height = 16.dp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
@@ -1,14 +1,24 @@
 package com.woocommerce.android.ui.dashboard.reviews
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.model.DashboardWidget
@@ -90,8 +100,12 @@ private fun ProductReviewsCardContent(
     Column(modifier) {
         Header(viewState.selectedFilter, onFilterSelected)
 
-        viewState.reviews.forEach { review ->
-            Text(text = review.review.fastStripHtml())
+        if (viewState.reviews.isEmpty()) {
+            EmptyView(selectedFilter = viewState.selectedFilter)
+        } else {
+            viewState.reviews.forEach { review ->
+                Text(text = review.review.fastStripHtml())
+            }
         }
     }
 }
@@ -124,6 +138,50 @@ private fun Header(
         )
 
         Divider()
+    }
+}
+
+@Composable
+fun EmptyView(
+    selectedFilter: ProductReviewStatus,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.img_empty_reviews),
+            contentDescription = null,
+            modifier = Modifier.sizeIn(maxWidth = 160.dp, maxHeight = 160.dp)
+        )
+
+        Text(
+            text = stringResource(
+                id = if (selectedFilter == ProductReviewStatus.ALL) {
+                    R.string.empty_review_list_title
+                } else {
+                    R.string.dashboard_reviews_card_empty_title_filtered
+                }
+            ),
+            style = MaterialTheme.typography.h6,
+            textAlign = TextAlign.Center
+        )
+
+        Text(
+            text = stringResource(
+                id = if (selectedFilter == ProductReviewStatus.ALL) {
+                    R.string.empty_review_list_message
+                } else {
+                    R.string.dashboard_reviews_card_empty_message_filtered
+                }
+            ),
+            style = MaterialTheme.typography.body1,
+            textAlign = TextAlign.Center
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
@@ -189,9 +189,7 @@ private fun ReviewListItem(
         ) {
             Text(
                 text = if (review.product == null) {
-                    stringResource(
-                        R.string.product_review_list_item_title, review.reviewerName
-                    )
+                    stringResource(R.string.product_review_list_item_title, review.reviewerName)
                 } else {
                     stringResource(
                         R.string.review_list_item_title,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
@@ -281,7 +281,7 @@ private fun Header(
         DashboardFilterableCardHeader(
             title = stringResource(id = R.string.dashboard_reviews_card_header_title),
             currentFilter = selectedFilter,
-            filterList = supportedFilters,
+            filterList = DashboardReviewsViewModel.supportedFilters,
             onFilterSelected = onFilterSelected,
             mapper = { ProductReviewStatus.getLocalizedLabel(LocalContext.current, it) }
         )
@@ -333,10 +333,3 @@ fun EmptyView(
         )
     }
 }
-
-private val supportedFilters = listOf(
-    ProductReviewStatus.ALL,
-    ProductReviewStatus.APPROVED,
-    ProductReviewStatus.HOLD,
-    ProductReviewStatus.SPAM
-)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
@@ -3,10 +3,11 @@ package com.woocommerce.android.ui.dashboard.reviews
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -22,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.viewModelWithFactory
 import com.woocommerce.android.ui.dashboard.DashboardFilterableCardHeader
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
@@ -116,9 +118,27 @@ private fun ReviewsLoading(
     onFilterSelected: (ProductReviewStatus) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column {
+    Column(modifier) {
         Header(selectedFilter, onFilterSelected)
-        CircularProgressIndicator(modifier = modifier)
+        repeat(3) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            ) {
+                SkeletonView(width = 24.dp, height = 24.dp)
+
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    modifier = Modifier
+                ) {
+                    SkeletonView(width = 260.dp, height = 16.dp)
+                    SkeletonView(width = 120.dp, height = 16.dp)
+                    SkeletonView(width = 60.dp, height = 16.dp)
+                    Spacer(modifier = Modifier)
+                    Divider()
+                }
+            }
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
@@ -14,8 +14,8 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -32,7 +32,10 @@ class DashboardReviewsViewModel @AssistedInject constructor(
     private val status = savedStateHandle.getStateFlow(viewModelScope, ProductReviewStatus.ALL)
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val viewState = combine(refreshTrigger, status) { refresh, status -> Pair(refresh, status) }
+    val viewState = status
+        .flatMapLatest {
+            refreshTrigger.map { refresh -> Pair(refresh, it) }
+        }
         .transformLatest { (refresh, status) ->
             emit(ViewState.Loading(status))
             emitAll(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
@@ -73,7 +73,9 @@ class DashboardReviewsViewModel @AssistedInject constructor(
         forceRefresh: Boolean,
         status: ProductReviewStatus
     ) = flow<Result<List<ProductReview>>> {
-        if (forceRefresh) {
+        val fetchBeforeEmit = forceRefresh || getCachedReviews(status).isEmpty()
+
+        if (fetchBeforeEmit) {
             reviewListRepository.fetchMostRecentReviews(status)
                 .onFailure {
                     emit(Result.failure(it))
@@ -83,7 +85,7 @@ class DashboardReviewsViewModel @AssistedInject constructor(
 
         emit(Result.success(getCachedReviews(status)))
 
-        if (!forceRefresh) {
+        if (!fetchBeforeEmit) {
             reviewListRepository.fetchMostRecentReviews(status)
                 .onFailure {
                     emit(Result.failure(it))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
@@ -28,6 +28,14 @@ class DashboardReviewsViewModel @AssistedInject constructor(
     @Assisted private val parentViewModel: DashboardViewModel,
     private val reviewListRepository: ReviewListRepository
 ) : ScopedViewModel(savedStateHandle) {
+    companion object {
+        val supportedFilters = listOf(
+            ProductReviewStatus.ALL,
+            ProductReviewStatus.APPROVED,
+            ProductReviewStatus.HOLD,
+            ProductReviewStatus.SPAM
+        )
+    }
     private val refreshTrigger = parentViewModel.refreshTrigger
         .onStart { emit(DashboardViewModel.RefreshEvent()) }
     private val status = savedStateHandle.getStateFlow(viewModelScope, ProductReviewStatus.ALL)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.model.ProductReview
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.reviews.ProductReviewStatus
 import com.woocommerce.android.ui.reviews.ReviewListRepository
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.assisted.Assisted
@@ -56,6 +57,10 @@ class DashboardReviewsViewModel @AssistedInject constructor(
         this.status.value = status
     }
 
+    fun onViewAllClicked() {
+        triggerEvent(OpenReviewsList)
+    }
+
     private fun observeMostRecentReviews(
         forceRefresh: Boolean,
         status: ProductReviewStatus
@@ -94,6 +99,8 @@ class DashboardReviewsViewModel @AssistedInject constructor(
 
         data object Error : ViewState
     }
+
+    data object OpenReviewsList : MultiLiveEvent.Event()
 
     @AssistedFactory
     interface Factory {

--- a/WooCommerce/src/main/res/drawable/ic_comment.xml
+++ b/WooCommerce/src/main/res/drawable/ic_comment.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path
-      android:fillColor="@color/color_icon"
+      android:fillColor="@color/color_on_surface_high"
       android:pathData="M12,16l-5,5v-5H5c-1.1,0 -2,-0.9 -2,-2V5c0,-1.1 0.9,-2 2,-2h14c1.1,0 2,0.9 2,2v9c0,1.1 -0.9,2 -2,2h-7z"/>
 </vector>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -87,6 +87,9 @@
         <action
             android:id="@+id/action_dashboard_to_editWidgetsFragment"
             app:destination="@id/dashboardWidgetEditorFragment" />
+        <action
+            android:id="@+id/action_dashboard_to_reviews"
+            app:destination="@id/reviews" />
     </fragment>
     <fragment
         android:id="@+id/orders"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -420,6 +420,8 @@
     <string name="dynamic_dashboard_widget_error_description"><![CDATA[Try reloading this card. If the issue persists, please <a href="support">contact support</a>.]]></string>
 
     <string name="dashboard_reviews_card_header_title">Status</string>
+    <string name="dashboard_reviews_card_empty_title_filtered">No reviews found</string>
+    <string name="dashboard_reviews_card_empty_message_filtered">No reviews match the selected filter, please try changing the filter</string>
     <!--
         Sign Up Flow
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -422,6 +422,7 @@
     <string name="dashboard_reviews_card_header_title">Status</string>
     <string name="dashboard_reviews_card_empty_title_filtered">No reviews found</string>
     <string name="dashboard_reviews_card_empty_message_filtered">No reviews match the selected filter, please try changing the filter</string>
+    <string name="dashboard_reviews_card_view_all_button">View all reviews</string>
     <!--
         Sign Up Flow
     -->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11474 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds the following:
- UI State of the reviews card.
- Content state of reviews card.
- Empty state for the reviews card.
- Logic to navigate to the reviews list from the card.

### Testing instructions
1. Open the app.
2. Enable the reviews card if needed.
3. Confirm the card works correctly.
4. Change the filter option.
5. Confirm the list of reviews shown is updated accordingly.

### Images/gif
<img src="https://github.com/woocommerce/woocommerce-android/assets/1657201/7c6084cf-ff52-4d3b-9666-6a929bcbb711" width=400 />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
