### PR TITLE
Adds OS version parameter in the feature flags payload

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepository.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.config
 
 import com.woocommerce.android.OnChangedException
-import com.woocommerce.android.util.DeviceInfoWrapper
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -12,8 +11,7 @@ import javax.inject.Singleton
 
 @Singleton
 class WPComRemoteFeatureFlagRepository @Inject constructor(
-    private val featureFlagsStore: FeatureFlagsStore,
-    private val deviceInfo: DeviceInfoWrapper,
+    private val featureFlagsStore: FeatureFlagsStore
 ) {
     companion object {
         private const val PLATFORM_NAME = "android"
@@ -34,7 +32,6 @@ class WPComRemoteFeatureFlagRepository @Inject constructor(
                 identifier = "",
                 marketingVersion = appVersion,
                 platform = PLATFORM_NAME,
-                osVersion = deviceInfo.osName,
             )
         )
         return if (result.isError) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepository.kt
@@ -1,9 +1,11 @@
 package com.woocommerce.android.config
 
+import android.os.Build
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.network.rest.wpcom.mobile.FeatureFlagsRestClient
 import org.wordpress.android.fluxc.store.mobile.FeatureFlagsStore
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -25,11 +27,14 @@ class WPComRemoteFeatureFlagRepository @Inject constructor(
     suspend fun fetchFeatureFlags(appVersion: String = ""): Result<Unit> {
         // Empty string are parameters not used by this app.
         val result = featureFlagsStore.fetchFeatureFlags(
-            buildNumber = "",
-            deviceId = "",
-            identifier = "",
-            marketingVersion = appVersion,
-            platform = PLATFORM_NAME
+            FeatureFlagsRestClient.FeatureFlagsPayload(
+                buildNumber = "",
+                deviceId = "",
+                identifier = "",
+                marketingVersion = appVersion,
+                platform = PLATFORM_NAME,
+                osVersion = Build.VERSION.RELEASE,
+            )
         )
         return if (result.isError) {
             WooLog.e(WooLog.T.UTILS, "Error fetching WPCom remote feature flags: ${result.error}")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepository.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.config
 
-import android.os.Build
 import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.util.DeviceInfoWrapper
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -12,7 +12,8 @@ import javax.inject.Singleton
 
 @Singleton
 class WPComRemoteFeatureFlagRepository @Inject constructor(
-    private val featureFlagsStore: FeatureFlagsStore
+    private val featureFlagsStore: FeatureFlagsStore,
+    private val deviceInfo: DeviceInfoWrapper,
 ) {
     companion object {
         private const val PLATFORM_NAME = "android"
@@ -33,7 +34,7 @@ class WPComRemoteFeatureFlagRepository @Inject constructor(
                 identifier = "",
                 marketingVersion = appVersion,
                 platform = PLATFORM_NAME,
-                osVersion = Build.VERSION.RELEASE,
+                osVersion = deviceInfo.osName,
             )
         )
         return if (result.isError) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepositoryTest.kt
@@ -28,7 +28,7 @@ class WPComRemoteFeatureFlagRepositoryTest : BaseUnitTest() {
     @Test
     fun `given fetching success, when fetchFeatureFlags is called, then get success Result`() = testBlocking {
         val fetchResult = mapOf("key" to true)
-        whenever(featureFlagStore.fetchFeatureFlags(any(), any(), any(), any(), any()))
+        whenever(featureFlagStore.fetchFeatureFlags(any()))
             .thenReturn(FeatureFlagsStore.FeatureFlagsResult(fetchResult))
 
         val result = sut.fetchFeatureFlags()
@@ -37,7 +37,7 @@ class WPComRemoteFeatureFlagRepositoryTest : BaseUnitTest() {
 
     @Test
     fun `given fetching failure, when fetchFeatureFlags is called, then get failure Result`() = testBlocking {
-        whenever(featureFlagStore.fetchFeatureFlags(any(), any(), any(), any(), any()))
+        whenever(featureFlagStore.fetchFeatureFlags(any()))
             .thenReturn(FeatureFlagsStore.FeatureFlagsResult(FeatureFlagsError(FeatureFlagsErrorType.GENERIC_ERROR)))
 
         val result = sut.fetchFeatureFlags()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.config
 
+import com.woocommerce.android.util.DeviceInfoWrapper
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -16,13 +17,16 @@ import org.wordpress.android.fluxc.store.mobile.FeatureFlagsStore
 @OptIn(ExperimentalCoroutinesApi::class)
 class WPComRemoteFeatureFlagRepositoryTest : BaseUnitTest() {
     private val featureFlagStore: FeatureFlagsStore = mock()
+    private val deviceInfo: DeviceInfoWrapper = mock()
     private lateinit var sut: WPComRemoteFeatureFlagRepository
 
     @Before
     fun setup() {
         sut = WPComRemoteFeatureFlagRepository(
-            featureFlagStore
+            featureFlagStore,
+            deviceInfo,
         )
+        whenever(deviceInfo.osName).thenReturn("14.0")
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/config/WPComRemoteFeatureFlagRepositoryTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.config
 
-import com.woocommerce.android.util.DeviceInfoWrapper
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -17,16 +16,13 @@ import org.wordpress.android.fluxc.store.mobile.FeatureFlagsStore
 @OptIn(ExperimentalCoroutinesApi::class)
 class WPComRemoteFeatureFlagRepositoryTest : BaseUnitTest() {
     private val featureFlagStore: FeatureFlagsStore = mock()
-    private val deviceInfo: DeviceInfoWrapper = mock()
     private lateinit var sut: WPComRemoteFeatureFlagRepository
 
     @Before
     fun setup() {
         sut = WPComRemoteFeatureFlagRepository(
             featureFlagStore,
-            deviceInfo,
         )
-        whenever(deviceInfo.osName).thenReturn("14.0")
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '3028-eb0a976762876b228eed98b564ea77ab97659673'
+    fluxCVersion = '3028-f6604adc729c62282778fc378fd66e9f7a63b1e2'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-e26e2ba5206fdb19371dfaded383ab0c591e1236'
+    fluxCVersion = '3028-eb0a976762876b228eed98b564ea77ab97659673'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
See pcdRpT-6Xn-p2

**Depends on `WordPress-FluxC-Android`:** https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3028

### Description
Adds `os_version` parameter in feature flags endpoint.

⚠️ Please do not merge before https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3028 is merged and the FluxC version on this PR is updated to point to `trunk`.

### Testing information
See https://github.com/wordpress-mobile/WordPress-Android/pull/20938


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->