### PR TITLE
Fix the visibility issue of the Blaze button on product detail screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Fix a crash on the Receipt Preview screen. [https://github.com/woocommerce/woocommerce-android/pull/11804]
 - [*] Shows meaningful errors from the backend when editing Min/Max Quantities in products and variations. [https://github.com/woocommerce/woocommerce-android/pull/11801]
+- [*] Fix the visibility issue of the Blaze button on product detail screen [https://github.com/woocommerce/woocommerce-android/pull/11837]
 
 19.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
@@ -59,7 +59,7 @@ enum class CampaignStatusUi(
     companion object {
         fun fromString(status: String): CampaignStatusUi? {
             return when (status) {
-                "pending" -> InModeration
+                "created", "pending" -> InModeration
                 "scheduled" -> Scheduled
                 "active" -> Active
                 "rejected" -> Rejected


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11756
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After creating a campaign from the product detail screen and returning the detail screen, the "Promote with Blaze button" was still visible. This PR fixes that issue.

After creating the campaign, the backend status of the campaign is `created` for a short moment, and then it becomes `pending`.  The app didn't recognize the `created` status. This has been added with this PR and matched with `InModeration` UI state.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open the "Products" screen.
2. Open the detail screen of a product.
3. Tap on the "**Promote with Blaze**" button and follow the steps to create a campaign.
4. After creating the campaign, it should return to the product detail screen. 
5. Ensure "**Promote with Blaze**" button is not visible.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<details>
  <summary>before video</summary>
 
https://github.com/woocommerce/woocommerce-android/assets/2471769/a7ece367-584b-4cec-bd2b-39659b59f321
</details>

<details>
  <summary>after video</summary>
 
https://github.com/woocommerce/woocommerce-android/assets/2471769/70d4a4af-82eb-4c57-a0fd-354c8fcb6bbe
</details>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->