### PR TITLE
[GLA Analytics] Allow tracks name support for analytics cards

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/AnalyticCardConfiguration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/AnalyticCardConfiguration.kt
@@ -20,6 +20,11 @@ enum class AnalyticsCards(
     GiftCards(R.string.analytics_gift_cards_card_title, isPlugin = true),
     GoogleAds(R.string.analytics_google_ads_card_title, isPlugin = true);
 
+    /**
+     * Changing the AnalyticsCard name can cause crashes due to the attachment of the name with the Data Store.
+     * To allow us to update the tracked name without causing issues to the Hub settings storage,
+     * this field separates the AnalyticsCard definition from the tracked information.
+     */
     val trackName: String
         get() = when (this) {
             Revenue -> "revenue"
@@ -27,7 +32,7 @@ enum class AnalyticsCards(
             Products -> "products"
             Session -> "session"
             Bundles -> "bundles"
-            GiftCards -> "giftCards"
+            GiftCards -> "giftcards"
             GoogleAds -> "googleCampaigns"
         }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/AnalyticCardConfiguration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/AnalyticCardConfiguration.kt
@@ -21,7 +21,9 @@ enum class AnalyticsCards(
     GoogleAds(R.string.analytics_google_ads_card_title, isPlugin = true);
 
     /**
-     * Changing the AnalyticsCard name can cause crashes due to the attachment of the name with the Data Store.
+     * Changing the AnalyticsCard name can cause crashes due to the attachment of the name with
+     * the Analytics Hub Settings Data Store.
+     *
      * To allow us to update the tracked name without causing issues to the Hub settings storage,
      * this field separates the AnalyticsCard definition from the tracked information.
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/AnalyticCardConfiguration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/AnalyticCardConfiguration.kt
@@ -8,12 +8,26 @@ data class AnalyticCardConfiguration(
     val isVisible: Boolean = true,
 )
 
-enum class AnalyticsCards(val resId: Int, val isPlugin: Boolean = false) {
+enum class AnalyticsCards(
+    val resId: Int,
+    val isPlugin: Boolean = false
+) {
     Revenue(R.string.analytics_revenue_card_title),
     Orders(R.string.analytics_orders_card_title),
     Products(R.string.analytics_products_card_title),
     Session(R.string.analytics_session_card_title, isPlugin = true),
     Bundles(R.string.analytics_bundles_card_title, isPlugin = true),
     GiftCards(R.string.analytics_gift_cards_card_title, isPlugin = true),
-    GoogleAds(R.string.analytics_google_ads_card_title, isPlugin = true),
+    GoogleAds(R.string.analytics_google_ads_card_title, isPlugin = true);
+
+    val trackName: String
+        get() = when (this) {
+            Revenue -> "revenue"
+            Orders -> "orders"
+            Products -> "products"
+            Session -> "session"
+            Bundles -> "bundles"
+            GiftCards -> "giftCards"
+            GoogleAds -> "googleCampaigns"
+        }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -695,7 +695,7 @@ class AnalyticsHubViewModel @Inject constructor(
                 .run { this as? DeltaPercentage.Value }?.value,
             reportUrl = getReportUrl(
                 selection = ranges,
-                card = ReportCard.GoogleAds
+                card = ReportCard.GoogleCampaigns
             ),
             items = googleAdsStats.googleAdsCampaigns.map {
                 AnalyticsHubListCardItemViewState(
@@ -776,7 +776,7 @@ class AnalyticsHubViewModel @Inject constructor(
     }
 }
 
-enum class ReportCard { Revenue, Orders, Products, Bundles, GiftCard, GoogleAds }
+enum class ReportCard { Revenue, Orders, Products, Bundles, GiftCard, GoogleCampaigns }
 
 fun AnalyticsCards.toReportCard(): ReportCard? {
     return when (this) {
@@ -785,7 +785,7 @@ fun AnalyticsCards.toReportCard(): ReportCard? {
         AnalyticsCards.Products -> ReportCard.Products
         AnalyticsCards.Bundles -> ReportCard.Bundles
         AnalyticsCards.GiftCards -> ReportCard.GiftCard
-        AnalyticsCards.GoogleAds -> ReportCard.GoogleAds
+        AnalyticsCards.GoogleAds -> ReportCard.GoogleCampaigns
         else -> null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/GetReportUrl.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/GetReportUrl.kt
@@ -22,7 +22,7 @@ class GetReportUrl @Inject constructor(
                 ReportCard.Products -> "path=%2Fanalytics%2Fproducts"
                 ReportCard.Bundles -> "path=%2Fanalytics%2Fbundles"
                 ReportCard.GiftCard -> "path=%2Fanalytics%2Fgift-cards"
-                ReportCard.GoogleAds -> "path=%2Fgoogle%2Freports"
+                ReportCard.GoogleCampaigns -> "path=%2Fgoogle%2Freports"
             }
             val period = getPeriod(selection)
             val compare = "compare=previous_period"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingsViewModel.kt
@@ -106,7 +106,7 @@ class AnalyticsHubSettingsViewModel @Inject constructor(
         val enabledCards = mutableListOf<String>()
         val disabledCards = mutableListOf<String>()
         configuration.forEach { cardConfiguration ->
-            val cardName = cardConfiguration.card.name.lowercase()
+            val cardName = cardConfiguration.card.trackName
             if (cardConfiguration.isVisible) {
                 enabledCards.add(cardName)
             } else {


### PR DESCRIPTION
Summary
==========
Fix issue #11989 by updating the AnalyticsCard Settings to work correctly with the expected tracks parameters as detailed below:

* If the merchants taps "See report" we track `analytics_hub_view_full_report_tapped`, and the custom prop `report` has value `googleCampaigns`.
* If the merchant customizes the analytics hub, we track `analytics_hub_settings_saved`, and the custom props `enabled_cards` and `disabled_cards` with `googleCampaigns` included with the expected property (depending on whether it is enabled or disabled).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.