### PR TITLE
Fix date formatting for API requests when using a non-standard numerals system

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -85,8 +85,14 @@ fun Date.getTimeString(context: Context): String = DateFormat.getTimeFormat(cont
 
 fun Date.getMediumDate(context: Context): String = DateFormat.getMediumDateFormat(context).format(this)
 
-fun Date.formatToYYYYmmDDhhmmss(): String =
-    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault()).format(this)
+/**
+ * Formats the date to a string in the format "yyyy-MM-dd'T'HH:mm:ss".
+ *
+ * @param locale The locale to use for formatting the date, defaults to [Locale.ROOT], as this is mostly used for API
+ * requests.
+ */
+fun Date.formatToYYYYmmDDhhmmss(locale: Locale = Locale.ROOT): String =
+    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", locale).format(this)
 
 val Date.pastTimeDeltaFromNowInDays
     get() = Calendar.getInstance().time


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### Description
While testing how the app's behave when using Arabic language, I found a very serious bug, multiple of our API requests fail, because they send the date formatted using [Arabic-Indic numerals](https://en.wikipedia.org/wiki/Eastern_Arabic_numerals), and thus the API calls fails, this impacts the stats card on the dashboard, all of the Analytics Hub cards, and the Products/variations sale dates. This impacts Arabic language, but could also impact other languages.

I updated the logic to use the `Locale.ROOT` by default when formatting those dates, which fixes the issues:
| Before | After |
| --- | --- |
| <img width="566" alt="Screenshot 2024-05-28 at 13 10 29" src="https://github.com/woocommerce/woocommerce-android/assets/1657201/7ba77fa2-26b9-4584-a992-4b589710dc0a"> | <img width="566" alt="Screenshot 2024-05-28 at 13 13 05" src="https://github.com/woocommerce/woocommerce-android/assets/1657201/2a61b256-e6ac-4b6e-9991-ca62ca72a376"> |

**Since this is a serious bug, I'm targeting 18.8 with the fix, but on the other hand, this has been a bug for a very long time, let me know if it's better to update the PR to target 18.9**


### Testing instructions
1. Set your phone to Arabic-Egypt language.
2. Open the app.
3. Pull-to-refresh the dashboard.
4. Confirm the stats card is working correctly.
5. Optionally: check the Analytics Hub, and the products sale feature (this might not be very straightforward when not knowing Arabic 😄)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
