### PR TITLE
Adds new feature flag to hide advice box from product prompt screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -338,7 +338,7 @@ private fun ProductPromptTextField(
                     modifier = Modifier
                         .onFocusChanged { focusState ->
                             isFocused = focusState.isFocused
-                            if (isFocused) {
+                            if (isFocused && FeatureFlag.PRODUCT_CREATION_WITH_AI_V2_M3.isEnabled()) {
                                 coroutineScope.launch { scrollState.animateScrollTo(scrollToPosition.roundToInt()) }
                             }
                         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -75,6 +75,7 @@ import com.woocommerce.android.ui.products.ai.components.SelectedImageSection
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.AiProductPromptState
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.PromptSuggestionBar
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.Tone
+import com.woocommerce.android.util.FeatureFlag
 import kotlinx.coroutines.launch
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource
 import kotlin.math.roundToInt
@@ -369,7 +370,10 @@ private fun ProductPromptTextField(
                 }
             }
         }
-        AnimatedVisibility(isFocused || state.productPrompt.isNotEmpty()) {
+        AnimatedVisibility(
+            (isFocused || state.productPrompt.isNotEmpty()) &&
+                FeatureFlag.PRODUCT_CREATION_WITH_AI_V2_M3.isEnabled()
+        ) {
             PromptSuggestions(
                 promptSuggestionBarState = state.promptSuggestionBarState,
                 modifier = Modifier.padding(top = 16.dp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -18,6 +18,7 @@ enum class FeatureFlag {
     GOOGLE_ADS_M1,
     GOOGLE_ADS_ANALYTICS_HUB_M1,
     PRODUCT_CREATION_WITH_AI_V2,
+    PRODUCT_CREATION_WITH_AI_V2_M3,
     SHOW_INBOX_CTA,
     BACKGROUND_TASKS;
 
@@ -34,7 +35,8 @@ enum class FeatureFlag {
             GOOGLE_ADS_M1,
             PRODUCT_CREATION_WITH_AI_V2,
             BACKGROUND_TASKS,
-            GOOGLE_ADS_ANALYTICS_HUB_M1 -> PackageUtils.isDebugBuild()
+            GOOGLE_ADS_ANALYTICS_HUB_M1,
+            PRODUCT_CREATION_WITH_AI_V2_M3 -> PackageUtils.isDebugBuild()
 
             CONNECTIVITY_TOOL,
             NEW_SHIPPING_SUPPORT,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12051 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Just adds a feature flag to be able to release milestone 1 of new product creation with AI flow, without enabling milestone 3: the advice box. More context on why we are postponing the release of milestone 3 to `19.7` while aiming to release milestone 1 in the next release `19.6`: p1721177823695299/1720515544.395649-slack-C03L1NF1EA3


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Testing information
1. Simply disable the `PRODUCT_CREATION_WITH_AI_V2_M3` flag from `FeatureFlag` file:

```patch
Subject: [PATCH] Adds new feature flag to hide advice box from product prompt screen
---
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt	(revision e66da5f530dd8126d4fd5b0d880409c8970ee15a)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt	(date 1721253154031)
@@ -35,8 +35,9 @@
             GOOGLE_ADS_M1,
             PRODUCT_CREATION_WITH_AI_V2,
             BACKGROUND_TASKS,
-            GOOGLE_ADS_ANALYTICS_HUB_M1,
-            PRODUCT_CREATION_WITH_AI_V2_M3 -> PackageUtils.isDebugBuild()
+            GOOGLE_ADS_ANALYTICS_HUB_M1 -> PackageUtils.isDebugBuild()
+
+            PRODUCT_CREATION_WITH_AI_V2_M3 -> false
 
             CONNECTIVITY_TOOL,
             NEW_SHIPPING_SUPPORT,

```
2. Open product creation with AI flow
3. Check that the advice box is never shown