### PR TITLE
[Tooling] Fix download of Wear Universal APK

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1127,7 +1127,7 @@ platform :android do
 
     # We have a convention that the Wear app's version code is offset by 50000 from the Mobile app's one
     # See https://github.com/woocommerce/woocommerce-android/blob/11ae376f2922e4b2eac3f87971b8c2246e56b37b/WooCommerce-Wear/build.gradle#L29
-    version_code_offset = { MOBILE_APP: 0, WEAR_APP: 50_000 }.fetch(app, 0)
+    version_code_offset = { MOBILE_APP => 0, WEAR_APP => 50_000 }.fetch(app, 0)
     download_universal_apk_from_google_play(
       package_name: APP_PACKAGE_NAME,
       version_code: build_code_current.to_i + version_code_offset,


### PR DESCRIPTION
### Description

Fix issue when the creation of the GitHub Release for the Wear app tries to download the Universal APK from Google Play

We initially tried to fix that in https://github.com/woocommerce/woocommerce-android/pull/11786 but we missed a Ruby syntax subtlety that made a our fix not work as expected and always return an offset of 0

See: https://github.com/woocommerce/woocommerce-android/pull/11786#discussion_r1659363391

### Testing information

- Change the lane from `private_lane` to `lane`
- Comment out the call to `create_release`
- Call `bundle exec fastlane create_gh_release app:WooCommerce-Wear version:19.3`
- Check that the downloaded APK is the one from the Wear App, with a versionCode > 50000 and not the one for the Mobile app

~Disclamer: I didn't test the fix myself (as I wrote the PR from my iPad)~ Tested this morning and it works.