### PR TITLE
Issue/11546 fix visitor stats for custom ranges

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/stats/stats_visits-day.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/stats/stats_visits-day.json
@@ -7,7 +7,7 @@
                 "equalTo": "day"
             },
             "quantity": {
-                "matches": "[0-9]+"
+                "equalTo": "1"
             },
             "date": {
                 "matches": "(.*)"
@@ -30,36 +30,7 @@
                 "visitors"
             ],
             "data": [
-                ["{{fnow offset='-29 days' format='yyyy-MM-dd'}}", 440],
-                ["{{fnow offset='-28 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-27 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-26 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-25 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-24 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-23 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-22 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-21 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-20 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-19 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-18 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-17 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-16 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-15 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-14 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-13 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-12 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-11 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-10 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-9 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-8 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-7 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-6 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-5 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-4 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-3 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-2 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow offset='-1 days' format='yyyy-MM-dd'}}", 0],
-                ["{{fnow format='yyyy-MM-dd'}}", 0]
+                ["{{fnow format='yyyy-MM-dd'}}", 440]
             ]
         },
         "headers": {

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/stats/stats_visits-month.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/stats/stats_visits-month.json
@@ -1,44 +1,70 @@
 {
-    "request": {
-        "method": "GET",
-        "urlPath": "/rest/v1.1/sites/161477129/stats/visits/",
-        "queryParameters": {
-            "unit": {
-                "equalTo": "month"
-            },
-            "quantity": {
-                "matches": "[0-9]+"
-            },
-            "date": {
-                "matches": "(.*)"
-            },
-            "stat_fields": {
-                "matches": "visitors"
-            }
-        }
-    },
-    "response": {
-        "status": 200,
-        "jsonBody": {
-            "date": "{{#assign 'currentYear'}}{{fnow format='yyyy'}}{{/assign}}{{currentYear}}-10-01",
-            "unit": "month",
-            "fields": [
-                "period",
-                "visitors"
-            ],
-            "data": [
-                ["{{currentYear}}-12-01", 12000],
-                ["{{currentYear}}-01-01", 0],
-                ["{{currentYear}}-02-01", 0],
-                ["{{currentYear}}-03-01", 0],
-                ["{{currentYear}}-04-01", 0],
-                ["{{currentYear}}-05-01", 0],
-                ["{{currentYear}}-06-01", 0],
-                ["{{currentYear}}-07-01", 0],
-                ["{{currentYear}}-08-01", 0],
-                ["{{currentYear}}-09-01", 0],
-                ["{{currentYear}}-10-01", 0]
-            ]
-        }
+  "request": {
+    "method": "GET",
+    "urlPath": "/rest/v1.1/sites/161477129/stats/visits/",
+    "queryParameters": {
+      "unit": {
+        "equalTo": "day"
+      },
+      "quantity": {
+        "matches": "(28|29|30|31)"
+      },
+      "date": {
+        "matches": "(.*)"
+      },
+      "stat_fields": {
+        "equalTo": "visitors"
+      },
+      "locale": {
+        "matches": "(.*)"
+      }
     }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "date": "{{fnow format='yyyy-MM-dd'}}",
+      "unit": "day",
+      "fields": [
+        "period",
+        "visitors"
+      ],
+      "data": [
+        ["{{fnow offset='-29 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-28 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-27 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-26 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-25 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-24 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-23 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-22 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-21 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-20 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-19 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-18 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-17 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-16 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-15 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-14 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-13 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-12 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-11 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-10 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-9 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-8 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-7 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-6 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-5 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-4 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-3 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-2 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow offset='-1 days' format='yyyy-MM-dd'}}", 0],
+        ["{{fnow format='yyyy-MM-dd'}}", 440]
+      ]
+    },
+    "headers": {
+      "Content-Type": "application/json",
+      "Connection": "keep-alive"
+    }
+  }
 }

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/stats/stats_visits-week.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/stats/stats_visits-week.json
@@ -4,10 +4,10 @@
         "urlPath": "/rest/v1.1/sites/161477129/stats/visits/",
         "queryParameters": {
             "unit": {
-                "equalTo": "week"
+                "equalTo": "day"
             },
             "quantity": {
-                "matches": "[0-9]+"
+                "equalTo": "7"
             },
             "date": {
                 "matches": "(.*)"
@@ -23,62 +23,18 @@
             "date": "2020-01-30",
             "unit": "week",
             "fields": [
-                "period", 
+                "period",
                 "visitors"
             ],
             "data": [
-                [
-                    "2019W11W04",
-                    0
-                ],
-                [
-                    "2019W11W11",
-                    0
-                ],
-                [
-                    "2019W11W18",
-                    0
-                ],
-                [
-                    "2019W11W25",
-                    0
-                ],
-                [
-                    "2019W12W02",
-                    0
-                ],
-                [
-                    "2019W12W09",
-                    0
-                ],
-                [
-                    "2019W12W16",
-                    0
-                ],
-                [
-                    "2019W12W23",
-                    0
-                ],
-                [
-                    "2019W12W30",
-                    0
-                ],
-                [
-                    "2020W01W06",
-                    0
-                ],
-                [
-                    "2020W01W13",
-                    0
-                ],
-                [
-                    "2020W01W20",
-                    0
-                ],
-                [
-                    "2020W01W27",
-                    0
-                ]
+              ["{{fnow offset='-7 days' format='yyyy-MM-dd'}}", 0],
+              ["{{fnow offset='-6 days' format='yyyy-MM-dd'}}", 0],
+              ["{{fnow offset='-5 days' format='yyyy-MM-dd'}}", 0],
+              ["{{fnow offset='-4 days' format='yyyy-MM-dd'}}", 0],
+              ["{{fnow offset='-3 days' format='yyyy-MM-dd'}}", 0],
+              ["{{fnow offset='-2 days' format='yyyy-MM-dd'}}", 0],
+              ["{{fnow offset='-1 days' format='yyyy-MM-dd'}}", 0],
+              ["{{fnow format='yyyy-MM-dd'}}", 440]
             ]
         }
     }

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/stats/stats_visits-year.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/stats/stats_visits-year.json
@@ -1,38 +1,44 @@
 {
-    "request": {
-        "method": "GET",
-        "urlPath": "/rest/v1.1/sites/161477129/stats/visits/",
-        "queryParameters": {
-            "unit": {
-                "equalTo": "year"
-            },
-            "quantity": {
-                "matches": "[0-9]+"
-            },
-            "date": {
-                "matches": "(.*)"
-            },
-            "stat_fields": {
-                "matches": "visitors"
-            }
-        }
-    },
-    "response": {
-        "status": 200,
-        "jsonBody": {
-            "date": "{{fnow format='yyyy-MM-dd'}}",
-            "unit": "year",
-            "fields": [
-                "period", 
-                "visitors"
-            ],
-            "data": [
-                ["{{fnow offset='-4 years' format='yyyy-MM-dd'}}", 500],
-                ["{{fnow offset='-3 years' format='yyyy-MM-dd'}}", 900],
-                ["{{fnow offset='-2 years' format='yyyy-MM-dd'}}", 1200],
-                ["{{fnow offset='-1 years' format='yyyy-MM-dd'}}", 1350],
-                ["{{fnow format='yyyy-MM-dd'}}", 1299]
-            ]
-        }
+  "request": {
+    "method": "GET",
+    "urlPath": "/rest/v1.1/sites/161477129/stats/visits/",
+    "queryParameters": {
+      "unit": {
+        "equalTo": "month"
+      },
+      "quantity": {
+        "matches": "[0-9]+"
+      },
+      "date": {
+        "matches": "(.*)"
+      },
+      "stat_fields": {
+        "matches": "visitors"
+      }
     }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "date": "{{#assign 'currentYear'}}{{fnow format='yyyy'}}{{/assign}}{{currentYear}}-10-01",
+      "unit": "month",
+      "fields": [
+        "period",
+        "visitors"
+      ],
+      "data": [
+        ["{{currentYear}}-12-01", 12000],
+        ["{{currentYear}}-01-01", 0],
+        ["{{currentYear}}-02-01", 0],
+        ["{{currentYear}}-03-01", 0],
+        ["{{currentYear}}-04-01", 0],
+        ["{{currentYear}}-05-01", 0],
+        ["{{currentYear}}-06-01", 0],
+        ["{{currentYear}}-07-01", 0],
+        ["{{currentYear}}-08-01", 0],
+        ["{{currentYear}}-09-01", 0],
+        ["{{currentYear}}-10-01", 0]
+      ]
+    }
+  }
 }

--- a/WooCommerce/src/androidTest/assets/mocks/mappings/stats/summary_stats-month.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/stats/summary_stats-month.json
@@ -16,8 +16,8 @@
     "jsonBody": {
       "date": "{{fnow format='yyyy-MM-dd'}}",
       "period": "month",
-      "views": 12000,
-      "visitors": 12000,
+      "views": 440,
+      "visitors": 440,
       "likes": 0,
       "reblogs": 0,
       "comments": 0,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -213,7 +213,7 @@ private fun StatsChart(
         statsView.showLastUpdate(lastUpdateState)
     }
 
-    LaunchedEffect(dateRange?.rangeSelection, revenueStatsState) {
+    LaunchedEffect(revenueStatsState) {
         when (revenueStatsState) {
             is DashboardStatsViewModel.RevenueStatsViewState.Content -> {
                 statsView.showErrorView(false)
@@ -239,7 +239,7 @@ private fun StatsChart(
         }
     }
 
-    LaunchedEffect(dateRange?.rangeSelection, visitorsStatsState) {
+    LaunchedEffect(visitorsStatsState) {
         visitorsStatsState?.let {
             statsView.showVisitorStats(it)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11546 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
While working fixing the UI tests for the dynamic dashboard, I added this [change](https://github.com/woocommerce/woocommerce-android/pull/11454/commits/5cd2327987c81ba5c961b520170a47014fb37108) to fix an issue with showing wrong data, but this change caused the linked issue.
Now that I spent more time understanding the cause of the UI test failure, I found the root cause, and I reverted the above change, the root cause is that we were returning wrong mocked data for the different tabs, I updated the mocks to match the granularities we use now.

**I'm targeting `18.7` with the fix because I think it should be fixed ASAP, but please let me know if you think it's best to target `trunk`.**

### Testing instructions
1. Log in to the app and enable Performance card on the My Store screen.
2. Switch to a non-custom range time range.
3. Then switch to a custom range.
4. Confirm the visitor stats are redacted.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
