### PR TITLE
[WooPOS] Lock orientation in landscape for woo pos activity

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.root
 
+import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
@@ -11,6 +12,8 @@ import dagger.hilt.android.AndroidEntryPoint
 class WooPosActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+
         setContent {
             MaterialTheme {
                 WooPosRootHost()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11591
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR locks the orientation in landscape on the Woo POS activity.

That works fine on all the devices but big tablets-emulators. I am wondering, @backwardstruck @samiuelson, if you have a real Android tablet to test that? I want to confirm that the issue in the emulator itself

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="589" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/4923871/100138e9-3ee1-4eba-98b6-7c357d99c65f">
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
