### PR TITLE
[Tooling] Use a shared Buildkite pipeline vars file

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,10 +4,6 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   # Common plugin settings to use with the `plugins` key.
-  - &ci_toolkit
-    automattic/a8c-ci-toolkit#3.0.1
-  - &test_collector
-    test-collector#v1.10.0
   - &test_collector_common_params
       files: "WooCommerce/build/buildkite-test-analytics/*.xml"
       format: "junit"
@@ -19,7 +15,7 @@ steps:
   - label: "Gradle Wrapper Validation"
     command: |
       validate_gradle_wrapper
-    plugins: [*ci_toolkit]
+    plugins: [$CI_TOOLKIT]
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
@@ -43,7 +39,7 @@ steps:
           echo "--- 🧹 Linting"
           cp gradle.properties-example gradle.properties
           ./gradlew detektAll
-        plugins: [*ci_toolkit]
+        plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/detekt/detekt.html"
 
@@ -52,7 +48,7 @@ steps:
           echo "--- 🧹 Linting"
           cp gradle.properties-example gradle.properties
           ./gradlew lintJalapenoDebug
-        plugins: [*ci_toolkit]
+        plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
@@ -61,7 +57,7 @@ steps:
           cp gradle.properties-example gradle.properties
           .buildkite/commands/dependency-tree-diff.sh
         if: build.pull_request.id != null
-        plugins: [*ci_toolkit]
+        plugins: [$CI_TOOLKIT]
 
   ########################################
   - group: "🛠 Prototype Builds"
@@ -71,13 +67,13 @@ steps:
         command: |
           ".buildkite/commands/prototype-build.sh" "WooCommerce"
         if: build.pull_request.id != null
-        plugins: [*ci_toolkit]
+        plugins: [$CI_TOOLKIT]
 
       - label: "🛠 Prototype Build: Wear App"
         command: |
           ".buildkite/commands/prototype-build.sh" "WooCommerce-Wear"
         if: build.pull_request.id != null
-        plugins: [*ci_toolkit]
+        plugins: [$CI_TOOLKIT]
 
   ########################################
   - group: "🔬 Tests"
@@ -86,8 +82,8 @@ steps:
       - label: "Unit tests"
         command: .buildkite/commands/run-unit-tests.sh
         plugins:
-          - *ci_toolkit
-          - *test_collector :
+          - $CI_TOOLKIT
+          - $TEST_COLLECTOR :
               <<: *test_collector_common_params
               api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS"
         artifact_paths:
@@ -98,13 +94,13 @@ steps:
           echo "--- ⚒️ Building"
           cp gradle.properties-example gradle.properties
           ./gradlew assembleJalapenoDebugAndroidTest
-        plugins: [*ci_toolkit]
+        plugins: [$CI_TOOLKIT]
 
       - label: "Instrumented tests"
         command: .buildkite/commands/run-instrumented-tests.sh
         plugins:
-          - *ci_toolkit
-          - *test_collector :
+          - $CI_TOOLKIT
+          - $TEST_COLLECTOR :
               <<: *test_collector_common_params
               api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS"
         artifact_paths:

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,12 +4,6 @@
 # This pipeline is meant to be run via the Buildkite API, and is
 # only used for release builds
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.0.1
-
 agents:
   queue: "android"
 
@@ -18,7 +12,7 @@ steps:
     command: |
       validate_gradle_wrapper
     priority: 1
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
@@ -27,7 +21,7 @@ steps:
     command: |
       ".buildkite/commands/release-build.sh" "WooCommerce"
     priority: 1
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     notify:
       - slack: "#build-and-ship"
 
@@ -35,7 +29,7 @@ steps:
     command: |
       ".buildkite/commands/release-build.sh" "WooCommerce-Wear"
     priority: 1
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     if: build.env('INCLUDE_WEAR_APP') == "true"
     notify:
       - slack: "#build-and-ship"

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -6,8 +6,7 @@ agents:
 
 steps:
   - label: "Complete Code Freeze"
-    plugins:
-      - automattic/a8c-ci-toolkit#3.0.1
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-environment.sh
 

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -6,8 +6,7 @@ agents:
 
 steps:
   - label: "Finalize Hotfix Release"
-    plugins:
-      - automattic/a8c-ci-toolkit#3.0.1
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-environment.sh
 

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -6,8 +6,7 @@ agents:
 
 steps:
   - label: "Finalize Release"
-    plugins:
-      - automattic/a8c-ci-toolkit#3.0.1
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-environment.sh
 

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -6,8 +6,7 @@ agents:
 
 steps:
   - label: "New Beta Release"
-    plugins:
-      - automattic/a8c-ci-toolkit#3.0.1
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-environment.sh
 

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -11,8 +11,7 @@ steps:
         key: "version_code"
         format: "[0-9]+" # Only allow numbers
   - label: "New Hotfix Release"
-    plugins:
-      - automattic/a8c-ci-toolkit#3.0.1
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-environment.sh
 

--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -6,8 +6,7 @@ agents:
 
 steps:
   - label: " Start Code Freeze"
-    plugins:
-      - automattic/a8c-ci-toolkit#3.0.1
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-environment.sh
 

--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -1,12 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &ci_toolkit
-      automattic/a8c-ci-toolkit#3.0.1
-
 agents:
   queue: "android"
 
@@ -16,7 +10,7 @@ steps:
       echo "--- 📊 Analyzing"
       cp gradle.properties-example gradle.properties
       ./gradlew buildHealth
-    plugins: [*ci_toolkit]
+    plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "build/reports/dependency-analysis/build-health-report.*"
     notify:

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+ # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
+ # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
+
+ export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.4.2"
+ export TEST_COLLECTOR="test-collector#v1.10.1"


### PR DESCRIPTION
## References

The PR https://github.com/Automattic/buildkite-ci/pull/459, which updates the upload step to use the `shared-pipeline-vars` file, has already been deployed and the solution in the present PR should already work.

See also: https://wp.me/paaHJt-5Rr

## What it does

This PR introduces the pipeline variables `CI_TOOLKIT` and `TEST_COLLECTOR`, both defined in `./buildkite/shared-pipeline-vars`, and replaces them across all pipelines.

### How to test

 - Make sure CI is 🟢 