### PR TITLE
Display feedback survey

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -55,6 +55,12 @@ object AppUrls {
             "https://automattic.survey.fm/product-creation-with-ai-dec-2023"
         }
 
+    val CROWDSIGNAL_ORDER_SHIPPING_LINES_SURVEY = if (BuildConfig.DEBUG) {
+        "https://automattic.survey.fm/order-creation-shipping-lines-survey-testing"
+    } else {
+        "https://automattic.survey.fm/order-creation-shipping-lines-survey-production"
+    }
+
     // Will be used later when the feature is fully launched.
     const val COUPONS_SURVEY = "https://automattic.survey.fm/woo-app-coupon-management-production"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -360,6 +360,7 @@ class AnalyticsTracker private constructor(
         const val VALUE_PRODUCT_ADDONS_FEEDBACK = "product_addons"
         const val VALUE_COUPONS_FEEDBACK = "coupons"
         const val VALUE_ANALYTICS_HUB_FEEDBACK = "analytics_hub"
+        const val VALUE_ORDER_SHIPPING_LINES_FEEDBACK = "order_shipping_lines"
         const val VALUE_STATE_ON = "on"
         const val VALUE_STATE_OFF = "off"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -30,6 +30,7 @@ data class FeatureFeedbackSettings(
         COUPONS,
         ANALYTICS_HUB,
         TAP_TO_PAY,
+        ORDER_SHIPPING_LINES
     }
 
     fun isFeedbackGivenMoreThanDaysAgo(days: Int) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBA
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_OPENED
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_STORE_SETUP_CONTEXT
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_ORDER_SHIPPING_LINES_FEEDBACK
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUCT_ADDONS_FEEDBACK
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SHIPPING_LABELS_M4_FEEDBACK
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SIMPLE_PAYMENTS_FEEDBACK
@@ -52,6 +53,7 @@ class FeedbackSurveyFragment : androidx.fragment.app.Fragment(R.layout.fragment_
             SurveyType.ADDONS -> VALUE_PRODUCT_ADDONS_FEEDBACK
             SurveyType.ANALYTICS_HUB -> VALUE_ANALYTICS_HUB_FEEDBACK
             SurveyType.PAYMENTS_HUB_TAP_TO_PAY -> VALUE_TAP_TO_PAY_FEEDBACK
+            SurveyType.ORDER_SHIPPING_LINES -> VALUE_ORDER_SHIPPING_LINES_FEEDBACK
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -13,7 +13,8 @@ enum class SurveyType(private val untaggedUrl: String, private val milestone: In
     ADDONS(AppUrls.ADDONS_SURVEY),
     STORE_ONBOARDING(AppUrls.CROWDSIGNAL_STORE_SETUP_SURVEY),
     ANALYTICS_HUB(AppUrls.CROWDSIGNAL_ANALYTICS_HUB_SURVEY),
-    PAYMENTS_HUB_TAP_TO_PAY(AppUrls.CROWDSIGNAL_TAP_TO_PAY_SURVEY);
+    PAYMENTS_HUB_TAP_TO_PAY(AppUrls.CROWDSIGNAL_TAP_TO_PAY_SURVEY),
+    ORDER_SHIPPING_LINES(AppUrls.CROWDSIGNAL_ORDER_SHIPPING_LINES_SURVEY);
 
     val url
         get() = "$untaggedUrl?$platformTag$appVersionTag$milestoneTag"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -32,6 +32,7 @@ import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderCreateEditFormBinding
 import com.woocommerce.android.databinding.LayoutOrderCreationCustomerInfoBinding
@@ -55,6 +56,7 @@ import com.woocommerce.android.ui.compose.component.FeedbackDialog
 import com.woocommerce.android.ui.compose.theme.WooTheme
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.coupons.selector.CouponSelectorFragment.Companion.KEY_COUPON_SELECTOR_RESULT
+import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.ui.orders.CustomAmountTypeBottomSheetDialog
@@ -446,7 +448,7 @@ class OrderCreateEditFormFragment :
                             message = stringResource(id = R.string.order_creation_shipping_feedback_message),
                             action = stringResource(id = R.string.order_creation_feedback_action),
                             isShown = show,
-                            onAction = { viewModel.onCloseShippingFeedback() },
+                            onAction = { viewModel.onSendShippingFeedback() },
                             onClose = { viewModel.onCloseShippingFeedback() },
                         )
                     }
@@ -1186,6 +1188,8 @@ class OrderCreateEditFormFragment :
             }
 
             is Exit -> findNavController().navigateUp()
+
+            is ShippingLinesFeedback -> sendShippingLinesFeedback()
         }
     }
 
@@ -1296,5 +1300,11 @@ class OrderCreateEditFormFragment :
         if (requireContext().windowSizeClass != WindowSizeClass.Compact) {
             sharedViewModel.onProductSelectionStateChanged(false)
         }
+    }
+
+    private fun sendShippingLinesFeedback() {
+        NavGraphMainDirections
+            .actionGlobalFeedbackSurveyFragment(SurveyType.ORDER_SHIPPING_LINES)
+            .apply { findNavController().navigateSafely(this) }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1295,6 +1295,10 @@ class OrderCreateEditViewModel @Inject constructor(
         }
     }
 
