### PR TITLE
[Product AI v2] Undo snackbar when package photo is removed

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewFragment.kt
@@ -7,15 +7,18 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
+import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.products.details.ProductDetailFragment
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class AiProductPreviewFragment : BaseFragment() {
@@ -23,6 +26,11 @@ class AiProductPreviewFragment : BaseFragment() {
         get() = AppBarStatus.Hidden
 
     private val viewModel: AiProductPreviewViewModel by viewModels()
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
+
+    private var undoSnackBar: Snackbar? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {
@@ -38,6 +46,15 @@ class AiProductPreviewFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+                is MultiLiveEvent.Event.ShowUndoSnackbar -> {
+                    undoSnackBar = uiMessageResolver.getUndoSnack(
+                        message = event.message,
+                        actionListener = event.undoAction
+                    ).also {
+                        it.addCallback(event.dismissAction)
+                        it.show()
+                    }
+                }
                 is AiProductPreviewViewModel.NavigateToProductDetailScreen -> findNavController().navigateSafely(
                     directions = NavGraphMainDirections.actionGlobalProductDetailFragment(
                         mode = ProductDetailFragment.Mode.ShowProduct(
@@ -51,5 +68,10 @@ class AiProductPreviewFragment : BaseFragment() {
                 )
             }
         }
+    }
+
+    override fun onDestroyView() {
+        undoSnackBar?.dismiss()
+        super.onDestroyView()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModel.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.ui.products.ai.ProductPropertyCard
 import com.woocommerce.android.ui.products.ai.SaveAiGeneratedProduct
 import com.woocommerce.android.ui.products.ai.components.ImageAction
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
@@ -42,7 +43,8 @@ class AiProductPreviewViewModel @Inject constructor(
     private val generateProductWithAI: GenerateProductWithAI,
     private val uploadImage: UploadImage,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    private val saveAiGeneratedProduct: SaveAiGeneratedProduct
+    private val saveAiGeneratedProduct: SaveAiGeneratedProduct,
+    private val resourceProvider: ResourceProvider
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         private const val DEFAULT_COUNT_OF_VARIANTS = 3
@@ -136,7 +138,17 @@ class AiProductPreviewViewModel @Inject constructor(
     fun onImageActionSelected(action: ImageAction) {
         when (action) {
             ImageAction.View -> imageState.value = imageState.value.copy(showImageFullScreen = true)
-            ImageAction.Remove -> imageState.value = imageState.value.copy(image = null)
+            ImageAction.Remove -> {
+                val previousState = imageState.value
+                imageState.value = imageState.value.copy(image = null)
+                triggerEvent(
+                    MultiLiveEvent.Event.ShowUndoSnackbar(
+                        message = resourceProvider.getString(R.string.ai_product_creation_photo_removed),
+                        undoAction = { imageState.value = previousState }
+                    )
+                )
+            }
+
             else -> error("Unsupported action: $action")
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.products.ai.components.ImageAction
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -31,7 +32,8 @@ class AiProductPromptViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val tracker: AnalyticsTrackerWrapper,
     private val textRecognitionEngine: TextRecognitionEngine,
-    private val prefs: AppPrefsWrapper
+    private val prefs: AppPrefsWrapper,
+    private val resourceProvider: ResourceProvider
 ) : ScopedViewModel(savedState = savedStateHandle) {
     companion object {
         private const val SUGGESTIONS_BAR_INITIAL_PROGRESS = 0.05F
@@ -205,10 +207,20 @@ class AiProductPromptViewModel @Inject constructor(
                 tracker.track(AnalyticsEvent.PRODUCT_CREATION_AI_STARTED_PACKAGE_PHOTO_SELECTION_FLOW)
                 _state.value = _state.value.copy(isMediaPickerDialogVisible = true)
             }
-            ImageAction.Remove -> _state.value = _state.value.copy(
-                selectedImage = null,
-                noTextDetectedMessage = false,
-            )
+
+            ImageAction.Remove -> {
+                val previousState = _state.value
+                _state.value = _state.value.copy(
+                    selectedImage = null,
+                    noTextDetectedMessage = false,
+                )
+                triggerEvent(
+                    Event.ShowUndoSnackbar(
+                        message = resourceProvider.getString(R.string.ai_product_creation_photo_removed),
+                        undoAction = { _state.value = previousState }
+                    )
+                )
+            }
         }
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2256,6 +2256,7 @@
     <string name="ai_product_creation_prompt_suggestion_almost_there"><![CDATA[<b>Great prompt!</b> Where was it made?]]></string>
     <string name="ai_product_creation_prompt_suggestion_great_prompt"><![CDATA[<b>Great prompt!</b> You\'ve given us enough to work with, but you may add more detail to make it even better.]]></string>
     <string name="ai_product_creation_error_media_upload">Failed to upload the selected product image.</string>
+    <string name="ai_product_creation_photo_removed">Photo removed</string>
 
     <!--
         Product Add more details Bottom sheet


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12086
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds logic to show an Undo Snackbar when the package photo is removed in both the "Starting information" and the "Preview" screens.

### Testing information
1. Use a Jetpack website with Jetpack AI.
2. Open the app and start Product Creation with AI.
3. Add a package photo.
4. Tap on the menu button for the package photo, then select "Remove"
5. Notice the Snackbar.
6. Tap on "Undo"
7. Confirm the photo is restored.
8. Continue the product generation.
9. In the preview screen, and after the product is generated, tap on the menu button of the package photo then select "Remove"
10. Notice the Snackbar.
11. Tap on "Undo"
12. Confirm the photo is restored.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->