### PR TITLE
Fix Application Password tracks and presentation rule

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -42,7 +42,6 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.module.ApplicationPasswordsClientId
 import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.INVALID_CREDENTIALS
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
 import org.wordpress.android.login.LoginAnalyticsListener

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -270,7 +270,6 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
                 if (FeatureFlag.APP_PASSWORD_TUTORIAL.isEnabled()) {
                     when (authenticationError?.errorType) {
-                        GENERIC_ERROR,
                         INVALID_CREDENTIALS -> errorDialogMessage.value = authenticationError.errorMessage
                         else -> {
                             fetchSiteForTutorial(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialViewModel.kt
@@ -39,6 +39,7 @@ class ApplicationPasswordTutorialViewModel @Inject constructor(
     }
 
     fun onWebPageLoaded(url: String) {
+        analyticsTracker.track(AnalyticsEvent.APPLICATION_PASSWORDS_AUTHORIZATION_WEB_VIEW_SHOWN)
         if (url.startsWith(REDIRECTION_URL)) {
             triggerEvent(ExitWithResult(url))
         }


### PR DESCRIPTION
Summary
==========
This PR fixes two things regarding the Application Password flow:
1. During the Better Errors project, the `APPLICATION_PASSWORDS_AUTHORIZATION_WEB_VIEW_SHOWN` track trigger was incorrectly removed, caused by the shift to the Application Password Tutorial screen. This PR brings it back and is now attached to the new flow as expected.
2. The Application Password screen was triggered only when the authentication succeeded, but a recaptcha pattern was detected. It should be triggered for every error that's not an HTTP 404/incorrect credentials/network error.

How
==========
When the `ApplicationPasswordTutorialViewModel.onWebPageLoaded` is called, the `APPLICATION_PASSWORDS_AUTHORIZATION_WEB_VIEW_SHOWN` track is triggered.

When a `GENERIC_ERROR` is triggered within the Login Site Credentials, the Application Password flow is started.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.