### PR TITLE
Issue/11909 scan image and fill text

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/TextRecognitionEngine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/TextRecognitionEngine.kt
@@ -9,6 +9,7 @@ import coil.request.SuccessResult
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import com.woocommerce.android.util.WooLog
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
@@ -27,6 +28,7 @@ class TextRecognitionEngine @Inject constructor(
             val result = textRecognizer.process(image).await()
             Result.success(result.textBlocks.map { it.text })
         } catch (e: Exception) {
+            WooLog.d(WooLog.T.AI, "Failed to scan text from image: ${e.message}")
             Result.failure(e)
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptFragment.kt
@@ -14,12 +14,14 @@ import com.woocommerce.android.mediapicker.MediaPickerHelper
 import com.woocommerce.android.mediapicker.MediaPickerHelper.MediaPickerResultHandler
 import com.woocommerce.android.model.Product.Image
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.ShowMediaDialog
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.ViewImage
 import com.woocommerce.android.ui.products.images.ProductImageViewerFragmentDirections
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -32,6 +34,9 @@ class AiProductPromptFragment : BaseFragment(), MediaPickerResultHandler {
 
     @Inject
     lateinit var mediaPickerHelper: MediaPickerHelper
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
@@ -57,6 +62,7 @@ class AiProductPromptFragment : BaseFragment(), MediaPickerResultHandler {
                 is ViewImage -> showImageDetail(event.mediaUri)
 
                 is ShowMediaDialog -> mediaPickerHelper.showMediaPicker(event.source)
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -404,7 +404,6 @@ private fun InformativeMessage(message: String) {
                 colorResource(id = R.color.tag_bg_main)
             )
     ) {
-
         Icon(
             painter = painterResource(R.drawable.ic_info_outline_20dp),
             contentDescription = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -193,6 +193,12 @@ fun AiProductPromptScreen(
                     onImageActionSelected = onImageActionSelected
                 )
 
+                if (uiState.noTextDetectedMessage) {
+                    InformativeMessage(
+                        stringResource(id = R.string.product_creation_package_photo_no_text_detected)
+                    )
+                }
+
                 ToneDropDown(
                     tone = uiState.selectedTone,
                     onToneSelected = onToneSelected
@@ -344,9 +350,6 @@ private fun ProductPromptTextField(
 
             when {
                 state.isScanningImage -> ImageScanning()
-                state.noTextDetectedMessage -> InformativeMessage(
-                    stringResource(id = R.string.product_creation_package_photo_no_text_detected)
-                )
                 state.mediaUri != null -> UploadedImageRow(
                     state.mediaUri,
                     onImageActionSelected
@@ -395,6 +398,7 @@ private fun InformativeMessage(message: String) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .padding(vertical = 16.dp)
             .clip(RoundedCornerShape(dimensionResource(id = R.dimen.minor_100)))
             .background(
                 colorResource(id = R.color.tag_bg_main)
@@ -513,6 +517,30 @@ private fun AiProductPromptScreenPreview() {
             isScanningImage = false,
             showImageFullScreen = false,
             noTextDetectedMessage = false
+        ),
+        onBackButtonClick = {},
+        onPromptUpdated = {},
+        onReadTextFromProductPhoto = {},
+        onGenerateProductClicked = {},
+        onToneSelected = {},
+        onMediaPickerDialogDismissed = {},
+        onMediaLibraryRequested = {},
+        onImageActionSelected = {}
+    )
+}
+
+@Preview
+@Composable
+private fun AiProductPromptScreenWithErrorPreview() {
+    AiProductPromptScreen(
+        uiState = AiProductPromptState(
+            productPrompt = "Product prompt test",
+            selectedTone = Tone.Casual,
+            isMediaPickerDialogVisible = false,
+            mediaUri = null,
+            isScanningImage = false,
+            showImageFullScreen = false,
+            noTextDetectedMessage = true
         ),
         onBackButtonClick = {},
         onPromptUpdated = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -16,9 +16,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.DropdownMenu
@@ -340,10 +342,7 @@ private fun ProductPromptTextField(
             Divider()
 
             when {
-                state.isScanningImage -> {
-                    // TODO() show progress while scanning image
-                }
-
+                state.isScanningImage -> ImageScanning()
                 state.mediaUri != null -> UploadedImageRow(
                     state.mediaUri,
                     onImageActionSelected
@@ -362,6 +361,28 @@ private fun ProductPromptTextField(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun ImageScanning() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, top = 16.dp, bottom = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentWidth()
+                .padding(end = 16.dp)
+        )
+        Text(
+            text = stringResource(id = R.string.ai_product_creation_scanning_image),
+            style = MaterialTheme.typography.subtitle1,
+            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -350,7 +350,7 @@ private fun ProductPromptTextField(
 
             when {
                 state.isScanningImage -> ImageScanning()
-                state.mediaUri != null -> UploadedImageRow(
+                state.mediaUri != null -> SelectedImageRow(
                     state.mediaUri,
                     onImageActionSelected
                 )
@@ -427,7 +427,7 @@ private fun InformativeMessage(message: String) {
 }
 
 @Composable
-private fun UploadedImageRow(
+private fun SelectedImageRow(
     mediaUri: String,
     onImageActionSelected: (ImageAction) -> Unit
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
@@ -343,6 +344,9 @@ private fun ProductPromptTextField(
 
             when {
                 state.isScanningImage -> ImageScanning()
+                state.noTextDetectedMessage -> InformativeMessage(
+                    stringResource(id = R.string.product_creation_package_photo_no_text_detected)
+                )
                 state.mediaUri != null -> UploadedImageRow(
                     state.mediaUri,
                     onImageActionSelected
@@ -382,6 +386,39 @@ private fun ImageScanning() {
             text = stringResource(id = R.string.ai_product_creation_scanning_image),
             style = MaterialTheme.typography.subtitle1,
             color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+        )
+    }
+}
+
+@Composable
+private fun InformativeMessage(message: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(dimensionResource(id = R.dimen.minor_100)))
+            .background(
+                colorResource(id = R.color.tag_bg_main)
+            )
+    ) {
+
+        Icon(
+            painter = painterResource(R.drawable.ic_info_outline_20dp),
+            contentDescription = null,
+            modifier = Modifier
+                .padding(dimensionResource(id = R.dimen.major_100))
+                .size(dimensionResource(id = R.dimen.major_150)),
+            tint = colorResource(id = R.color.tag_text_main),
+        )
+        Text(
+            text = message,
+            color = colorResource(id = R.color.tag_text_main),
+            modifier = Modifier
+                .weight(1f)
+                .padding(
+                    top = dimensionResource(id = R.dimen.major_100),
+                    end = dimensionResource(id = R.dimen.major_100),
+                    bottom = dimensionResource(id = R.dimen.major_100)
+                )
         )
     }
 }
@@ -474,7 +511,8 @@ private fun AiProductPromptScreenPreview() {
             isMediaPickerDialogVisible = false,
             mediaUri = null,
             isScanningImage = false,
-            showImageFullScreen = false
+            showImageFullScreen = false,
+            noTextDetectedMessage = false
         ),
         onBackButtonClick = {},
         onPromptUpdated = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -442,7 +442,7 @@ private fun SelectedImageRow(
             modifier = Modifier.padding(end = 16.dp)
         )
         Text(
-            text = stringResource(id = R.string.ai_product_creation_image_uploaded),
+            text = stringResource(id = R.string.ai_product_creation_image_selected),
             style = MaterialTheme.typography.subtitle1,
         )
         Spacer(modifier = Modifier.weight(1f))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -381,7 +381,6 @@ private fun ImageScanning() {
     ) {
         CircularProgressIndicator(
             modifier = Modifier
-                .fillMaxWidth()
                 .wrapContentWidth()
                 .padding(end = 16.dp)
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -388,7 +388,6 @@ private fun ImageScanning() {
         Text(
             text = stringResource(id = R.string.ai_product_creation_scanning_image),
             style = MaterialTheme.typography.subtitle1,
-            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
         )
     }
 }
@@ -445,7 +444,6 @@ private fun SelectedImageRow(
         Text(
             text = stringResource(id = R.string.ai_product_creation_image_uploaded),
             style = MaterialTheme.typography.subtitle1,
-            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
         )
         Spacer(modifier = Modifier.weight(1f))
         ImageActionsMenu(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
@@ -125,7 +125,7 @@ class AiProductPromptViewModel @Inject constructor(
             Replace -> _state.value = _state.value.copy(isMediaPickerDialogVisible = true)
             Remove -> _state.value = _state.value.copy(
                 mediaUri = null,
-                isScanningImage = false,
+                noTextDetectedMessage = false,
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
@@ -79,7 +79,10 @@ class AiProductPromptViewModel @Inject constructor(
     }
 
     fun onMediaSelected(mediaUri: String) {
-        _state.value = _state.value.copy(mediaUri = mediaUri)
+        _state.value = _state.value.copy(isScanningImage = true)
+
+
+//        _state.value = _state.value.copy(mediaUri = mediaUri)
     }
 
     fun onImageActionSelected(imageAction: ImageAction) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
@@ -123,7 +123,10 @@ class AiProductPromptViewModel @Inject constructor(
         when (imageAction) {
             View -> _state.value = _state.value.copy(showImageFullScreen = true)
             Replace -> _state.value = _state.value.copy(isMediaPickerDialogVisible = true)
-            Remove -> _state.value = _state.value.copy(mediaUri = null)
+            Remove -> _state.value = _state.value.copy(
+                mediaUri = null,
+                isScanningImage = false,
+            )
         }
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2227,6 +2227,7 @@
     <string name="ai_product_creation_remove_image">Remove photo</string>
     <string name="ai_product_creation_image_uploaded">Photo uploaded</string>
     <string name="ai_product_creation_scanning_image">Scanning image</string>
+    <string name="ai_product_creation_scanning_photo_error">Error while trying to scan the text from the photo. Please try again</string>
 
     <!--
         Product Add more details Bottom sheet

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2225,7 +2225,7 @@
     <string name="ai_product_creation_view_image">View photo</string>
     <string name="ai_product_creation_replace_image">Replace photo</string>
     <string name="ai_product_creation_remove_image">Remove photo</string>
-    <string name="ai_product_creation_image_uploaded">Photo selected</string>
+    <string name="ai_product_creation_image_selected">Photo selected</string>
     <string name="ai_product_creation_scanning_image">Scanning image</string>
     <string name="ai_product_creation_scanning_photo_error">Error while trying to scan the text from the photo. Please try again</string>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2226,6 +2226,7 @@
     <string name="ai_product_creation_replace_image">Replace photo</string>
     <string name="ai_product_creation_remove_image">Remove photo</string>
     <string name="ai_product_creation_image_uploaded">Photo uploaded</string>
+    <string name="ai_product_creation_scanning_image">Scanning image</string>
 
     <!--
         Product Add more details Bottom sheet

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2225,7 +2225,7 @@
     <string name="ai_product_creation_view_image">View photo</string>
     <string name="ai_product_creation_replace_image">Replace photo</string>
     <string name="ai_product_creation_remove_image">Remove photo</string>
-    <string name="ai_product_creation_image_uploaded">Photo uploaded</string>
+    <string name="ai_product_creation_image_uploaded">Photo selected</string>
     <string name="ai_product_creation_scanning_image">Scanning image</string>
     <string name="ai_product_creation_scanning_photo_error">Error while trying to scan the text from the photo. Please try again</string>
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11909 
Previous PR: https://github.com/woocommerce/woocommerce-android/pull/11907
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds logic to scan product package images and fill the prompt with the detected text. 
Continuation of this other PR https://github.com/woocommerce/woocommerce-android/pull/11907
This part adds the missing logic to scan the text from the selected image and populate the product prompt. 
I'll add unit test in a subsequent PR. 

### Testing information
1. Trigger product creation with AI flow
2. Add an image by clicking on Read text from product photo
3. Check that a loading state is displayed while the image is being scanned
4. If the image has any text on it, check that the text field is populated with it. Each keyword will be separated by black space. This replicates iOS behavior, however I'm not sure if we should split this with `,` instead. I asked about it here: p1720184504232449-slack-C03L1NF1EA3
5. Add an image without text and check that the informative message about not being able to detect any text from the selected image is displayed. 

Couple behavioral notes: 
- If text is detected from an image populate it. (Overwrite previously detected text)
- If text is not detected from an image show the error message. Don’t clear the previous text. (Irrespective of whether the previous text is detected from an image or user entered.)

Full discussion here: p1719903989276319-slack-C03L1NF1EA3


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-android/assets/2663464/5cf490ee-95e3-4b69-ad7c-820b8901ea3b



- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->