### PR TITLE
UI M1 fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Buttons.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.compose.component
 
 import android.content.res.Configuration
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -143,6 +144,7 @@ fun WCOutlinedButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
     colors: ButtonColors = ButtonDefaults.outlinedButtonColors(),
+    border: BorderStroke? = ButtonDefaults.outlinedBorder,
     content: @Composable RowScope.() -> Unit
 ) {
     OutlinedButton(
@@ -151,6 +153,7 @@ fun WCOutlinedButton(
         colors = colors,
         contentPadding = contentPadding,
         interactionSource = interactionSource,
+        border = border,
         modifier = modifier,
     ) {
         ProvideTextStyle(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/AmountBigDecimalTextField.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/AmountBigDecimalTextField.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidView
 import com.google.android.material.textfield.TextInputLayout
+import com.woocommerce.android.R
 import com.woocommerce.android.extensions.filterNotNull
 import com.woocommerce.android.widgets.WCMaterialOutlinedCurrencyEditTextView
 import java.math.BigDecimal
@@ -28,13 +29,16 @@ fun AmountBigDecimalTextField(
                     onValueChange(it)
                 }
                 boxBackgroundMode = TextInputLayout.BOX_BACKGROUND_NONE
-                val textSize = 24f
+                val textSize = 28f
                 editText.apply {
                     background = null
+                    setTextAppearance(R.style.TextAppearance_Woo_EditText)
                     setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize)
                 }
                 prefixTextView.apply {
+                    setTextAppearance(R.style.TextAppearance_Woo_EditText)
                     setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize)
+                    setTextColor(context.getColor(R.color.color_on_surface_disabled))
                 }
                 suffixTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingFragment.kt
@@ -37,7 +37,11 @@ class OrderShippingFragment : BaseFragment() {
         }
     }
 
-    override fun getFragmentTitle() = getString(R.string.order_creation_shipping_title_add)
+    override fun getFragmentTitle() = if (viewModel.isEditFlow) {
+        getString(R.string.order_creation_shipping_title_edit)
+    } else {
+        getString(R.string.order_creation_shipping_title_add)
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         viewModel.event.observe(viewLifecycleOwner) { event ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.creation.shipping
 
 import android.content.res.Configuration
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
@@ -142,20 +144,24 @@ fun UpdateShippingScreen(
                 .padding(16.dp)
                 .align(Alignment.BottomCenter)
         ) {
+            if (isEditFlow) {
+                WCOutlinedButton(
+                    onClick = { onRemove() },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colors.error
+                    ),
+                    border = BorderStroke(1.dp, MaterialTheme.colors.error)
+                ) {
+                    Text(stringResource(id = R.string.order_creation_remove_shipping))
+                }
+            }
             WCColoredButton(
                 enabled = isSaveChangesEnabled,
                 onClick = { onSaveChanges() },
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text(stringResource(id = R.string.order_creation_shipping_add))
-            }
-            if (isEditFlow) {
-                WCOutlinedButton(
-                    onClick = { onRemove() },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text(stringResource(id = R.string.order_creation_remove_shipping))
-                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
@@ -59,7 +59,7 @@ fun UpdateShippingScreen(
                 name = currentState.name,
                 amount = currentState.amount,
                 method = currentState.method?.title,
-                isEditFlow = currentState.isEditFlow,
+                isEditFlow = viewModel.isEditFlow,
                 isSaveChangesEnabled = currentState.isSaveChangesEnabled,
                 onNameChanged = { name -> viewModel.onNameChanged(name) },
                 onAmountChanged = { amount -> viewModel.onAmountChanged(amount) },
@@ -161,7 +161,12 @@ fun UpdateShippingScreen(
                 onClick = { onSaveChanges() },
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text(stringResource(id = R.string.order_creation_shipping_add))
+                val buttonResId = if (isEditFlow) {
+                    R.string.order_creation_shipping_edit
+                } else {
+                    R.string.order_creation_shipping_add
+                }
+                Text(stringResource(id = buttonResId))
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
@@ -176,7 +177,7 @@ fun FieldSelectValue(
     modifier: Modifier = Modifier
 ) {
     val display = text ?: hint.orEmpty()
-    val alpha = if (text == null) 0.6f else 1f
+    val alpha = if (text == null) 0.38f else 1f
     Box(
         modifier = modifier
             .padding(8.dp)
@@ -186,7 +187,8 @@ fun FieldSelectValue(
     ) {
         Text(
             text = display,
-            fontSize = 24.sp,
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Bold,
             modifier = Modifier
                 .align(Alignment.CenterStart)
                 .alpha(alpha)
@@ -214,7 +216,8 @@ fun FieldEditValue(
         value = text,
         onValueChange = onValueChange,
         textStyle = TextStyle(
-            fontSize = 24.sp,
+            fontWeight = FontWeight.Bold,
+            fontSize = 28.sp,
             color = MaterialTheme.colors.onSurface
         ),
         cursorBrush = SolidColor(colors.cursorColor(false).value),
@@ -228,7 +231,9 @@ fun FieldEditValue(
                 placeholder = @Composable {
                     Text(
                         text = stringResource(id = R.string.order_creation_add_shipping_name_hint),
-                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 28.sp,
+                        color = MaterialTheme.colors.onSurface.copy(alpha = .38f)
                     )
                 },
                 enabled = true,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModel.kt
@@ -30,13 +30,14 @@ class OrderShippingViewModel @Inject constructor(
     private val navArgs: OrderShippingFragmentArgs by savedState.navArgs()
     val viewState: MutableStateFlow<ViewState>
 
+    val isEditFlow = navArgs.currentShippingLine != null
+
     init {
         val state = if (navArgs.currentShippingLine == null) {
             ViewState.ShippingState(
                 method = null,
                 name = null,
                 amount = BigDecimal.ZERO,
-                isEditFlow = false,
                 isSaveChangesEnabled = false
             )
         } else {
@@ -49,7 +50,6 @@ class OrderShippingViewModel @Inject constructor(
                     method = getShippingMethodById(shippingLine.methodId),
                     name = shippingLine.methodTitle,
                     amount = shippingLine.total,
-                    isEditFlow = true,
                     isSaveChangesEnabled = false
                 )
             }
@@ -139,7 +139,6 @@ class OrderShippingViewModel @Inject constructor(
             val method: ShippingMethod?,
             val name: String?,
             val amount: BigDecimal,
-            val isEditFlow: Boolean,
             val isSaveChangesEnabled: Boolean
         ) : ViewState()
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -687,9 +687,11 @@
     <string name="order_creation_payment_tax_label">Taxes</string>
     <string name="order_creation_shipping_name">Name</string>
     <string name="order_creation_shipping_title_add">Add Shipping</string>
+    <string name="order_creation_shipping_title_edit">Edit Shipping</string>
     <string name="order_creation_shipping_methods_title">Method</string>
     <string name="order_creation_shipping_methods_error">Error while fetching your shipping methods. Please try again</string>
     <string name="order_creation_shipping_add">Add Shipping</string>
+    <string name="order_creation_shipping_edit">Edit Shipping</string>
     <string name="order_creation_add_shipping">Add shipping</string>
     <string name="order_creation_add_shipping_method">Method</string>
     <string name="order_creation_add_shipping_amount">Amount</string>

--- a/WooCommerce/src/main/res/values/type.xml
+++ b/WooCommerce/src/main/res/values/type.xml
@@ -49,6 +49,13 @@
         <item name="lineHeight">@dimen/line_height_major_25</item>
     </style>
 
+    <style name="TextAppearance.Woo.EditText" parent="TextAppearance.MaterialComponents.Headline6">
+        <item name="fontFamily">@font/roboto_medium</item>
+        <item name="android:textSize">@dimen/text_major_25</item>
+        <item name="android:textStyle">bold</item>
+        <item name="lineHeight">@dimen/line_height_major_25</item>
+    </style>
+
     <style name="TextAppearance.Woo.Subtitle1" parent="TextAppearance.MaterialComponents.Subtitle1">
         <item name="fontFamily">@font/roboto</item>
         <item name="android:textSize">@dimen/text_minor_125</item>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/shipping/OrderShippingViewModelTest.kt
@@ -54,7 +54,7 @@ class OrderShippingViewModelTest : BaseUnitTest() {
         assertThat((viewState as OrderShippingViewModel.ViewState.ShippingState).name).isNull()
         assertThat(viewState.method).isNull()
         assertThat(viewState.amount).isEqualByComparingTo(BigDecimal.ZERO)
-        assertThat(viewState.isEditFlow).isFalse
+        assertThat(viewModel.isEditFlow).isFalse
     }
 
     @Test
@@ -70,7 +70,7 @@ class OrderShippingViewModelTest : BaseUnitTest() {
         assertThat((viewState as OrderShippingViewModel.ViewState.ShippingState).name)
             .isEqualTo(editArgs.currentShippingLine?.methodTitle)
         assertThat(viewState.amount).isEqualByComparingTo(editArgs.currentShippingLine?.total)
-        assertThat(viewState.isEditFlow).isTrue
+        assertThat(viewModel.isEditFlow).isTrue
     }
 
     @Test


### PR DESCRIPTION
Closes: #11603

### Description
This PR fixes some design issues detected during the beta testing of M1

- [x] The font style should be `bold` in the Add shipping screen
- [x] The Remove shipping from order should be red and appear on top of the Add Shipping button
- [x] Change between Add Shipping or Edit Shipping depending on the flow


### Testing instructions
TC1
1. Open the app
2. Navigate to the orders tab
3. Add a new order (+)
4. Add a product to enable the shipping lines
5. Add a shipping line
6. Check that the editable text of the shipping fields is displayed in bold font style
7. Check that the screen title and button (at the bottom of the screen) display `Add Shipping`
8. Save the shipping line

TC2
1. Using the shipping line from TC1
2. With the order on create/edit mode, tap on the shipping line
3. Check that the screen title and button (at the bottom of the screen) display `Edit Shipping`
4. Check that the style of the remove button is outlined and using the color red
5. Check that the editable text of the shipping fields is displayed in bold font style

### Images/gif
| Add Screen  | Edit Screen |
| ------------- | ------------- |
| <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/fe3966c9-71b9-4647-83aa-0b1e0d9a2a0a" />  | <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/f1359cbd-40ea-4deb-85f4-218f59bfd648" />  |



- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
