### PR TITLE
[Tooling] Ruby-fy `send_strings_for_translation` & `commit_strings` lanes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -714,17 +714,14 @@ platform :android do
 
   #####################################################################################
   # localize_libs
-  # -----------------------------------------------------------------------------------
-  # This lane gets the data from the dependencies and updates the main strings.xml file
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  # fastlane localize_libs
   #
-  # Example:
-  # fastlane localize_libs
-  #####################################################################################
+  # This lane gets the data from the dependencies and updates the main `strings.xml` file,
+  # so that they are included when that file is sent to GlotPress for translation.
+  #
+  # @example fastlane localize_libs
+  #
   desc 'Merge libraries strings files into the main app one'
-  lane :localize_libs do |options|
+  lane :localize_libs do
     REMOTE_LIBRARIES_STRINGS_PATHS.each do |lib|
       download_path = android_download_file_by_version(
         library_name: lib[:name],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -754,7 +754,7 @@ platform :android do
     end
 
     is_repo_clean = `git status --porcelain`.empty?
-    commit_strings(options) unless is_repo_clean
+    commit_strings(auto_commit: options[:auto_commit]) unless is_repo_clean
   end
 
   # This lane downloads the translated metadata (release notes, app store strings, title, etc.) from GlotPress and updates the local files.
@@ -808,19 +808,6 @@ platform :android do
   ########################################################################
   # Helper Lanes
   ########################################################################
-  private_lane :commit_strings do |options|
-    if options[:auto_commit]
-      git_add(path: MAIN_STRINGS_PATH)
-      git_commit(
-        path: MAIN_STRINGS_PATH,
-        message: 'Update strings for translation',
-        allow_nothing_to_commit: true
-      )
-    else
-      UI.important("Your #{MAIN_STRINGS_PATH} has changed.")
-      UI.input('Please, review the changes, commit them and press return to continue.')
-    end
-  end
 
   #####################################################################################
   # build_bundle
@@ -858,6 +845,7 @@ platform :android do
     end
     artifact_final_path
   end
+
   #####################################################################################
   # screenshots
   # -----------------------------------------------------------------------------------
@@ -1155,11 +1143,37 @@ platform :android do
     )
   end
 
-  private_lane :freeze_strings_for_translation do
-    # A WPCOM job is responsible to import the file at path `FROZEN_STRINGS_PATH` into GlotPress
-    # If you decide to change the path to `FROZEN_STRINGS_PATH` at some point, ensure you also update
-    # https://opengrok.a8c.com/source/xref/wpcom/bin/i18n/import-github-originals.php?r=accd6334#33
+  # Commits the changes to the original English `strings.xml` file,
+  # typically after having called `localize_libs` to include translations from libraries in it
+  #
+  # @param [Boolean] auto_commit If true, will actually create the git commit.
+  #                              If false, will simply print a message suggesting to review changes
+  #
+  private_lane :commit_strings do |auto_commit: true|
+    if auto_commit
+      git_add(path: MAIN_STRINGS_PATH)
+      git_commit(
+        path: MAIN_STRINGS_PATH,
+        message: 'Update strings for translation',
+        allow_nothing_to_commit: true
+      )
+    else
+      UI.important("Your #{MAIN_STRINGS_PATH} has changed.")
+      UI.input('Please, review the changes, commit them and press return to continue.')
+    end
+  end
 
