### PR TITLE
Revert changes that made changing stock status stop working

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockViewModel.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.dashboard.stock
 
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
@@ -48,14 +47,10 @@ class DashboardProductStockViewModel @AssistedInject constructor(
 
     private val _refreshTrigger = MutableSharedFlow<DashboardViewModel.RefreshEvent>(extraBufferCapacity = 1)
     private val refreshTrigger = merge(parentViewModel.refreshTrigger, _refreshTrigger)
-        .onStart {
-            if (productStockState.value !is ViewState.Success) {
-                emit(DashboardViewModel.RefreshEvent()) // Avoid refreshing when stock items are already loaded
-            }
-        }
+        .onStart { emit(DashboardViewModel.RefreshEvent()) }
     private val status = savedStateHandle.getStateFlow<ProductStockStatus>(viewModelScope, ProductStockStatus.LowStock)
 
-    val productStockState: LiveData<ViewState> = status
+    val productStockState = status
         .flatMapLatest {
             refreshTrigger.map { refresh -> Pair(refresh, it) }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes: https://github.com/woocommerce/woocommerce-android/issues/11841
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In an attempt to avoid unnecessary refreshes of the stock status card I applied these changes [here](https://github.com/woocommerce/woocommerce-android/pull/11743/commits/2117eef12ff89e372e13b1505cab789047fef3ed). But that led to a bug in the Product Stock Card. So, I'm reverting those changes. 

About the initial "bug" I was trying to fix [here](https://github.com/woocommerce/woocommerce-android/pull/11743): The card refreshing after coming back from the device locked screen. I think the problem impacts most of the dashboard cards we implemented as we followed the same pattern. Only that in the product stock card is more visible because of the loading state. But when checking how other cards behave in the scenario of coming back to the app from the device lock screen, I noticed almost all cards triggered network requests in the background. So, the "problem" is more widespread than I thought and requires a thoughtful redesign of the refresh pattern we are currently using. 

However, I don't think any of this is a major issue and definitely not a priority. So for now, I'd rather keep the card working as expected and getting extra refreshes in some rare ocassions. 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Run the app and enable the stock card. Change between the different statuses and notice that the list is not updated: 

https://github.com/woocommerce/woocommerce-android/assets/2663464/a468102c-5fe3-4b96-a0b8-0b6a7a98418c



### Testing information
- Check that changing the different stock statuses for product stock card updates the content as expected. 
