### PR TITLE
Issue/11718 minor beta fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsCard.kt
@@ -87,6 +87,7 @@ private fun HandleEvents(event: LiveData<MultiLiveEvent.Event>) {
                 is DashboardReviewsViewModel.OpenReviewsList -> navController.navigateSafely(
                     DashboardFragmentDirections.actionDashboardToReviews()
                 )
+
                 is DashboardReviewsViewModel.OpenReviewDetail -> {
                     // Open the review list screen first as it's responsible for handling review status changes
                     navController.navigateSafely(
@@ -176,10 +177,9 @@ private fun ProductReviewsCardContent(
         if (viewState.reviews.isEmpty()) {
             EmptyView(selectedFilter = viewState.selectedFilter)
         } else {
-            viewState.reviews.forEachIndexed { index, productReview ->
+            viewState.reviews.forEach { productReview ->
                 ReviewListItem(
                     review = productReview,
-                    showDivider = index < viewState.reviews.size - 1,
                     onClicked = { onReviewClicked(productReview) }
                 )
             }
@@ -190,7 +190,6 @@ private fun ProductReviewsCardContent(
 @Composable
 private fun ReviewListItem(
     review: ProductReview,
-    showDivider: Boolean,
     onClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -259,10 +258,7 @@ private fun ReviewListItem(
             }
 
             Spacer(modifier = Modifier)
-
-            if (showDivider) {
-                Divider()
-            }
+            Divider()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockViewModel.kt
@@ -49,13 +49,13 @@ class DashboardProductStockViewModel @AssistedInject constructor(
     private val _refreshTrigger = MutableSharedFlow<DashboardViewModel.RefreshEvent>(extraBufferCapacity = 1)
     private val refreshTrigger = merge(parentViewModel.refreshTrigger, _refreshTrigger)
         .onStart {
-            if(productStockState.value !is ViewState.Success) {
+            if (productStockState.value !is ViewState.Success) {
                 emit(DashboardViewModel.RefreshEvent()) // Avoid refreshing when stock items are already loaded
             }
         }
     private val status = savedStateHandle.getStateFlow<ProductStockStatus>(viewModelScope, ProductStockStatus.LowStock)
 
-    val productStockState : LiveData<ViewState> = status
+    val productStockState: LiveData<ViewState> = status
         .flatMapLatest {
             refreshTrigger.map { refresh -> Pair(refresh, it) }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11718
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds the following fixes from the beta feedback: 

- Avoid refreshing stock card when locking the device and then opening the app again. 
- missing a divider on top of "View all reviews" button.


### Testing information
- Launch the app
- Select Product reviews card and check the the divider on the last item displayed is not missing
- Select product stock card
- Send the app to the background
- Lock the device
- Reopen the app and check the stock card is not refreshed. 