+  # Copy the original English `strings.xml` file into the location from where the WPCOM job will pick them
+  #
+  # The reason for the WPCOM job to import the file from `FROZEN_STRINGS_PATH` and not `MAIN_STRINGS_PATH` is so
+  # that it picks the file's content as it was at the time of code freeze, and does not risk picking up changes
+  # that could be made to the `MAIN_STRINGS_PATH` file on `trunk` _after_ code freeze, by devs working on features.
+  #
+  # A WPCOM job is responsible to import the `FROZEN_STRINGS_PATH` file into GlotPress (as opposed to e.g. us sending them via API).
+  # Note: If you decide to change the path to `FROZEN_STRINGS_PATH` at some point, ensure you also update it in the WPCOM job:
+  #       https://opengrok.a8c.com/source/xref/wpcom/bin/i18n/import-github-originals.php?r=accd6334#33
+  #
+  private_lane :freeze_strings_for_translation do
     FileUtils.mkdir_p(File.dirname(FROZEN_STRINGS_PATH))
     FileUtils.cp(MAIN_STRINGS_PATH, FROZEN_STRINGS_PATH)
     git_add(path: FROZEN_STRINGS_PATH)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,7 +41,7 @@ DEV_RELEASE_NOTES_PATH = {
 RAW_SCREENSHOTS_DIR = File.join(Dir.pwd, 'screenshots', 'raw')
 RAW_SCREENSHOTS_PROCESSING_DIR = File.join(Dir.pwd, 'screenshots', 'raw_tmp')
 PROMO_SCREENSHOTS_DIR = File.join(Dir.pwd, 'screenshots', 'promo_screenshots')
-FROZEN_STRINGS_DIR_PATH = File.join(Dir.pwd, 'resources', 'values')
+FROZEN_STRINGS_PATH = File.join(Dir.pwd, 'resources', 'values', 'strings.xml')
 REMOTE_LIBRARIES_STRINGS_PATHS = [
   {
     name: 'Login Library',
@@ -1153,9 +1153,19 @@ platform :android do
   end
 
   private_lane :send_strings_for_translation do
-    sh("cd .. && mkdir -p #{FROZEN_STRINGS_DIR_PATH} && cp #{MAIN_STRINGS_PATH} #{FROZEN_STRINGS_DIR_PATH} && git add #{FROZEN_STRINGS_DIR_PATH}/strings.xml")
-    sh('git diff-index --quiet HEAD || git commit -m "Send strings to translation."')
-    sh('git push origin HEAD')
+    # A WPCOM job is responsible to import the file at path `FROZEN_STRINGS_PATH` into GlotPress
+    # If you decide to change the path to `FROZEN_STRINGS_PATH` at some point, ensure you also update
+    # https://opengrok.a8c.com/source/xref/wpcom/bin/i18n/import-github-originals.php?r=accd6334#33
+
+    FileUtils.mkdir_p(File.dirname(FROZEN_STRINGS_PATH))
+    FileUtils.cp(MAIN_STRINGS_PATH, FROZEN_STRINGS_PATH)
+    git_add(path: FROZEN_STRINGS_PATH)
+    git_commit(
+      path: FROZEN_STRINGS_PATH,
+      message: 'Send strings to translation.',
+      allow_nothing_to_commit: true
+    )
+    push_to_git_remote(tags: false)
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -753,8 +753,11 @@ platform :android do
       end
     end
 
-    is_repo_clean = `git status --porcelain`.empty?
-    commit_strings(auto_commit: options[:auto_commit]) unless is_repo_clean
+    git_commit(
+      path: MAIN_STRINGS_PATH,
+      message: 'Include lib strings for translation',
+      allow_nothing_to_commit: true
+    )
   end
 
   # This lane downloads the translated metadata (release notes, app store strings, title, etc.) from GlotPress and updates the local files.
@@ -1143,26 +1146,6 @@ platform :android do
     )
   end
 
-  # Commits the changes to the original English `strings.xml` file,
-  # typically after having called `localize_libs` to include translations from libraries in it
-  #
-  # @param [Boolean] auto_commit If true, will actually create the git commit.
-  #                              If false, will simply print a message suggesting to review changes
-  #
-  private_lane :commit_strings do |auto_commit: true|
-    if auto_commit
-      git_add(path: MAIN_STRINGS_PATH)
-      git_commit(
-        path: MAIN_STRINGS_PATH,
-        message: 'Update strings for translation',
-        allow_nothing_to_commit: true
-      )
-    else
-      UI.important("Your #{MAIN_STRINGS_PATH} has changed.")
-      UI.input('Please, review the changes, commit them and press return to continue.')
-    end
-  end
-
   # Copy the original English `strings.xml` file into the location from where the WPCOM job will pick them
   #
   # The reason for the WPCOM job to import the file from `FROZEN_STRINGS_PATH` and not `MAIN_STRINGS_PATH` is so
@@ -1179,7 +1162,7 @@ platform :android do
     git_add(path: FROZEN_STRINGS_PATH)
     git_commit(
       path: FROZEN_STRINGS_PATH,
-      message: 'Freeze strings for translation.',
+      message: 'Freeze strings for translation',
       allow_nothing_to_commit: true
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1179,7 +1179,7 @@ platform :android do
     git_add(path: FROZEN_STRINGS_PATH)
     git_commit(
       path: FROZEN_STRINGS_PATH,
-      message: 'Send strings to translation.',
+      message: 'Freeze strings for translation.',
       allow_nothing_to_commit: true
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -810,9 +810,13 @@ platform :android do
   ########################################################################
   private_lane :commit_strings do |options|
     if options[:auto_commit]
-      sh("cd .. && git add #{MAIN_STRINGS_PATH}")
-      sh("git commit -m 'Update strings for translation'")
-      sh('git push origin HEAD')
+      git_add(path: MAIN_STRINGS_PATH)
+      git_commit(
+        path: MAIN_STRINGS_PATH,
+        message: 'Update strings for translation',
+        allow_nothing_to_commit: true
+      )
+      push_to_git_remote
     else
       UI.important("Your #{MAIN_STRINGS_PATH} has changed.")
       UI.input('Please, review the changes, commit them and press return to continue.')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -200,7 +200,7 @@ platform :android do
 
     update_play_store_strings
     localize_libs
-    send_strings_for_translation
+    freeze_strings_for_translation
 
     push_to_git_remote(tags: false)
 
@@ -816,7 +816,6 @@ platform :android do
         message: 'Update strings for translation',
         allow_nothing_to_commit: true
       )
-      push_to_git_remote
     else
       UI.important("Your #{MAIN_STRINGS_PATH} has changed.")
       UI.input('Please, review the changes, commit them and press return to continue.')
@@ -1156,7 +1155,7 @@ platform :android do
     )
   end
 
-  private_lane :send_strings_for_translation do
+  private_lane :freeze_strings_for_translation do
     # A WPCOM job is responsible to import the file at path `FROZEN_STRINGS_PATH` into GlotPress
     # If you decide to change the path to `FROZEN_STRINGS_PATH` at some point, ensure you also update
     # https://opengrok.a8c.com/source/xref/wpcom/bin/i18n/import-github-originals.php?r=accd6334#33
@@ -1169,7 +1168,6 @@ platform :android do
       message: 'Send strings to translation.',
       allow_nothing_to_commit: true
     )
-    push_to_git_remote(tags: false)
   end
 
   #####################################################################################


### PR DESCRIPTION
### Description

I noticed that the `send_strings_for_translation` and `commit_strings` lanes were written by calling `sh` directly to run some `mkdir`+`cp`+`git add` + `git commit` commands.

 - This PR replaces it with more idiomatic approach using Ruby code (`FileUtils.mkdir_p`, `FileUtils.cp`, fastlane's `git_add` and `git_commit` actions) for readability and consistency.
 - It also stops making those lanes do the `git push`, since the only caller of those helper lanes—which is `complete_code_freeze` lane—ends up already calling `push_to_git_remote` after calling those two.
 - It also now enables `auto_commit:true` by default on `commit_strings` lane, while I noticed that it was not on by default when called from `complete_code_freeze`->`localize_libs`->`commit_strings`, which could have led to CI job failing because CI is not interactive, while `complete_code_freeze` is now run from CI and not from RM's Macs anymore
 - Finally I renamed `send_strings_for_translation` to `freeze_strings_for_translation` so its name would be more accurate, and added some comments about how the WPCOM job is pulling those into GlotPress.

### Testing

 - Cut a testing branch from this PR's head branch, `git push -u` it (tracking it so it'd be easier to delete it from remote alongside the local branch at the end of the test)
 - Testing `commit_strings`:
    - Make dummy changes to the `values/strings.xml` file
    - Change `private_lane` to `lane` on `commit_strings`
    - Run `bundle exec fastlane commit_strings auto_commit:false` and verify it prints the prompt message. Type enter (without doing anything) to validate the prompt and exit the lane
    - Run `bundle exec fastlane commit_strings` and verify it created a commit containing your dummy changes from `values/strings.xml`
 - Testing `freeze_strings_for_translation`:
    - `git rm -r fastlane/resources/values`, then commit the deletion
    - Change `private_lane` to `lane` on `freeze_strings_for_translation`
    - Run `bundle exec fastlane freeze_strings_for_translation` and verify it re-created the `fastlane/resources/values/` folder and created a commit containing the `fastlane/resources/values/strings.xml` file
 - Delete your testing branch from git remote.

### Target branch

Targeting `release/19.2` because it already contains changes to the `send_strings_for_translations` lane when Thomaz fixed the missing `/`, so targeting `trunk` would have led to conflicts. Will probably rebase to target `trunk` once the `release/19.2->trunk` backmerge PR post-code-freeze have landed though.