### PR TITLE
Remove a reference to an unused page from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ $ ./gradlew :WooCommerce:connectedVanillaDebugAndroidTest # assemble, install an
     - [Using Android Resources](docs/using-android-resources.md)
     - [Localization](docs/localization.md)
     - [Themes & Styling Practices](docs/theming-styling-best-practices.md)
-    - [Subtree'd Library Projects](docs/subtreed-library-projects.md)
     - [Optimising screens for tablets](docs/supporting-tablets.md)
 - Data
     - [Tracking Events](docs/tracking-events.md)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This removes the "Subtree'd Library Projects" link from the docs list on the README page. The page was already removed with #5407 since subtree library projects are unused.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Review the [README.md](https://github.com/woocommerce/woocommerce-android/blob/8f8b0c6498363af5c1604494dd5093ce4d75579a/README.md) to ensure the link to "Subtree'd Library Projects" has been removed.


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->