### PR TITLE
[Woo POS] Start payment flow in Totals screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderFacade.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderFacade.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderActivity.Companion.WOO_POS_CARD_PAYMENT_RESULT_KEY
 import com.woocommerce.android.util.parcelable
 import dagger.hilt.android.scopes.ActivityRetainedScoped
 import kotlinx.coroutines.flow.Flow
@@ -29,9 +30,14 @@ class WooPosCardReaderFacade @Inject constructor(cardReaderManager: CardReaderMa
         paymentResultLauncher = activity!!.registerForActivityResult(
             ActivityResultContracts.StartActivityForResult()
         ) { result ->
-            val paymentResult = result.data!!.parcelable<WooPosCardReaderPaymentResult>(
-                WooPosCardReaderActivity.WOO_POS_CARD_PAYMENT_RESULT_KEY
-            )
+            val paymentResult = if (result.data != null && result.resultCode == AppCompatActivity.RESULT_OK) {
+                result.data!!.parcelable<WooPosCardReaderPaymentResult>(
+                    WOO_POS_CARD_PAYMENT_RESULT_KEY
+                )
+            } else {
+                WooPosCardReaderPaymentResult.Failure
+            }
+
             paymentContinuation?.resume(paymentResult!!)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
@@ -21,6 +21,7 @@ sealed class ChildToParentEvent {
     data object CheckoutClicked : ChildToParentEvent()
     data object BackFromCheckoutToCartClicked : ChildToParentEvent()
     data class ItemClickedInProductSelector(val productId: Long) : ChildToParentEvent()
+    data class OrderDraftCreated(val orderId: Long) : ChildToParentEvent()
 }
 
 interface WooPosChildrenToParentEventReceiver {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeParentToChildCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeParentToChildCommunication.kt
@@ -20,6 +20,7 @@ class WooPosParentToChildrenCommunication @Inject constructor() :
 sealed class ParentToChildrenEvent {
     data object BackFromCheckoutToCartClicked : ParentToChildrenEvent()
     data class ItemClickedInProductSelector(val productId: Long) : ParentToChildrenEvent()
+    data class OrderDraftCreated(val orderId: Long) : ParentToChildrenEvent()
 }
 
 interface WooPosParentToChildrenEventReceiver {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -58,6 +58,9 @@ class WooPosHomeViewModel @Inject constructor(
                             ParentToChildrenEvent.ItemClickedInProductSelector(event.productId)
                         )
                     }
+                    is ChildToParentEvent.OrderDraftCreated -> {
+                        sendEventToChildren(ParentToChildrenEvent.OrderDraftCreated(event.orderId))
+                    }
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartRepository.kt
@@ -1,17 +1,28 @@
 package com.woocommerce.android.ui.woopos.home.cart
 
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.Product
+import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
 import com.woocommerce.android.util.DateUtils
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.store.WCProductStore
+import java.math.BigDecimal
 import java.util.Date
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class WooPosCartRepository @Inject constructor(
     private val orderCreateEditRepository: OrderCreateEditRepository,
     private val dateUtils: DateUtils,
+    private val store: WCProductStore,
+    private val site: SelectedSite,
 ) {
-    suspend fun createOrderWithProducts(productIds: List<Long>): Result<Order> {
-        check(productIds.isNotEmpty()) { "Cart is empty" }
+    suspend fun createOrderWithProducts(productIds: List<Long>): Result<Order> = withContext(IO) {
+        check(productIds.isNotEmpty()) { "List of IDs is empty" }
         val order = Order.getEmptyOrder(
             dateCreated = dateUtils.getCurrentDateInSiteTimeZone() ?: Date(),
             dateModified = dateUtils.getCurrentDateInSiteTimeZone() ?: Date()
@@ -21,16 +32,26 @@ class WooPosCartRepository @Inject constructor(
                 .groupingBy { it }
                 .eachCount()
                 .map { (productId, quantity) ->
+                    val product = getProductById(productId)
                     Order.Item.EMPTY.copy(
+                        itemId = 0L,
                         productId = productId,
+                        variationId = 0L,
                         quantity = quantity.toFloat(),
                         total = EMPTY_TOTALS_SUBTOTAL_VALUE,
                         subtotal = EMPTY_TOTALS_SUBTOTAL_VALUE,
+                        price = product?.price ?: BigDecimal.ZERO,
+                        sku = product?.sku.orEmpty(),
+                        attributesList = emptyList(),
                     )
                 }
         )
 
-        return orderCreateEditRepository.createOrUpdateOrder(order)
+        orderCreateEditRepository.createOrUpdateOrder(order)
+    }
+
+    suspend fun getProductById(productId: Long): Product? = withContext(IO) {
+        store.getProductByRemoteId(site.getOrNull()!!, productId)?.toAppModel()
     }
 
     private companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.OrderDraftCreated
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
@@ -22,7 +21,6 @@ import javax.inject.Inject
 class WooPosCartViewModel @Inject constructor(
     private val childrenToParentEventSender: WooPosChildrenToParentEventSender,
     private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver,
-    private val site: SelectedSite,
     private val repository: WooPosCartRepository,
     savedState: SavedStateHandle,
 ) : ViewModel() {
@@ -101,8 +99,7 @@ class WooPosCartViewModel @Inject constructor(
                         if (state.value.isOrderCreationInProgress) return@collect
 
                         val itemClicked = viewModelScope.async {
-                            repository.getProductById(event.productId)?.toCartListItem()
-                                ?: throw IllegalStateException("Product not found")
+                            repository.getProductById(event.productId)?.toCartListItem()!!
                         }
 
                         val currentState = _state.value

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsViewModel.kt
@@ -3,12 +3,14 @@ package com.woocommerce.android.ui.woopos.home.products
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -23,9 +25,13 @@ class WooPosProductsViewModel @Inject constructor(
     private var loadMoreProductsJob: Job? = null
 
     val viewState: StateFlow<WooPosProductsViewState> =
-        productsDataSource.products.map { products ->
-            calculateViewState(products)
-        }.toStateFlow(WooPosProductsViewState(products = emptyList()))
+        productsDataSource.products
+            .map {
+                it.filter { product -> product.productType == ProductType.SIMPLE && product.price != null }
+            }
+            .map { products ->
+                calculateViewState(products)
+            }.toStateFlow(WooPosProductsViewState(products = emptyList()))
 
     init {
         launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -10,13 +10,17 @@ import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 
 @Composable
 fun WooPosTotalsScreen() {
+    val viewModel: WooPosTotalsViewModel = hiltViewModel()
+    val state = viewModel.state.collectAsState()
     Card(
         shape = RoundedCornerShape(16.dp),
         backgroundColor = MaterialTheme.colors.surface,
@@ -34,7 +38,18 @@ fun WooPosTotalsScreen() {
                     color = MaterialTheme.colors.primary,
                 )
 
-                Button(onClick = { /*TODO*/ }) {
+                if (state.value.orderId != null) {
+                    Text(
+                        text = "Order ID: ${state.value.orderId}",
+                        style = MaterialTheme.typography.h4,
+                        color = MaterialTheme.colors.primary,
+                    )
+                }
+
+                Button(
+                    onClick = { viewModel.onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked) },
+                    enabled = state.value.isCollectPaymentButtonEnabled
+                ) {
                     Text("Collect Card Payment")
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
 import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -32,6 +33,10 @@ fun WooPosTotalsScreen() {
                     style = MaterialTheme.typography.h3,
                     color = MaterialTheme.colors.primary,
                 )
+
+                Button(onClick = { /*TODO*/ }) {
+                    Text("Collect Card Payment")
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsState.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.ui.woopos.home.totals
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class WooPosTotalsState(
+    val orderId: Long?,// TODO: remove. Ultimately we don't need to display order id anywhere
+    val isCollectPaymentButtonEnabled: Boolean,
+): Parcelable {
+
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsState.kt
@@ -5,6 +5,6 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class WooPosTotalsState(
-    val orderId: Long?, // TODO: remove. Ultimately we don't need to display order id anywhere
+    val orderId: Long?,
     val isCollectPaymentButtonEnabled: Boolean,
 ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsState.kt
@@ -5,8 +5,6 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class WooPosTotalsState(
-    val orderId: Long?,// TODO: remove. Ultimately we don't need to display order id anywhere
+    val orderId: Long?, // TODO: remove. Ultimately we don't need to display order id anywhere
     val isCollectPaymentButtonEnabled: Boolean,
-): Parcelable {
-
-}
+) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsUIEvent.kt
@@ -1,0 +1,5 @@
+package com.woocommerce.android.ui.woopos.home.totals
+
+sealed class WooPosTotalsUIEvent {
+    data object CollectPaymentClicked : WooPosTotalsUIEvent()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -1,8 +1,31 @@
 package com.woocommerce.android.ui.woopos.home.totals
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
+import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class WooPosTotalsViewModel @Inject constructor() : ViewModel()
+class WooPosTotalsViewModel @Inject constructor(
+    private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver,
+) : ViewModel() {
+    init {
+        listenUpEvents()
+    }
+
+    private fun listenUpEvents() {
+        viewModelScope.launch {
+            parentToChildrenEventReceiver.events.collect { event ->
+                when (event) {
+                    is ParentToChildrenEvent.OrderDraftCreated -> {
+                        // update view state
+                    }
+                    else -> Unit
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -33,7 +33,8 @@ class WooPosTotalsViewModel @Inject constructor(
         when (event) {
             is WooPosTotalsUIEvent.CollectPaymentClicked -> {
                 viewModelScope.launch {
-                    cardReaderFacade.collectPayment(state.value.orderId!!)
+                    val orderId = state.value.orderId!!
+                    cardReaderFacade.collectPayment(orderId)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -1,19 +1,42 @@
 package com.woocommerce.android.ui.woopos.home.totals
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
+import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class WooPosTotalsViewModel @Inject constructor(
     private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver,
+    private val cardReaderFacade: WooPosCardReaderFacade,
+    savedState: SavedStateHandle,
 ) : ViewModel() {
+    private val _state = savedState.getStateFlow(
+        scope = viewModelScope,
+        initialValue = WooPosTotalsState(orderId = null, isCollectPaymentButtonEnabled = false),
+        key = "totalsViewState"
+    )
+    val state: StateFlow<WooPosTotalsState> = _state
+
     init {
         listenUpEvents()
+    }
+
+    fun onUIEvent(event: WooPosTotalsUIEvent) {
+        when (event) {
+            is WooPosTotalsUIEvent.CollectPaymentClicked -> {
+                viewModelScope.launch {
+                    cardReaderFacade.collectPayment(state.value.orderId!!)
+                }
+            }
+        }
     }
 
     private fun listenUpEvents() {
@@ -21,8 +44,9 @@ class WooPosTotalsViewModel @Inject constructor(
             parentToChildrenEventReceiver.events.collect { event ->
                 when (event) {
                     is ParentToChildrenEvent.OrderDraftCreated -> {
-                        // update view state
+                        _state.value = state.value.copy(orderId = event.orderId, isCollectPaymentButtonEnabled = true)
                     }
+
                     else -> Unit
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.totals
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -34,7 +35,8 @@ class WooPosTotalsViewModel @Inject constructor(
             is WooPosTotalsUIEvent.CollectPaymentClicked -> {
                 viewModelScope.launch {
                     val orderId = state.value.orderId!!
-                    cardReaderFacade.collectPayment(orderId)
+                    val result = cardReaderFacade.collectPayment(orderId)
+                    Log.d("WooPosTotalsViewModel", "Payment result: $result")
                 }
             }
         }

--- a/WooCommerce/src/main/res/layout/activity_woo_pos_card_reader.xml
+++ b/WooCommerce/src/main/res/layout/activity_woo_pos_card_reader.xml
@@ -1,7 +1,18 @@
-<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/woopos_card_reader_nav_host_fragment"
-    android:name="androidx.navigation.fragment.NavHostFragment"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:defaultNavHost="true"  />
+    android:id="@+id/snack_root"
+    android:layout_width="0dp"
+    android:layout_height="0dp"
+    android:layout_weight="1"
+    app:layout_constraintBottom_toTopOf="@+id/trial_bar"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/woopos_card_reader_nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:defaultNavHost="true" />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartCartRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartCartRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.cart
 
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
 import com.woocommerce.android.util.DateUtils
 import kotlinx.coroutines.test.runTest
@@ -10,6 +11,9 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.store.WCProductStore
 import java.util.Date
 import kotlin.test.Test
 
@@ -25,9 +29,23 @@ class WooPosCartCartRepositoryTest {
         on { getCurrentDateInSiteTimeZone() }.thenReturn(mockedDate)
     }
 
+    private val productStore: WCProductStore = mock {
+        onBlocking { getProductByRemoteId(any(), any()) }.thenReturn(
+            WCProductModel().apply {
+                attributes = "[]"
+            }
+        )
+    }
+    private val site: SelectedSite = mock {
+        onBlocking { get() }.thenReturn(SiteModel())
+        onBlocking { getOrNull() }.thenReturn(SiteModel())
+    }
+
     val repository = WooPosCartRepository(
         orderCreateEditRepository = orderCreateEditRepository,
-        dateUtils = dateUtils
+        dateUtils = dateUtils,
+        store = productStore,
+        site = site
     )
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.cart
 
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
@@ -13,7 +12,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.WCProductModel
 import kotlin.test.Test
 import kotlin.test.assertEquals
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11709, #11723 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR introduced the following changes:
1. Fixes order creation API request
2. Passes order ID from Cart to Totals screen
3. Starts card reader payment collection flow when clicking "collect payment" in the Totals screen
4. Filters products in the product selector – showing only simple products that have a price defined
5. Adds several improvements to WooPosCardReaderActivity, e.g. ability to display snack bars

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

The newly introduced feature in this PR aims to collect payment for products added to the cart.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
1. Add products to cart, and go the Checkout
2. Wait for the order to be created and click "Collect Payment"
3. Ensure the happy path for payment collection is successfull

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4527432/87bb7750-68d5-4f56-8373-77fba416a87f


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->