### PR TITLE
[Dynamic Dashboard] Stock card 19.0 beta feedback updates

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
@@ -127,7 +127,7 @@ private fun DashboardProductStockCard(
             }
 
             is DashboardProductStockViewModel.ViewState.Success -> {
-                ProductReviewsCardContent(
+                ProductStockCardContent(
                     selectedFilter = viewState.selectedFilter,
                     productStockItems = viewState.productStockItems,
                     onFilterSelected = onFilterSelected,
@@ -189,7 +189,7 @@ private fun ProductStockLoading(
 }
 
 @Composable
-private fun ProductReviewsCardContent(
+private fun ProductStockCardContent(
     selectedFilter: ProductStockStatus,
     productStockItems: List<ProductStockItem>,
     onFilterSelected: (ProductStockStatus) -> Unit,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
@@ -274,7 +274,9 @@ fun ProductStockRow(
             Spacer(modifier = Modifier.height(8.dp))
             Row(modifier = Modifier.padding(bottom = 4.dp)) {
                 Text(
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(end = 8.dp),
                     text = product.name,
                     style = MaterialTheme.typography.subtitle1,
                     maxLines = 2,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
@@ -263,11 +263,12 @@ fun ProductStockRow(
             .fillMaxWidth()
             .clickable { onItemClicked(product) }
             .padding(horizontal = 16.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.Top
     ) {
         ProductThumbnail(
             imageUrl = product.imageUrl ?: "",
             contentDescription = stringResource(id = R.string.product_image_content_description),
+            modifier = Modifier.padding(top = 12.dp)
         )
         Column(modifier = Modifier.padding(start = 8.dp)) {
             Spacer(modifier = Modifier.height(8.dp))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockViewModel.kt
@@ -58,7 +58,10 @@ class DashboardProductStockViewModel @AssistedInject constructor(
             emit(Loading(status))
             productStockRepository.fetchProductStockReport(status, refresh.isForced)
                 .fold(
-                    onSuccess = { emit(ViewState.Success(it, status)) },
+                    onSuccess = {
+                        val sortedProductStockItems = it.sortedBy { item -> item.stockQuantity }
+                        emit(ViewState.Success(sortedProductStockItems, status))
+                    },
                     onFailure = {
                         when ((it as? WooException)?.error?.type) {
                             WooErrorType.API_NOT_FOUND -> emit(ViewState.Error.WCAnalyticsDisabled)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11718
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the following:

1. Align the product thumbnail to the top. Now, if the product title goes longer than 1 line, the image stays fixed to the top.
2. Logic to sort product items by stock quantity, lowest first.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

#### Product thumbnail
1. You will need a product with a really long name. Or else, just edit `DashboardProductStockCard` on line 278 and hack in a longer name for the product. I used `text = product.name + product.name + product.name + product.name + product.name + product.name,`
3. Start app, enable Stock card on My Store,
4. Ensure the thumbnail stays aligned to the top like the screenshot below,
5. Optionally also check the thumbnail with one line product title and ensure it still looks good too.

| Single line | Multiple lines |
|-|-|
| ![Screenshot_20240614_151516](https://github.com/woocommerce/woocommerce-android/assets/266376/17ea44b3-4556-46e9-93ea-dddd0196d813) | <img src="https://github.com/woocommerce/woocommerce-android/assets/266376/4f9b0937-befb-4e05-93f3-52d841ac1483"> |

#### Product sorting
I think just check the code and smoke test that the result is always ordered correctly, also by changing various product's stocks and re-checking the card.