### PR TITLE
Avoid race conditions and ensure statsTimeRangeSelection is set

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -197,10 +197,6 @@ private fun StatsChart(
     // is applying all properties on each composition (even the unchanged ones) which creates issues with the legacy
     // view.
 
-    LaunchedEffect(lastUpdateState) {
-        statsView.showLastUpdate(lastUpdateState)
-    }
-
     LaunchedEffect(revenueStatsState) {
         when (revenueStatsState) {
             is DashboardStatsViewModel.RevenueStatsViewState.Content -> {
@@ -230,8 +226,15 @@ private fun StatsChart(
 
     LaunchedEffect(visitorsStatsState) {
         visitorsStatsState?.let {
-            statsView.showVisitorStats(it)
+            statsView.showVisitorStats(
+                it,
+                dateRange?.rangeSelection
+            )
         }
+    }
+
+    LaunchedEffect(lastUpdateState) {
+        statsView.showLastUpdate(lastUpdateState)
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -197,10 +197,6 @@ private fun StatsChart(
     // is applying all properties on each composition (even the unchanged ones) which creates issues with the legacy
     // view.
 
-    LaunchedEffect(dateRange?.rangeSelection) {
-        dateRange?.rangeSelection?.let { statsView.loadDashboardStats(it) }
-    }
-
     LaunchedEffect(lastUpdateState) {
         statsView.showLastUpdate(lastUpdateState)
     }
@@ -208,6 +204,7 @@ private fun StatsChart(
     LaunchedEffect(revenueStatsState) {
         when (revenueStatsState) {
             is DashboardStatsViewModel.RevenueStatsViewState.Content -> {
+                dateRange?.rangeSelection?.let { statsView.loadDashboardStats(it) }
                 statsView.showErrorView(false)
                 statsView.showSkeleton(false)
                 statsView.updateView(revenueStatsState.revenueStats)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
@@ -92,7 +92,6 @@ class DashboardStatsView @JvmOverloads constructor(
             // to appear, and we remove the chart's empty string so it doesn't briefly show
             // up before the chart data is added once the request completes
             if (value) {
-                clearStatsHeaderValues()
                 binding.chart.setNoDataText(null)
                 binding.chart.clear()
             } else {
@@ -399,7 +398,8 @@ class DashboardStatsView @JvmOverloads constructor(
         binding.chart.isVisible = !show
     }
 
-    fun showVisitorStats(statsViewState: VisitorStatsViewState) {
+    fun showVisitorStats(statsViewState: VisitorStatsViewState, rangeSelection: StatsTimeRangeSelection?) {
+        rangeSelection?.let { statsTimeRangeSelection = it }
         // Reset click listeners
         binding.statsViewRow.emptyVisitorStatsIcon.setOnClickListener(null)
         binding.statsViewRow.emptyVisitorStatsIndicator.setOnClickListener(null)
@@ -726,6 +726,7 @@ class DashboardStatsView @JvmOverloads constructor(
                     dateString,
                     statsTimeRangeSelection.revenueStatsGranularity
                 )
+
                 else -> error("Unsupported range value used in my store tab: ${statsTimeRangeSelection.selectionType}")
             }.also { result -> trackUnexpectedFormat(result, dateString) }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11776 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Tricky bug here. I'll try to provide context on what I think is happening and then explain the proposed solution.
The [crash](https://a8c.sentry.io/issues/5354507623/?project=1459556&referrer=github_integration) we are trying to resolve here is due to a race condition due to async updates of the UI.
The way we update the UI for the stats card is by using effects through `LaunchedEffect()` functions. [LaunchedEffect](https://developer.android.com/develop/ui/compose/side-effects#launchedeffect) starts a suspending function. That means that the order of execution of the following LaunchedEffects is not guaranteed: 

```kotlin
    LaunchedEffect(dateRange?.rangeSelection) {
        dateRange?.rangeSelection?.let { statsView.loadDashboardStats(it) }
    }

    LaunchedEffect(lastUpdateState) {
        statsView.showLastUpdate(lastUpdateState)
    }

    LaunchedEffect(revenueStatsState) {
        when (revenueStatsState) {
            is DashboardStatsViewModel.RevenueStatsViewState.Content -> {
                statsView.showErrorView(false)
                statsView.showSkeleton(false)
                statsView.updateView(revenueStatsState.revenueStats)
            }
...
        }
    }

    LaunchedEffect(visitorsStatsState) {
        visitorsStatsState?.let {
            statsView.showVisitorStats(it)
        }
    }
```

When the call to `statsView.updateView(revenueStatsState.revenueStats)` happens before the call to ` dateRange?.rangeSelection?.let { statsView.loadDashboardStats(it) }` the app will crash. 

About the proposed fix, I'll try to explain it right where the code changes are applied. That will provide better context

### Steps to reproduce
Applying a small delay inside `LaunchedEffect(dateRange?.rangeSelection)`:

```kotlin
    LaunchedEffect(dateRange?.rangeSelection) {
        delay(500)
        dateRange?.rangeSelection?.let { statsView.loadDashboardStats(it) }
    }
```
We'll be able to reproduce the race condition consistently and the crash will happen all the time.

### Testing information

- Activate the performance card in the dashboard. 
- Smoke test it by changing through all the different date ranges, by dragging your finger through the chart, by swiping to refresh, enabling "Don't Keep activities" and navigating back and forth to the dashboard scree. In essence, test any possible scenario for the card looking for possible UI issues. 