### PR TITLE
Adds tracking for dynamic dashboard M2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -188,6 +188,7 @@ sealed class AnalyticsEvent(override val siteless: Boolean = false) : IAnalytics
     object DYNAMIC_DASHBOARD_HIDE_CARD_TAPPED : AnalyticsEvent()
     object DYNAMIC_DASHBOARD_EDITOR_SAVE_TAPPED : AnalyticsEvent()
     object DYNAMIC_DASHBOARD_CARD_RETRY_TAPPED : AnalyticsEvent()
+    object DYNAMIC_DASHBOARD_ADD_NEW_SECTIONS_TAPPED : AnalyticsEvent()
 
     // -- Analytics Hub
     object ANALYTICS_HUB_DATE_RANGE_BUTTON_TAPPED : AnalyticsEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -189,6 +189,7 @@ sealed class AnalyticsEvent(override val siteless: Boolean = false) : IAnalytics
     object DYNAMIC_DASHBOARD_EDITOR_SAVE_TAPPED : AnalyticsEvent()
     object DYNAMIC_DASHBOARD_CARD_RETRY_TAPPED : AnalyticsEvent()
     object DYNAMIC_DASHBOARD_ADD_NEW_SECTIONS_TAPPED : AnalyticsEvent()
+    object DYNAMIC_DASHBOARD_CARD_INTERACTED : AnalyticsEvent()
 
     // -- Analytics Hub
     object ANALYTICS_HUB_DATE_RANGE_BUTTON_TAPPED : AnalyticsEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -665,8 +665,8 @@ class AnalyticsTracker private constructor(
 
         // Dynamic Dashboard
         const val KEY_NEW_CARD_AVAILABLE = "new_card_available"
-        const val KEY_SELECTED_CARDS = "cards"
-        const val KEY_FIRST_CARD_TYPE = "first_card_type"
+        const val KEY_DASHBOARD_ENABLED_CARDS = "enabled_cards"
+        const val KEY_SORTED_CARDS = "sorted_cards"
 
         var sendUsageStats: Boolean = true
             set(value) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -663,6 +663,9 @@ class AnalyticsTracker private constructor(
         const val KEY_ENABLED_CARDS = "enabled_cards"
         const val KEY_DISABLED_CARDS = "disabled_cards"
 
+        // Dynamic Dashboard
+        const val KEY_NEW_CARD_AVAILABLE = "new_card_available"
+
         var sendUsageStats: Boolean = true
             set(value) {
                 if (value != field) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -665,7 +665,7 @@ class AnalyticsTracker private constructor(
 
         // Dynamic Dashboard
         const val KEY_NEW_CARD_AVAILABLE = "new_card_available"
-        const val KEY_DASHBOARD_ENABLED_CARDS = "enabled_cards"
+        const val KEY_CARDS = "cards"
         const val KEY_SORTED_CARDS = "sorted_cards"
 
         var sendUsageStats: Boolean = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -665,6 +665,8 @@ class AnalyticsTracker private constructor(
 
         // Dynamic Dashboard
         const val KEY_NEW_CARD_AVAILABLE = "new_card_available"
+        const val KEY_SELECTED_CARDS = "cards"
+        const val KEY_FIRST_CARD_TYPE = "first_card_type"
 
         var sendUsageStats: Boolean = true
             set(value) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
@@ -34,7 +34,7 @@ data class DashboardWidget(
         ORDERS(R.string.my_store_widget_orders_title, "orders"),
         COUPONS(R.string.my_store_widget_coupons_title, "coupons"),
         INBOX(R.string.inbox_screen_title, "inbox"),
-        PRODUCT_STOCK(R.string.my_store_widget_product_stock_title, "product_stock");
+        PRODUCT_STOCK(R.string.my_store_widget_product_stock_title, "stock");
 
         companion object {
             // Use the feature flag [DYNAMIC_DASHBOARD_M2] to filter out unsupported widgets during development

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
@@ -34,7 +34,7 @@ data class DashboardWidget(
         ORDERS(R.string.my_store_widget_orders_title, "orders"),
         COUPONS(R.string.my_store_widget_coupons_title, "coupons"),
         INBOX(R.string.inbox_screen_title, "inbox"),
-        PRODUCT_STOCK(R.string.my_store_widget_product_stock_title, "stock");
+        STOCK(R.string.my_store_widget_product_stock_title, "stock");
 
         companion object {
             // Use the feature flag [DYNAMIC_DASHBOARD_M2] to filter out unsupported widgets during development
@@ -44,7 +44,7 @@ data class DashboardWidget(
                         it != DashboardWidget.Type.ORDERS &&
                             it != DashboardWidget.Type.REVIEWS &&
                             it != DashboardWidget.Type.COUPONS &&
-                            it != DashboardWidget.Type.PRODUCT_STOCK &&
+                            it != DashboardWidget.Type.STOCK &&
                             it != DashboardWidget.Type.INBOX
                         )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -160,7 +160,7 @@ private fun ConfigurableWidgetCard(
             modifier = modifier
         )
 
-        DashboardWidget.Type.PRODUCT_STOCK -> DashboardProductStockCard(
+        DashboardWidget.Type.STOCK -> DashboardProductStockCard(
             parentViewModel = dashboardViewModel,
             modifier = modifier
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsEvent.DYNAMIC_DASHBOARD_CARD_INTERACTED
 import com.woocommerce.android.analytics.AnalyticsEvent.FEATURE_JETPACK_BENEFITS_BANNER
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -190,6 +191,13 @@ class DashboardViewModel @Inject constructor(
 
     fun onShowSnackbar(@StringRes message: Int) {
         triggerEvent(Event.ShowSnackbar(message))
+    }
+
+    fun trackCardInteracted(type: String) {
+        analyticsTrackerWrapper.track(
+            DYNAMIC_DASHBOARD_CARD_INTERACTED,
+            mapOf(AnalyticsTracker.KEY_TYPE to type)
+        )
     }
 
     private fun mapWidgetsToUiModels(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -165,7 +165,10 @@ class DashboardViewModel @Inject constructor(
     }
 
     fun onEditWidgetsClicked() {
-        analyticsTrackerWrapper.track(AnalyticsEvent.DYNAMIC_DASHBOARD_EDIT_LAYOUT_BUTTON_TAPPED)
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.DYNAMIC_DASHBOARD_EDIT_LAYOUT_BUTTON_TAPPED,
+            mapOf(AnalyticsTracker.KEY_NEW_CARD_AVAILABLE to hasNewWidgets.value.toString())
+        )
         triggerEvent(OpenEditWidgets)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -240,6 +240,7 @@ class DashboardViewModel @Inject constructor(
             NewWidgetsCard(
                 isVisible = hasNewWidgets,
                 onShowCardsClick = {
+                    analyticsTrackerWrapper.track(AnalyticsEvent.DYNAMIC_DASHBOARD_ADD_NEW_SECTIONS_TAPPED)
                     triggerEvent(OpenEditWidgets)
                 }
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
@@ -51,7 +51,7 @@ import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 @Suppress("LongParameterList")
 class DashboardBlazeViewModel @AssistedInject constructor(
     savedStateHandle: SavedStateHandle,
-    @Assisted parentViewModel: DashboardViewModel,
+    @Assisted private val parentViewModel: DashboardViewModel,
     observeMostRecentBlazeCampaign: ObserveMostRecentBlazeCampaign,
     private val productListRepository: ProductListRepository,
     private val blazeUrlsHelper: BlazeUrlsHelper,
@@ -144,6 +144,7 @@ class DashboardBlazeViewModel @AssistedInject constructor(
                 )
             ),
             onCampaignClicked = {
+                parentViewModel.trackCardInteracted(DashboardWidget.Type.BLAZE.trackingIdentifier)
                 analyticsTrackerWrapper.track(
                     stat = BLAZE_CAMPAIGN_DETAIL_SELECTED,
                     properties = mapOf(
@@ -169,6 +170,7 @@ class DashboardBlazeViewModel @AssistedInject constructor(
     }
 
     private fun viewAllCampaigns() {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.BLAZE.trackingIdentifier)
         analyticsTrackerWrapper.track(
             stat = BLAZE_CAMPAIGN_LIST_ENTRY_POINT_SELECTED,
             properties = mapOf(
@@ -208,6 +210,7 @@ class DashboardBlazeViewModel @AssistedInject constructor(
     )
 
     private fun launchCampaignCreation(productId: Long?) {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.BLAZE.trackingIdentifier)
         triggerEvent(LaunchBlazeCampaignCreation(productId))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsViewModel.kt
@@ -5,7 +5,11 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.WooException
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.CouponPerformanceReport
+import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
@@ -56,6 +60,7 @@ class DashboardCouponsViewModel @AssistedInject constructor(
     private val appPrefs: AppPrefsWrapper,
     private val couponUtils: CouponUtils,
     private val parameterRepository: ParameterRepository,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     coroutineDispatchers: CoroutineDispatchers
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
@@ -152,6 +157,12 @@ class DashboardCouponsViewModel @AssistedInject constructor(
     }
 
     fun onRetryClicked() {
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.DYNAMIC_DASHBOARD_CARD_RETRY_TAPPED,
+            mapOf(
+                AnalyticsTracker.KEY_TYPE to DashboardWidget.Type.COUPONS.trackingIdentifier
+            )
+        )
         _refreshTrigger.tryEmit(RefreshEvent())
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsViewModel.kt
@@ -119,6 +119,7 @@ class DashboardCouponsViewModel @AssistedInject constructor(
     }.asLiveData()
 
     fun onTabSelected(selectionType: SelectionType) {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.COUPONS.trackingIdentifier)
         if (selectionType != SelectionType.CUSTOM) {
             appPrefs.setActiveCouponsTab(selectionType.name)
         } else {
@@ -131,6 +132,7 @@ class DashboardCouponsViewModel @AssistedInject constructor(
     }
 
     fun onEditCustomRangeTapped() {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.COUPONS.trackingIdentifier)
         triggerEvent(
             OpenDatePicker(
                 fromDate = dateRangeState.value?.customRange?.start ?: Date(),
@@ -149,10 +151,12 @@ class DashboardCouponsViewModel @AssistedInject constructor(
     }
 
     fun onViewAllClicked() {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.COUPONS.trackingIdentifier)
         triggerEvent(ViewAllCoupons)
     }
 
     fun onCouponClicked(couponId: Long) {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.COUPONS.trackingIdentifier)
         triggerEvent(ViewCouponDetails(couponId))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/inbox/DashboardInboxViewModel.kt
@@ -132,6 +132,7 @@ class DashboardInboxViewModel @AssistedInject constructor(
     }
 
     private fun onNoteDismissed(noteId: Long) {
+        parentViewModel.trackCardInteracted(INBOX.trackingIdentifier)
         viewModelScope.launch {
             inboxRepository.dismissNote(noteId)
                 .onFailure { showSyncError() }
@@ -139,6 +140,7 @@ class DashboardInboxViewModel @AssistedInject constructor(
     }
 
     private fun onNoteAction(actionId: Long, noteId: Long) {
+        parentViewModel.trackCardInteracted(INBOX.trackingIdentifier)
         val clickedNote = (viewState.value as? ViewState.Content)?.notes?.firstOrNull { noteId == it.id }
         clickedNote?.let {
             when {
@@ -171,6 +173,7 @@ class DashboardInboxViewModel @AssistedInject constructor(
     }
 
     private fun onNavigateToInbox() {
+        parentViewModel.trackCardInteracted(INBOX.trackingIdentifier)
         triggerEvent(NavigateToInbox)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/onboarding/DashboardOnboardingViewModel.kt
@@ -104,14 +104,17 @@ class DashboardOnboardingViewModel @AssistedInject constructor(
         }.asLiveData()
 
     private fun viewAllClicked() {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.ONBOARDING.trackingIdentifier)
         triggerEvent(NavigateToOnboardingFullScreen)
     }
 
     private fun onShareFeedbackClicked() {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.ONBOARDING.trackingIdentifier)
         triggerEvent(NavigateToSurvey)
     }
 
     fun onTaskClicked(task: OnboardingTaskUi) {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.ONBOARDING.trackingIdentifier)
         when (task.taskUiResources) {
             AboutYourStoreTaskRes -> triggerEvent(NavigateToAboutYourStore)
             AddProductTaskRes -> triggerEvent(NavigateToAddProduct)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersViewModel.kt
@@ -159,6 +159,7 @@ class DashboardOrdersViewModel @AssistedInject constructor(
         }
 
     private fun onNavigateToOrders() {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.ORDERS.trackingIdentifier)
         triggerEvent(NavigateToOrders)
     }
 
@@ -173,10 +174,12 @@ class DashboardOrdersViewModel @AssistedInject constructor(
     }
 
     fun onFilterSelected(filter: OrderStatusOption) {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.ORDERS.trackingIdentifier)
         selectedFilter.value = filter.key
     }
 
     fun onOrderClicked(orderId: Long) {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.ORDERS.trackingIdentifier)
         triggerEvent(NavigateToOrderDetails(orderId))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
@@ -4,6 +4,10 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.model.ProductReview
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.reviews.ProductReviewStatus
@@ -35,7 +39,8 @@ class DashboardReviewsViewModel @AssistedInject constructor(
     savedStateHandle: SavedStateHandle,
     @Assisted private val parentViewModel: DashboardViewModel,
     private val reviewListRepository: ReviewListRepository,
-    private val reviewModerationHandler: ReviewModerationHandler
+    private val reviewModerationHandler: ReviewModerationHandler,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         val supportedFilters = listOf(
@@ -87,6 +92,12 @@ class DashboardReviewsViewModel @AssistedInject constructor(
     }
 
     fun onRetryClicked() {
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.DYNAMIC_DASHBOARD_CARD_RETRY_TAPPED,
+            mapOf(
+                AnalyticsTracker.KEY_TYPE to DashboardWidget.Type.REVIEWS.trackingIdentifier
+            )
+        )
         _refreshTrigger.tryEmit(DashboardViewModel.RefreshEvent())
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModel.kt
@@ -80,14 +80,17 @@ class DashboardReviewsViewModel @AssistedInject constructor(
         .asLiveData()
 
     fun onFilterSelected(status: ProductReviewStatus) {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.REVIEWS.trackingIdentifier)
         this.status.value = status
     }
 
     fun onViewAllClicked() {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.REVIEWS.trackingIdentifier)
         triggerEvent(OpenReviewsList)
     }
 
     fun onReviewClicked(review: ProductReview) {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.REVIEWS.trackingIdentifier)
         triggerEvent(OpenReviewDetail(review))
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
@@ -124,6 +124,7 @@ class DashboardStatsViewModel @AssistedInject constructor(
     }
 
     fun onTabSelected(selectionType: SelectionType) {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.STATS.trackingIdentifier)
         usageTracksEventEmitter.interacted()
         if (selectionType != SelectionType.CUSTOM) {
             appPrefsWrapper.setActiveStatsTab(selectionType.name)
@@ -156,6 +157,7 @@ class DashboardStatsViewModel @AssistedInject constructor(
     }
 
     fun onAddCustomRangeClicked() {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.STATS.trackingIdentifier)
         triggerEvent(
             OpenDatePicker(
                 fromDate = dateRangeState.value?.customRange?.start ?: Date(),
@@ -172,6 +174,7 @@ class DashboardStatsViewModel @AssistedInject constructor(
     }
 
     fun onViewAnalyticsClicked() {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.STATS.trackingIdentifier)
         AnalyticsTracker.track(AnalyticsEvent.DASHBOARD_SEE_MORE_ANALYTICS_TAPPED)
         dateRangeState.value?.rangeSelection?.let {
             triggerEvent(OpenAnalytics(it))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
@@ -60,7 +60,7 @@ fun DashboardProductStockCard(
     viewModel.productStockState.observeAsState().value?.let { viewState ->
         DashboardProductStockCard(
             viewState = viewState,
-            onHideClicked = { parentViewModel.onHideWidgetClicked(DashboardWidget.Type.PRODUCT_STOCK) },
+            onHideClicked = { parentViewModel.onHideWidgetClicked(DashboardWidget.Type.STOCK) },
             onFilterSelected = viewModel::onFilterSelected,
             onProductClicked = viewModel::onProductClicked,
             onRetryClicked = viewModel::onRetryClicked,
@@ -104,10 +104,10 @@ private fun DashboardProductStockCard(
     modifier: Modifier = Modifier,
 ) {
     WidgetCard(
-        titleResource = DashboardWidget.Type.PRODUCT_STOCK.titleResource,
+        titleResource = DashboardWidget.Type.STOCK.titleResource,
         menu = DashboardWidgetMenu(
             listOf(
-                DashboardWidget.Type.PRODUCT_STOCK.defaultHideMenuEntry(onHideClicked)
+                DashboardWidget.Type.STOCK.defaultHideMenuEntry(onHideClicked)
             )
         ),
         isError = viewState is DashboardProductStockViewModel.ViewState.Error,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockViewModel.kt
@@ -3,6 +3,10 @@ package com.woocommerce.android.ui.dashboard.stock
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.stock.DashboardProductStockViewModel.ViewState.Loading
 import com.woocommerce.android.ui.products.ProductStockStatus
@@ -29,6 +33,7 @@ class DashboardProductStockViewModel @AssistedInject constructor(
     savedStateHandle: SavedStateHandle,
     @Assisted private val parentViewModel: DashboardViewModel,
     private val productStockRepository: ProductStockRepository,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         val supportedFilters = listOf(
@@ -61,6 +66,12 @@ class DashboardProductStockViewModel @AssistedInject constructor(
     }
 
     fun onRetryClicked() {
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.DYNAMIC_DASHBOARD_CARD_RETRY_TAPPED,
+            mapOf(
+                AnalyticsTracker.KEY_TYPE to DashboardWidget.Type.STOCK.trackingIdentifier
+            )
+        )
         _refreshTrigger.tryEmit(DashboardViewModel.RefreshEvent())
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockViewModel.kt
@@ -62,6 +62,7 @@ class DashboardProductStockViewModel @AssistedInject constructor(
         }.asLiveData()
 
     fun onFilterSelected(productStockStatus: ProductStockStatus) {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.STOCK.trackingIdentifier)
         this.status.value = productStockStatus
     }
 
@@ -76,6 +77,7 @@ class DashboardProductStockViewModel @AssistedInject constructor(
     }
 
     fun onProductClicked(product: ProductStockItem) {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.STOCK.trackingIdentifier)
         val id = when {
             product.parentProductId != 0L -> product.parentProductId
             else -> product.productId

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockViewModel.kt
@@ -3,11 +3,11 @@ package com.woocommerce.android.ui.dashboard.stock
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.WooException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.DashboardWidget
-import com.woocommerce.android.WooException
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.stock.DashboardProductStockViewModel.ViewState.Loading
 import com.woocommerce.android.ui.products.ProductStockStatus

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
@@ -157,6 +157,7 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
     }
 
     fun onTabSelected(selectionType: SelectionType) {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.POPULAR_PRODUCTS.trackingIdentifier)
         usageTracksEventEmitter.interacted()
         if (selectionType != SelectionType.CUSTOM) {
             appPrefsWrapper.setActiveTopPerformersTab(selectionType.name)
@@ -171,6 +172,7 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
     }
 
     fun onEditCustomRangeTapped() {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.POPULAR_PRODUCTS.trackingIdentifier)
         val event = if (selectedDateRange.value?.customRange == null) {
             AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_ADD_BUTTON_TAPPED
         } else {
@@ -198,6 +200,7 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
 
     private fun onTopPerformerTapped(productId: Long) {
         triggerEvent(OpenTopPerformer(productId))
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.POPULAR_PRODUCTS.trackingIdentifier)
         analyticsTrackerWrapper.track(AnalyticsEvent.TOP_EARNER_PRODUCT_TAPPED)
         usageTracksEventEmitter.interacted()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsEvent.DYNAMIC_DASHBOARD_EDITOR_SAVE_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.DashboardWidget
@@ -78,20 +78,25 @@ class DashboardWidgetEditorViewModel @Inject constructor(
 
     fun onSaveClicked() {
         viewModelScope.launch {
-            analyticsTracker.track(
-                AnalyticsEvent.DYNAMIC_DASHBOARD_EDITOR_SAVE_TAPPED,
-                mapOf(
-                    AnalyticsTracker.KEY_FIRST_CARD_TYPE to editedWidgets.first().type.trackingIdentifier,
-                    AnalyticsTracker.KEY_SELECTED_CARDS to editedWidgets
-                        .filter { it.isVisible }
-                        .map { it.type.trackingIdentifier }
-                        .sorted()
-                        .joinToString(",")
-                )
-            )
+            trackSelectedCards()
             dashboardRepository.updateWidgets(editedWidgets)
             triggerEvent(Exit)
         }
+    }
+
+    private fun trackSelectedCards() {
+        val visibleCardTrackingIdentifiers = editedWidgets
+            .filter { it.isSelected }
+            .map { it.type.trackingIdentifier }
+        analyticsTracker.track(
+            DYNAMIC_DASHBOARD_EDITOR_SAVE_TAPPED,
+            mapOf(
+                AnalyticsTracker.KEY_SORTED_CARDS to visibleCardTrackingIdentifiers.joinToString(","),
+                AnalyticsTracker.KEY_DASHBOARD_ENABLED_CARDS to visibleCardTrackingIdentifiers
+                    .sorted()
+                    .joinToString(",")
+            )
+        )
     }
 
     fun onSelectionChange(dashboardWidget: DashboardWidget, selected: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
@@ -79,11 +79,12 @@ class DashboardWidgetEditorViewModel @Inject constructor(
         viewModelScope.launch {
             analyticsTracker.track(
                 AnalyticsEvent.DYNAMIC_DASHBOARD_EDITOR_SAVE_TAPPED,
-                mapOf("cards" to editedWidgets
-                    .filter { it.isVisible }
-                    .map { it.type.trackingIdentifier }
-                    .sorted()
-                    .joinToString(",")
+                mapOf(
+                    "cards" to editedWidgets
+                        .filter { it.isVisible }
+                        .map { it.type.trackingIdentifier }
+                        .sorted()
+                        .joinToString(",")
                 )
             )
             dashboardRepository.updateWidgets(editedWidgets)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.dashboard.data.DashboardRepository
@@ -80,7 +81,8 @@ class DashboardWidgetEditorViewModel @Inject constructor(
             analyticsTracker.track(
                 AnalyticsEvent.DYNAMIC_DASHBOARD_EDITOR_SAVE_TAPPED,
                 mapOf(
-                    "cards" to editedWidgets
+                    AnalyticsTracker.KEY_FIRST_CARD_TYPE to editedWidgets.first().type.trackingIdentifier,
+                    AnalyticsTracker.KEY_SELECTED_CARDS to editedWidgets
                         .filter { it.isVisible }
                         .map { it.type.trackingIdentifier }
                         .sorted()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
@@ -79,7 +79,12 @@ class DashboardWidgetEditorViewModel @Inject constructor(
         viewModelScope.launch {
             analyticsTracker.track(
                 AnalyticsEvent.DYNAMIC_DASHBOARD_EDITOR_SAVE_TAPPED,
-                mapOf("cards" to editedWidgets.filter { it.isVisible }.joinToString(","))
+                mapOf("cards" to editedWidgets
+                    .filter { it.isVisible }
+                    .map { it.type.trackingIdentifier }
+                    .sorted()
+                    .joinToString(",")
+                )
             )
             dashboardRepository.updateWidgets(editedWidgets)
             triggerEvent(Exit)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModel.kt
@@ -92,7 +92,7 @@ class DashboardWidgetEditorViewModel @Inject constructor(
             DYNAMIC_DASHBOARD_EDITOR_SAVE_TAPPED,
             mapOf(
                 AnalyticsTracker.KEY_SORTED_CARDS to visibleCardTrackingIdentifiers.joinToString(","),
-                AnalyticsTracker.KEY_DASHBOARD_ENABLED_CARDS to visibleCardTrackingIdentifiers
+                AnalyticsTracker.KEY_CARDS to visibleCardTrackingIdentifiers
                     .sorted()
                     .joinToString(",")
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsViewModelTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.dashboard.coupons
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Coupon
 import com.woocommerce.android.model.CouponPerformanceReport
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRange
@@ -92,6 +93,7 @@ class DashboardCouponsViewModelTest : BaseUnitTest() {
         on { dateRange } doReturn rangeFlow
         onBlocking { updateDateRange(any()) } doAnswer { rangeFlow.value = it.arguments[0] as StatsTimeRange }
     }
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
 
     private lateinit var viewModel: DashboardCouponsViewModel
 
@@ -114,6 +116,7 @@ class DashboardCouponsViewModelTest : BaseUnitTest() {
             coroutineDispatchers = coroutinesTestRule.testDispatchers,
             dateRangeFormatter = dateRangeFormatter,
             customDateRangeDataStore = customDateRangeDataStore,
+            analyticsTrackerWrapper = analyticsTrackerWrapper
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.dashboard.reviews
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.ActionStatus
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.RefreshEvent
@@ -50,6 +51,7 @@ class DashboardReviewsViewModelTest : BaseUnitTest() {
     private val parentViewModel: DashboardViewModel = mock {
         on { refreshTrigger } doReturn emptyFlow()
     }
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
 
     private lateinit var viewModel: DashboardReviewsViewModel
 
@@ -60,7 +62,8 @@ class DashboardReviewsViewModelTest : BaseUnitTest() {
             savedStateHandle = SavedStateHandle(),
             parentViewModel = parentViewModel,
             reviewListRepository = reviewListRepository,
-            reviewModerationHandler = reviewModerationHandler
+            reviewModerationHandler = reviewModerationHandler,
+            analyticsTrackerWrapper = analyticsTrackerWrapper
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11633 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description

The main thing in this PR is adding the analytics for the dynamic dashboard M2: pffQ75-dy-p2

![Screenshot 2024-06-05 at 17 41 04](https://github.com/woocommerce/woocommerce-android/assets/2663464/34bbecbd-18f9-4adf-8e39-bd0a50a5bbe5)

Additionally, it adds some minor fixed to the existing tracking of M1
- Update `trackingIdentifier` for `STOCK` card: 671c9fa506729a1d83bee72a138b764ea4e27104
- Use the `trackingIdentifier` value when tracking `DYNAMIC_DASHBOARD_EDITOR_SAVE_TAPPED` : 5d551ac708efbdf3eb04ca0c991afe1d1388f008
- Added event `DYNAMIC_DASHBOARD_CARD_INTERACTED` for existing cards from M1. This event will be fired for the main actions. Sometimes, an event is already fired for that interaction, but we decided to add this new event to all cards for consistency. 


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
As usual, follow the screenshot above and check in the Android logcat that the correct events are fired by checking for the logs like: `🔵 Tracked: dynamic_dashboard_edit_layout_button_tapped, Properties: {"new_card_available":"false"`
