### PR TITLE
[POS] Change Button Label to "Checkout" for Consistency with US Market Terminology

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4130,7 +4130,7 @@
     <string name="woopos_reader_disconnected">Reader Disconnected</string>
     <string name="woopos_checkout">Checkout</string>
     <string name="woopos_reader_unknown">Reader Status Unknown</string>
-    <string name="woopos_checkout_button">Check out</string>
+    <string name="woopos_checkout_button">Checkout</string>
     <string name="woopos_remove_item_from_cart_content_description">Remove item from cart</string>
     <string name="woopos_cart_title">Cart</string>
     <string name="woopos_clear_cart_button">Clear all</string>


### PR DESCRIPTION
### Description  
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Per @staskus suggestion, update the button label from "Check out" to "Checkout". Aligns the terminology with standard US market practices.

Slack discussion for context:
https://a8c.slack.com/archives/C029KQRGV/p1720016210937649

### Steps to reproduce  
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Add a product on the POS home screen.
2. Verify the button is labeled "Checkout".

### Testing information  
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
- Tested functionality to ensure "Checkout" button performs expected actions.

### Images/gif  

![Screenshot_20240703_141804](https://github.com/woocommerce/woocommerce-android/assets/947561/278774a8-81ea-422c-9b95-4d0cc4eb0ae9)


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
