### PR TITLE
Issue/11559 unit test for fetching stock sales

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/stock/ProductStockRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/stock/ProductStockRepository.kt
@@ -88,12 +88,15 @@ class ProductStockRepository @Inject constructor(
         }
 
     private suspend fun getVariationsSales(variationIds: List<Long>, startDate: String, endDate: String) =
-        stockReportStore.fetchProductVariationsSalesReport(
-            site = selectedSite.get(),
-            startDate = startDate,
-            endDate = endDate,
-            productVariationIds = variationIds,
-        )
+        when {
+            variationIds.isEmpty() -> WooResult(emptyArray())
+            else -> stockReportStore.fetchProductVariationsSalesReport(
+                site = selectedSite.get(),
+                startDate = startDate,
+                endDate = endDate,
+                productVariationIds = variationIds,
+            )
+        }
 
     private fun mapToProductStockItems(
         stockReport: ProductStockItems,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/stock/ProductStockRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/stock/ProductStockRepositoryTest.kt
@@ -1,0 +1,223 @@
+package com.woocommerce.android.ui.products.stock
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.products.ProductStockStatus
+import com.woocommerce.android.ui.products.ProductStockStatus.Companion.toCoreProductStockStatus
+import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ProductStockItemApiResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ReportsProductApiResponse
+import org.wordpress.android.fluxc.store.ProductStockItems
+import org.wordpress.android.fluxc.store.WCLeaderboardsStore
+import org.wordpress.android.fluxc.store.WCProductStockReportStore
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProductStockRepositoryTest : BaseUnitTest() {
+    private val stockReportStock: WCProductStockReportStore = mock()
+    private val leaderboardsStore: WCLeaderboardsStore = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { get() } doReturn SiteModel().apply {
+            url = "https://woosite.com"
+        }
+    }
+    private val dateUtils: DateUtils = mock {
+        on { getCurrentDateTimeMinusDays(30) } doReturn ANY_START_DATE_IN_MILLIS
+    }
+
+    private var productStockRepository = ProductStockRepository(
+        stockReportStore = stockReportStock,
+        leaderboardsStore = leaderboardsStore,
+        selectedSite = selectedSite,
+        dateUtils = dateUtils
+    )
+
+    @Test
+    fun `when fetching stock fails, then sales are not fetched and error is returned`() = testBlocking {
+        givenFetchProductStockReturnsError(LOW_STOCK_STATUS, WooError(GENERIC_ERROR, UNKNOWN))
+
+        val result = productStockRepository.fetchProductStockReport(LOW_STOCK_STATUS)
+
+        verify(leaderboardsStore, never()).fetchProductSalesReport(any(), any(), any(), any())
+        verify(leaderboardsStore, never()).fetchProductVariationsSalesReport(any(), any(), any(), any())
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `given fetching stock succeeds, when fetching product sales, stock and sales are merged successfully`() =
+        testBlocking {
+            givenFetchProductStockReturns(LOW_STOCK_STATUS, PRODUCT_STOCK_ITEMS)
+            givenFetchProductSalesSuccess()
+
+            val result = productStockRepository.fetchProductStockReport(LOW_STOCK_STATUS)
+
+            assertEquals(STOCK_AND_SALES_REPORT, result.getOrNull())
+        }
+
+    @Test
+    fun `given product stock with only products, when fetching product sales, fetch only sales for products`() =
+        testBlocking {
+            givenFetchProductStockReturns(LOW_STOCK_STATUS, PRODUCT_STOCK_ITEMS)
+            givenFetchProductSalesSuccess()
+
+            productStockRepository.fetchProductStockReport(LOW_STOCK_STATUS)
+
+            verify(leaderboardsStore).fetchProductSalesReport(any(), any(), any(), any())
+            verify(leaderboardsStore, never()).fetchProductVariationsSalesReport(any(), any(), any(), any())
+        }
+
+    @Test
+    fun `given product stock with only variations, when fetching product sales, fetch only sales for variations`() =
+        testBlocking {
+            givenFetchProductStockReturns(LOW_STOCK_STATUS, PRODUCT_STOCK_ITEMS_WITH_ONLY_VARIATIONS)
+            givenFetchProductVariationSalesSuccess()
+
+            productStockRepository.fetchProductStockReport(LOW_STOCK_STATUS)
+
+            verify(leaderboardsStore).fetchProductVariationsSalesReport(any(), any(), any(), any())
+            verify(leaderboardsStore, never()).fetchProductSalesReport(any(), any(), any(), any())
+        }
+
+    @Test
+    fun `given product stock with variations and products, when fetching product sales, fetch sales for both types`() =
+        testBlocking {
+            givenFetchProductStockReturns(LOW_STOCK_STATUS, PRODUCT_STOCK_ITEMS_WITH_VARIATIONS)
+            givenFetchProductSalesSuccess()
+            givenFetchProductVariationSalesSuccess()
+
+            val result = productStockRepository.fetchProductStockReport(LOW_STOCK_STATUS)
+
+            verify(leaderboardsStore).fetchProductSalesReport(any(), any(), any(), any())
+            verify(leaderboardsStore).fetchProductVariationsSalesReport(any(), any(), any(), any())
+            assertEquals(STOCK_AND_SALES_REPORT_WITH_VARIATION, result.getOrNull())
+        }
+
+    private suspend fun givenFetchProductStockReturnsError(stockStatus: ProductStockStatus, wooError: WooError) {
+        whenever(
+            stockReportStock.fetchProductStockReport(
+                selectedSite.get(),
+                stockStatus.toCoreProductStockStatus()
+            )
+        ).thenReturn(WooResult(wooError))
+    }
+
+    private suspend fun givenFetchProductStockReturns(stockStatus: ProductStockStatus, stockItems: ProductStockItems) {
+        whenever(
+            stockReportStock.fetchProductStockReport(
+                selectedSite.get(),
+                stockStatus.toCoreProductStockStatus()
+            )
+        ).thenReturn(WooResult(stockItems))
+    }
+
+    private suspend fun givenFetchProductSalesSuccess() {
+        whenever(
+            leaderboardsStore.fetchProductSalesReport(
+                any(),
+                any(),
+                any(),
+                eq(PRODUCT_STOCK_ITEMS.map { it.productId!! })
+            )
+        ).thenReturn(WooResult(PRODUCT_SALES_REPORT))
+    }
+
+    private suspend fun givenFetchProductVariationSalesSuccess() {
+        whenever(
+            leaderboardsStore.fetchProductVariationsSalesReport(
+                any(),
+                any(),
+                any(),
+                eq(PRODUCT_STOCK_ITEMS_WITH_ONLY_VARIATIONS.map { it.productId!! })
+            )
+        ).thenReturn(WooResult(PRODUCT_VARIATION_SALES_REPORT))
+    }
+
+    private companion object {
+        val LOW_STOCK_STATUS = ProductStockStatus.LowStock
+        const val ANY_START_DATE_IN_MILLIS = 1704063600L
+        val PRODUCT_VARIATION_STOCK = ProductStockItemApiResponse(
+            productId = 2,
+            parentId = 1,
+            stockQuantity = 1,
+            stockStatus = "instock",
+            name = "Product 1 Variation",
+        )
+        val PRODUCT_STOCK_ITEMS: ProductStockItems = arrayOf(
+            ProductStockItemApiResponse(
+                productId = 1,
+                parentId = 0,
+                name = "Product 1",
+                stockQuantity = 1,
+                stockStatus = "instock",
+            )
+        )
+        val PRODUCT_STOCK_ITEMS_WITH_VARIATIONS: ProductStockItems = arrayOf(
+            ProductStockItemApiResponse(
+                productId = 1,
+                parentId = 0,
+                name = "Product 1",
+                stockQuantity = 1,
+                stockStatus = "instock",
+            ),
+            PRODUCT_VARIATION_STOCK
+        )
+        val PRODUCT_STOCK_ITEMS_WITH_ONLY_VARIATIONS: ProductStockItems = arrayOf(PRODUCT_VARIATION_STOCK)
+        val PRODUCT_SALES_REPORT = arrayOf(
+            ReportsProductApiResponse(
+                productId = 1,
+                variationId = null,
+                itemsSold = 2,
+            ),
+        )
+        val PRODUCT_VARIATION_SALES_REPORT = arrayOf(
+            ReportsProductApiResponse(
+                productId = 1,
+                variationId = 2,
+                itemsSold = 2,
+            ),
+        )
+        val STOCK_AND_SALES_REPORT = listOf(
+            ProductStockItem(
+                productId = 1,
+                parentProductId = 0,
+                name = "Product 1",
+                stockQuantity = 1,
+                itemsSold = 2,
+                imageUrl = null
+            )
+        )
+        val STOCK_AND_SALES_REPORT_WITH_VARIATION = listOf(
+            ProductStockItem(
+                productId = 1,
+                parentProductId = 0,
+                name = "Product 1",
+                stockQuantity = 1,
+                itemsSold = 2,
+                imageUrl = null
+            ),
+            ProductStockItem(
+                productId = 2,
+                parentProductId = 1,
+                name = "Product 1 Variation",
+                stockQuantity = 1,
+                itemsSold = 2,
+                imageUrl = null
+            )
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/stock/ProductStockRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/stock/ProductStockRepositoryTest.kt
@@ -22,15 +22,13 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ProductStockItemApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.reports.ReportsProductApiResponse
 import org.wordpress.android.fluxc.store.ProductStockItems
-import org.wordpress.android.fluxc.store.WCLeaderboardsStore
-import org.wordpress.android.fluxc.store.WCProductStockReportStore
+import org.wordpress.android.fluxc.store.WCProductReportsStore
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ProductStockRepositoryTest : BaseUnitTest() {
-    private val stockReportStock: WCProductStockReportStore = mock()
-    private val leaderboardsStore: WCLeaderboardsStore = mock()
+    private val stockReportStock: WCProductReportsStore = mock()
     private val selectedSite: SelectedSite = mock {
         on { get() } doReturn SiteModel().apply {
             url = "https://woosite.com"
@@ -42,7 +40,6 @@ class ProductStockRepositoryTest : BaseUnitTest() {
 
     private var productStockRepository = ProductStockRepository(
         stockReportStore = stockReportStock,
-        leaderboardsStore = leaderboardsStore,
         selectedSite = selectedSite,
         dateUtils = dateUtils
     )
@@ -53,8 +50,8 @@ class ProductStockRepositoryTest : BaseUnitTest() {
 
         val result = productStockRepository.fetchProductStockReport(LOW_STOCK_STATUS)
 
-        verify(leaderboardsStore, never()).fetchProductSalesReport(any(), any(), any(), any())
-        verify(leaderboardsStore, never()).fetchProductVariationsSalesReport(any(), any(), any(), any())
+        verify(stockReportStock, never()).fetchProductSalesReport(any(), any(), any(), any())
+        verify(stockReportStock, never()).fetchProductVariationsSalesReport(any(), any(), any(), any())
         assertTrue(result.isFailure)
     }
 
@@ -77,8 +74,8 @@ class ProductStockRepositoryTest : BaseUnitTest() {
 
             productStockRepository.fetchProductStockReport(LOW_STOCK_STATUS)
 
-            verify(leaderboardsStore).fetchProductSalesReport(any(), any(), any(), any())
-            verify(leaderboardsStore, never()).fetchProductVariationsSalesReport(any(), any(), any(), any())
+            verify(stockReportStock).fetchProductSalesReport(any(), any(), any(), any())
+            verify(stockReportStock, never()).fetchProductVariationsSalesReport(any(), any(), any(), any())
         }
 
     @Test
@@ -89,8 +86,8 @@ class ProductStockRepositoryTest : BaseUnitTest() {
 
             productStockRepository.fetchProductStockReport(LOW_STOCK_STATUS)
 
-            verify(leaderboardsStore).fetchProductVariationsSalesReport(any(), any(), any(), any())
-            verify(leaderboardsStore, never()).fetchProductSalesReport(any(), any(), any(), any())
+            verify(stockReportStock).fetchProductVariationsSalesReport(any(), any(), any(), any())
+            verify(stockReportStock, never()).fetchProductSalesReport(any(), any(), any(), any())
         }
 
     @Test
@@ -102,8 +99,8 @@ class ProductStockRepositoryTest : BaseUnitTest() {
 
             val result = productStockRepository.fetchProductStockReport(LOW_STOCK_STATUS)
 
-            verify(leaderboardsStore).fetchProductSalesReport(any(), any(), any(), any())
-            verify(leaderboardsStore).fetchProductVariationsSalesReport(any(), any(), any(), any())
+            verify(stockReportStock).fetchProductSalesReport(any(), any(), any(), any())
+            verify(stockReportStock).fetchProductVariationsSalesReport(any(), any(), any(), any())
             assertEquals(STOCK_AND_SALES_REPORT_WITH_VARIATION, result.getOrNull())
         }
 
@@ -127,7 +124,7 @@ class ProductStockRepositoryTest : BaseUnitTest() {
 
     private suspend fun givenFetchProductSalesSuccess() {
         whenever(
-            leaderboardsStore.fetchProductSalesReport(
+            stockReportStock.fetchProductSalesReport(
                 any(),
                 any(),
                 any(),
@@ -138,7 +135,7 @@ class ProductStockRepositoryTest : BaseUnitTest() {
 
     private suspend fun givenFetchProductVariationSalesSuccess() {
         whenever(
-            leaderboardsStore.fetchProductVariationsSalesReport(
+            stockReportStock.fetchProductVariationsSalesReport(
                 any(),
                 any(),
                 any(),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11559 
<!-- Id number of the GitHub issue this PR addresses. -->
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds unit tests to `ProductStockRepository.` Additionally, it provides a small fix that I noticed while testing: avoid fetching product variation sales reports if there are no variations in the stock report API result. 

### Testing information
Getting a green status for all the checks should suffice. 
