### PR TITLE
Migrate to use `jetpack-ai-query` endpoint for ai generated content

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.86.0'
+    fluxCVersion = '3039-dd2dd49efbeb31e7b8f3bd0a6425cd08ed5ba43b'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '3039-dd2dd49efbeb31e7b8f3bd0a6425cd08ed5ba43b'
+    fluxCVersion = 'trunk-e7f84fab139d1211941b37e1fc710207cb25eb47'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11802


### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Replaces `wpcom/v2/text-completion` endpoint usages with `wpcom/v2/jetpack-ai-query endpoint`

### Testing information
Smoke test AI features from the app. For example: 
- For an atomic site or a self hosted site with Jetpack connection and `Jetpack AI` module enabled follow the screen recording steps and check that the product content is generated successfully: 


https://github.com/woocommerce/woocommerce-android/assets/2663464/471f9905-b554-4530-bcfa-2a751b804c44




