### PR TITLE
Release EOSL M3

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/FeatureFeedbackSettings.kt
@@ -33,6 +33,8 @@ data class FeatureFeedbackSettings(
         ORDER_SHIPPING_LINES
     }
 
+    fun isFeedbackMoreThanDaysAgo(days: Int) = Date(settingChangeDate).pastTimeDeltaFromNowInDays greaterThan days
+
     fun isFeedbackGivenMoreThanDaysAgo(days: Int) =
         feedbackState == FeedbackState.GIVEN &&
             Date(settingChangeDate).pastTimeDeltaFromNowInDays greaterThan days

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -1304,7 +1304,7 @@ class OrderCreateEditViewModel @Inject constructor(
         val settings =
             feedbackRepository.getFeatureFeedbackSetting(FeatureFeedbackSettings.Feature.ORDER_SHIPPING_LINES)
         return settings.feedbackState == FeatureFeedbackSettings.FeedbackState.UNANSWERED ||
-            settings.isFeedbackGivenMoreThanDaysAgo(DAYS_BEFORE_SHOWING_SHIPPING_FEEDBACK)
+            settings.isFeedbackMoreThanDaysAgo(DAYS_BEFORE_SHOWING_SHIPPING_FEEDBACK)
     }
 
     fun onSendShippingFeedback() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -32,15 +32,15 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
-            DYNAMIC_DASHBOARD_M2,
-            EOSL_M3 -> PackageUtils.isDebugBuild()
+            DYNAMIC_DASHBOARD_M2 -> PackageUtils.isDebugBuild()
 
             OTHER_PAYMENT_METHODS,
             CONNECTIVITY_TOOL,
             CUSTOM_RANGE_ANALYTICS,
             NEW_SHIPPING_SUPPORT,
             APP_PASSWORD_TUTORIAL,
-            EOSL_M1 -> true
+            EOSL_M1,
+            EOSL_M3 -> true
         }
     }
 }


### PR DESCRIPTION


### Description
This PR releases shipping line feedback (M3).


### Testing instructions
1. Open the app
2. Navigate to the orders tab
3. Tap on add new order (+)
4. Add a product to enable the shipping section
5. Add a new shipping line
6. Check that the feedback control is displayed
7. Tap on share feedback to close the control
8. Check that the app navigates to CrowdSignal
9. Complete the survey flow
10. Add/Update/Delete a shipping line
11. Check that the feedback control is not displayed again (we want the control to be displayed only once)

### Images/gif

https://github.com/woocommerce/woocommerce-android/assets/18119390/96c8aabb-7705-4d0f-a4c5-54ef6ba01458


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->