### PR TITLE
Add NA support

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -111,7 +111,9 @@ import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavi
 import com.woocommerce.android.ui.orders.creation.product.discount.CurrencySymbolFinder
 import com.woocommerce.android.ui.orders.creation.shipping.GetShippingMethodsWithOtherValue
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingLineDetails
+import com.woocommerce.android.ui.orders.creation.shipping.ShippingMethodsRepository
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingUpdateResult
+import com.woocommerce.android.ui.orders.creation.shipping.getMethodIdOrDefault
 import com.woocommerce.android.ui.orders.creation.taxes.GetAddressFromTaxRate
 import com.woocommerce.android.ui.orders.creation.taxes.GetTaxRatesInfoDialogViewState
 import com.woocommerce.android.ui.orders.creation.taxes.TaxBasedOnSetting
@@ -384,7 +386,13 @@ class OrderCreateEditViewModel @Inject constructor(
             val shippingMethodsMap = shippingMethods.value.associateBy { it.id }
 
             shippingLines.map { shippingLine ->
-                val method = shippingLine.methodId?.let { shippingMethodsMap[it] }
+                val method = shippingLine.methodId?.let {
+                    if (it == " ") {
+                        shippingMethodsMap[ShippingMethodsRepository.NA_ID]
+                    } else {
+                        shippingMethodsMap[it]
+                    }
+                }
                 ShippingLineDetails(
                     id = shippingLine.itemId,
                     name = shippingLine.methodTitle,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1529,7 +1529,7 @@ class OrderCreateEditViewModel @Inject constructor(
                 shippingUpdateResult.id != null -> draft.shippingLines.map { shippingLine ->
                     if (shippingLine.itemId == shippingUpdateResult.id) {
                         shippingLine.copy(
-                            methodId = shippingUpdateResult.methodId ?: "other",
+                            methodId = shippingUpdateResult.getMethodIdOrDefault(),
                             total = shippingUpdateResult.amount,
                             methodTitle = shippingUpdateResult.name
                         )
@@ -1541,7 +1541,7 @@ class OrderCreateEditViewModel @Inject constructor(
                 draft.shippingLines.isNotEmpty() -> draft.shippingLines.toMutableList().also {
                     it.add(
                         ShippingLine(
-                            methodId = shippingUpdateResult.methodId ?: "other",
+                            methodId = shippingUpdateResult.getMethodIdOrDefault(),
                             total = shippingUpdateResult.amount,
                             methodTitle = shippingUpdateResult.name
                         )
@@ -1550,7 +1550,7 @@ class OrderCreateEditViewModel @Inject constructor(
 
                 else -> listOf(
                     ShippingLine(
-                        methodId = shippingUpdateResult.methodId ?: "other",
+                        methodId = shippingUpdateResult.getMethodIdOrDefault(),
                         total = shippingUpdateResult.amount,
                         methodTitle = shippingUpdateResult.name
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodById.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodById.kt
@@ -7,12 +7,14 @@ class GetShippingMethodById @Inject constructor(
     private val shippingMethodsRepository: ShippingMethodsRepository
 ) {
     suspend operator fun invoke(shippingMethodId: String?): ShippingMethod {
-        val other = shippingMethodsRepository.getOtherShippingMethod()
-        if (shippingMethodId == ShippingMethodsRepository.OTHER_ID || shippingMethodId == null) {
-            return other
+        return when {
+            shippingMethodId.isNullOrEmpty() -> shippingMethodsRepository.getNAShippingMethod()
+            shippingMethodId == ShippingMethodsRepository.OTHER_ID -> shippingMethodsRepository.getOtherShippingMethod()
+            else -> {
+                val result = shippingMethodsRepository.getShippingMethodById(shippingMethodId)
+                    ?: shippingMethodsRepository.fetchShippingMethodByIdAndSaveResult(shippingMethodId).model
+                result ?: shippingMethodsRepository.getOtherShippingMethod()
+            }
         }
-        val result = shippingMethodsRepository.getShippingMethodById(shippingMethodId)
-            ?: shippingMethodsRepository.fetchShippingMethodByIdAndSaveResult(shippingMethodId).model
-        return result ?: other
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodsWithOtherValue.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodsWithOtherValue.kt
@@ -12,7 +12,10 @@ class GetShippingMethodsWithOtherValue @Inject constructor(
         return shippingMethodsRepository.observeShippingMethods()
             .map { list ->
                 val withOtherValue = list.toMutableList()
-                    .also { it.add(shippingMethodsRepository.getOtherShippingMethod()) }
+                    .also {
+                        it.add(0, shippingMethodsRepository.getNAShippingMethod())
+                        it.add(shippingMethodsRepository.getOtherShippingMethod())
+                    }
                 withOtherValue
             }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingMethodsViewModel.kt
@@ -57,7 +57,7 @@ class OrderShippingMethodsViewModel @Inject constructor(
         getShippingMethodsWithOtherValue()
             .withIndex()
             .filter { indexedFetchedShippingMethods ->
-                indexedFetchedShippingMethods.index != 0 || indexedFetchedShippingMethods.value.size != 1
+                indexedFetchedShippingMethods.index != 0 || indexedFetchedShippingMethods.value.size != 2
             }
             .collect { fetchedShippingMethods ->
                 var methodsUIList = fetchedShippingMethods.value.map { ShippingMethodUI(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
@@ -105,7 +105,7 @@ fun UpdateShippingScreen(
             )
             FieldSelectValue(
                 text = method,
-                hint = stringResource(id = R.string.order_creation_add_shipping_method_select_hint),
+                hint = stringResource(id = R.string.na),
                 onSelect = onSelectMethod,
                 modifier = Modifier.fillMaxWidth()
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
@@ -153,6 +153,12 @@ data class ShippingUpdateResult(
     val methodId: String?
 ) : Parcelable
 
+fun ShippingUpdateResult.getMethodIdOrDefault() = if (this.methodId.isNullOrEmpty()) {
+    " " // Default should be N/A Id (""), but passing "" fails, so we add a space
+} else {
+    this.methodId
+}
+
 data class UpdateShipping(val shippingUpdate: ShippingUpdateResult) : MultiLiveEvent.Event()
 data class RemoveShipping(val id: Long) : MultiLiveEvent.Event()
 data class SelectShippingMethod(val currentMethodId: String?) : MultiLiveEvent.Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingMethodsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingMethodsRepository.kt
@@ -24,6 +24,7 @@ class ShippingMethodsRepository @Inject constructor(
 ) {
     companion object {
         const val OTHER_ID = "other"
+        const val NA_ID = ""
     }
 
     suspend fun fetchShippingMethodsAndSaveResults(
@@ -84,6 +85,13 @@ class ShippingMethodsRepository @Inject constructor(
         return ShippingMethod(
             id = OTHER_ID,
             title = resourceProvider.getString(R.string.other)
+        )
+    }
+
+    fun getNAShippingMethod(): ShippingMethod {
+        return ShippingMethod(
+            id = NA_ID,
+            title = resourceProvider.getString(R.string.na)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -55,6 +55,7 @@ import com.woocommerce.android.ui.orders.OrderStatusUpdateSource
 import com.woocommerce.android.ui.orders.creation.shipping.GetShippingMethodsWithOtherValue
 import com.woocommerce.android.ui.orders.creation.shipping.RefreshShippingMethods
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingLineDetails
+import com.woocommerce.android.ui.orders.creation.shipping.ShippingMethodsRepository
 import com.woocommerce.android.ui.orders.details.customfields.CustomOrderFieldsHelper
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentCollectibilityChecker
@@ -178,7 +179,13 @@ class OrderDetailViewModel @Inject constructor(
             val shippingMethodsMap = shippingMethods.value.associateBy { it.id }
             var shouldRefreshShippingMethods = false
             val result = shippingLines.map { shippingLine ->
-                val method = shippingLine.methodId?.let { shippingMethodsMap[it] }
+                val method = shippingLine.methodId?.let {
+                    if (it == " ") {
+                        shippingMethodsMap[ShippingMethodsRepository.NA_ID]
+                    } else {
+                        shippingMethodsMap[it]
+                    }
+                }
                 shouldRefreshShippingMethods = shouldRefreshShippingMethods ||
                     shippingLine.methodId.isNullOrEmpty().not() && method == null && shippingMethods.index == 0
                 ShippingLineDetails(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -134,6 +134,7 @@
     <string name="selection_count">%d selected</string>
     <string name="please_wait">Please wait…</string>
     <string name="other">Other</string>
+    <string name="na">N/A</string>
     <string name="free">free</string>
     <string name="and">and</string>
     <string name="generic_string" translatable="false">%s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodByIdTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodByIdTest.kt
@@ -47,7 +47,6 @@ class GetShippingMethodByIdTest : BaseUnitTest() {
         )
 
         whenever(shippingMethodsStore.fetchShippingMethod(siteModel, methodId)).doReturn(WooResult(fetchResult))
-        whenever(resourceProvider.getString(any())).doReturn("Other")
 
         val result = sut.invoke(methodId)
         assertThat(result).isNotNull
@@ -67,6 +66,21 @@ class GetShippingMethodByIdTest : BaseUnitTest() {
         )
         assertThat(result).isNotNull
         assertThat(result.id).isEqualTo(ShippingMethodsRepository.OTHER_ID)
+    }
+
+    @Test
+    fun `when the method id is empty, then return is the expected`() = testBlocking {
+        whenever(resourceProvider.getString(any())).doReturn("N/A")
+
+        val result = sut.invoke(ShippingMethodsRepository.NA_ID)
+
+        // If is empty doesn't need to fetch the values from the API
+        verify(shippingMethodsStore, never()).fetchShippingMethod(
+            siteModel,
+            ShippingMethodsRepository.NA_ID
+        )
+        assertThat(result).isNotNull
+        assertThat(result.id).isEqualTo(ShippingMethodsRepository.NA_ID)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodsWithOtherValueTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/GetShippingMethodsWithOtherValueTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.creation.shipping
 
+import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -8,7 +9,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -44,11 +44,12 @@ class GetShippingMethodsWithOtherValueTest : BaseUnitTest() {
             )
         }
         whenever(shippingMethodsStore.observeShippingMethods(siteModel)).doReturn(flowOf(fetchResult))
-        whenever(resourceProvider.getString(any())).doReturn("Other")
+        whenever(resourceProvider.getString(R.string.other)).doReturn("Other")
+        whenever(resourceProvider.getString(R.string.na)).doReturn("N/A")
 
         val result = sut.invoke().first()
         assertThat(result).isNotNull
-        assertThat(result.size).isEqualTo(4) // List + Other
+        assertThat(result.size).isEqualTo(5) // List + Other + N/A
         val other = result.firstOrNull { it.id == ShippingMethodsRepository.OTHER_ID }
         assertThat(other).isNotNull
     }


### PR DESCRIPTION
Closes: #11600
### Why
Raised while running the testing plan for Android, we agreed to include the N/A option in the list of shipping methods.

### Description
This PR introduces the N/A (not applicable) option to the list of shipping methods. It incorporates this new option into the shipping methods repository and updates the shipping methods use cases to reflect this addition.

### Testing instructions
TC1
1. Open the app
2. Navigate to Orders
3. Add a new product to enable the shipping section
4. Tap on Add new shipping
5. Check that now, by default, the N/A option is suggested
6. Tap on Select shipping method and check that the N/A is displayed among the shipping method options.
7. Select the N/A option and add the shipping line
8. Check that the shipping line is added to the order and that the shipping method field displays N/A
9. Create the order and check that the shipping line is displayed and that the shipping method field displays N/A

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/12ee7144-9901-4e3e-ba34-b1bf5abcdf44

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
