### PR TITLE
Set the correct event when Blaze campaign is created successfully

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModel.kt
@@ -124,7 +124,7 @@ class BlazeCampaignPaymentSummaryViewModel @Inject constructor(
             ).fold(
                 onSuccess = {
                     campaignCreationState.value = null
-                    analyticsTrackerWrapper.track(stat = AnalyticsEvent.BLAZE_CREATION_PAYMENT_SUBMIT_CAMPAIGN_TAPPED)
+                    analyticsTrackerWrapper.track(stat = AnalyticsEvent.BLAZE_CAMPAIGN_CREATION_SUCCESS)
                     dashboardRepository.updateWidgetVisibility(type = DashboardWidget.Type.ONBOARDING, isVisible = true)
                     triggerEvent(NavigateToStartingScreenWithSuccessBottomSheet)
                 },


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes an accidental change coming from a wrong merge conflict resolution. The event `BLAZE_CAMPAIGN_CREATION_SUCCESS` which should be tracked when a Blaze campaign is created, was accidentally overridden by the event `BLAZE_CREATION_PAYMENT_SUBMIT_CAMPAIGN_TAPPED` which before this fix, is being tracked twice. 

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
1. Using a Jetpack connected store with at least 1 product publisjed
2. Create a Blaze marketing campaign following the steps from the screen recording below
3. Once the campaign is created successfully, check in Androdi Studio logcat for the following log: `🔵 Tracked: blaze_campaign_creation_success, Properties: ...`

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/b075a083-1711-4044-8c1c-ea44c4fa00b4



- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
