### PR TITLE
[Product AI v2] Handle saving the AI generation tone

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -41,7 +41,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.prefs.DeveloperOptionsViewModel.DeveloperOptionsViewState.UpdateOptions
 import com.woocommerce.android.ui.prefs.domain.DomainFlowSource
 import com.woocommerce.android.ui.products.ProductType
-import com.woocommerce.android.ui.products.ai.AboutProductSubViewModel.AiTone
+import com.woocommerce.android.ui.products.ai.AiTone
 import com.woocommerce.android.ui.promobanner.PromoBannerType
 import com.woocommerce.android.util.PreferenceUtils
 import com.woocommerce.android.util.ThemeOption

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubScreen.kt
@@ -43,9 +43,8 @@ import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCModalBottomSheetLayout
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
-import com.woocommerce.android.ui.products.ai.AboutProductSubViewModel.AiTone
-import com.woocommerce.android.ui.products.ai.AboutProductSubViewModel.AiTone.Casual
 import com.woocommerce.android.ui.products.ai.AboutProductSubViewModel.UiState
+import com.woocommerce.android.ui.products.ai.AiTone.Casual
 import kotlinx.coroutines.launch
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubViewModel.kt
@@ -75,5 +75,4 @@ class AboutProductSubViewModel(
         val productFeatures: String,
         val selectedAiTone: AiTone
     ) : Parcelable
-
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AboutProductSubViewModel.kt
@@ -1,15 +1,12 @@
 package com.woocommerce.android.ui.products.ai
 
 import android.os.Parcelable
-import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.ui.products.ai.AboutProductSubViewModel.AiTone
 import com.woocommerce.android.viewmodel.getStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -79,15 +76,4 @@ class AboutProductSubViewModel(
         val selectedAiTone: AiTone
     ) : Parcelable
 
