### PR TITLE
[Wear App] Adjust orders list to Play Store requirements

### DIFF
--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/list/OrdersListScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/list/OrdersListScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -116,6 +117,11 @@ private fun OrdersLazyColumn(
     ) {
         ScalingLazyColumn(
             modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(
+                top = 56.dp,
+                start = 12.dp,
+                end = 12.dp
+            ),
             autoCentering = AutoCenteringParams(itemIndex = 0),
             state = state
         ) {
@@ -184,10 +190,10 @@ fun OrderListItem(
     }
 }
 
-@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true)
-@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
-@Preview(device = WearDevices.SQUARE, showSystemUi = true)
-@Preview(device = WearDevices.RECT, showSystemUi = true)
+@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, fontScale = 2.0f)
+@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true, fontScale = 1.4f)
+@Preview(device = WearDevices.SQUARE, showSystemUi = true, fontScale = 2.0f)
+@Preview(device = WearDevices.RECT, showSystemUi = true, fontScale = 2.0f)
 @Composable
 fun Preview() {
     OrdersListScreen(
@@ -200,7 +206,7 @@ fun Preview() {
                 id = 0L,
                 date = "25 Feb",
                 number = "#125",
-                customerName = "John Doe",
+                customerName = "John Doe Doe Doe DOe",
                 total = "$100.00",
                 status = "Processing"
             ),

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/list/OrdersListScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/list/OrdersListScreen.kt
@@ -190,10 +190,10 @@ fun OrderListItem(
     }
 }
 
-@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true, fontScale = 2.0f)
-@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true, fontScale = 1.4f)
-@Preview(device = WearDevices.SQUARE, showSystemUi = true, fontScale = 2.0f)
-@Preview(device = WearDevices.RECT, showSystemUi = true, fontScale = 2.0f)
+@Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true)
+@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
+@Preview(device = WearDevices.SQUARE, showSystemUi = true)
+@Preview(device = WearDevices.RECT, showSystemUi = true)
 @Composable
 fun Preview() {
     OrdersListScreen(

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/list/OrdersListScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/list/OrdersListScreen.kt
@@ -119,8 +119,8 @@ private fun OrdersLazyColumn(
             modifier = Modifier.fillMaxSize(),
             contentPadding = PaddingValues(
                 top = 56.dp,
-                start = 12.dp,
-                end = 12.dp
+                start = 14.dp,
+                end = 14.dp
             ),
             autoCentering = AutoCenteringParams(itemIndex = 0),
             state = state
@@ -168,6 +168,7 @@ fun OrderListItem(
                 text = order.customerName,
                 style = WooTypography.body1,
                 color = Color.White,
+                maxLines = 1,
                 textAlign = TextAlign.Start,
                 modifier = Modifier.fillMaxWidth()
             )
@@ -191,7 +192,7 @@ fun OrderListItem(
 }
 
 @Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true)
-@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
+@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true, fontScale = 1.4f)
 @Preview(device = WearDevices.SQUARE, showSystemUi = true)
 @Preview(device = WearDevices.RECT, showSystemUi = true)
 @Composable
@@ -206,7 +207,7 @@ fun Preview() {
                 id = 0L,
                 date = "25 Feb",
                 number = "#125",
-                customerName = "John Doe Doe Doe DOe",
+                customerName = "John Doe Very Long Name",
                 total = "$100.00",
                 status = "Processing"
             ),

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/list/OrdersListScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/list/OrdersListScreen.kt
@@ -83,6 +83,7 @@ fun OrdersListScreen(
                         errorText = stringResource(id = R.string.orders_list_failed_to_load),
                         onRetryClicked = onRetryClicked
                     )
+
                     else -> OrdersLazyColumn(orders, onOrderClicked, modifier)
                 }
             }
@@ -157,10 +158,12 @@ fun OrderListItem(
             ) {
                 Text(
                     text = order.date,
+                    maxLines = 1,
                     color = WooColors.woo_purple_20
                 )
                 Text(
                     text = order.number,
+                    maxLines = 1,
                     color = WooColors.woo_gray_alpha
                 )
             }
@@ -176,6 +179,7 @@ fun OrderListItem(
                 text = order.total,
                 style = WooTypography.body1,
                 color = Color.White,
+                maxLines = 1,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Start,
                 modifier = Modifier.fillMaxWidth()

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/list/OrdersListScreen.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/list/OrdersListScreen.kt
@@ -120,8 +120,8 @@ private fun OrdersLazyColumn(
             modifier = Modifier.fillMaxSize(),
             contentPadding = PaddingValues(
                 top = 56.dp,
-                start = 14.dp,
-                end = 14.dp
+                start = 20.dp,
+                end = 20.dp
             ),
             autoCentering = AutoCenteringParams(itemIndex = 0),
             state = state
@@ -196,7 +196,7 @@ fun OrderListItem(
 }
 
 @Preview(device = WearDevices.LARGE_ROUND, showSystemUi = true)
-@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true, fontScale = 1.4f)
+@Preview(device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Preview(device = WearDevices.SQUARE, showSystemUi = true)
 @Preview(device = WearDevices.RECT, showSystemUi = true)
 @Composable


### PR DESCRIPTION
Summary
==========
Adjust the Order List screen bounds to avoid text being cut during large font sizes.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.