### PR TITLE
[Login] Fix some issues

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 19.6
 -----
-
+- [*] [Login] Improved login reliability by addressing some edge-case issues [https://github.com/woocommerce/woocommerce-android/pull/12033]
 
 19.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -324,7 +324,7 @@ class SitePickerViewModel @Inject constructor(
                 loadAndDisplaySites()
             }
         )
-        sitePickerViewState = sitePickerViewState.copy(isSkeletonViewVisible = false)
+        sitePickerViewState = sitePickerViewState.copy(isSkeletonViewVisible = false, isPrimaryBtnVisible = true)
     }
 
     private fun loadWooNotFoundView(site: SiteModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -140,6 +140,8 @@ class SitePickerViewModel @Inject constructor(
         val result = repository.fetchWooCommerceSites()
         val duration = System.currentTimeMillis() - startTime
 
+        sitePickerViewState = sitePickerViewState.copy(isSkeletonViewVisible = false)
+
         when {
             result.isError -> triggerEvent(ShowSnackbar(string.site_picker_error))
             result.model != null -> {
@@ -152,7 +154,6 @@ class SitePickerViewModel @Inject constructor(
                 onSitesLoaded(repository.getSites())
             }
         }
-        sitePickerViewState = sitePickerViewState.copy(isSkeletonViewVisible = false)
     }
 
     private suspend fun getSitesFromDb(): List<SiteModel> {

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-025008c28331ecf1b4f69009348b01bad42bac99'
+    fluxCVersion = '3053-765928e3458599d1970115bc63affa2a9db2a93e'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '3053-765928e3458599d1970115bc63affa2a9db2a93e'
+    fluxCVersion = 'trunk-46e6111f3f8f5c2cb3fe176ab2c51ce6293f57ed'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12032 Closes: #12046
<!-- Id number of the GitHub issue this PR addresses. -->

⚠️ Please don't merge until the FluxC hash is updated.

### Description
This PR fixes three issues:
1. #11931 by updating FluxC to include the changes of the FluxC [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3053).
2. #12032 by clearing the cached websites before proceeding with the login flow.
3. #12046 by making sure to show the primary button after finishing with the site fetch.

The three issues have a deeper explanation of the causes of the issues.

### Steps to reproduce
**Use `trunk`**
1. Use a Jetpack connected website.
2. To prepare the website, please install the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin, then add the following snippet:
```PHP
function modify_pre_get_shortlink_defaults($return, $id, $context, $allow_slugs) { 
	if ($id == 0) {
		return home_url( '/' );
	}
    return $return; 
}
// Add the filter to return the `shortlink` type as the `Link` header for the home page as well
add_filter( "pre_get_shortlink", "modify_pre_get_shortlink_defaults", 10, 4 );
```
3. Open the app.
5. Enter the site URL.
6. Use site credentials for signing.
7. Enter some credentials (no matter if they are wrong or right).
8. Notice that the Dialog will show `Fetching website` after a while, **then the login will fail.**
9. Attempt the login using the WebView.
10. **Notice that the login still fails with a generic error.**
11. Go back to the WordPress.com email screen.
12. Sign in using WordPress.com.
13. **Notice that the Account Mismatch screen is shown.**
14. Go back to the Site Picker.
15. **Notice that the Continue button is hidden.**

The three bugs are highlighted in the steps using bold text.
 
### Testing information
#### TC1: Testing the fix of #11931
1. Use the website from the above steps.
2. Test site credentials sign in.
3. Confirm the login works without issues.

#### TC2: Testing the fix of #12032
1. Use a Jetpack connected website (it can be the same website from the above steps)
2. Install the plugin [WPS Hide Login](https://wordpress.org/plugins/wps-hide-login/) on your website.
3. Test site credentials login.
4. When it fails, don't use the WebView login.
5. Go back to the WordPress.com email screen, then proceed with WordPress.com login.
6. Confirm the login works as expected.

#### TC3: Testing the fix of #12046
1. Start the login, and enter the address of a website not connected to your account (tip: you can use `wordpress.com` here 😄)
2. Proceed with WordPress.com login.
3. When the Account Mismatch screen is shown, go back.
4. Confirm the Continue button is shown.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->