### PR TITLE
[Tooling] Replace `wear-` prefix with `w` suffix in the release name

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1111,10 +1111,11 @@ platform :android do
   # Private lanes
   #####################################################################################
 
-  # Creates a new GitHub Release for the given version.
+  # Creates a new GitHub Release for the given version. The name (and tag) of the release will be exactly as
+  # the `version` parameter, with a `w` appended in the case of a Wear OS app.
   #
   # @param [String] app The Android app to create the release for (`MOBILE_APP` or `WEAR_APP`)
-  # @param [String] version The version of the app.
+  # @param [String] version The version of the app, as in the `versionName` property from `version.properties`.
   # @param [Boolean] prerelease If true, the GitHub Release will have the prerelease flag
   #
   # @example Running the lane

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1141,7 +1141,7 @@ platform :android do
     create_release(
       repository: GITHUB_REPO,
       # 'version' is used for the release name as well as the tag that's going to be created for the release
-      version: app == WEAR_APP ? "wear-#{version}" : version,
+      version: version,
       release_notes_file_path: METADATA_SOURCE_CHANGELOG_FILE_PATH[app],
       prerelease: prerelease,
       release_assets: release_assets.join(',')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1141,7 +1141,7 @@ platform :android do
     create_release(
       repository: GITHUB_REPO,
       # 'version' is used for the release name as well as the tag that's going to be created for the release
-      version: version,
+      version: app == WEAR_APP ? "#{version}w" : version,
       release_notes_file_path: METADATA_SOURCE_CHANGELOG_FILE_PATH[app],
       prerelease: prerelease,
       release_assets: release_assets.join(',')


### PR DESCRIPTION
Our Wear OS version names conventioned to [use a a `w` suffix](https://github.com/woocommerce/woocommerce-android/blob/11ae376f2922e4b2eac3f87971b8c2246e56b37b/WooCommerce-Wear/build.gradle#L39) in the `versionName`.
This PR updates the used Github version name to follow the same convention, removing the `wear-` prefix.