### PR TITLE
Fix Application Passwords login issue

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [**] Shipping: Merchants can now use multiple shipping lines for a single order. [https://github.com/woocommerce/woocommerce-android/pull/11580]
 - [*] More Menu: UI improvements for the More Menu screen [https://github.com/woocommerce/woocommerce-android/pull/11566]
 - [**] Cash Payments: Added the option for users to calculate change due when receiving cash for the order. [https://github.com/woocommerce/woocommerce-android/pull/11594]
+- [***] Login: fixed a bug that caused some intermittent failures when signing in using Application Passwords [https://github.com/woocommerce/woocommerce-android/pull/11650]
 
 18.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -101,15 +101,6 @@ class SelectedSite @Inject constructor(
             .build()
     }
 
-    fun exists(): Boolean {
-        val siteModel = siteStore.getSiteByLocalId(getSelectedSiteId())
-        return siteModel != null
-    }
-
-    fun getIfExists(): SiteModel? = if (exists()) get() else null
-
-    fun getSelectedSiteId() = PreferenceUtils.getInt(getPreferences(), SELECTED_SITE_LOCAL_ID, -1)
-
     @Synchronized
     fun reset() {
         wasReset = true
@@ -118,6 +109,15 @@ class SelectedSite @Inject constructor(
         siteComponent = null
         siteCoroutineScope?.cancel()
     }
+
+    fun exists(): Boolean {
+        val siteModel = siteStore.getSiteByLocalId(getSelectedSiteId())
+        return siteModel != null
+    }
+
+    fun getIfExists(): SiteModel? = if (exists()) get() else null
+
+    fun getSelectedSiteId() = PreferenceUtils.getInt(getPreferences(), SELECTED_SITE_LOCAL_ID, -1)
 
     private fun getPreferences() = PreferenceManager.getDefaultSharedPreferences(context)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -63,26 +63,29 @@ class SelectedSite @Inject constructor(
     fun get(): SiteModel {
         state.value?.let { return it }
 
-        getSelectedSiteFromPersistence()?.let {
-            state.value = it
-            return it
-        }
+        synchronized(this) {
+            getSelectedSiteFromPersistence()?.let {
+                state.value = it
+                return it
+            }
 
-        // if the selected site id is valid but the site isn't in the site store, reset the
-        // preference. this can happen if the user has been removed from the active site.
-        val localSiteId = getSelectedSiteId()
-        if (localSiteId > -1) {
-            getPreferences().edit().remove(SELECTED_SITE_LOCAL_ID).apply()
-        }
+            // if the selected site id is valid but the site isn't in the site store, reset the
+            // preference. this can happen if the user has been removed from the active site.
+            val localSiteId = getSelectedSiteId()
+            if (localSiteId > -1) {
+                getPreferences().edit().remove(SELECTED_SITE_LOCAL_ID).apply()
+            }
 
-        if (wasReset) {
-            throw SelectedSiteResetException()
-        } else {
-            throw SelectedSiteUninitializedException(localSiteId)
+            if (wasReset) {
+                throw SelectedSiteResetException()
+            } else {
+                throw SelectedSiteUninitializedException(localSiteId)
+            }
         }
     }
 
     @Suppress("DEPRECATION")
+    @Synchronized
     fun set(siteModel: SiteModel) {
         wasReset = false
         state.value = siteModel
@@ -107,6 +110,7 @@ class SelectedSite @Inject constructor(
 
     fun getSelectedSiteId() = PreferenceUtils.getInt(getPreferences(), SELECTED_SITE_LOCAL_ID, -1)
 
+    @Synchronized
     fun reset() {
         wasReset = true
         state.value = null


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11649 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
We identify an issue with login where the fact that `SelectedSite`'s operations are not thread-safe can break the login flow, for more information on the exact flow where this happens, please check this [comment](https://github.com/woocommerce/woocommerce-android/issues/11649#issuecomment-2145811408).
This PR fixes the issue by making `SelectedSite` thread safe.

### Steps to reproduce
1. Check out `trunk`.
2. Apply the patch from below (the patch just attempts to increase the chance of the race condition)
3. Launch the app then sign in using Application Passwords.
4. Notice that the login doesn't work, the prologue screen is shown after the successful login.

**You might still need to repeat (3) few times to hit the issue.**

### Testing information
##### Confirm the issue is fixed
1. Check out the branch of this PR.
2. Apply the patch from below (the patch just attempts to increase the chance of the race condition)
3. Launch the app then sign in using Application Passwords.
4. Confirm the login works without issues.
5. Repeat few times to confirm the issue is fixed.

##### Non-regression
1. Smoke test the app.
2. Smoke test the site picker.

<details>
<summary>
<h3>Patch</h3>
</summary>

```patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt	(revision faa398d1f8c6015b4102f02fed0b800b6a53fb44)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt	(date 1717438482298)
@@ -30,7 +30,9 @@
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
@@ -49,6 +51,7 @@
 import org.wordpress.android.util.UrlUtils
 import java.net.URI
 import javax.inject.Inject
+import kotlin.random.Random
 
 @HiltViewModel
 class LoginSiteCredentialsViewModel @Inject constructor(
@@ -272,6 +275,7 @@
                     when (authenticationError?.errorType) {
                         GENERIC_ERROR,
                         INVALID_CREDENTIALS -> errorDialogMessage.value = authenticationError.errorMessage
+
                         else -> {
                             fetchSiteForTutorial(
                                 username = state.username,
@@ -390,7 +394,13 @@
                     loginAnalyticsListener.trackAnalyticsSignIn(false)
                 }
                 appPrefs.removeLoginSiteAddress()
+                repeat(10) {
+                    launch(Dispatchers.Default) {
+                        selectedSite.getOrNull()
+                    }
+                }
                 selectedSite.set(site)
+
                 triggerEvent(LoggedIn(selectedSite.getSelectedSiteId()))
             },
             onFailure = { exception ->
```

</details>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->