### PR TITLE
Add check if plugin setup is completed

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
@@ -41,5 +41,5 @@ class IsWooPosEnabled @Inject constructor(
 
     private fun isPluginSetupEnabled(paymentAccount: WCPaymentAccountResult): Boolean =
         paymentAccount.status == WCPaymentAccountResult.WCPaymentAccountStatus.COMPLETE ||
-                paymentAccount.status == WCPaymentAccountResult.WCPaymentAccountStatus.ENABLED
+            paymentAccount.status == WCPaymentAccountResult.WCPaymentAccountStatus.ENABLED
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
@@ -35,10 +35,11 @@ class IsWooPosEnabled @Inject constructor(
                 ippPlugin == WOOCOMMERCE_PAYMENTS &&
                 paymentAccount.storeCurrencies.default.lowercase() == "usd" &&
                 isWindowSizeExpandedAndBigger() &&
-                isPluginSetupCompleted(paymentAccount)
+                isPluginSetupEnabled(paymentAccount)
             ).also { cachedResult = it }
     }
 
-    private fun isPluginSetupCompleted(paymentAccount: WCPaymentAccountResult): Boolean =
-        paymentAccount.status == WCPaymentAccountResult.WCPaymentAccountStatus.COMPLETE
+    private fun isPluginSetupEnabled(paymentAccount: WCPaymentAccountResult): Boolean =
+        paymentAccount.status == WCPaymentAccountResult.WCPaymentAccountStatus.COMPLETE ||
+                paymentAccount.status == WCPaymentAccountResult.WCPaymentAccountStatus.ENABLED
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
 import com.woocommerce.android.util.IsWindowClassExpandedAndBigger
+import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
 import javax.inject.Inject
@@ -33,7 +34,11 @@ class IsWooPosEnabled @Inject constructor(
             countryCode.lowercase() == "us" &&
                 ippPlugin == WOOCOMMERCE_PAYMENTS &&
                 paymentAccount.storeCurrencies.default.lowercase() == "usd" &&
-                isWindowSizeExpandedAndBigger()
+                isWindowSizeExpandedAndBigger() &&
+                isPluginSetupCompleted(paymentAccount)
             ).also { cachedResult = it }
     }
+
+    private fun isPluginSetupCompleted(paymentAccount: WCPaymentAccountResult): Boolean =
+        paymentAccount.status == WCPaymentAccountResult.WCPaymentAccountStatus.COMPLETE
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabledTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabledTest.kt
@@ -87,6 +87,13 @@ class IsWooPosEnabledTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given woo payments setup not completed, then return false`() = testBlocking {
+        val result = buildPaymentAccountResult(status = WCPaymentAccountResult.WCPaymentAccountStatus.NO_ACCOUNT)
+        whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
+        assertFalse(sut())
+    }
+
+    @Test
     fun `given big enough screen, woo payments enabled, USD currency and store in the US, then return true`() = testBlocking {
         val result = buildPaymentAccountResult(defaultCurrency = "USD", countryCode = "US", status = COMPLETE)
         whenever(ippStore.loadAccount(any(), any())).thenReturn(result)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabledTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabledTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.COMPLETE
+import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.ENABLED
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.StoreCurrencies
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
@@ -87,7 +88,7 @@ class IsWooPosEnabledTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given woo payments setup not completed, then return false`() = testBlocking {
+    fun `given woo payments setup not completed or enabled, then return false`() = testBlocking {
         val result = buildPaymentAccountResult(status = WCPaymentAccountResult.WCPaymentAccountStatus.NO_ACCOUNT)
         whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
         assertFalse(sut())
@@ -96,6 +97,13 @@ class IsWooPosEnabledTest : BaseUnitTest() {
     @Test
     fun `given big enough screen, woo payments enabled, USD currency and store in the US, then return true`() = testBlocking {
         val result = buildPaymentAccountResult(defaultCurrency = "USD", countryCode = "US", status = COMPLETE)
+        whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
+        assertTrue(sut())
+    }
+
+    @Test
+    fun `given big enough screen, woo payments enabled, USD currency, store in the US, and status enabled, then return true`() = testBlocking {
+        val result = buildPaymentAccountResult(defaultCurrency = "USD", countryCode = "US", status = ENABLED)
         whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
         assertTrue(sut())
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
This PR updates conditions to show the POS entry point - now it's required that Woo Payments onboarding is complete.
Context: p91TBi-beb-p2#comment-12134

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
* Verify "Woo POS" button is visible in the menu more screen if the Woo Payments onboarding is completed (plus other conditions are met – big screen size, USD currency, US location, and Woo Payments plugin activated)
* You can also verify the button is not present in case onboarding is not completed

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->