### PR TITLE
[Product AI v2] Delete publish button

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/SaveAiGeneratedProduct.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/SaveAiGeneratedProduct.kt
@@ -16,7 +16,6 @@ class SaveAiGeneratedProduct @Inject constructor(
     @Suppress("ReturnCount")
     suspend operator fun invoke(
         product: Product,
-        publishProduct: Boolean,
         selectedImage: Product.Image?
     ): Pair<Boolean, Long> {
         // Create missing categories
@@ -51,7 +50,7 @@ class SaveAiGeneratedProduct @Inject constructor(
             categories = product.categories - missingCategories.toSet() + createdCategories.orEmpty(),
             tags = product.tags - missingTags.toSet() + createdTags.orEmpty(),
             images = listOfNotNull(selectedImage),
-            status = if (publishProduct) ProductStatus.PUBLISH else ProductStatus.DRAFT
+            status = ProductStatus.DRAFT
         )
 
         return productDetailRepository.addProduct(updatedProduct)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewScreen.kt
@@ -82,7 +82,6 @@ fun AiProductPreviewScreen(viewModel: AiProductPreviewViewModel) {
             onSelectNextVariant = viewModel::onSelectNextVariant,
             onSelectPreviousVariant = viewModel::onSelectPreviousVariant,
             onSaveProductAsDraft = viewModel::onSaveProductAsDraft,
-            onPublishProduct = viewModel::onPublishProduct,
             onGenerateAgainClick = viewModel::onGenerateAgainClicked
         )
     }
@@ -101,7 +100,6 @@ private fun AiProductPreviewScreen(
     onSelectNextVariant: () -> Unit,
     onSelectPreviousVariant: () -> Unit,
     onSaveProductAsDraft: () -> Unit,
-    onPublishProduct: () -> Unit,
     onGenerateAgainClick: () -> Unit
 ) {
     Scaffold(
@@ -128,12 +126,6 @@ private fun AiProductPreviewScreen(
                                 onClick = onSaveProductAsDraft
                             ) {
                                 Text(text = stringResource(id = R.string.product_detail_save_as_draft))
-                            }
-                            WCTextButton(
-                                enabled = state is AiProductPreviewViewModel.State.Success,
-                                onClick = onPublishProduct
-                            ) {
-                                Text(text = stringResource(id = R.string.product_detail_publish))
                             }
                         }
                     }
@@ -607,7 +599,6 @@ private fun ProductPreviewLoadingPreview() {
             onSelectNextVariant = {},
             onSelectPreviousVariant = {},
             onSaveProductAsDraft = {},
-            onPublishProduct = {},
             onGenerateAgainClick = {}
         )
     }
