### PR TITLE
Enable Inbox Notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 19.4
 -----
-
+- [***] Inbox Notes have been enabled in both the Dynamic Dashboard and the Hub Menu, offering users a centralized and non-intrusive method for receiving important updates, feature announcements, and pertinent information. [https://github.com/woocommerce/woocommerce-android/pull/11900]
 
 19.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxUtils.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.ui.inbox.domain.InboxNote.NoteType.SURVEY
 import com.woocommerce.android.ui.inbox.domain.InboxNote.Status.ACTIONED
 import com.woocommerce.android.ui.inbox.domain.InboxNoteAction
 import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.ResourceProvider
 import org.wordpress.android.util.DateTimeUtils
 import java.util.Date
@@ -61,9 +62,10 @@ fun InboxNote.mapInboxActionsToUi(
         return emptyList()
     }
 
-    val noteActionsUi = actions
-        .map { it.toInboxActionUi(id, onAction) }
-        .toMutableList()
+    val noteActionsUi = mutableListOf<InboxNoteActionUi>()
+    if (FeatureFlag.SHOW_INBOX_CTA.isEnabled()) {
+        noteActionsUi.addAll(actions.map { it.toInboxActionUi(id, onAction) })
+    }
 
     addDismissActionIfMissing(noteActionsUi, onDismiss)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -18,7 +18,8 @@ enum class FeatureFlag {
     EOSL_M1,
     EOSL_M3,
     GOOGLE_ADS_M1,
-    PRODUCT_CREATION_WITH_AI_V2;
+    PRODUCT_CREATION_WITH_AI_V2,
+    SHOW_INBOX_CTA;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -38,7 +39,8 @@ enum class FeatureFlag {
             APP_PASSWORD_TUTORIAL,
             EOSL_M1,
             EOSL_M3,
-            INBOX -> true
+            INBOX,
+            SHOW_INBOX_CTA -> true
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -26,7 +26,6 @@ enum class FeatureFlag {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
 
-            INBOX,
             WOO_POS,
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
@@ -38,7 +37,8 @@ enum class FeatureFlag {
             NEW_SHIPPING_SUPPORT,
             APP_PASSWORD_TUTORIAL,
             EOSL_M1,
-            EOSL_M3 -> true
+            EOSL_M3,
+            INBOX -> true
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11845 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This enables the Inbox Notes by setting its local feature flag to `true`. Additionally, this introduces a new local feature flag that manages the visibility of CTAs on inbox notes.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log in.
2. Tap the ✎ icon at the top.
3. Verify that "Inbox" is listed on the "Customize" screen.
4. Enable "Inbox" and SAVE.
5. Verify that you view the "Inbox" card on the "My store" page.
6. Verify there are CTA buttons on inbox notes.
7. Navigate back.
8. Navigate to Menu → Inbox.
9. Repeat 6.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- This PR includes a link for the debug build. It's safer to test this on a release build because Inbox Notes is already enabled for debug builds. If you can't test release builds, that's fine too. This is a very straightforward change, and we can test it on the beta. I've already tested this with the release build.
- It's expected that there will be READ MORE buttons on long notes on the My Store screen. CTA buttons will be displayed after tapping READ MORE.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|before|after|
|-|-|
|<img src="https://github.com/woocommerce/woocommerce-android/assets/2471769/23ae6f26-614e-4de5-9093-6aa4f3244ecb" width=250>|<img src="https://github.com/woocommerce/woocommerce-android/assets/2471769/558901bf-a89c-4f8c-a21b-5611223ba5a1" width=250>)|
|<img src="https://github.com/woocommerce/woocommerce-android/assets/2471769/732d5f12-e15a-480d-ace9-6322cc3086d4" width=250>|<img src="https://github.com/woocommerce/woocommerce-android/assets/2471769/da26fe7e-c218-476a-adfc-401b00c84c01" width=250>|

|SHOW_INBOX_CTA = true|SHOW_INBOX_CTA = false|
|-|-|
|<img src="https://github.com/woocommerce/woocommerce-android/assets/2471769/e24540d6-3fac-432c-be87-05b6b4dc493b" width=250>|<img src="https://github.com/woocommerce/woocommerce-android/assets/2471769/7857d030-0474-4b9e-9924-3edad6ad0deb" width=250>|
|<img src="https://github.com/woocommerce/woocommerce-android/assets/2471769/d854e473-f117-4906-8cb4-142b1b17dd89" width=250>|<img src="https://github.com/woocommerce/woocommerce-android/assets/2471769/d74d1feb-534e-4048-a9b9-4e232dfd2ba6" width=250>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->