### PR TITLE
[Tooling] Remove redundant lint task

### DIFF
--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -7,9 +7,6 @@
 agents:
   queue: "android"
 
-agents:
-  queue: "android"
-
 steps:
   - label: "Gradle Wrapper Validation"
     command: |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -447,8 +447,7 @@ platform :android do
     android_download_translations(
       res_dir: RES_DIR_PATH,
       glotpress_url: GLOTPRESS_APP_STRINGS_PROJECT_URL,
-      locales: SUPPORTED_LOCALES,
-      lint_task: 'lintVanillaRelease'
+      locales: SUPPORTED_LOCALES
     )
   end
 


### PR DESCRIPTION
### Description
Follow up to https://github.com/woocommerce/woocommerce-android/pull/11886.

Due to an error when running the `finalize_release` lane during the `19.4` release, the PR above was reverted on 9f7335c34ac5abce286574771c612b4869094ae9.

Apparently, the revert was reverted again when merging to trunk (864d123ecf60f6fde5071ca6635a90a9f8f0db42), and the release `19.5` continued normally, running on the trusted agent without errors, likely due to the release lanes so far not having any Gradle task. That would happen on `finalize_release`, as it did for `19.4`, given the trusted agent won't run Gradle / Android related tasks. (cc @ThomazFB)

This PR removes the `lintVanillaRelease` task run that is indirectly triggered by `finalize_release`, making sure the release can fully run in the trusted agent.

The lint task also seemed redundant for the release process, as we'll run lint again on `build_bundle` (called by the release lane `build_and_upload_release`), `Fastfile:839`, when building the release.

### Testing information

Make sure the release task works successfully when running `finalize_release` for the version `19.5`.

---

**Note**: I won't revert the credential to use a read-only one yet to make things easy to revert if needed. The release pipelines should already use the bot for git operations.