### PR TITLE
[Dynamic Dashboard] Improve colors in Dark Mode for better visibility

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersCard.kt
@@ -313,7 +313,7 @@ private fun OrderListItem(order: OrderItem, onOrderClicked: (OrderItem) -> Unit)
                     end.linkTo(parent.end)
                 },
             text = order.status,
-            textColor = MaterialTheme.colors.onSurface,
+            textColor = colorResource(id = R.color.color_on_secondary),
             backgroundColor = colorResource(id = order.statusColor),
             fontWeight = FontWeight.Normal
         )

--- a/WooCommerce/src/main/res/drawable/ic_rounded_chcekbox_unchecked.xml
+++ b/WooCommerce/src/main/res/drawable/ic_rounded_chcekbox_unchecked.xml
@@ -5,6 +5,6 @@
     android:viewportHeight="24">
   <path
       android:pathData="M12,0C5.37,0 0,5.37 0,12C0,18.62 5.37,24 12,24C18.62,24 24,18.62 24,12C23.99,5.37 18.62,0 12,0ZM12,22C6.47,22 2,17.52 2,12C2,6.47 6.47,2 12,2C17.52,2 22,6.47 22,12C21.99,17.52 17.52,21.99 12,22Z"
-      android:fillColor="#3C3C43"
+      android:fillColor="@color/color_on_surface"
       android:fillAlpha="0.3"/>
 </vector>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11718 
<!-- Id number of the GitHub issue this PR addresses. -->


### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates text color in Dark mode for "Most recent orders" card's order status label, as well as the color of checkmark in Customize mode.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

0. Ensure your test site has recent orders,
1. Start app, enable dark mode if you haven't,
2. Enable "Most recent orders" card in Dashboard if you haven't, compare the label color with screenshot below
3. Go to "Customize", compare the inactive checkmark with screenshot below. Also try with lower brightness on your screen (can be real device or simulator) and ensure they're still visible.


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

"Most recent orders" card:

| Before | After |
|-|-|
| ![Screenshot_20240613_152426](https://github.com/woocommerce/woocommerce-android/assets/266376/79871718-49d8-409c-86a9-307fbbf92344) | ![Screenshot_20240613_133155](https://github.com/woocommerce/woocommerce-android/assets/266376/efdb6faf-002f-49a3-a7e3-8bd6e2faec88) |

"Customize" checkmarks:
| Before | After |
|-|-|
| ![Screenshot_20240613_152433](https://github.com/woocommerce/woocommerce-android/assets/266376/1d65ab4a-21a6-4161-9fe5-2611d7824e14) | ![Screenshot_20240613_151955](https://github.com/woocommerce/woocommerce-android/assets/266376/c6d20396-69a2-4c5d-ab38-634b9c2fce6d) |
