### PR TITLE
[Payment Method Improvements] Gray out button until payment amount is greater or equal to amount due

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorFragment.kt
@@ -58,13 +58,8 @@ class ChangeDueCalculatorFragment : BaseFragment() {
         return ComposeView(requireContext()).apply {
             setContent {
                 val uiState by viewModel.uiState.collectAsState()
-                val recordTransactionDetailsChecked by viewModel.recordTransactionDetailsChecked.collectAsState()
-                val currencySymbol = viewModel.getCurrencySymbol()
                 ChangeDueCalculatorScreen(
                     uiState = uiState,
-                    recordTransactionDetailsChecked = recordTransactionDetailsChecked,
-                    canCompleteOrder = viewModel.canCompleteOrder(),
-                    currencySymbol = currencySymbol,
                     onNavigateUp = viewModel::onBackPressed,
                     onCompleteOrderClick = viewModel::addOrderNoteIfChecked,
                     onAmountReceivedChanged = { viewModel.updateAmountReceived(it) },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorFragment.kt
@@ -53,7 +53,7 @@ class ChangeDueCalculatorFragment : BaseFragment() {
                     uiState = uiState,
                     recordTransactionDetailsChecked = recordTransactionDetailsChecked,
                     canCompleteOrder = viewModel.canCompleteOrder(),
-                    currencySymbol =currencySymbol,
+                    currencySymbol = currencySymbol,
                     onNavigateUp = viewModel::onBackPressed,
                     onCompleteOrderClick = {
                         MainScope().launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorFragment.kt
@@ -51,6 +51,7 @@ class ChangeDueCalculatorFragment : BaseFragment() {
                 ChangeDueCalculatorScreen(
                     uiState = uiState,
                     recordTransactionDetailsChecked = recordTransactionDetailsChecked,
+                    canCompleteOrder = viewModel.canCompleteOrder(),
                     onNavigateUp = viewModel::onBackPressed,
                     onCompleteOrderClick = {
                         MainScope().launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorFragment.kt
@@ -61,7 +61,7 @@ class ChangeDueCalculatorFragment : BaseFragment() {
                 ChangeDueCalculatorScreen(
                     uiState = uiState,
                     onNavigateUp = viewModel::onBackPressed,
-                    onCompleteOrderClick = viewModel::addOrderNoteIfChecked,
+                    onCompleteOrderClick = viewModel::onOrderComplete,
                     onAmountReceivedChanged = { viewModel.updateAmountReceived(it) },
                     onRecordTransactionDetailsCheckedChanged = {
                         viewModel.updateRecordTransactionDetailsChecked(it)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorFragment.kt
@@ -48,10 +48,12 @@ class ChangeDueCalculatorFragment : BaseFragment() {
             setContent {
                 val uiState by viewModel.uiState.collectAsState()
                 val recordTransactionDetailsChecked by viewModel.recordTransactionDetailsChecked.collectAsState()
+                val currencySymbol = viewModel.getCurrencySymbol()
                 ChangeDueCalculatorScreen(
                     uiState = uiState,
                     recordTransactionDetailsChecked = recordTransactionDetailsChecked,
                     canCompleteOrder = viewModel.canCompleteOrder(),
+                    currencySymbol =currencySymbol,
                     onNavigateUp = viewModel::onBackPressed,
                     onCompleteOrderClick = {
                         MainScope().launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -53,8 +53,6 @@ import java.math.BigDecimal
 fun ChangeDueCalculatorScreen(
     uiState: ChangeDueCalculatorViewModel.UiState,
     recordTransactionDetailsChecked: Boolean,
-    canCompleteOrder: Boolean,
-    currencySymbol: String,
     onNavigateUp: () -> Unit,
     onCompleteOrderClick: () -> Unit,
     onAmountReceivedChanged: (BigDecimal) -> Unit,
@@ -131,7 +129,7 @@ fun ChangeDueCalculatorScreen(
                         text = if (uiState.change < BigDecimal.ZERO) {
                             "-"
                         } else {
-                            "$currencySymbol${uiState.change.toPlainString()}"
+                            "${uiState.currencySymbol}${uiState.change.toPlainString()}"
                         },
                         style = MaterialTheme.typography.h3,
                         fontWeight = FontWeight.Bold,
@@ -150,7 +148,7 @@ fun ChangeDueCalculatorScreen(
 
                     MarkOrderAsCompleteButton(
                         loading = uiState.loading,
-                        enabled = canCompleteOrder,
+                        enabled = uiState.canCompleteOrder,
                         onClick = onCompleteOrderClick,
                         modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)
                     )
@@ -228,11 +226,11 @@ fun ChangeDueCalculatorScreenSuccessPreview() {
             amountDue = BigDecimal("666.00"),
             change = BigDecimal("0.00"),
             amountReceived = BigDecimal("0.00"),
-            loading = true
+            loading = false,
+            canCompleteOrder = true,
+            currencySymbol = "$"
         ),
         recordTransactionDetailsChecked = false,
-        canCompleteOrder = false,
-        currencySymbol = "$",
         onNavigateUp = {},
         onCompleteOrderClick = {},
         onAmountReceivedChanged = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.BigDecimalTextFieldValueMapper
@@ -218,8 +218,8 @@ private fun getTitleText(uiState: ChangeDueCalculatorViewModel.UiState): String 
 }
 
 @Composable
-@Preview(showBackground = true)
-fun ChangeDueCalculatorScreenSuccessPreview() {
+@PreviewLightDark
+fun ChangeDueCalculatorScreenSuccessPreviewUnchecked() {
     ChangeDueCalculatorScreen(
         uiState = ChangeDueCalculatorViewModel.UiState(
             amountDue = BigDecimal("666.00"),
@@ -227,9 +227,50 @@ fun ChangeDueCalculatorScreenSuccessPreview() {
             amountReceived = BigDecimal("0.00"),
             loading = false,
             canCompleteOrder = true,
-            currencySymbol = "$"
+            currencySymbol = "$",
+            recordTransactionDetailsChecked = false,
         ),
-        recordTransactionDetailsChecked = false,
+        onNavigateUp = {},
+        onCompleteOrderClick = {},
+        onAmountReceivedChanged = {},
+        onRecordTransactionDetailsCheckedChanged = {}
+    )
+}
+
+@Composable
+@PreviewLightDark
+fun ChangeDueCalculatorScreenSuccessPreviewChecked() {
+    ChangeDueCalculatorScreen(
+        uiState = ChangeDueCalculatorViewModel.UiState(
+            amountDue = BigDecimal("666.00"),
+            change = BigDecimal("0.00"),
+            amountReceived = BigDecimal("0.00"),
+            loading = true,
+            canCompleteOrder = true,
+            currencySymbol = "€",
+            recordTransactionDetailsChecked = true,
+        ),
+        onNavigateUp = {},
+        onCompleteOrderClick = {},
+        onAmountReceivedChanged = {},
+        onRecordTransactionDetailsCheckedChanged = {}
+    )
+}
+
+
+@Composable
+@PreviewLightDark
+fun ChangeDueCalculatorScreenSuccessPreviewDisabled() {
+    ChangeDueCalculatorScreen(
+        uiState = ChangeDueCalculatorViewModel.UiState(
+            amountDue = BigDecimal("666.00"),
+            change = BigDecimal("0.00"),
+            amountReceived = BigDecimal("0.00"),
+            loading = false,
+            canCompleteOrder = false,
+            currencySymbol = "€",
+            recordTransactionDetailsChecked = true,
+        ),
         onNavigateUp = {},
         onCompleteOrderClick = {},
         onAmountReceivedChanged = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -257,7 +257,6 @@ fun ChangeDueCalculatorScreenSuccessPreviewChecked() {
     )
 }
 
-
 @Composable
 @PreviewLightDark
 fun ChangeDueCalculatorScreenSuccessPreviewDisabled() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -52,7 +52,6 @@ import java.math.BigDecimal
 @Composable
 fun ChangeDueCalculatorScreen(
     uiState: ChangeDueCalculatorViewModel.UiState,
-    recordTransactionDetailsChecked: Boolean,
     onNavigateUp: () -> Unit,
     onCompleteOrderClick: () -> Unit,
     onAmountReceivedChanged: (BigDecimal) -> Unit,
@@ -142,7 +141,7 @@ fun ChangeDueCalculatorScreen(
 
                     RecordTransactionDetailsNote(
                         modifier = Modifier.fillMaxWidth(),
-                        checked = recordTransactionDetailsChecked,
+                        checked = uiState.recordTransactionDetailsChecked,
                         onCheckedChange = onRecordTransactionDetailsCheckedChanged
                     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -52,6 +52,7 @@ fun ChangeDueCalculatorScreen(
     uiState: ChangeDueCalculatorViewModel.UiState,
     recordTransactionDetailsChecked: Boolean,
     canCompleteOrder: Boolean,
+    currencySymbol: String,
     onNavigateUp: () -> Unit,
     onCompleteOrderClick: () -> Unit,
     onAmountReceivedChanged: (BigDecimal) -> Unit,
@@ -142,7 +143,7 @@ fun ChangeDueCalculatorScreen(
                             )
                             Spacer(modifier = Modifier.height(8.dp))
                             Text(
-                                text = if (uiState.change < BigDecimal.ZERO) "-" else uiState.change.toPlainString(),
+                                text = if (uiState.change < BigDecimal.ZERO) "-" else "$currencySymbol${uiState.change.toPlainString()}",
                                 style = LocalTextStyle.current.copy(
                                     fontWeight = FontWeight.Bold,
                                     fontSize = TextUnit(44f, TextUnitType.Sp)
@@ -207,7 +208,7 @@ fun MarkOrderAsCompleteButton(onClick: () -> Unit, enabled: Boolean, modifier: M
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp),
-        enabled=enabled
+        enabled = enabled
     ) {
         Text(text = stringResource(R.string.cash_payments_mark_order_as_complete))
     }
@@ -236,6 +237,7 @@ fun ChangeDueCalculatorScreenSuccessPreview() {
         ),
         recordTransactionDetailsChecked = false,
         canCompleteOrder = false,
+        currencySymbol = "$",
         onNavigateUp = {},
         onCompleteOrderClick = {},
         onAmountReceivedChanged = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -143,7 +143,11 @@ fun ChangeDueCalculatorScreen(
                             )
                             Spacer(modifier = Modifier.height(8.dp))
                             Text(
-                                text = if (uiState.change < BigDecimal.ZERO) "-" else "$currencySymbol${uiState.change.toPlainString()}",
+                                text = if (uiState.change < BigDecimal.ZERO) {
+                                    "-"
+                                } else {
+                                    "$currencySymbol${uiState.change.toPlainString()}"
+                                },
                                 style = LocalTextStyle.current.copy(
                                     fontWeight = FontWeight.Bold,
                                     fontSize = TextUnit(44f, TextUnitType.Sp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -51,6 +51,7 @@ import java.math.BigDecimal
 fun ChangeDueCalculatorScreen(
     uiState: ChangeDueCalculatorViewModel.UiState,
     recordTransactionDetailsChecked: Boolean,
+    canCompleteOrder: Boolean,
     onNavigateUp: () -> Unit,
     onCompleteOrderClick: () -> Unit,
     onAmountReceivedChanged: (BigDecimal) -> Unit,
@@ -162,6 +163,7 @@ fun ChangeDueCalculatorScreen(
 
                         MarkOrderAsCompleteButton(
                             onClick = onCompleteOrderClick,
+                            enabled = canCompleteOrder,
                             modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)
                         )
                     }
@@ -199,12 +201,13 @@ fun RecordTransactionDetailsNote(
 }
 
 @Composable
-fun MarkOrderAsCompleteButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
+fun MarkOrderAsCompleteButton(onClick: () -> Unit, enabled: Boolean, modifier: Modifier = Modifier) {
     Button(
         onClick = onClick,
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp)
+            .padding(horizontal = 16.dp),
+        enabled=enabled
     ) {
         Text(text = stringResource(R.string.cash_payments_mark_order_as_complete))
     }
@@ -232,6 +235,7 @@ fun ChangeDueCalculatorScreenSuccessPreview() {
             amountReceived = BigDecimal("0.00")
         ),
         recordTransactionDetailsChecked = false,
+        canCompleteOrder = false,
         onNavigateUp = {},
         onCompleteOrderClick = {},
         onAmountReceivedChanged = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -131,7 +131,7 @@ fun ChangeDueCalculatorScreen(
                         text = if (uiState.change < BigDecimal.ZERO) {
                             "-"
                         } else {
-                            uiState.change.toPlainString()
+                            "$currencySymbol${uiState.change.toPlainString()}"
                         },
                         style = MaterialTheme.typography.h3,
                         fontWeight = FontWeight.Bold,
@@ -148,17 +148,16 @@ fun ChangeDueCalculatorScreen(
                         onCheckedChange = onRecordTransactionDetailsCheckedChanged
                     )
 
-                        MarkOrderAsCompleteButton(
-                            loading = uiState.loading,
-                            enabled = canCompleteOrder,
-                            onClick = onCompleteOrderClick,
-                            modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)
-                        )
-                    }
+                    MarkOrderAsCompleteButton(
+                        loading = uiState.loading,
+                        enabled = canCompleteOrder,
+                        onClick = onCompleteOrderClick,
+                        modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)
+                    )
                 }
             }
-            Spacer(modifier = Modifier.height(16.dp))
         }
+        Spacer(modifier = Modifier.height(16.dp))
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModel.kt
@@ -66,7 +66,7 @@ class ChangeDueCalculatorViewModel @Inject constructor(
         }
     }
 
-    private fun getCurrencySymbol(): String {
+    fun getCurrencySymbol(): String {
         val siteParameters = parameterRepository.getParameters()
         return siteParameters.currencySymbol.orEmpty()
     }
@@ -74,6 +74,7 @@ class ChangeDueCalculatorViewModel @Inject constructor(
     fun updateRecordTransactionDetailsChecked(checked: Boolean) {
         _recordTransactionDetailsChecked.value = checked
     }
+
     suspend fun addOrderNoteIfChecked(noteStringTemplate: String) {
         if (recordTransactionDetailsChecked.value) {
             val noteString = generateOrderNoteString(noteStringTemplate)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModel.kt
@@ -58,7 +58,7 @@ class ChangeDueCalculatorViewModel @Inject constructor(
                 amountDue = order.total,
                 change = BigDecimal.ZERO,
                 amountReceived = BigDecimal.ZERO,
-                canCompleteOrder = canCompleteOrder(),
+                canCompleteOrder = false,
                 currencySymbol = getCurrencySymbol(),
             )
         }
@@ -71,7 +71,11 @@ class ChangeDueCalculatorViewModel @Inject constructor(
     fun updateAmountReceived(amount: BigDecimal) {
         val currentState = _uiState.value
         val newChange = amount - currentState.amountDue
-        _uiState.value = currentState.copy(amountReceived = amount, change = newChange)
+        _uiState.value = currentState.copy(
+            amountReceived = amount,
+            change = newChange,
+            canCompleteOrder = newChange >= BigDecimal.ZERO,
+        )
     }
 
     fun updateRecordTransactionDetailsChecked(checked: Boolean) {
@@ -120,10 +124,5 @@ class ChangeDueCalculatorViewModel @Inject constructor(
             "$currencySymbol${state.amountReceived.toPlainString()}",
             "$currencySymbol${state.change.toPlainString()}"
         )
-    }
-
-    private fun canCompleteOrder(): Boolean {
-        val currentState = _uiState.value
-        return currentState.amountReceived >= currentState.amountDue
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModel.kt
@@ -104,4 +104,13 @@ class ChangeDueCalculatorViewModel @Inject constructor(
             else -> noteStringTemplate
         }
     }
+
+    fun canCompleteOrder(): Boolean {
+        val currentState = _uiState.value
+        return if (currentState is UiState.Success) {
+            currentState.amountReceived >= currentState.amountDue
+        } else {
+            false
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModel.kt
@@ -82,7 +82,7 @@ class ChangeDueCalculatorViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(recordTransactionDetailsChecked = checked)
     }
 
-    fun addOrderNoteIfChecked() {
+    fun onOrderComplete() {
         if (_uiState.value.recordTransactionDetailsChecked) {
             launch {
                 val noteStringTemplate = resourceProvider.getString(R.string.cash_payments_order_note_text)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -27,7 +28,12 @@ class ChangeDueCalculatorViewModelTest : BaseUnitTest() {
 
     private val orderDetailRepository: OrderDetailRepository = mock()
 
-    private val parameterRepository: ParameterRepository = mock()
+    private val parameters: SiteParameters = mock {
+        on { currencySymbol }.thenReturn("$")
+    }
+    private val parameterRepository: ParameterRepository = mock {
+        on { getParameters() }.thenReturn(parameters)
+    }
 
     private val savedStateHandle: SavedStateHandle = SavedStateHandle(mapOf("orderId" to 1L))
 


### PR DESCRIPTION
Closes: #11604
<!-- Id number of the GitHub issue this PR addresses. -->

This PR is branched off of https://github.com/woocommerce/woocommerce-android/pull/11594

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->


**Gray out "Mark order as complete" button:**
   - The "Mark order as complete" button is disabled if the amount of cash received is less than the amount due. This prevents users from completing the order without receiving sufficient payment.

**Display correct currency symbol in change due field:**
   - The change due field now correctly displays the currency symbol, aligning with the currency used for the transaction.


### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->

0. Enable `OTHER_PAYMENT_METHODS`

1. **Gray out button test:**
   - Navigate to an order that needs to be paid with cash.
   - Enter a cash received amount that is less than the amount due.
   - Verify that the "Mark order as complete" button is grayed out and disabled.
   - Enter a cash received amount that is equal to or greater than the amount due.
   - Verify that the "Mark order as complete" button is enabled.

2. **Currency symbol in change due field test:**
   - Verify that the change due field displays the correct currency symbol as defined by the app's currency settings.


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

---

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

