### PR TITLE
[Tooling] Run Danger on the Linter Agent

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,6 +21,16 @@ steps:
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
 
+  - label: "☢️ Danger - PR Check"
+    command: danger
+    key: danger
+    if: "build.pull_request.id != null"
+    retry:
+      manual:
+        permit_on_passed: true
+    agents:
+      queue: "linter"
+
   - label: "detekt"
     command: |
       echo "--- 🧹 Linting"

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -1,13 +1,17 @@
-name: ☢️ Danger
+name: ☢️ Trigger Danger On Buildkite
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize, edited, labeled, unlabeled, milestoned, demilestoned]
+    types: [labeled, unlabeled, milestoned, demilestoned]
 
 jobs:
   dangermattic:
-    # runs on draft PRs only for opened / synchronize events
-    if: ${{ (github.event.pull_request.draft == false) || (github.event.pull_request.draft == true && contains(fromJSON('["opened", "synchronize"]'), github.event.action)) }}
-    uses: Automattic/dangermattic/.github/workflows/reusable-run-danger.yml@v1.0.0
+    if: ${{ (github.event.pull_request.draft == false) }}
+    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1.1.0
+    with:
+      org-slug: "automattic"
+      pipeline-slug: "woocommerce-android"
+      retry-step-key: "danger"
+      build-commit-sha: "${{ github.event.pull_request.head.sha }}"
     secrets:
-      github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN }}
+      buildkite-api-token: ${{ secrets.TRIGGER_BK_BUILD_TOKEN }}

--- a/Dangerfile
+++ b/Dangerfile
@@ -3,7 +3,8 @@
 github.dismiss_out_of_range_messages
 
 # `files: []` forces rubocop to scan all files, not just the ones modified in the PR
-rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inline_comment: true, include_cop_names: true)
+# Added a custom `rubocop_cmd` to prevent RuboCop from running using `bundle exec`, which we don't want on the linter agent
+rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inline_comment: true, include_cop_names: true, rubocop_cmd: ': | rubocop')
 
 manifest_pr_checker.check_gemfile_lock_updated
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -3,8 +3,8 @@
 github.dismiss_out_of_range_messages
 
 # `files: []` forces rubocop to scan all files, not just the ones modified in the PR
-# Added a custom `rubocop_cmd` to prevent RuboCop from running using `bundle exec`, which we don't want on the linter agent
-rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inline_comment: true, include_cop_names: true, rubocop_cmd: ': | rubocop')
+# Prevent RuboCop from running using `bundle exec`, which we don't want on the linter agent
+rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inline_comment: true, include_cop_names: true, skip_bundle_exec: true)
 
 manifest_pr_checker.check_gemfile_lock_updated
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'danger-dangermattic', '~> 1.0'
+gem 'danger-dangermattic', '~> 1.1'
 gem 'fastlane', '~> 2.216'
 gem 'nokogiri'
 gem 'rubocop', '~> 1.60'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,14 +66,14 @@ GEM
       no_proxy_fix
       octokit (>= 4.0)
       terminal-table (>= 1, < 4)
-    danger-dangermattic (1.0.2)
+    danger-dangermattic (1.1.1)
       danger (~> 9.4)
       danger-plugin-api (~> 1.0)
-      danger-rubocop (~> 0.12)
-      rubocop (~> 1.61)
+      danger-rubocop (~> 0.13)
+      rubocop (~> 1.63)
     danger-plugin-api (1.0.0)
       danger (> 2.0)
-    danger-rubocop (0.12.0)
+    danger-rubocop (0.13.0)
       danger
       rubocop (~> 1.0)
     declarative (0.0.20)
@@ -277,7 +277,7 @@ GEM
     rexml (3.2.6)
     rmagick (4.3.0)
     rouge (2.0.7)
-    rubocop (1.62.1)
+    rubocop (1.63.5)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -336,7 +336,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  danger-dangermattic (~> 1.0)
+  danger-dangermattic (~> 1.1)
   fastlane (~> 2.216)
   fastlane-plugin-wpmreleasetoolkit (~> 9.2)
   nokogiri


### PR DESCRIPTION
This PR uses the new Linter Agent on Buildkite to run the Danger jobs.

Because Danger will now run on Buildkite, this PR uses a new GitHub Actions workflow (see https://github.com/Automattic/dangermattic/pull/64 for more details) to retry the Buildkite jobs when the PR state (such as the milestone and labels) changes.