### PR TITLE
Fix the broken table on the documentation page of the Tracking Events

### DIFF
--- a/docs/tracking-events.md
+++ b/docs/tracking-events.md
@@ -34,24 +34,22 @@ class OrderDetailViewModel {
 ```
 
 ### Naming Conventions
-| Name Token | Associated Property | Event Type | Description |
-| --- | --- | --- | --- |
-| _action | type | Action | When there are multiple actions |
-| _add | * | Action | User request to add something new such as an order note |
-| _change | "from: to:" | Action | When a value changes |
-| _confirmation_dialog_result | result="positive|negative" | View | Result of a confirmation dialog |
-| _date | range: | Action | For a date range switcher in a graph or list |
-| _failed | "errorContext:$initiated-classname
-            errorType:$errorType
-            errorDescription:$errorDescription" | Data | Errors for user initiated requests |
-| _filter | * | Action | A list has been filtered or searched |
-| _loaded | * | Data | The data to populate a view has loaded |
-| _open | * | Action | An item from a list was opened by the user |
-| _pulled_to_refresh | type | View | User gesture to do a manual refresh of the view |
-| _reselected | * | View | The user reselected a bottom bar, tab, or dropdown/list option, option. Typically preceded by _tab_ or _bar_ |
-| _selected | type | View | The user selected a bottom bar, tab, or dropdown/list option, option, Typically preceded by _tab_ or _bar_ |
-| _show | name: | Action | Tracks views shown to the user |
-| _success | * | Data | A successful user initiated request |
-| _tapped | * | View | The user clicked on a clickable view, typically preceeded by _button_, _link_, _menu |
-| _toggled | state="on|off" | View | User toggled an option |
-| _undo |  | Action | The user chose to undo a previous action or change |
+| Name Token | Associated Property                                                                              | Event Type | Description |
+| --- |--------------------------------------------------------------------------------------------------| --- | --- |
+| _action | type                                                                                             | Action | When there are multiple actions |
+| _add | *                                                                                                | Action | User request to add something new such as an order note |
+| _change | "from: to:"                                                                                      | Action | When a value changes |
+| _confirmation_dialog_result | result="positive                                                                                 |negative" | View | Result of a confirmation dialog |
+| _date | range:                                                                                           | Action | For a date range switcher in a graph or list |
+| _failed | "errorContext:$initiated-classname<br>errorType:$errorType<br>errorDescription:$errorDescription" | Data | Errors for user initiated requests |
+| _filter | *                                                                                                | Action | A list has been filtered or searched |
+| _loaded | *                                                                                                | Data | The data to populate a view has loaded |
+| _open | *                                                                                                | Action | An item from a list was opened by the user |
+| _pulled_to_refresh | type                                                                                             | View | User gesture to do a manual refresh of the view |
+| _reselected | *                                                                                                | View | The user reselected a bottom bar, tab, or dropdown/list option, option. Typically preceded by _tab_ or _bar_ |
+| _selected | type                                                                                             | View | The user selected a bottom bar, tab, or dropdown/list option, option, Typically preceded by _tab_ or _bar_ |
+| _show | name:                                                                                            | Action | Tracks views shown to the user |
+| _success | *                                                                                                | Data | A successful user initiated request |
+| _tapped | *                                                                                                | View | The user clicked on a clickable view, typically preceeded by _button_, _link_, _menu |
+| _toggled | state="on                                                                                        |off" | View | User toggled an option |
+| _undo |                                                                                                  | Action | The user chose to undo a previous action or change |

--- a/docs/tracking-events.md
+++ b/docs/tracking-events.md
@@ -34,22 +34,22 @@ class OrderDetailViewModel {
 ```
 
 ### Naming Conventions
-| Name Token | Associated Property                                                                              | Event Type | Description |
-| --- |--------------------------------------------------------------------------------------------------| --- | --- |
-| _action | type                                                                                             | Action | When there are multiple actions |
-| _add | *                                                                                                | Action | User request to add something new such as an order note |
-| _change | "from: to:"                                                                                      | Action | When a value changes |
-| _confirmation_dialog_result | result="positive                                                                                 |negative" | View | Result of a confirmation dialog |
-| _date | range:                                                                                           | Action | For a date range switcher in a graph or list |
+| Name Token | Associated Property | Event Type | Description |
+| --- | --- | --- | --- |
+| _action | type | Action | When there are multiple actions |
+| _add | * | Action | User request to add something new such as an order note |
+| _change | "from: to:" | Action | When a value changes |
+| _confirmation_dialog_result | result="positive\|negative" | View | Result of a confirmation dialog |
+| _date | range: | Action | For a date range switcher in a graph or list |
 | _failed | "errorContext:$initiated-classname<br>errorType:$errorType<br>errorDescription:$errorDescription" | Data | Errors for user initiated requests |
-| _filter | *                                                                                                | Action | A list has been filtered or searched |
-| _loaded | *                                                                                                | Data | The data to populate a view has loaded |
-| _open | *                                                                                                | Action | An item from a list was opened by the user |
-| _pulled_to_refresh | type                                                                                             | View | User gesture to do a manual refresh of the view |
-| _reselected | *                                                                                                | View | The user reselected a bottom bar, tab, or dropdown/list option, option. Typically preceded by _tab_ or _bar_ |
-| _selected | type                                                                                             | View | The user selected a bottom bar, tab, or dropdown/list option, option, Typically preceded by _tab_ or _bar_ |
-| _show | name:                                                                                            | Action | Tracks views shown to the user |
-| _success | *                                                                                                | Data | A successful user initiated request |
-| _tapped | *                                                                                                | View | The user clicked on a clickable view, typically preceeded by _button_, _link_, _menu |
-| _toggled | state="on                                                                                        |off" | View | User toggled an option |
-| _undo |                                                                                                  | Action | The user chose to undo a previous action or change |
+| _filter | * | Action | A list has been filtered or searched |
+| _loaded | * | Data | The data to populate a view has loaded |
+| _open | * | Action | An item from a list was opened by the user |
+| _pulled_to_refresh | type | View | User gesture to do a manual refresh of the view |
+| _reselected | * | View | The user reselected a bottom bar, tab, or dropdown/list option, option. Typically preceded by _tab_ or _bar_ |
+| _selected | type | View | The user selected a bottom bar, tab, or dropdown/list option, option, Typically preceded by _tab_ or _bar_ |
+| _show | name: | Action | Tracks views shown to the user |
+| _success | * | Data | A successful user initiated request |
+| _tapped | * | View | The user clicked on a clickable view, typically preceeded by _button_, _link_, _menu |
+| _toggled | state="on\|off" | View | User toggled an option |
+| _undo | | Action | The user chose to undo a previous action or change |


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes the broken table on the documentation page for Tracking Events.  I only replaced paragraphs with `<br>` tags and added "\\" character before "|".

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- See the live [Tracking Events](https://github.com/woocommerce/woocommerce-android/blob/trunk/docs/tracking-events.md) page to see the broken table in the Naming Conventions section. 
- Review updated [Tracking Events](https://github.com/woocommerce/woocommerce-android/blob/57cb7f7e25cfe62195654cedefef9d2aa27a9a2c/docs/tracking-events.md) to ensure the table is fixed.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md --