### PR TITLE
[Tooling] Fix `finalize_release` lane and `options` parameter not needed anymore

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -439,7 +439,7 @@ platform :android do
   # bundle exec fastlane download_translations
   #####################################################################################
   desc 'Download the latest app translations from GlotPress and update the strings.xml files accordingly'
-  lane :download_translations do |_options|
+  lane :download_translations do
     android_download_translations(
       res_dir: RES_DIR_PATH,
       glotpress_url: GLOTPRESS_APP_STRINGS_PROJECT_URL,
@@ -471,7 +471,7 @@ platform :android do
 
     # Don't check translation coverage in CI
     check_translation_progress_all unless is_ci
-    download_translations(options)
+    download_translations
 
     # Bump the release version and build code
     UI.message 'Bumping final release version and build code...'


### PR DESCRIPTION
Fix CI failure https://buildkite.com/automattic/woocommerce-android/builds/21844#01905ff4-c8af-4766-b7f7-4c5a88004ba5/225-274

(Issue introduced after our recent cleanup from https://github.com/woocommerce/woocommerce-android/commit/49758d572bc0eb4ce2d5e17202fa041d25b172d3 / https://github.com/woocommerce/woocommerce-android/pull/11726 hence why it's new)