### PR TITLE
Issue/11862 product prompt suggestion bar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AiFeedbackForm.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AiFeedbackForm.kt
@@ -28,7 +28,7 @@ fun AiFeedbackForm(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
             .background(
-                color = colorResource(id = R.color.ai_feedback_form_background),
+                color = colorResource(id = R.color.ai_product_suggestion_box_background),
                 shape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
             )
             .padding(dimensionResource(id = R.dimen.major_100))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -213,40 +213,6 @@ fun AiProductPromptScreen(
 }
 
 @Composable
-private fun PromptSuggestions(
-    promptSuggestionBarState: PromptSuggestionBar,
-    modifier: Modifier = Modifier
-) {
-    val animatedProgress = animateFloatAsState(
-        targetValue = promptSuggestionBarState.progress,
-        animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec,
-        label = ""
-    ).value
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(dimensionResource(id = R.dimen.minor_100)))
-            .background(colorResource(id = R.color.ai_generated_text_background))
-            .padding(16.dp)
-    ) {
-        LinearProgressIndicator(
-            progress = animatedProgress,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(4.dp)
-                .clip(RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))),
-            color = colorResource(id = promptSuggestionBarState.progressBarColorRes)
-        )
-        Text(
-            text = annotatedStringRes(promptSuggestionBarState.messageRes),
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = 8.dp),
-        )
-    }
-}
-
-@Composable
 private fun ToneDropDown(
     tone: Tone,
     onToneSelected: (Tone) -> Unit,
@@ -408,6 +374,40 @@ private fun ProductPromptTextField(
                 modifier = Modifier.padding(top = 16.dp)
             )
         }
+    }
+}
+
+@Composable
+private fun PromptSuggestions(
+    promptSuggestionBarState: PromptSuggestionBar,
+    modifier: Modifier = Modifier
+) {
+    val animatedProgress = animateFloatAsState(
+        targetValue = promptSuggestionBarState.progress,
+        animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec,
+        label = ""
+    ).value
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(dimensionResource(id = R.dimen.minor_100)))
+            .background(colorResource(id = R.color.ai_generated_text_background))
+            .padding(16.dp)
+    ) {
+        LinearProgressIndicator(
+            progress = animatedProgress,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(4.dp)
+                .clip(RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))),
+            color = colorResource(id = promptSuggestionBarState.progressBarColorRes)
+        )
+        Text(
+            text = annotatedStringRes(promptSuggestionBarState.messageRes),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = 8.dp),
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.products.ai.productinfo
 
 import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
+import androidx.annotation.ColorRes
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -26,7 +28,9 @@ import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ProgressIndicatorDefaults
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
@@ -169,6 +173,13 @@ fun AiProductPromptScreen(
                     )
                 }
 
+                PromptSuggestions(
+                    progress = 0.5f,
+                    message = "Add your product’s name and key features, benefits, or details to help it get found online.",
+                    colorRes = R.color.divider_color,
+                    modifier = Modifier.padding(top = 16.dp)
+                )
+
                 ToneDropDown(
                     tone = uiState.selectedTone,
                     onToneSelected = onToneSelected
@@ -192,6 +203,43 @@ fun AiProductPromptScreen(
         MediaPickerDialog(
             onMediaPickerDialogDismissed,
             onMediaLibraryRequested
+        )
+    }
+}
+
+@Composable
+fun PromptSuggestions(
+    progress: Float = 0f,
+    message: String,
+    @ColorRes colorRes: Int,
+    modifier: Modifier = Modifier
+) {
+    val animatedProgress = animateFloatAsState(
+        targetValue = progress,
+        animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec,
+        label = ""
+    ).value
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(dimensionResource(id = R.dimen.minor_100)))
+            .background(colorResource(id = R.color.ai_feedback_form_background))
+            .padding(16.dp)
+    ) {
+        LinearProgressIndicator(
+            progress = animatedProgress,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(4.dp)
+                .clip(RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))),
+            backgroundColor = colorResource(id = colorRes),
+            color = colorResource(id = R.color.divider_color)
+        )
+        Text(
+            text = message,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = 8.dp),
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -394,7 +394,7 @@ private fun ProductPromptTextField(
                 }
             }
         }
