### PR TITLE
Remove ternary usage from Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1130,7 +1130,13 @@ platform :android do
     )
 
     install_url = "#{PROTOTYPE_BUILD_DOMAIN}/#{upload_path}"
-    platform_name = app == WEAR_APP ? '⌚️ Wear OS' : app == MOBILE_APP ? '📱 Mobile' : '_(Unknown)_'
+    platform_name = if app == WEAR_APP
+                      '⌚️ Wear OS'
+                    elsif app == MOBILE_APP
+                      '📱 Mobile'
+                    else
+                      '_(Unknown)_'
+                    end
     comment_body = prototype_build_details_comment(
       app_display_name: "#{app} Android",
       download_url: install_url,


### PR DESCRIPTION
# Summary

A quick lint fix for the Fastlane file causing an error from the Danger bot

<img width="1485" alt="image" src="https://github.com/woocommerce/woocommerce-android/assets/5920403/739e1364-a979-49b4-b89a-ce2285e6d0f3">