### PR TITLE
[Woo POS] Handle card payment cancelation and failure events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
@@ -59,7 +59,9 @@ import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectV
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectViewState.MultipleExternalReadersFoundState
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectViewState.ScanningFailedState
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.CardReadersHub
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Refund
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType.BUILT_IN
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType.EXTERNAL
@@ -523,9 +525,7 @@ class CardReaderConnectViewModel @Inject constructor(
     private fun exitFlow(connected: Boolean) {
         if (!connected) {
             when (val param = arguments.cardReaderFlowParam) {
-                is CardReaderFlowParam.CardReadersHub,
-                is Payment,
-                is CardReaderFlowParam.PaymentOrRefund.Refund -> {
+                is CardReadersHub, is Payment, is Refund -> {
                     if (param is Payment && param.paymentType == Payment.PaymentType.WOO_POS) {
                         returnToWooPos()
                     } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
@@ -525,8 +525,9 @@ class CardReaderConnectViewModel @Inject constructor(
     private fun exitFlow(connected: Boolean) {
         if (!connected) {
             when (val param = arguments.cardReaderFlowParam) {
-                is CardReadersHub, is Payment, is Refund -> {
-                    if (param is Payment && param.paymentType == Payment.PaymentType.WOO_POS) {
+                is CardReadersHub, is Refund -> triggerEvent(ExitWithResult(false))
+                is Payment -> {
+                    if (param.paymentType == Payment.PaymentType.WOO_POS) {
                         returnToWooPos()
                     } else {
                         triggerEvent(ExitWithResult(false))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodEvent.kt
@@ -36,7 +36,10 @@ data class NavigateToOrderDetails(
     val orderId: Long
 ) : MultiLiveEvent.Event()
 
-object ReturnResultToWooPos : MultiLiveEvent.Event()
+sealed class ReturnResultToWooPos : MultiLiveEvent.Event() {
+    data object Success : ReturnResultToWooPos()
+    data object Failure : ReturnResultToWooPos()
+}
 
 data class NavigateToTapToPaySummary(
     val order: Order

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -38,7 +38,6 @@ import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderActivity
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderPaymentResult
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UiHelpers
-import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -38,6 +38,7 @@ import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderActivity
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderPaymentResult
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.UiHelpers
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -287,7 +288,7 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
                         Bundle().apply {
                             putParcelable(
                                 WooPosCardReaderActivity.WOO_POS_CARD_PAYMENT_RESULT_KEY,
-                                WooPosCardReaderPaymentResult.Success,
+                                event.asWooPosCardReaderPaymentResult(),
                             )
                         }
                     )
@@ -295,6 +296,13 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
             }
         }
     }
+
+    private fun ReturnResultToWooPos.asWooPosCardReaderPaymentResult() =
+        if (this is ReturnResultToWooPos.Success) {
+            WooPosCardReaderPaymentResult.Success
+        } else {
+            WooPosCardReaderPaymentResult.Failure
+        }
 
     private fun setupResultHandlers() {
         handleDialogResult<Boolean>(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -297,10 +297,9 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
     }
 
     private fun ReturnResultToWooPos.asWooPosCardReaderPaymentResult() =
-        if (this is ReturnResultToWooPos.Success) {
-            WooPosCardReaderPaymentResult.Success
-        } else {
-            WooPosCardReaderPaymentResult.Failure
+        when (this) {
+            is ReturnResultToWooPos.Success -> WooPosCardReaderPaymentResult.Success
+            else -> WooPosCardReaderPaymentResult.Failure
         }
 
     private fun setupResultHandlers() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
@@ -345,6 +345,9 @@ class SelectPaymentMethodViewModel @Inject constructor(
                     source = AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_SOURCE_PAYMENT_METHOD,
                     flow = cardReaderPaymentFlowParam.toAnalyticsFlowName(),
                 )
+                if (cardReaderPaymentFlowParam.paymentType == WOO_POS) {
+                    triggerEvent(ReturnResultToWooPos.Failure)
+                }
             }
         }
     }
@@ -453,7 +456,7 @@ class SelectPaymentMethodViewModel @Inject constructor(
                 SIMPLE -> NavigateBackToHub(CardReadersHub())
                 TRY_TAP_TO_PAY -> NavigateToTapToPaySummary(order.first())
                 ORDER, ORDER_CREATION -> NavigateBackToOrderList(order.first())
-                WOO_POS -> ReturnResultToWooPos
+                WOO_POS -> ReturnResultToWooPos.Success
             }
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodViewModel.kt
@@ -345,10 +345,16 @@ class SelectPaymentMethodViewModel @Inject constructor(
                     source = AnalyticsTracker.VALUE_SIMPLE_PAYMENTS_SOURCE_PAYMENT_METHOD,
                     flow = cardReaderPaymentFlowParam.toAnalyticsFlowName(),
                 )
-                if (cardReaderPaymentFlowParam.paymentType == WOO_POS) {
-                    triggerEvent(ReturnResultToWooPos.Failure)
-                }
+                handleWooPosPaymentFailure()
             }
+        }
+    }
+
+    private fun handleWooPosPaymentFailure() {
+        // In case payment was initiated from the Woo POS mode, we need to propagate the payment
+        // result back, to close the SelectPaymentMethodFragment and handle failure on the Woo POS end.
+        if (cardReaderPaymentFlowParam.paymentType == WOO_POS) {
+            triggerEvent(ReturnResultToWooPos.Failure)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderViewModel.kt
@@ -1,28 +1,13 @@
 package com.woocommerce.android.ui.woopos.cardreader
 
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.R
-import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
-import com.woocommerce.android.model.Order
-import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
-import com.woocommerce.android.ui.payments.cardreader.CardReaderCountryConfigProvider
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderActivity.Companion.WOO_POS_CARD_READER_MODE_KEY
-import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
-import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
 @HiltViewModel
 class WooPosCardReaderViewModel @Inject constructor(
-    private val orderCreateEditRepository: OrderCreateEditRepository,
-    private val resourceProvider: ResourceProvider,
-    private val cardReaderCountryConfigProvider: CardReaderCountryConfigProvider,
-    private val wooStore: WooCommerceStore,
-    private val selectedSite: SelectedSite,
     savedStateHandle: SavedStateHandle,
 ) : ScopedViewModel(savedStateHandle) {
     init {
@@ -34,37 +19,10 @@ class WooPosCardReaderViewModel @Inject constructor(
             is WooPosCardReaderMode.Payment -> {
                 if (mode.orderId != -1L) {
                     triggerEvent(WooPosCardReaderEvent.Payment(mode.orderId))
-                } else {
-                    launch {
-                        createTestOrder(
-                            onSuccess = { order ->
-                                triggerEvent(WooPosCardReaderEvent.Payment(order.id))
-                            },
-                            onFailure = {
-                                Log.e("WooPosCardReaderViewModel", "Failed to create test order")
-                            }
-                        )
-                    }
                 }
             }
 
             null -> error("WooPosCardReaderMode not found in savedStateHandle")
         }
-    }
-
-    private suspend fun createTestOrder(onSuccess: (Order) -> Unit, onFailure: () -> Unit) {
-        val countryConfig = cardReaderCountryConfigProvider.provideCountryConfigFor(
-            wooStore.getStoreCountryCode(selectedSite.get())
-        ) as CardReaderConfigForSupportedCountry
-
-        val result = orderCreateEditRepository.createSimplePaymentOrder(
-            countryConfig.minimumAllowedChargeAmount,
-            customerNote = resourceProvider.getString(R.string.card_reader_tap_to_pay_test_payment_note),
-            isTaxable = false,
-        )
-        result.fold(
-            onSuccess = { onSuccess(it) },
-            onFailure = { onFailure() }
-        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/SnackbarHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/SnackbarHandler.kt
@@ -1,0 +1,36 @@
+package com.woocommerce.android.ui.woopos.common.composeui.component
+
+import androidx.compose.material.SnackbarDuration
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.SnackbarResult
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.ui.woopos.home.totals.SnackbarMessage
+import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsState
+import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsUIEvent
+
+@Composable
+fun SnackbarHandler(
+    state: WooPosTotalsState,
+    snackbarHostState: SnackbarHostState,
+    onUIEvent: (WooPosTotalsUIEvent) -> Unit
+) {
+    val snackbarState = state.snackbarMessage
+    if (snackbarState is SnackbarMessage.Triggered) {
+        val message = stringResource(snackbarState.message)
+        LaunchedEffect(state.snackbarMessage) {
+            val result = snackbarHostState.showSnackbar(
+                message = message,
+                duration = SnackbarDuration.Long,
+            )
+            when (result) {
+                SnackbarResult.Dismissed -> {
+                    onUIEvent(WooPosTotalsUIEvent.SnackbarDismissed)
+                }
+
+                SnackbarResult.ActionPerformed -> Unit
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/snackbar/WooPosSnackbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/snackbar/WooPosSnackbar.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.woopos.common.composeui.component
+package com.woocommerce.android.ui.woopos.common.composeui.component.snackbar
 
 import androidx.compose.material.SnackbarDuration
 import androidx.compose.material.SnackbarHostState
@@ -6,20 +6,17 @@ import androidx.compose.material.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.res.stringResource
-import com.woocommerce.android.ui.woopos.home.totals.SnackbarMessage
-import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsState
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsUIEvent
 
 @Composable
-fun SnackbarHandler(
-    state: WooPosTotalsState,
+fun WooPosSnackbar(
+    state: WooPosSnackbarState,
     snackbarHostState: SnackbarHostState,
     onUIEvent: (WooPosTotalsUIEvent) -> Unit
 ) {
-    val snackbarState = state.snackbarMessage
-    if (snackbarState is SnackbarMessage.Triggered) {
-        val message = stringResource(snackbarState.message)
-        LaunchedEffect(state.snackbarMessage) {
+    if (state is WooPosSnackbarState.Triggered) {
+        val message = stringResource(state.message)
+        LaunchedEffect(state) {
             val result = snackbarHostState.showSnackbar(
                 message = message,
                 duration = SnackbarDuration.Long,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/snackbar/WooPosSnackbarState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/snackbar/WooPosSnackbarState.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.ui.woopos.common.composeui.component.snackbar
+
+import android.os.Parcelable
+import androidx.annotation.StringRes
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+sealed class WooPosSnackbarState : Parcelable {
+    data class Triggered(@StringRes val message: Int) : WooPosSnackbarState()
+    data object Hidden : WooPosSnackbarState()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.SnackbarHandler
 
 @Composable
 fun WooPosTotalsScreen() {
@@ -151,31 +152,6 @@ private fun Totals(
                 enabled = state.isCollectPaymentButtonEnabled,
             ) {
                 Text("Collect Card Payment")
-            }
-        }
-    }
-}
-
-@Composable
-private fun SnackbarHandler(
-    state: WooPosTotalsState,
-    snackbarHostState: SnackbarHostState,
-    onUIEvent: (WooPosTotalsUIEvent) -> Unit
-) {
-    val snackbarState = state.snackbarMessage
-    if (snackbarState is SnackbarMessage.Triggered) {
-        val message = stringResource(snackbarState.message)
-        LaunchedEffect(state.snackbarMessage) {
-            val result = snackbarHostState.showSnackbar(
-                message = message,
-                duration = SnackbarDuration.Long,
-            )
-            when (result) {
-                SnackbarResult.Dismissed -> {
-                    onUIEvent(WooPosTotalsUIEvent.SnackbarDismissed)
-                }
-
-                SnackbarResult.ActionPerformed -> Unit
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -15,22 +15,18 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
-import androidx.compose.material.SnackbarDuration
 import androidx.compose.material.SnackbarHost
 import androidx.compose.material.SnackbarHostState
-import androidx.compose.material.SnackbarResult
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
-import com.woocommerce.android.ui.woopos.common.composeui.component.SnackbarHandler
+import com.woocommerce.android.ui.woopos.common.composeui.component.snackbar.WooPosSnackbar
 
 @Composable
 fun WooPosTotalsScreen() {
@@ -61,7 +57,7 @@ private fun WooPosTotalsScreen(state: WooPosTotalsState, onUIEvent: (WooPosTotal
                 onUIEvent = onUIEvent
             )
         }
-        SnackbarHandler(state, snackbarHostState, onUIEvent)
+        WooPosSnackbar(state.snackbar, snackbarHostState, onUIEvent)
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -1,16 +1,13 @@
 package com.woocommerce.android.ui.woopos.home.totals
 
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.Card
@@ -25,138 +22,157 @@ import androidx.compose.material.SnackbarResult
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
-import kotlinx.coroutines.flow.MutableStateFlow
 
 @Composable
 fun WooPosTotalsScreen() {
     val viewModel: WooPosTotalsViewModel = hiltViewModel()
-    val state = viewModel.state.collectAsState()
+    val state = viewModel.state.collectAsState().value
+    WooPosTotalsScreen(state, viewModel::onUIEvent)
+}
+
+@Composable
+private fun WooPosTotalsScreen(state: WooPosTotalsState, onUIEvent: (WooPosTotalsUIEvent) -> Unit) {
     val snackbarHostState = remember { SnackbarHostState() }
     Scaffold(
         snackbarHost = {
             SnackbarHost(hostState = snackbarHostState)
         }
     ) { padding ->
-        Card(
-            shape = RoundedCornerShape(16.dp),
-            backgroundColor = MaterialTheme.colors.surface,
-            elevation = 4.dp,
-            modifier = Modifier.padding(16.dp),
-        ) {
-            Column(
-                modifier = Modifier
-                    .padding(padding)
-                    .fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
+        if (state.isLoading) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
             ) {
-                if (totalsState.value.orderId != null) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "Subtotal: ",
-                            style = MaterialTheme.typography.h6,
-                            color = MaterialTheme.colors.primary
-                        )
-                        Spacer(modifier = Modifier.weight(1f))
-                        Text(
-                            text = totalsState.value.orderSubtotalText,
-                            style = MaterialTheme.typography.h6,
-                            color = MaterialTheme.colors.primary
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
+                CircularProgressIndicator()
+            }
+        } else {
+            Totals(
+                modifier = Modifier.padding(padding),
+                state = state,
+                onUIEvent = onUIEvent
+            )
+        }
+        SnackbarHandler(state, snackbarHostState, onUIEvent)
+    }
+}
 
-                    Divider()
+@Composable
+private fun Totals(
+    modifier: Modifier = Modifier,
+    state: WooPosTotalsState,
+    onUIEvent: (WooPosTotalsUIEvent) -> Unit
+) {
+    Card(
+        shape = RoundedCornerShape(16.dp),
+        backgroundColor = MaterialTheme.colors.surface,
+        elevation = 4.dp,
+        modifier = Modifier.padding(16.dp),
+    ) {
+        Column(
+            modifier = modifier
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Subtotal: ",
+                    style = MaterialTheme.typography.h6,
+                    color = MaterialTheme.colors.primary
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Text(
+                    text = state.orderSubtotalText,
+                    style = MaterialTheme.typography.h6,
+                    color = MaterialTheme.colors.primary
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
 
-                    Spacer(modifier = Modifier.height(16.dp))
+            Divider()
 
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "Taxes: ",
-                            style = MaterialTheme.typography.h6,
-                            color = MaterialTheme.colors.primary
-                        )
-                        Spacer(modifier = Modifier.weight(1f))
-                        Text(
-                            text = totalsState.value.orderTaxText,
-                            style = MaterialTheme.typography.h6,
-                            color = MaterialTheme.colors.primary
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
-                    Divider()
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Taxes: ",
+                    style = MaterialTheme.typography.h6,
+                    color = MaterialTheme.colors.primary
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Text(
+                    text = state.orderTaxText,
+                    style = MaterialTheme.typography.h6,
+                    color = MaterialTheme.colors.primary
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
 
-                    Spacer(modifier = Modifier.height(16.dp))
+            Divider()
 
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "Total: ",
-                            style = MaterialTheme.typography.h6,
-                            color = MaterialTheme.colors.primary
-                        )
-                        Spacer(modifier = Modifier.weight(1f))
-                        Text(
-                            text = totalsState.value.orderTotalText,
-                            style = MaterialTheme.typography.h4,
-                            color = MaterialTheme.colors.primary
-                        )
-                    }
-                }
+            Spacer(modifier = Modifier.height(16.dp))
 
-                Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Total: ",
+                    style = MaterialTheme.typography.h6,
+                    color = MaterialTheme.colors.primary
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Text(
+                    text = state.orderTotalText,
+                    style = MaterialTheme.typography.h4,
+                    color = MaterialTheme.colors.primary
+                )
+            }
 
-                Divider()
+            Spacer(modifier = Modifier.height(16.dp))
 
-                Spacer(modifier = Modifier.height(16.dp))
+            Divider()
 
-                Button(
-                    onClick = { onCollectPaymentClick() },
-                    enabled = totalsState.value.isCollectPaymentButtonEnabled,
-                ) {
-                    Text("Collect Card Payment")
-                }
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = { onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked) },
+                enabled = state.isCollectPaymentButtonEnabled,
+            ) {
+                Text("Collect Card Payment")
             }
         }
     }
 }
-SnackbarHandler(state, snackbarHostState, viewModel)
-}
 
 @Composable
 private fun SnackbarHandler(
-    state: State<WooPosTotalsState>,
+    state: WooPosTotalsState,
     snackbarHostState: SnackbarHostState,
-    viewModel: WooPosTotalsViewModel
+    onUIEvent: (WooPosTotalsUIEvent) -> Unit
 ) {
-    val snackbarState = state.value.snackbarMessage
+    val snackbarState = state.snackbarMessage
     if (snackbarState is SnackbarMessage.Triggered) {
         val message = stringResource(snackbarState.message)
-        LaunchedEffect(state.value.snackbarMessage) {
+        LaunchedEffect(state.snackbarMessage) {
             val result = snackbarHostState.showSnackbar(
                 message = message,
                 duration = SnackbarDuration.Long,
             )
             when (result) {
                 SnackbarResult.Dismissed -> {
-                    viewModel.onUIEvent(WooPosTotalsUIEvent.SnackbarDismissed)
+                    onUIEvent(WooPosTotalsUIEvent.SnackbarDismissed)
                 }
 
                 SnackbarResult.ActionPerformed -> Unit
@@ -168,19 +184,14 @@ private fun SnackbarHandler(
 @Composable
 @WooPosPreview
 fun WooPosTotalsScreenPreview() {
-    val totalsState = MutableStateFlow(
-        WooPosTotalsState(
-            orderId = 1234L,
+    WooPosTotalsScreen(
+        state = WooPosTotalsState(
             orderSubtotalText = "$420.00",
             orderTotalText = "$462.00",
             orderTaxText = "$42.00",
             isCollectPaymentButtonEnabled = true,
             isLoading = false
-        )
-    )
-
-    WooPosTotalsScreen(
-        state = totalsState,
-        onCollectPaymentClick = {}
+        ),
+        onUIEvent = {}
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.totals
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -8,11 +8,20 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.SnackbarDuration
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.SnackbarResult
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
@@ -21,17 +30,23 @@ import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 fun WooPosTotalsScreen() {
     val viewModel: WooPosTotalsViewModel = hiltViewModel()
     val state = viewModel.state.collectAsState()
-    Card(
-        shape = RoundedCornerShape(16.dp),
-        backgroundColor = MaterialTheme.colors.surface,
-        elevation = 4.dp,
-        modifier = Modifier.padding(16.dp)
-    ) {
-        Box(
-            Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center,
+    val snackbarHostState = remember { SnackbarHostState() }
+    Scaffold(
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState)
+        }
+    ) { padding ->
+        Card(
+            shape = RoundedCornerShape(16.dp),
+            backgroundColor = MaterialTheme.colors.surface,
+            elevation = 4.dp,
+            modifier = Modifier.padding(16.dp),
         ) {
-            Column {
+            Column(
+                modifier = Modifier.padding(padding).fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
                 Text(
                     text = "Totals",
                     style = MaterialTheme.typography.h3,
@@ -52,6 +67,32 @@ fun WooPosTotalsScreen() {
                 ) {
                     Text("Collect Card Payment")
                 }
+            }
+        }
+    }
+    SnackbarHandler(state, snackbarHostState, viewModel)
+}
+
+@Composable
+private fun SnackbarHandler(
+    state: State<WooPosTotalsState>,
+    snackbarHostState: SnackbarHostState,
+    viewModel: WooPosTotalsViewModel
+) {
+    val snackbarState = state.value.snackbarMessage
+    if (snackbarState is SnackbarMessage.Triggered) {
+        val message = stringResource(snackbarState.message)
+        LaunchedEffect(state.value.snackbarMessage) {
+            val result = snackbarHostState.showSnackbar(
+                message = message,
+                duration = SnackbarDuration.Long,
+            )
+            when (result) {
+                SnackbarResult.Dismissed -> {
+                    viewModel.onUIEvent(WooPosTotalsUIEvent.SnackbarDismissed)
+                }
+
+                SnackbarResult.ActionPerformed -> Unit
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsState.kt
@@ -6,7 +6,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class WooPosTotalsState(
-    val orderId: Long?,
+    val orderId: Long? = null,
     val isCollectPaymentButtonEnabled: Boolean,
     var orderSubtotalText: String,
     var orderTaxText: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsState.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.totals
 
 import android.os.Parcelable
-import androidx.annotation.StringRes
+import com.woocommerce.android.ui.woopos.common.composeui.component.snackbar.WooPosSnackbarState
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -11,12 +11,6 @@ data class WooPosTotalsState(
     var orderSubtotalText: String,
     var orderTaxText: String,
     var orderTotalText: String,
-    val snackbarMessage: SnackbarMessage = SnackbarMessage.Hidden,
+    val snackbar: WooPosSnackbarState = WooPosSnackbarState.Hidden,
     val isLoading: Boolean,
 ) : Parcelable
-
-@Parcelize
-sealed class SnackbarMessage : Parcelable {
-    data class Triggered(@StringRes val message: Int) : SnackbarMessage()
-    data object Hidden : SnackbarMessage()
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsState.kt
@@ -12,7 +12,7 @@ data class WooPosTotalsState(
 ) : Parcelable
 
 @Parcelize
-sealed class SnackbarMessage: Parcelable {
+sealed class SnackbarMessage : Parcelable {
     data class Triggered(@StringRes val message: Int) : SnackbarMessage()
-    data object Hidden: SnackbarMessage()
+    data object Hidden : SnackbarMessage()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsState.kt
@@ -1,10 +1,18 @@
 package com.woocommerce.android.ui.woopos.home.totals
 
 import android.os.Parcelable
+import androidx.annotation.StringRes
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class WooPosTotalsState(
     val orderId: Long?,
     val isCollectPaymentButtonEnabled: Boolean,
+    val snackbarMessage: SnackbarMessage = SnackbarMessage.Hidden,
 ) : Parcelable
+
+@Parcelize
+sealed class SnackbarMessage: Parcelable {
+    data class Triggered(@StringRes val message: Int) : SnackbarMessage()
+    data object Hidden: SnackbarMessage()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsUIEvent.kt
@@ -2,4 +2,5 @@ package com.woocommerce.android.ui.woopos.home.totals
 
 sealed class WooPosTotalsUIEvent {
     data object CollectPaymentClicked : WooPosTotalsUIEvent()
+    data object SnackbarDismissed: WooPosTotalsUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsUIEvent.kt
@@ -2,5 +2,5 @@ package com.woocommerce.android.ui.woopos.home.totals
 
 sealed class WooPosTotalsUIEvent {
     data object CollectPaymentClicked : WooPosTotalsUIEvent()
-    data object SnackbarDismissed: WooPosTotalsUIEvent()
+    data object SnackbarDismissed : WooPosTotalsUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -5,8 +5,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderPaymentResult
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
@@ -29,7 +30,6 @@ class WooPosTotalsViewModel @Inject constructor(
     private val _state = savedState.getStateFlow(
         scope = viewModelScope,
         initialValue = WooPosTotalsState(
-            orderId = null,
             isCollectPaymentButtonEnabled = false,
             orderSubtotalText = "",
             orderTaxText = "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderPaymentResult
+import com.woocommerce.android.ui.woopos.common.composeui.component.snackbar.WooPosSnackbarState
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
 import com.woocommerce.android.util.CurrencyFormatter
@@ -54,7 +55,7 @@ class WooPosTotalsViewModel @Inject constructor(
                         // navigate to success screen
                     } else {
                         _state.value = state.value.copy(
-                            snackbarMessage = SnackbarMessage.Triggered(
+                            snackbar = WooPosSnackbarState.Triggered(
                                 R.string.woopos_payment_failed_please_try_again
                             )
                         )
@@ -64,7 +65,7 @@ class WooPosTotalsViewModel @Inject constructor(
 
             WooPosTotalsUIEvent.SnackbarDismissed ->
                 _state.value =
-                    state.value.copy(snackbarMessage = SnackbarMessage.Hidden)
+                    state.value.copy(snackbar = WooPosSnackbarState.Hidden)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -51,14 +51,17 @@ class WooPosTotalsViewModel @Inject constructor(
                 viewModelScope.launch {
                     val orderId = state.value.orderId!!
                     val result = cardReaderFacade.collectPayment(orderId)
-                    if (result is WooPosCardReaderPaymentResult.Success) {
-                        // navigate to success screen
-                    } else {
-                        _state.value = state.value.copy(
-                            snackbar = WooPosSnackbarState.Triggered(
-                                R.string.woopos_payment_failed_please_try_again
+                    when (result) {
+                        is WooPosCardReaderPaymentResult.Success -> {
+                            // navigate to success screen
+                        }
+                        is WooPosCardReaderPaymentResult.Failure-> {
+                            _state.value = state.value.copy(
+                                snackbar = WooPosSnackbarState.Triggered(
+                                    R.string.woopos_payment_failed_please_try_again
+                                )
                             )
-                        )
+                        }
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -4,7 +4,9 @@ import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderPaymentResult
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -37,8 +39,15 @@ class WooPosTotalsViewModel @Inject constructor(
                     val orderId = state.value.orderId!!
                     val result = cardReaderFacade.collectPayment(orderId)
                     Log.d("WooPosTotalsViewModel", "Payment result: $result")
+                    if (result is WooPosCardReaderPaymentResult.Success) {
+                        // TODO: navigate to success screen
+                    } else {
+                        _state.value = state.value.copy(snackbarMessage = SnackbarMessage.Triggered(R.string.woopos_payment_failed_please_try_again))
+                    }
                 }
             }
+
+            WooPosTotalsUIEvent.SnackbarDismissed -> _state.value = state.value.copy(snackbarMessage = SnackbarMessage.Hidden)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.woopos.home.totals
 
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -51,7 +50,6 @@ class WooPosTotalsViewModel @Inject constructor(
                 viewModelScope.launch {
                     val orderId = state.value.orderId!!
                     val result = cardReaderFacade.collectPayment(orderId)
-                    Log.d("WooPosTotalsViewModel", "Payment result: $result")
                     if (result is WooPosCardReaderPaymentResult.Success) {
                         // navigate to success screen
                     } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -55,7 +55,7 @@ class WooPosTotalsViewModel @Inject constructor(
                         is WooPosCardReaderPaymentResult.Success -> {
                             // navigate to success screen
                         }
-                        is WooPosCardReaderPaymentResult.Failure-> {
+                        is WooPosCardReaderPaymentResult.Failure -> {
                             _state.value = state.value.copy(
                                 snackbar = WooPosSnackbarState.Triggered(
                                     R.string.woopos_payment_failed_please_try_again

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -40,14 +40,20 @@ class WooPosTotalsViewModel @Inject constructor(
                     val result = cardReaderFacade.collectPayment(orderId)
                     Log.d("WooPosTotalsViewModel", "Payment result: $result")
                     if (result is WooPosCardReaderPaymentResult.Success) {
-                        // TODO: navigate to success screen
+                        // navigate to success screen
                     } else {
-                        _state.value = state.value.copy(snackbarMessage = SnackbarMessage.Triggered(R.string.woopos_payment_failed_please_try_again))
+                        _state.value = state.value.copy(
+                            snackbarMessage = SnackbarMessage.Triggered(
+                                R.string.woopos_payment_failed_please_try_again
+                            )
+                        )
                     }
                 }
             }
 
-            WooPosTotalsUIEvent.SnackbarDismissed -> _state.value = state.value.copy(snackbarMessage = SnackbarMessage.Hidden)
+            WooPosTotalsUIEvent.SnackbarDismissed ->
+                _state.value =
+                    state.value.copy(snackbarMessage = SnackbarMessage.Hidden)
         }
     }
 
@@ -56,7 +62,10 @@ class WooPosTotalsViewModel @Inject constructor(
             parentToChildrenEventReceiver.events.collect { event ->
                 when (event) {
                     is ParentToChildrenEvent.OrderDraftCreated -> {
-                        _state.value = state.value.copy(orderId = event.orderId, isCollectPaymentButtonEnabled = true)
+                        _state.value = state.value.copy(
+                            orderId = event.orderId,
+                            isCollectPaymentButtonEnabled = true
+                        )
                     }
 
                     else -> Unit

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4128,9 +4128,9 @@
     <string name="woo_pos_checkout_button">Checkout</string>
     <string name="woo_pos_remove_item_from_cart_content_description">Remove item from cart</string>
     <string name="woo_pos_car_pane_title">Cart</string>
-
     <string name="woopos_exit_confirmation_title">Exit POS</string>
     <string name="woopos_exit_confirmation_message">Are you sure you want to exit POS?</string>
     <string name="woopos_exit_confirmation_confirm_button">Exit</string>
     <string name="woopos_exit_confirmation_dismiss_button">Cancel</string>
+    <string name="woopos_payment_failed_please_try_again">Payment failed. Please try again.</string>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11725
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR propagates payment cancelation events to `WooPosCardReaderActivity`. Cancelation events from "card reader connection", and "card reader payment collection" states of the payment flow should now be correctly propagated to the WooPos mode, and a snack bar should be displayed informing about payment failure.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
1. It's crucial to verify there is no regression in the existing IPP flow:
* The happy path of the payment flow should remain unchanged
* Cancellation events should be handled correctly (navigate back to the "select payment method" screen)
2. In the WooPos mode whenever the payment flow is canceled a snackbar with an error message should appear on the screen. Using the "back" navigation user should return to the products and cart (Home) screen.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/4527432/23e662ee-d0c9-4cdb-9a5e-5a6a0d28c50a


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->