### PR TITLE
[Stats] Fix issue with date formatting of selected dates

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
@@ -40,12 +40,15 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -75,6 +78,12 @@ class DashboardStatsViewModel @AssistedInject constructor(
     val currencyFormatter: CurrencyFormatter
 ) : ScopedViewModel(savedStateHandle) {
     private val selectedDateRange = getSelectedDateRange()
+        .onEach {
+            // Reset selected chart date when date range changes
+            selectedChartDate.value = null
+        }
+        .shareIn(viewModelScope, started = SharingStarted.WhileSubscribed(), replay = 1)
+
     private val selectedChartDate = MutableStateFlow<String?>(null)
 
     val dateRangeState = combine(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11643 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes the linked issue, the cause of the date formatting failure is the following:
1. When the user selects a given date in the chart, the value is updated in the ViewModel.
2. Then when the user switches to a different tab, the selected date is cleared by the `View` itself.
3. (2) happens after the fact, and given the `combine` operator, we will try to format the selected date from the previous tab.

This PR updates the logic by making sure the selected date is cleared before, it's cleared whenever the selected range changes.

### Steps to reproduce
In `trunk`, these steps:
1. Use the Performance card in the dynamic dashboard.
2. Switch to a tab with some data.
3. Select an individual date.
4. Monitor `logcat`.
5. Switch to a different tab.
6. This will be logged:
`Date string argument is not of format...`
`Tracked: stats_unexpected_format...`

### Testing information
1. Switch to this branch.
2. Repeat 1-5 from above
3. Confirm no warning is logged in Logcat.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->