-        AnimatedVisibility(isFocused) {
+        AnimatedVisibility(isFocused || state.productPrompt.isNotEmpty()) {
             PromptSuggestions(
                 promptSuggestionBarState = state.promptSuggestionBarState,
                 modifier = Modifier.padding(top = 16.dp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -362,7 +362,9 @@ private fun ProductPromptTextField(
                 state.selectedImage != null -> SelectedImageSection(
                     image = state.selectedImage,
                     onImageActionSelected = onImageActionSelected,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(color = colorResource(id = R.color.ai_generated_text_background),)
                 )
 
                 else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -52,7 +52,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -292,7 +292,11 @@ private fun ProductPromptTextField(
     var isFocused by remember { mutableStateOf(false) }
     var scrollToPosition by remember { mutableFloatStateOf(0F) }
 
-    Column {
+    Column(
+        modifier = Modifier.onGloballyPositioned {
+            scrollToPosition = it.positionInParent().y
+        }
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -336,9 +340,6 @@ private fun ProductPromptTextField(
                             if (isFocused) {
                                 coroutineScope.launch { scrollState.animateScrollTo(scrollToPosition.roundToInt()) }
                             }
-                        }
-                        .onGloballyPositioned { coordinates ->
-                            scrollToPosition = coordinates.positionInRoot().y
                         }
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -447,7 +447,7 @@ private fun AiProductPromptScreenPreview() {
             showImageFullScreen = false,
             noTextDetectedMessage = false,
             promptSuggestionBarState = PromptSuggestionBar(
-                progressBarColorRes = R.color.linear_progress_background_disabled,
+                progressBarColorRes = R.color.linear_progress_background_gray,
                 messageRes = R.string.ai_product_creation_prompt_suggestion_initial,
                 progress = 0.1f
             )
@@ -476,7 +476,7 @@ private fun AiProductPromptScreenWithErrorPreview() {
             showImageFullScreen = false,
             noTextDetectedMessage = true,
             promptSuggestionBarState = PromptSuggestionBar(
-                progressBarColorRes = R.color.linear_progress_background_disabled,
+                progressBarColorRes = R.color.linear_progress_background_gray,
                 messageRes = R.string.ai_product_creation_prompt_suggestion_initial,
                 progress = 0.1f
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -59,7 +59,6 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.mediapicker.MediaPickerDialog
 import com.woocommerce.android.ui.compose.annotatedStringRes
-import com.woocommerce.android.ui.compose.component.ProductThumbnail
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
@@ -68,7 +67,6 @@ import com.woocommerce.android.ui.products.ai.components.FullScreenImageViewer
 import com.woocommerce.android.ui.products.ai.components.ImageAction
 import com.woocommerce.android.ui.products.ai.components.SelectedImageSection
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.AiProductPromptState
-import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.ImageAction
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.PromptSuggestionBar
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.Tone
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.products.ai.productinfo
 
 import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
-import androidx.annotation.ColorRes
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -67,6 +66,8 @@ import com.woocommerce.android.ui.products.ai.components.FullScreenImageViewer
 import com.woocommerce.android.ui.products.ai.components.ImageAction
 import com.woocommerce.android.ui.products.ai.components.SelectedImageSection
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.AiProductPromptState
+import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.ImageAction
+import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.PromptSuggestionBar
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.Tone
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource
 
@@ -171,19 +172,14 @@ fun AiProductPromptScreen(
                         stringResource(id = R.string.product_creation_package_photo_no_text_detected)
                     )
                 }
-
                 PromptSuggestions(
-                    progress = 0.1f,
-                    message = "Add your product’s name and key features, benefits, or details to help it get found online.",
-                    colorRes = R.color.linear_progress_background_disabled,
+                    promptSuggestionBarState = uiState.promptSuggestionBarState,
                     modifier = Modifier.padding(top = 16.dp)
                 )
-
                 ToneDropDown(
                     tone = uiState.selectedTone,
                     onToneSelected = onToneSelected
                 )
-
                 Spacer(modifier = Modifier.weight(1f))
 
                 // Button will scroll with the rest of UI on landscape mode, or... (see below)
@@ -208,13 +204,11 @@ fun AiProductPromptScreen(
 
 @Composable
 fun PromptSuggestions(
-    progress: Float = 0f,
-    message: String,
-    @ColorRes colorRes: Int,
+    promptSuggestionBarState: PromptSuggestionBar,
     modifier: Modifier = Modifier
 ) {
     val animatedProgress = animateFloatAsState(
-        targetValue = progress,
+        targetValue = promptSuggestionBarState.progress,
         animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec,
         label = ""
     ).value
@@ -231,10 +225,10 @@ fun PromptSuggestions(
                 .fillMaxWidth()
                 .height(4.dp)
                 .clip(RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))),
-            color = colorResource(id = colorRes)
+            color = colorResource(id = promptSuggestionBarState.progressBarColorRes)
         )
         Text(
-            text = message,
+            text = stringResource(id = promptSuggestionBarState.messageRes),
             modifier = Modifier
                 .fillMaxSize()
                 .padding(top = 8.dp),
@@ -451,7 +445,12 @@ private fun AiProductPromptScreenPreview() {
             selectedImage = null,
             isScanningImage = false,
             showImageFullScreen = false,
-            noTextDetectedMessage = false
+            noTextDetectedMessage = false,
+            promptSuggestionBarState = PromptSuggestionBar(
+                progressBarColorRes = R.color.linear_progress_background_disabled,
+                messageRes = R.string.ai_product_creation_prompt_suggestion_initial,
+                progress = 0.1f
+            )
         ),
         onBackButtonClick = {},
         onPromptUpdated = {},
@@ -475,7 +474,12 @@ private fun AiProductPromptScreenWithErrorPreview() {
             selectedImage = null,
             isScanningImage = false,
             showImageFullScreen = false,
-            noTextDetectedMessage = true
+            noTextDetectedMessage = true,
+            promptSuggestionBarState = PromptSuggestionBar(
+                progressBarColorRes = R.color.linear_progress_background_disabled,
+                messageRes = R.string.ai_product_creation_prompt_suggestion_initial,
+                progress = 0.1f
+            )
         ),
         onBackButtonClick = {},
         onPromptUpdated = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -58,6 +58,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.mediapicker.MediaPickerDialog
+import com.woocommerce.android.ui.compose.annotatedStringRes
+import com.woocommerce.android.ui.compose.component.ProductThumbnail
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
@@ -228,7 +230,7 @@ fun PromptSuggestions(
             color = colorResource(id = promptSuggestionBarState.progressBarColorRes)
         )
         Text(
-            text = stringResource(id = promptSuggestionBarState.messageRes),
+            text = annotatedStringRes(promptSuggestionBarState.messageRes),
             modifier = Modifier
                 .fillMaxSize()
                 .padding(top = 8.dp),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -173,9 +173,9 @@ fun AiProductPromptScreen(
                 }
 
                 PromptSuggestions(
-                    progress = 0.5f,
+                    progress = 0.1f,
                     message = "Add your product’s name and key features, benefits, or details to help it get found online.",
-                    colorRes = R.color.divider_color,
+                    colorRes = R.color.linear_progress_background_disabled,
                     modifier = Modifier.padding(top = 16.dp)
                 )
 
@@ -222,7 +222,7 @@ fun PromptSuggestions(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(dimensionResource(id = R.dimen.minor_100)))
-            .background(colorResource(id = R.color.ai_feedback_form_background))
+            .background(colorResource(id = R.color.ai_product_suggestion_box_background))
             .padding(16.dp)
     ) {
         LinearProgressIndicator(
@@ -231,8 +231,7 @@ fun PromptSuggestions(
                 .fillMaxWidth()
                 .height(4.dp)
                 .clip(RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))),
-            backgroundColor = colorResource(id = colorRes),
-            color = colorResource(id = R.color.divider_color)
+            color = colorResource(id = colorRes)
         )
         Text(
             text = message,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
@@ -257,7 +256,6 @@ private fun ToneDropDown(
         Text(
             text = stringResource(id = R.string.product_creation_ai_tone_title),
             style = MaterialTheme.typography.subtitle1,
-            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
         )
         Spacer(modifier = Modifier.weight(1f))
         Text(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -118,7 +118,9 @@ fun AiProductPromptScreen(
     val scrollState = rememberScrollState()
 
     @Composable
-    fun GenerateProductButton(modifier: Modifier = Modifier) {
+    fun GenerateProductButton(
+        modifier: Modifier = Modifier
+    ) {
         WCColoredButton(
             enabled = uiState.productPrompt.isNotEmpty(),
             onClick = onGenerateProductClicked,
@@ -141,12 +143,12 @@ fun AiProductPromptScreen(
             modifier = Modifier
                 .background(MaterialTheme.colors.surface)
                 .padding(padding)
-                .padding(16.dp)
                 .fillMaxSize()
         ) {
             Column(
                 modifier = Modifier
                     .weight(1f)
+                    .padding(horizontal = 16.dp)
                     .verticalScroll(scrollState)
             ) {
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
@@ -184,17 +186,18 @@ fun AiProductPromptScreen(
                     onToneSelected = onToneSelected,
                     modifier = Modifier.padding(bottom = 56.dp)
                 )
-                Spacer(modifier = Modifier.weight(1f))
 
                 // Button will scroll with the rest of UI on landscape mode, or... (see below)
                 if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                    GenerateProductButton(Modifier.padding(top = 16.dp))
+                    Divider()
+                    GenerateProductButton(Modifier.padding(16.dp))
                 }
             }
 
             // Button will stick to the bottom on portrait mode
             if (orientation == Configuration.ORIENTATION_PORTRAIT) {
-                GenerateProductButton()
+                Divider()
+                GenerateProductButton(modifier = Modifier.padding(16.dp))
             }
         }
     }
@@ -207,7 +210,7 @@ fun AiProductPromptScreen(
 }
 
 @Composable
-fun PromptSuggestions(
+private fun PromptSuggestions(
     promptSuggestionBarState: PromptSuggestionBar,
     modifier: Modifier = Modifier
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -50,6 +51,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -72,9 +75,9 @@ import com.woocommerce.android.ui.products.ai.components.SelectedImageSection
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.AiProductPromptState
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.PromptSuggestionBar
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.Tone
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource
+import kotlin.math.roundToInt
 
 @Composable
 fun AiProductPromptScreen(viewModel: AiProductPromptViewModel) {
@@ -321,6 +324,8 @@ private fun ProductPromptTextField(
 ) {
     val coroutineScope = rememberCoroutineScope()
     var isFocused by remember { mutableStateOf(false) }
+    var scrollToPosition by remember { mutableFloatStateOf(0F) }
+
     Column {
         Column(
             modifier = Modifier
@@ -363,11 +368,11 @@ private fun ProductPromptTextField(
                         .onFocusChanged { focusState ->
                             isFocused = focusState.isFocused
                             if (isFocused) {
-                                coroutineScope.launch {
-                                    delay(300) // Delay to ensure advice box is shown before scrolling
-                                    scrollState.animateScrollTo(scrollState.maxValue)
-                                }
+                                coroutineScope.launch { scrollState.animateScrollTo(scrollToPosition.roundToInt()) }
                             }
+                        }
+                        .onGloballyPositioned { coordinates ->
+                            scrollToPosition = coordinates.positionInRoot().y
                         }
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
@@ -76,7 +76,7 @@ class AiProductPromptViewModel @Inject constructor(
                 )
             }
 
-            wordCount < 11 -> {
+            wordCount < 8 -> {
                 PromptSuggestionBar(
                     progressBarColorRes = R.color.ai_linear_progress_background_more_red,
                     messageRes = R.string.ai_product_creation_prompt_suggestion_add_more_details,
@@ -84,7 +84,7 @@ class AiProductPromptViewModel @Inject constructor(
                 )
             }
 
-            wordCount < 20 -> {
+            wordCount < 17 -> {
                 PromptSuggestionBar(
                     progressBarColorRes = R.color.ai_linear_progress_background_orange,
                     messageRes = R.string.ai_product_creation_prompt_suggestion_getting_better,
@@ -92,7 +92,7 @@ class AiProductPromptViewModel @Inject constructor(
                 )
             }
 
-            wordCount < 30 -> {
+            wordCount < 27 -> {
                 PromptSuggestionBar(
                     progressBarColorRes = R.color.ai_linear_progress_background_yellow,
                     messageRes = R.string.ai_product_creation_prompt_suggestion_almost_there,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
@@ -156,10 +156,8 @@ class AiProductPromptViewModel @Inject constructor(
                         )
                     )
                     if (keywords.isNotEmpty()) {
-                        _state.value = _state.value.copy(
-                            productPrompt = keywords.joinToString(separator = DEFAULT_PROMPT_DELIMITER),
-                            noTextDetectedMessage = false
-                        )
+                        onPromptUpdated(keywords.joinToString(separator = DEFAULT_PROMPT_DELIMITER))
+                        _state.value = _state.value.copy(noTextDetectedMessage = false)
                     } else {
                         _state.value = _state.value.copy(noTextDetectedMessage = true)
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.products.ai.productinfo
 
 import android.os.Parcelable
+import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
@@ -29,6 +30,9 @@ class AiProductPromptViewModel @Inject constructor(
     private val tracker: AnalyticsTrackerWrapper,
     private val textRecognitionEngine: TextRecognitionEngine,
 ) : ScopedViewModel(savedState = savedStateHandle) {
+    companion object {
+        private const val SUGGESTIONS_BAR_INITIAL_PROGRESS = 0.06F
+    }
     private val _state = savedStateHandle.getStateFlow(
         viewModelScope,
         AiProductPromptState(
@@ -38,7 +42,12 @@ class AiProductPromptViewModel @Inject constructor(
             selectedImage = null,
             isScanningImage = false,
             showImageFullScreen = false,
-            noTextDetectedMessage = false
+            noTextDetectedMessage = false,
+            promptSuggestionBarState = PromptSuggestionBar(
+                progressBarColorRes = R.color.linear_progress_background_disabled,
+                messageRes = R.string.ai_product_creation_prompt_suggestion_initial,
+                progress = SUGGESTIONS_BAR_INITIAL_PROGRESS
+            )
         )
     )
 
@@ -147,7 +156,15 @@ class AiProductPromptViewModel @Inject constructor(
         val isScanningImage: Boolean,
         val showImageFullScreen: Boolean,
         val noTextDetectedMessage: Boolean,
+        val promptSuggestionBarState: PromptSuggestionBar
     ) : Parcelable
+
+    @Parcelize
+    data class PromptSuggestionBar(
+        @ColorRes val progressBarColorRes: Int,
+        @StringRes val messageRes: Int,
+        val progress: Float,
+    ): Parcelable
 
     enum class Tone(@StringRes val displayName: Int, val slug: String) {
         Casual(R.string.product_creation_ai_tone_casual, "Casual"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
@@ -64,6 +64,7 @@ class AiProductPromptViewModel @Inject constructor(
         updatePromptSuggestionBarState(prompt)
     }
 
+    @Suppress("MagicNumber")
     private fun updatePromptSuggestionBarState(prompt: String) {
         val wordCount = prompt.split(DEFAULT_PROMPT_DELIMITER).size
         val promptSuggestionBarState = when {

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -199,10 +199,10 @@
     <color name="woo_payments_setup_bullet_background">@color/woo_purple_80</color>
 
     <!--
-    AI
+    Product Creation using AI
     -->
     <color name="ai_generated_text_background">@color/woo_black_80</color>
-    <color name="ai_feedback_form_background">@color/woo_white_alpha_012</color>
+    <color name="ai_product_suggestion_box_background">@color/woo_white_alpha_012</color>
 
     <!--
     Tap To Pay About

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -254,11 +254,6 @@
     <color name="free_trial_banner_content">@color/color_on_surface</color>
 
     <!--
-    Product Creation using AI
-    -->
-    <color name="linear_progress_background">@color/woo_purple_0</color>
-
-    <!--
     Highlight tooltip
     -->
     <color name="highlights_tooltip_background">@color/woo_gray_80</color>
@@ -275,10 +270,12 @@
     <color name="woo_payments_setup_bullet_background">@color/woo_purple_0</color>
 
     <!--
-    AI
+    Product Creation using AI
     -->
+    <color name="linear_progress_background">@color/woo_purple_0</color>
+    <color name="linear_progress_background_disabled">@color/woo_gray_20</color>
     <color name="ai_generated_text_background">@color/woo_gray_6</color>
-    <color name="ai_feedback_form_background">@color/woo_black_alpha_008</color>
+    <color name="ai_product_suggestion_box_background">@color/woo_black_alpha_008</color>
 
     <!--
     Tap To Pay About

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -273,7 +273,11 @@
     Product Creation using AI
     -->
     <color name="linear_progress_background">@color/woo_purple_0</color>
-    <color name="linear_progress_background_disabled">@color/woo_gray_20</color>
+    <color name="linear_progress_background_gray">@color/woo_gray_20</color>
+    <color name="ai_linear_progress_background_more_red">@color/woo_red_50</color>
+    <color name="ai_linear_progress_background_orange">@color/woo_orange_30</color>
+    <color name="ai_linear_progress_background_yellow">@color/woo_yellow_30</color>
+    <color name="ai_linear_progress_background_green">@color/woo_green_50</color>
     <color name="ai_generated_text_background">@color/woo_gray_6</color>
     <color name="ai_product_suggestion_box_background">@color/woo_black_alpha_008</color>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2235,6 +2235,11 @@
     <string name="ai_product_creation_image_selected_subtitle">Photo will be added to product</string>
     <string name="ai_product_creation_scanning_image">Scanning image</string>
     <string name="ai_product_creation_scanning_photo_error">Error while trying to scan the text from the photo. Please try again</string>
+    <string name="ai_product_creation_prompt_suggestion_initial">Add your product’s name and key features, benefits, or details to help it get found online.</string>
+    <string name="ai_product_creation_prompt_suggestion_add_more_details">Add more details. The more details you provide, the better your generated details will be.</string>
+    <string name="ai_product_creation_prompt_suggestion_getting_better">Getting better. How does the t-shirt fit? Does it have any other unique properties?</string>
+    <string name="ai_product_creation_prompt_suggestion_almost_there">Almost there. Where was it made?</string>
+    <string name="ai_product_creation_prompt_suggestion_great_prompt">Great prompt! You’ve given us enough to work with, but you may add more detail to make it even better.</string>
 
     <!--
         Product Add more details Bottom sheet

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2236,10 +2236,10 @@
     <string name="ai_product_creation_scanning_image">Scanning image</string>
     <string name="ai_product_creation_scanning_photo_error">Error while trying to scan the text from the photo. Please try again</string>
     <string name="ai_product_creation_prompt_suggestion_initial">Add your product\'s name and key features, benefits, or details to help it get found online.</string>
-    <string name="ai_product_creation_prompt_suggestion_add_more_details"><b>Add more details.</b> The more details you provide, the better your generated details will be.</string>
-    <string name="ai_product_creation_prompt_suggestion_getting_better"><b>Getting better.</b> Can you describe the fit and any distinctive features of the item?</string>
-    <string name="ai_product_creation_prompt_suggestion_almost_there"><b>Great prompt!</b> Where was it made?</string>
-    <string name="ai_product_creation_prompt_suggestion_great_prompt"><b>Great prompt!</b> You\'ve given us enough to work with, but you may add more detail to make it even better.</string>
+    <string name="ai_product_creation_prompt_suggestion_add_more_details"><![CDATA[<b>Add more details.</b> The more details you provide, the better your generated details will be.]]></string>
+    <string name="ai_product_creation_prompt_suggestion_getting_better"><![CDATA[<b>Getting better.</b> Can you describe the fit and any distinctive features of the item?]]></string>
+    <string name="ai_product_creation_prompt_suggestion_almost_there"><![CDATA[<b>Great prompt!</b> Where was it made?]]></string>
+    <string name="ai_product_creation_prompt_suggestion_great_prompt"><![CDATA[<b>Great prompt!</b> You\'ve given us enough to work with, but you may add more detail to make it even better.]]></string>
 
     <!--
         Product Add more details Bottom sheet

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2235,11 +2235,11 @@
     <string name="ai_product_creation_image_selected_subtitle">Photo will be added to product</string>
     <string name="ai_product_creation_scanning_image">Scanning image</string>
     <string name="ai_product_creation_scanning_photo_error">Error while trying to scan the text from the photo. Please try again</string>
-    <string name="ai_product_creation_prompt_suggestion_initial">Add your product’s name and key features, benefits, or details to help it get found online.</string>
-    <string name="ai_product_creation_prompt_suggestion_add_more_details">Add more details. The more details you provide, the better your generated details will be.</string>
-    <string name="ai_product_creation_prompt_suggestion_getting_better">Getting better. How does the t-shirt fit? Does it have any other unique properties?</string>
-    <string name="ai_product_creation_prompt_suggestion_almost_there">Almost there. Where was it made?</string>
-    <string name="ai_product_creation_prompt_suggestion_great_prompt">Great prompt! You’ve given us enough to work with, but you may add more detail to make it even better.</string>
+    <string name="ai_product_creation_prompt_suggestion_initial">Add your product\'s name and key features, benefits, or details to help it get found online.</string>
+    <string name="ai_product_creation_prompt_suggestion_add_more_details"><b>Add more details.</b> The more details you provide, the better your generated details will be.</string>
+    <string name="ai_product_creation_prompt_suggestion_getting_better"><b>Getting better.</b> Can you describe the fit and any distinctive features of the item?</string>
+    <string name="ai_product_creation_prompt_suggestion_almost_there"><b>Great prompt!</b> Where was it made?</string>
+    <string name="ai_product_creation_prompt_suggestion_great_prompt"><b>Great prompt!</b> You\'ve given us enough to work with, but you may add more detail to make it even better.</string>
 
     <!--
         Product Add more details Bottom sheet


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11862
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds ai prompt assistant Sgacycoxaxh8EbKoi5FklH-fi-1072_38166

![Screenshot 2024-07-11 at 15 52 42](https://github.com/woocommerce/woocommerce-android/assets/2663464/47e15b1f-09fe-4267-b17d-bc42c13f2569)

iOS PR for reference: https://github.com/woocommerce/woocommerce-ios/pull/13280

The agreed prompt length ranges to update the progress are

```
   case 0:
            status = .start
        case 1...7:
            status = .inProgress
        case 8...17:
            status = .halfway
        case 17...27:
            status = .almostDone
        default:
            status = .completed
```

Additionally, the following behaviors where agreed: p1720746132174129/1720515544.395649-slack-C03L1NF1EA3

- The “Read text from product photo” is visible all the time
- The advice box is only visible when the text field gains focus or the prompt is not empty
- The screen automatically scrolls up when the text field gains focus to ensure the advice box is not overlayed by the keyboard on smaller screens

### Testing information
- Log into an atomic or Jetpack connected site
- Navigate to product tabs and click on add product with AI
- Add a prompt manually and see how the advice box gets updated accordingly
- Check that the behavior described above is met

### Images/gif

https://github.com/user-attachments/assets/6f7f7aa6-20e5-44a1-8f87-4bc0fdbe3986

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->