### PR TITLE
Remove WireMock duplication from Dependabot ignore config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,6 @@ updates:
       # updates with Kotlin breaking changes. For that it has been decided to update this library on a manual basis
       - dependency-name: "org.assertj:assertj-core"
       # Ignore dependencies that were added only to address security vulnerabilities of transitive WireMock dependencies
-      - dependency-name: "com.github.tomakehurst:wiremock"
       - dependency-name: "org.eclipse.jetty:jetty-webapp"
       - dependency-name: "com.fasterxml.jackson.core:jackson-databind"
       - dependency-name: "com.jayway.jsonpath:json-path"


### PR DESCRIPTION
Fixes the Dependabot config.