### PR TITLE
[Woo Pos] FF, entry point and empty pos activity

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -14,8 +14,10 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACTION_OPEN_DOCUMENT" />
     <uses-permission android:name="android.permission.NFC" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
     <uses-permission android:name="android.permission.CAMERA" />
 
     <queries>
@@ -47,16 +49,17 @@
         <activity
             android:name=".ui.main.MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.Woo.Splash"
-            android:windowSoftInputMode="adjustResize"
-            android:launchMode="singleTop">
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <meta-data android:name="android.app.shortcuts"
+            <meta-data
+                android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />
 
             <intent-filter android:autoVerify="true">
@@ -65,19 +68,20 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
 
-                <data android:scheme="https"/>
+                <data android:scheme="https" />
 
-                <data android:host="woocommerce.com"/>
+                <data android:host="woocommerce.com" />
 
-                <data android:path="/mobile/orders/details"/>
-                <data android:path="/mobile/payments"/>
-                <data android:path="/mobile/payments/tap-to-pay"/>
-                <data android:pathPrefix="/products/hardware/"/>
+                <data android:path="/mobile/orders/details" />
+                <data android:path="/mobile/payments" />
+                <data android:path="/mobile/payments/tap-to-pay" />
+                <data android:pathPrefix="/products/hardware/" />
             </intent-filter>
 
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
-                <action android:name="android.intent.action.SEND_MULTIPLE"/>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />
             </intent-filter>
@@ -94,15 +98,15 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="woocommerce"/>
-                <data android:host="jetpack-connected"/>
+                <data android:scheme="woocommerce" />
+                <data android:host="jetpack-connected" />
                 <data android:host="app-login" />
             </intent-filter>
         </activity>
         <activity
             android:name=".ui.login.MagicLinkInterceptActivity"
-            android:theme="@style/LoginTheme"
-            android:exported="true">
+            android:exported="true"
+            android:theme="@style/LoginTheme">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -155,7 +159,8 @@
         <activity
             android:name="com.google.mlkit.vision.codescanner.internal.GmsBarcodeScanningDelegateActivity"
             android:screenOrientation="unspecified"
-            tools:replace="android:screenOrientation"/>
+            tools:replace="android:screenOrientation" />
+        <activity android:name="com.woocommerce.android.ui.woopos.root.WooPosActivity" />
 
         <!-- Stats today app widget -->
         <meta-data
@@ -201,8 +206,8 @@
 
         <service
             android:name=".media.ProductImagesJobService"
-            android:permission="android.permission.BIND_JOB_SERVICE"
-            android:exported="false" />
+            android:exported="false"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
 
         <!-- Provider for exposing file URIs on Android 7+ (required for camera) -->
         <provider
@@ -229,17 +234,22 @@
             android:name="com.google.mlkit.vision.DEPENDENCIES"
             android:value="barcode_ui,ocr" />
 
-        <meta-data android:name="io.sentry.traces.activity.enable" android:value="false" />
+        <meta-data
+            android:name="io.sentry.traces.activity.enable"
+            android:value="false" />
 
         <!-- Trigger Google Play services to install the backported photo picker module. -->
-        <service android:name="com.google.android.gms.metadata.ModuleDependencies"
+        <service
+            android:name="com.google.android.gms.metadata.ModuleDependencies"
             android:enabled="false"
             android:exported="false"
             tools:ignore="MissingClass">
             <intent-filter>
                 <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
             </intent-filter>
