### PR TITLE
Address WireMock security vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,4 +28,9 @@ updates:
       # Assertj is a java first library only used for testing. It has caused troubles several times due to library
       # updates with Kotlin breaking changes. For that it has been decided to update this library on a manual basis
       - dependency-name: "org.assertj:assertj-core"
-
+      # Ignore dependencies that were added only to address security vulnerabilities of transitive WireMock dependencies
+      - dependency-name: "com.github.tomakehurst:wiremock"
+      - dependency-name: "org.eclipse.jetty:jetty-webapp"
+      - dependency-name: "com.fasterxml.jackson.core:jackson-databind"
+      - dependency-name: "com.jayway.jsonpath:json-path"
+      - dependency-name: "commons-fileupload:commons-fileupload"

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -354,11 +354,28 @@ dependencies {
 
     // Dependencies for screenshots
     androidTestImplementation 'tools.fastlane:screengrab:2.1.1'
-    androidTestImplementation('com.github.tomakehurst:wiremock:2.26.3') {
+    androidTestImplementation('com.github.tomakehurst:wiremock') {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
         exclude group: 'org.apache.commons', module: 'commons-lang3'
         exclude group: 'asm', module: 'asm'
         exclude group: 'org.json', module: 'json'
+    }
+    constraints {
+        androidTestImplementation("com.github.tomakehurst:wiremock:2.26.3") {
+            because("newer versions of WireMock use Java APIs not available on Android")
+        }
+        androidTestImplementation('org.eclipse.jetty:jetty-webapp:9.4.51.v20230217') {
+            because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
+        }
+        androidTestImplementation('com.fasterxml.jackson.core:jackson-databind:2.12.7.1') {
+            because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
+        }
+        androidTestImplementation('com.jayway.jsonpath:json-path:2.9.0') {
+            because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
+        }
+        androidTestImplementation('commons-fileupload:commons-fileupload:1.5') {
+            because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
+        }
     }
     androidTestImplementation "org.apache.httpcomponents:httpclient-android:$httpClientAndroidVersion"
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR will address vulnerabilities detected in WireMock transitive dependencies:

- https://github.com/woocommerce/woocommerce-android/security/dependabot/111
- https://github.com/woocommerce/woocommerce-android/security/dependabot/108
- https://github.com/woocommerce/woocommerce-android/security/dependabot/101
- https://github.com/woocommerce/woocommerce-android/security/dependabot/99
- https://github.com/woocommerce/woocommerce-android/security/dependabot/100
- https://github.com/woocommerce/woocommerce-android/security/dependabot/98
- https://github.com/woocommerce/woocommerce-android/security/dependabot/87
- https://github.com/woocommerce/woocommerce-android/security/dependabot/89

Not all of them are relevant for context of the mobile app, but I list them here anyway.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Green CI checks are fine


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->