### PR TITLE
[Woo POS] Show pictures in landscape mode on tablets in card reader flows

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -152,7 +152,7 @@ class CardReaderConnectDialogFragment : PaymentsBaseDialogFragment(R.layout.card
 
     private fun moveToState(binding: CardReaderConnectDialogBinding, viewState: CardReaderConnectViewState) {
         UiHelpers.setTextOrHide(binding.headerLabel, viewState.headerLabel)
-        UiHelpers.setImageOrHideInLandscape(binding.illustration, viewState.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, viewState.illustration)
         UiHelpers.setTextOrHide(binding.hintLabel, viewState.hintLabel)
         UiHelpers.setTextOrHide(binding.primaryActionBtn, viewState.primaryActionLabel)
         UiHelpers.setTextOrHide(binding.secondaryActionBtn, viewState.secondaryActionLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/adapter/MultipleCardReadersFoundViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/adapter/MultipleCardReadersFoundViewHolder.kt
@@ -47,7 +47,10 @@ sealed class MultipleCardReadersFoundViewHolder(
         override fun onBind(uiState: ListItemViewState) {
             uiState as ScanningInProgressListItem
             UiHelpers.setTextOrHide(binding.cardReaderConnectProgressLabel, uiState.label)
-            UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.cardReaderConnectProgressIndicator, uiState.scanningIcon)
+            UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(
+                binding.cardReaderConnectProgressIndicator,
+                uiState.scanningIcon
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/adapter/MultipleCardReadersFoundViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/adapter/MultipleCardReadersFoundViewHolder.kt
@@ -47,7 +47,7 @@ sealed class MultipleCardReadersFoundViewHolder(
         override fun onBind(uiState: ListItemViewState) {
             uiState as ScanningInProgressListItem
             UiHelpers.setTextOrHide(binding.cardReaderConnectProgressLabel, uiState.label)
-            UiHelpers.setImageOrHideInLandscape(binding.cardReaderConnectProgressIndicator, uiState.scanningIcon)
+            UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.cardReaderConnectProgressIndicator, uiState.scanningIcon)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailFragment.kt
@@ -135,7 +135,7 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                 is NotConnectedState -> {
                     with(binding.readerDisconnectedState) {
                         UiHelpers.setTextOrHide(cardReaderDetailConnectHeaderLabel, state.headerLabel)
-                        UiHelpers.setImageOrHideInLandscape(cardReaderDetailIllustration, state.illustration)
+                        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(cardReaderDetailIllustration, state.illustration)
                         UiHelpers.setTextOrHide(cardReaderDetailFirstHintLabel, state.firstHintLabel)
                         UiHelpers.setTextOrHide(cardReaderDetailFirstHintNumberLabel, state.firstHintNumber)
                         UiHelpers.setTextOrHide(cardReaderDetailSecondHintLabel, state.secondHintLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailFragment.kt
@@ -135,7 +135,10 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                 is NotConnectedState -> {
                     with(binding.readerDisconnectedState) {
                         UiHelpers.setTextOrHide(cardReaderDetailConnectHeaderLabel, state.headerLabel)
-                        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(cardReaderDetailIllustration, state.illustration)
+                        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(
+                            cardReaderDetailIllustration,
+                            state.illustration
+                        )
                         UiHelpers.setTextOrHide(cardReaderDetailFirstHintLabel, state.firstHintLabel)
                         UiHelpers.setTextOrHide(cardReaderDetailFirstHintNumberLabel, state.firstHintNumber)
                         UiHelpers.setTextOrHide(cardReaderDetailSecondHintLabel, state.secondHintLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -165,7 +165,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         UiHelpers.setTextOrHide(binding.enableCashOnDelivery, state.enableCashOnDeliveryButtonLabel)
         UiHelpers.setTextOrHide(binding.textSupport, state.contactSupportLabel)
         UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreLabel)
-        UiHelpers.setImageOrHideInLandscape(binding.illustration, state.cardIllustration)
+        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, state.cardIllustration)
 
         if (state.shouldShowProgress) {
             binding.enableCashOnDelivery.isEnabled = false
@@ -245,7 +245,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingLoadingBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeaderTv, state.headerLabel)
         UiHelpers.setTextOrHide(binding.hintTv, state.hintLabel)
-        UiHelpers.setImageOrHideInLandscape(binding.illustrationIv, state.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustrationIv, state.illustration)
     }
 
     private fun showGenericErrorState(
@@ -255,7 +255,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingGenericErrorBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textSupport, state.contactSupportLabel)
         UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreLabel)
-        UiHelpers.setImageOrHideInLandscape(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, state.illustration)
         binding.textSupport.setOnClickListener {
             state.onContactSupportActionClicked.invoke()
         }
@@ -269,7 +269,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         state: CardReaderOnboardingViewState.NoConnectionErrorState
     ) {
         val binding = FragmentCardReaderOnboardingNetworkErrorBinding.bind(view)
-        UiHelpers.setImageOrHideInLandscape(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, state.illustration)
         binding.buttonRetry.setOnClickListener {
             state.onRetryButtonActionClicked.invoke()
         }
@@ -282,7 +282,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingStripeBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeader, state.headerLabel)
         UiHelpers.setTextOrHide(binding.textLabel, state.hintLabel)
-        UiHelpers.setImageOrHideInLandscape(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, state.illustration)
 
         UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreButton.label)
         binding.learnMoreContainer.learnMore.setOnClickListener {
@@ -318,7 +318,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingWcpayBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeader, state.headerLabel)
         UiHelpers.setTextOrHide(binding.textLabel, state.hintLabel)
-        UiHelpers.setImageOrHideInLandscape(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, state.illustration)
 
         UiHelpers.setTextOrHide(binding.primaryButton, state.actionButtonPrimary.label)
         binding.primaryButton.setWhiteIcon(state.actionButtonPrimary.icon)
@@ -348,7 +348,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         binding.primaryButton.visibility = View.GONE
         UiHelpers.setTextOrHide(binding.secondaryButton, state.refreshButtonLabel)
         UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreLabel)
-        UiHelpers.setImageOrHideInLandscape(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, state.illustration)
         binding.secondaryButton.setOnClickListener {
             state.refreshButtonAction.invoke()
         }
@@ -363,7 +363,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
     ) {
         val binding = FragmentCardReaderOnboardingUnsupportedBinding.bind(view)
         UiHelpers.setTextOrHide(binding.unsupportedCountryHeader, state.headerLabel)
-        UiHelpers.setImageOrHideInLandscape(binding.unsupportedCountryIllustration, state.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.unsupportedCountryIllustration, state.illustration)
         UiHelpers.setTextOrHide(binding.unsupportedCountryHint, state.hintLabel)
         UiHelpers.setTextOrHide(binding.unsupportedCountryHelp, state.contactSupportLabel)
         UiHelpers.setTextOrHide(binding.unsupportedCountryLearnMoreContainer.learnMore, state.learnMoreLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -363,7 +363,10 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
     ) {
         val binding = FragmentCardReaderOnboardingUnsupportedBinding.bind(view)
         UiHelpers.setTextOrHide(binding.unsupportedCountryHeader, state.headerLabel)
-        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.unsupportedCountryIllustration, state.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(
+            binding.unsupportedCountryIllustration,
+            state.illustration
+        )
         UiHelpers.setTextOrHide(binding.unsupportedCountryHint, state.hintLabel)
         UiHelpers.setTextOrHide(binding.unsupportedCountryHelp, state.contactSupportLabel)
         UiHelpers.setTextOrHide(binding.unsupportedCountryLearnMoreContainer.learnMore, state.learnMoreLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderWelcomeDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderWelcomeDialogFragment.kt
@@ -23,7 +23,7 @@ class CardReaderWelcomeDialogFragment : PaymentsBaseDialogFragment(R.layout.card
 
     private fun initObservers(binding: CardReaderWelcomeDialogBinding) {
         viewModel.viewState.observe(viewLifecycleOwner) { viewState ->
-            UiHelpers.setImageOrHideInLandscape(binding.illustration, viewState.img)
+            UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, viewState.img)
             UiHelpers.setTextOrHide(binding.headerLabel, viewState.header)
             UiHelpers.setTextOrHide(binding.text, viewState.text)
             UiHelpers.setTextOrHide(binding.actionBtn, viewState.buttonLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
@@ -104,7 +104,7 @@ class CardReaderPaymentDialogFragment : PaymentsBaseDialogFragment(R.layout.card
             announceForAccessibility(binding, viewState)
             UiHelpers.setTextOrHide(binding.headerLabel, viewState.headerLabel)
             UiHelpers.setTextOrHide(binding.amountLabel, viewState.amountWithCurrencyLabel)
-            UiHelpers.setImageOrHideInLandscape(binding.illustration, viewState.illustration)
+            UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, viewState.illustration)
             UiHelpers.setTextOrHide(binding.paymentStateLabel, viewState.paymentStateLabel)
             (binding.paymentStateLabel.layoutParams as ViewGroup.MarginLayoutParams)
                 .topMargin = resources.getDimensionPixelSize(viewState.paymentStateLabelTopMargin)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/update/CardReaderUpdateDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/update/CardReaderUpdateDialogFragment.kt
@@ -76,7 +76,7 @@ class CardReaderUpdateDialogFragment : PaymentsBaseDialogFragment(R.layout.card_
                     UiHelpers.updateVisibility(this, state.progress != null)
                     currentProgressPercentage = state.progress ?: 0
                 }
-                UiHelpers.setImageOrHideInLandscape(progressImageView, state.illustration)
+                UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(progressImageView, state.illustration)
                 actionButton.setOnClickListener { state.button?.onActionClicked?.invoke() }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsToggleOptionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsToggleOptionView.kt
@@ -57,7 +57,7 @@ class WCSettingsToggleOptionView @JvmOverloads constructor(
                     isInEditMode,
                     R.styleable.WCSettingsToggleOptionView_toggleOptionIcon,
                     R.styleable.WCSettingsToggleOptionView_tools_toggleOptionIcon
-                ).let { UiHelpers.setImageOrHideInLandscape(binding.toggleSettingIcon, it, setInvisible = true) }
+                ).let { UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.toggleSettingIcon, it, setInvisible = true) }
 
                 // Set the view checked state
                 binding.toggleSettingSwitch.isChecked = StyleAttrUtils.getBoolean(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsToggleOptionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsToggleOptionView.kt
@@ -57,7 +57,13 @@ class WCSettingsToggleOptionView @JvmOverloads constructor(
                     isInEditMode,
                     R.styleable.WCSettingsToggleOptionView_toggleOptionIcon,
                     R.styleable.WCSettingsToggleOptionView_tools_toggleOptionIcon
-                ).let { UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.toggleSettingIcon, it, setInvisible = true) }
+                ).let {
+                    UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(
+                        binding.toggleSettingIcon,
+                        it,
+                        setInvisible = true
+                    )
+                }
 
                 // Set the view checked state
                 binding.toggleSettingSwitch.isChecked = StyleAttrUtils.getBoolean(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UiHelpers.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UiHelpers.kt
@@ -72,9 +72,15 @@ object UiHelpers {
         }
     }
 
-    fun setImageOrHideInLandscape(imageView: ImageView, @DrawableRes resId: Int?, setInvisible: Boolean = false) {
+    fun setImageOrHideInLandscapeOnNonExpandedScreenSizes(
+        imageView: ImageView,
+        @DrawableRes resId: Int?,
+        setInvisible: Boolean = false
+    ) {
         val isLandscape = DisplayUtils.isLandscape(imageView.context)
-        updateVisibility(imageView, resId != null && !isLandscape, setInvisible)
+        val isExpandedOrBigger = imageView.context.windowSizeClass == WindowSizeClass.ExpandedAndBigger
+        val showImage = resId != null && (!isLandscape || isExpandedOrBigger)
+        updateVisibility(imageView, showImage, setInvisible)
         resId?.let {
             imageView.setImageResource(resId)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UiHelpers.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UiHelpers.kt
@@ -79,7 +79,8 @@ object UiHelpers {
     ) {
         val isLandscape = DisplayUtils.isLandscape(imageView.context)
         val isExpandedOrBigger = imageView.context.windowSizeClass == WindowSizeClass.ExpandedAndBigger
-        val showImage = resId != null && (!isLandscape || isExpandedOrBigger)
+        val shouldShowBasedOnOrientationAndSize = !isLandscape || isExpandedOrBigger
+        val showImage = resId != null && shouldShowBasedOnOrientationAndSize
         updateVisibility(imageView, showImage, setInvisible)
         resId?.let {
             imageView.setImageResource(resId)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11675
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
There is a method that hides images on the card reader flow in landscape orientation. I guess this was done based on the reasonable assumption that almost all users are phone users. That doesn't work for POS so this PR slightly modifies the method to stop hiding images on big screens

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Run the card reader flows connection/payment (doesn't matter from the POS or not) in landscape mode a big tablet and a phone. Notice that pictures in the flow are shown on the tablet and are not shown on a phone

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4923871/78fb1342-43c4-469b-9218-99ab1f1f137c


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->