### PR TITLE
[Tooling] Fix Wear App Universal .apk download

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1129,14 +1129,16 @@ platform :android do
   # @example Running the lane
   #          bundle exec fastlane create_gh_release app:WEAR_APP version:1.0.0 prerelease:true
   #
-  lane :create_gh_release do |app:, version:, prerelease: false|
+  private_lane :create_gh_release do |app:, version:, prerelease: false|
+    validate_app_param!(app)
+
     universal_apk_path = File.join(PROJECT_ROOT_FOLDER, 'artifacts', universal_apk_name(app, version))
 
-    # We have a convention that the Wear app's version code is incremented by 50000
-    build_code_to_download = app == MOBILE_APP ? build_code_current : (build_code_current.to_i + 50_000).to_s
+    # We have a convention that the Wear app's version code is offset by 50000 from the Mobile app's one
+    version_code_offset = { MOBILE_APP: 0, WEAR_APP: 50_000 }.fetch(app, 0)
     download_universal_apk_from_google_play(
       package_name: APP_PACKAGE_NAME,
-      version_code: build_code_to_download,
+      version_code: build_code_current.to_i + version_code_offset,
       destination: universal_apk_path,
       json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1135,6 +1135,7 @@ platform :android do
     universal_apk_path = File.join(PROJECT_ROOT_FOLDER, 'artifacts', universal_apk_name(app, version))
 
     # We have a convention that the Wear app's version code is offset by 50000 from the Mobile app's one
+    # See https://github.com/woocommerce/woocommerce-android/blob/11ae376f2922e4b2eac3f87971b8c2246e56b37b/WooCommerce-Wear/build.gradle#L29
     version_code_offset = { MOBILE_APP: 0, WEAR_APP: 50_000 }.fetch(app, 0)
     download_universal_apk_from_google_play(
       package_name: APP_PACKAGE_NAME,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1129,12 +1129,14 @@ platform :android do
   # @example Running the lane
   #          bundle exec fastlane create_gh_release app:WEAR_APP version:1.0.0 prerelease:true
   #
-  private_lane :create_gh_release do |app:, version:, prerelease: false|
+  lane :create_gh_release do |app:, version:, prerelease: false|
     universal_apk_path = File.join(PROJECT_ROOT_FOLDER, 'artifacts', universal_apk_name(app, version))
 
+    # We have a convention that the Wear app's version code is incremented by 50000
+    build_code_to_download = app == MOBILE_APP ? build_code_current : (build_code_current.to_i + 50_000).to_s
     download_universal_apk_from_google_play(
       package_name: APP_PACKAGE_NAME,
-      version_code: build_code_current,
+      version_code: build_code_to_download,
       destination: universal_apk_path,
       json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
     )


### PR DESCRIPTION
During the GitHub Release creation step (`create_gh_release` lane), the build failed for the Wear app.

This is due to the fact that [we have a convention](https://github.com/woocommerce/woocommerce-android/blob/11ae376f2922e4b2eac3f87971b8c2246e56b37b/WooCommerce-Wear/build.gradle#L29) to increment the Wear App by 50000.
While running the `create_gh_release ` lane, we try to download the Universal .apk from Google Play (calling the action `download_universal_apk_from_google_play`) using the App version code, which fails for the Wear app.

This PR fixes the issue by also adding a 50000 increment to the version code when trying to download the universal .apk while running a Wear App build.