### PR TITLE
[HACK Week: Watch App] Introduce better products loading

### DIFF
--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/extensions/OrderEntityExt.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/extensions/OrderEntityExt.kt
@@ -27,7 +27,8 @@ fun WearOrder.toOrderEntity() = OrderEntity(
     total = total,
     status = status,
     billingFirstName = billingFirstName,
-    billingLastName = billingLastName
+    billingLastName = billingLastName,
+    lineItems = lineItemsJson
 )
 
 fun OrderAddress.Billing.toWearOrderAddress() = WearOrderAddress(

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/extensions/OrderEntityExt.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/extensions/OrderEntityExt.kt
@@ -15,7 +15,8 @@ fun OrderEntity.toWearOrder() = WearOrder(
     status = status,
     billingFirstName = billingFirstName,
     billingLastName = billingLastName,
-    address = getBillingAddress().toWearOrderAddress()
+    address = getBillingAddress().toWearOrderAddress(),
+    lineItemsJson = lineItems
 )
 
 fun WearOrder.toOrderEntity() = OrderEntity(

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/OrderItem.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/OrderItem.kt
@@ -1,9 +1,7 @@
 package com.woocommerce.android.model
 
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
-import java.math.BigDecimal
 import org.wordpress.android.fluxc.model.order.LineItem
+import java.math.BigDecimal
 
 data class OrderItem(
     val itemId: Long,
@@ -22,9 +20,3 @@ fun LineItem.toAppModel() = OrderItem(
     price = price?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
     total = total?.toBigDecimalOrNull() ?: BigDecimal.ZERO
 )
-
-fun String.fromJson(gson: Gson): List<OrderItem> {
-    val responseType = object : TypeToken<List<LineItem>>() {}.type
-    val items = gson.fromJson(this, responseType) as? List<LineItem> ?: emptyList()
-    return items.map { it.toAppModel() }
-}

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/OrderItem.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/OrderItem.kt
@@ -5,6 +5,7 @@ import org.wordpress.android.fluxc.model.order.LineItem
 
 data class OrderItem(
     val itemId: Long,
+    val name: String,
     val quantity: Float,
     val totalTax: BigDecimal,
     val price: BigDecimal,
@@ -13,6 +14,7 @@ data class OrderItem(
 
 fun LineItem.toAppModel() = OrderItem(
     itemId = id ?: 0L,
+    name = name.orEmpty(),
     quantity = quantity ?: 0F,
     totalTax = totalTax?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
     price = price?.toBigDecimalOrNull() ?: BigDecimal.ZERO,

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/OrderItem.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/OrderItem.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android.model
+
+import java.math.BigDecimal
+import org.wordpress.android.fluxc.model.order.LineItem
+
+data class OrderItem(
+    val itemId: Long,
+    val quantity: Float,
+    val totalTax: BigDecimal,
+    val price: BigDecimal,
+    val total: BigDecimal
+)
+
+fun LineItem.toAppModel() = OrderItem(
+    itemId = id ?: 0L,
+    quantity = quantity ?: 0F,
+    totalTax = totalTax?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+    price = price?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
+    total = total?.toBigDecimalOrNull() ?: BigDecimal.ZERO
+)

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/OrderItem.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/OrderItem.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.model
 
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import java.math.BigDecimal
 import org.wordpress.android.fluxc.model.order.LineItem
 
@@ -20,3 +22,9 @@ fun LineItem.toAppModel() = OrderItem(
     price = price?.toBigDecimalOrNull() ?: BigDecimal.ZERO,
     total = total?.toBigDecimalOrNull() ?: BigDecimal.ZERO
 )
+
+fun String.fromJson(gson: Gson): List<OrderItem> {
+    val responseType = object : TypeToken<List<LineItem>>() {}.type
+    val items = gson.fromJson(this, responseType) as? List<LineItem> ?: emptyList()
+    return items.map { it.toAppModel() }
+}

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/Refund.kt
@@ -1,11 +1,11 @@
 package com.woocommerce.android.model
 
 import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.model.refunds.WCRefundModel
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.util.Date
-import kotlinx.parcelize.Parcelize
-import org.wordpress.android.fluxc.model.refunds.WCRefundModel
 
 @Parcelize
 data class Refund(

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/Refund.kt
@@ -1,0 +1,112 @@
+package com.woocommerce.android.model
+
+import android.os.Parcelable
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.util.Date
+import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.model.refunds.WCRefundModel
+
+@Parcelize
+data class Refund(
+    val id: Long,
+    val dateCreated: Date,
+    val amount: BigDecimal,
+    val reason: String?,
+    val automaticGatewayRefund: Boolean,
+    val items: List<Item>,
+    val shippingLines: List<ShippingLine>,
+    val feeLines: List<FeeLine>,
+) : Parcelable {
+    @Parcelize
+    data class Item(
+        val productId: Long,
+        val quantity: Int,
+        val id: Long = 0,
+        val name: String = "",
+        val variationId: Long = 0,
+        val subtotal: BigDecimal = BigDecimal.ZERO,
+        val total: BigDecimal = BigDecimal.ZERO,
+        val totalTax: BigDecimal = BigDecimal.ZERO,
+        val sku: String = "",
+        val price: BigDecimal = BigDecimal.ZERO,
+        val orderItemId: Long = 0
+    ) : Parcelable
+
+    @Parcelize
+    data class ShippingLine(
+        val itemId: Long,
+        val methodId: String,
+        val methodTitle: String,
+        val totalTax: BigDecimal,
+        val total: BigDecimal
+    ) : Parcelable
+
+    @Parcelize
+    data class FeeLine(
+        val id: Long,
+        val name: String,
+        val totalTax: BigDecimal,
+        val total: BigDecimal,
+    ) : Parcelable
+
+    fun getRefundMethod(
+        paymentMethodTitle: String,
+        isCashPayment: Boolean,
+        defaultValue: String
+    ): String {
+        return when {
+            paymentMethodTitle.isBlank() -> defaultValue
+            automaticGatewayRefund || isCashPayment -> paymentMethodTitle
+            else -> "$defaultValue - $paymentMethodTitle"
+        }
+    }
+}
+
+fun WCRefundModel.toAppModel(): Refund {
+    return Refund(
+        id,
+        dateCreated,
+        amount,
+        reason,
+        automaticGatewayRefund,
+        items.map { it.toAppModel() },
+        shippingLineItems.map { it.toAppModel() },
+        feeLineItems.map { it.toAppModel() },
+    )
+}
+
+fun WCRefundModel.WCRefundItem.toAppModel(): Refund.Item {
+    return Refund.Item(
+        productId ?: -1,
+        -quantity, // WCRefundItem.quantity is NEGATIVE
+        itemId,
+        name ?: "",
+        variationId ?: -1,
+        -subtotal, // WCRefundItem.subtotal is NEGATIVE
+        -(total ?: BigDecimal.ZERO), // WCRefundItem.total is NEGATIVE
+        -totalTax, // WCRefundItem.totalTax is NEGATIVE
+        sku ?: "",
+        price ?: BigDecimal.ZERO,
+        metaData?.get(0)?.value?.toString()?.toLongOrNull() ?: -1
+    )
+}
+
+fun WCRefundModel.WCRefundShippingLine.toAppModel(): Refund.ShippingLine {
+    return Refund.ShippingLine(
+        itemId = metaData?.get(0)?.value?.toString()?.toLongOrNull() ?: -1,
+        methodId = methodId ?: "",
+        methodTitle = methodTitle ?: "",
+        totalTax = -totalTax, // WCRefundShippineLine.totalTax is NEGATIVE
+        total = (total) // WCREfundShippingLine.total is NEGATIVE
+    )
+}
+
+fun WCRefundModel.WCRefundFeeLine.toAppModel(): Refund.FeeLine {
+    return Refund.FeeLine(
+        id = metaData?.get(0)?.value?.toString()?.toLongOrNull() ?: -1,
+        name = name,
+        totalTax = -totalTax, // WCRefundFeeLine.totalTax is NEGATIVE
+        total = (total), // WCRefundFeeLine.total is NEGATIVE
+    )
+}

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/Refund.kt
@@ -14,9 +14,7 @@ data class Refund(
     val amount: BigDecimal,
     val reason: String?,
     val automaticGatewayRefund: Boolean,
-    val items: List<Item>,
-    val shippingLines: List<ShippingLine>,
-    val feeLines: List<FeeLine>,
+    val items: List<Item>
 ) : Parcelable {
     @Parcelize
     data class Item(
@@ -32,35 +30,6 @@ data class Refund(
         val price: BigDecimal = BigDecimal.ZERO,
         val orderItemId: Long = 0
     ) : Parcelable
-
-    @Parcelize
-    data class ShippingLine(
-        val itemId: Long,
-        val methodId: String,
-        val methodTitle: String,
-        val totalTax: BigDecimal,
-        val total: BigDecimal
-    ) : Parcelable
-
-    @Parcelize
-    data class FeeLine(
-        val id: Long,
-        val name: String,
-        val totalTax: BigDecimal,
-        val total: BigDecimal,
-    ) : Parcelable
-
-    fun getRefundMethod(
-        paymentMethodTitle: String,
-        isCashPayment: Boolean,
-        defaultValue: String
-    ): String {
-        return when {
-            paymentMethodTitle.isBlank() -> defaultValue
-            automaticGatewayRefund || isCashPayment -> paymentMethodTitle
-            else -> "$defaultValue - $paymentMethodTitle"
-        }
-    }
 }
 
 fun WCRefundModel.toAppModel(): Refund {
@@ -70,9 +39,7 @@ fun WCRefundModel.toAppModel(): Refund {
         amount,
         reason,
         automaticGatewayRefund,
-        items.map { it.toAppModel() },
-        shippingLineItems.map { it.toAppModel() },
-        feeLineItems.map { it.toAppModel() },
+        items.map { it.toAppModel() }
     )
 }
 
@@ -89,25 +56,6 @@ fun WCRefundModel.WCRefundItem.toAppModel(): Refund.Item {
         sku ?: "",
         price ?: BigDecimal.ZERO,
         metaData?.get(0)?.value?.toString()?.toLongOrNull() ?: -1
-    )
-}
-
-fun WCRefundModel.WCRefundShippingLine.toAppModel(): Refund.ShippingLine {
-    return Refund.ShippingLine(
-        itemId = metaData?.get(0)?.value?.toString()?.toLongOrNull() ?: -1,
-        methodId = methodId ?: "",
-        methodTitle = methodTitle ?: "",
-        totalTax = -totalTax, // WCRefundShippineLine.totalTax is NEGATIVE
-        total = (total) // WCREfundShippingLine.total is NEGATIVE
-    )
-}
-
-fun WCRefundModel.WCRefundFeeLine.toAppModel(): Refund.FeeLine {
-    return Refund.FeeLine(
-        id = metaData?.get(0)?.value?.toString()?.toLongOrNull() ?: -1,
-        name = name,
-        totalTax = -totalTax, // WCRefundFeeLine.totalTax is NEGATIVE
-        total = (total), // WCRefundFeeLine.total is NEGATIVE
     )
 }
 

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/Refund.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/model/Refund.kt
@@ -148,11 +148,3 @@ fun List<Refund>.getMaxRefundQuantities(
     }
     return map
 }
-
-data class OrderItem(
-    val itemId: Long,
-    val quantity: Float,
-    val totalTax: BigDecimal,
-    val price: BigDecimal,
-    val total: BigDecimal
-)

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersRepository.kt
@@ -23,9 +23,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCRefundStore
 import org.wordpress.android.fluxc.store.WCWearableStore
 import javax.inject.Inject
-import org.wordpress.android.fluxc.store.WCRefundStore
 
 class OrdersRepository @Inject constructor(
     @DataStoreQualifier(DataStoreType.ORDERS) private val ordersDataStore: DataStore<Preferences>,

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersRepository.kt
@@ -64,6 +64,12 @@ class OrdersRepository @Inject constructor(
         orderId = orderId
     )
 
+    fun getOrderRefunds(
+        selectedSite: SiteModel,
+        orderId: Long
+    ) = refundStore.getAllRefunds(selectedSite, orderId)
+        .map { it.toAppModel() }
+
     fun observeOrdersDataChanges(
         selectedSite: SiteModel
     ) = orderStore.observeOrdersForSite(selectedSite)

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersRepository.kt
@@ -52,6 +52,13 @@ class OrdersRepository @Inject constructor(
         ?.map { it.toAppModel() }
         ?: emptyList()
 
+    suspend fun fetchSingleOrder(
+        selectedSite: SiteModel,
+        orderId: Long
+    ) = orderStore.fetchSingleOrder(selectedSite, orderId)
+        .takeUnless { it.isError }
+        ?.let { getOrderFromId(selectedSite, orderId) }
+
     suspend fun getStoredOrders(
         selectedSite: SiteModel
     ) = orderStore.getOrdersForSite(selectedSite)

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersRepository.kt
@@ -52,13 +52,6 @@ class OrdersRepository @Inject constructor(
         ?.map { it.toAppModel() }
         ?: emptyList()
 
-    suspend fun fetchSingleOrder(
-        selectedSite: SiteModel,
-        orderId: Long
-    ) = orderStore.fetchSingleOrder(selectedSite, orderId)
-        .takeUnless { it.isError }
-        ?.let { getOrderFromId(selectedSite, orderId) }
-
     suspend fun getStoredOrders(
         selectedSite: SiteModel
     ) = orderStore.getOrdersForSite(selectedSite)

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/OrdersRepository.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.datastore.DataStoreType
 import com.woocommerce.android.extensions.getSiteId
 import com.woocommerce.android.extensions.toOrderEntity
 import com.woocommerce.android.extensions.toWearOrder
+import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.ui.login.LoginRepository
 import com.woocommerce.commons.DataParameters.ORDERS_JSON
 import com.woocommerce.commons.DataParameters.ORDER_ID
@@ -24,12 +25,14 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCWearableStore
 import javax.inject.Inject
+import org.wordpress.android.fluxc.store.WCRefundStore
 
 class OrdersRepository @Inject constructor(
     @DataStoreQualifier(DataStoreType.ORDERS) private val ordersDataStore: DataStore<Preferences>,
     private val loginRepository: LoginRepository,
     private val wearableStore: WCWearableStore,
-    private val orderStore: WCOrderStore
+    private val orderStore: WCOrderStore,
+    private val refundStore: WCRefundStore
 ) {
     private val gson by lazy { Gson() }
 
@@ -39,6 +42,15 @@ class OrdersRepository @Inject constructor(
         site = selectedSite,
         shouldStoreData = true
     )
+
+    suspend fun fetchOrderRefunds(
+        selectedSite: SiteModel,
+        orderId: Long
+    ) = refundStore.fetchAllRefunds(selectedSite, orderId)
+        .takeUnless { it.isError }
+        ?.model
+        ?.map { it.toAppModel() }
+        ?: emptyList()
 
     suspend fun getStoredOrders(
         selectedSite: SiteModel

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/details/FetchOrderProducts.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/details/FetchOrderProducts.kt
@@ -15,9 +15,9 @@ import com.woocommerce.commons.MessagePath.REQUEST_ORDER_PRODUCTS
 import com.woocommerce.commons.WearOrderedProduct
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flow
 import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
-import kotlinx.coroutines.flow.flow
 
 class FetchOrderProducts @Inject constructor(
     private val phoneRepository: PhoneConnectionRepository,
@@ -68,10 +68,10 @@ class FetchOrderProducts @Inject constructor(
     private suspend fun retrieveOrderLineItems(
         selectedSite: SiteModel,
         orderId: Long
-    ) = (ordersRepository.getOrderFromId(selectedSite, orderId)
+    ) = ordersRepository.getOrderFromId(selectedSite, orderId)
         ?.getLineItemList()
         ?.map { it.toAppModel() }
-        ?: emptyList())
+        ?: emptyList()
 
     private fun List<Refund>.asWearOrderedProducts(
         orderItems: List<OrderItem>

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/details/FetchOrderProducts.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/details/FetchOrderProducts.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.orders.details
 
 import com.woocommerce.android.extensions.combineWithTimeout
+import com.woocommerce.android.model.getNonRefundedProducts
 import com.woocommerce.android.phone.PhoneConnectionRepository
+import com.woocommerce.android.system.NetworkStatus
 import com.woocommerce.android.ui.orders.OrdersRepository
 import com.woocommerce.android.ui.orders.details.FetchOrderProducts.OrderProductsRequest.Error
 import com.woocommerce.android.ui.orders.details.FetchOrderProducts.OrderProductsRequest.Finished
@@ -13,25 +15,18 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flowOf
 import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.flow
 
 class FetchOrderProducts @Inject constructor(
     private val phoneRepository: PhoneConnectionRepository,
-    private val ordersRepository: OrdersRepository
+    private val ordersRepository: OrdersRepository,
+    private val networkStatus: NetworkStatus
 ) {
     suspend operator fun invoke(
         selectedSite: SiteModel,
         orderId: Long
     ): Flow<OrderProductsRequest> {
-        if (phoneRepository.isPhoneConnectionAvailable().not()) {
-            return flowOf(Error)
-        }
-
-        phoneRepository.sendMessage(
-            REQUEST_ORDER_PRODUCTS,
-            orderId.toString().toByteArray()
-        )
-
-        return ordersRepository.observeOrderProductsDataChanges(orderId, selectedSite.siteId)
+        return selectDataSource(selectedSite, orderId)
             .combineWithTimeout(TIMEOUT_FOR_ORDER_PRODUCTS) { orderProducts, isTimeout ->
                 when {
                     orderProducts.isNotEmpty() -> Finished(orderProducts)
@@ -39,6 +34,33 @@ class FetchOrderProducts @Inject constructor(
                     else -> Error
                 }
             }.filterNotNull()
+    }
+
+    private suspend fun selectDataSource(
+        selectedSite: SiteModel,
+        orderId: Long
+    ): Flow<List<WearOrderedProduct>> {
+        return when {
+            networkStatus.isConnected() -> flow {
+                ordersRepository.fetchOrderRefunds(selectedSite, orderId)
+                    .getNonRefundedProducts(emptyList())
+                    .map {
+                        WearOrderedProduct(
+                            amount = it.quantity.toString(),
+                            total = it.total.toString(),
+                            name = it.name
+                        )
+                    }
+            }
+            phoneRepository.isPhoneConnectionAvailable() -> {
+                phoneRepository.sendMessage(
+                    REQUEST_ORDER_PRODUCTS,
+                    orderId.toString().toByteArray()
+                )
+                ordersRepository.observeOrderProductsDataChanges(orderId, selectedSite.siteId)
+            }
+            else -> flowOf(emptyList()) // Retrieve stored data instead
+        }
     }
 
     sealed class OrderProductsRequest {

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/details/FetchOrderProducts.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/details/FetchOrderProducts.kt
@@ -58,7 +58,7 @@ class FetchOrderProducts @Inject constructor(
         selectedSite: SiteModel,
         orderId: Long
     ) = flow<List<WearOrderedProduct>> {
-        val orderItems = ordersRepository.getOrderFromId(selectedSite, orderId)
+        val orderItems = ordersRepository.fetchSingleOrder(selectedSite, orderId)
             ?.getLineItemList()
             ?.map { it.toAppModel() }
             ?: emptyList()

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/details/FetchOrderProducts.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/details/FetchOrderProducts.kt
@@ -58,7 +58,7 @@ class FetchOrderProducts @Inject constructor(
         selectedSite: SiteModel,
         orderId: Long
     ) = flow<List<WearOrderedProduct>> {
-        val orderItems = ordersRepository.fetchSingleOrder(selectedSite, orderId)
+        val orderItems = ordersRepository.getOrderFromId(selectedSite, orderId)
             ?.getLineItemList()
             ?.map { it.toAppModel() }
             ?: emptyList()

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/details/FetchOrderProducts.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/ui/orders/details/FetchOrderProducts.kt
@@ -46,6 +46,7 @@ class FetchOrderProducts @Inject constructor(
             networkStatus.isConnected() -> flow {
                 ordersRepository.fetchOrderRefunds(selectedSite, orderId)
                     .asWearOrderedProducts(retrieveOrderLineItems(selectedSite, orderId))
+                    .let { emit(it) }
             }
 
             phoneRepository.isPhoneConnectionAvailable() -> {
@@ -59,6 +60,7 @@ class FetchOrderProducts @Inject constructor(
             else -> flow {
                 ordersRepository.getOrderRefunds(selectedSite, orderId)
                     .asWearOrderedProducts(retrieveOrderLineItems(selectedSite, orderId))
+                    .let { emit(it) }
             }
         }
     }
@@ -88,6 +90,6 @@ class FetchOrderProducts @Inject constructor(
     }
 
     companion object {
-        const val TIMEOUT_FOR_ORDER_PRODUCTS = 5000L
+        const val TIMEOUT_FOR_ORDER_PRODUCTS = 10000L
     }
 }

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/orders/details/FetchOrderProductsTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/ui/orders/details/FetchOrderProductsTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -39,8 +40,10 @@ class FetchOrderProductsTest : BaseUnitTest() {
     @Test
     fun `returns Error when phone connection is not available`() = testBlocking {
         whenever(phoneRepository.isPhoneConnectionAvailable()).thenReturn(false)
+        whenever(ordersRepository.getOrderFromId(selectedSite, 1L)).thenReturn(null)
+        whenever(ordersRepository.getOrderRefunds(selectedSite, 1L)).thenReturn(emptyList())
 
-        val result = sut.invoke(selectedSite, 1L).first()
+        val result = sut.invoke(selectedSite, 1L).last()
 
         assertThat(result).isEqualTo(OrderProductsRequest.Error)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/GetWearableOrderProducts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/GetWearableOrderProducts.kt
@@ -12,7 +12,7 @@ class GetWearableOrderProducts @Inject constructor(
         orderId: Long
     ): List<WearOrderedProduct> {
         val orderItems = orderDetailRepository
-            .fetchOrderById(orderId)?.items
+            .getOrderById(orderId)?.items
             ?: return emptyList()
 
         return orderDetailRepository.getOrderRefunds(orderId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/wear/WearableConnectionRepository.kt
@@ -124,7 +124,8 @@ class WearableConnectionRepository @Inject constructor(
                 total = it.total,
                 billingFirstName = it.billingFirstName,
                 billingLastName = it.billingLastName,
-                address = orderAddress
+                address = orderAddress,
+                lineItemsJson = it.lineItems
             )
         }
 

--- a/libs/commons/src/main/java/com/woocommerce/commons/WearSharedModels.kt
+++ b/libs/commons/src/main/java/com/woocommerce/commons/WearSharedModels.kt
@@ -9,7 +9,8 @@ data class WearOrder(
     val status: String,
     val billingFirstName: String,
     val billingLastName: String,
-    val address: WearOrderAddress
+    val address: WearOrderAddress,
+    val lineItemsJson: String
 )
 
 data class WearOrderedProduct(


### PR DESCRIPTION
Summary
==========
Improve how the Products from an Order are retrieved. Instead of relying exclusively on the phone to acquire the data, it's now capable of fetching it by itself and only requesting from the phone when there's no network available.

It also improves how the Phone fetches the ordered products to use the cache for better overall performance.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.