### PR TITLE
[Dynamic Dashboard] Error view for when WCAdmin is disabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WCAdminNotEnabledErrorView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WCAdminNotEnabledErrorView.kt
@@ -1,0 +1,67 @@
+package com.woocommerce.android.ui.dashboard
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun WCAdminNotAvailableErrorView(
+    title: String,
+    onContactSupportClick: () -> Unit
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.img_woo_generic_error),
+            contentDescription = null
+        )
+
+        Text(
+            text = title,
+            style = MaterialTheme.typography.h6,
+            textAlign = TextAlign.Center
+        )
+
+        Text(
+            text = stringResource(id = R.string.dashboard_wcadmin_inactive_description),
+            style = MaterialTheme.typography.body1,
+            textAlign = TextAlign.Center
+        )
+
+        WCOutlinedButton(
+            text = stringResource(id = R.string.dashboard_wcadmin_inactive_contact_us),
+            onClick = onContactSupportClick
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun WCAdminNotAvailableErrorViewPreview() {
+    WooThemeWithBackground {
+        WCAdminNotAvailableErrorView(
+            title = stringResource(id = R.string.my_store_stats_plugin_inactive_title),
+            onContactSupportClick = {}
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WCAnalyticsNotEnabledErrorView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/WCAnalyticsNotEnabledErrorView.kt
@@ -20,7 +20,7 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
-fun WCAdminNotAvailableErrorView(
+fun WCAnalyticsNotAvailableErrorView(
     title: String,
     onContactSupportClick: () -> Unit
 ) {
@@ -43,13 +43,13 @@ fun WCAdminNotAvailableErrorView(
         )
 
         Text(
-            text = stringResource(id = R.string.dashboard_wcadmin_inactive_description),
+            text = stringResource(id = R.string.dashboard_wcanalytics_inactive_description),
             style = MaterialTheme.typography.body1,
             textAlign = TextAlign.Center
         )
 
         WCOutlinedButton(
-            text = stringResource(id = R.string.dashboard_wcadmin_inactive_contact_us),
+            text = stringResource(id = R.string.dashboard_wcanalytics_inactive_contact_us),
             onClick = onContactSupportClick
         )
     }
@@ -59,7 +59,7 @@ fun WCAdminNotAvailableErrorView(
 @Preview
 private fun WCAdminNotAvailableErrorViewPreview() {
     WooThemeWithBackground {
-        WCAdminNotAvailableErrorView(
+        WCAnalyticsNotAvailableErrorView(
             title = stringResource(id = R.string.my_store_stats_plugin_inactive_title),
             onContactSupportClick = {}
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsCard.kt
@@ -42,6 +42,7 @@ import com.woocommerce.android.ui.dashboard.DashboardDateRangeHeader
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
+import com.woocommerce.android.ui.dashboard.WCAdminNotAvailableErrorView
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.coupons.DashboardCouponsViewModel.DateRangeState
@@ -197,9 +198,10 @@ private fun DashboardCouponsCard(
                 }
 
                 is State.Error -> {
-                    WidgetError(
-                        onContactSupportClicked = onContactSupportClick,
-                        onRetryClicked = onRetryClick
+                    CouponsErrorView(
+                        error = viewState,
+                        onRetryClick = onRetryClick,
+                        onContactSupportClick = onContactSupportClick
                     )
                 }
             }
@@ -347,5 +349,27 @@ private fun Header(modifier: Modifier = Modifier) {
             style = MaterialTheme.typography.subtitle2,
             color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
         )
+    }
+}
+
+@Composable
+fun CouponsErrorView(
+    error: State.Error,
+    onRetryClick: () -> Unit,
+    onContactSupportClick: () -> Unit
+) {
+    when (error) {
+        State.Error.Generic -> {
+            WidgetError(
+                onContactSupportClicked = onContactSupportClick,
+                onRetryClicked = onRetryClick
+            )
+        }
+        State.Error.WCAdminInactive -> {
+            WCAdminNotAvailableErrorView(
+                title = stringResource(id = R.string.dashboard_coupons_wcadmin_inactive_title),
+                onContactSupportClick = onContactSupportClick
+            )
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsCard.kt
@@ -42,7 +42,7 @@ import com.woocommerce.android.ui.dashboard.DashboardDateRangeHeader
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
-import com.woocommerce.android.ui.dashboard.WCAdminNotAvailableErrorView
+import com.woocommerce.android.ui.dashboard.WCAnalyticsNotAvailableErrorView
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.coupons.DashboardCouponsViewModel.DateRangeState
@@ -365,9 +365,9 @@ fun CouponsErrorView(
                 onRetryClicked = onRetryClick
             )
         }
-        State.Error.WCAdminInactive -> {
-            WCAdminNotAvailableErrorView(
-                title = stringResource(id = R.string.dashboard_coupons_wcadmin_inactive_title),
+        State.Error.WCAnalyticsInactive -> {
+            WCAnalyticsNotAvailableErrorView(
+                title = stringResource(id = R.string.dashboard_coupons_wcanalytics_inactive_title),
                 onContactSupportClick = onContactSupportClick
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsCard.kt
@@ -165,11 +165,11 @@ private fun DashboardCouponsCard(
             titleResource = R.string.dashboard_coupons_view_all_button,
             action = onViewAllClick
         ),
-        isError = viewState is Error,
+        isError = viewState is State.Error,
         modifier = modifier
     ) {
         Column {
-            if (viewState !is Error) {
+            if (viewState !is State.Error) {
                 DashboardDateRangeHeader(
                     rangeSelection = dateRangeState.rangeSelection,
                     dateFormatted = dateRangeState.rangeFormatted,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsViewModel.kt
@@ -99,7 +99,7 @@ class DashboardCouponsViewModel @AssistedInject constructor(
                             onFailure = { error ->
                                 when {
                                     error is WooException && error.error.type == WooErrorType.API_NOT_FOUND ->
-                                        State.Error.WCAdminInactive
+                                        State.Error.WCAnalyticsInactive
 
                                     else -> State.Error.Generic
                                 }
@@ -245,7 +245,7 @@ class DashboardCouponsViewModel @AssistedInject constructor(
         data class Loaded(val coupons: List<CouponUiModel>) : State
         enum class Error : State {
             Generic,
-            WCAdminInactive
+            WCAnalyticsInactive
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -29,7 +29,7 @@ import com.woocommerce.android.ui.dashboard.DashboardDateRangeHeader
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardStatsUsageTracksEventEmitter
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
-import com.woocommerce.android.ui.dashboard.WCAdminNotAvailableErrorView
+import com.woocommerce.android.ui.dashboard.WCAnalyticsNotAvailableErrorView
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.defaultHideMenuEntry
@@ -104,7 +104,7 @@ fun DashboardStatsCard(
             }
 
             else -> {
-                WCAdminNotAvailableErrorView(
+                WCAnalyticsNotAvailableErrorView(
                     title = stringResource(id = R.string.my_store_stats_plugin_inactive_title),
                     onContactSupportClick = parentViewModel::onContactSupportClicked
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -1,28 +1,19 @@
 package com.woocommerce.android.ui.dashboard.stats
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
@@ -32,13 +23,13 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
-import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.compose.viewModelWithFactory
 import com.woocommerce.android.ui.dashboard.DashboardDateRangeHeader
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
 import com.woocommerce.android.ui.dashboard.DashboardStatsUsageTracksEventEmitter
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
+import com.woocommerce.android.ui.dashboard.WCAdminNotAvailableErrorView
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.defaultHideMenuEntry
@@ -113,7 +104,8 @@ fun DashboardStatsCard(
             }
 
             else -> {
-                PluginNotAvailableError(
+                WCAdminNotAvailableErrorView(
+                    title = stringResource(id = R.string.my_store_stats_plugin_inactive_title),
                     onContactSupportClick = parentViewModel::onContactSupportClicked
                 )
             }
@@ -243,39 +235,6 @@ private fun StatsChart(
         visitorsStatsState?.let {
             statsView.showVisitorStats(it)
         }
-    }
-}
-
-@Composable
-private fun PluginNotAvailableError(onContactSupportClick: () -> Unit) {
-    Column(
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp)
-    ) {
-        Image(
-            painter = painterResource(id = R.drawable.img_empty_search),
-            contentDescription = null
-        )
-
-        Text(
-            text = stringResource(id = R.string.my_store_stats_plugin_inactive_title),
-            style = MaterialTheme.typography.h6,
-            textAlign = TextAlign.Center
-        )
-
-        Text(
-            text = stringResource(id = R.string.my_store_stats_plugin_inactive_description),
-            style = MaterialTheme.typography.body1,
-            textAlign = TextAlign.Center
-        )
-
-        WCOutlinedButton(
-            text = stringResource(id = R.string.my_store_stats_plugin_inactive_contact_us),
-            onClick = onContactSupportClick
-        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.LiveData
@@ -309,10 +308,4 @@ private fun HandleEvents(
             event.removeObserver(observer)
         }
     }
-}
-
-@Composable
-@Preview
-fun PluginNotAvailableErrorPreview() {
-    PluginNotAvailableError(onContactSupportClick = {})
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
@@ -215,7 +215,7 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
                 onFailure = {
                     _topPerformersState.value = _topPerformersState.value?.copy(
                         error = if ((it as? WooException)?.error?.type == WooErrorType.API_NOT_FOUND) {
-                            ErrorType.WCAdminInactive
+                            ErrorType.WCAnalyticsInactive
                         } else {
                             ErrorType.Generic
                         },
@@ -304,7 +304,7 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
     )
 
     enum class ErrorType {
-        Generic, WCAdminInactive
+        Generic, WCAnalyticsInactive
     }
 
     data class OpenTopPerformer(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -49,7 +49,7 @@ import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.Op
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.TopPerformerProductUiModel
-import com.woocommerce.android.ui.dashboard.WCAdminNotAvailableErrorView
+import com.woocommerce.android.ui.dashboard.WCAnalyticsNotAvailableErrorView
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.stats.DashboardStatsTestTags
@@ -365,9 +365,9 @@ private fun TopPerformersErrorView(
     onRetryClicked: () -> Unit
 ) {
     when (errorType) {
-        DashboardTopPerformersViewModel.ErrorType.WCAdminInactive -> {
-            WCAdminNotAvailableErrorView(
-                title = stringResource(id = R.string.dashboard_top_performers_wcadmin_inactive_title),
+        DashboardTopPerformersViewModel.ErrorType.WCAnalyticsInactive -> {
+            WCAnalyticsNotAvailableErrorView(
+                title = stringResource(id = R.string.dashboard_top_performers_wcanalytics_inactive_title),
                 onContactSupportClick = onContactSupportClicked
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersWidgetCard.kt
@@ -49,6 +49,7 @@ import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.Op
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
 import com.woocommerce.android.ui.dashboard.TopPerformerProductUiModel
+import com.woocommerce.android.ui.dashboard.WCAdminNotAvailableErrorView
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.stats.DashboardStatsTestTags
@@ -81,10 +82,11 @@ fun DashboardTopPerformersWidgetCard(
             menu = topPerformersState.menu,
             button = topPerformersState.onOpenAnalyticsTapped,
             modifier = modifier.testTag(DashboardStatsTestTags.DASHBOARD_TOP_PERFORMERS_CARD),
-            isError = topPerformersState.isError
+            isError = topPerformersState.error != null
         ) {
             when {
-                topPerformersState.isError -> TopPerformersErrorView(
+                topPerformersState.error != null -> TopPerformersErrorView(
+                    errorType = topPerformersState.error,
                     onContactSupportClicked = parentViewModel::onContactSupportClicked,
                     onRetryClicked = topPerformersViewModel::onRefresh
                 )
@@ -358,13 +360,24 @@ private fun TopPerformersEmptyView(modifier: Modifier = Modifier) {
 
 @Composable
 private fun TopPerformersErrorView(
+    errorType: DashboardTopPerformersViewModel.ErrorType,
     onContactSupportClicked: () -> Unit,
     onRetryClicked: () -> Unit
 ) {
-    WidgetError(
-        onContactSupportClicked = onContactSupportClicked,
-        onRetryClicked = onRetryClicked
-    )
+    when (errorType) {
+        DashboardTopPerformersViewModel.ErrorType.WCAdminInactive -> {
+            WCAdminNotAvailableErrorView(
+                title = stringResource(id = R.string.dashboard_top_performers_wcadmin_inactive_title),
+                onContactSupportClick = onContactSupportClicked
+            )
+        }
+        else -> {
+            WidgetError(
+                onContactSupportClicked = onContactSupportClicked,
+                onRetryClicked = onRetryClicked
+            )
+        }
+    }
 }
 
 @LightDarkThemePreviews
@@ -407,7 +420,6 @@ private fun TopPerformersWidgetCardPreview() {
                 onClick = {}
             ),
         ),
-        isError = false,
         isLoading = false,
         titleStringRes = DashboardWidget.Type.POPULAR_PRODUCTS.titleResource,
         menu = DashboardWidgetMenu(emptyList()),
@@ -432,7 +444,7 @@ private fun TopPerformersWidgetCardPreview() {
             onEditCustomRangeTapped = {}
         )
         DashboardTopPerformersContent(
-            topPerformersState = topPerformersState.copy(isError = true),
+            topPerformersState = topPerformersState.copy(error = DashboardTopPerformersViewModel.ErrorType.Generic),
             lastUpdateState = "Last update: 8:52 AM",
             selectedDateRange = selectedDateRange,
             onTabSelected = {},

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -25,8 +25,6 @@ Language: ar
     <string name="dynamic_dashboard_widget_menu_item_hide">إخفاء %s</string>
     <string name="my_store_widget_onboarding_completed">مكتمل</string>
     <string name="my_store_widget_feedback_title">ملاحظات</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">هل لا تزال تحتاج إلى مساعدة؟ اتصل بنا</string>
-    <string name="my_store_stats_plugin_inactive_description">تأكد من أنك تقوم بتشغيل أحدث إصدار من WooCommerce على موقعك وأنك قمت بتفعيل مسؤول WooCommerce.</string>
     <string name="my_store_stats_plugin_inactive_title">يتعذر علينا عرض\n تحليلات متجرك</string>
     <string name="store_onboarding_task_view_all_tasks">عرض جميع المهام</string>
     <string name="analytics_session_no_available_description">تعتمد تحليلات الجلسة على أعداد الزائرين الفريدة غير المتاحة لنطاقات التواريخ المخصصة</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -25,8 +25,6 @@ Language: de
     <string name="dynamic_dashboard_widget_menu_item_hide">%s ausblenden</string>
     <string name="my_store_widget_onboarding_completed">Abgeschlossen</string>
     <string name="my_store_widget_feedback_title">Feedback</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">Du benötigst dennoch Hilfe? Kontaktiere uns</string>
-    <string name="my_store_stats_plugin_inactive_description">Achte darauf, dass auf deiner Website die neueste Version von WooCommerce ausgeführt wird und WooCommerce Admin aktiviert ist.</string>
     <string name="my_store_stats_plugin_inactive_title">Wir können die\n Analysen deines Shops nicht anzeigen</string>
     <string name="store_onboarding_task_view_all_tasks">Alle Aufgaben anzeigen</string>
     <string name="analytics_session_no_available_description">Analysedaten für Sitzungen basieren auf Besucherzahlen, die für individuelle Zeiträume nicht verfügbar sind</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -25,8 +25,6 @@ Language: es
     <string name="dynamic_dashboard_widget_menu_item_hide">Ocultar %s</string>
     <string name="my_store_widget_onboarding_completed">Completado</string>
     <string name="my_store_widget_feedback_title">Comentarios</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">¿Aún necesitas ayuda? Contacto</string>
-    <string name="my_store_stats_plugin_inactive_description">Asegúrate de estar ejecutando la última versión de WooCommerce en tu sitio web y de haber activado WooCommerce Admin.</string>
     <string name="my_store_stats_plugin_inactive_title">No podemos visualizar el\n análisis de tu tienda</string>
     <string name="store_onboarding_task_view_all_tasks">Ver todas las tareas</string>
     <string name="analytics_session_no_available_description">Los análisis de sesiones se basan en los recuentos de visitantes únicos, que no están disponibles para rangos de fechas personalizados</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -25,8 +25,6 @@ Language: fr
     <string name="dynamic_dashboard_widget_menu_item_hide">Masquer %s</string>
     <string name="my_store_widget_onboarding_completed">Terminé</string>
     <string name="my_store_widget_feedback_title">Commentaire</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">Besoin d’une aide supplémentaire ? Nous contacter</string>
-    <string name="my_store_stats_plugin_inactive_description">Veillez à exécuter la dernière version de WooCommerce sur votre site et à ce que WooCommerce Admin soit activé.</string>
     <string name="my_store_stats_plugin_inactive_title">Nous ne sommes pas en mesure d’afficher\n les statistiques de votre boutique</string>
     <string name="store_onboarding_task_view_all_tasks">Voir toutes les tâches</string>
     <string name="analytics_session_no_available_description">Les analyses de session se basent sur le nombre de visites uniques indisponibles pour les plages de dates personnalisées</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -25,8 +25,6 @@ Language: he_IL
     <string name="dynamic_dashboard_widget_menu_item_hide">להסתיר את %s</string>
     <string name="my_store_widget_onboarding_completed">הושלם</string>
     <string name="my_store_widget_feedback_title">משוב</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">עדיין דרושה לך עזרה? ליצירת קשר</string>
-    <string name="my_store_stats_plugin_inactive_description">עליך לוודא שמותקנת באתר שלך הגרסה האחרונה של WooCommerce ושהתוסף של WooCommerce Admin מופעל.</string>
     <string name="my_store_stats_plugin_inactive_title">אנחנו לא יכולים להציג את \n הנתונים האנליטיים של החנות</string>
     <string name="store_onboarding_task_view_all_tasks">להציג את כל המשימות</string>
     <string name="analytics_session_no_available_description">נתונים אנליטיים של הפעלות מסתמכים על מספר המבקרים הייחודיים, והם לא זמינים בטווח תאריכים מותאם אישית</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -25,8 +25,6 @@ Language: id
     <string name="dynamic_dashboard_widget_menu_item_hide">Sembunyikan %s</string>
     <string name="my_store_widget_onboarding_completed">Selesai</string>
     <string name="my_store_widget_feedback_title">Feedback</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">Masih butuh bantuan? Hubungi kami</string>
-    <string name="my_store_stats_plugin_inactive_description">Pastikan Anda mengoperasikan WooCommerce versi terbaru di situs Anda dan telah mengaktifkan WooCommerce Admin.</string>
     <string name="my_store_stats_plugin_inactive_title">Kami tidak dapat menampilkan \n Anda analitik toko</string>
     <string name="store_onboarding_task_view_all_tasks">Lihat semua tugas</string>
     <string name="analytics_session_no_available_description">Analitik sesi bergantung pada jumlah pengunjung unik yang tidak tersedia untuk rentang tanggal kustom</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -36,8 +36,6 @@ Language: it
     <string name="dynamic_dashboard_widget_menu_item_hide">Nascondi %s</string>
     <string name="my_store_widget_onboarding_completed">Completata</string>
     <string name="my_store_widget_feedback_title">Feedback</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">Hai ancora bisogno di aiuto? Contattaci</string>
-    <string name="my_store_stats_plugin_inactive_description">Assicurati di star utilizzando la versione più recente di WooCommerce sul tuo sito e di aver attivato WooCommerce Admin.</string>
     <string name="my_store_stats_plugin_inactive_title">Non possiamo visualizzare il tuo\n analisi del negozio</string>
     <string name="store_onboarding_task_view_all_tasks">Visualizza tutte le attività</string>
     <string name="analytics_session_no_available_description">L\'analisi delle sessioni si basa su un numero unico di visitatori non disponibile per intervalli di date personalizzati</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -25,8 +25,6 @@ Language: ja_JP
     <string name="dynamic_dashboard_widget_menu_item_hide">%s を非表示</string>
     <string name="my_store_widget_onboarding_completed">完了</string>
     <string name="my_store_widget_feedback_title">フィードバック</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">さらにサポートが必要ですか ? お問い合わせ</string>
-    <string name="my_store_stats_plugin_inactive_description">サイトで最新バージョンの WooCommerce を実行していることと、WooCommerce Admin を有効にしていることを確認してください。</string>
     <string name="my_store_stats_plugin_inactive_title">次を表示できません:\n ストアのアナリティクス</string>
     <string name="store_onboarding_task_view_all_tasks">すべてのタスクを表示</string>
     <string name="analytics_session_no_available_description">セッション分析はカスタムの日付範囲で利用できないユニーク訪問者数に基づいています</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -25,8 +25,6 @@ Language: ko_KR
     <string name="dynamic_dashboard_widget_menu_item_hide">%s 숨기기</string>
     <string name="my_store_widget_onboarding_completed">완료됨</string>
     <string name="my_store_widget_feedback_title">피드백</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">여전히 도움이 필요하신가요? 문의하기</string>
-    <string name="my_store_stats_plugin_inactive_description">사이트에서 WooCommerce 최신 버전을 실행하고 있으며 WooCommerce 관리자가 활성화되어 있는지 확인하세요.</string>
     <string name="my_store_stats_plugin_inactive_title">스토어 분석을\n 표시할 수 없음</string>
     <string name="store_onboarding_task_view_all_tasks">모든 작업 보기</string>
     <string name="analytics_session_no_available_description">세션 분석에서는 사용자 정의 범위에 사용할 수 없는 고유 방문자 수를 이용합니다</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -25,8 +25,6 @@ Language: nl
     <string name="dynamic_dashboard_widget_menu_item_hide">Verbergen %s</string>
     <string name="my_store_widget_onboarding_completed">Voltooid</string>
     <string name="my_store_widget_feedback_title">Feedback</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">Meer hulp nodig? Neem contact met ons op</string>
-    <string name="my_store_stats_plugin_inactive_description">Zorg dat je de nieuwste versie van WooCommerce gebruikt op je site en dat WooCommerce Admin geactiveerd is.</string>
     <string name="my_store_stats_plugin_inactive_title">We kunnen de\n analyses van je winkel niet weergeven</string>
     <string name="store_onboarding_task_view_all_tasks">Alle taken bekijken</string>
     <string name="analytics_session_no_available_description">Sessie-analyses gebruiken tellingen van unieke bezoekers, die niet beschikbaar zijn voor aangepaste datumbereiken</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -25,8 +25,6 @@ Language: pt_BR
     <string name="dynamic_dashboard_widget_menu_item_hide">Ocultar %s</string>
     <string name="my_store_widget_onboarding_completed">Concluída</string>
     <string name="my_store_widget_feedback_title">Feedback</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">Ainda precisa de ajuda? Fale conosco</string>
-    <string name="my_store_stats_plugin_inactive_description">Use a versão mais recente do WooCommerce no seu site e certifique-se de que o WooCommerce Admin está ativado.</string>
     <string name="my_store_stats_plugin_inactive_title">Não podemos exibir\n a análise do seu site</string>
     <string name="store_onboarding_task_view_all_tasks">Visualizar todas as tarefas</string>
     <string name="analytics_session_no_available_description">A análise da sessão depende da contagem de visitantes diferentes, não disponíveis para datas personalizadas</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -25,8 +25,6 @@ Language: ru
     <string name="dynamic_dashboard_widget_menu_item_hide">Скрыть %s</string>
     <string name="my_store_widget_onboarding_completed">Завершено</string>
     <string name="my_store_widget_feedback_title">Обратная связь</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">Вам по-прежнему требуется помощь? Свяжитесь с нами</string>
-    <string name="my_store_stats_plugin_inactive_description">Убедитесь, что на сайте используется последняя версия WooCommerce и вы активировали WooCommerce Admin.</string>
     <string name="my_store_stats_plugin_inactive_title">Не удалось отобразить\n аналитику вашего магазина</string>
     <string name="store_onboarding_task_view_all_tasks">Посмотреть все задачи</string>
     <string name="analytics_session_no_available_description">Аналитические данные сеанса основываются на количестве уникальных посетителей, которое невозможно определить для произвольных временных промежутков.</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -30,9 +30,7 @@ Language: sv_SE
     <string name="dynamic_dashboard_widget_menu_item_hide">Dölj %s</string>
     <string name="my_store_widget_onboarding_completed">Slutförd</string>
     <string name="my_store_widget_feedback_title">Feedback</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">Behöver du fortfarande hjälp? Kontakta oss</string>
     <string name="dynamic_dashboard_widget_error_title">Kan inte ladda data</string>
-    <string name="my_store_stats_plugin_inactive_description">Se till att du kör den senaste versionen av WooCommerce på din webbplats och att du har WooCommerce Admin aktiverad.</string>
     <string name="my_store_stats_plugin_inactive_title">Vi kan inte visa din\n butiks analys</string>
     <string name="my_store_widget_unavailable">Inte tillgänglig</string>
     <string name="dashboard_stats_custom_range_label">Anpassad</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -25,8 +25,6 @@ Language: tr
     <string name="dynamic_dashboard_widget_menu_item_hide">Şunu Gizle: %s</string>
     <string name="my_store_widget_onboarding_completed">Tamamlandı</string>
     <string name="my_store_widget_feedback_title">Geri bildirim</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">Hâlâ yardıma ihtiyacınız mı var? Bizimle iletişim kurun</string>
-    <string name="my_store_stats_plugin_inactive_description">Sitenizde en son WooCommerce sürümünü çalıştırdığınızdan ve WooCommerce Admin\'i etkinleştirdiğinizden emin olun.</string>
     <string name="my_store_stats_plugin_inactive_title">Mağazanızın analizlerini\n gösteremiyoruz</string>
     <string name="store_onboarding_task_view_all_tasks">Tüm görevleri görüntüle</string>
     <string name="analytics_session_no_available_description">Oturum analizleri, özel tarih aralıklarında kullanılamayan benzersiz ziyaretçi sayılarına dayanır</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -25,8 +25,6 @@ Language: zh_CN
     <string name="dynamic_dashboard_widget_menu_item_hide">隐藏 %s</string>
     <string name="my_store_widget_onboarding_completed">已完成</string>
     <string name="my_store_widget_feedback_title">反馈</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">仍需帮助？ 联系我们</string>
-    <string name="my_store_stats_plugin_inactive_description">确保您的站点上运行的是最新版本的 WooCommerce，并且已激活 WooCommerce Admin。</string>
     <string name="my_store_stats_plugin_inactive_title">我们无法显示您的\n 商店分析</string>
     <string name="store_onboarding_task_view_all_tasks">查看所有任务</string>
     <string name="analytics_session_no_available_description">会话分析依赖于独立访客数，但不适用于自定义日期范围</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -25,8 +25,6 @@ Language: zh_TW
     <string name="dynamic_dashboard_widget_menu_item_hide">隱藏「%s」</string>
     <string name="my_store_widget_onboarding_completed">已完成</string>
     <string name="my_store_widget_feedback_title">意見回饋</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">仍然需要幫助嗎？ 聯絡我們</string>
-    <string name="my_store_stats_plugin_inactive_description">請確認你的網站執行最新版本的 WooCommerce，並已啟用 WooCommerce Admin。</string>
     <string name="my_store_stats_plugin_inactive_title">我們無法顯示你的\n 商店分析</string>
     <string name="store_onboarding_task_view_all_tasks">檢視所有工作項目</string>
     <string name="analytics_session_no_available_description">自訂日期範圍無法提供工作階段分析所仰賴的不重複訪客數</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -387,7 +387,7 @@
     <string name="dashboard_top_performers_total_orders">Total orders: %s</string>
     <string name="dashboard_top_performers_empty">No activity this period</string>
     <string name="dashboard_top_performers_net_sales">Net sales: %s</string>
-    <string name="dashboard_top_performers_wcadmin_inactive_title">Unable to load the top performers</string>
+    <string name="dashboard_top_performers_wcanalytics_inactive_title">Unable to load the top performers</string>
 
     <string name="dashboard_action_view_order">View Order</string>
     <string name="dashboard_action_view_orders">View Orders</string>
@@ -430,10 +430,10 @@
     <string name="dashboard_coupons_card_header_uses">Uses</string>
     <string name="dashboard_coupons_view_all_button">View all coupons</string>
     <string name="dashboard_coupons_card_empty_view_message">No coupon usage during this period</string>
-    <string name="dashboard_coupons_wcadmin_inactive_title">Unable to load coupon usage report</string>
+    <string name="dashboard_coupons_wcanalytics_inactive_title">Unable to load coupon usage report</string>
 
-    <string name="dashboard_wcadmin_inactive_description">Make sure you are running the latest version of WooCommerce on your site and that you have WooCommerce Admin activated.</string>
-    <string name="dashboard_wcadmin_inactive_contact_us">Still need help? Contact us</string>
+    <string name="dashboard_wcanalytics_inactive_description">Make sure you are running the latest version of WooCommerce on your site and that you have WooCommerce Analytics activated.</string>
+    <string name="dashboard_wcanalytics_inactive_contact_us">Still need help? Contact us</string>
     <!--
         Sign Up Flow
     -->

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -387,6 +387,7 @@
     <string name="dashboard_top_performers_total_orders">Total orders: %s</string>
     <string name="dashboard_top_performers_empty">No activity this period</string>
     <string name="dashboard_top_performers_net_sales">Net sales: %s</string>
+    <string name="dashboard_top_performers_wcadmin_inactive_title">Unable to load the top performers</string>
 
     <string name="dashboard_action_view_order">View Order</string>
     <string name="dashboard_action_view_orders">View Orders</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -430,6 +430,7 @@
     <string name="dashboard_coupons_card_header_uses">Uses</string>
     <string name="dashboard_coupons_view_all_button">View all coupons</string>
     <string name="dashboard_coupons_card_empty_view_message">No coupon usage during this period</string>
+    <string name="dashboard_coupons_wcadmin_inactive_title">Unable to load coupon usage report</string>
 
     <string name="dashboard_wcadmin_inactive_description">Make sure you are running the latest version of WooCommerce on your site and that you have WooCommerce Admin activated.</string>
     <string name="dashboard_wcadmin_inactive_contact_us">Still need help? Contact us</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -393,8 +393,6 @@
     <string name="dashboard_action_view_all_orders">View all orders</string>
 
     <string name="my_store_stats_plugin_inactive_title">We can\'t display your\n store\'s analytics</string>
-    <string name="my_store_stats_plugin_inactive_description">Make sure you are running the latest version of WooCommerce on your site and that you have WooCommerce Admin activated.</string>
-    <string name="my_store_stats_plugin_inactive_contact_us">Still need help? Contact us</string>
     <string name="my_store_custom_range_content_description">Add custom date range stats</string>
     <string name="my_store_custom_range_granularity_label">%s interval</string>
     <string name="my_store_custom_range_granularity_hour">Hourly</string>
@@ -432,6 +430,8 @@
     <string name="dashboard_coupons_view_all_button">View all coupons</string>
     <string name="dashboard_coupons_card_empty_view_message">No coupon usage during this period</string>
 
+    <string name="dashboard_wcadmin_inactive_description">Make sure you are running the latest version of WooCommerce on your site and that you have WooCommerce Admin activated.</string>
+    <string name="dashboard_wcadmin_inactive_contact_us">Still need help? Contact us</string>
     <!--
         Sign Up Flow
     -->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11544 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds the following changes:
1. Introduces a common error view to use when WCAdmin is not available and the card's API depends on it.
2. Updates the Performance and Top Performers cards to use the new component.
3. Updates the Coupons card to use it too.

### Testing instructions
1. Disable WCAdmin (in a non-atomic website, WooCommerce -> Settings -> Advanced -> Features -> Enable WooCommerce Analytics)
2. Open the app.
3. Test Performance, Top Performers and Coupons cards.
4. Confirm all show the correct error view.

### Images/gif
<img src="https://github.com/woocommerce/woocommerce-android/assets/1657201/74229c32-301f-4c82-b93f-5130fbd3bd67" width=360 />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
