### PR TITLE
[Woo POS] Update entry point eligibility condition to use woo 6.6.0

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.woopos
 
+import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.IsWindowClassExpandedAndBigger
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
@@ -16,6 +18,7 @@ class IsWooPosEnabled @Inject constructor(
     private val getActivePaymentsPlugin: GetActivePaymentsPlugin,
     private val isWindowSizeExpandedAndBigger: IsWindowClassExpandedAndBigger,
     private val isWooPosFFEnabled: IsWooPosFFEnabled,
+    private val getWooCoreVersion: GetWooCorePluginCachedVersion,
 ) {
     private var cachedResult: Boolean? = null
 
@@ -35,11 +38,22 @@ class IsWooPosEnabled @Inject constructor(
                 ippPlugin == WOOCOMMERCE_PAYMENTS &&
                 paymentAccount.storeCurrencies.default.lowercase() == "usd" &&
                 isWindowSizeExpandedAndBigger() &&
-                isPluginSetupEnabled(paymentAccount)
+                isPluginSetupEnabled(paymentAccount) &&
+                isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps()
             ).also { cachedResult = it }
     }
 
     private fun isPluginSetupEnabled(paymentAccount: WCPaymentAccountResult): Boolean =
         paymentAccount.status == WCPaymentAccountResult.WCPaymentAccountStatus.COMPLETE ||
             paymentAccount.status == WCPaymentAccountResult.WCPaymentAccountStatus.ENABLED
+
+    private fun isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps(): Boolean {
+        val wooCoreVersion = getWooCoreVersion() ?: return false
+        return wooCoreVersion.semverCompareTo(WC_VERSION_SUPPORTS_ORDER_AUTO_DRAFTS_AND_EXTRA_PAYMENTS_PROPS) >= 0
+    }
+
+
+    private companion object {
+        const val WC_VERSION_SUPPORTS_ORDER_AUTO_DRAFTS_AND_EXTRA_PAYMENTS_PROPS = "6.6.0"
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
@@ -52,7 +52,6 @@ class IsWooPosEnabled @Inject constructor(
         return wooCoreVersion.semverCompareTo(WC_VERSION_SUPPORTS_ORDER_AUTO_DRAFTS_AND_EXTRA_PAYMENTS_PROPS) >= 0
     }
 
-
     private companion object {
         const val WC_VERSION_SUPPORTS_ORDER_AUTO_DRAFTS_AND_EXTRA_PAYMENTS_PROPS = "6.6.0"
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabledTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabledTest.kt
@@ -30,7 +30,7 @@ class IsWooPosEnabledTest : BaseUnitTest() {
     private val getActivePaymentsPlugin: GetActivePaymentsPlugin = mock()
     private val isWindowSizeExpandedAndBigger: IsWindowClassExpandedAndBigger = mock()
     private val isWooPosFFEnabled: IsWooPosFFEnabled = mock()
-    private val getWooCoreVersion: GetWooCorePluginCachedVersion = mock() {
+    private val getWooCoreVersion: GetWooCorePluginCachedVersion = mock {
         on { invoke() }.thenReturn("6.6.0")
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabledTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabledTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos
 
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.IsWindowClassExpandedAndBigger
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -29,6 +30,9 @@ class IsWooPosEnabledTest : BaseUnitTest() {
     private val getActivePaymentsPlugin: GetActivePaymentsPlugin = mock()
     private val isWindowSizeExpandedAndBigger: IsWindowClassExpandedAndBigger = mock()
     private val isWooPosFFEnabled: IsWooPosFFEnabled = mock()
+    private val getWooCoreVersion: GetWooCorePluginCachedVersion = mock() {
+        on { invoke() }.thenReturn("6.6.0")
+    }
 
     private lateinit var sut: IsWooPosEnabled
 
@@ -46,6 +50,7 @@ class IsWooPosEnabledTest : BaseUnitTest() {
             getActivePaymentsPlugin = getActivePaymentsPlugin,
             isWindowSizeExpandedAndBigger = isWindowSizeExpandedAndBigger,
             isWooPosFFEnabled = isWooPosFFEnabled,
+            getWooCoreVersion = getWooCoreVersion,
         )
     }
 
@@ -105,6 +110,38 @@ class IsWooPosEnabledTest : BaseUnitTest() {
     fun `given big enough screen, woo payments enabled, USD currency, store in the US, and status enabled, then return true`() = testBlocking {
         val result = buildPaymentAccountResult(defaultCurrency = "USD", countryCode = "US", status = ENABLED)
         whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
+        assertTrue(sut())
+    }
+
+    @Test
+    fun `given woo version 6_5_0, when invoked, then return false`() = testBlocking {
+        val result = buildPaymentAccountResult(defaultCurrency = "USD", countryCode = "US", status = ENABLED)
+        whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
+        whenever(getWooCoreVersion.invoke()).thenReturn("6.5.0")
+        assertFalse(sut())
+    }
+
+    @Test
+    fun `given woo version 6_6_0, when invoked, then return true`() = testBlocking {
+        val result = buildPaymentAccountResult(defaultCurrency = "USD", countryCode = "US", status = ENABLED)
+        whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
+        whenever(getWooCoreVersion.invoke()).thenReturn("6.6.0")
+        assertTrue(sut())
+    }
+
+    @Test
+    fun `given woo version 6_6_0_1, when invoked, then return true`() = testBlocking {
+        val result = buildPaymentAccountResult(defaultCurrency = "USD", countryCode = "US", status = ENABLED)
+        whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
+        whenever(getWooCoreVersion.invoke()).thenReturn("6.6.0.1")
+        assertTrue(sut())
+    }
+
+    @Test
+    fun `given woo version 10_0_1, when invoked, then return true`() = testBlocking {
+        val result = buildPaymentAccountResult(defaultCurrency = "USD", countryCode = "US", status = ENABLED)
+        whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
+        whenever(getWooCoreVersion.invoke()).thenReturn("10.0.1")
         assertTrue(sut())
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11663
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Update entry point eligibility condition to use Woo 6.6.0

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
That's tricky to reproduce e2e, as you'll need to downgrade Woo version, so maybe just manually set different versions on the line `IsWooPosEnabled::51` to validate the output

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->