### PR TITLE
Enables dynamic dashboard M2 cards in production 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 - [*] Payments: Slightly bigger dialog sizes on bigger screens for better user experience [https://github.com/woocommerce/woocommerce-android/pull/11638]
 - [*] Fixed an issue that could cause push notifications to stop working after long periods [https://github.com/woocommerce/woocommerce-android/pull/11672]
 - [*] Login: fixed a bug where the error message was not displayed when the login fails [https://github.com/woocommerce/woocommerce-android/pull/11682]
+- [***] You can now add more sections to the My Store screen including contents for the last orders, top products with low stock, top active coupons and more! [https://github.com/woocommerce/woocommerce-android/issues/11460]
 
 18.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -30,15 +30,15 @@ enum class FeatureFlag {
             WOO_POS,
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
-            ORDER_CREATION_AUTO_TAX_RATE,
-            DYNAMIC_DASHBOARD_M2 -> PackageUtils.isDebugBuild()
+            ORDER_CREATION_AUTO_TAX_RATE -> PackageUtils.isDebugBuild()
 
             OTHER_PAYMENT_METHODS,
             CONNECTIVITY_TOOL,
             NEW_SHIPPING_SUPPORT,
             APP_PASSWORD_TUTORIAL,
             EOSL_M1,
-            EOSL_M3 -> true
+            EOSL_M3,
+            DYNAMIC_DASHBOARD_M2 -> true
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Enables dynamic dashboard M2 cards in production 
<!-- Id number of the GitHub issue this PR addresses. -->

### Testing information
Not much to test as everything has been tested already. But in case you want to check something, just smoke test the feature by adding the new cards to my store

