### PR TITLE
[Payment Method Improvements] Update change due based on user input

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorFragment.kt
@@ -38,7 +38,7 @@ class ChangeDueCalculatorFragment : BaseFragment() {
                     uiState = uiState,
                     onNavigateUp = { viewModel.onBackPressed() },
                     onCompleteOrderClick = {},
-                    onAmountReceivedChanged = {}
+                    onAmountReceivedChanged = { viewModel.updateAmountReceived(it) }
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorFragment.kt
@@ -37,7 +37,8 @@ class ChangeDueCalculatorFragment : BaseFragment() {
                 ChangeDueCalculatorScreen(
                     uiState = uiState,
                     onNavigateUp = { viewModel.onBackPressed() },
-                    onCompleteOrderClick = {}
+                    onCompleteOrderClick = {},
+                    onAmountReceivedChanged = {}
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -139,7 +139,7 @@ fun ChangeDueCalculatorScreen(
                             )
                             Spacer(modifier = Modifier.height(8.dp))
                             Text(
-                                text = "$0.00",
+                                text = uiState.change.toPlainString(),
                                 style = LocalTextStyle.current.copy(
                                     fontWeight = FontWeight.Bold,
                                     fontSize = TextUnit(44f, TextUnitType.Sp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -226,7 +226,8 @@ fun ChangeDueCalculatorScreenSuccessPreview() {
     ChangeDueCalculatorScreen(
         uiState = ChangeDueCalculatorViewModel.UiState.Success(
             amountDue = BigDecimal("666.00"),
-            change = BigDecimal("0.00")
+            change = BigDecimal("0.00"),
+            amountReceived = BigDecimal("0.00")
         ),
         onNavigateUp = {},
         onCompleteOrderClick = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -55,7 +55,6 @@ fun ChangeDueCalculatorScreen(
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     var amountReceived by remember { mutableStateOf(BigDecimal.ZERO) }
-     }
 
     WooThemeWithBackground {
         Scaffold(
@@ -125,7 +124,6 @@ fun ChangeDueCalculatorScreen(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(top = 8.dp, bottom = 8.dp, start = 16.dp)
-                          view.setValueIfDifferent(amountReceived)
                         )
 
                         Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -39,6 +40,7 @@ import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.filterNotNull
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.widgets.WCMaterialOutlinedCurrencyEditTextView
 import java.math.BigDecimal
@@ -47,9 +49,13 @@ import java.math.BigDecimal
 fun ChangeDueCalculatorScreen(
     uiState: ChangeDueCalculatorViewModel.UiState,
     onNavigateUp: () -> Unit,
-    onCompleteOrderClick: () -> Unit
+    onCompleteOrderClick: () -> Unit,
+    onAmountReceivedChanged: (BigDecimal) -> Unit
 ) {
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    var amountReceived by remember { mutableStateOf(BigDecimal.ZERO) }
+     }
 
     WooThemeWithBackground {
         Scaffold(
@@ -109,12 +115,17 @@ fun ChangeDueCalculatorScreen(
                                     supportsNegativeValues = false
                                     hint = hintString
                                     setValueIfDifferent(uiState.amountDue)
+                                    value.filterNotNull().observe(lifecycleOwner) {
+                                        onAmountReceivedChanged(it)
+                                        amountReceived = it
+                                    }
                                     view = this
                                 }
                             },
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(top = 8.dp, bottom = 8.dp, start = 16.dp)
+                          view.setValueIfDifferent(amountReceived)
                         )
 
                         Column(
@@ -220,6 +231,7 @@ fun ChangeDueCalculatorScreenSuccessPreview() {
             change = BigDecimal("0.00")
         ),
         onNavigateUp = {},
-        onCompleteOrderClick = {}
+        onCompleteOrderClick = {},
+        onAmountReceivedChanged = {}
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -54,7 +54,6 @@ fun ChangeDueCalculatorScreen(
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
-    var amountReceived by remember { mutableStateOf(BigDecimal.ZERO) }
 
     WooThemeWithBackground {
         Scaffold(
@@ -116,7 +115,6 @@ fun ChangeDueCalculatorScreen(
                                     setValueIfDifferent(uiState.amountDue)
                                     value.filterNotNull().observe(lifecycleOwner) {
                                         onAmountReceivedChanged(it)
-                                        amountReceived = it
                                     }
                                     view = this
                                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -137,7 +137,7 @@ fun ChangeDueCalculatorScreen(
                             )
                             Spacer(modifier = Modifier.height(8.dp))
                             Text(
-                                text = uiState.change.toPlainString(),
+                                text = if (uiState.change < BigDecimal.ZERO) "-" else uiState.change.toPlainString(),
                                 style = LocalTextStyle.current.copy(
                                     fontWeight = FontWeight.Bold,
                                     fontSize = TextUnit(44f, TextUnitType.Sp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModel.kt
@@ -24,7 +24,7 @@ class ChangeDueCalculatorViewModel @Inject constructor(
 
     sealed class UiState {
         data object Loading : UiState()
-        data class Success(val amountDue: BigDecimal, val change: BigDecimal) : UiState()
+        data class Success(val amountDue: BigDecimal, val change: BigDecimal, val amountReceived: BigDecimal) : UiState()
         data object Error : UiState()
     }
 
@@ -42,7 +42,7 @@ class ChangeDueCalculatorViewModel @Inject constructor(
         launch {
             val order = orderDetailRepository.getOrderById(orderId)
             order?.let {
-                _uiState.value = UiState.Success(amountDue = order.total, change = BigDecimal.ZERO)
+                _uiState.value = UiState.Success(amountDue = order.total, change = BigDecimal.ZERO, amountReceived = BigDecimal.ZERO)
             } ?: run {
                 _uiState.value = UiState.Error
             }
@@ -51,5 +51,12 @@ class ChangeDueCalculatorViewModel @Inject constructor(
 
     fun onBackPressed() {
         _navigationEvent.value = Unit
+    }
+
+    fun updateAmountReceived(amount: BigDecimal) {
+        val currentState = _uiState.value
+        if (currentState is UiState.Success) {
+            _uiState.value = currentState.copy(amountReceived = amount)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModel.kt
@@ -24,7 +24,11 @@ class ChangeDueCalculatorViewModel @Inject constructor(
 
     sealed class UiState {
         data object Loading : UiState()
-        data class Success(val amountDue: BigDecimal, val change: BigDecimal, val amountReceived: BigDecimal) : UiState()
+        data class Success(
+            val amountDue: BigDecimal,
+            val change: BigDecimal,
+            val amountReceived: BigDecimal
+        ) : UiState()
         data object Error : UiState()
     }
 
@@ -56,7 +60,8 @@ class ChangeDueCalculatorViewModel @Inject constructor(
     fun updateAmountReceived(amount: BigDecimal) {
         val currentState = _uiState.value
         if (currentState is UiState.Success) {
-            _uiState.value = currentState.copy(amountReceived = amount)
+            val newChange = amount - currentState.amountDue
+            _uiState.value = currentState.copy(amountReceived = amount, change = newChange)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModel.kt
@@ -29,6 +29,7 @@ class ChangeDueCalculatorViewModel @Inject constructor(
             val change: BigDecimal,
             val amountReceived: BigDecimal
         ) : UiState()
+
         data object Error : UiState()
     }
 
@@ -46,7 +47,8 @@ class ChangeDueCalculatorViewModel @Inject constructor(
         launch {
             val order = orderDetailRepository.getOrderById(orderId)
             order?.let {
-                _uiState.value = UiState.Success(amountDue = order.total, change = BigDecimal.ZERO, amountReceived = BigDecimal.ZERO)
+                _uiState.value =
+                    UiState.Success(amountDue = order.total, change = BigDecimal.ZERO, amountReceived = BigDecimal.ZERO)
             } ?: run {
                 _uiState.value = UiState.Error
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11584
<!-- Id number of the GitHub issue this PR addresses. -->

### Description


I added the `unit-tests-exemption` label as this PR is dependent on others and will likely change. Updating the test is ticketed here:
https://github.com/woocommerce/woocommerce-android/issues/11542

This PR is to update the change due correctly based on the user input for how much cash was given.

### Testing instructions


1. Enable OTHER_PAYMENT_METHODS
1. Go to an order that needs to be paid
1. Select "Cash"
2. Enter a cash value

Expected: You should see the correct values update for Cash received and Change Due


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
