### PR TITLE
Fetch only simple products in the POS mode

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsDataSource.kt
@@ -5,6 +5,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface WooPosProductsDataSource {
     val products: Flow<List<Product>>
-    suspend fun loadProducts()
+    suspend fun loadSimpleProducts()
     suspend fun loadMore()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsDataSourceImpl.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsDataSourceImpl.kt
@@ -1,16 +1,21 @@
 package com.woocommerce.android.ui.woopos.home.products
 
 import com.woocommerce.android.model.Product
+import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.selector.ProductListHandler
 import kotlinx.coroutines.flow.Flow
+import org.wordpress.android.fluxc.store.WCProductStore
 import javax.inject.Inject
 
 class WooPosProductsDataSourceImpl @Inject constructor(private val handler: ProductListHandler) :
     WooPosProductsDataSource {
     override val products: Flow<List<Product>> = handler.productsFlow
 
-    override suspend fun loadProducts() {
-        handler.loadFromCacheAndFetch(searchType = ProductListHandler.SearchType.DEFAULT)
+    override suspend fun loadSimpleProducts() {
+        handler.loadFromCacheAndFetch(
+            searchType = ProductListHandler.SearchType.DEFAULT,
+            filters = mapOf(WCProductStore.ProductFilterOption.TYPE to ProductType.SIMPLE.value)
+        )
     }
 
     override suspend fun loadMore() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsViewModel.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.woopos.home.products
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -26,7 +25,7 @@ class WooPosProductsViewModel @Inject constructor(
     val viewState: StateFlow<WooPosProductsViewState> =
         productsDataSource.products
             .map {
-                it.filter { product -> product.productType == ProductType.SIMPLE && product.price != null }
+                it.filter { product -> product.price != null }
             }
             .map { products ->
                 calculateViewState(products)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsViewModel.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -35,7 +34,7 @@ class WooPosProductsViewModel @Inject constructor(
 
     init {
         launch {
-            productsDataSource.loadProducts()
+            productsDataSource.loadSimpleProducts()
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11757 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates the logic for fetching products in the POS mode. Instead of fetching all products and filter out non-simple products locally, we are now fetching only Simple products from the remote.

This approach avoids scenarios in which we'd for example fetch first 25 products all of which would be non-simple products. As a side benefit, it minimizes the data transfered over network.


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Empty Products Table
1. Ensure the Products table is empty (eg. using Flipper)
2. Enter the POS Mode
3. Notice only Simple products are fetched from the remote (use an inspector in AS or Flipper or similar)
4. Notice only Simple products are displayed on the UI.
5. Exit the POS mode
6. Go to Product List
7. Notice non-simple products are added to the list
8. Go back to the POS mode and make sure only simple Products are displayed


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No UI facing changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->11757