### PR TITLE
[Dynamic Dashboard] Advertise new widgets on the dashboard

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.mystore.data.DashboardWidgetDataModel
+import com.woocommerce.android.util.FeatureFlag
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -32,7 +33,20 @@ data class DashboardWidget(
         REVIEWS(R.string.my_store_widget_reviews_title, "reviews"),
         ORDERS(R.string.my_store_widget_orders_title, "orders"),
         COUPONS(R.string.my_store_widget_coupons_title, "coupons"),
-        PRODUCT_STOCK(R.string.my_store_widget_product_stock_title, "product_stock"),
+        PRODUCT_STOCK(R.string.my_store_widget_product_stock_title, "product_stock");
+
+        companion object {
+            // Use the feature flag [DYNAMIC_DASHBOARD_M2] to filter out unsupported widgets during development
+            val supportedWidgets: List<Type> = Type.entries
+                .filter {
+                    FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled() || (
+                        it != DashboardWidget.Type.ORDERS &&
+                            it != DashboardWidget.Type.REVIEWS &&
+                            it != DashboardWidget.Type.COUPONS &&
+                            it != DashboardWidget.Type.PRODUCT_STOCK
+                        )
+                }
+        }
     }
 
     sealed interface Status : Parcelable {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -97,6 +97,13 @@ private fun WidgetList(
                             modifier = widgetModifier
                         )
                     }
+
+                    is DashboardViewModel.DashboardWidgetUiModel.NewWidgetsCard -> {
+                        NewWidgetsCard(
+                            state = it,
+                            modifier = widgetModifier
+                        )
+                    }
                 }
             }
         }
@@ -238,5 +245,38 @@ private fun FeedbackCard(
                 modifier = Modifier.weight(1f)
             )
         }
+    }
+}
+
+@Composable
+private fun NewWidgetsCard(
+    state: DashboardViewModel.DashboardWidgetUiModel.NewWidgetsCard,
+    modifier: Modifier
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .border(
+                width = 1.dp,
+                color = colorResource(id = R.color.woo_gray_5),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .padding(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.dashboard_new_widgets_card_title),
+            style = MaterialTheme.typography.h6,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.dashboard_new_widgets_card_description),
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        WCColoredButton(
+            onClick = state.onShowCardsClick,
+            text = "Add new sections"
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentDashboardBinding
+import com.woocommerce.android.extensions.getColorCompat
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.scrollStartEvents
 import com.woocommerce.android.extensions.showDateRangePicker
@@ -88,7 +89,9 @@ class DashboardFragment :
     private val binding get() = _binding!!
 
     private val editButtonBadge by lazy {
-        BadgeDrawable.create(requireContext())
+        BadgeDrawable.create(requireContext()).apply {
+            backgroundColor = requireContext().getColorCompat(R.color.color_primary)
+        }
     }
 
     private val mainNavigationRouter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -88,9 +88,7 @@ class DashboardFragment :
     private val binding get() = _binding!!
 
     private val editButtonBadge by lazy {
-        BadgeDrawable.create(requireContext()).apply {
-            badgeGravity = BadgeDrawable.TOP_START
-        }
+        BadgeDrawable.create(requireContext())
     }
 
     private val mainNavigationRouter
@@ -326,6 +324,12 @@ class DashboardFragment :
     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
         menuInflater.inflate(R.menu.menu_dashboard_fragment, menu)
 
+        // Attach the badge to the top-left corner of the edit widgets button
+        editButtonBadge.badgeGravity = if (resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL) {
+            BadgeDrawable.TOP_END
+        } else {
+            BadgeDrawable.TOP_START
+        }
         BadgeUtils.attachBadgeDrawable(
             editButtonBadge,
             requireActivity().findViewById(R.id.toolbar),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -5,6 +5,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.annotation.OptIn
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
@@ -14,6 +15,9 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.withCreated
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.badge.BadgeDrawable
+import com.google.android.material.badge.BadgeUtils
+import com.google.android.material.badge.ExperimentalBadgeUtils
 import com.google.android.play.core.review.ReviewManagerFactory
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
@@ -82,6 +86,12 @@ class DashboardFragment :
 
     private var _binding: FragmentDashboardBinding? = null
     private val binding get() = _binding!!
+
+    private val editButtonBadge by lazy {
+        BadgeDrawable.create(requireContext()).apply {
+            badgeGravity = BadgeDrawable.TOP_START
+        }
+    }
 
     private val mainNavigationRouter
         get() = activity as? MainNavigationRouter
@@ -183,6 +193,9 @@ class DashboardFragment :
             ) {
                 initJitm()
             }
+        }
+        dashboardViewModel.hasNewWidgets.observe(viewLifecycleOwner) { hasNewWidgets ->
+            editButtonBadge.isVisible = hasNewWidgets
         }
     }
 
