### PR TITLE
[Woo POS] Removed usages of ScopedViewModel

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cart/WooPosCartViewModel.kt
@@ -1,11 +1,8 @@
 package com.woocommerce.android.ui.woopos.cart
 
-import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.viewmodel.ScopedViewModel
+import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class WooPosCartViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle,
-) : ScopedViewModel(savedStateHandle)
+class WooPosCartViewModel @Inject constructor() : ViewModel()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/checkout/WooPosCheckoutViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/checkout/WooPosCheckoutViewModel.kt
@@ -1,11 +1,8 @@
 package com.woocommerce.android.ui.woopos.checkout
 
-import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.viewmodel.ScopedViewModel
+import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class WooPosCheckoutViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle,
-) : ScopedViewModel(savedStateHandle)
+class WooPosCheckoutViewModel @Inject constructor() : ViewModel()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11622
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Removed the usage of `scopedviewmodel` from dummy VMs we currently have.
* I didn't touch `WooPosCardReaderViewModel` as this is part of the wrapper around card reader flow which is disposable in the case of extracting the POS anyway
* I didn't prepare anything specific to send events, as [the current recommendation](https://developer.android.com/topic/architecture/ui-layer/events#handle-viewmodel-events) is to treat them as part of the state:
```
                viewModel.uiState.collect { uiState ->
                    uiState.userMessage?.let {
                        // TODO: Show Snackbar with userMessage.

                        // Once the message is displayed and
                        // dismissed, notify the ViewModel.
                        viewModel.userMessageShown()
                    }
                    ...
                }
```
* Use `viewModelScope.launch` to launch coroutines


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
No testing is required. Maybe just read/understand the recommendation on how to display one-shot things in compose

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->