### PR TITLE
Fix widget size

### DIFF
--- a/WooCommerce/src/main/res/values/dimens_base.xml
+++ b/WooCommerce/src/main/res/values/dimens_base.xml
@@ -155,6 +155,6 @@ so that's the baseline as defined in `major_100`.
     <dimen name="stats_widget_list_item_min_height">30dp</dimen>
     <dimen name="stats_widget_content_height">120dp</dimen>
     <dimen name="stats_widget_min_width">250dp</dimen>
-    <dimen name="stats_widget_min_height">150dp</dimen>
+    <dimen name="stats_widget_min_height">75dp</dimen>
 
 </resources>


### PR DESCRIPTION
### Description
This PR reduces the size required to add the Today's widget to the screen. The size of a home widget in terms of the blocks (or cells) it occupies on the screen is determined by the `android:minWidth` and `android:minHeight` attributes in the AppWidgetProviderInfo XML file. Each block or cell typically corresponds to 40dp for width and 40dp for height, which is the standard size for a grid cell on most Android launchers. 

Our widget was using a `minHeight` of 150dp (4 cells) when it only occupies 75dp (2 cells). This PR fixes this issue by modifying the widget's `minHeight`.


### Testing information
1. Find the Woo app on the OS Launcher
2. Long press the app
3. Tap on widgets
4. Drag the Today stats widget
5. Check that now the widget only requires 2 rows of height

### Images/gif

#### Before
https://github.com/woocommerce/woocommerce-android/assets/18119390/21f242fe-526e-49ba-82f9-fa1c3a76e125

#### After
https://github.com/woocommerce/woocommerce-android/assets/18119390/be4ece4c-bff9-4210-8c73-611d068a4520


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->