### PR TITLE
Return the category from the API result rather than getting it from the DB

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.products.categories
 
 import android.os.Parcelable
-import android.text.TextUtils
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -137,7 +136,6 @@ class AddProductCategoryViewModel @Inject constructor(
 
         launch {
             if (networkStatus.isConnected()) {
-                val categoryNameTrimmed = TextUtils.htmlEncode(categoryName.trim())
                 val requestResult = when {
                     addProductCategoryViewState.isEditingMode -> updateProductCategory(categoryName, parentId)
                     else -> addNewProductCategory(categoryName, parentId)
@@ -149,12 +147,10 @@ class AddProductCategoryViewModel @Inject constructor(
                             else -> R.string.add_product_category_success
                         }
                         triggerEvent(ShowSnackbar(successString))
-                        val addedCategory = productCategoriesRepository
-                            .getProductCategoryByNameAndParentId(categoryNameTrimmed, parentId)
                         val action =
                             if (addProductCategoryViewState.isEditingMode) UpdateAction.Update else UpdateAction.Add
                         triggerEvent(
-                            ExitWithResult(CategoryUpdateResult(addedCategory!!, action))
+                            ExitWithResult(CategoryUpdateResult(it, action))
                         )
                     }
                     .onFailure {


### PR DESCRIPTION
Another attempt to fix this crash: #11210

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I wasn't able to reproduce the crash but I've made the code nullably safe and removed a DB access that I'm not sure why was it there in the first place. I think is a leftover from legacy implementation that I missed refactoring when I added the edit and remove functionality. 

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
Smoke test product category feature: 
- Adding new product categories
- Editing categories (changing name or parent)
- Deleting categories with or without child categories

