### PR TITLE
[Woo Pos] WooPosActivity exported in debug to make it possible to start from AS

### DIFF
--- a/WooCommerce/src/debug/AndroidManifest.xml
+++ b/WooCommerce/src/debug/AndroidManifest.xml
@@ -41,6 +41,11 @@
             android:exported="true"
             android:theme="@style/Theme.Woo" />
 
+        <activity
+            android:name="com.woocommerce.android.ui.woopos.root.WooPosActivity"
+            android:exported="true"
+            tools:replace="android:exported" />
+
     </application>
 
 </manifest>

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -160,7 +160,9 @@
             android:name="com.google.mlkit.vision.codescanner.internal.GmsBarcodeScanningDelegateActivity"
             android:screenOrientation="unspecified"
             tools:replace="android:screenOrientation" />
-        <activity android:name="com.woocommerce.android.ui.woopos.root.WooPosActivity" />
+        <activity
+            android:name="com.woocommerce.android.ui.woopos.root.WooPosActivity"
+            android:exported="false" />
 
         <!-- Stats today app widget -->
         <meta-data


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11501 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

WooPosActivity exported in debug to make it possible to start from AS

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Using run configuration:
* Notice that in debug mode Woo activity starts right away
* Notice that in release mode it doesn't start

<img width="960" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/4923871/b52feed5-f830-450b-ab59-d0d095ec3d5c">


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
