### PR TITLE
[Dynamic Dashboard] Improvements to the custom range selection logic

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -861,11 +861,11 @@ object AppPrefs {
 
     fun getActiveStatsTab() = getString(DeletablePrefKey.ACTIVE_STATS_GRANULARITY)
 
-    fun setActiveTopPerformersGranularity(selectionName: String) {
+    fun setActiveTopPerformersTab(selectionName: String) {
         setString(DeletablePrefKey.ACTIVE_TOP_PERFORMERS_GRANULARITY, selectionName)
     }
 
-    fun getActiveTopPerformersGranularity() = getString(DeletablePrefKey.ACTIVE_TOP_PERFORMERS_GRANULARITY)
+    fun getActiveTopPerformersTab() = getString(DeletablePrefKey.ACTIVE_TOP_PERFORMERS_GRANULARITY)
 
     fun setCustomDomainsSource(source: String) {
         setString(DeletablePrefKey.CUSTOM_DOMAINS_SOURCE, source)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -212,12 +212,12 @@ class AppPrefsWrapper @Inject constructor() {
     fun getActiveStoreStatsTab() =
         AppPrefs.getActiveStatsTab()
 
-    fun setActiveTopPerformersGranularity(selectionName: String) {
-        AppPrefs.setActiveTopPerformersGranularity(selectionName)
+    fun setActiveTopPerformersTab(selectionName: String) {
+        AppPrefs.setActiveTopPerformersTab(selectionName)
     }
 
-    fun getActiveTopPerformersGranularity() =
-        AppPrefs.getActiveTopPerformersGranularity()
+    fun getActiveTopPerformersTab() =
+        AppPrefs.getActiveTopPerformersTab()
 
     fun setCustomDomainsSource(source: DomainFlowSource) {
         AppPrefs.setCustomDomainsSource(source.name)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
@@ -115,12 +115,13 @@ class DashboardStatsViewModel @AssistedInject constructor(
 
     fun onTabSelected(selectionType: SelectionType) {
         usageTracksEventEmitter.interacted()
-        appPrefsWrapper.setActiveStatsTab(selectionType.name)
-
-        if (selectionType == SelectionType.CUSTOM) {
+        if (selectionType != SelectionType.CUSTOM) {
+            appPrefsWrapper.setActiveStatsTab(selectionType.name)
+        } else {
             if (dateRangeState.value?.customRange == null) {
                 onAddCustomRangeClicked()
             } else {
+                appPrefsWrapper.setActiveStatsTab(SelectionType.CUSTOM.name)
                 analyticsTrackerWrapper.track(
                     AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_TAB_SELECTED
                 )
@@ -136,11 +137,11 @@ class DashboardStatsViewModel @AssistedInject constructor(
             )
         )
 
-        if (dateRangeState.value?.rangeSelection?.selectionType != SelectionType.CUSTOM) {
-            onTabSelected(SelectionType.CUSTOM)
-        }
         viewModelScope.launch {
             customDateRangeDataStore.updateDateRange(range)
+            if (dateRangeState.value?.rangeSelection?.selectionType != SelectionType.CUSTOM) {
+                onTabSelected(SelectionType.CUSTOM)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/GetSelectedRangeForTopPerformers.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/GetSelectedRangeForTopPerformers.kt
@@ -13,6 +13,6 @@ class GetSelectedRangeForTopPerformers @Inject constructor(
 ) : GetSelectedDateRange(appPrefs, customDateRangeDataStore, dateUtils) {
     override fun getSelectedRange(): SelectionType =
         runCatching {
-            SelectionType.valueOf(appPrefs.getActiveTopPerformersGranularity())
+            SelectionType.valueOf(appPrefs.getActiveTopPerformersTab())
         }.getOrDefault(SelectionType.TODAY)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
@@ -158,12 +158,12 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
     fun onTabSelected(selectionType: SelectionType) {
         usageTracksEventEmitter.interacted()
         if (selectionType != SelectionType.CUSTOM) {
-            appPrefsWrapper.setActiveTopPerformersGranularity(selectionType.name)
+            appPrefsWrapper.setActiveTopPerformersTab(selectionType.name)
         } else {
             if (selectedDateRange.value?.customRange == null) {
                 onEditCustomRangeTapped()
             } else {
-                appPrefsWrapper.setActiveTopPerformersGranularity(SelectionType.CUSTOM.name)
+                appPrefsWrapper.setActiveTopPerformersTab(SelectionType.CUSTOM.name)
                 analyticsTrackerWrapper.track(AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_TAB_SELECTED)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -90,11 +90,11 @@ fun DashboardTopPerformersWidgetCard(
                 )
 
                 else -> DashboardTopPerformersContent(
-                    topPerformersState,
-                    selectedDateRange,
-                    lastUpdateState,
-                    topPerformersViewModel::onGranularityChanged,
-                    topPerformersViewModel::onEditCustomRangeTapped
+                    topPerformersState = topPerformersState,
+                    selectedDateRange = selectedDateRange,
+                    lastUpdateState = lastUpdateState,
+                    onTabSelected = topPerformersViewModel::onTabSelected,
+                    onEditCustomRangeTapped = topPerformersViewModel::onEditCustomRangeTapped
                 )
             }
         }
@@ -120,7 +120,7 @@ fun DashboardTopPerformersContent(
     topPerformersState: TopPerformersState?,
     selectedDateRange: TopPerformersDateRange?,
     lastUpdateState: String?,
-    onGranularityChanged: (SelectionType) -> Unit,
+    onTabSelected: (SelectionType) -> Unit,
     onEditCustomRangeTapped: () -> Unit,
 ) {
     Column {
@@ -129,7 +129,7 @@ fun DashboardTopPerformersContent(
                 rangeSelection = it.rangeSelection,
                 dateFormatted = it.dateFormatted,
                 onCustomRangeClick = onEditCustomRangeTapped,
-                onTabSelected = onGranularityChanged
+                onTabSelected = onTabSelected
             )
         }
         Divider(modifier = Modifier.padding(bottom = 16.dp))
@@ -377,6 +377,7 @@ private fun TopPerformersWidgetCardPreview() {
             calendar = Calendar.getInstance(),
             locale = Locale.getDefault(),
         ),
+        customRange = null,
         dateFormatted = "Today"
     )
     val topPerformersState = TopPerformersState(
@@ -420,28 +421,28 @@ private fun TopPerformersWidgetCardPreview() {
             topPerformersState = topPerformersState,
             lastUpdateState = "Last update: 8:52 AM",
             selectedDateRange = selectedDateRange,
-            onGranularityChanged = {},
+            onTabSelected = {},
             onEditCustomRangeTapped = {}
         )
         DashboardTopPerformersContent(
             topPerformersState = topPerformersState.copy(isLoading = true),
             lastUpdateState = "Last update: 8:52 AM",
             selectedDateRange = selectedDateRange,
-            onGranularityChanged = {},
+            onTabSelected = {},
             onEditCustomRangeTapped = {}
         )
         DashboardTopPerformersContent(
             topPerformersState = topPerformersState.copy(isError = true),
             lastUpdateState = "Last update: 8:52 AM",
             selectedDateRange = selectedDateRange,
-            onGranularityChanged = {},
+            onTabSelected = {},
             onEditCustomRangeTapped = {}
         )
         DashboardTopPerformersContent(
             topPerformersState = topPerformersState.copy(topPerformers = emptyList()),
             lastUpdateState = "Last update: 8:52 AM",
             selectedDateRange = selectedDateRange,
-            onGranularityChanged = {},
+            onTabSelected = {},
             onEditCustomRangeTapped = {}
         )
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11509 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes the logic of the custom range in the top performers card, the logic is as follows now:
When selecting the custom ranges dropdown entry, if a custom range has already been saved, it will be used directly; otherwise, the date picker will be shown.

The PR also fixes an issue where dismissing the date picker would not cancel the change to the "Custom Range" entry.

### Testing instructions
1. Clear the app's data for the following steps (you can alternatively remove the datastore files from the storage).
2. Open the app.
3. In the performance card, tap on the range button.
4. Select "Custom Range"
5. Confirm the date picker is shown.
6. Dismiss it.
7. Confirm the range didn't change.
8. Re-select "Custom Range"
9. Choose a range in the date picker.
10. Confirm the range was updated.
11. Switch to a different range.
12. Switch to the "Custom range"
13. Confirm the previous range is applied automatically.
14. Repeat 3 to 13 for the top performers card.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
