### PR TITLE
[Dynamic Dashboard] Hide the new widgets announcement card when the "share store" card is shown

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
@@ -43,14 +43,14 @@ data class DashboardWidget(
             titleResource = R.string.my_store_widget_blaze_title,
             trackingIdentifier = "blaze"
         ),
+        INBOX(
+            titleResource = R.string.inbox_screen_title,
+            trackingIdentifier = "inbox",
+            isSupported = FeatureFlag.INBOX.isEnabled()
+        ),
         REVIEWS(
             titleResource = R.string.my_store_widget_reviews_title,
             trackingIdentifier = "reviews",
-            isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()
-        ),
-        ORDERS(
-            titleResource = R.string.my_store_widget_orders_title,
-            trackingIdentifier = "orders",
             isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()
         ),
         COUPONS(
@@ -58,14 +58,14 @@ data class DashboardWidget(
             trackingIdentifier = "coupons",
             isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()
         ),
-        INBOX(
-            titleResource = R.string.inbox_screen_title,
-            trackingIdentifier = "inbox",
-            isSupported = FeatureFlag.INBOX.isEnabled()
-        ),
         STOCK(
             titleResource = R.string.my_store_widget_product_stock_title,
             trackingIdentifier = "stock",
+            isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()
+        ),
+        ORDERS(
+            titleResource = R.string.my_store_widget_orders_title,
+            trackingIdentifier = "orders",
             isSupported = FeatureFlag.DYNAMIC_DASHBOARD_M2.isEnabled()
         );
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -282,7 +282,7 @@ private fun NewWidgetsCard(
         Spacer(modifier = Modifier.height(16.dp))
         WCColoredButton(
             onClick = state.onShowCardsClick,
-            text = "Add new sections"
+            text = stringResource(id = R.string.dashboard_new_widgets_card_button)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -249,7 +249,7 @@ class DashboardViewModel @Inject constructor(
 
         add(
             NewWidgetsCard(
-                isVisible = hasNewWidgets,
+                isVisible = hasNewWidgets && !shouldShowShareCard,
                 onShowCardsClick = {
                     analyticsTrackerWrapper.track(AnalyticsEvent.DYNAMIC_DASHBOARD_ADD_NEW_SECTIONS_TAPPED)
                     triggerEvent(OpenEditWidgets)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -448,6 +448,7 @@
 
     <string name="dashboard_new_widgets_card_title">Looking for more insights?</string>
     <string name="dashboard_new_widgets_card_description">Add new sections to customize your store management experience</string>
+    <string name="dashboard_new_widgets_card_button">Add new Sections</string>
     <!--
         Sign Up Flow
     -->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11677 Closes: #11689
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR has two main changes:
- Updates the logic to avoid showing the NewWidgetdCard if the Share Store card is shown. More context on this here p1717560988330199-slack-C03L1NF1EA3
- Updates the default order of cards to match iOS

### Testing information
1. Checkout the branch, then disable the feature flag `DYNAMIC_DASHBOARD_M2`
2. Clear the app's data (alternatively remove the datastore configuration files manually)
3. Open the app.
4. Now go back to the code and enable the feature flag `DYNAMIC_DASHBOARD_M2`
5. Re-Open the app.
6. Switch to a public site that doesn't have any orders.
7. Confirm the new widgets card is not shown (the badge will still be shown).
8. Switch to a different site that has orders.
9. Open the widget editor.
10. Confirm the default order matches the expected one.

### Images/gif
##### New widgets announcement
<img src="https://github.com/woocommerce/woocommerce-android/assets/1657201/fd2de4d1-61c0-4837-a82d-ed0fc50db80a" width=360 />

##### Default order
<img src="https://github.com/woocommerce/woocommerce-android/assets/1657201/42fc3f4b-1341-49f4-9f70-9aec51af724d" width=360 />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->