### PR TITLE
Issue/11899 new image selector

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptFragment.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.mediapicker.MediaPickerHelper
 import com.woocommerce.android.mediapicker.MediaPickerHelper.MediaPickerResultHandler
 import com.woocommerce.android.model.Product.Image
@@ -17,8 +16,6 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.ShowMediaDialog
-import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.ViewImage
-import com.woocommerce.android.ui.products.images.ProductImageViewerFragmentDirections
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -54,8 +51,6 @@ class AiProductPromptFragment : BaseFragment(), MediaPickerResultHandler {
             when (event) {
                 Exit -> findNavController().navigateUp()
 
-                is ViewImage -> showImageDetail(event.mediaUri)
-
                 is ShowMediaDialog -> mediaPickerHelper.showMediaPicker(event.source)
             }
         }
@@ -75,25 +70,5 @@ class AiProductPromptFragment : BaseFragment(), MediaPickerResultHandler {
 
     private fun onImageSelected(mediaUri: String) {
         viewModel.onMediaSelected(mediaUri)
-    }
-
-    private fun showImageDetail(imageUri: String) {
-        val action = ProductImageViewerFragmentDirections.actionGlobalProductImageViewerFragment(
-            isDeletingAllowed = false,
-            mediaId = 1,
-            remoteId = 0,
-            requestCode = 0,
-            selectedImage = null,
-            showChooser = false,
-            images = arrayOf(
-                Image(
-                    id = 0,
-                    name = null,
-                    source = imageUri,
-                    dateCreated = null,
-                )
-            )
-        )
-        findNavController().navigateSafely(action)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptFragment.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products.ai.productinfo
 
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -8,19 +9,26 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.mediapicker.MediaPickerHelper
+import com.woocommerce.android.mediapicker.MediaPickerHelper.MediaPickerResultHandler
+import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.ShowMediaDialog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
-class AiProductPromptFragment : BaseFragment() {
+class AiProductPromptFragment : BaseFragment(), MediaPickerResultHandler {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     private val viewModel: AiProductPromptViewModel by viewModels()
 
-    override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Hidden
+    @Inject
+    lateinit var mediaPickerHelper: MediaPickerHelper
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
@@ -42,7 +50,25 @@ class AiProductPromptFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 Exit -> findNavController().navigateUp()
+
+                is ShowMediaDialog -> mediaPickerHelper.showMediaPicker(event.source)
             }
         }
+    }
+
+    override fun onDeviceMediaSelected(imageUris: List<Uri>, source: String) {
+        if (imageUris.isNotEmpty()) {
+            onImageSelected(imageUris.first().toString())
+        }
+    }
+
+    override fun onWPMediaSelected(images: List<Image>) {
+        if (images.isNotEmpty()) {
+            onImageSelected(images.first().source)
+        }
+    }
+
+    private fun onImageSelected(mediaUri: String) {
+        viewModel.onMediaSelected(mediaUri)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptFragment.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.mediapicker.MediaPickerHelper
 import com.woocommerce.android.mediapicker.MediaPickerHelper.MediaPickerResultHandler
 import com.woocommerce.android.model.Product.Image
@@ -16,6 +17,8 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.ShowMediaDialog
+import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.ViewImage
+import com.woocommerce.android.ui.products.images.ProductImageViewerFragmentDirections
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -51,6 +54,8 @@ class AiProductPromptFragment : BaseFragment(), MediaPickerResultHandler {
             when (event) {
                 Exit -> findNavController().navigateUp()
 
+                is ViewImage -> showImageDetail(event.mediaUri)
+
                 is ShowMediaDialog -> mediaPickerHelper.showMediaPicker(event.source)
             }
         }
@@ -70,5 +75,25 @@ class AiProductPromptFragment : BaseFragment(), MediaPickerResultHandler {
 
     private fun onImageSelected(mediaUri: String) {
         viewModel.onMediaSelected(mediaUri)
+    }
+
+    private fun showImageDetail(imageUri: String) {
+        val action = ProductImageViewerFragmentDirections.actionGlobalProductImageViewerFragment(
+            isDeletingAllowed = false,
+            mediaId = 1,
+            remoteId = 0,
+            requestCode = 0,
+            selectedImage = null,
+            showChooser = false,
+            images = arrayOf(
+                Image(
+                    id = 0,
+                    name = null,
+                    source = imageUri,
+                    dateCreated = null,
+                )
+            )
+        )
+        findNavController().navigateSafely(action)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.mediapicker.MediaPickerDialog
+import com.woocommerce.android.ui.compose.component.ProductThumbnail
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
@@ -142,7 +143,7 @@ fun AiProductPromptScreen(
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_250)))
 
                 ProductPromptTextField(
-                    productPrompt = uiState.productPrompt,
+                    state = uiState,
                     onPromptUpdated = onPromptUpdated,
                     onReadTextFromProductPhoto = onReadTextFromProductPhoto,
                 )
@@ -245,7 +246,7 @@ private fun ToneDropDown(
 
 @Composable
 private fun ProductPromptTextField(
-    productPrompt: String,
+    state: AiProductPromptState,
     onPromptUpdated: (String) -> Unit,
     onReadTextFromProductPhoto: () -> Unit
 ) {
@@ -266,7 +267,7 @@ private fun ProductPromptTextField(
                 .clip(RoundedCornerShape(10.dp))
         ) {
             Box {
-                if (productPrompt.isEmpty()) {
+                if (state.productPrompt.isEmpty()) {
                     Text(
                         text = stringResource(id = R.string.ai_product_creation_prompt_placeholder),
                         style = MaterialTheme.typography.body1,
@@ -279,7 +280,7 @@ private fun ProductPromptTextField(
                 }
 
                 WCOutlinedTextField(
-                    value = productPrompt,
+                    value = state.productPrompt,
                     onValueChange = onPromptUpdated,
                     label = "", // Can't use label here as it breaks the visual design.
                     placeholderText = "", // Uses Text() above instead.
@@ -295,15 +296,44 @@ private fun ProductPromptTextField(
 
             Divider()
 
-            WCTextButton(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = dimensionResource(id = R.dimen.minor_50)),
-                onClick = onReadTextFromProductPhoto,
-                icon = ImageVector.vectorResource(id = R.drawable.ic_gridicons_camera_primary),
-                allCaps = false,
-                text = stringResource(id = R.string.ai_product_creation_read_text_from_photo_button),
-            )
+            when {
+                state.isScanningImage -> {
+                    // TODO() show progress while scanning image
+                }
+
+                state.mediaUri != null -> {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        ProductThumbnail(
+                            imageUrl = state.mediaUri,
+                            contentDescription = stringResource(id = R.string.product_image_content_description),
+                            modifier = Modifier.padding(end = 16.dp)
+                        )
+                        Text(
+                            text = stringResource(id = R.string.product_creation_ai_tone_title),
+                            style = MaterialTheme.typography.subtitle1,
+                            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
+                }
+
+                else -> {
+                    WCTextButton(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = dimensionResource(id = R.dimen.minor_50)),
+                        onClick = onReadTextFromProductPhoto,
+                        icon = ImageVector.vectorResource(id = R.drawable.ic_gridicons_camera_primary),
+                        allCaps = false,
+                        text = stringResource(id = R.string.ai_product_creation_read_text_from_photo_button),
+                    )
+                }
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -102,6 +102,7 @@ private fun FullScreenImage(
     viewModel: AiProductPromptViewModel,
     state: AiProductPromptState
 ) {
+    BackHandler(onBack = viewModel::onImageFullScreenDismissed)
     Column {
         Toolbar(
             navigationIcon = Filled.Close,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -114,7 +114,7 @@ private fun FullScreenImage(
                 .crossfade(true)
                 .build(),
             contentDescription = null,
-            contentScale = ContentScale.Crop,
+            contentScale = ContentScale.Inside,
             modifier = Modifier.fillMaxSize()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -382,7 +382,7 @@ private fun UploadedImageRow(
             modifier = Modifier.padding(end = 16.dp)
         )
         Text(
-            text = stringResource(id = R.string.product_creation_ai_tone_title),
+            text = stringResource(id = R.string.ai_product_creation_image_uploaded),
             style = MaterialTheme.typography.subtitle1,
             color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -339,7 +340,7 @@ private fun UploadedImageRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(16.dp),
+            .padding(start = 16.dp, top = 16.dp, bottom = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         ProductThumbnail(
@@ -387,7 +388,7 @@ private fun ImageActionsMenu(
                 DropdownMenuItem(
                     modifier = Modifier
                         .height(dimensionResource(id = R.dimen.major_175))
-                        .padding(end = 32.dp),
+                        .width(200.dp),
                     onClick = {
                         showMenu = false
                         onImageActionSelected(item)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -52,12 +52,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.mediapicker.MediaPickerDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.AiProductPromptState
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.Tone
+import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource
 
 @Composable
 fun AiProductPromptScreen(viewModel: AiProductPromptViewModel) {
@@ -70,7 +72,9 @@ fun AiProductPromptScreen(viewModel: AiProductPromptViewModel) {
             onPromptUpdated = viewModel::onPromptUpdated,
             onReadTextFromProductPhoto = viewModel::onReadTextFromProductPhoto,
             onGenerateProductClicked = viewModel::onGenerateProductClicked,
-            onToneSelected = viewModel::onToneSelected
+            onToneSelected = viewModel::onToneSelected,
+            onMediaPickerDialogDismissed = viewModel::onMediaPickerDialogDismissed,
+            onMediaLibraryRequested = viewModel::onMediaLibraryRequested
         )
     }
 }
@@ -82,7 +86,9 @@ fun AiProductPromptScreen(
     onPromptUpdated: (String) -> Unit,
     onReadTextFromProductPhoto: () -> Unit,
     onGenerateProductClicked: () -> Unit,
-    onToneSelected: (Tone) -> Unit
+    onToneSelected: (Tone) -> Unit,
+    onMediaPickerDialogDismissed: () -> Unit,
+    onMediaLibraryRequested: (DataSource) -> Unit
 ) {
     val orientation = LocalConfiguration.current.orientation
 
@@ -159,6 +165,12 @@ fun AiProductPromptScreen(
                 GenerateProductButton()
             }
         }
+    }
+    if (uiState.isMediaPickerDialogVisible) {
+        MediaPickerDialog(
+            onMediaPickerDialogDismissed,
+            onMediaLibraryRequested
+        )
     }
 }
 
@@ -302,12 +314,17 @@ private fun AiProductPromptScreenPreview() {
     AiProductPromptScreen(
         uiState = AiProductPromptState(
             productPrompt = "Product prompt test",
-            selectedTone = Tone.Casual
+            selectedTone = Tone.Casual,
+            isMediaPickerDialogVisible = false,
+            mediaUri = null,
+            isScanningImage = false
         ),
         onBackButtonClick = {},
         onPromptUpdated = {},
         onReadTextFromProductPhoto = {},
         onGenerateProductClicked = {},
-        onToneSelected = {}
+        onToneSelected = {},
+        onMediaPickerDialogDismissed = {},
+        onMediaLibraryRequested = {}
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -30,9 +30,11 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.Icons.Outlined
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -46,7 +48,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
@@ -55,6 +59,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest.Builder
 import com.woocommerce.android.R
 import com.woocommerce.android.mediapicker.MediaPickerDialog
 import com.woocommerce.android.ui.compose.component.ProductThumbnail
@@ -73,16 +79,42 @@ fun AiProductPromptScreen(viewModel: AiProductPromptViewModel) {
     BackHandler(onBack = viewModel::onBackButtonClick)
 
     viewModel.state.observeAsState().value?.let { state ->
-        AiProductPromptScreen(
-            uiState = state,
-            onBackButtonClick = viewModel::onBackButtonClick,
-            onPromptUpdated = viewModel::onPromptUpdated,
-            onReadTextFromProductPhoto = viewModel::onAddImageForScanning,
-            onGenerateProductClicked = viewModel::onGenerateProductClicked,
-            onToneSelected = viewModel::onToneSelected,
-            onMediaPickerDialogDismissed = viewModel::onMediaPickerDialogDismissed,
-            onMediaLibraryRequested = viewModel::onMediaLibraryRequested,
-            onImageActionSelected = viewModel::onImageActionSelected
+        if (state.showImageFullScreen) {
+            FullScreenImage(viewModel, state)
+        } else {
+            AiProductPromptScreen(
+                uiState = state,
+                onBackButtonClick = viewModel::onBackButtonClick,
+                onPromptUpdated = viewModel::onPromptUpdated,
+                onReadTextFromProductPhoto = viewModel::onAddImageForScanning,
+                onGenerateProductClicked = viewModel::onGenerateProductClicked,
+                onToneSelected = viewModel::onToneSelected,
+                onMediaPickerDialogDismissed = viewModel::onMediaPickerDialogDismissed,
+                onMediaLibraryRequested = viewModel::onMediaLibraryRequested,
+                onImageActionSelected = viewModel::onImageActionSelected
+            )
+        }
+    }
+}
+
+@Composable
+private fun FullScreenImage(
+    viewModel: AiProductPromptViewModel,
+    state: AiProductPromptState
+) {
+    Column {
+        Toolbar(
+            navigationIcon = Filled.Close,
+            onNavigationButtonClick = viewModel::onImageFullScreenDismissed
+        )
+        AsyncImage(
+            model = Builder(LocalContext.current)
+                .data(state.mediaUri)
+                .crossfade(true)
+                .build(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize()
         )
     }
 }
@@ -419,7 +451,8 @@ private fun AiProductPromptScreenPreview() {
             selectedTone = Tone.Casual,
             isMediaPickerDialogVisible = false,
             mediaUri = null,
-            isScanningImage = false
+            isScanningImage = false,
+            showImageFullScreen = false
         ),
         onBackButtonClick = {},
         onPromptUpdated = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
@@ -34,7 +34,8 @@ class AiProductPromptViewModel @Inject constructor(
             selectedTone = Tone.Casual,
             isMediaPickerDialogVisible = false,
             mediaUri = null,
-            isScanningImage = false
+            isScanningImage = false,
+            showImageFullScreen = false
         )
     )
 
@@ -81,17 +82,16 @@ class AiProductPromptViewModel @Inject constructor(
         _state.value = _state.value.copy(mediaUri = mediaUri)
     }
 
-    fun onImageActionSelected(imageAction: AiProductPromptViewModel.ImageAction) {
+    fun onImageActionSelected(imageAction: ImageAction) {
         when (imageAction) {
-            View -> {
-                state.value?.mediaUri?.let { mediaUri ->
-                    triggerEvent(ViewImage(mediaUri))
-                }
-            }
-
+            View -> _state.value = _state.value.copy(showImageFullScreen = true)
             Replace -> _state.value = _state.value.copy(isMediaPickerDialogVisible = true)
             Remove -> _state.value = _state.value.copy(mediaUri = null)
         }
+    }
+
+    fun onImageFullScreenDismissed() {
+        _state.value = _state.value.copy(showImageFullScreen = false)
     }
 
     @Parcelize
@@ -100,7 +100,8 @@ class AiProductPromptViewModel @Inject constructor(
         val selectedTone: Tone,
         val isMediaPickerDialogVisible: Boolean,
         val mediaUri: String?,
-        val isScanningImage: Boolean
+        val isScanningImage: Boolean,
+        val showImageFullScreen: Boolean
     ) : Parcelable
 
     enum class Tone(@StringRes val displayName: Int, val slug: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
@@ -119,7 +119,7 @@ class AiProductPromptViewModel @Inject constructor(
     enum class ImageAction(@StringRes val displayName: Int) {
         View(R.string.ai_product_creation_view_image),
         Replace(R.string.ai_product_creation_replace_image),
-        Remove(R.string.ai_product_creation_remove_image);
+        Remove(R.string.ai_product_creation_remove_image)
     }
 
     data class ShowMediaDialog(val source: DataSource) : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
@@ -9,6 +9,9 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.ImageAction.Remove
+import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.ImageAction.Replace
+import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.ImageAction.View
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -45,7 +48,7 @@ class AiProductPromptViewModel @Inject constructor(
         _state.value = _state.value.copy(productPrompt = prompt)
     }
 
-    fun onReadTextFromProductPhoto() {
+    fun onAddImageForScanning() {
         tracker.track(
             AnalyticsEvent.PRODUCT_NAME_AI_PACKAGE_IMAGE_BUTTON_TAPPED,
             mapOf(
@@ -67,7 +70,7 @@ class AiProductPromptViewModel @Inject constructor(
     }
 
     fun onGenerateProductClicked() {
-        TODO("Not yet implemented")
+        // TODO()
     }
 
     fun onToneSelected(tone: Tone) {
@@ -76,6 +79,19 @@ class AiProductPromptViewModel @Inject constructor(
 
     fun onMediaSelected(mediaUri: String) {
         _state.value = _state.value.copy(mediaUri = mediaUri)
+    }
+
+    fun onImageActionSelected(imageAction: AiProductPromptViewModel.ImageAction) {
+        when (imageAction) {
+            View -> {
+                state.value?.mediaUri?.let { mediaUri ->
+                    triggerEvent(ViewImage(mediaUri))
+                }
+            }
+
+            Replace -> _state.value = _state.value.copy(isMediaPickerDialogVisible = true)
+            Remove -> _state.value = _state.value.copy(mediaUri = null)
+        }
     }
 
     @Parcelize
@@ -99,5 +115,12 @@ class AiProductPromptViewModel @Inject constructor(
         }
     }
 
+    enum class ImageAction(@StringRes val displayName: Int) {
+        View(R.string.ai_product_creation_view_image),
+        Replace(R.string.ai_product_creation_replace_image),
+        Remove(R.string.ai_product_creation_remove_image);
+    }
+
     data class ShowMediaDialog(val source: DataSource) : Event()
+    data class ViewImage(val mediaUri: String) : Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
@@ -123,5 +123,4 @@ class AiProductPromptViewModel @Inject constructor(
     }
 
     data class ShowMediaDialog(val source: DataSource) : Event()
-    data class ViewImage(val mediaUri: String) : Event()
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2225,6 +2225,7 @@
     <string name="ai_product_creation_view_image">View photo</string>
     <string name="ai_product_creation_replace_image">Replace photo</string>
     <string name="ai_product_creation_remove_image">Remove photo</string>
+    <string name="ai_product_creation_image_uploaded">Photo uploaded</string>
 
     <!--
         Product Add more details Bottom sheet

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2222,6 +2222,9 @@
     <string name="product_creation_survey_button_remind_me_later">Remind Me Later</string>
     <string name="product_creation_survey_button_dont_show_again">Don\’t show it Again</string>
     <string name="ai_product_creation_generate_details_button">Generate Product Details</string>
+    <string name="ai_product_creation_view_image">View photo</string>
+    <string name="ai_product_creation_replace_image">Replace photo</string>
+    <string name="ai_product_creation_remove_image">Remove photo</string>
 
     <!--
         Product Add more details Bottom sheet


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11899 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Add all the logic to handle adding, replacing or removing and product image to be scanned and extract a prompt from it. 
Not that this PR only adds the logic to manage the image and update the UI accordingly, the scanning of the image will be tackled in a different PR. 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
1. Trigger product creation with AI flow
2. Add an image by clicking on `Read text from product photo`
3. Check that the UI is updated with the image
4. Click on the three options available to manage the image: `view`, `replace`, `remove`. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/e8897eb2-43e3-4dcf-b360-8e2188599723
