### PR TITLE
[Woo POS] Bottom toolbar that shared across the screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cart/WooPosCartNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cart/WooPosCartNavigation.kt
@@ -6,19 +6,13 @@ import androidx.navigation.compose.composable
 
 internal const val CART_ROUTE = "cart"
 
-internal fun NavGraphBuilder.cartScreen(
-    onCheckoutClick: () -> Unit,
-    onConnectToCardReaderClicked: () -> Unit,
-    onCollectPaymentWithCardReader: () -> Unit,
-) {
+internal fun NavGraphBuilder.cartScreen(onCheckoutClick: () -> Unit) {
     composable(CART_ROUTE) {
         val viewModel: WooPosCartViewModel = hiltViewModel()
 
         WooPosCartScreen(
             viewModel = viewModel,
             onCheckoutClick = onCheckoutClick,
-            onConnectToCardReaderClicked = onConnectToCardReaderClicked,
-            onCollectPaymentWithCardReader = onCollectPaymentWithCardReader,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cart/WooPosCartScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.woocommerce.android.ui.woopos.util.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 
 @Composable
 @Suppress("UNUSED_PARAMETER")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cart/WooPosCartScreen.kt
@@ -2,9 +2,7 @@ package com.woocommerce.android.ui.woopos.cart
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
@@ -20,22 +18,12 @@ import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 fun WooPosCartScreen(
     viewModel: WooPosCartViewModel,
     onCheckoutClick: () -> Unit,
-    onConnectToCardReaderClicked: () -> Unit,
-    onCollectPaymentWithCardReader: () -> Unit,
 ) {
-    WooPosCartScreen(
-        onCheckoutClick = onCheckoutClick,
-        onConnectToCardReaderClicked = onConnectToCardReaderClicked,
-        onCollectPaymentWithCardReader = onCollectPaymentWithCardReader,
-    )
+    WooPosCartScreen(onCheckoutClick = onCheckoutClick)
 }
 
 @Composable
-private fun WooPosCartScreen(
-    onCheckoutClick: () -> Unit,
-    onConnectToCardReaderClicked: () -> Unit,
-    onCollectPaymentWithCardReader: () -> Unit,
-) {
+private fun WooPosCartScreen(onCheckoutClick: () -> Unit) {
     Box(
         Modifier
             .fillMaxSize()
@@ -51,18 +39,6 @@ private fun WooPosCartScreen(
             Button(onClick = onCheckoutClick) {
                 Text("Checkout")
             }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Button(onClick = onConnectToCardReaderClicked) {
-                Text("Connect to Card Reader")
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Button(onClick = onCollectPaymentWithCardReader) {
-                Text("Collect Payment with Card Reader")
-            }
         }
     }
 }
@@ -70,9 +46,5 @@ private fun WooPosCartScreen(
 @Composable
 @WooPosPreview
 fun WooPosCartScreenPreview() {
-    WooPosCartScreen(
-        onCheckoutClick = {},
-        onConnectToCardReaderClicked = {},
-        onCollectPaymentWithCardReader = {},
-    )
+    WooPosCartScreen(onCheckoutClick = {})
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/checkout/WooPosCheckoutScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/checkout/WooPosCheckoutScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.woocommerce.android.ui.woopos.util.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 
 @Composable
 @Suppress("UNUSED_PARAMETER")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/checkout/WooPosCheckoutViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/checkout/WooPosCheckoutViewModel.kt
@@ -1,21 +1,11 @@
 package com.woocommerce.android.ui.woopos.checkout
 
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalytics
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class WooPosCheckoutViewModel @Inject constructor(
-    private val analyticsTracker: WooPosAnalyticsTracker,
     savedStateHandle: SavedStateHandle,
-) : ScopedViewModel(savedStateHandle) {
-    init {
-        launch {
-            analyticsTracker.track(WooPosAnalytics.Event.Test)
-        }
-    }
-}
+) : ScopedViewModel(savedStateHandle)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosComposePreviewAnnotation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosComposePreviewAnnotation.kt
@@ -1,6 +1,6 @@
 @file:Suppress("MatchingDeclarationName", "Filename")
 
-package com.woocommerce.android.ui.woopos.util
+package com.woocommerce.android.ui.woopos.common.composeui
 
 import android.content.res.Configuration
 import androidx.compose.ui.tooling.preview.Devices

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MagicNumber")
+
 package com.woocommerce.android.ui.woopos.common.composeui
 
 import androidx.compose.foundation.isSystemInDarkTheme

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
@@ -1,0 +1,44 @@
+package com.woocommerce.android.ui.woopos.common.composeui
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.darkColors
+import androidx.compose.material.lightColors
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.woocommerce.android.ui.compose.theme.WooTypography
+
+private val DarkColorPalette = darkColors(
+    primary = Color(0xFF1E88E5),
+    primaryVariant = Color(0xFF1565C0),
+    secondary = Color(0xFFD32F2F),
+    onPrimary = Color.White,
+    secondaryVariant = Color(0xFFB39DDB),
+    surface = Color.White,
+    onSurface = Color.Black,
+)
+
+private val LightColorPalette = lightColors(
+    primary = Color(0xFF1E88E5),
+    primaryVariant = Color(0xFF1565C0),
+    secondary = Color(0xFFD32F2F),
+    onPrimary = Color.White,
+    secondaryVariant = Color(0xFFB39DDB),
+    surface = Color.Black,
+    onSurface = Color.White
+)
+
+@Composable
+fun WooPosTheme(content: @Composable () -> Unit) {
+    val colors = if (isSystemInDarkTheme()) {
+        DarkColorPalette
+    } else {
+        LightColorPalette
+    }
+
+    MaterialTheme(
+        colors = colors,
+        typography = WooTypography,
+        content = content
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -5,9 +5,9 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.material.MaterialTheme
 import androidx.lifecycle.lifecycleScope
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosTheme
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosRootHost
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -25,7 +25,7 @@ class WooPosActivity : AppCompatActivity() {
         lifecycle.addObserver(wooPosCardReaderFacade)
 
         setContent {
-            MaterialTheme {
+            WooPosTheme {
                 WooPosRootHost(
                     connectToCardReader = {
                         lifecycleScope.launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -2,15 +2,10 @@ package com.woocommerce.android.ui.woopos.root
 
 import android.content.pm.ActivityInfo
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.lifecycleScope
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
-import com.woocommerce.android.ui.woopos.common.composeui.WooPosTheme
-import com.woocommerce.android.ui.woopos.root.navigation.WooPosRootHost
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -25,26 +20,7 @@ class WooPosActivity : AppCompatActivity() {
         lifecycle.addObserver(wooPosCardReaderFacade)
 
         setContent {
-            WooPosTheme {
-                WooPosRootHost(
-                    connectToCardReader = {
-                        lifecycleScope.launch {
-                            wooPosCardReaderFacade.connectToReader()
-                        }
-                        lifecycleScope.launch {
-                            wooPosCardReaderFacade.readerStatus.collect {
-                                Toast.makeText(this@WooPosActivity, "Reader status: $it", Toast.LENGTH_SHORT).show()
-                            }
-                        }
-                    },
-                    collectPaymentWithCardReader = {
-                        lifecycleScope.launch {
-                            val result = wooPosCardReaderFacade.collectPayment(-1)
-                            Toast.makeText(this@WooPosActivity, "Payment result: $result", Toast.LENGTH_SHORT).show()
-                        }
-                    }
-                )
-            }
+            WooPosRootScreen()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosRootBottomToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosRootBottomToolbar.kt
@@ -37,14 +37,14 @@ fun WooPosBottomToolbar(onUIEvent: (WooPosRootUIEvents) -> Unit) {
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            TextButton(onClick = { onUIEvent(WooPosRootUIEvents.ExitPOS) }) {
+            TextButton(onClick = { onUIEvent(WooPosRootUIEvents.ExitPOSClicked) }) {
                 Text(
                     text = stringResource(id = R.string.woopos_exit_pos),
                     color = MaterialTheme.colors.onSurface,
                     style = MaterialTheme.typography.button
                 )
             }
-            TextButton(onClick = { onUIEvent(WooPosRootUIEvents.ExitPOS) }) {
+            TextButton(onClick = { onUIEvent(WooPosRootUIEvents.ExitPOSClicked) }) {
                 Text(
                     text = stringResource(id = R.string.woopos_reader_connected),
                     color = MaterialTheme.colors.secondaryVariant,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosRootBottomToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosRootBottomToolbar.kt
@@ -1,0 +1,67 @@
+package com.woocommerce.android.ui.woopos.root
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosTheme
+
+@Composable
+fun WooPosBottomToolbar(onUIEvent: (WooPosRootUIEvents) -> Unit) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight(),
+        color = MaterialTheme.colors.surface
+    ) {
+        Row(
+            modifier = Modifier
+                .height(64.dp)
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TextButton(onClick = { onUIEvent(WooPosRootUIEvents.ExitPOS) }) {
+                Text(
+                    text = stringResource(id = R.string.woopos_exit_pos),
+                    color = MaterialTheme.colors.onSurface,
+                    style = MaterialTheme.typography.button
+                )
+            }
+            TextButton(onClick = { onUIEvent(WooPosRootUIEvents.ExitPOS) }) {
+                Text(
+                    text = stringResource(id = R.string.woopos_reader_connected),
+                    color = MaterialTheme.colors.secondaryVariant,
+                    style = MaterialTheme.typography.button
+                )
+            }
+        }
+    }
+}
+
+@WooPosPreview
+@Composable
+fun PreviewWooPosBottomToolbar() {
+    WooPosTheme {
+        Column {
+            Spacer(modifier = Modifier.weight(1f))
+            WooPosBottomToolbar {}
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosRootScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosRootScreen.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.woopos.root
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosTheme
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosRootHost
+
+@Composable
+fun WooPosRootScreen() {
+    val viewModel: WooPosRootViewModel = hiltViewModel()
+    WooPosRootScreen(viewModel::onUiEvent)
+}
+
+@Composable
+private fun WooPosRootScreen(onUIEvent: (WooPosRootUIEvents) -> Unit) {
+    WooPosTheme {
+        Column {
+            WooPosRootHost(modifier = Modifier.weight(1f))
+            WooPosBottomToolbar(onUIEvent)
+        }
+    }
+}
+
+@WooPosPreview
+@Composable
+fun PreviewWooPosRootScreen() {
+    WooPosTheme {
+        WooPosRootScreen({})
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosRootUIEvents.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosRootUIEvents.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.woopos.root
 
 sealed class WooPosRootUIEvents {
-    data object ExitPOS : WooPosRootUIEvents()
-    data object ConnectToAReader: WooPosRootUIEvents()
+    data object ExitPOSClicked : WooPosRootUIEvents()
+    data object ConnectToAReaderClicked : WooPosRootUIEvents()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosRootUIEvents.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosRootUIEvents.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.ui.woopos.root
+
+sealed class WooPosRootUIEvents {
+    data object ExitPOS : WooPosRootUIEvents()
+    data object ConnectToAReader: WooPosRootUIEvents()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosRootViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosRootViewModel.kt
@@ -8,8 +8,8 @@ import javax.inject.Inject
 class WooPosRootViewModel @Inject constructor() : ViewModel() {
     fun onUiEvent(event: WooPosRootUIEvents) {
         when (event) {
-            WooPosRootUIEvents.ConnectToAReader -> TODO()
-            WooPosRootUIEvents.ExitPOS -> TODO()
+            WooPosRootUIEvents.ConnectToAReaderClicked -> TODO()
+            WooPosRootUIEvents.ExitPOSClicked -> TODO()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosRootViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosRootViewModel.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.ui.woopos.root
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class WooPosRootViewModel @Inject constructor() : ViewModel() {
+    fun onUiEvent(event: WooPosRootUIEvents) {
+        when (event) {
+            WooPosRootUIEvents.ConnectToAReader -> TODO()
+            WooPosRootUIEvents.ExitPOS -> TODO()
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosMainFlowGraph.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosMainFlowGraph.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.woopos.root.navigation
 
-import android.content.Context
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.navigation
@@ -11,22 +10,12 @@ import com.woocommerce.android.ui.woopos.checkout.navigateToCheckoutScreen
 
 const val MAIN_GRAPH_ROUTE = "main-graph"
 
-fun NavGraphBuilder.checkoutGraph(
-    navController: NavController,
-    onConnectToCardReaderClicked: (Context) -> Unit,
-    collectPaymentWithCardReader: (Context) -> Unit,
-) {
+fun NavGraphBuilder.checkoutGraph(navController: NavController) {
     navigation(
         startDestination = CART_ROUTE,
         route = MAIN_GRAPH_ROUTE,
     ) {
-        cartScreen(
-            onCheckoutClick = navController::navigateToCheckoutScreen,
-            onConnectToCardReaderClicked = { onConnectToCardReaderClicked(navController.context) },
-            onCollectPaymentWithCardReader = { collectPaymentWithCardReader(navController.context) },
-        )
-        checkoutScreen(
-            onBackClick = navController::popBackStack
-        )
+        cartScreen(onCheckoutClick = navController::navigateToCheckoutScreen)
+        checkoutScreen(onBackClick = navController::popBackStack)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosRootHost.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosRootHost.kt
@@ -1,18 +1,16 @@
 package com.woocommerce.android.ui.woopos.root.navigation
 
-import android.content.Context
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 
 @Composable
-fun WooPosRootHost(
-    connectToCardReader: (context: Context) -> Unit,
-    collectPaymentWithCardReader: (context: Context) -> Unit,
-) {
+fun WooPosRootHost(modifier: Modifier = Modifier) {
     val rootController = rememberNavController()
 
     NavHost(
+        modifier = modifier,
         navController = rootController,
         startDestination = MAIN_GRAPH_ROUTE,
         enterTransition = { screenSlideIn() },
@@ -20,10 +18,6 @@ fun WooPosRootHost(
         popEnterTransition = { screenFadeIn() },
         popExitTransition = { screenSlideOut() },
     ) {
-        checkoutGraph(
-            navController = rootController,
-            onConnectToCardReaderClicked = { context -> connectToCardReader(context) },
-            collectPaymentWithCardReader = { context -> collectPaymentWithCardReader(context) },
-        )
+        checkoutGraph(navController = rootController)
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4110,4 +4110,10 @@
     <string name="login_app_password_exit_dialog_message">It seems that you have not approved the app connection yet. Are you sure you want to exit?</string>
     <string name="login_app_password_exit_dialog_confirmation">Exit Anyway</string>
     <string name="login_app_password_exit_dialog_cancel">Cancel</string>
+
+    <!--
+    Woo POS
+    -->
+    <string name="woopos_exit_pos">Exit POS</string>
+    <string name="woopos_reader_connected">Reader Connected</string>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

part of: #11644
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR adds:
* Skeleton for compose theme
* Bottom toolbar that is placed below nav host
* Removes some stuff that we used for testing other integrations

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-android/assets/4923871/db72fc09-47ec-45d0-9036-a1e107dcbe85


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->