### PR TITLE
Shipping Lines Feedback UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/FeedbackDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/FeedbackDialog.kt
@@ -1,0 +1,137 @@
+package com.woocommerce.android.ui.compose.component
+
+import android.content.res.Configuration
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Card
+import androidx.compose.material.Colors
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+@Suppress("MagicNumber")
+val Colors.feedbackSurface: Color get() = if (isLight) Color(0xFF271B3D) else Color(0xFFCFB9F6)
+
+@Suppress("MagicNumber")
+val Colors.onFeedbackSurface: Color get() = if (isLight) Color(0xFFCFB9F6) else Color(0xFF271B3D)
+
+@Composable
+fun FeedbackDialog(
+    title: String,
+    message: String,
+    action: String,
+    isShown: Boolean,
+    onAction: () -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colorStops = arrayOf(
+        .6f to Color.Transparent,
+        1f to MaterialTheme.colors.feedbackSurface.copy(alpha = .4f),
+    )
+
+    Box(modifier = modifier) {
+        AnimatedVisibility(
+            visible = isShown,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            label = "background_transition",
+        ) {
+            Box(
+                modifier = modifier
+                    .background(Brush.verticalGradient(colorStops = colorStops))
+                    .fillMaxSize()
+            )
+        }
+
+        AnimatedVisibility(
+            visible = isShown,
+            enter = slideInVertically(initialOffsetY = { it }),
+            exit = slideOutVertically(targetOffsetY = { it }),
+            label = "card_transition",
+            modifier = Modifier.align(Alignment.BottomCenter)
+        ) {
+            Card(
+                backgroundColor = MaterialTheme.colors.feedbackSurface,
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Row {
+                    Column(modifier = Modifier.weight(2f, true)) {
+                        val fontSize = 16.sp
+                        Text(
+                            text = title,
+                            fontSize = fontSize,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colors.onPrimary,
+                            modifier = Modifier.padding(start = 16.dp, top = 12.dp)
+                        )
+                        Text(
+                            text = message,
+                            fontSize = fontSize,
+                            color = MaterialTheme.colors.onPrimary.copy(alpha = .9f),
+                            modifier = Modifier.padding(start = 16.dp, top = 4.dp)
+                        )
+                        WCTextButton(
+                            onClick = { onAction() },
+                            modifier = Modifier.padding(start = 8.dp)
+                        ) {
+                            Text(
+                                text = action,
+                                fontSize = fontSize,
+                                color = MaterialTheme.colors.onFeedbackSurface
+                            )
+                        }
+                    }
+                    IconButton(
+                        onClick = { onClose() },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Close,
+                            tint = MaterialTheme.colors.onPrimary.copy(alpha = .75f),
+                            contentDescription = stringResource(id = R.string.close)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun FeedbackDialogPreview() {
+    WooThemeWithBackground {
+        FeedbackDialog(
+            title = "Shipping added!",
+            message = "Does Woo make shipping easy?",
+            action = "Share your feedback",
+            isShown = true,
+            onAction = {},
+            onClose = {}
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -93,6 +93,7 @@ import com.woocommerce.android.ui.products.selector.ProductSelectorSharedViewMod
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
@@ -410,7 +411,9 @@ class OrderCreateEditFormFragment :
 
         bindShippingLinesSection(binding)
 
-        bindFeedbackSection(binding)
+        if (FeatureFlag.EOSL_M3.isEnabled()) {
+            bindFeedbackSection(binding)
+        }
 
         observeViewStateChanges(binding)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnLifecycleDestroyed
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
@@ -50,6 +51,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.barcodescanner.BarcodeScanningFragment
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.compose.component.FeedbackDialog
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.coupons.selector.CouponSelectorFragment.Companion.KEY_COUPON_SELECTOR_RESULT
@@ -408,6 +410,8 @@ class OrderCreateEditFormFragment :
 
         bindShippingLinesSection(binding)
 
+        bindFeedbackSection(binding)
+
         observeViewStateChanges(binding)
 
         viewModel.event.observe(viewLifecycleOwner) { handleViewModelEvents(it, binding) }
@@ -424,6 +428,26 @@ class OrderCreateEditFormFragment :
                             modifier = Modifier.padding(bottom = 1.dp),
                             onAdd = { viewModel.onAddOrEditShipping() },
                             onEdit = { id -> viewModel.onAddOrEditShipping(id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun bindFeedbackSection(binding: FragmentOrderCreateEditFormBinding) {
+        binding.feedbackSection.apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                viewModel.viewStateData.liveData.observeAsState().value?.showShippingFeedback?.let { show ->
+                    WooTheme {
+                        FeedbackDialog(
+                            title = stringResource(id = R.string.order_creation_shipping_feedback_title),
+                            message = stringResource(id = R.string.order_creation_shipping_feedback_message),
+                            action = stringResource(id = R.string.order_creation_feedback_action),
+                            isShown = show,
+                            onAction = { viewModel.onCloseShippingFeedback() },
+                            onClose = { viewModel.onCloseShippingFeedback() },
                         )
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -2033,6 +2033,7 @@ class OrderCreateEditViewModel @Inject constructor(
         val customAmountSectionState: CustomAmountSectionState = CustomAmountSectionState(),
         val windowSizeClass: WindowSizeClass = WindowSizeClass.Compact,
         val isRecalculateNeeded: Boolean = false,
+        val showShippingFeedback: Boolean = false,
     ) : Parcelable {
         @IgnoredOnParcel
         val canCreateOrder: Boolean =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -19,6 +19,7 @@ enum class FeatureFlag {
     DYNAMIC_DASHBOARD,
     APP_PASSWORD_TUTORIAL,
     EOSL_M1,
+    EOSL_M3,
     DYNAMIC_DASHBOARD_M2;
 
     fun isEnabled(context: Context? = null): Boolean {
@@ -34,7 +35,8 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
-            DYNAMIC_DASHBOARD_M2 -> PackageUtils.isDebugBuild()
+            DYNAMIC_DASHBOARD_M2,
+            EOSL_M3 -> PackageUtils.isDebugBuild()
 
             DYNAMIC_DASHBOARD,
             CONNECTIVITY_TOOL,

--- a/WooCommerce/src/main/res/layout/fragment_order_create_edit_form.xml
+++ b/WooCommerce/src/main/res/layout/fragment_order_create_edit_form.xml
@@ -144,6 +144,15 @@
         app:layout_constraintStart_toEndOf="@+id/two_pane_layout_guideline"
         tools:composableName="com.woocommerce.android.ui.orders.creation.totals.OrderCreateEditTotalsFullViewKt" />
 
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/feedback_section"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@+id/scrollView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/two_pane_layout_guideline"
+        tools:composableName="com.woocommerce.android.ui.compose.component.FeedbackDialogKt" />
+
     <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/loadingProgress"
         android:layout_width="0dp"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -755,6 +755,10 @@
     <string name="customer_picker_guest_customer_not_allowed_message">This user is a guest, and guests can\'t be used for filtering orders.</string>
     <string name="customer_picker_guest">Guest</string>
 
+    <string name="order_creation_shipping_feedback_title">Shipping added!</string>
+    <string name="order_creation_shipping_feedback_message">Does Woo make shipping easy?</string>
+    <string name="order_creation_feedback_action">Share your feedback</string>
+
     <!--
          Barcode Scanning
     -->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11398

### Why
After releasing the new shipping line support feature, we want to collect user feedback.

### Description
This PR adds the `FeedbackDialog` control, which displays the shipping lines' feedback. The PR only handles the UI and animations. This PR also ensures that the logic to display the shipping lines is executed only once after a change in the order's shipping lines. The logic to display the shipping line and the links to the crowdsignal will be added in a different PR.

### Testing instructions
1. Open the app
2. Navigate to the orders tab
3. Tap on add new order (+)
4. Add a product to enable the shipping section
5. Add a new shipping line
6. Check that the feedback control is displayed
7. Tap on close or share feedback to close the control
8. Add/Update/Delete a shipping line
9. Check that the feedback control is not displayed again (we want the control to be displayed only once)

### Images/gif

| Light Mode  | Dark Mode |
| ------------- | ------------- |
| <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/a65c7fbe-f9c1-4e8e-858f-5f50a2fc8b73" />  | <img width="300" src="https://github.com/woocommerce/woocommerce-android/assets/18119390/bb8fd458-4105-4bdd-a1e4-4d1ff8cb0bd3" />  |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
