### PR TITLE
[UI Tests] Removed the currency code check.

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/login/SiteAddressScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/login/SiteAddressScreen.kt
@@ -7,6 +7,7 @@ class SiteAddressScreen : Screen {
     constructor() : super(org.wordpress.android.login.R.id.input)
 
     fun proceedWith(siteAddress: String): EmailAddressScreen {
+        clickOn(org.wordpress.android.login.R.id.input)
         typeTextInto(org.wordpress.android.login.R.id.input, siteAddress)
         clickOn(R.id.bottom_button)
 

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
@@ -120,7 +120,9 @@ class ProductListScreen : Screen {
                 ViewMatchers.withChild(
                     Matchers.allOf(
                         ViewMatchers.withId(R.id.productStockAndStatus),
-                        ViewMatchers.withText(Matchers.containsString("${product.stockStatus}${product.variations} • ")),
+                        ViewMatchers.withText(
+                            Matchers.containsString("${product.stockStatus}${product.variations} • ")
+                        ),
                         ViewMatchers.withText(Matchers.containsString(product.priceDiscountedRaw))
                     )
                 ),

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/products/ProductListScreen.kt
@@ -120,10 +120,8 @@ class ProductListScreen : Screen {
                 ViewMatchers.withChild(
                     Matchers.allOf(
                         ViewMatchers.withId(R.id.productStockAndStatus),
-                        ViewMatchers.withText(
-                            "${product.stockStatus}${product.variations} • \$${product.priceDiscountedRaw}.00"
-
-                        )
+                        ViewMatchers.withText(Matchers.containsString("${product.stockStatus}${product.variations} • ")),
+                        ViewMatchers.withText(Matchers.containsString(product.priceDiscountedRaw))
                     )
                 ),
                 ViewMatchers.withChild(


### PR DESCRIPTION
### Description
This PR addresses two issues:
1. cad76b13c3a0608d01ea4de80ca9922857733b51 In certain cases the currency code might not be displayed in the products list. Since this happens in the test env only, it's not considered an issue. More details in p1715691662649999-slack-C6H8C3G23. The fix is removing the check for currency code and the `.00` ending in the price:

<img width="365" alt="Screenshot 2024-05-15 at 23 14 35" src="https://github.com/woocommerce/woocommerce-android/assets/73365754/46f0abdf-36bc-43f3-80e0-66096145f698">

2. da431ed3dd60022ace8cf0382f8b360283a86730 A known "Nuage Laboratoire" account issue - wordpress-mobile/WordPress-Android/pull/16993 - started taking place in WCAndroid tests too. I attempt a similar fix to address it.

<img width="283" alt="Screenshot 2024-05-15 at 23 12 27" src="https://github.com/woocommerce/woocommerce-android/assets/73365754/5bd258b1-1b17-482f-8069-5a65a4fdf502">


### Testing instructions
- CI is 🟢