### PR TITLE
Use `dependency-submission@v3`

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -17,8 +17,4 @@ jobs:
           java-version: '17'
       - run: cp gradle.properties-example gradle.properties
       - name: Setup Gradle to generate and submit dependency graphs
-        uses: gradle/gradle-build-action@v2
-        with:
-          dependency-graph: generate-and-submit
-      - name: Generate the dependency graph which will be submitted post-job
-        run: ./gradlew dependencies
+        uses: gradle/actions/dependency-submission@v3


### PR DESCRIPTION
### Why?

This small PR fixes and improves the way we send project dependencies to GitHub, to benefit from Dependabot (Security) Alerts.

Instead of running `dependencies` task (which resolves only build dependencies), we'll rely on a custom, default task accessible via GitHub Action.

> "By default action executes a built-in task that is designed to resolve all build dependencies (:ForceDependencyResolutionPlugin_resolveAllDependencies)."

Source: https://github.com/gradle/actions/blob/main/docs/dependency-submission.md#gradle-execution

> ForceDependencyResolutionPlugin creates a ForceDependencyResolutionPlugin_resolveAllDependencies task that will attempt to resolve all dependencies for a Gradle build, by simply invoking dependencies on all projects.

Source: https://github.com/gradle/github-dependency-graph-gradle-plugin?tab=readme-ov-file#usage

