### PR TITLE
[Application Passwords Login] Replace empty error messages with generic error message

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 19.0
 -----
 - [*] Payments: Slightly bigger dialog sizes on bigger screens for better user experience [https://github.com/woocommerce/woocommerce-android/pull/11638]
+- [*] Login: fixed a bug where the error message was not displayed when the login fails [https://github.com/woocommerce/woocommerce-android/pull/11682]
 
 18.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -199,7 +199,7 @@ class WPApiSiteRepository @Inject constructor(
         INVALID_RESPONSE -> UiStringRes(string.login_site_credentials_invalid_response)
         CUSTOM_LOGIN_URL -> UiStringRes(string.login_site_credentials_custom_login_url)
         CUSTOM_ADMIN_URL -> UiStringRes(string.login_site_credentials_custom_admin_url)
-        else -> message?.let { UiStringText(it) }
+        else -> message?.takeIf { it.isNotEmpty() }?.let { UiStringText(it) }
     }
 
     data class CookieNonceAuthenticationException(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11646 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
We received a complaint from the HEs that some users are sharing screenshots where the error message was not visible on the site credentials' dialog, and the thought was that it was because using the dark theme.
But after investigating, I found out that this happens regardless of the theme, what happens is that we are showing an empty message.

The cause is that we didn't account for empty messages here https://github.com/woocommerce/woocommerce-android/blob/a5af5d86397584cf9daf6484d6b06f752c30ca60/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt#L202

This PR updates the logic to ignore empty messages on the above line, so that we replace it with a generic error.

### Testing information
The testing is complicated, feel free to ignore if you are confident in the changes
1. Install WordFence security on your site.
2. Open Firewall settings `wp-admin/admin.php?page=WordfenceWAF&subpage=waf_options&source=dashboard`
3. Enable the firewall, then scroll to the bottom, and enable rate limiting (I used `2` requests per minute)
4. Open the app.
5. Enter the site's URL, then proceed to site credentials login.
6. Enter some wrong credentials.
7. On the dialog, click on Cancel.
8. Repeat 6-7 one more time.
9. Enter some credentials.
10. Notice the dialog shows an error message with `Login failed with status code 503`.

### Images/gif
| Before | After |
| --- | --- |
| ![Screenshot_20240606_114647](https://github.com/woocommerce/woocommerce-android/assets/1657201/27ed4f28-daa2-486a-8f61-7cd872f0d868) | ![Screenshot_20240606_115902](https://github.com/woocommerce/woocommerce-android/assets/1657201/4f06dd98-e7c8-4814-bb40-ebd3cee19c4a) |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->