### PR TITLE
[Dynamic Dashboard] Enable M2 feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 - [*] Payments: Slightly bigger dialog sizes on bigger screens for better user experience [https://github.com/woocommerce/woocommerce-android/pull/11638]
 - [*] Fixed an issue that could cause push notifications to stop working after long periods [https://github.com/woocommerce/woocommerce-android/pull/11672]
 - [*] Login: fixed a bug where the error message was not displayed when the login fails [https://github.com/woocommerce/woocommerce-android/pull/11682]
+- [***] Dashboard: Added new cards to allow merchants to get more insights about their store [https://github.com/woocommerce/woocommerce-android/issues/11460]
 
 18.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -30,9 +30,9 @@ enum class FeatureFlag {
             WOO_POS,
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
-            ORDER_CREATION_AUTO_TAX_RATE,
-            DYNAMIC_DASHBOARD_M2 -> PackageUtils.isDebugBuild()
+            ORDER_CREATION_AUTO_TAX_RATE -> PackageUtils.isDebugBuild()
 
+            DYNAMIC_DASHBOARD_M2,
             OTHER_PAYMENT_METHODS,
             CONNECTIVITY_TOOL,
             NEW_SHIPPING_SUPPORT,


### PR DESCRIPTION
Closes: #11687 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR just enables the M2 feature flag.

### Testing information
All features were tested in previous PRs, and we'll test this more during the beta release.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->