### PR TITLE
Fix overflowing SKU text in the Order Creation Flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableGroupedProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableGroupedProductCard.kt
@@ -312,6 +312,8 @@ fun ExpandableChildrenProductCard(
                     .constrainAs(sku) {
                         start.linkTo(name.start)
                         top.linkTo(stock.bottom)
+                        end.linkTo(parent.end)
+                        width = Dimension.fillToConstraints
                     }
                     .padding(
                         start = dimensionResource(id = R.dimen.major_100),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -195,6 +195,8 @@ fun ExpandableProductCard(
                     .constrainAs(sku) {
                         start.linkTo(name.start)
                         top.linkTo(stock.bottom)
+                        end.linkTo(parent.end)
+                        width = Dimension.fillToConstraints
                     }
                     .padding(
                         start = dimensionResource(id = R.dimen.major_100),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12047
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When SKU of a product is long and the product is added to an order in the Order Creation flow, the SKU text overflows outside of the boundaries of the view it's located in.

This PR fixes the issue by constraining the end of the view to the end of the parent, ensuring the SKU won't overflow. The change is made in two different locations, to ensure the issue is fixed even for grouped products which have their own implementation of the `ExpandableProductCard`.



### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Start the order creation flow
2. Add a product with a long SKU into the order
3. Expand the added product by clicking on the chevron icon
4. Notice the SKU overflows

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Start the order creation flow
2. Add a **non-grouped** product with a long SKU into the order
3. Add a **grouped** product with a long SKU into the order
4. Expand the added products by clicking on the chevron icons
5. Notice the SKU don't overflow

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

|  | Before | After |
|---|---|---|
|  | <img src="https://github.com/user-attachments/assets/d8987ec8-c7f7-4a52-88b0-75b07710c77c" width="250px" /> | <img src="https://github.com/user-attachments/assets/5d1e0238-1483-4b0b-9d3b-f9a0f984d6d6" width="250px" /> |




- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->