### PR TITLE
Issue/11520 invalidate pos eligibility cache

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
@@ -40,7 +40,6 @@ class IsWooPosEnabled @Inject constructor(
         if (onboardingStatus.preferredPlugin != PluginType.WOOCOMMERCE_PAYMENTS) return false
         if (!isIPPOnboardingCompleted(onboardingStatus)) return false
 
-
         val paymentAccount = getOrFetchPaymentAccount(selectedSite, WOOCOMMERCE_PAYMENTS) ?: return false
         if (paymentAccount.country.lowercase() != "us") return false
         return paymentAccount.storeCurrencies.default.lowercase() == "usd"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabled.kt
@@ -2,9 +2,9 @@ package com.woocommerce.android.ui.woopos
 
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState
+import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.IsWindowClassExpandedAndBigger
 import org.wordpress.android.fluxc.model.SiteModel
@@ -20,7 +20,6 @@ private typealias LocalSiteId = Int
 class IsWooPosEnabled @Inject constructor(
     private val selectedSite: SelectedSite,
     private val ippStore: WCInPersonPaymentsStore,
-    private val getActivePaymentsPlugin: GetActivePaymentsPlugin,
     private val isWindowSizeExpandedAndBigger: IsWindowClassExpandedAndBigger,
     private val isWooPosFFEnabled: IsWooPosFFEnabled,
     private val getWooCoreVersion: GetWooCorePluginCachedVersion,
@@ -33,20 +32,18 @@ class IsWooPosEnabled @Inject constructor(
         val selectedSite = selectedSite.getOrNull() ?: return false
 
         if (!isWooPosFFEnabled()) return false
+        if (!isWindowSizeExpandedAndBigger()) return false
+        if (!isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps()) return false
 
-        val ippPlugin = getActivePaymentsPlugin() ?: return false
         val onboardingStatus = cardReaderOnboardingChecker.getOnboardingState()
-        val paymentAccount = getOrFetchPaymentAccount(selectedSite, ippPlugin) ?: return false
-        val countryCode = paymentAccount.country
 
-        return (
-            countryCode.lowercase() == "us" &&
-                ippPlugin == WOOCOMMERCE_PAYMENTS &&
-                paymentAccount.storeCurrencies.default.lowercase() == "usd" &&
-                isWindowSizeExpandedAndBigger() &&
-                isIPPOnboardingCompleted(onboardingStatus) &&
-                isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps()
-            )
+        if (onboardingStatus.preferredPlugin != PluginType.WOOCOMMERCE_PAYMENTS) return false
+        if (!isIPPOnboardingCompleted(onboardingStatus)) return false
+
+
+        val paymentAccount = getOrFetchPaymentAccount(selectedSite, WOOCOMMERCE_PAYMENTS) ?: return false
+        if (paymentAccount.country.lowercase() != "us") return false
+        return paymentAccount.storeCurrencies.default.lowercase() == "usd"
     }
 
     private suspend fun getOrFetchPaymentAccount(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabledTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabledTest.kt
@@ -38,7 +38,7 @@ class IsWooPosEnabledTest : BaseUnitTest() {
 
     @Before
     fun setup() = testBlocking {
-        whenever(selectedSite.getOrNull()).thenReturn(SiteModel())
+        whenever(selectedSite.getOrNull()).thenReturn(SiteModel().also { it.id = 1 })
         whenever(getActivePaymentsPlugin()).thenReturn(WOOCOMMERCE_PAYMENTS)
         whenever(isWindowSizeExpandedAndBigger()).thenReturn(true)
         whenever(ippStore.loadAccount(any(), any())).thenReturn(buildPaymentAccountResult())
@@ -143,6 +143,19 @@ class IsWooPosEnabledTest : BaseUnitTest() {
         whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
         whenever(getWooCoreVersion.invoke()).thenReturn("10.0.1")
         assertTrue(sut())
+    }
+
+    @Test
+    fun `given siteA's cached, when switched to siteB, then cached value for siteA is not used`() = testBlocking {
+        // ensure the value is cached for siteA
+        sut()
+        // switch to a non-eligible site
+        whenever(selectedSite.getOrNull()).thenReturn(SiteModel().also { it.id = 2 })
+        whenever(getActivePaymentsPlugin()).thenReturn(STRIPE)
+        whenever(isWindowSizeExpandedAndBigger()).thenReturn(false)
+        whenever(ippStore.loadAccount(any(), any())).thenReturn(buildPaymentAccountResult(countryCode = "AU"))
+
+        assertFalse(sut())
     }
 
     private fun buildPaymentAccountResult(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabledTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/IsWooPosEnabledTest.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.woopos
 
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.payments.GetActivePaymentsPlugin
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState
+import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.IsWindowClassExpandedAndBigger
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -12,13 +14,9 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult
-import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.COMPLETE
-import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.ENABLED
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult.WCPaymentAccountStatus.StoreCurrencies
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore
-import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType.STRIPE
-import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -27,7 +25,7 @@ import kotlin.test.assertTrue
 class IsWooPosEnabledTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock()
     private val ippStore: WCInPersonPaymentsStore = mock()
-    private val getActivePaymentsPlugin: GetActivePaymentsPlugin = mock()
+    private val cardReaderOnboardingChecker: CardReaderOnboardingChecker = mock()
     private val isWindowSizeExpandedAndBigger: IsWindowClassExpandedAndBigger = mock()
     private val isWooPosFFEnabled: IsWooPosFFEnabled = mock()
     private val getWooCoreVersion: GetWooCorePluginCachedVersion = mock {
@@ -39,7 +37,9 @@ class IsWooPosEnabledTest : BaseUnitTest() {
     @Before
     fun setup() = testBlocking {
         whenever(selectedSite.getOrNull()).thenReturn(SiteModel().also { it.id = 1 })
-        whenever(getActivePaymentsPlugin()).thenReturn(WOOCOMMERCE_PAYMENTS)
+        val onboardingCompleted = mock<CardReaderOnboardingState.OnboardingCompleted>()
+        whenever(onboardingCompleted.preferredPlugin).thenReturn(PluginType.WOOCOMMERCE_PAYMENTS)
+        whenever(cardReaderOnboardingChecker.getOnboardingState()).thenReturn(onboardingCompleted)
         whenever(isWindowSizeExpandedAndBigger()).thenReturn(true)
         whenever(ippStore.loadAccount(any(), any())).thenReturn(buildPaymentAccountResult())
         whenever(isWooPosFFEnabled()).thenReturn(true)
@@ -47,12 +47,27 @@ class IsWooPosEnabledTest : BaseUnitTest() {
         sut = IsWooPosEnabled(
             selectedSite = selectedSite,
             ippStore = ippStore,
-            getActivePaymentsPlugin = getActivePaymentsPlugin,
+            cardReaderOnboardingChecker = cardReaderOnboardingChecker,
             isWindowSizeExpandedAndBigger = isWindowSizeExpandedAndBigger,
             isWooPosFFEnabled = isWooPosFFEnabled,
             getWooCoreVersion = getWooCoreVersion,
         )
     }
+
+    @Test
+    fun `given big enough screen, IPP Onboarding completed, USD currency, store in the US, then return true`() =
+        testBlocking {
+            whenever(selectedSite.getOrNull()).thenReturn(SiteModel().also { it.id = 1 })
+            whenever(isWindowSizeExpandedAndBigger()).thenReturn(true)
+            val onboardingCompleted = mock<CardReaderOnboardingState.OnboardingCompleted>()
+            whenever(cardReaderOnboardingChecker.getOnboardingState()).thenReturn(onboardingCompleted)
+            whenever(onboardingCompleted.preferredPlugin).thenReturn(PluginType.WOOCOMMERCE_PAYMENTS)
+            whenever(ippStore.loadAccount(any(), any()))
+                .thenReturn(buildPaymentAccountResult(countryCode = "US", defaultCurrency = "USD"))
+            whenever(isWooPosFFEnabled()).thenReturn(true)
+
+            assertTrue(sut())
+        }
 
     @Test
     fun `given store not in the US, then return false`() = testBlocking {
@@ -75,14 +90,37 @@ class IsWooPosEnabledTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given ipp plugin is not enabled, then return false`() = testBlocking {
-        whenever(getActivePaymentsPlugin()).thenReturn(null)
+    fun `given ipp onboarding is Completed, then return true`() = testBlocking {
+        val onboardingCompleted = mock<CardReaderOnboardingState.OnboardingCompleted>()
+        whenever(onboardingCompleted.preferredPlugin).thenReturn(PluginType.WOOCOMMERCE_PAYMENTS)
+        whenever(cardReaderOnboardingChecker.getOnboardingState()).thenReturn(onboardingCompleted)
+
+        assertTrue(sut())
+    }
+
+    @Test
+    fun `given ipp onboarding is Pending Requirements, then return true`() = testBlocking {
+        val onboardingCompleted = mock<CardReaderOnboardingState.StripeAccountPendingRequirement>()
+        whenever(onboardingCompleted.preferredPlugin).thenReturn(PluginType.WOOCOMMERCE_PAYMENTS)
+        whenever(cardReaderOnboardingChecker.getOnboardingState()).thenReturn(onboardingCompleted)
+
+        assertTrue(sut())
+    }
+
+    @Test
+    fun `given ipp onboarding is WCPayNotInstalled, then return false`() = testBlocking {
+        val onboardingCompleted = CardReaderOnboardingState.WcpayNotInstalled
+        whenever(cardReaderOnboardingChecker.getOnboardingState()).thenReturn(onboardingCompleted)
+
         assertFalse(sut())
     }
 
     @Test
     fun `given ipp plugin is not woo payments, then return false`() = testBlocking {
-        whenever(getActivePaymentsPlugin()).thenReturn(STRIPE)
+        val onboardingCompleted = mock<CardReaderOnboardingState.OnboardingCompleted>()
+        whenever(onboardingCompleted.preferredPlugin).thenReturn(PluginType.STRIPE_EXTENSION_GATEWAY)
+        whenever(cardReaderOnboardingChecker.getOnboardingState()).thenReturn(onboardingCompleted)
+
         assertFalse(sut())
     }
 
@@ -93,78 +131,35 @@ class IsWooPosEnabledTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given woo payments setup not completed or enabled, then return false`() = testBlocking {
-        val result = buildPaymentAccountResult(status = WCPaymentAccountResult.WCPaymentAccountStatus.NO_ACCOUNT)
-        whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
-        assertFalse(sut())
-    }
-
-    @Test
-    fun `given big enough screen, woo payments enabled, USD currency and store in the US, then return true`() = testBlocking {
-        val result = buildPaymentAccountResult(defaultCurrency = "USD", countryCode = "US", status = COMPLETE)
-        whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
-        assertTrue(sut())
-    }
-
-    @Test
-    fun `given big enough screen, woo payments enabled, USD currency, store in the US, and status enabled, then return true`() = testBlocking {
-        val result = buildPaymentAccountResult(defaultCurrency = "USD", countryCode = "US", status = ENABLED)
-        whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
-        assertTrue(sut())
-    }
-
-    @Test
     fun `given woo version 6_5_0, when invoked, then return false`() = testBlocking {
-        val result = buildPaymentAccountResult(defaultCurrency = "USD", countryCode = "US", status = ENABLED)
-        whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
         whenever(getWooCoreVersion.invoke()).thenReturn("6.5.0")
         assertFalse(sut())
     }
 
     @Test
     fun `given woo version 6_6_0, when invoked, then return true`() = testBlocking {
-        val result = buildPaymentAccountResult(defaultCurrency = "USD", countryCode = "US", status = ENABLED)
-        whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
         whenever(getWooCoreVersion.invoke()).thenReturn("6.6.0")
         assertTrue(sut())
     }
 
     @Test
     fun `given woo version 6_6_0_1, when invoked, then return true`() = testBlocking {
-        val result = buildPaymentAccountResult(defaultCurrency = "USD", countryCode = "US", status = ENABLED)
-        whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
         whenever(getWooCoreVersion.invoke()).thenReturn("6.6.0.1")
         assertTrue(sut())
     }
 
     @Test
     fun `given woo version 10_0_1, when invoked, then return true`() = testBlocking {
-        val result = buildPaymentAccountResult(defaultCurrency = "USD", countryCode = "US", status = ENABLED)
-        whenever(ippStore.loadAccount(any(), any())).thenReturn(result)
         whenever(getWooCoreVersion.invoke()).thenReturn("10.0.1")
         assertTrue(sut())
     }
 
-    @Test
-    fun `given siteA's cached, when switched to siteB, then cached value for siteA is not used`() = testBlocking {
-        // ensure the value is cached for siteA
-        sut()
-        // switch to a non-eligible site
-        whenever(selectedSite.getOrNull()).thenReturn(SiteModel().also { it.id = 2 })
-        whenever(getActivePaymentsPlugin()).thenReturn(STRIPE)
-        whenever(isWindowSizeExpandedAndBigger()).thenReturn(false)
-        whenever(ippStore.loadAccount(any(), any())).thenReturn(buildPaymentAccountResult(countryCode = "AU"))
-
-        assertFalse(sut())
-    }
-
     private fun buildPaymentAccountResult(
-        status: WCPaymentAccountResult.WCPaymentAccountStatus = COMPLETE,
         countryCode: String = "US",
         defaultCurrency: String = "USD"
     ) = WooResult(
         WCPaymentAccountResult(
-            status,
+            status = mock(),
             hasPendingRequirements = false,
             hasOverdueRequirements = false,
             currentDeadline = null,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11520 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
I started working on this issue with the plan to make sure the cache is invalidated when the user switches sites. At first I decided to make the cache site-specific to avoid calling `invalidate` from some other place in the codebase => this was implemented in the first two commits (a0e04605d5354fabb7363b9519ffcf1d91ae39ac and 234986b695520b5b0b984d94b869a550b01a41e0).


------------------------------

However, upon further investigation, I realized two additional issues:
1. The cache isn't refreshed/invalidated when the user completes onboarding.
2. The existing implementation checks the state of WooPayments account instead of IPP Onboarding state.

I fixed both by using the existing CardReaderOnboardingChecker class instead of relying on a custom implementation for the POS. The onboarding checker returns the state of the onboarding and handles any necessary caching internally. This was implemented in 5ce81cc9233ea32f8b12900316640183953e327b. (cc @jaclync)

------------------------------

The next thing I realized was that we still need to cache WCPaymentAccountResult. This was implemented in d48b6bf255fab0e6fae2ef0ba031d30952cf3f92 and caches the result per site, to ensure the feature works as inteded upon site switch.

I noticed the existing IPP onboarding implementation doesn't check the currency at all and uses [store's address instead of WooPayments account address to check the country](https://github.com/woocommerce/woocommerce-android/blob/2f0a696c6163819f46c929a60f94502bb719f12e/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingChecker.kt#L339). This is potentially something we could do for POS as well, but considering the POS should check the currency and the fact that WooPayments account is the true source of truth, I think it's better to keep it as is, wdyt?

------------------------------


Last three commits:
- a50bda1122df5691727ca121c450fc36b507e29c - I rearranged the conditional checks to ensure we emit remote requests only if all the previous conditions pass.
- 6f5c3793f62e9af5d4492035f0f1ef7f2c18c832 and 501d688f82250caeeea7027427b733abec9b81b4 - Updates the unit tests

To Test:
- Testing all the possible scenarios manually would be very time consuming. Considering we'll likely make further changes to this class and logic in the upcoming weeks, and considering the unit tests should serve us well here, I recommend smoke testing the following flow and carefully reviewing the unit tests :

1. Use a device eligible for POS and select a site eligible for POS
2. Make sure the POS entry point is visible and works
3. Switch to a site which is not eligible for POS (eg. isn't located in the US)
4. Make sure the POS entry point is not visible
5. Switch back to the first site and make sure the entry point is visible and works.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

cc @kidinov Just in case you'd notice some issue with the approach to re-use CardReaderOnboardingChecker.