### PR TITLE
[Woo POS] Rename strings we use for POS to make them consistent

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -121,7 +121,7 @@ private fun WooPosCartScreen(
                         .align(Alignment.BottomCenter)
                         .fillMaxWidth(),
                     enabled = state.itemsInCart.isNotEmpty() && !state.isOrderCreationInProgress,
-                    text = stringResource(R.string.woo_pos_checkout_button),
+                    text = stringResource(R.string.woopos_checkout_button),
                     onClick = { onUIEvent(WooPosCartUIEvent.CheckoutClicked) }
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -166,7 +166,7 @@ private fun CartToolbar(
         Spacer(modifier = Modifier.width(16.dp))
 
         Text(
-            text = stringResource(R.string.woopos_car_pane_title),
+            text = stringResource(R.string.woopos_cart_title),
             style = MaterialTheme.typography.h4,
             color = MaterialTheme.colors.onBackground,
             fontWeight = FontWeight.Bold

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -157,7 +157,7 @@ private fun CartToolbar(
         IconButton(onClick = { onBackClicked() }) {
             Icon(
                 imageVector = ImageVector.vectorResource(toolbar.icon),
-                contentDescription = stringResource(R.string.woo_pos_cart_back_content_description),
+                contentDescription = stringResource(R.string.woopos_cart_back_content_description),
                 tint = MaterialTheme.colors.onBackground,
                 modifier = Modifier.size(28.dp)
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -186,7 +186,7 @@ private fun CartToolbar(
 
             TextButton(onClick = { onClearAllClicked() }) {
                 Text(
-                    text = stringResource(R.string.woo_pos_clear_cart_button),
+                    text = stringResource(R.string.woopos_clear_cart_button),
                     style = MaterialTheme.typography.h6,
                     color = MaterialTheme.colors.primary,
                     fontWeight = FontWeight.SemiBold,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -166,7 +166,7 @@ private fun CartToolbar(
         Spacer(modifier = Modifier.width(16.dp))
 
         Text(
-            text = stringResource(R.string.woo_pos_car_pane_title),
+            text = stringResource(R.string.woopos_car_pane_title),
             style = MaterialTheme.typography.h4,
             color = MaterialTheme.colors.onBackground,
             fontWeight = FontWeight.Bold

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -153,7 +153,7 @@ class WooPosCartViewModel @Inject constructor(
     private fun updateToolbarState(newState: WooPosCartState): WooPosCartState {
         val itemsCount = if (newState.itemsInCart.isNotEmpty()) {
             resourceProvider.getString(
-                R.string.woo_pos_items_in_cart,
+                R.string.woopos_items_in_cart,
                 newState.itemsInCart.size
             )
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
@@ -125,7 +125,7 @@ fun WooPosPaymentSuccessScreen(
                     )
                     Spacer(modifier = Modifier.width(12.dp))
                     Text(
-                        text = stringResource(R.string.woo_pos_new_transaction_button),
+                        text = stringResource(R.string.woopos_new_transaction_button),
                         style = MaterialTheme.typography.h4,
                         fontWeight = FontWeight.SemiBold,
                         textAlign = TextAlign.Center,

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -13,7 +13,7 @@ Language: ar
     <string name="woopos_exit_confirmation_title">إنهاء POS</string>
     <string name="woo_pos_car_pane_title">عربة التسوق</string>
     <string name="woo_pos_remove_item_from_cart_content_description">إزالة عنصر من عربة التسوق</string>
-    <string name="woo_pos_checkout_button">السداد</string>
+    <string name="woopos_checkout_button">السداد</string>
     <string name="woopos_reader_unknown">حالة القارئ مجهولة</string>
     <string name="woopos_checkout">السداد</string>
     <string name="woopos_reader_disconnected">تم فصل القارئ</string>

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -11,7 +11,7 @@ Language: ar
     <string name="woopos_exit_confirmation_confirm_button">إنهاء</string>
     <string name="woopos_exit_confirmation_message">هل تريد بالتأكيد إنهاء POS؟</string>
     <string name="woopos_exit_confirmation_title">إنهاء POS</string>
-    <string name="woo_pos_car_pane_title">عربة التسوق</string>
+    <string name="woopos_car_pane_title">عربة التسوق</string>
     <string name="woopos_remove_item_from_cart_content_description">إزالة عنصر من عربة التسوق</string>
     <string name="woopos_checkout_button">السداد</string>
     <string name="woopos_reader_unknown">حالة القارئ مجهولة</string>

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -11,7 +11,7 @@ Language: ar
     <string name="woopos_exit_confirmation_confirm_button">إنهاء</string>
     <string name="woopos_exit_confirmation_message">هل تريد بالتأكيد إنهاء POS؟</string>
     <string name="woopos_exit_confirmation_title">إنهاء POS</string>
-    <string name="woopos_car_pane_title">عربة التسوق</string>
+    <string name="woopos_cart_title">عربة التسوق</string>
     <string name="woopos_remove_item_from_cart_content_description">إزالة عنصر من عربة التسوق</string>
     <string name="woopos_checkout_button">السداد</string>
     <string name="woopos_reader_unknown">حالة القارئ مجهولة</string>

--- a/WooCommerce/src/main/res/values-ar/strings.xml
+++ b/WooCommerce/src/main/res/values-ar/strings.xml
@@ -12,7 +12,7 @@ Language: ar
     <string name="woopos_exit_confirmation_message">هل تريد بالتأكيد إنهاء POS؟</string>
     <string name="woopos_exit_confirmation_title">إنهاء POS</string>
     <string name="woo_pos_car_pane_title">عربة التسوق</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">إزالة عنصر من عربة التسوق</string>
+    <string name="woopos_remove_item_from_cart_content_description">إزالة عنصر من عربة التسوق</string>
     <string name="woopos_checkout_button">السداد</string>
     <string name="woopos_reader_unknown">حالة القارئ مجهولة</string>
     <string name="woopos_checkout">السداد</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -11,7 +11,7 @@ Language: de
     <string name="woopos_exit_confirmation_confirm_button">Beenden</string>
     <string name="woopos_exit_confirmation_message">Bist du sicher, dass du POS beenden möchtest?</string>
     <string name="woopos_exit_confirmation_title">POS beenden</string>
-    <string name="woopos_car_pane_title">Warenkorb</string>
+    <string name="woopos_cart_title">Warenkorb</string>
     <string name="woopos_remove_item_from_cart_content_description">Artikel aus Warenkorb entfernen</string>
     <string name="woopos_checkout_button">Bezahlen</string>
     <string name="woopos_reader_unknown">Status des Lesegeräts unbekannt</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -11,7 +11,7 @@ Language: de
     <string name="woopos_exit_confirmation_confirm_button">Beenden</string>
     <string name="woopos_exit_confirmation_message">Bist du sicher, dass du POS beenden möchtest?</string>
     <string name="woopos_exit_confirmation_title">POS beenden</string>
-    <string name="woo_pos_car_pane_title">Warenkorb</string>
+    <string name="woopos_car_pane_title">Warenkorb</string>
     <string name="woopos_remove_item_from_cart_content_description">Artikel aus Warenkorb entfernen</string>
     <string name="woopos_checkout_button">Bezahlen</string>
     <string name="woopos_reader_unknown">Status des Lesegeräts unbekannt</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -12,7 +12,7 @@ Language: de
     <string name="woopos_exit_confirmation_message">Bist du sicher, dass du POS beenden möchtest?</string>
     <string name="woopos_exit_confirmation_title">POS beenden</string>
     <string name="woo_pos_car_pane_title">Warenkorb</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">Artikel aus Warenkorb entfernen</string>
+    <string name="woopos_remove_item_from_cart_content_description">Artikel aus Warenkorb entfernen</string>
     <string name="woopos_checkout_button">Bezahlen</string>
     <string name="woopos_reader_unknown">Status des Lesegeräts unbekannt</string>
     <string name="woopos_checkout">Bezahlen</string>

--- a/WooCommerce/src/main/res/values-de/strings.xml
+++ b/WooCommerce/src/main/res/values-de/strings.xml
@@ -13,7 +13,7 @@ Language: de
     <string name="woopos_exit_confirmation_title">POS beenden</string>
     <string name="woo_pos_car_pane_title">Warenkorb</string>
     <string name="woo_pos_remove_item_from_cart_content_description">Artikel aus Warenkorb entfernen</string>
-    <string name="woo_pos_checkout_button">Bezahlen</string>
+    <string name="woopos_checkout_button">Bezahlen</string>
     <string name="woopos_reader_unknown">Status des Lesegeräts unbekannt</string>
     <string name="woopos_checkout">Bezahlen</string>
     <string name="woopos_reader_disconnected">Lesegerät nicht verbunden</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -11,7 +11,7 @@ Language: es
     <string name="woopos_exit_confirmation_confirm_button">Salir</string>
     <string name="woopos_exit_confirmation_message">¿Estás seguro que quieres salir del punto de venta?</string>
     <string name="woopos_exit_confirmation_title">Salir del punto de venta</string>
-    <string name="woo_pos_car_pane_title">Carrito</string>
+    <string name="woopos_car_pane_title">Carrito</string>
     <string name="woopos_remove_item_from_cart_content_description">Eliminar elemento del carrito</string>
     <string name="woopos_checkout_button">Finalizar compra</string>
     <string name="woopos_reader_unknown">Estado del lector desconocido</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -12,7 +12,7 @@ Language: es
     <string name="woopos_exit_confirmation_message">¿Estás seguro que quieres salir del punto de venta?</string>
     <string name="woopos_exit_confirmation_title">Salir del punto de venta</string>
     <string name="woo_pos_car_pane_title">Carrito</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">Eliminar elemento del carrito</string>
+    <string name="woopos_remove_item_from_cart_content_description">Eliminar elemento del carrito</string>
     <string name="woopos_checkout_button">Finalizar compra</string>
     <string name="woopos_reader_unknown">Estado del lector desconocido</string>
     <string name="woopos_checkout">Finalizar compra</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -11,7 +11,7 @@ Language: es
     <string name="woopos_exit_confirmation_confirm_button">Salir</string>
     <string name="woopos_exit_confirmation_message">¿Estás seguro que quieres salir del punto de venta?</string>
     <string name="woopos_exit_confirmation_title">Salir del punto de venta</string>
-    <string name="woopos_car_pane_title">Carrito</string>
+    <string name="woopos_cart_title">Carrito</string>
     <string name="woopos_remove_item_from_cart_content_description">Eliminar elemento del carrito</string>
     <string name="woopos_checkout_button">Finalizar compra</string>
     <string name="woopos_reader_unknown">Estado del lector desconocido</string>

--- a/WooCommerce/src/main/res/values-es/strings.xml
+++ b/WooCommerce/src/main/res/values-es/strings.xml
@@ -13,7 +13,7 @@ Language: es
     <string name="woopos_exit_confirmation_title">Salir del punto de venta</string>
     <string name="woo_pos_car_pane_title">Carrito</string>
     <string name="woo_pos_remove_item_from_cart_content_description">Eliminar elemento del carrito</string>
-    <string name="woo_pos_checkout_button">Finalizar compra</string>
+    <string name="woopos_checkout_button">Finalizar compra</string>
     <string name="woopos_reader_unknown">Estado del lector desconocido</string>
     <string name="woopos_checkout">Finalizar compra</string>
     <string name="woopos_reader_disconnected">Lector desconectado</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -13,7 +13,7 @@ Language: fr
     <string name="woopos_exit_confirmation_title">Quitter le PDV</string>
     <string name="woo_pos_car_pane_title">Panier</string>
     <string name="woo_pos_remove_item_from_cart_content_description">Retirer l’élément du panier</string>
-    <string name="woo_pos_checkout_button">Validation de la commande</string>
+    <string name="woopos_checkout_button">Validation de la commande</string>
     <string name="woopos_reader_unknown">État du lecteur inconnu</string>
     <string name="woopos_checkout">Validation de la commande</string>
     <string name="woopos_reader_disconnected">Lecteur déconnecté</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -12,7 +12,7 @@ Language: fr
     <string name="woopos_exit_confirmation_message">Voulez-vous vraiment quitter le PDV ?</string>
     <string name="woopos_exit_confirmation_title">Quitter le PDV</string>
     <string name="woo_pos_car_pane_title">Panier</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">Retirer l’élément du panier</string>
+    <string name="woopos_remove_item_from_cart_content_description">Retirer l’élément du panier</string>
     <string name="woopos_checkout_button">Validation de la commande</string>
     <string name="woopos_reader_unknown">État du lecteur inconnu</string>
     <string name="woopos_checkout">Validation de la commande</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -11,7 +11,7 @@ Language: fr
     <string name="woopos_exit_confirmation_confirm_button">Quitter</string>
     <string name="woopos_exit_confirmation_message">Voulez-vous vraiment quitter le PDV ?</string>
     <string name="woopos_exit_confirmation_title">Quitter le PDV</string>
-    <string name="woo_pos_car_pane_title">Panier</string>
+    <string name="woopos_car_pane_title">Panier</string>
     <string name="woopos_remove_item_from_cart_content_description">Retirer l’élément du panier</string>
     <string name="woopos_checkout_button">Validation de la commande</string>
     <string name="woopos_reader_unknown">État du lecteur inconnu</string>

--- a/WooCommerce/src/main/res/values-fr/strings.xml
+++ b/WooCommerce/src/main/res/values-fr/strings.xml
@@ -11,7 +11,7 @@ Language: fr
     <string name="woopos_exit_confirmation_confirm_button">Quitter</string>
     <string name="woopos_exit_confirmation_message">Voulez-vous vraiment quitter le PDV ?</string>
     <string name="woopos_exit_confirmation_title">Quitter le PDV</string>
-    <string name="woopos_car_pane_title">Panier</string>
+    <string name="woopos_cart_title">Panier</string>
     <string name="woopos_remove_item_from_cart_content_description">Retirer l’élément du panier</string>
     <string name="woopos_checkout_button">Validation de la commande</string>
     <string name="woopos_reader_unknown">État du lecteur inconnu</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -13,7 +13,7 @@ Language: he_IL
     <string name="woopos_exit_confirmation_title">לצאת מ-POS</string>
     <string name="woo_pos_car_pane_title">עגלת קניות</string>
     <string name="woo_pos_remove_item_from_cart_content_description">להסיר את הפריט מעגלת הקניות</string>
-    <string name="woo_pos_checkout_button">תשלום בקופה</string>
+    <string name="woopos_checkout_button">תשלום בקופה</string>
     <string name="woopos_reader_unknown">הסטטוס של הקורא לא ידוע</string>
     <string name="woopos_checkout">קופה</string>
     <string name="woopos_reader_disconnected">הקורא מנותק</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -11,7 +11,7 @@ Language: he_IL
     <string name="woopos_exit_confirmation_confirm_button">יציאה</string>
     <string name="woopos_exit_confirmation_message">האם ברצונך לצאת מ-POS?</string>
     <string name="woopos_exit_confirmation_title">לצאת מ-POS</string>
-    <string name="woopos_car_pane_title">עגלת קניות</string>
+    <string name="woopos_cart_title">עגלת קניות</string>
     <string name="woopos_remove_item_from_cart_content_description">להסיר את הפריט מעגלת הקניות</string>
     <string name="woopos_checkout_button">תשלום בקופה</string>
     <string name="woopos_reader_unknown">הסטטוס של הקורא לא ידוע</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -11,7 +11,7 @@ Language: he_IL
     <string name="woopos_exit_confirmation_confirm_button">יציאה</string>
     <string name="woopos_exit_confirmation_message">האם ברצונך לצאת מ-POS?</string>
     <string name="woopos_exit_confirmation_title">לצאת מ-POS</string>
-    <string name="woo_pos_car_pane_title">עגלת קניות</string>
+    <string name="woopos_car_pane_title">עגלת קניות</string>
     <string name="woopos_remove_item_from_cart_content_description">להסיר את הפריט מעגלת הקניות</string>
     <string name="woopos_checkout_button">תשלום בקופה</string>
     <string name="woopos_reader_unknown">הסטטוס של הקורא לא ידוע</string>

--- a/WooCommerce/src/main/res/values-he/strings.xml
+++ b/WooCommerce/src/main/res/values-he/strings.xml
@@ -12,7 +12,7 @@ Language: he_IL
     <string name="woopos_exit_confirmation_message">האם ברצונך לצאת מ-POS?</string>
     <string name="woopos_exit_confirmation_title">לצאת מ-POS</string>
     <string name="woo_pos_car_pane_title">עגלת קניות</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">להסיר את הפריט מעגלת הקניות</string>
+    <string name="woopos_remove_item_from_cart_content_description">להסיר את הפריט מעגלת הקניות</string>
     <string name="woopos_checkout_button">תשלום בקופה</string>
     <string name="woopos_reader_unknown">הסטטוס של הקורא לא ידוע</string>
     <string name="woopos_checkout">קופה</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -11,7 +11,7 @@ Language: id
     <string name="woopos_exit_confirmation_confirm_button">Keluar</string>
     <string name="woopos_exit_confirmation_message">Anda yakin ingin keluar dari POS?</string>
     <string name="woopos_exit_confirmation_title">Keluar dari POS</string>
-    <string name="woo_pos_car_pane_title">Keranjang</string>
+    <string name="woopos_car_pane_title">Keranjang</string>
     <string name="woopos_remove_item_from_cart_content_description">Hapus item dari keranjang</string>
     <string name="woopos_checkout_button">Checkout</string>
     <string name="woopos_reader_unknown">Status Pembaca Tidak Diketahui</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -13,7 +13,7 @@ Language: id
     <string name="woopos_exit_confirmation_title">Keluar dari POS</string>
     <string name="woo_pos_car_pane_title">Keranjang</string>
     <string name="woo_pos_remove_item_from_cart_content_description">Hapus item dari keranjang</string>
-    <string name="woo_pos_checkout_button">Checkout</string>
+    <string name="woopos_checkout_button">Checkout</string>
     <string name="woopos_reader_unknown">Status Pembaca Tidak Diketahui</string>
     <string name="woopos_checkout">Checkout</string>
     <string name="woopos_reader_disconnected">Sambungan Pembaca Terputus</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -12,7 +12,7 @@ Language: id
     <string name="woopos_exit_confirmation_message">Anda yakin ingin keluar dari POS?</string>
     <string name="woopos_exit_confirmation_title">Keluar dari POS</string>
     <string name="woo_pos_car_pane_title">Keranjang</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">Hapus item dari keranjang</string>
+    <string name="woopos_remove_item_from_cart_content_description">Hapus item dari keranjang</string>
     <string name="woopos_checkout_button">Checkout</string>
     <string name="woopos_reader_unknown">Status Pembaca Tidak Diketahui</string>
     <string name="woopos_checkout">Checkout</string>

--- a/WooCommerce/src/main/res/values-id/strings.xml
+++ b/WooCommerce/src/main/res/values-id/strings.xml
@@ -11,7 +11,7 @@ Language: id
     <string name="woopos_exit_confirmation_confirm_button">Keluar</string>
     <string name="woopos_exit_confirmation_message">Anda yakin ingin keluar dari POS?</string>
     <string name="woopos_exit_confirmation_title">Keluar dari POS</string>
-    <string name="woopos_car_pane_title">Keranjang</string>
+    <string name="woopos_cart_title">Keranjang</string>
     <string name="woopos_remove_item_from_cart_content_description">Hapus item dari keranjang</string>
     <string name="woopos_checkout_button">Checkout</string>
     <string name="woopos_reader_unknown">Status Pembaca Tidak Diketahui</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -13,7 +13,7 @@ Language: it
     <string name="woopos_exit_confirmation_title">Esci da POS</string>
     <string name="woo_pos_car_pane_title">Carrello</string>
     <string name="woo_pos_remove_item_from_cart_content_description">Rimuovi elemento dal carrello</string>
-    <string name="woo_pos_checkout_button">Pagamento</string>
+    <string name="woopos_checkout_button">Pagamento</string>
     <string name="woopos_reader_unknown">Stato del lettore sconosciuto</string>
     <string name="woopos_checkout">Pagamento</string>
     <string name="woopos_reader_disconnected">Lettore disconnesso</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -11,7 +11,7 @@ Language: it
     <string name="woopos_exit_confirmation_confirm_button">Esci</string>
     <string name="woopos_exit_confirmation_message">Desideri uscire da POS?</string>
     <string name="woopos_exit_confirmation_title">Esci da POS</string>
-    <string name="woo_pos_car_pane_title">Carrello</string>
+    <string name="woopos_car_pane_title">Carrello</string>
     <string name="woopos_remove_item_from_cart_content_description">Rimuovi elemento dal carrello</string>
     <string name="woopos_checkout_button">Pagamento</string>
     <string name="woopos_reader_unknown">Stato del lettore sconosciuto</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -12,7 +12,7 @@ Language: it
     <string name="woopos_exit_confirmation_message">Desideri uscire da POS?</string>
     <string name="woopos_exit_confirmation_title">Esci da POS</string>
     <string name="woo_pos_car_pane_title">Carrello</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">Rimuovi elemento dal carrello</string>
+    <string name="woopos_remove_item_from_cart_content_description">Rimuovi elemento dal carrello</string>
     <string name="woopos_checkout_button">Pagamento</string>
     <string name="woopos_reader_unknown">Stato del lettore sconosciuto</string>
     <string name="woopos_checkout">Pagamento</string>

--- a/WooCommerce/src/main/res/values-it/strings.xml
+++ b/WooCommerce/src/main/res/values-it/strings.xml
@@ -11,7 +11,7 @@ Language: it
     <string name="woopos_exit_confirmation_confirm_button">Esci</string>
     <string name="woopos_exit_confirmation_message">Desideri uscire da POS?</string>
     <string name="woopos_exit_confirmation_title">Esci da POS</string>
-    <string name="woopos_car_pane_title">Carrello</string>
+    <string name="woopos_cart_title">Carrello</string>
     <string name="woopos_remove_item_from_cart_content_description">Rimuovi elemento dal carrello</string>
     <string name="woopos_checkout_button">Pagamento</string>
     <string name="woopos_reader_unknown">Stato del lettore sconosciuto</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -12,7 +12,7 @@ Language: ja_JP
     <string name="woopos_exit_confirmation_message">POS を終了してもよいですか ?</string>
     <string name="woopos_exit_confirmation_title">POS を終了</string>
     <string name="woo_pos_car_pane_title">お買い物カゴ</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">お買い物カゴからアイテムを削除</string>
+    <string name="woopos_remove_item_from_cart_content_description">お買い物カゴからアイテムを削除</string>
     <string name="woopos_checkout_button">購入手続き</string>
     <string name="woopos_reader_unknown">Reader ステータス不明</string>
     <string name="woopos_checkout">購入手続き</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -11,7 +11,7 @@ Language: ja_JP
     <string name="woopos_exit_confirmation_confirm_button">終了</string>
     <string name="woopos_exit_confirmation_message">POS を終了してもよいですか ?</string>
     <string name="woopos_exit_confirmation_title">POS を終了</string>
-    <string name="woopos_car_pane_title">お買い物カゴ</string>
+    <string name="woopos_cart_title">お買い物カゴ</string>
     <string name="woopos_remove_item_from_cart_content_description">お買い物カゴからアイテムを削除</string>
     <string name="woopos_checkout_button">購入手続き</string>
     <string name="woopos_reader_unknown">Reader ステータス不明</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -13,7 +13,7 @@ Language: ja_JP
     <string name="woopos_exit_confirmation_title">POS を終了</string>
     <string name="woo_pos_car_pane_title">お買い物カゴ</string>
     <string name="woo_pos_remove_item_from_cart_content_description">お買い物カゴからアイテムを削除</string>
-    <string name="woo_pos_checkout_button">購入手続き</string>
+    <string name="woopos_checkout_button">購入手続き</string>
     <string name="woopos_reader_unknown">Reader ステータス不明</string>
     <string name="woopos_checkout">購入手続き</string>
     <string name="woopos_reader_disconnected">Reader 切断済み</string>

--- a/WooCommerce/src/main/res/values-ja/strings.xml
+++ b/WooCommerce/src/main/res/values-ja/strings.xml
@@ -11,7 +11,7 @@ Language: ja_JP
     <string name="woopos_exit_confirmation_confirm_button">終了</string>
     <string name="woopos_exit_confirmation_message">POS を終了してもよいですか ?</string>
     <string name="woopos_exit_confirmation_title">POS を終了</string>
-    <string name="woo_pos_car_pane_title">お買い物カゴ</string>
+    <string name="woopos_car_pane_title">お買い物カゴ</string>
     <string name="woopos_remove_item_from_cart_content_description">お買い物カゴからアイテムを削除</string>
     <string name="woopos_checkout_button">購入手続き</string>
     <string name="woopos_reader_unknown">Reader ステータス不明</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -11,7 +11,7 @@ Language: ko_KR
     <string name="woopos_exit_confirmation_confirm_button">종료</string>
     <string name="woopos_exit_confirmation_message">POS를 종료하시겠어요?</string>
     <string name="woopos_exit_confirmation_title">POS 종료</string>
-    <string name="woo_pos_car_pane_title">장바구니</string>
+    <string name="woopos_car_pane_title">장바구니</string>
     <string name="woopos_remove_item_from_cart_content_description">장바구니에서 아이템 빼기</string>
     <string name="woopos_checkout_button">체크아웃</string>
     <string name="woopos_reader_unknown">리더 상태 알 수 없음</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -11,7 +11,7 @@ Language: ko_KR
     <string name="woopos_exit_confirmation_confirm_button">종료</string>
     <string name="woopos_exit_confirmation_message">POS를 종료하시겠어요?</string>
     <string name="woopos_exit_confirmation_title">POS 종료</string>
-    <string name="woopos_car_pane_title">장바구니</string>
+    <string name="woopos_cart_title">장바구니</string>
     <string name="woopos_remove_item_from_cart_content_description">장바구니에서 아이템 빼기</string>
     <string name="woopos_checkout_button">체크아웃</string>
     <string name="woopos_reader_unknown">리더 상태 알 수 없음</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -13,7 +13,7 @@ Language: ko_KR
     <string name="woopos_exit_confirmation_title">POS 종료</string>
     <string name="woo_pos_car_pane_title">장바구니</string>
     <string name="woo_pos_remove_item_from_cart_content_description">장바구니에서 아이템 빼기</string>
-    <string name="woo_pos_checkout_button">체크아웃</string>
+    <string name="woopos_checkout_button">체크아웃</string>
     <string name="woopos_reader_unknown">리더 상태 알 수 없음</string>
     <string name="woopos_checkout">체크아웃</string>
     <string name="woopos_reader_disconnected">리더 연결 해제됨</string>

--- a/WooCommerce/src/main/res/values-ko/strings.xml
+++ b/WooCommerce/src/main/res/values-ko/strings.xml
@@ -12,7 +12,7 @@ Language: ko_KR
     <string name="woopos_exit_confirmation_message">POS를 종료하시겠어요?</string>
     <string name="woopos_exit_confirmation_title">POS 종료</string>
     <string name="woo_pos_car_pane_title">장바구니</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">장바구니에서 아이템 빼기</string>
+    <string name="woopos_remove_item_from_cart_content_description">장바구니에서 아이템 빼기</string>
     <string name="woopos_checkout_button">체크아웃</string>
     <string name="woopos_reader_unknown">리더 상태 알 수 없음</string>
     <string name="woopos_checkout">체크아웃</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -11,7 +11,7 @@ Language: nl
     <string name="woopos_exit_confirmation_confirm_button">Afsluiten</string>
     <string name="woopos_exit_confirmation_message">Weet je zeker dat je POS wilt afsluiten?</string>
     <string name="woopos_exit_confirmation_title">POS afsluiten</string>
-    <string name="woopos_car_pane_title">Winkelwagen</string>
+    <string name="woopos_cart_title">Winkelwagen</string>
     <string name="woopos_remove_item_from_cart_content_description">Artikel uit winkelwagen verwijderen</string>
     <string name="woopos_checkout_button">Afrekenen</string>
     <string name="woopos_reader_unknown">Status van lezer is onbekend</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -13,7 +13,7 @@ Language: nl
     <string name="woopos_exit_confirmation_title">POS afsluiten</string>
     <string name="woo_pos_car_pane_title">Winkelwagen</string>
     <string name="woo_pos_remove_item_from_cart_content_description">Artikel uit winkelwagen verwijderen</string>
-    <string name="woo_pos_checkout_button">Afrekenen</string>
+    <string name="woopos_checkout_button">Afrekenen</string>
     <string name="woopos_reader_unknown">Status van lezer is onbekend</string>
     <string name="woopos_checkout">Afrekenen</string>
     <string name="woopos_reader_disconnected">Verbinding met lezer is verbroken</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -12,7 +12,7 @@ Language: nl
     <string name="woopos_exit_confirmation_message">Weet je zeker dat je POS wilt afsluiten?</string>
     <string name="woopos_exit_confirmation_title">POS afsluiten</string>
     <string name="woo_pos_car_pane_title">Winkelwagen</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">Artikel uit winkelwagen verwijderen</string>
+    <string name="woopos_remove_item_from_cart_content_description">Artikel uit winkelwagen verwijderen</string>
     <string name="woopos_checkout_button">Afrekenen</string>
     <string name="woopos_reader_unknown">Status van lezer is onbekend</string>
     <string name="woopos_checkout">Afrekenen</string>

--- a/WooCommerce/src/main/res/values-nl/strings.xml
+++ b/WooCommerce/src/main/res/values-nl/strings.xml
@@ -11,7 +11,7 @@ Language: nl
     <string name="woopos_exit_confirmation_confirm_button">Afsluiten</string>
     <string name="woopos_exit_confirmation_message">Weet je zeker dat je POS wilt afsluiten?</string>
     <string name="woopos_exit_confirmation_title">POS afsluiten</string>
-    <string name="woo_pos_car_pane_title">Winkelwagen</string>
+    <string name="woopos_car_pane_title">Winkelwagen</string>
     <string name="woopos_remove_item_from_cart_content_description">Artikel uit winkelwagen verwijderen</string>
     <string name="woopos_checkout_button">Afrekenen</string>
     <string name="woopos_reader_unknown">Status van lezer is onbekend</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -13,7 +13,7 @@ Language: pt_BR
     <string name="woo_pos_remove_item_from_cart_content_description">Remover item do carrinho</string>
     <string name="woopos_exit_confirmation_message">Tem certeza de que deseja sair do PDV?</string>
     <string name="woopos_exit_confirmation_title">Sair do PDV</string>
-    <string name="woo_pos_checkout_button">Finalizar compra</string>
+    <string name="woopos_checkout_button">Finalizar compra</string>
     <string name="woopos_reader_unknown">Status do leitor desconhecido</string>
     <string name="woopos_checkout">Checkout</string>
     <string name="woopos_reader_disconnected">Leitor desconectado</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -9,7 +9,7 @@ Language: pt_BR
     <string name="blaze_campaign_preview_audience_section_title">Público</string>
     <string name="woopos_exit_confirmation_dismiss_button">Cancelar</string>
     <string name="woopos_exit_confirmation_confirm_button">Sair</string>
-    <string name="woo_pos_car_pane_title">Carrinho</string>
+    <string name="woopos_car_pane_title">Carrinho</string>
     <string name="woopos_remove_item_from_cart_content_description">Remover item do carrinho</string>
     <string name="woopos_exit_confirmation_message">Tem certeza de que deseja sair do PDV?</string>
     <string name="woopos_exit_confirmation_title">Sair do PDV</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -9,7 +9,7 @@ Language: pt_BR
     <string name="blaze_campaign_preview_audience_section_title">Público</string>
     <string name="woopos_exit_confirmation_dismiss_button">Cancelar</string>
     <string name="woopos_exit_confirmation_confirm_button">Sair</string>
-    <string name="woopos_car_pane_title">Carrinho</string>
+    <string name="woopos_cart_title">Carrinho</string>
     <string name="woopos_remove_item_from_cart_content_description">Remover item do carrinho</string>
     <string name="woopos_exit_confirmation_message">Tem certeza de que deseja sair do PDV?</string>
     <string name="woopos_exit_confirmation_title">Sair do PDV</string>

--- a/WooCommerce/src/main/res/values-pt-rBR/strings.xml
+++ b/WooCommerce/src/main/res/values-pt-rBR/strings.xml
@@ -10,7 +10,7 @@ Language: pt_BR
     <string name="woopos_exit_confirmation_dismiss_button">Cancelar</string>
     <string name="woopos_exit_confirmation_confirm_button">Sair</string>
     <string name="woo_pos_car_pane_title">Carrinho</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">Remover item do carrinho</string>
+    <string name="woopos_remove_item_from_cart_content_description">Remover item do carrinho</string>
     <string name="woopos_exit_confirmation_message">Tem certeza de que deseja sair do PDV?</string>
     <string name="woopos_exit_confirmation_title">Sair do PDV</string>
     <string name="woopos_checkout_button">Finalizar compra</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -13,7 +13,7 @@ Language: ru
     <string name="woopos_exit_confirmation_title">Закрыть POS</string>
     <string name="woo_pos_car_pane_title">Корзина</string>
     <string name="woo_pos_remove_item_from_cart_content_description">Удалить товар из корзины</string>
-    <string name="woo_pos_checkout_button">Оформление заказа</string>
+    <string name="woopos_checkout_button">Оформление заказа</string>
     <string name="woopos_reader_unknown">Статус считывающего устройства неизвестен</string>
     <string name="woopos_checkout">Оформление заказа</string>
     <string name="woopos_reader_disconnected">Считывающее устройство отключено</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -12,7 +12,7 @@ Language: ru
     <string name="woopos_exit_confirmation_message">Вы уверены, что хотите закрыть POS?</string>
     <string name="woopos_exit_confirmation_title">Закрыть POS</string>
     <string name="woo_pos_car_pane_title">Корзина</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">Удалить товар из корзины</string>
+    <string name="woopos_remove_item_from_cart_content_description">Удалить товар из корзины</string>
     <string name="woopos_checkout_button">Оформление заказа</string>
     <string name="woopos_reader_unknown">Статус считывающего устройства неизвестен</string>
     <string name="woopos_checkout">Оформление заказа</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -11,7 +11,7 @@ Language: ru
     <string name="woopos_exit_confirmation_confirm_button">Выход</string>
     <string name="woopos_exit_confirmation_message">Вы уверены, что хотите закрыть POS?</string>
     <string name="woopos_exit_confirmation_title">Закрыть POS</string>
-    <string name="woo_pos_car_pane_title">Корзина</string>
+    <string name="woopos_car_pane_title">Корзина</string>
     <string name="woopos_remove_item_from_cart_content_description">Удалить товар из корзины</string>
     <string name="woopos_checkout_button">Оформление заказа</string>
     <string name="woopos_reader_unknown">Статус считывающего устройства неизвестен</string>

--- a/WooCommerce/src/main/res/values-ru/strings.xml
+++ b/WooCommerce/src/main/res/values-ru/strings.xml
@@ -11,7 +11,7 @@ Language: ru
     <string name="woopos_exit_confirmation_confirm_button">Выход</string>
     <string name="woopos_exit_confirmation_message">Вы уверены, что хотите закрыть POS?</string>
     <string name="woopos_exit_confirmation_title">Закрыть POS</string>
-    <string name="woopos_car_pane_title">Корзина</string>
+    <string name="woopos_cart_title">Корзина</string>
     <string name="woopos_remove_item_from_cart_content_description">Удалить товар из корзины</string>
     <string name="woopos_checkout_button">Оформление заказа</string>
     <string name="woopos_reader_unknown">Статус считывающего устройства неизвестен</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -12,7 +12,7 @@ Language: sv_SE
     <string name="woopos_exit_confirmation_message">Är du säker på att du vill avsluta POS?</string>
     <string name="woopos_exit_confirmation_title">Avsluta POS</string>
     <string name="woo_pos_car_pane_title">Varukorg</string>
-    <string name="woo_pos_checkout_button">Kassa</string>
+    <string name="woopos_checkout_button">Kassa</string>
     <string name="woo_pos_remove_item_from_cart_content_description">Ta bort vara från varukorg</string>
     <string name="dashboard_new_widgets_card_button">Lägg till nya sektioner</string>
     <string name="dashboard_product_stock_empty_products">Inga produkter hittades för den valda lagerstatusen</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -11,7 +11,7 @@ Language: sv_SE
     <string name="woopos_exit_confirmation_confirm_button">Avsluta</string>
     <string name="woopos_exit_confirmation_message">Är du säker på att du vill avsluta POS?</string>
     <string name="woopos_exit_confirmation_title">Avsluta POS</string>
-    <string name="woopos_car_pane_title">Varukorg</string>
+    <string name="woopos_cart_title">Varukorg</string>
     <string name="woopos_checkout_button">Kassa</string>
     <string name="woopos_remove_item_from_cart_content_description">Ta bort vara från varukorg</string>
     <string name="dashboard_new_widgets_card_button">Lägg till nya sektioner</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -11,7 +11,7 @@ Language: sv_SE
     <string name="woopos_exit_confirmation_confirm_button">Avsluta</string>
     <string name="woopos_exit_confirmation_message">Är du säker på att du vill avsluta POS?</string>
     <string name="woopos_exit_confirmation_title">Avsluta POS</string>
-    <string name="woo_pos_car_pane_title">Varukorg</string>
+    <string name="woopos_car_pane_title">Varukorg</string>
     <string name="woopos_checkout_button">Kassa</string>
     <string name="woopos_remove_item_from_cart_content_description">Ta bort vara från varukorg</string>
     <string name="dashboard_new_widgets_card_button">Lägg till nya sektioner</string>

--- a/WooCommerce/src/main/res/values-sv/strings.xml
+++ b/WooCommerce/src/main/res/values-sv/strings.xml
@@ -13,7 +13,7 @@ Language: sv_SE
     <string name="woopos_exit_confirmation_title">Avsluta POS</string>
     <string name="woo_pos_car_pane_title">Varukorg</string>
     <string name="woopos_checkout_button">Kassa</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">Ta bort vara från varukorg</string>
+    <string name="woopos_remove_item_from_cart_content_description">Ta bort vara från varukorg</string>
     <string name="dashboard_new_widgets_card_button">Lägg till nya sektioner</string>
     <string name="dashboard_product_stock_empty_products">Inga produkter hittades för den valda lagerstatusen</string>
     <string name="woopos_reader_disconnected">Läsare frånkopplad</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -12,7 +12,7 @@ Language: tr
     <string name="woopos_exit_confirmation_message">POS\'tan çıkmak istediğinizden emin misiniz?</string>
     <string name="woopos_exit_confirmation_title">POS\'tan çık</string>
     <string name="woo_pos_car_pane_title">Sepet</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">Ürünü sepetten çıkarın</string>
+    <string name="woopos_remove_item_from_cart_content_description">Ürünü sepetten çıkarın</string>
     <string name="woopos_checkout_button">Ödeme</string>
     <string name="woopos_reader_unknown">Okuyucu Durumu Bilinmiyor</string>
     <string name="woopos_checkout">Ödeme</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -11,7 +11,7 @@ Language: tr
     <string name="woopos_exit_confirmation_confirm_button">Çıkış</string>
     <string name="woopos_exit_confirmation_message">POS\'tan çıkmak istediğinizden emin misiniz?</string>
     <string name="woopos_exit_confirmation_title">POS\'tan çık</string>
-    <string name="woopos_car_pane_title">Sepet</string>
+    <string name="woopos_cart_title">Sepet</string>
     <string name="woopos_remove_item_from_cart_content_description">Ürünü sepetten çıkarın</string>
     <string name="woopos_checkout_button">Ödeme</string>
     <string name="woopos_reader_unknown">Okuyucu Durumu Bilinmiyor</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -13,7 +13,7 @@ Language: tr
     <string name="woopos_exit_confirmation_title">POS\'tan çık</string>
     <string name="woo_pos_car_pane_title">Sepet</string>
     <string name="woo_pos_remove_item_from_cart_content_description">Ürünü sepetten çıkarın</string>
-    <string name="woo_pos_checkout_button">Ödeme</string>
+    <string name="woopos_checkout_button">Ödeme</string>
     <string name="woopos_reader_unknown">Okuyucu Durumu Bilinmiyor</string>
     <string name="woopos_checkout">Ödeme</string>
     <string name="woopos_reader_disconnected">Okuyucu Bağlantısı Kesildi</string>

--- a/WooCommerce/src/main/res/values-tr/strings.xml
+++ b/WooCommerce/src/main/res/values-tr/strings.xml
@@ -11,7 +11,7 @@ Language: tr
     <string name="woopos_exit_confirmation_confirm_button">Çıkış</string>
     <string name="woopos_exit_confirmation_message">POS\'tan çıkmak istediğinizden emin misiniz?</string>
     <string name="woopos_exit_confirmation_title">POS\'tan çık</string>
-    <string name="woo_pos_car_pane_title">Sepet</string>
+    <string name="woopos_car_pane_title">Sepet</string>
     <string name="woopos_remove_item_from_cart_content_description">Ürünü sepetten çıkarın</string>
     <string name="woopos_checkout_button">Ödeme</string>
     <string name="woopos_reader_unknown">Okuyucu Durumu Bilinmiyor</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -13,7 +13,7 @@ Language: zh_CN
     <string name="woopos_exit_confirmation_title">退出 POS 机</string>
     <string name="woo_pos_car_pane_title">购物车</string>
     <string name="woo_pos_remove_item_from_cart_content_description">将商品从购物车中移除</string>
-    <string name="woo_pos_checkout_button">结账</string>
+    <string name="woopos_checkout_button">结账</string>
     <string name="woopos_reader_unknown">读卡器状态未知</string>
     <string name="woopos_checkout">结账</string>
     <string name="woopos_reader_disconnected">读卡器已断开连接</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -12,7 +12,7 @@ Language: zh_CN
     <string name="woopos_exit_confirmation_message">是否确定要退出 POS 机？</string>
     <string name="woopos_exit_confirmation_title">退出 POS 机</string>
     <string name="woo_pos_car_pane_title">购物车</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">将商品从购物车中移除</string>
+    <string name="woopos_remove_item_from_cart_content_description">将商品从购物车中移除</string>
     <string name="woopos_checkout_button">结账</string>
     <string name="woopos_reader_unknown">读卡器状态未知</string>
     <string name="woopos_checkout">结账</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -11,7 +11,7 @@ Language: zh_CN
     <string name="woopos_exit_confirmation_confirm_button">退出</string>
     <string name="woopos_exit_confirmation_message">是否确定要退出 POS 机？</string>
     <string name="woopos_exit_confirmation_title">退出 POS 机</string>
-    <string name="woo_pos_car_pane_title">购物车</string>
+    <string name="woopos_car_pane_title">购物车</string>
     <string name="woopos_remove_item_from_cart_content_description">将商品从购物车中移除</string>
     <string name="woopos_checkout_button">结账</string>
     <string name="woopos_reader_unknown">读卡器状态未知</string>

--- a/WooCommerce/src/main/res/values-zh-rCN/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rCN/strings.xml
@@ -11,7 +11,7 @@ Language: zh_CN
     <string name="woopos_exit_confirmation_confirm_button">退出</string>
     <string name="woopos_exit_confirmation_message">是否确定要退出 POS 机？</string>
     <string name="woopos_exit_confirmation_title">退出 POS 机</string>
-    <string name="woopos_car_pane_title">购物车</string>
+    <string name="woopos_cart_title">购物车</string>
     <string name="woopos_remove_item_from_cart_content_description">将商品从购物车中移除</string>
     <string name="woopos_checkout_button">结账</string>
     <string name="woopos_reader_unknown">读卡器状态未知</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -11,7 +11,7 @@ Language: zh_TW
     <string name="woopos_exit_confirmation_confirm_button">結束</string>
     <string name="woopos_exit_confirmation_message">你確定要結束 POS 嗎？</string>
     <string name="woopos_exit_confirmation_title">結束 POS</string>
-    <string name="woo_pos_car_pane_title">購物車</string>
+    <string name="woopos_car_pane_title">購物車</string>
     <string name="woopos_remove_item_from_cart_content_description">從購物車移除項目</string>
     <string name="woopos_checkout_button">結帳</string>
     <string name="woopos_reader_unknown">讀卡機狀態不明</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -12,7 +12,7 @@ Language: zh_TW
     <string name="woopos_exit_confirmation_message">你確定要結束 POS 嗎？</string>
     <string name="woopos_exit_confirmation_title">結束 POS</string>
     <string name="woo_pos_car_pane_title">購物車</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">從購物車移除項目</string>
+    <string name="woopos_remove_item_from_cart_content_description">從購物車移除項目</string>
     <string name="woopos_checkout_button">結帳</string>
     <string name="woopos_reader_unknown">讀卡機狀態不明</string>
     <string name="woopos_checkout">結帳</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -11,7 +11,7 @@ Language: zh_TW
     <string name="woopos_exit_confirmation_confirm_button">結束</string>
     <string name="woopos_exit_confirmation_message">你確定要結束 POS 嗎？</string>
     <string name="woopos_exit_confirmation_title">結束 POS</string>
-    <string name="woopos_car_pane_title">購物車</string>
+    <string name="woopos_cart_title">購物車</string>
     <string name="woopos_remove_item_from_cart_content_description">從購物車移除項目</string>
     <string name="woopos_checkout_button">結帳</string>
     <string name="woopos_reader_unknown">讀卡機狀態不明</string>

--- a/WooCommerce/src/main/res/values-zh-rTW/strings.xml
+++ b/WooCommerce/src/main/res/values-zh-rTW/strings.xml
@@ -13,7 +13,7 @@ Language: zh_TW
     <string name="woopos_exit_confirmation_title">結束 POS</string>
     <string name="woo_pos_car_pane_title">購物車</string>
     <string name="woo_pos_remove_item_from_cart_content_description">從購物車移除項目</string>
-    <string name="woo_pos_checkout_button">結帳</string>
+    <string name="woopos_checkout_button">結帳</string>
     <string name="woopos_reader_unknown">讀卡機狀態不明</string>
     <string name="woopos_checkout">結帳</string>
     <string name="woopos_reader_disconnected">讀卡機已中斷連結</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4132,7 +4132,7 @@
     <string name="woopos_reader_unknown">Reader Status Unknown</string>
     <string name="woopos_checkout_button">Check out</string>
     <string name="woopos_remove_item_from_cart_content_description">Remove item from cart</string>
-    <string name="woo_pos_car_pane_title">Cart</string>
+    <string name="woopos_car_pane_title">Cart</string>
     <string name="woo_pos_clear_cart_button">Clear all</string>
 
     <string name="woopos_exit_confirmation_title">Exit POS</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4133,7 +4133,7 @@
     <string name="woopos_checkout_button">Check out</string>
     <string name="woopos_remove_item_from_cart_content_description">Remove item from cart</string>
     <string name="woopos_car_pane_title">Cart</string>
-    <string name="woo_pos_clear_cart_button">Clear all</string>
+    <string name="woopos_clear_cart_button">Clear all</string>
 
     <string name="woopos_exit_confirmation_title">Exit POS</string>
     <string name="woopos_exit_confirmation_message">Are you sure you want to exit POS?</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4131,7 +4131,7 @@
     <string name="woopos_checkout">Checkout</string>
     <string name="woopos_reader_unknown">Reader Status Unknown</string>
     <string name="woopos_checkout_button">Check out</string>
-    <string name="woo_pos_remove_item_from_cart_content_description">Remove item from cart</string>
+    <string name="woopos_remove_item_from_cart_content_description">Remove item from cart</string>
     <string name="woo_pos_car_pane_title">Cart</string>
     <string name="woo_pos_clear_cart_button">Clear all</string>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4142,7 +4142,7 @@
     <string name="woopos_items_in_cart">%d items</string>
     <string name="woopos_product_image_description">Product Image</string>
     <string name="woopos_products_screen_title">Products</string>
-    <string name="woo_pos_cart_back_content_description">Cart icon</string>
+    <string name="woopos_cart_back_content_description">Cart icon</string>
     <string name="woopos_payment_failed_please_try_again">Payment failed. Please try again.</string>
     <string name="woopos_payment_successful_label">Payment successful</string>
     <string name="woo_pos_new_transaction_button">New transaction</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4139,7 +4139,7 @@
     <string name="woopos_exit_confirmation_message">Are you sure you want to exit POS?</string>
     <string name="woopos_exit_confirmation_confirm_button">Exit</string>
     <string name="woopos_exit_confirmation_dismiss_button">Cancel</string>
-    <string name="woo_pos_items_in_cart">%d items</string>
+    <string name="woopos_items_in_cart">%d items</string>
     <string name="woopos_product_image_description">Product Image</string>
     <string name="woopos_products_screen_title">Products</string>
     <string name="woo_pos_cart_back_content_description">Cart icon</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4130,7 +4130,7 @@
     <string name="woopos_reader_disconnected">Reader Disconnected</string>
     <string name="woopos_checkout">Checkout</string>
     <string name="woopos_reader_unknown">Reader Status Unknown</string>
-    <string name="woo_pos_checkout_button">Check out</string>
+    <string name="woopos_checkout_button">Check out</string>
     <string name="woo_pos_remove_item_from_cart_content_description">Remove item from cart</string>
     <string name="woo_pos_car_pane_title">Cart</string>
     <string name="woo_pos_clear_cart_button">Clear all</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4145,7 +4145,7 @@
     <string name="woopos_cart_back_content_description">Cart icon</string>
     <string name="woopos_payment_failed_please_try_again">Payment failed. Please try again.</string>
     <string name="woopos_payment_successful_label">Payment successful</string>
-    <string name="woo_pos_new_transaction_button">New transaction</string>
+    <string name="woopos_new_transaction_button">New transaction</string>
     <string name="woopos_payment_subtotal_label">Subtotal</string>
     <string name="woopos_payment_tax_label">Tax</string>
     <string name="woopos_payment_total_label">Total</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4132,7 +4132,7 @@
     <string name="woopos_reader_unknown">Reader Status Unknown</string>
     <string name="woopos_checkout_button">Check out</string>
     <string name="woopos_remove_item_from_cart_content_description">Remove item from cart</string>
-    <string name="woopos_car_pane_title">Cart</string>
+    <string name="woopos_cart_title">Cart</string>
     <string name="woopos_clear_cart_button">Clear all</string>
 
     <string name="woopos_exit_confirmation_title">Exit POS</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -27,8 +27,8 @@ class WooPosCartViewModelTest : BaseUnitTest() {
     }
     private val repository: WooPosCartRepository = mock()
     private val resourceProvider: ResourceProvider = mock {
-        on { getString(eq(R.string.woo_pos_items_in_cart), eq(1)) }.thenReturn("Items in cart: 1")
-        on { getString(eq(R.string.woo_pos_items_in_cart), eq(2)) }.thenReturn("Items in cart: 2")
+        on { getString(eq(R.string.woopos_items_in_cart), eq(1)) }.thenReturn("Items in cart: 1")
+        on { getString(eq(R.string.woopos_items_in_cart), eq(2)) }.thenReturn("Items in cart: 2")
     }
     private val formatPrice: WooPosFormatPrice = mock {
         onBlocking { invoke(eq(BigDecimal("10.0"))) }.thenReturn("10.0$")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11835
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Renames woopos strings to follow the same pattern

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->