### PR TITLE
[Wear App] Add missing Wear app release notes

### DIFF
--- a/fastlane/metadata/PlayStoreStrings.pot
+++ b/fastlane/metadata/PlayStoreStrings.pot
@@ -12,9 +12,7 @@ msgstr ""
 
 #. translators: Release notes for the latest Wear App version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
 msgctxt "wear_release_note"
-msgid ""
-"\n"
-"\n"
+msgid "Introduces the new Woo WearOS app featuring instant updates on store data and orders at glance!"
 msgstr ""
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/fastlane/metadata/wear/en-US/changelogs/default.txt
+++ b/fastlane/metadata/wear/en-US/changelogs/default.txt
@@ -1,2 +1,1 @@
-
-
+Introduces the new Woo WearOS app featuring instant updates on store data and orders at glance!


### PR DESCRIPTION
Summary
==========
Add the missing Wear app release notes that was meant to be introduced through the 19.2 release.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.