### PR TITLE
[Dynamic Dashboard] Update products stock card error when WCAnalytics is disabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
@@ -38,6 +38,7 @@ import com.woocommerce.android.ui.compose.viewModelWithFactory
 import com.woocommerce.android.ui.dashboard.DashboardFilterableCardHeader
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
+import com.woocommerce.android.ui.dashboard.WCAnalyticsNotAvailableErrorView
 import com.woocommerce.android.ui.dashboard.WidgetCard
 import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.defaultHideMenuEntry
@@ -131,10 +132,17 @@ private fun DashboardProductStockCard(
                 )
             }
 
-            is DashboardProductStockViewModel.ViewState.Error -> {
+            DashboardProductStockViewModel.ViewState.Error.WCAnalyticsDisabled -> {
+                WCAnalyticsNotAvailableErrorView(
+                    title = stringResource(id = R.string.dashboard_product_stock_wcanalytics_inactive_title),
+                    onContactSupportClick = onContactSupportClicked
+                )
+            }
+
+            DashboardProductStockViewModel.ViewState.Error.Generic -> {
                 WidgetError(
-                    onContactSupportClicked = onContactSupportClicked,
-                    onRetryClicked = onRetryClicked
+                    onRetryClicked = onRetryClicked,
+                    onContactSupportClicked = onContactSupportClicked
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/stock/ProductStockRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/stock/ProductStockRepository.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products.stock
 
 import android.os.Parcelable
+import com.woocommerce.android.WooException
 import com.woocommerce.android.extensions.formatToYYYYmmDDhhmmss
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ProductStockStatus
@@ -31,12 +32,12 @@ class ProductStockRepository @Inject constructor(
             stockStatus = stockStatus.toCoreProductStockStatus()
         ).let { stockReportResult ->
             if (stockReportResult.isError) {
-                Result.failure(Exception(stockReportResult.error.message))
+                Result.failure(WooException(stockReportResult.error!!))
             } else {
                 val (productSalesResult, variationSalesResult) = getProductSalesReports(stockReportResult.model!!)
-                return when {
-                    productSalesResult.isError -> Result.failure(Exception(productSalesResult.error.message))
-                    variationSalesResult.isError -> Result.failure(Exception(variationSalesResult.error.message))
+                when {
+                    productSalesResult.isError -> Result.failure(WooException(productSalesResult.error))
+                    variationSalesResult.isError -> Result.failure(WooException(variationSalesResult.error))
                     else ->
                         Result.success(
                             mapToProductStockItems(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -444,6 +444,7 @@
     <string name="dashboard_product_stock_products">Products</string>
     <string name="dashboard_product_stock_sales_last_30_days">%d items sold in last 30 days</string>
     <string name="dashboard_product_stock_no_sales_last_30_days">No items sold in the last 30 days</string>
+    <string name="dashboard_product_stock_wcanalytics_inactive_title">Unable to load product stock reports</string>
 
     <string name="dashboard_new_widgets_card_title">Looking for more insights?</string>
     <string name="dashboard_new_widgets_card_description">Add new sections to customize your store management experience</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11544 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates the product stock card to show the correct error screen when WCAnalytics feature is disabled on the website.

### Testing information
1. Disable WooCommerce Analytics in this wp-admin page `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Open the app, and add the Stock card.
3. Confirm the correct error screen is shown.

### Images/gif
<img src="https://github.com/woocommerce/woocommerce-android/assets/1657201/b46c0d62-a5f9-47b3-bbaf-da8b31a73f8b" width=360 />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->