-            <meta-data android:name="photopicker_activity:0:required" android:value="" />
+            <meta-data
+                android:name="photopicker_activity:0:required"
+                android:value="" />
         </service>
 
     </application>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.moremenu
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -20,6 +21,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.NavigateToSettingsEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.NavigateToSubscriptionsEvent
+import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.NavigateToWooPosEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.OpenBlazeCampaignCreationEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.OpenBlazeCampaignListEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.StartSitePickerEvent
@@ -30,6 +32,7 @@ import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewP
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewReviewsEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuViewModel.MoreMenuEvent.ViewStoreEvent
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
+import com.woocommerce.android.ui.woopos.root.WooPosActivity
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -99,9 +102,15 @@ class MoreMenuFragment : TopLevelFragment() {
                 is ViewPayments -> navigateToPayments()
                 is OpenBlazeCampaignCreationEvent -> openBlazeCreationFlow()
                 is OpenBlazeCampaignListEvent -> openBlazeCampaignList()
+                is NavigateToWooPosEvent -> openWooPos()
             }
         }
     }
+
+    private fun openWooPos() {
+        startActivity(Intent(requireContext(), WooPosActivity::class.java))
+    }
+
     private fun openBlazeCampaignList() {
         findNavController().navigateSafely(
             MoreMenuFragmentDirections.actionMoreMenuToBlazeCampaignListFragment()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.payments.taptopay.isAvailable
 import com.woocommerce.android.ui.plans.domain.SitePlan
 import com.woocommerce.android.ui.plans.repository.SitePlanRepository
+import com.woocommerce.android.ui.woopos.IsWooPosEnabled
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -57,6 +58,7 @@ class MoreMenuViewModel @Inject constructor(
     private val moreMenuNewFeatureHandler: MoreMenuNewFeatureHandler,
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
     private val isBlazeEnabled: IsBlazeEnabled,
+    private val isWooPosAvailable: IsWooPosEnabled,
 ) : ScopedViewModel(savedState) {
     val moreMenuViewState =
         combine(
@@ -133,6 +135,14 @@ class MoreMenuViewModel @Inject constructor(
             icon = R.drawable.ic_more_menu_inbox,
             isEnabled = moreMenuRepository.isInboxEnabled(),
             onClick = ::onInboxButtonClick
+        ),
+        MenuUiButton(
+            title = R.string.more_menu_button_woo_pos,
+            description = R.string.more_menu_button_woo_pos_description,
+            icon = R.drawable.ic_more_menu_payments,
+            isEnabled = isWooPosAvailable(),
+            onClick = {
+            }
         )
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -142,6 +142,7 @@ class MoreMenuViewModel @Inject constructor(
             icon = R.drawable.ic_more_menu_payments,
             isEnabled = isWooPosEnabled(),
             onClick = {
+                triggerEvent(MoreMenuEvent.NavigateToWooPosEvent)
             }
         )
     )
@@ -326,5 +327,6 @@ class MoreMenuViewModel @Inject constructor(
         object ViewReviewsEvent : MoreMenuEvent()
         object ViewInboxEvent : MoreMenuEvent()
         object ViewCouponsEvent : MoreMenuEvent()
+        object NavigateToWooPosEvent : MoreMenuEvent()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -58,7 +58,7 @@ class MoreMenuViewModel @Inject constructor(
     private val moreMenuNewFeatureHandler: MoreMenuNewFeatureHandler,
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
     private val isBlazeEnabled: IsBlazeEnabled,
-    private val isWooPosAvailable: IsWooPosEnabled,
+    private val isWooPosEnabled: IsWooPosEnabled,
 ) : ScopedViewModel(savedState) {
     val moreMenuViewState =
         combine(
@@ -140,7 +140,7 @@ class MoreMenuViewModel @Inject constructor(
             title = R.string.more_menu_button_woo_pos,
             description = R.string.more_menu_button_woo_pos_description,
             icon = R.drawable.ic_more_menu_payments,
-            isEnabled = isWooPosAvailable(),
+            isEnabled = isWooPosEnabled(),
             onClick = {
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
@@ -3,6 +3,6 @@ package com.woocommerce.android.ui.woopos
 import com.woocommerce.android.util.FeatureFlag
 import javax.inject.Inject
 
-class WooPosFeatureFlagEnabled @Inject constructor() {
-    fun isEnabled() = FeatureFlag.WOO_POS.isEnabled()
+class IsWooPosEnabled @Inject constructor() {
+    operator fun invoke() = FeatureFlag.WOO_POS.isEnabled()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPosFeatureFlagEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPosFeatureFlagEnabled.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.woopos
+
+import com.woocommerce.android.util.FeatureFlag
+import javax.inject.Inject
+
+class WooPosFeatureFlagEnabled @Inject constructor() {
+    fun isEnabled() = FeatureFlag.WOO_POS.isEnabled()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -1,0 +1,29 @@
+package com.woocommerce.android.ui.woopos.root
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+class WooPosActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            Box(
+                Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "Woo POS!",
+                    style = MaterialTheme.typography.h3,
+                    color = MaterialTheme.colors.primary,
+                )
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -6,6 +6,7 @@ import android.content.Context
  * "Feature flags" are used to hide in-progress features from release versions
  */
 enum class FeatureFlag {
+    WOO_POS,
     DB_DOWNGRADE,
     MORE_MENU_INBOX,
     WC_SHIPPING_BANNER,
@@ -28,6 +29,7 @@ enum class FeatureFlag {
 
             OTHER_PAYMENT_METHODS,
             MORE_MENU_INBOX,
+            WOO_POS,
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3660,6 +3660,9 @@
     <string name="more_menu_button_settings">Settings</string>
     <string name="more_menu_button_settings_description">Update your preferences</string>
 
+    <string name="more_menu_button_woo_pos">Woo Pos</string>
+    <string name="more_menu_button_woo_pos_description">Temporary entry point to POS mode</string>
+
     <!--
     Composite products
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
 import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.plans.domain.SitePlan
 import com.woocommerce.android.ui.plans.repository.SitePlanRepository
+import com.woocommerce.android.ui.woopos.IsWooPosEnabled
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -72,6 +73,9 @@ class MoreMenuViewModelTests : BaseUnitTest() {
     private val isBlazeEnabled: IsBlazeEnabled = mock {
         onBlocking { invoke() } doReturn true
     }
+    private val isWooPosEnabled: IsWooPosEnabled = mock {
+        on { invoke() } doReturn true
+    }
 
     private val blazeCampaignsStore: BlazeCampaignsStore = mock()
 
@@ -92,6 +96,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             blazeCampaignsStore = blazeCampaignsStore,
             tapToPayAvailabilityStatus = tapToPayAvailabilityStatus,
             isBlazeEnabled = isBlazeEnabled,
+            isWooPosEnabled = isWooPosEnabled,
         )
     }
 
@@ -401,5 +406,36 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         }.last()
 
         assertThat(event).isEqualTo(MoreMenuViewModel.MoreMenuEvent.OpenBlazeCampaignListEvent)
+    }
+
+    @Test
+    fun `given isWooPosEnabled returns false, when building state, then WooPOS button is not displayed`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(isWooPosEnabled.invoke()).thenReturn(false)
+            }
+
+            // WHEN
+            val states = viewModel.moreMenuViewState.captureValues()
+
+            // THEN
+            assertThat(states.last().generalMenuItems.first { it.title == R.string.more_menu_button_woo_pos }.isEnabled)
+                .isFalse()
+        }
+
+    @Test
+    fun `given isWooPosEnabled returns true, when building state, then WooPOS button is displayed`() = testBlocking {
+        // GIVEN
+        setup {
+            whenever(isWooPosEnabled.invoke()).thenReturn(true)
+        }
+
+        // WHEN
+        val states = viewModel.moreMenuViewState.captureValues()
+
+        // THEN
+        assertThat(states.last().generalMenuItems.first { it.title == R.string.more_menu_button_woo_pos }.isEnabled)
+            .isTrue()
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11494
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds:
* POS FF
* POS button that visible when FF is on in the "more" screen
* Dummy POS activity

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
* Make sure that in release mode the POS button is not visible and visible and opens POS activity in debug mode

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/4923871/66038a7f-2332-40bc-b772-f39b501459ed



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
