### PR TITLE
[Tooling] Fix outdated changelogs removal logic

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1225,7 +1225,7 @@ platform :android do
   def delete_old_changelogs
     obsolete_changelogs = [MOBILE_APP, WEAR_APP].flat_map do |app|
       Dir.glob(File.join(METADATA_DIR_PATH[app], '*', 'changelogs', 'default.txt'))
-         .reject { |file| File.dirname(file, 2) == 'en-US' }
+         .reject { |file| File.basename(File.dirname(file, 2)) == 'en-US' }
     end
     FileUtils.rm_f(obsolete_changelogs)
     obsolete_changelogs

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,0 +1,1 @@
+Now, seamlessly sync with our new WearOS app for instant updates on store data and orders. Plus, enjoy added flexibility with edit support for Min/Max Quantities directly from product details. Update your WooCommerce app now for a seamless and enhanced experience!

--- a/fastlane/metadata/wear/en-US/changelogs/default.txt
+++ b/fastlane/metadata/wear/en-US/changelogs/default.txt
@@ -1,0 +1,1 @@
+Introduces the new Woo WearOS app featuring instant updates on store data and orders at glance!


### PR DESCRIPTION
Adding back the `fastlane/metadata/*/en-US/changelogs/default.txt` files and fixing the Fastlane logic that tries to remove instead of keeping them.