### PR TITLE
[Tooling] Cherry pick #11886 (trusted agent for push)

### DIFF
--- a/.buildkite/commands/configure-environment.sh
+++ b/.buildkite/commands/configure-environment.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -eu
-
-echo '--- :git: Configure Git for Release Management'
-.buildkite/commands/configure-git-for-release-management.sh
-
-echo '--- :ruby: Setup Ruby Tools'
-install_gems

--- a/.buildkite/commands/configure-git-for-release-management.sh
+++ b/.buildkite/commands/configure-git-for-release-management.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -eu
-
-# Git command line client is not configured in Buildkite. Temporarily, we configure it in each step.
-# Later on, we should be able to configure the agent instead.
-add_host_to_ssh_known_hosts github.com
-git config --global user.email "mobile+wpmobilebot@automattic.com"
-git config --global user.name "Automattic Release Bot"

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -1,17 +1,20 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-agents:
-  queue: "android"
-
 steps:
   - label: "Complete Code Freeze"
     plugins: [$CI_TOOLKIT]
     command: |
-      .buildkite/commands/configure-environment.sh
+      echo '--- :robot_face: Use bot for git operations'
+      source use-bot-for-git
 
       echo '--- :git: Checkout Release Branch'
       .buildkite/commands/checkout-release-branch.sh
 
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
+
       echo '--- :snowflake: Complete Code Freeze'
       bundle exec fastlane complete_code_freeze skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
+    agents:
+        queue: "tumblr-metal"

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -1,17 +1,20 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-agents:
-  queue: "android"
-
 steps:
   - label: "Finalize Hotfix Release"
     plugins: [$CI_TOOLKIT]
     command: |
-      .buildkite/commands/configure-environment.sh
+      echo '--- :robot_face: Use bot for git operations'
+      source use-bot-for-git
 
       echo '--- :git: Checkout Release Branch'
       .buildkite/commands/checkout-release-branch.sh
 
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
+
       echo '--- :fire: Finalize Hotfix Release'
       bundle exec fastlane finalize_hotfix_release skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
+    agents:
+        queue: "tumblr-metal"

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -1,17 +1,20 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-agents:
-  queue: "android"
-
 steps:
   - label: "Finalize Release"
     plugins: [$CI_TOOLKIT]
     command: |
-      .buildkite/commands/configure-environment.sh
+      echo '--- :robot_face: Use bot for git operations'
+      source use-bot-for-git
 
       echo '--- :git: Checkout Release Branch'
       .buildkite/commands/checkout-release-branch.sh
 
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
+
       echo '--- :shipit: Finalize Release'
       bundle exec fastlane finalize_release skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
+    agents:
+        queue: "tumblr-metal"

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -1,17 +1,20 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-agents:
-  queue: "android"
-
 steps:
   - label: "New Beta Release"
     plugins: [$CI_TOOLKIT]
     command: |
-      .buildkite/commands/configure-environment.sh
+      echo '--- :robot_face: Use bot for git operations'
+      source use-bot-for-git
 
       echo '--- :git: Checkout Release Branch'
       .buildkite/commands/checkout-release-branch.sh
 
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
+
       echo '--- :shipit: New Beta Release'
       bundle exec fastlane new_beta_release skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
+    agents:
+        queue: "tumblr-metal"

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -1,9 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-agents:
-  queue: "android"
-
 steps:
   - input: "What version code do you want to use for the new hotfix release?"
     fields:
@@ -13,10 +10,16 @@ steps:
   - label: "New Hotfix Release"
     plugins: [$CI_TOOLKIT]
     command: |
-      .buildkite/commands/configure-environment.sh
+      echo '--- :robot_face: Use bot for git operations'
+      source use-bot-for-git
+
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
 
       # Get the version code from the Buildkite 'input' step
       VERSION_CODE=$(buildkite-agent meta-data get version_code)
 
       echo '--- :fire: Start New Hotfix Release'
       bundle exec fastlane new_hotfix_release version_name:${VERSION} version_code:${VERSION_CODE} skip_confirm:true
+    agents:
+        queue: "tumblr-metal"

--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -1,14 +1,17 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-agents:
-  queue: "android"
-
 steps:
   - label: " Start Code Freeze"
     plugins: [$CI_TOOLKIT]
     command: |
-      .buildkite/commands/configure-environment.sh
+      echo '--- :robot_face: Use bot for git operations'
+      source use-bot-for-git
+
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
 
       echo '--- :snowflake: Start Code Freeze'
       bundle exec fastlane start_code_freeze skip_confirm:true
+    agents:
+        queue: "tumblr-metal"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,10 +244,8 @@ GEM
     naturally (2.2.1)
     nkf (0.2.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.16.5)
+    nokogiri (1.16.6)
       mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
-    nokogiri (1.16.5-arm64-darwin)
       racc (~> 1.4)
     octokit (6.1.1)
       faraday (>= 1, < 3)
@@ -336,7 +334,6 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
-  arm64-darwin-22
   ruby
 
 DEPENDENCIES


### PR DESCRIPTION
Cherry-picking the PR #11886 (already merged to `trunk`), so that the upcoming `19.4` release tasks can use the `use-bot-for-git` script. 