### PR TITLE
Fix not outdated data supported cards

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -132,6 +132,7 @@ class DashboardFragment :
         }
 
         binding.myStoreRefreshLayout.setOnRefreshListener {
+            binding.myStoreRefreshLayout.isRefreshing = false
             dashboardViewModel.onPullToRefresh()
             refreshJitm()
         }


### PR DESCRIPTION
### Description
This small PR fix an issue with the refresh indicator of cards that still doesn't support the outdated card behavior.

### Testing information
1. Hide all cards from the dashboard except the most active coupon in the Google Ads campaign
2. Pull to refresh the screen
3. Check that the refresh indicator hides 

### Images/gif

https://github.com/user-attachments/assets/060d76a7-d23d-4cdd-bb6e-9047ade252bb


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->