### PR TITLE
[Dynamic Dashboard] Hide inbox card when its feature flag is disabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
@@ -34,7 +34,7 @@ data class DashboardWidget(
         REVIEWS(R.string.my_store_widget_reviews_title, "reviews", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()),
         ORDERS(R.string.my_store_widget_orders_title, "orders", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()),
         COUPONS(R.string.my_store_widget_coupons_title, "coupons", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()),
-        INBOX(R.string.inbox_screen_title, "inbox", isSupported = FeatureFlag.MORE_MENU_INBOX.isEnabled()),
+        INBOX(R.string.inbox_screen_title, "inbox", isSupported = FeatureFlag.INBOX.isEnabled()),
         PRODUCT_STOCK(R.string.my_store_widget_product_stock_title, "product_stock", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled());
 
         companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
@@ -24,30 +24,21 @@ data class DashboardWidget(
 
     enum class Type(
         @StringRes val titleResource: Int,
-        val trackingIdentifier: String
+        val trackingIdentifier: String,
+        private val isSupported: Boolean = true,
     ) {
         ONBOARDING(R.string.my_store_widget_onboarding_title, "store_setup"),
         STATS(R.string.my_store_widget_stats_title, "performance"),
         POPULAR_PRODUCTS(R.string.my_store_widget_top_products_title, "top_performers"),
         BLAZE(R.string.my_store_widget_blaze_title, "blaze"),
-        REVIEWS(R.string.my_store_widget_reviews_title, "reviews"),
-        ORDERS(R.string.my_store_widget_orders_title, "orders"),
-        COUPONS(R.string.my_store_widget_coupons_title, "coupons"),
-        INBOX(R.string.inbox_screen_title, "inbox"),
-        PRODUCT_STOCK(R.string.my_store_widget_product_stock_title, "product_stock");
+        REVIEWS(R.string.my_store_widget_reviews_title, "reviews", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()),
+        ORDERS(R.string.my_store_widget_orders_title, "orders", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()),
+        COUPONS(R.string.my_store_widget_coupons_title, "coupons", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()),
+        INBOX(R.string.inbox_screen_title, "inbox", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()),
+        PRODUCT_STOCK(R.string.my_store_widget_product_stock_title, "product_stock", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled());
 
         companion object {
-            // Use the feature flag [DYNAMIC_DASHBOARD_M2] to filter out unsupported widgets during development
-            val supportedWidgets: List<Type> = Type.entries
-                .filter {
-                    FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled() || (
-                        it != DashboardWidget.Type.ORDERS &&
-                            it != DashboardWidget.Type.REVIEWS &&
-                            it != DashboardWidget.Type.COUPONS &&
-                            it != DashboardWidget.Type.PRODUCT_STOCK &&
-                            it != DashboardWidget.Type.INBOX
-                        )
-                }
+            val supportedWidgets: List<Type> = Type.entries.filter { it.isSupported }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
@@ -27,15 +27,47 @@ data class DashboardWidget(
         val trackingIdentifier: String,
         private val isSupported: Boolean = true,
     ) {
-        ONBOARDING(R.string.my_store_widget_onboarding_title, "store_setup"),
-        STATS(R.string.my_store_widget_stats_title, "performance"),
-        POPULAR_PRODUCTS(R.string.my_store_widget_top_products_title, "top_performers"),
-        BLAZE(R.string.my_store_widget_blaze_title, "blaze"),
-        REVIEWS(R.string.my_store_widget_reviews_title, "reviews", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()),
-        ORDERS(R.string.my_store_widget_orders_title, "orders", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()),
-        COUPONS(R.string.my_store_widget_coupons_title, "coupons", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()),
-        INBOX(R.string.inbox_screen_title, "inbox", isSupported = FeatureFlag.INBOX.isEnabled()),
-        PRODUCT_STOCK(R.string.my_store_widget_product_stock_title, "product_stock", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled());
+        ONBOARDING(
+            titleResource = R.string.my_store_widget_onboarding_title,
+            trackingIdentifier = "store_setup"
+        ),
+        STATS(
+            titleResource = R.string.my_store_widget_stats_title,
+            trackingIdentifier = "performance"
+        ),
+        POPULAR_PRODUCTS(
+            titleResource = R.string.my_store_widget_top_products_title,
+            trackingIdentifier = "top_performers"
+        ),
+        BLAZE(
+            titleResource = R.string.my_store_widget_blaze_title,
+            trackingIdentifier = "blaze"
+        ),
+        REVIEWS(
+            titleResource = R.string.my_store_widget_reviews_title,
+            trackingIdentifier = "reviews",
+            isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()
+        ),
+        ORDERS(
+            titleResource = R.string.my_store_widget_orders_title,
+            trackingIdentifier = "orders",
+            isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()
+        ),
+        COUPONS(
+            titleResource = R.string.my_store_widget_coupons_title,
+            trackingIdentifier = "coupons",
+            isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()
+        ),
+        INBOX(
+            titleResource = R.string.inbox_screen_title,
+            trackingIdentifier = "inbox",
+            isSupported = FeatureFlag.INBOX.isEnabled()
+        ),
+        PRODUCT_STOCK(
+            titleResource = R.string.my_store_widget_product_stock_title,
+            trackingIdentifier = "product_stock",
+            isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()
+        );
 
         companion object {
             val supportedWidgets: List<Type> = Type.entries.filter { it.isSupported }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
@@ -34,7 +34,7 @@ data class DashboardWidget(
         REVIEWS(R.string.my_store_widget_reviews_title, "reviews", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()),
         ORDERS(R.string.my_store_widget_orders_title, "orders", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()),
         COUPONS(R.string.my_store_widget_coupons_title, "coupons", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()),
-        INBOX(R.string.inbox_screen_title, "inbox", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()),
+        INBOX(R.string.inbox_screen_title, "inbox", isSupported = FeatureFlag.MORE_MENU_INBOX.isEnabled()),
         PRODUCT_STOCK(R.string.my_store_widget_product_stock_title, "product_stock", isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled());
 
         companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepository.kt
@@ -19,7 +19,7 @@ class MoreMenuRepository @Inject constructor(
 
     suspend fun isInboxEnabled(): Boolean =
         withContext(Dispatchers.IO) {
-            if (!selectedSite.exists() || !FeatureFlag.MORE_MENU_INBOX.isEnabled()) return@withContext false
+            if (!selectedSite.exists() || !FeatureFlag.INBOX.isEnabled()) return@withContext false
 
             val currentWooCoreVersion = getWooVersion() ?: return@withContext false
             currentWooCoreVersion.semverCompareTo(INBOX_MINIMUM_SUPPORTED_VERSION) >= 0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -8,7 +8,7 @@ import android.content.Context
 enum class FeatureFlag {
     WOO_POS,
     DB_DOWNGRADE,
-    MORE_MENU_INBOX,
+    INBOX,
     WC_SHIPPING_BANNER,
     OTHER_PAYMENT_METHODS,
     BETTER_CUSTOMER_SEARCH_M2,
@@ -26,7 +26,7 @@ enum class FeatureFlag {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
 
-            MORE_MENU_INBOX,
+            INBOX,
             WOO_POS,
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11524 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds a simple check to make sure the inbox card is hidden when the global `INBOX` feature flag is disabled.

### Testing information
1. Disable the `FeatureFlag.INBOX` feature flag.
2. Open the app.
3. Confirm that the inbox card is hidden in the widget editor screen.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->