+    fun onSendShippingFeedback() {
+        viewState = viewState.copy(showShippingFeedback = false)
+        triggerEvent(ShippingLinesFeedback)
+    }
     fun onCloseShippingFeedback() {
         viewState = viewState.copy(showShippingFeedback = false)
     }
@@ -2128,6 +2132,8 @@ data class OnCustomAmountTypeSelected(
 ) : Event()
 
 object OnSelectedProductsSyncRequested : Event()
+
+object ShippingLinesFeedback : Event()
 
 @Parcelize
 data class CustomAmountUIModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1318,7 +1318,13 @@ class OrderCreateEditViewModel @Inject constructor(
         }
     }
     fun onCloseShippingFeedback() {
-        viewState = viewState.copy(showShippingFeedback = false)
+        launch {
+            feedbackRepository.saveFeatureFeedback(
+                FeatureFeedbackSettings.Feature.ORDER_SHIPPING_LINES,
+                FeatureFeedbackSettings.FeedbackState.DISMISSED
+            )
+            viewState = viewState.copy(showShippingFeedback = false)
+        }
     }
 
     private fun onExpandCollapseTotalsClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -84,12 +84,14 @@ import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.extensions.runWithContext
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Address.Companion.EMPTY
+import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.model.Order.ShippingLine
 import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.tracker.OrderDurationRecorder
 import com.woocommerce.android.ui.barcodescanner.BarcodeScanningTracker
+import com.woocommerce.android.ui.feedback.FeedbackRepository
 import com.woocommerce.android.ui.orders.CustomAmountUIModel
 import com.woocommerce.android.ui.orders.OrderNavigationTarget.ViewOrderStatusSelector
 import com.woocommerce.android.ui.orders.creation.CreateUpdateOrder.OrderUpdateStatus
@@ -208,6 +210,7 @@ class OrderCreateEditViewModel @Inject constructor(
     private val mapFeeLineToCustomAmountUiModel: MapFeeLineToCustomAmountUiModel,
     private val currencySymbolFinder: CurrencySymbolFinder,
     private val totalsHelper: OrderCreateEditTotalsHelper,
+    private val feedbackRepository: FeedbackRepository,
     dateUtils: DateUtils,
     autoSyncOrder: AutoSyncOrder,
     autoSyncPriceModifier: AutoSyncPriceModifier,
@@ -221,6 +224,7 @@ class OrderCreateEditViewModel @Inject constructor(
         private const val PARAMETERS_KEY = "parameters_key"
         private const val ORDER_CUSTOM_FEE_NAME = "order_custom_fee"
         const val DELAY_BEFORE_SHOWING_SHIPPING_FEEDBACK = 1000L
+        const val DAYS_BEFORE_SHOWING_SHIPPING_FEEDBACK = 7
     }
 
     val viewStateData = LiveDataDelegate(savedState, ViewState())
@@ -475,7 +479,8 @@ class OrderCreateEditViewModel @Inject constructor(
                 .asFlow()
                 .drop(1)
                 .take(1)
-                .collect {
+                .takeIf { shouldDisplayShippingLinesFeedback() }
+                ?.collect {
                     delay(DELAY_BEFORE_SHOWING_SHIPPING_FEEDBACK)
                     viewState = viewState.copy(showShippingFeedback = true)
                 }
@@ -1293,6 +1298,13 @@ class OrderCreateEditViewModel @Inject constructor(
                 triggerEvent(Exit)
             }
         }
+    }
+
+    private fun shouldDisplayShippingLinesFeedback(): Boolean {
+        val settings =
+            feedbackRepository.getFeatureFeedbackSetting(FeatureFeedbackSettings.Feature.ORDER_SHIPPING_LINES)
+        return settings.feedbackState == FeatureFeedbackSettings.FeedbackState.UNANSWERED ||
+            settings.isFeedbackGivenMoreThanDaysAgo(DAYS_BEFORE_SHOWING_SHIPPING_FEEDBACK)
     }
 
     fun onSendShippingFeedback() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1308,8 +1308,14 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     fun onSendShippingFeedback() {
-        viewState = viewState.copy(showShippingFeedback = false)
-        triggerEvent(ShippingLinesFeedback)
+        launch {
+            feedbackRepository.saveFeatureFeedback(
+                FeatureFeedbackSettings.Feature.ORDER_SHIPPING_LINES,
+                FeatureFeedbackSettings.FeedbackState.GIVEN
+            )
+            viewState = viewState.copy(showShippingFeedback = false)
+            triggerEvent(ShippingLinesFeedback)
+        }
     }
     fun onCloseShippingFeedback() {
         viewState = viewState.copy(showShippingFeedback = false)


### PR DESCRIPTION
Closes: #11399

### Why
After releasing the new shipping line support feature, we want to collect user feedback.

### Description
This pull request includes the logic for navigating to the CrowdSignal survey and for displaying the survey only after the merchant has used the shipping lines functionality, provided that there is a gap of at least 7 days from the last time we requested feedback.

### Testing instructions
1. Open the app
2. Navigate to the orders tab
3. Tap on add new order (+)
4. Add a product to enable the shipping section
5. Add a new shipping line
6. Check that the feedback control is displayed
7. Tap on close or share feedback to close the control
8. Add/Update/Delete a shipping line
9. Check that the feedback control is not displayed again (we want the control to be displayed only once)

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/96c8aabb-7705-4d0f-a4c5-54ef6ba01458

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
