### PR TITLE
[Dynamic Dashboard] Fix date header layout to work better with large fonts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 18.7
 -----
 - [*] Products: Fixed a bug that caused the app to crash sometimes during screen rotation [https://github.com/woocommerce/woocommerce-android/pull/11484]
+- [*] Dashboard: Fixed an issue that caused the date range picker to be invisible when using large fonts [https://github.com/woocommerce/woocommerce-android/pull/11552]
 
 18.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsHeader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsHeader.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
@@ -56,12 +57,14 @@ fun DashboardStatsHeader(
             style = MaterialTheme.typography.body2,
             color = MaterialTheme.colors.onSurface
         )
-        val isCustomRange = rangeSelection.selectionType == SelectionType.CUSTOM
 
+        val isCustomRange = rangeSelection.selectionType == SelectionType.CUSTOM
         Row(
             horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = dimen.minor_100)),
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
+                .weight(1f)
+                .wrapContentSize(align = Alignment.CenterStart)
                 .then(if (isCustomRange) Modifier.clickable(onClick = onCustomRangeClick) else Modifier)
                 .padding(dimensionResource(id = dimen.minor_100))
         ) {
@@ -72,7 +75,8 @@ fun DashboardStatsHeader(
                     MaterialTheme.colors.primary
                 } else {
                     MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
-                }
+                },
+                modifier = Modifier.weight(1f, fill = false)
             )
             if (isCustomRange) {
                 Icon(
@@ -83,8 +87,6 @@ fun DashboardStatsHeader(
                 )
             }
         }
-
-        Spacer(modifier = Modifier.weight(1f))
 
         Box {
             var isMenuExpanded by remember { mutableStateOf(false) }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11551 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR just fixes the layout of the date header we use in the dynamic dashboard to work better with large fonts.

### Testing instructions
1. Enable large fonts on your phone (from the Accessibility or Display settings).
2. Open the app.
3. Make sure the Peformance card is enabled.
4. Choose a custom range.
5. Confirm the calendar button is still visible.

### Images/gif
<img width=360 src="https://github.com/woocommerce/woocommerce-android/assets/1657201/4420edaa-be09-478a-a882-2732ecf1f301"/>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
