### PR TITLE
Issue/11381 update variation name in order creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableGroupedProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableGroupedProductCard.kt
@@ -60,7 +60,7 @@ import com.woocommerce.android.ui.orders.creation.OrderCreationProduct
 import com.woocommerce.android.ui.orders.creation.ProductInfo
 import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.ui.products.ProductType
-import com.woocommerce.android.util.getStockText
+import com.woocommerce.android.util.getVariationAttributesAndStockText
 import java.math.BigDecimal
 
 @Composable
@@ -290,7 +290,7 @@ fun ExpandableChildrenProductCard(
             color = MaterialTheme.colors.onSurface
         )
         Text(
-            text = product.getStockText(LocalContext.current),
+            text = product.getVariationAttributesAndStockText(LocalContext.current),
             modifier = Modifier
                 .constrainAs(stock) {
                     start.linkTo(name.start)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -86,7 +86,7 @@ import com.woocommerce.android.ui.orders.creation.ProductInfo
 import com.woocommerce.android.ui.orders.creation.isSynced
 import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.ui.products.ProductType
-import com.woocommerce.android.util.getStockText
+import com.woocommerce.android.util.getVariationAttributesAndStockText
 import java.math.BigDecimal
 
 const val ANIM_DURATION_MILLIS = 128
@@ -158,7 +158,7 @@ fun ExpandableProductCard(
             color = MaterialTheme.colors.onSurface
         )
         Text(
-            text = product.getStockText(LocalContext.current),
+            text = product.getVariationAttributesAndStockText(LocalContext.current),
             modifier = Modifier
                 .constrainAs(stock) {
                     start.linkTo(name.start)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ProductUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ProductUtils.kt
@@ -86,3 +86,10 @@ private fun getInStockText(
         else -> getString(R.string.product_stock_status_instock, null)
     }
 }
+
+fun OrderCreationProduct.getVariationAttributesAndStockText(context: Context): String {
+    return buildString {
+        append(item.attributesDescription.takeIf { it.isNotEmpty() }?.let { "$it \u2981 " } ?: StringUtils.EMPTY)
+        append(getStockText(context))
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11381 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR brings consistency with the iOS app - we show selected variation attributes on variable item in the order creation (see images below).



### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Test Variable Product
1. Tap on the plus sign icon on the order list
2. Tap on 'Add Product'
3. Add a variable product into the order
4. Notice the product row contains information about the selected variation.

Test Bundled Product With Variable Product
1. Tap on the plus sign icon on the order list
2. Tap on 'Add Product'
3. Add a bundled product which contains a variable product into the order
4. Notice the product row contains information about the selected variation.
 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| x | Before  | After  |
|---|---|---|
|  Variable | <img width="200" alt="Screenshot 2024-06-21 at 10 44 36" src="https://github.com/woocommerce/woocommerce-android/assets/2261188/756d66f6-81ce-4670-a379-19b98ef89d97"> | <img width="200" alt="Screenshot 2024-06-21 at 10 44 36" src="https://github.com/woocommerce/woocommerce-android/assets/2261188/89da2a88-929f-44bd-914c-9f2fc7071fab"> |
|  Bundled | <img width="200" alt="Screenshot 2024-06-21 at 10 44 06" src="https://github.com/woocommerce/woocommerce-android/assets/2261188/afbdb2ef-1d24-405e-ac43-abb9e02a2ad1"> | <img width="200" alt="Screenshot 2024-06-21 at 10 53 58" src="https://github.com/woocommerce/woocommerce-android/assets/2261188/d3f31f84-cead-4a87-849d-aebe090b33c2"> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->381