### PR TITLE
Shipping lines m2 analytics

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -259,6 +259,7 @@ enum class AnalyticsEvent(val siteless: Boolean = false) {
     ORDER_DETAILS_GIFT_CARD_SHOWN,
     ORDER_PRODUCTS_LOADED,
     ORDER_DETAIL_TRASH_TAPPED,
+    ORDER_DETAILS_SHIPPING_METHODS_SHOWN,
 
     // - Order detail editing
     ORDER_DETAIL_EDIT_FLOW_STARTED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -325,6 +325,7 @@ class AnalyticsTracker private constructor(
         const val KEY_COUPONS_COUNT = "coupons_count"
         const val KEY_USE_GIFT_CARD = "use_gift_card"
         const val KEY_IS_GIFT_CARD_REMOVED = "removed"
+        const val KEY_SHIPPING_LINES_COUNT = "shipping_lines_count"
 
         const val KEY_WAS_ECOMMERCE_TRIAL = "was_ecommerce_trial"
         const val KEY_PLAN_PRODUCT_SLUG = "plan_product_slug"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1334,6 +1334,7 @@ class OrderCreateEditViewModel @Inject constructor(
                 }
                 mutableMap[KEY_COUPONS_COUNT] = orderDraft.value?.couponLines?.size ?: 0
                 mutableMap[KEY_USE_GIFT_CARD] = orderDraft.value?.selectedGiftCard.isNotNullOrEmpty()
+                mutableMap[KEY_SHIPPING_LINES_COUNT] = orderDraft.value?.shippingLines?.size ?: 0
             }
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -61,6 +61,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_PRODUCT_
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SCANNING_BARCODE_FORMAT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SCANNING_FAILURE_REASON
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SCANNING_SOURCE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SHIPPING_LINES_COUNT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SHIPPING_METHOD
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_STATUS
@@ -1522,13 +1523,6 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     fun onUpdatedShipping(shippingUpdateResult: ShippingUpdateResult) {
-        tracker.track(
-            ORDER_SHIPPING_METHOD_ADD,
-            buildMap {
-                put(KEY_FLOW, flow)
-                putIfNotNull(KEY_SHIPPING_METHOD to shippingUpdateResult.methodId)
-            }
-        )
         _orderDraft.update { draft ->
             val shipping = when {
                 shippingUpdateResult.id != null -> draft.shippingLines.map { shippingLine ->
@@ -1561,6 +1555,15 @@ class OrderCreateEditViewModel @Inject constructor(
                     )
                 )
             }
+
+            tracker.track(
+                ORDER_SHIPPING_METHOD_ADD,
+                buildMap {
+                    put(KEY_FLOW, flow)
+                    putIfNotNull(KEY_SHIPPING_METHOD to shippingUpdateResult.methodId)
+                    put(KEY_SHIPPING_LINES_COUNT, shipping.size)
+                }
+            )
 
             draft.copy(shippingLines = shipping)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -77,7 +77,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -13,6 +13,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SHIPPING_LINES_COUNT
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.analytics.IsScreenLargerThanCompactValue
 import com.woocommerce.android.analytics.deviceTypeToAnalyticsString
@@ -76,7 +77,10 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -220,6 +224,15 @@ class OrderDetailViewModel @Inject constructor(
                     paymentTypeFlow = CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.ORDER_CREATION
                 )
             )
+        }
+        launch {
+            val shippingLines = _shippingLineList.drop(1).filter { it.isNotEmpty() }.first()
+            if (shippingLines.isNotEmpty()) {
+                analyticsTracker.track(
+                    AnalyticsEvent.ORDER_DETAILS_SHIPPING_METHODS_SHOWN,
+                    mapOf(KEY_SHIPPING_LINES_COUNT to shippingLines.size)
+                )
+            }
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -314,7 +314,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     @Test
     fun `when shipping line added or edited, send tracks event`() {
         val result = ShippingUpdateResult(
-            id = 1L,
+            id = null,
             amount = BigDecimal.TEN,
             name = "Other",
             methodId = "other"
@@ -325,7 +325,8 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             AnalyticsEvent.ORDER_SHIPPING_METHOD_ADD,
             mapOf(
                 AnalyticsTracker.KEY_FLOW to tracksFlow,
-                AnalyticsTracker.KEY_SHIPPING_METHOD to result.methodId
+                AnalyticsTracker.KEY_SHIPPING_METHOD to result.methodId,
+                AnalyticsTracker.KEY_SHIPPING_LINES_COUNT to 1
             )
         )
     }


### PR DESCRIPTION
Closes: #11397 

### Description
This PR adds the tracking events for M2

- [x] Update the event `order_creation_success`. Update the event to include the custom property `shipping_lines_count` to track the number of shipping lines within that order. Event registration: https://github.com/Automattic/tracks-events-registration/pull/2438
- [x] Update the event `order_shipping_method_add`. Update the event to include the custom property `shipping_lines_count` to track the number of shipping lines within that order. Event registration: https://github.com/Automattic/tracks-events-registration/pull/2439
- [x] Add the event `order_details_shipping_methods_shown` triggered in the order details screen when the screen is displaying the shipping lines section. Add the custom property `shipping_lines_count` to track the number of shipping lines within that order. Event registration: https://github.com/Automattic/tracks-events-registration/pull/2440

### Testing instructions
1. Open the app
2. Go to the orders screen
3. Tap on add new order (+)
4. Add a product to enable the shipping section
5. Add a new shipping line to the order
6. Check that the event `order_shipping_method_add` is triggered and that it contains a custom property `shipping_lines_count` with the number of shipping lines
7. Optionally add another shipping line to the order
8. Tap on create
9. Check that the event `order_creation_success` is triggered and that it contains a custom property `shipping_lines_count` with the number of shipping lines
10. Check that the app navigates to the order details screen
11. Check that the event `order_details_shipping_methods_shown` is triggered and that it contains a custom property `shipping_lines_count` with the number of shipping lines 

### Images/gif
```
🔵 Tracked: order_shipping_method_add, Properties: {"flow":"creation","shipping_method":"local_pickup","shipping_lines_count":1,"blog_id":222408976,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"wooexpress-small-bundle-yearly","store_id":"b6468f83-4986-44f1-b4ce-6021649dbf29","is_debug":true,"site_url":"https:\/\/woo-practically-automatic-witch.wpcomstaging.com","cached_woo_core_version":"8.9.1"}

```

```
🔵 Tracked: order_creation_success, Properties: {"milliseconds_since_order_add_new":"264904","coupons_count":0,"use_gift_card":false,"shipping_lines_count":2,"blog_id":222408976,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"wooexpress-small-bundle-yearly","store_id":"b6468f83-4986-44f1-b4ce-6021649dbf29","is_debug":true,"site_url":"https:\/\/woo-practically-automatic-witch.wpcomstaging.com","cached_woo_core_version":"8.9.1"}

```

```

🔵 Tracked: order_details_shipping_methods_shown, Properties: {"shipping_lines_count":2,"blog_id":222408976,"is_wpcom_store":true,"was_ecommerce_trial":true,"plan_product_slug":"wooexpress-small-bundle-yearly","store_id":"b6468f83-4986-44f1-b4ce-6021649dbf29","is_debug":true,"site_url":"https:\/\/woo-practically-automatic-witch.wpcomstaging.com","cached_woo_core_version":"8.9.1"}

```


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
