### PR TITLE
[Dynamic Dashboard] Navigate to reviews details from reviews card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
@@ -72,6 +72,10 @@ class DashboardReviewsViewModel @AssistedInject constructor(
         triggerEvent(OpenReviewsList)
     }
 
+    fun onReviewClicked(review: ProductReview) {
+        triggerEvent(OpenReviewDetail(review))
+    }
+
     fun onRetryClicked() {
         _refreshTrigger.tryEmit(DashboardViewModel.RefreshEvent())
     }
@@ -118,6 +122,7 @@ class DashboardReviewsViewModel @AssistedInject constructor(
     }
 
     data object OpenReviewsList : MultiLiveEvent.Event()
+    data class OpenReviewDetail(val review: ProductReview) : MultiLiveEvent.Event()
 
     @AssistedFactory
     interface Factory {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
@@ -40,8 +40,7 @@ class DashboardReviewsViewModel @AssistedInject constructor(
         val supportedFilters = listOf(
             ProductReviewStatus.ALL,
             ProductReviewStatus.APPROVED,
-            ProductReviewStatus.HOLD,
-            ProductReviewStatus.SPAM
+            ProductReviewStatus.HOLD
         )
     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -419,7 +419,7 @@
             app:argType="long" />
         <argument
             android:name="tempStatus"
-            android:defaultValue="null"
+            android:defaultValue="@null"
             app:argType="string"
             app:nullable="true" />
         <argument


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11474 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds logic for navigating to the review details from the reviews card, please check the comments for more details on the approach.

### Testing instructions
1. Open the app.
2. Make sure the reviews card is enabled in the dashboard.
3. Click on one of the reviews.
4. Confirm it opens the review details.
5. Click on "Approve/Approved" to change the review's status.
6. Go back to the dashboard by tapping on back twice.
7. Confirm the review status was updated accordingly.

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/1657201/8a287d25-09ac-46e4-b79d-bd4f03befdea



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
