### PR TITLE
Disable Tablet instrumentation tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -104,4 +104,4 @@ steps:
               <<: *test_collector_common_params
               api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS"
         artifact_paths:
-          - "**/build/instrumented-tests-phone/**/*"
+          - "**/build/instrumented-tests/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -96,7 +96,7 @@ steps:
           ./gradlew assembleJalapenoDebugAndroidTest
         plugins: [$CI_TOOLKIT]
 
-      - label: "Instrumented tests - Phone"
+      - label: "Instrumented tests"
         command: .buildkite/commands/run-instrumented-tests.sh "Pixel2.arm" "30" "portrait"
         plugins:
           - $CI_TOOLKIT
@@ -105,13 +105,3 @@ steps:
               api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS"
         artifact_paths:
           - "**/build/instrumented-tests-phone/**/*"
-
-      - label: "Instrumented tests - Tablet"
-        command: .buildkite/commands/run-instrumented-tests.sh "MediumTablet.arm" "32" "landscape"
-        plugins:
-          - $CI_TOOLKIT
-          - $TEST_COLLECTOR :
-              <<: *test_collector_common_params
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_TABLET"
-        artifact_paths:
-          - "**/build/instrumented-tests-tablet/**/*"


### PR DESCRIPTION
This small PR disables instrumentation tests executed on tablets, as they're quite flaky at this moment. Discussed internally: p1721130793181969/1720597729.342809-slack-CGPNUU63E