-    enum class AiTone(@StringRes val displayName: Int, val slug: String) {
-        Casual(R.string.product_creation_ai_tone_casual, "Casual"),
-        Formal(R.string.product_creation_ai_tone_formal, "Formal"),
-        Flowery(R.string.product_creation_ai_tone_flowery, "Flowery"),
-        Convincing(R.string.product_creation_ai_tone_convincing, "Convincing");
-
-        companion object {
-            fun fromString(source: String): AiTone =
-                AiTone.values().firstOrNull { it.slug == source } ?: Casual
-        }
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AiTone.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AiTone.kt
@@ -11,6 +11,6 @@ enum class AiTone(@StringRes val displayName: Int, val slug: String) {
 
     companion object {
         fun fromString(source: String): AiTone =
-            AiTone.values().firstOrNull { it.slug == source } ?: Casual
+            AiTone.entries.firstOrNull { it.slug == source } ?: Casual
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AiTone.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/AiTone.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.android.ui.products.ai
+
+import androidx.annotation.StringRes
+import com.woocommerce.android.R
+
+enum class AiTone(@StringRes val displayName: Int, val slug: String) {
+    Casual(R.string.product_creation_ai_tone_casual, "Casual"),
+    Formal(R.string.product_creation_ai_tone_formal, "Formal"),
+    Flowery(R.string.product_creation_ai_tone_flowery, "Flowery"),
+    Convincing(R.string.product_creation_ai_tone_convincing, "Convincing");
+
+    companion object {
+        fun fromString(source: String): AiTone =
+            AiTone.values().firstOrNull { it.slug == source } ?: Casual
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/GenerateProductWithAILegacy.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/GenerateProductWithAILegacy.kt
@@ -11,8 +11,7 @@ import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductHelper
 import com.woocommerce.android.ui.products.ProductStatus.DRAFT
 import com.woocommerce.android.ui.products.ProductType.SIMPLE
-import com.woocommerce.android.ui.products.ai.AboutProductSubViewModel.AiTone
-import com.woocommerce.android.ui.products.ai.AboutProductSubViewModel.AiTone.Casual
+import com.woocommerce.android.ui.products.ai.AiTone.Casual
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/ProductPreviewSubViewModel.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.Product
-import com.woocommerce.android.ui.products.ai.AboutProductSubViewModel.AiTone
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
@@ -48,6 +49,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -288,7 +290,8 @@ private fun ProductPreviewContent(
 
         WCOutlinedButton(
             onClick = onGenerateAgainClick,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
                 .padding(top = 16.dp)
         ) {
             Text(text = stringResource(id = R.string.product_creation_ai_preview_generate_again))
@@ -323,6 +326,9 @@ private fun ProductTextField(
         BasicTextField(
             value = state.value,
             onValueChange = onValueChange,
+            textStyle = TextStyle.Default.copy(
+                color = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+            ),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/GenerateProductWithAI.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/GenerateProductWithAI.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products.ai.preview
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.WooException
 import com.woocommerce.android.ai.AIRepository
@@ -12,7 +13,6 @@ import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ai.AIProductModel
-import com.woocommerce.android.ui.products.ai.AiTone
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
@@ -28,7 +28,8 @@ class GenerateProductWithAI @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val categoriesRepository: ProductCategoriesRepository,
     private val tagsRepository: ProductTagsRepository,
-    private val parametersRepository: ParameterRepository
+    private val parametersRepository: ParameterRepository,
+    private val appPrefs: AppPrefsWrapper
 ) {
     private lateinit var languageISOCode: String
     private var isProductCategoriesFetched = false
@@ -57,8 +58,7 @@ class GenerateProductWithAI @Inject constructor(
 
         return aiRepository.generateProduct(
             productKeyWords = productFeatures,
-            // TODO pass the tone to use
-            tone = AiTone.Casual.name,
+            tone = appPrefs.aiContentGenerationTone.name,
             weightUnit = siteParameters.weightUnit!!,
             dimensionUnit = siteParameters.dimensionUnit!!,
             currency = siteParameters.currencyCode!!,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/GenerateProductWithAI.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/GenerateProductWithAI.kt
@@ -12,7 +12,7 @@ import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ai.AIProductModel
-import com.woocommerce.android.ui.products.ai.AboutProductSubViewModel
+import com.woocommerce.android.ui.products.ai.AiTone
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.ui.products.tags.ProductTagsRepository
@@ -58,7 +58,7 @@ class GenerateProductWithAI @Inject constructor(
         return aiRepository.generateProduct(
             productKeyWords = productFeatures,
             // TODO pass the tone to use
-            tone = AboutProductSubViewModel.AiTone.Casual.name,
+            tone = AiTone.Casual.name,
             weightUnit = siteParameters.weightUnit!!,
             dimensionUnit = siteParameters.dimensionUnit!!,
             currency = siteParameters.currencyCode!!,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptScreen.kt
@@ -69,12 +69,12 @@ import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.products.ai.AiTone
 import com.woocommerce.android.ui.products.ai.components.FullScreenImageViewer
 import com.woocommerce.android.ui.products.ai.components.ImageAction
 import com.woocommerce.android.ui.products.ai.components.SelectedImageSection
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.AiProductPromptState
 import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.PromptSuggestionBar
-import com.woocommerce.android.ui.products.ai.productinfo.AiProductPromptViewModel.Tone
 import kotlinx.coroutines.launch
 import org.wordpress.android.mediapicker.api.MediaPickerSetup.DataSource
 import kotlin.math.roundToInt
@@ -112,7 +112,7 @@ fun AiProductPromptScreen(
     onPromptUpdated: (String) -> Unit,
     onReadTextFromProductPhoto: () -> Unit,
     onGenerateProductClicked: () -> Unit,
-    onToneSelected: (Tone) -> Unit,
+    onToneSelected: (AiTone) -> Unit,
     onMediaPickerDialogDismissed: () -> Unit,
     onMediaLibraryRequested: (DataSource) -> Unit,
     onImageActionSelected: (ImageAction) -> Unit
@@ -214,8 +214,8 @@ fun AiProductPromptScreen(
 
 @Composable
 private fun ToneDropDown(
-    tone: Tone,
-    onToneSelected: (Tone) -> Unit,
+    tone: AiTone,
+    onToneSelected: (AiTone) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -251,7 +251,7 @@ private fun ToneDropDown(
                 modifier = Modifier
                     .defaultMinSize(minWidth = 250.dp)
             ) {
-                Tone.entries.forEach {
+                AiTone.entries.forEach {
                     DropdownMenuItem(
                         onClick = {
                             onToneSelected(it)
@@ -471,7 +471,7 @@ private fun AiProductPromptScreenPreview() {
     AiProductPromptScreen(
         uiState = AiProductPromptState(
             productPrompt = "Product prompt test",
-            selectedTone = Tone.Casual,
+            selectedTone = AiTone.Casual,
             isMediaPickerDialogVisible = false,
             selectedImage = null,
             isScanningImage = false,
@@ -500,7 +500,7 @@ private fun AiProductPromptScreenWithErrorPreview() {
     AiProductPromptScreen(
         uiState = AiProductPromptState(
             productPrompt = "Product prompt test",
-            selectedTone = Tone.Casual,
+            selectedTone = AiTone.Casual,
             isMediaPickerDialogVisible = false,
             selectedImage = null,
             isScanningImage = false,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12065 
<!-- Id number of the GitHub issue this PR addresses. -->

⚠️ Please don't merge, I'll handle merging myself

### Description
While working on the tracking task, I noticed that we missed adding the logic to save the AI generation tone to the app prefs, this PR adds this, and handles passing it when generating the product.

This was done in the following order:
1. Extracted the `AiTone` to its own file to be reusable by the V2 components.
2. Updated the new prompt screen to use `AiTone` and removed the duplicated enum `Tone`.
3. Added logic to save the `AiTone` to the app prefs when a new value is selected.
4. Updated the generation logic to read the value from the app prefs.

### Testing information
1. Use a Jetpack website with Jetpack AI (an atomic website will work)
2. Open the product creation using AI.
3. Choose a tone.
4. Go back, then re-open the product creation using AI.
5. Confirm the tone was persisted.
6. Optional: Open flipper then launch product generation, and confirm the selected tone is part of the AI prompt.


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->