@@ -664,7 +655,6 @@ private fun ProductPreviewContentPreview() {
             onSelectNextVariant = {},
             onSelectPreviousVariant = {},
             onSaveProductAsDraft = {},
-            onPublishProduct = {},
             onGenerateAgainClick = {}
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModel.kt
@@ -196,10 +196,6 @@ class AiProductPreviewViewModel @Inject constructor(
         addAiGeneratedProduct(publishProduct = false)
     }
 
-    fun onPublishProduct() {
-        addAiGeneratedProduct(publishProduct = true)
-    }
-
     private fun addAiGeneratedProduct(publishProduct: Boolean) {
         val product = generatedProduct.value?.getOrNull()?.toProduct(selectedVariant.value) ?: return
         savingProductState.value = SavingProductState.Loading
@@ -219,7 +215,6 @@ class AiProductPreviewViewModel @Inject constructor(
                 savingProductState.value = SavingProductState.Error(
                     messageRes = R.string.error_generic,
                     onRetryClick = when {
-                        publishProduct -> ::onPublishProduct
                         else -> ::onSaveProductAsDraft
                     },
                     onDismissClick = { savingProductState.value = SavingProductState.Idle }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModel.kt
@@ -193,10 +193,6 @@ class AiProductPreviewViewModel @Inject constructor(
 
     fun onSaveProductAsDraft() {
         analyticsTracker.track(AnalyticsEvent.PRODUCT_CREATION_AI_SAVE_AS_DRAFT_BUTTON_TAPPED)
-        addAiGeneratedProduct(publishProduct = false)
-    }
-
-    private fun addAiGeneratedProduct(publishProduct: Boolean) {
         val product = generatedProduct.value?.getOrNull()?.toProduct(selectedVariant.value) ?: return
         savingProductState.value = SavingProductState.Loading
         viewModelScope.launch {
@@ -208,15 +204,12 @@ class AiProductPreviewViewModel @Inject constructor(
                     description = editedFields.descriptions[selectedVariant.value] ?: product.description,
                     shortDescription = editedFields.shortDescriptions[selectedVariant.value] ?: product.shortDescription
                 ),
-                publishProduct,
                 imageState.value.getImage()
             )
             if (!success) {
                 savingProductState.value = SavingProductState.Error(
                     messageRes = R.string.error_generic,
-                    onRetryClick = when {
-                        else -> ::onSaveProductAsDraft
-                    },
+                    onRetryClick = ::onSaveProductAsDraft,
                     onDismissClick = { savingProductState.value = SavingProductState.Idle }
                 )
                 analyticsTracker.track(AnalyticsEvent.PRODUCT_CREATION_AI_SAVE_AS_DRAFT_FAILED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModel.kt
@@ -191,6 +191,12 @@ class AiProductPreviewViewModel @Inject constructor(
         }
     }
 
+    fun onGenerateAgainClicked() {
+        userEditedFields.value = UserEditedFields()
+        selectedVariant.value = 0
+        generateProduct()
+    }
+
     fun onSaveProductAsDraft() {
         analyticsTracker.track(AnalyticsEvent.PRODUCT_CREATION_AI_SAVE_AS_DRAFT_BUTTON_TAPPED)
         val product = generatedProduct.value?.getOrNull()?.toProduct(selectedVariant.value) ?: return
@@ -241,12 +247,6 @@ class AiProductPreviewViewModel @Inject constructor(
     }
 
     private fun ImageState.getImage() = (image as? WPMediaLibraryImage)?.content
-
-    fun onGenerateAgainClicked() {
-        userEditedFields.value = UserEditedFields()
-        selectedVariant.value = 0
-        generateProduct()
-    }
 
     sealed interface State {
         data object Loading : State

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2149,7 +2149,6 @@
     <string name="product_selection_menu_update_stock_status">Update stock status</string>
     <string name="product_selection_menu_select_all">Select all</string>
     <string name="product_detail_save_as_draft">Save as draft</string>
-    <string name="product_detail_publish">Publish</string>
     <string name="product_detail_linked_products">Linked products</string>
     <string name="upsells_label">Upsells</string>
     <string name="upsells_desc">Products promoted instead of the currently viewed product (ie: more profitable products)</string>


### PR DESCRIPTION
### Description
When working on the M1 tasks, I added the "publish" button since it was in the Figma designs, but I just learnt that it's not supposed to be added, and that it's part of M2 which we won't work on right now. (p1721305237103029/1721289273.650489-slack-C03L1NF1EA3)

This PR simply removes the button and its logic.

### Testing information
1. Use a Jetpack website with Jetpack AI (an atomic website will work fine)
2. Open the product creation with AI.
3. Add some features and generate the product.
4. Confirm the screen has only the button `save as draft`.

### Images/gif
| Before | After |
| --- | --- |
| ![Screenshot_20240718_132733](https://github.com/user-attachments/assets/2bb05ed6-d363-468a-9931-bd765e47fa91) | ![Screenshot_20240718_133055](https://github.com/user-attachments/assets/dd868e85-be83-43ab-ae6f-6127f012c066) |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