@@ -309,8 +322,15 @@ class DashboardFragment :
 
     override fun shouldExpandToolbar() = binding.statsScrollView.scrollY == 0
 
+    @OptIn(ExperimentalBadgeUtils::class)
     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
         menuInflater.inflate(R.menu.menu_dashboard_fragment, menu)
+
+        BadgeUtils.attachBadgeDrawable(
+            editButtonBadge,
+            requireActivity().findViewById(R.id.toolbar),
+            R.id.menu_edit_screen_widgets
+        )
     }
 
     override fun onMenuItemSelected(menuItem: MenuItem): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -102,8 +102,9 @@ class DashboardViewModel @Inject constructor(
         feedbackPrefs.userFeedbackIsDueObservable
     ) { widgets, userFeedbackIsDue ->
         mapWidgetsToUiModels(widgets, userFeedbackIsDue)
-    }
-        .asLiveData()
+    }.asLiveData()
+
+    val hasNewWidgets = dashboardRepository.hasNewWidgets.asLiveData()
 
     init {
         ConnectionChangeReceiver.getEventBus().register(this)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenEditWidgets
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel.NewWidgetsCard
 import com.woocommerce.android.ui.dashboard.data.DashboardRepository
 import com.woocommerce.android.ui.prefs.privacy.banner.domain.ShouldShowPrivacyBanner
 import com.woocommerce.android.util.PackageUtils
@@ -99,9 +100,10 @@ class DashboardViewModel @Inject constructor(
 
     val dashboardWidgets = combine(
         dashboardRepository.widgets,
+        dashboardRepository.hasNewWidgets,
         feedbackPrefs.userFeedbackIsDueObservable
-    ) { widgets, userFeedbackIsDue ->
-        mapWidgetsToUiModels(widgets, userFeedbackIsDue)
+    ) { configurableWidgets, hasNewWidgets, userFeedbackIsDue ->
+        mapWidgetsToUiModels(configurableWidgets, hasNewWidgets, userFeedbackIsDue)
     }.asLiveData()
 
     val hasNewWidgets = dashboardRepository.hasNewWidgets.asLiveData()
@@ -184,6 +186,7 @@ class DashboardViewModel @Inject constructor(
 
     private fun mapWidgetsToUiModels(
         widgets: List<DashboardWidget>,
+        hasNewWidgets: Boolean,
         userFeedbackIsDue: Boolean
     ): List<DashboardWidgetUiModel> = buildList {
         addAll(
@@ -224,6 +227,15 @@ class DashboardViewModel @Inject constructor(
                     )
                     feedbackPrefs.lastFeedbackDate = Calendar.getInstance().time
                     triggerEvent(DashboardEvent.FeedbackNegativeAction)
+                }
+            )
+        )
+
+        add(
+            NewWidgetsCard(
+                isVisible = hasNewWidgets,
+                onShowCardsClick = {
+                    triggerEvent(OpenEditWidgets)
                 }
             )
         )
@@ -277,6 +289,11 @@ class DashboardViewModel @Inject constructor(
             val onShown: () -> Unit,
             val onPositiveClick: () -> Unit,
             val onNegativeClick: () -> Unit
+        ) : DashboardWidgetUiModel
+
+        data class NewWidgetsCard(
+            override val isVisible: Boolean,
+            val onShowCardsClick: () -> Unit
         ) : DashboardWidgetUiModel
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
@@ -39,7 +39,11 @@ class DashboardDataStore @Inject constructor(
             } else {
                 it
             }
-        }.map { it.widgetsList }
+        }.map {
+            it.widgetsList.filter { widget ->
+                DashboardWidget.Type.supportedWidgets.any { type -> type.name == widget.type }
+            }
+        }
 
     suspend fun updateDashboard(dashboard: DashboardDataModel) {
         runCatching {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.scopes.ActivityRetainedScoped
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
@@ -56,6 +57,10 @@ class DashboardRepository @Inject constructor(
         onboardingWidgetStatus
     ) { widgets, siteOrdersState, blazeWidgetStatus, onboardingWidgetStatus ->
         widgets.toDomainModel(siteOrdersState, blazeWidgetStatus, onboardingWidgetStatus)
+    }
+
+    val hasNewWidgets = dashboardDataStore.widgets.map { widgets ->
+        widgets.size != DashboardWidget.Type.supportedWidgets.size
     }
 
     suspend fun updateWidgets(widgets: List<DashboardWidget>) = dashboardDataStore.updateDashboard(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
@@ -60,7 +60,7 @@ class DashboardRepository @Inject constructor(
     }
 
     val hasNewWidgets = dashboardDataStore.widgets.map { widgets ->
-        widgets.size != DashboardWidget.Type.supportedWidgets.size
+        widgets.size < DashboardWidget.Type.supportedWidgets.size
     }
 
     suspend fun updateWidgets(widgets: List<DashboardWidget>) = dashboardDataStore.updateDashboard(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
@@ -81,6 +81,20 @@ class DashboardRepository @Inject constructor(
         updateWidgets(dataStoreWidgets)
     }
 
+    suspend fun addNewWidgetsToTheConfig() {
+        val widgets = widgets.first()
+        val newWidgets = DashboardWidget.Type.supportedWidgets
+            .filter { widgetType -> widgets.none { it.type == widgetType } }
+            .map { widgetType ->
+                DashboardWidget(
+                    type = widgetType,
+                    isSelected = false,
+                    status = DashboardWidget.Status.Available
+                )
+            }
+        updateWidgets(widgets + newWidgets)
+    }
+
     private fun List<DashboardWidgetDataModel>.toDomainModel(
         siteOrdersState: DashboardWidget.Status,
         blazeWidgetStatus: DashboardWidget.Status,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
@@ -44,7 +44,17 @@ class DashboardWidgetEditorViewModel @Inject constructor(
         get() = viewState.value?.isSaveButtonEnabled == true
 
     init {
+        addNewWidgetsToTheConfig()
         loadWidgets()
+    }
+
+    /**
+     * Add new widgets to the config to make sure the flag of new widgets is disabled when the user opens the editor.
+     */
+    private fun addNewWidgetsToTheConfig() {
+        viewModelScope.launch {
+            dashboardRepository.addNewWidgetsToTheConfig()
+        }
     }
 
     private fun loadWidgets() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
@@ -44,29 +44,25 @@ class DashboardWidgetEditorViewModel @Inject constructor(
         get() = viewState.value?.isSaveButtonEnabled == true
 
     init {
-        addNewWidgetsToTheConfig()
-        loadWidgets()
+        viewModelScope.launch {
+            addNewWidgetsToTheConfig()
+            loadWidgets()
+        }
     }
 
     /**
      * Add new widgets to the config to make sure the flag of new widgets is disabled when the user opens the editor.
      */
-    private fun addNewWidgetsToTheConfig() {
-        viewModelScope.launch {
-            dashboardRepository.addNewWidgetsToTheConfig()
-        }
-    }
+    private suspend fun addNewWidgetsToTheConfig() = dashboardRepository.addNewWidgetsToTheConfig()
 
-    private fun loadWidgets() {
-        viewModelScope.launch {
-            dashboardRepository.widgets.collectIndexed { index, storedWidgets ->
-                editedWidgets = if (index == 0) {
-                    storedWidgets
-                } else {
-                    editedWidgets.map { dashboardWidget ->
-                        val storedWidget = storedWidgets.first { it.type == dashboardWidget.type }
-                        dashboardWidget.copy(status = storedWidget.status)
-                    }
+    private suspend fun loadWidgets() {
+        dashboardRepository.widgets.collectIndexed { index, storedWidgets ->
+            editedWidgets = if (index == 0) {
+                storedWidgets
+            } else {
+                editedWidgets.map { dashboardWidget ->
+                    val storedWidget = storedWidgets.first { it.type == dashboardWidget.type }
+                    dashboardWidget.copy(status = storedWidget.status)
                 }
             }
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -441,6 +441,8 @@
     <string name="dashboard_product_stock_levels">Stock levels</string>
     <string name="dashboard_product_stock_products">Products</string>
 
+    <string name="dashboard_new_widgets_card_title">Looking for more insights?</string>
+    <string name="dashboard_new_widgets_card_description">Add new sections to customize your store management experience</string>
     <!--
         Sign Up Flow
     -->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11514 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds logic to show a new card and a badge to communicate to the users that we support new cards in the dashboard.
Originally, the plan was to use just a simple Boolean SharedPreferences flag, but we faced an issue of how to differentiate between app upgrades and new installations, since the card is expected to be shown only for users during the upgrade from M1 to M2, so we decided to revert to a more dynamic approach: we'll compare the number of cards in the saved config against the list of supported cards by the app, and when we have more supported cards than saved, we'll show the card.
This meant changing how the new cards are added, as now, they'll be added to the config only after opening the widget editor.

### Testing instructions
1. Disable the DYNAMIC_DASHBOARD_M2 feature flag.
2. Open the app, and open the widget editor screen.
3. Make some changes, then save.
4. Enable the DYNAMIC_DASHBOARD_M2 feature flag.
5. Open the app.
6. Confirm the badge and the new card "Looking for more insights?" are shown.
7. Tap on "Add new sections"
8. Confirm the widget editor screen is shown.
9. Go back, confirm the badge and the new card are hidden now.

### Images/gif
<img width=360 src="https://github.com/woocommerce/woocommerce-android/assets/1657201/4fbd0ad3-4f71-40f9-aa50-4c1b56caf486" />


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
