### PR TITLE
[Dynamic Dashboard] Inbox card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
@@ -33,6 +33,7 @@ data class DashboardWidget(
         ORDERS(R.string.my_store_widget_orders_title, "orders"),
         COUPONS(R.string.my_store_widget_coupons_title, "coupons"),
         PRODUCT_STOCK(R.string.my_store_widget_product_stock_title, "product_stock"),
+        INBOX(R.string.inbox_screen_title, "inbox"),
     }
 
     sealed interface Status : Parcelable {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
 import com.woocommerce.android.ui.dashboard.blaze.DashboardBlazeCard
 import com.woocommerce.android.ui.dashboard.coupons.DashboardCouponsCard
+import com.woocommerce.android.ui.dashboard.inbox.DashboardInboxCard
 import com.woocommerce.android.ui.dashboard.onboarding.DashboardOnboardingCard
 import com.woocommerce.android.ui.dashboard.orders.DashboardOrdersCard
 import com.woocommerce.android.ui.dashboard.reviews.DashboardReviewsCard
@@ -153,6 +154,11 @@ private fun ConfigurableWidgetCard(
         )
 
         DashboardWidget.Type.PRODUCT_STOCK -> DashboardProductStockCard(
+            parentViewModel = dashboardViewModel,
+            modifier = modifier
+        )
+
+        DashboardWidget.Type.INBOX -> DashboardInboxCard(
             parentViewModel = dashboardViewModel,
             modifier = modifier
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -49,10 +49,12 @@ import com.woocommerce.android.ui.main.MainNavigationRouter
 import com.woocommerce.android.ui.prefs.privacy.banner.PrivacyBannerFragmentDirections
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.wordpress.android.util.ToastUtils
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -164,6 +166,8 @@ class DashboardFragment :
                 is FeedbackPositiveAction -> handleFeedbackRequestPositiveClick()
 
                 is FeedbackNegativeAction -> mainNavigationRouter?.showFeedbackSurvey()
+
+                is ShowSnackbar -> ToastUtils.showToast(requireContext(), event.message)
 
                 else -> event.isHandled = false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -29,6 +29,7 @@ import com.woocommerce.android.ui.dashboard.data.DashboardRepository
 import com.woocommerce.android.ui.prefs.privacy.banner.domain.ShouldShowPrivacyBanner
 import com.woocommerce.android.util.PackageUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -179,6 +180,10 @@ class DashboardViewModel @Inject constructor(
 
     fun onContactSupportClicked() {
         triggerEvent(DashboardEvent.ContactSupport)
+    }
+
+    fun onShowSnackbar(@StringRes message: Int) {
+        triggerEvent(Event.ShowSnackbar(message))
     }
 
     private fun mapWidgetsToUiModels(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxCard.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -57,10 +55,11 @@ fun DashboardInboxCard(
     }
 ) {
     viewModel.viewState.observeAsState().value?.let { state ->
+        val button = (state as? ViewState.Content)?.notes?.takeIf { it.isNotEmpty() }?.let { viewModel.button }
         WidgetCard(
             titleResource = state.title,
             menu = viewModel.menu,
-            button = viewModel.button,
+            button = button,
             modifier = modifier,
             isError = state is ViewState.Error
         ) {
@@ -208,8 +207,7 @@ fun EmptyView() {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(dimensionResource(id = R.dimen.major_200))
-            .verticalScroll(rememberScrollState()),
+            .padding(dimensionResource(id = R.dimen.major_200)),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxCard.kt
@@ -3,13 +3,10 @@ package com.woocommerce.android.ui.dashboard.inbox
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -30,7 +27,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
-import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.compose.viewModelWithFactory
 import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
@@ -40,6 +36,7 @@ import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.inbox.DashboardInboxViewModel.NavigateToInbox
 import com.woocommerce.android.ui.dashboard.inbox.DashboardInboxViewModel.ViewState
 import com.woocommerce.android.ui.inbox.InboxNoteActionEvent
+import com.woocommerce.android.ui.inbox.InboxNoteItemSkeleton
 import com.woocommerce.android.ui.inbox.InboxNoteRow
 import com.woocommerce.android.ui.inbox.InboxNoteUi
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -135,68 +132,11 @@ fun LatestNotes(
 private fun Loading() {
     Column {
         repeat(3) {
-            LoadingItem()
+            InboxNoteItemSkeleton()
             Divider(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = 16.dp)
-            )
-        }
-    }
-}
-
-@Composable
-private fun LoadingItem() {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = dimensionResource(id = R.dimen.major_100))
-    ) {
-        // Date
-        SkeletonView(
-            modifier = Modifier
-                .padding(top = dimensionResource(id = R.dimen.major_100))
-                .height(18.dp)
-                .width(120.dp)
-        )
-
-        // Title
-        SkeletonView(
-            modifier = Modifier
-                .padding(top = dimensionResource(id = R.dimen.major_75))
-                .height(20.dp)
-                .width(300.dp)
-        )
-
-        // Description
-        SkeletonView(
-            modifier = Modifier
-                .padding(top = dimensionResource(id = R.dimen.major_75))
-                .height(18.dp)
-                .width(350.dp)
-        )
-
-        SkeletonView(
-            modifier = Modifier
-                .padding(top = dimensionResource(id = R.dimen.minor_50))
-                .height(18.dp)
-                .width(300.dp)
-        )
-
-        // Actions
-        Row(
-            modifier = Modifier
-                .padding(vertical = dimensionResource(id = R.dimen.major_100))
-                .fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100))
-        ) {
-            SkeletonView(
-                width = dimensionResource(id = R.dimen.skeleton_text_large_width),
-                height = 18.dp
-            )
-            SkeletonView(
-                width = dimensionResource(id = R.dimen.major_350),
-                height = 18.dp
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxCard.kt
@@ -1,0 +1,243 @@
+package com.woocommerce.android.ui.dashboard.inbox
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.ui.compose.animations.SkeletonView
+import com.woocommerce.android.ui.compose.rememberNavController
+import com.woocommerce.android.ui.compose.viewModelWithFactory
+import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
+import com.woocommerce.android.ui.dashboard.DashboardViewModel
+import com.woocommerce.android.ui.dashboard.WidgetCard
+import com.woocommerce.android.ui.dashboard.WidgetError
+import com.woocommerce.android.ui.dashboard.inbox.DashboardInboxViewModel.NavigateToInbox
+import com.woocommerce.android.ui.dashboard.inbox.DashboardInboxViewModel.ViewState
+import com.woocommerce.android.ui.inbox.InboxNoteActionEvent
+import com.woocommerce.android.ui.inbox.InboxNoteRow
+import com.woocommerce.android.ui.inbox.InboxNoteUi
+import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.ChromeCustomTabUtils.Height.Partial.ThreeQuarters
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+
+@Composable
+fun DashboardInboxCard(
+    parentViewModel: DashboardViewModel,
+    modifier: Modifier = Modifier,
+    viewModel: DashboardInboxViewModel = viewModelWithFactory { factory: DashboardInboxViewModel.Factory ->
+        factory.create(parentViewModel)
+    }
+) {
+    viewModel.viewState.observeAsState().value?.let { state ->
+        WidgetCard(
+            titleResource = state.title,
+            menu = viewModel.menu,
+            button = viewModel.button,
+            modifier = modifier,
+            isError = state is ViewState.Error
+        ) {
+            when (state) {
+                is ViewState.Content -> LatestNotes(state.notes)
+                is ViewState.Error -> WidgetError(
+                    onContactSupportClicked = parentViewModel::onContactSupportClicked,
+                    onRetryClicked = viewModel::onRefresh
+                )
+                is ViewState.Loading -> Loading()
+            }
+        }
+    }
+
+    HandleEvents(viewModel.event, parentViewModel::onShowSnackbar)
+}
+
+@Composable
+private fun HandleEvents(
+    event: LiveData<Event>,
+    onShowSnackbar: (message: Int) -> Unit
+) {
+    val navController = rememberNavController()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
+
+    DisposableEffect(event, navController, lifecycleOwner) {
+        val observer = Observer { event: Event ->
+            when (event) {
+                is NavigateToInbox -> {
+                    navController.navigateSafely(
+                        DashboardFragmentDirections.actionDashboardToInboxFragment()
+                    )
+                }
+                is Event.ShowSnackbar -> onShowSnackbar(event.message)
+
+                is InboxNoteActionEvent.OpenUrlEvent -> {
+                    ChromeCustomTabUtils.launchUrl(context, event.url, ThreeQuarters)
+                }
+            }
+        }
+
+        event.observe(lifecycleOwner, observer)
+
+        onDispose {
+            event.removeObserver(observer)
+        }
+    }
+}
+
+@Composable
+fun LatestNotes(
+    notes: List<InboxNoteUi>
+) {
+    Column {
+        if (notes.isEmpty()) {
+            EmptyView()
+        } else {
+            notes.forEach { note ->
+                InboxNoteRow(note, limitDescription = true)
+
+                Divider(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Loading() {
+    Column {
+        repeat(3) {
+            LoadingItem()
+            Divider(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingItem() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+    ) {
+        // Date
+        SkeletonView(
+            modifier = Modifier
+                .padding(top = dimensionResource(id = R.dimen.major_100))
+                .height(18.dp)
+                .width(120.dp)
+        )
+
+        // Title
+        SkeletonView(
+            modifier = Modifier
+                .padding(top = dimensionResource(id = R.dimen.major_75))
+                .height(20.dp)
+                .width(300.dp)
+        )
+
+        // Description
+        SkeletonView(
+            modifier = Modifier
+                .padding(top = dimensionResource(id = R.dimen.major_75))
+                .height(18.dp)
+                .width(350.dp)
+        )
+
+        SkeletonView(
+            modifier = Modifier
+                .padding(top = dimensionResource(id = R.dimen.minor_50))
+                .height(18.dp)
+                .width(300.dp)
+        )
+
+        // Actions
+        Row(
+            modifier = Modifier
+                .padding(vertical = dimensionResource(id = R.dimen.major_100))
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100))
+        ) {
+            SkeletonView(
+                width = dimensionResource(id = R.dimen.skeleton_text_large_width),
+                height = 18.dp
+            )
+            SkeletonView(
+                width = dimensionResource(id = R.dimen.major_350),
+                height = 18.dp
+            )
+        }
+    }
+}
+
+@Composable
+fun EmptyView() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(dimensionResource(id = R.dimen.major_200))
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.img_empty_inbox),
+            contentDescription = null,
+        )
+        Spacer(Modifier.size(dimensionResource(id = R.dimen.major_100)))
+        Text(
+            text = stringResource(id = R.string.empty_inbox_title),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.h6,
+            modifier = Modifier.padding(
+                start = dimensionResource(id = R.dimen.major_150),
+                end = dimensionResource(id = R.dimen.major_150)
+            )
+        )
+    }
+}
+
+@Composable
+@Preview
+fun PreviewEmptyView() {
+    EmptyView()
+}
+
+@Composable
+@Preview
+fun PreviewLoadingCard() {
+    Loading()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxViewModel.kt
@@ -138,7 +138,7 @@ class DashboardInboxViewModel @AssistedInject constructor(
         }
     }
 
-    private fun onNoteAction(actionId:Long, noteId: Long) {
+    private fun onNoteAction(actionId: Long, noteId: Long) {
         val clickedNote = (viewState.value as? ViewState.Content)?.notes?.firstOrNull { noteId == it.id }
         clickedNote?.let {
             when {
@@ -183,7 +183,6 @@ class DashboardInboxViewModel @AssistedInject constructor(
         )
         _refreshTrigger.tryEmit(RefreshEvent(isForced = true))
     }
-
 
     sealed class ViewState {
         data object Loading : ViewState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxViewModel.kt
@@ -1,0 +1,202 @@
+package com.woocommerce.android.ui.dashboard.inbox
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.model.DashboardWidget.Type.INBOX
+import com.woocommerce.android.ui.dashboard.DashboardViewModel
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.RefreshEvent
+import com.woocommerce.android.ui.dashboard.defaultHideMenuEntry
+import com.woocommerce.android.ui.dashboard.inbox.DashboardInboxViewModel.Factory
+import com.woocommerce.android.ui.inbox.InboxNoteActionEvent
+import com.woocommerce.android.ui.inbox.InboxNoteUi
+import com.woocommerce.android.ui.inbox.domain.InboxNote
+import com.woocommerce.android.ui.inbox.domain.InboxRepository
+import com.woocommerce.android.ui.inbox.toInboxNoteUi
+import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.ResourceProvider
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.transformLatest
+import kotlinx.coroutines.launch
+
+@Suppress("LongParameterList")
+@HiltViewModel(assistedFactory = Factory::class)
+class DashboardInboxViewModel @AssistedInject constructor(
+    private val resourceProvider: ResourceProvider,
+    private val dateUtils: DateUtils,
+    private val inboxRepository: InboxRepository,
+    savedStateHandle: SavedStateHandle,
+    @Assisted private val parentViewModel: DashboardViewModel,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+) : ScopedViewModel(savedStateHandle) {
+    companion object {
+        const val MAX_NUMBER_OF_NOTES_TO_DISPLAY_IN_CARD = 3
+    }
+
+    private val _refreshTrigger = MutableSharedFlow<RefreshEvent>(extraBufferCapacity = 1)
+    private val refreshTrigger = merge(parentViewModel.refreshTrigger, _refreshTrigger)
+        .onStart { emit(RefreshEvent()) }
+
+    val menu = DashboardWidgetMenu(
+        items = listOf(
+            DashboardWidget.Type.INBOX.defaultHideMenuEntry {
+                parentViewModel.onHideWidgetClicked(INBOX)
+            }
+        )
+    )
+
+    val button = DashboardWidgetAction(
+        titleResource = R.string.dashboard_action_view_all_messages,
+        action = ::onNavigateToInbox
+    )
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val viewState = refreshTrigger
+        .transformLatest {
+            val shouldFetchFirst = it.isForced || inboxRepository.observeInboxNotes().first().isEmpty()
+            if (shouldFetchFirst) {
+                emit(ViewState.Loading)
+            }
+
+            emitAll(
+                observeMostRecentNotes(shouldFetchFirst)
+                    .map { result ->
+                        result.fold(
+                            onSuccess = { notes ->
+                                ViewState.Content(
+                                    notes
+                                        .take(MAX_NUMBER_OF_NOTES_TO_DISPLAY_IN_CARD)
+                                        .map { note ->
+                                            note.toInboxNoteUi(
+                                                dateUtils,
+                                                resourceProvider,
+                                                ::onNoteAction
+                                            ) { _, noteId -> onNoteDismissed(noteId) }
+                                        }
+                                )
+                            },
+                            onFailure = { ViewState.Error }
+                        )
+                    }
+            )
+        }
+        .asLiveData()
+
+    private fun observeMostRecentNotes(shouldFetchFirst: Boolean) = channelFlow<Result<List<InboxNote>>> {
+        if (shouldFetchFirst) {
+            inboxRepository.fetchInboxNotes()
+                .onFailure {
+                    send(Result.failure(it))
+                    return@channelFlow
+                }
+        }
+
+        coroutineScope {
+            val notesJob = launch {
+                inboxRepository.observeInboxNotes()
+                    .collect { notes ->
+                        send(Result.success(notes))
+                    }
+            }
+
+            if (!shouldFetchFirst) {
+                inboxRepository.fetchInboxNotes()
+                    .onFailure {
+                        notesJob.cancel()
+                        send(Result.failure(it))
+                    }
+            }
+        }
+    }
+
+    private fun onNoteDismissed(noteId: Long) {
+        viewModelScope.launch {
+            inboxRepository.dismissNote(noteId)
+                .onFailure { showSyncError() }
+        }
+    }
+
+    private fun onNoteAction(actionId:Long, noteId: Long) {
+        val clickedNote = (viewState.value as? ViewState.Content)?.notes?.firstOrNull { noteId == it.id }
+        clickedNote?.let {
+            when {
+                it.isSurvey -> markSurveyAsAnswered(clickedNote.id, actionId)
+                else -> openActionUrl(clickedNote, actionId)
+            }
+        }
+    }
+
+    private fun openActionUrl(clickedNote: InboxNoteUi, actionId: Long) {
+        val clickedAction = clickedNote.actions.firstOrNull { actionId == it.id }
+        clickedAction?.let {
+            if (it.url.isNotEmpty()) {
+                viewModelScope.launch {
+                    inboxRepository.markInboxNoteAsActioned(clickedNote.id, actionId)
+                }
+                triggerEvent(InboxNoteActionEvent.OpenUrlEvent(it.url))
+            }
+        }
+    }
+
+    private fun markSurveyAsAnswered(noteId: Long, actionId: Long) {
+        viewModelScope.launch {
+            inboxRepository.markInboxNoteAsActioned(noteId, actionId)
+        }
+    }
+
+    private fun showSyncError() {
+        triggerEvent(Event.ShowSnackbar(R.string.inbox_screen_sync_error))
+    }
+
+    private fun onNavigateToInbox() {
+        triggerEvent(NavigateToInbox)
+    }
+
+    fun onRefresh() {
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.DYNAMIC_DASHBOARD_CARD_RETRY_TAPPED,
+            mapOf(
+                AnalyticsTracker.KEY_TYPE to DashboardWidget.Type.INBOX.trackingIdentifier
+            )
+        )
+        _refreshTrigger.tryEmit(RefreshEvent(isForced = true))
+    }
+
+
+    sealed class ViewState {
+        data object Loading : ViewState()
+        data object Error : ViewState()
+        data class Content(val notes: List<InboxNoteUi>) : ViewState()
+
+        @StringRes val title: Int = INBOX.titleResource
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(parentViewModel: DashboardViewModel): DashboardInboxViewModel
+    }
+
+    data object NavigateToInbox : Event()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxFragment.kt
@@ -15,7 +15,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.inbox.InboxViewModel.InboxNoteActionEvent.OpenUrlEvent
+import com.woocommerce.android.ui.inbox.InboxNoteActionEvent.OpenUrlEvent
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils.Height.Partial.ThreeQuarters
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxNoteActionEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxNoteActionEvent.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.ui.inbox
+
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+
+sealed class InboxNoteActionEvent : Event() {
+    data class OpenUrlEvent(val url: String) : InboxNoteActionEvent()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxNoteActionUi.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxNoteActionUi.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.inbox
+
+import androidx.annotation.ColorRes
+
+data class InboxNoteActionUi(
+    val id: Long,
+    val parentNoteId: Long,
+    val label: String,
+    @ColorRes val textColor: Int,
+    val url: String,
+    val isDismissing: Boolean = false,
+    val onClick: (Long, Long) -> Unit
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxNoteUi.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxNoteUi.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.ui.inbox
+
+data class InboxNoteUi(
+    val id: Long,
+    val title: String,
+    val description: String,
+    val dateCreated: String,
+    val isSurvey: Boolean,
+    val isActioned: Boolean,
+    val actions: List<InboxNoteActionUi>
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -190,9 +192,10 @@ fun InboxNoteRow(note: InboxNoteUi, limitDescription: Boolean = false) {
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun InboxNoteActionsRow(actions: List<InboxNoteActionUi>) {
-    Row(
+    FlowRow(
         modifier = Modifier
             .padding(
                 start = dimensionResource(id = R.dimen.minor_100),
@@ -207,9 +210,10 @@ private fun InboxNoteActionsRow(actions: List<InboxNoteActionUi>) {
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun InboxNoteSurveyActionsRow(actions: List<InboxNoteActionUi>) {
-    Row(
+    FlowRow(
         modifier = Modifier.padding(
             start = dimensionResource(id = R.dimen.major_100),
             end = dimensionResource(id = R.dimen.major_100),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxScreen.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.inbox
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
@@ -31,6 +33,8 @@ import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
@@ -39,15 +43,15 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.core.text.HtmlCompat
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.toAnnotatedString
-import com.woocommerce.android.ui.inbox.InboxViewModel.InboxNoteActionUi
-import com.woocommerce.android.ui.inbox.InboxViewModel.InboxNoteUi
 import com.woocommerce.android.ui.inbox.InboxViewModel.InboxState
 
 @Composable
@@ -139,7 +143,9 @@ fun InboxNotes(
 }
 
 @Composable
-fun InboxNoteRow(note: InboxNoteUi) {
+fun InboxNoteRow(note: InboxNoteUi, limitDescription: Boolean = false) {
+    val displayShowMoreButton = remember { mutableStateOf(limitDescription && note.description.length > 100) }
+
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_75))
@@ -160,13 +166,26 @@ fun InboxNoteRow(note: InboxNoteUi) {
                 style = MaterialTheme.typography.subtitle1
             )
             Text(
+                modifier = Modifier.animateContentSize(),
                 text = HtmlCompat.fromHtml(note.description, HtmlCompat.FROM_HTML_MODE_LEGACY).toAnnotatedString(),
-                style = MaterialTheme.typography.body2
+                style = MaterialTheme.typography.body2,
+                maxLines = if (displayShowMoreButton.value) 2 else Int.MAX_VALUE,
+                overflow = TextOverflow.Ellipsis
             )
         }
-        when {
-            note.isSurvey -> InboxNoteSurveyActionsRow(note.actions)
-            else -> InboxNoteActionsRow(note.actions)
+        AnimatedContent(displayShowMoreButton.value, label = "Animated note action bar") { isMoreButtonVisible ->
+            if (isMoreButtonVisible) {
+                WCTextButton(
+                    modifier = Modifier.padding(start = dimensionResource(id = R.dimen.minor_100)),
+                    onClick = { displayShowMoreButton.value = false },
+                    text = stringResource(id = R.string.read_more)
+                )
+            } else {
+                when {
+                    note.isSurvey -> InboxNoteSurveyActionsRow(note.actions)
+                    else -> InboxNoteActionsRow(note.actions)
+                }
+            }
         }
     }
 }
@@ -346,6 +365,12 @@ private fun InboxNoteButtonsSkeleton() {
 @Composable
 private fun InboxPreview(@PreviewParameter(SampleInboxProvider::class, 1) state: InboxState) {
     InboxScreen(state)
+}
+
+@Preview
+@Composable
+private fun EmptyInboxPreview() {
+    InboxEmptyCase()
 }
 
 class SampleInboxProvider : PreviewParameterProvider<InboxState> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxUtils.kt
@@ -1,0 +1,109 @@
+package com.woocommerce.android.ui.inbox
+
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.inbox.InboxViewModel.Companion.DEFAULT_DISMISS_LABEL
+import com.woocommerce.android.ui.inbox.domain.InboxNote
+import com.woocommerce.android.ui.inbox.domain.InboxNote.NoteType.SURVEY
+import com.woocommerce.android.ui.inbox.domain.InboxNote.Status.ACTIONED
+import com.woocommerce.android.ui.inbox.domain.InboxNoteAction
+import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.viewmodel.ResourceProvider
+import org.wordpress.android.util.DateTimeUtils
+import java.util.Date
+
+@SuppressWarnings("MagicNumber", "ReturnCount")
+fun String.formatNoteCreationDate(dateUtils: DateUtils, resourceProvider: ResourceProvider): String {
+    val creationDate = dateUtils.getDateFromIso8601String(this)
+    val now = Date()
+
+    val minutes = DateTimeUtils.minutesBetween(now, creationDate)
+    when {
+        minutes < 1 -> return resourceProvider.getString(R.string.inbox_note_recency_now)
+        minutes < 60 -> return resourceProvider.getString(R.string.inbox_note_recency_minutes, minutes)
+    }
+    val hours = DateTimeUtils.hoursBetween(now, creationDate)
+    when {
+        hours == 1 -> return resourceProvider.getString(R.string.inbox_note_recency_one_hour)
+        hours < 24 -> return resourceProvider.getString(R.string.inbox_note_recency_hours, hours)
+    }
+    val days = DateTimeUtils.daysBetween(now, creationDate)
+    when {
+        days == 1 -> return resourceProvider.getString(R.string.inbox_note_recency_one_day)
+        days < 30 -> return resourceProvider.getString(R.string.inbox_note_recency_days, days)
+    }
+    return resourceProvider.getString(
+        R.string.inbox_note_recency_date_time,
+        dateUtils.toDisplayMMMddYYYYDate(creationDate?.time ?: 0) ?: ""
+    )
+}
+
+fun InboxNote.toInboxNoteUi(
+    dateUtils: DateUtils,
+    resourceProvider: ResourceProvider,
+    onAction: (Long, Long) -> Unit,
+    onDismiss: (Long, Long) -> Unit
+) =
+    InboxNoteUi(
+        id = id,
+        title = title,
+        description = description,
+        dateCreated = dateCreated.formatNoteCreationDate(dateUtils, resourceProvider),
+        isSurvey = type == SURVEY,
+        isActioned = status == ACTIONED,
+        actions = mapInboxActionsToUi(onAction, onDismiss),
+    )
+
+fun InboxNote.mapInboxActionsToUi(
+    onAction: (Long, Long) -> Unit,
+    onDismiss: (Long, Long) -> Unit
+): List<InboxNoteActionUi> {
+    if (type == SURVEY && status == ACTIONED) {
+        return emptyList()
+    }
+
+    val noteActionsUi = actions
+        .map { it.toInboxActionUi(id, onAction) }
+        .toMutableList()
+
+    addDismissActionIfMissing(noteActionsUi, onDismiss)
+
+    return noteActionsUi
+}
+
+fun InboxNote.addDismissActionIfMissing(
+    noteActionsUi: MutableList<InboxNoteActionUi>,
+    onDismiss: (Long, Long) -> Unit
+) {
+    if (!actionsHaveDismiss(noteActionsUi)) {
+        noteActionsUi.add(
+            InboxNoteActionUi(
+                id = 0,
+                parentNoteId = id,
+                label = DEFAULT_DISMISS_LABEL,
+                textColor = R.color.color_surface_variant,
+                url = "",
+                onClick = { actionId, noteId -> onDismiss(actionId, noteId) }
+            )
+        )
+    }
+}
+
+fun actionsHaveDismiss(noteActionsUi: List<InboxNoteActionUi>) =
+    noteActionsUi.any { it.label == DEFAULT_DISMISS_LABEL }
+
+fun InboxNoteAction.toInboxActionUi(parentNoteId: Long, onClick: (Long, Long) -> Unit) =
+    InboxNoteActionUi(
+        id = id,
+        parentNoteId = parentNoteId,
+        label = label,
+        textColor = getActionTextColor(),
+        url = url,
+        onClick = onClick
+    )
+
+fun InboxNoteAction.getActionTextColor() =
+    if (isPrimary) {
+        R.color.color_secondary
+    } else {
+        R.color.color_surface_variant
+    }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxViewModel.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.inbox
 
-import androidx.annotation.ColorRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -18,10 +17,6 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_IS_LOADI
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_INBOX_NOTE_ACTION_DISMISS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_INBOX_NOTE_ACTION_DISMISS_ALL
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_INBOX_NOTE_ACTION_OPEN
-import com.woocommerce.android.ui.inbox.domain.InboxNote
-import com.woocommerce.android.ui.inbox.domain.InboxNote.NoteType.SURVEY
-import com.woocommerce.android.ui.inbox.domain.InboxNote.Status.ACTIONED
-import com.woocommerce.android.ui.inbox.domain.InboxNoteAction
 import com.woocommerce.android.ui.inbox.domain.InboxRepository
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -31,8 +26,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import org.wordpress.android.util.DateTimeUtils
-import java.util.Date
 import javax.inject.Inject
 
 @HiltViewModel
@@ -124,7 +117,14 @@ class InboxViewModel @Inject constructor(
     private fun inboxNotesLocalUpdates() =
         inboxRepository.observeInboxNotes()
             .map { inboxNotes ->
-                val notes = inboxNotes.map { it.toInboxNoteUi() }
+                val notes = inboxNotes.map {
+                    it.toInboxNoteUi(
+                        dateUtils,
+                        resourceProvider,
+                        ::handleInboxNoteAction,
+                        ::dismissNote
+                    )
+                }
                 InboxState(
                     isLoading = false,
                     notes = notes,
@@ -132,59 +132,6 @@ class InboxViewModel @Inject constructor(
                     isRefreshing = false
                 )
             }
-
-    private fun InboxNote.toInboxNoteUi() =
-        InboxNoteUi(
-            id = id,
-            title = title,
-            description = description,
-            dateCreated = formatNoteCreationDate(dateCreated),
-            isSurvey = type == SURVEY,
-            isActioned = status == ACTIONED,
-            actions = mapInboxActionsToUi(),
-        )
-
-    private fun InboxNote.mapInboxActionsToUi(): List<InboxNoteActionUi> {
-        if (type == SURVEY && status == ACTIONED) {
-            return emptyList()
-        }
-
-        val noteActionsUi = actions
-            .map { it.toInboxActionUi(id) }
-            .toMutableList()
-
-        addDismissActionIfMissing(noteActionsUi)
-
-        return noteActionsUi
-    }
-
-    private fun InboxNote.addDismissActionIfMissing(noteActionsUi: MutableList<InboxNoteActionUi>) {
-        if (!actionsHaveDismiss(noteActionsUi)) {
-            noteActionsUi.add(
-                InboxNoteActionUi(
-                    id = 0,
-                    parentNoteId = id,
-                    label = DEFAULT_DISMISS_LABEL,
-                    textColor = R.color.color_surface_variant,
-                    url = "",
-                    onClick = { actionId, noteId -> dismissNote(actionId, noteId) }
-                )
-            )
-        }
-    }
-
-    private fun actionsHaveDismiss(noteActionsUi: List<InboxNoteActionUi>) =
-        noteActionsUi.any { it.label == DEFAULT_DISMISS_LABEL }
-
-    private fun InboxNoteAction.toInboxActionUi(parentNoteId: Long) =
-        InboxNoteActionUi(
-            id = id,
-            parentNoteId = parentNoteId,
-            label = label,
-            textColor = getActionTextColor(),
-            url = url,
-            onClick = ::handleInboxNoteAction
-        )
 
     private fun handleInboxNoteAction(actionId: Long, noteId: Long) {
         val clickedNote = inboxState.value?.notes?.firstOrNull { noteId == it.id }
@@ -218,25 +165,25 @@ class InboxViewModel @Inject constructor(
     private fun dismissNote(actionId: Long, noteId: Long) {
         trackInboxNoteActionClicked(VALUE_INBOX_NOTE_ACTION_DISMISS)
         viewModelScope.launch {
-            updateDismissingActionState(noteId, actionId, isDimissing = true)
+            updateDismissingActionState(noteId, actionId, isDismissing = true)
             inboxRepository
                 .dismissNote(noteId)
                 .fold(
                     onFailure = { showSyncError() },
                     onSuccess = {}
                 )
-            updateDismissingActionState(noteId, actionId, isDimissing = false)
+            updateDismissingActionState(noteId, actionId, isDismissing = false)
         }
     }
 
-    private fun updateDismissingActionState(noteId: Long, actionId: Long, isDimissing: Boolean) {
+    private fun updateDismissingActionState(noteId: Long, actionId: Long, isDismissing: Boolean) {
         _inboxState.value = _inboxState.value?.copy(
             notes = _inboxState.value?.notes?.map { note ->
                 if (note.id == noteId) {
                     val updatedActions =
                         note.actions.map { action ->
                             if (action.id == actionId) {
-                                action.copy(isDismissing = isDimissing)
+                                action.copy(isDismissing = isDismissing)
                             } else {
                                 action
                             }
@@ -253,39 +200,6 @@ class InboxViewModel @Inject constructor(
         triggerEvent(Event.ShowSnackbar(R.string.inbox_screen_sync_error))
     }
 
-    private fun InboxNoteAction.getActionTextColor() =
-        if (isPrimary) {
-            R.color.color_secondary
-        } else {
-            R.color.color_surface_variant
-        }
-
-    @SuppressWarnings("MagicNumber", "ReturnCount")
-    private fun formatNoteCreationDate(createdDate: String): String {
-        val creationDate = dateUtils.getDateFromIso8601String(createdDate)
-        val now = Date()
-
-        val minutes = DateTimeUtils.minutesBetween(now, creationDate)
-        when {
-            minutes < 1 -> return resourceProvider.getString(R.string.inbox_note_recency_now)
-            minutes < 60 -> return resourceProvider.getString(R.string.inbox_note_recency_minutes, minutes)
-        }
-        val hours = DateTimeUtils.hoursBetween(now, creationDate)
-        when {
-            hours == 1 -> return resourceProvider.getString(R.string.inbox_note_recency_one_hour)
-            hours < 24 -> return resourceProvider.getString(R.string.inbox_note_recency_hours, hours)
-        }
-        val days = DateTimeUtils.daysBetween(now, creationDate)
-        when {
-            days == 1 -> return resourceProvider.getString(R.string.inbox_note_recency_one_day)
-            days < 30 -> return resourceProvider.getString(R.string.inbox_note_recency_days, days)
-        }
-        return resourceProvider.getString(
-            R.string.inbox_note_recency_date_time,
-            dateUtils.toDisplayMMMddYYYYDate(creationDate?.time ?: 0) ?: ""
-        )
-    }
-
     data class InboxState(
         val isLoading: Boolean = false,
         val notes: List<InboxNoteUi> = emptyList(),
@@ -293,27 +207,4 @@ class InboxViewModel @Inject constructor(
         val isRefreshing: Boolean = false
     )
 
-    data class InboxNoteUi(
-        val id: Long,
-        val title: String,
-        val description: String,
-        val dateCreated: String,
-        val isSurvey: Boolean,
-        val isActioned: Boolean,
-        val actions: List<InboxNoteActionUi>
-    )
-
-    data class InboxNoteActionUi(
-        val id: Long,
-        val parentNoteId: Long,
-        val label: String,
-        @ColorRes val textColor: Int,
-        val url: String,
-        val isDismissing: Boolean = false,
-        val onClick: (Long, Long) -> Unit
-    )
-
-    sealed class InboxNoteActionEvent : Event() {
-        data class OpenUrlEvent(val url: String) : InboxNoteActionEvent()
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxViewModel.kt
@@ -206,5 +206,4 @@ class InboxViewModel @Inject constructor(
         val onRefresh: () -> Unit = {},
         val isRefreshing: Boolean = false
     )
-
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -93,6 +93,9 @@
         <action
             android:id="@+id/action_dashboard_to_couponListFragment"
             app:destination="@id/nav_graph_coupons" />
+        <action
+            android:id="@+id/action_dashboard_to_inboxFragment"
+            app:destination="@id/inboxFragment" />
     </fragment>
     <fragment
         android:id="@+id/orders"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -394,6 +394,8 @@
     <string name="dashboard_action_view_orders">View Orders</string>
     <string name="dashboard_action_view_all_orders">View all orders</string>
 
+    <string name="dashboard_action_view_all_messages">View all messages</string>
+
     <string name="my_store_stats_plugin_inactive_title">We can\'t display your\n store\'s analytics</string>
     <string name="my_store_custom_range_content_description">Add custom date range stats</string>
     <string name="my_store_custom_range_granularity_label">%s interval</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/inbox/InboxViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/inbox/InboxViewModelTest.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.inbox.InboxViewModel.Companion.DEFAULT_DISMISS_LABEL
-import com.woocommerce.android.ui.inbox.InboxViewModel.InboxNoteActionUi
 import com.woocommerce.android.ui.inbox.InboxViewModel.InboxState
 import com.woocommerce.android.ui.inbox.domain.InboxNote
 import com.woocommerce.android.ui.inbox.domain.InboxRepository


### PR DESCRIPTION
Implements #11524. The PR reuses some UI elements from the `InboxScreen`.

[Screen_recording_20240530_144329.webm](https://github.com/woocommerce/woocommerce-android/assets/1522856/4baea863-2903-4af4-8c8d-c2e3e2829c54)

**To test:**
1. Start the app and log in to a site that has some Inbox notes
2. Select the Inbox card in the Dashboard settings
3. Notice the Inbox card is displayed with the 3 most recent notes
4. Tap on the `View more messages` button
5. Notice the Inbox screen is displayed
6. Go back
7. Notice the messages with a long description a truncated
8. Tap on the `Read more` button
9. Notice the message expands and displays the action buttons
10. Tap on the `Dismiss` button
11. Notice the card is reloaded with another note
12. Tap on some action button
13. Notice the appropriate website is opened
14. Pull to refresh
15. Notice the notes are refreshed