### PR TITLE
Don't ensure screenshot tests build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -89,13 +89,6 @@ steps:
         artifact_paths:
           - "**/build/test-results/*/*.xml"
 
-      - label: "Ensure Screenshot Tests Build"
-        command: |
-          echo "--- ⚒️ Building"
-          cp gradle.properties-example gradle.properties
-          ./gradlew assembleJalapenoDebugAndroidTest
-        plugins: [$CI_TOOLKIT]
-
       - label: "Instrumented tests"
         command: .buildkite/commands/run-instrumented-tests.sh "Pixel2.arm" "30" "portrait"
         plugins:


### PR DESCRIPTION
### Description 

This little PR removes `Ensure Screenshot Tests Build` job from the pipeline. For explanation and more context, please see commit message.

### To test

CI check should be fine.