### PR TITLE
Remove DYNAMIC_DASHBOARD feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/onboarding/StoreOnboardingFragment.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
-import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.transition.MaterialContainerTransform
@@ -19,18 +18,13 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.products.AddProductNavigator
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class StoreOnboardingFragment : BaseFragment() {
-    private val viewModel: StoreOnboardingViewModel by if (FeatureFlag.DYNAMIC_DASHBOARD.isEnabled()) {
-        viewModels()
-    } else {
-        activityViewModels()
-    }
+    private val viewModel: StoreOnboardingViewModel by viewModels()
 
     @Inject
     lateinit var addProductNavigator: AddProductNavigator

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -16,7 +16,6 @@ enum class FeatureFlag {
     CUSTOM_RANGE_ANALYTICS,
     CONNECTIVITY_TOOL,
     NEW_SHIPPING_SUPPORT,
-    DYNAMIC_DASHBOARD,
     APP_PASSWORD_TUTORIAL,
     EOSL_M1,
     DYNAMIC_DASHBOARD_M2;
@@ -36,7 +35,6 @@ enum class FeatureFlag {
             ORDER_CREATION_AUTO_TAX_RATE,
             DYNAMIC_DASHBOARD_M2 -> PackageUtils.isDebugBuild()
 
-            DYNAMIC_DASHBOARD,
             CONNECTIVITY_TOOL,
             CUSTOM_RANGE_ANALYTICS,
             NEW_SHIPPING_SUPPORT,


### PR DESCRIPTION
### Description
This PR removes the already enabled `DYNAMIC_DASHBOARD` feature flag.

### Testing instructions
1. Open the app, and enable the onboarding card in the dashboard (you will need a site with some unfinished onboarding tasks).
2. Tap on `View All Tasks`
3. Confirm the onboarding full screen works without issues. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
