### PR TITLE
[Product AI v2] Support editing the text fields

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.ButtonDefaults
@@ -31,6 +32,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Replay
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
@@ -62,6 +64,9 @@ fun AiProductPreviewScreen(viewModel: AiProductPreviewViewModel) {
     viewModel.state.observeAsState().value?.let { state ->
         AiProductPreviewScreen(
             state = state,
+            onNameChanged = viewModel::onNameChanged,
+            onDescriptionChanged = viewModel::onDescriptionChanged,
+            onShortDescriptionChanged = viewModel::onShortDescriptionChanged,
             onFeedbackReceived = viewModel::onFeedbackReceived,
             onBackButtonClick = viewModel::onBackButtonClick,
             onImageActionSelected = viewModel::onImageActionSelected,
@@ -75,6 +80,9 @@ fun AiProductPreviewScreen(viewModel: AiProductPreviewViewModel) {
 @Composable
 private fun AiProductPreviewScreen(
     state: AiProductPreviewViewModel.State,
+    onNameChanged: (String?) -> Unit,
+    onDescriptionChanged: (String?) -> Unit,
+    onShortDescriptionChanged: (String?) -> Unit,
     onFeedbackReceived: (Boolean) -> Unit,
     onBackButtonClick: () -> Unit,
     onImageActionSelected: (ImageAction) -> Unit,
@@ -130,6 +138,9 @@ private fun AiProductPreviewScreen(
 
                 is AiProductPreviewViewModel.State.Success -> ProductPreviewContent(
                     state = state,
+                    onNameChanged = onNameChanged,
+                    onDescriptionChanged = onDescriptionChanged,
+                    onShortDescriptionChanged = onShortDescriptionChanged,
                     onFeedbackReceived = onFeedbackReceived,
                     onImageActionSelected = onImageActionSelected,
                     onFullScreenImageDismissed = onFullScreenImageDismissed,
@@ -152,6 +163,9 @@ private fun AiProductPreviewScreen(
 @Composable
 private fun ProductPreviewContent(
     state: AiProductPreviewViewModel.State.Success,
+    onNameChanged: (String?) -> Unit,
+    onDescriptionChanged: (String?) -> Unit,
+    onShortDescriptionChanged: (String?) -> Unit,
     onFeedbackReceived: (Boolean) -> Unit,
     onImageActionSelected: (ImageAction) -> Unit,
     onFullScreenImageDismissed: () -> Unit,
@@ -174,28 +188,28 @@ private fun ProductPreviewContent(
             style = MaterialTheme.typography.subtitle1,
             fontWeight = FontWeight.SemiBold
         )
-        Text(
-            text = state.title,
+        ProductTextField(
+            state = state.name,
+            onValueChange = onNameChanged,
             modifier = Modifier
                 .fillMaxWidth()
                 .then(sectionsBorder)
-                .padding(dimensionResource(id = R.dimen.major_100))
         )
 
-        Text(
-            text = state.shortDescription,
+        ProductTextField(
+            state = state.shortDescription,
+            onValueChange = onShortDescriptionChanged,
             modifier = Modifier
                 .fillMaxWidth()
                 .then(sectionsBorder)
-                .padding(dimensionResource(id = R.dimen.major_100))
         )
 
-        Text(
-            text = state.description,
+        ProductTextField(
+            state = state.description,
+            onValueChange = onDescriptionChanged,
             modifier = Modifier
                 .fillMaxWidth()
                 .then(sectionsBorder)
-                .padding(dimensionResource(id = R.dimen.major_100))
         )
 
         if (state.shouldShowVariantSelector) {
@@ -242,6 +256,32 @@ private fun ProductPreviewContent(
             AiFeedbackForm(
                 onFeedbackReceived = onFeedbackReceived,
             )
+        }
+    }
+}
+
+@Composable
+private fun ProductTextField(
+    state: AiProductPreviewViewModel.TextFieldState,
+    onValueChange: (String?) -> Unit,
+    modifier: Modifier
+) {
+    Column(modifier) {
+        BasicTextField(
+            value = state.value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth().padding(16.dp)
+        )
+
+        AnimatedVisibility(state.isValueEditedManually) {
+            Column {
+                Divider()
+                WCTextButton(
+                    onClick = { onValueChange(null) },
+                    text = stringResource(id = R.string.product_creation_ai_preview_undo_edits),
+                    icon = Icons.Default.Replay
+                )
+            }
         }
     }
 }
@@ -491,6 +531,9 @@ private fun ProductPreviewLoadingPreview() {
     WooThemeWithBackground {
         AiProductPreviewScreen(
             state = AiProductPreviewViewModel.State.Loading,
+            onNameChanged = {},
+            onDescriptionChanged = {},
+            onShortDescriptionChanged = {},
             onFeedbackReceived = {},
             onBackButtonClick = {},
             onImageActionSelected = {},
@@ -538,6 +581,9 @@ private fun ProductPreviewContentPreview() {
                 ),
                 imageState = AiProductPreviewViewModel.ImageState(null)
             ),
+            onNameChanged = {},
+            onDescriptionChanged = {},
+            onShortDescriptionChanged = {},
             onFeedbackReceived = {},
             onBackButtonClick = {},
             onImageActionSelected = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewScreen.kt
@@ -300,7 +300,8 @@ private fun ProductTextField(
                 WCTextButton(
                     onClick = { onValueChange(null) },
                     text = stringResource(id = R.string.product_creation_ai_preview_undo_edits),
-                    icon = Icons.Default.Replay
+                    icon = Icons.Default.Replay,
+                    allCaps = false
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewScreen.kt
@@ -34,9 +34,14 @@ import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Replay
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -190,6 +195,7 @@ private fun ProductPreviewContent(
         )
         ProductTextField(
             state = state.name,
+            selectedVariant = state.selectedVariant,
             onValueChange = onNameChanged,
             modifier = Modifier
                 .fillMaxWidth()
@@ -198,6 +204,7 @@ private fun ProductPreviewContent(
 
         ProductTextField(
             state = state.shortDescription,
+            selectedVariant = state.selectedVariant,
             onValueChange = onShortDescriptionChanged,
             modifier = Modifier
                 .fillMaxWidth()
@@ -206,6 +213,7 @@ private fun ProductPreviewContent(
 
         ProductTextField(
             state = state.description,
+            selectedVariant = state.selectedVariant,
             onValueChange = onDescriptionChanged,
             modifier = Modifier
                 .fillMaxWidth()
@@ -263,14 +271,27 @@ private fun ProductPreviewContent(
 @Composable
 private fun ProductTextField(
     state: AiProductPreviewViewModel.TextFieldState,
+    selectedVariant: Int,
     onValueChange: (String?) -> Unit,
     modifier: Modifier
 ) {
+    val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
+
+    LaunchedEffect(selectedVariant) {
+        // Clear focus when the selected variant changes, otherwise the cursor will be at the wrong position
+        // depending on the previous variant's text length
+        focusManager.clearFocus()
+    }
+
     Column(modifier) {
         BasicTextField(
             value = state.value,
             onValueChange = onValueChange,
-            modifier = Modifier.fillMaxWidth().padding(16.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+                .focusRequester(focusRequester)
         )
 
         AnimatedVisibility(state.isValueEditedManually) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModel.kt
@@ -133,26 +133,36 @@ class AiProductPreviewViewModel @Inject constructor(
     }
 
     fun onNameChanged(name: String?) {
+        val generatedName = generatedProduct.value?.getOrNull()?.names?.get(selectedVariant.value)
+        val actualValue = if (name == generatedName) null else name
+
         userEditedFields.update {
-            it.copy(names = it.names.toMutableList().apply { set(selectedVariant.value, name) })
+            it.copy(names = it.names.toMutableList().apply { set(selectedVariant.value, actualValue) })
         }
     }
 
     fun onDescriptionChanged(description: String?) {
+        val generatedDescription = generatedProduct.value?.getOrNull()?.descriptions?.get(selectedVariant.value)
+        val actualValue = if (description == generatedDescription) null else description
+
         userEditedFields.update {
             it.copy(
                 descriptions = it.descriptions.toMutableList().apply {
-                    set(selectedVariant.value, description)
+                    set(selectedVariant.value, actualValue)
                 }
             )
         }
     }
 
     fun onShortDescriptionChanged(shortDescription: String?) {
+        val generatedShortDescription = generatedProduct.value?.getOrNull()?.shortDescriptions
+            ?.get(selectedVariant.value)
+        val actualValue = if (shortDescription == generatedShortDescription) null else shortDescription
+
         userEditedFields.update {
             it.copy(
                 shortDescriptions = it.shortDescriptions.toMutableList().apply {
-                    set(selectedVariant.value, shortDescription)
+                    set(selectedVariant.value, actualValue)
                 }
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModel.kt
@@ -145,10 +145,12 @@ class AiProductPreviewViewModel @Inject constructor(
     }
 
     fun onSelectNextVariant() {
+        saveUserEditedFields()
         selectedVariant.update { it + 1 }
     }
 
     fun onSelectPreviousVariant() {
+        saveUserEditedFields()
         selectedVariant.update { it - 1 }
     }
 
@@ -162,6 +164,27 @@ class AiProductPreviewViewModel @Inject constructor(
 
     fun onShortDescriptionChanged(shortDescription: String?) {
         userEditedShortDescription.value = shortDescription
+    }
+
+    private fun saveUserEditedFields() {
+        generatedProduct.update { result ->
+            result?.map { product ->
+                product.copy(
+                    names = product.names.toMutableList().apply {
+                        set(selectedVariant.value, userEditedName.value ?: get(selectedVariant.value))
+                    },
+                    descriptions = product.descriptions.toMutableList().apply {
+                        set(selectedVariant.value, userEditedDescription.value ?: get(selectedVariant.value))
+                    },
+                    shortDescriptions = product.shortDescriptions.toMutableList().apply {
+                        set(selectedVariant.value, userEditedShortDescription.value ?: get(selectedVariant.value))
+                    }
+                )
+            }
+        }
+        userEditedName.value = null
+        userEditedDescription.value = null
+        userEditedShortDescription.value = null
     }
 
     sealed interface State {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2219,6 +2219,7 @@
     <string name="product_creation_ai_preview_description_section">Product description</string>
     <string name="product_creation_ai_preview_details_section">Details</string>
     <string name="product_creation_ai_preview_variant_selector">Option %1$d of %2$d</string>
+    <string name="product_creation_ai_preview_undo_edits">Undo edits</string>
     <string name="product_creation_ai_select_previous_option">Select previous option</string>
     <string name="product_creation_ai_select_next_option">Select next option</string>
     <string name="product_creation_ai_tone_title">Tone and voice</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11996
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds logic to support:
- Editing the text fields (name, summary and description)
- Logic to show an "Undo" button for the edited fields, and to handle its action.
- UI updates to support the above changes.

### Testing information
1. Make sure you are signed in using a Jetpack site.
2. Open the app, and start AI product creation.
3. Enter some keywords, then proceed.
4. On the preview screen, make some changes to the text fields.
5. Confirm the Undo button is shown when there are some changes.
6. Click on the Undo button.
7. Confirm it resets the content.
8. Make some changes to the name field.
9. Click on "Next" to select a different Option.
10. Confirm the "Undo" button gets hidden, and the name was updated with the generated value.
11. Go back to the previous option.
12. Confirm the text of the name still contains the edited value before switching the option.

### Images/gif
<img src="https://github.com/user-attachments/assets/e03c857d-353b-42b0-8966-5a189845dcc2" width=400 />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->