### PR TITLE
Updated file name suffix with timeStamp instead of date formatter

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/FileUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/FileUtils.kt
@@ -3,9 +3,6 @@ package com.woocommerce.android.media
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.UTILS
 import java.io.File
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import javax.inject.Inject
 
 class FileUtils @Inject constructor() {
@@ -19,8 +16,7 @@ class FileUtils @Inject constructor() {
         fileExtension: String
     ): File? {
         return try {
-            val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
-            val fileName = "${prefix}_$timeStamp"
+            val fileName = "${prefix}_${System.currentTimeMillis()}"
             File.createTempFile(fileName, ".$fileExtension", storageDir)
         } catch (e: Exception) {
             WooLog.e(UTILS, "Unable to create a temp file", e)


### PR DESCRIPTION
 **Removing Simple Date Formatter and using System current milliseconds for File name**

### **Description**
This PR removes the SimpleDateFormatter implementation inside the FileUtils class while creating a temp file we are adding a simple date formatter to create a unique name for the file. So instead of using the Date formatter here using System.currentmillis will be a clean idea where it doesn't involve any date time formatting

### Testing instructions
Test if the file generation is working fine with new file names everytime.


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. 
