### PR TITLE
[Dependency Analysis] Add Custom Meta-Data to CI Schedule 

### DIFF
--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -16,6 +16,8 @@ steps:
     plugins: [*ci_toolkit]
     artifact_paths:
       - "build/reports/dependency-analysis/build-health-report.*"
+    meta_data:
+      scheduled-build: "dependency-analysis"
     notify:
       - slack: "#android-core-notifs"
         if: build.state == "failed"

--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -10,14 +10,13 @@ agents:
 steps:
   - label: "dependency analysis"
     command: |
+      buildkite-agent meta-data set "scheduled-build" "dependency-analysis"
       echo "--- 📊 Analyzing"
       cp gradle.properties-example gradle.properties
       ./gradlew buildHealth
     plugins: [*ci_toolkit]
     artifact_paths:
       - "build/reports/dependency-analysis/build-health-report.*"
-    meta_data:
-      scheduled-build: "dependency-analysis"
     notify:
       - slack: "#android-core-notifs"
         if: build.state == "failed"


### PR DESCRIPTION
Project Thread: paaHJt-6yU-p2

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds custom meta-data to the dependency analysis scheduled build so that it can be easily queried via Buildkite's REST API.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. CI: Using the `New Build` 🟢 CI button for [WCAndroid](https://buildkite.com/automattic/woocommerce-android/), test this standalone dependency analysis job (see form below). Then, when CI starts, make sure that adding `/meta-data` to that CI build's URL ([example](https://buildkite.com/automattic/woocommerce-android/builds/21733/meta-data)) will give you one extra meta-data, the `schedule-build` one, with a value of `dependency-analysis` (see screenshot below):
2. REST: Using the Buildkite's REST API you could query for this type of builds, using the [meta-data](https://buildkite.com/docs/apis/rest-api/builds#list-all-builds) query parameter, and see that the result is the expect one. Use this query: `https://api.buildkite.com/v2/organizations/automattic/pipelines/woocommerce-android/builds?meta_data[scheduled-build]=dependency-analysis`

![image](https://github.com/woocommerce/woocommerce-android/assets/9729923/17fc2c57-3a40-4a3f-b31d-f6092c964cc0)

![image](https://github.com/woocommerce/woocommerce-android/assets/9729923/cc4e5b3b-f564-4ad4-85a7-73faef3865d8)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->