### PR TITLE
Fix NPE in ReceiptPreviewFragment

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 19.3
 -----
-
+- [*] Fix a crash on the Receipt Preview screen. [https://github.com/woocommerce/woocommerce-android/pull/11804]
 
 19.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/preview/ReceiptPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/preview/ReceiptPreviewFragment.kt
@@ -69,7 +69,8 @@ class ReceiptPreviewFragment : BaseFragment(R.layout.fragment_receipt_preview), 
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        binding.receiptPreviewPreviewWebview.saveState(outState)
+        // onSaveInstanceState might be called after onDestroyView, so we need to check if `binding` is null.
+        _binding?.receiptPreviewPreviewWebview?.saveState(outState)
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11775 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a NPE which happens when fragment's `onSaveInstanceState` is invoked right before onDestroy. [The documentation for onSaveInstanceState says](https://developer.android.com/reference/androidx/fragment/app/Fragment#onSaveInstanceState(android.os.Bundle)) 
`
Note however: this method may be called at any time before [onDestroy](https://developer.android.com/reference/androidx/fragment/app/Fragment#onDestroy()). There are many situations where a fragment may be mostly torn down (such as when placed on the back stack with no UI showing), but its state will not be saved until its owning activity actually needs to save its state.
`.

This PR uses a naive solution, which simply checks whether we have an active reference to the view.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

I quickly tried to reproduce this issue without success. Considering the main goal of this PR is to ensure the app doesn't crash, I don't think it's necessary to spend time on the reproduction steps.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

No testing needed.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No UI changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->