### PR TITLE
Issue/increase awarness of downsides of saving view state

### DIFF
--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/extensions/FlowExt.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/extensions/FlowExt.kt
@@ -33,6 +33,9 @@ fun <T, R> Flow<T>.combineWithTimeout(
  * A helper function to create a [MutableStateFlow] that creates an entry in [SavedStateHandle] to persist value
  * through process-death.
  *
+ * !BEWARE! that only data that can't be easily recovered should be stored - e.g. user's input. Storing complete
+ * viewStates wastes device resources and often leads to issues such as TransactionTooLarge crashes.
+ *
  * Based on https://gist.github.com/marcellogalhardo/2a1ec56b7d00ba9af1ec9fd3583d53dc
  *
  * @param scope The scope used to synchronize the [StateFlow] and [SavedStateHandle]

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/login/LoginViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/login/LoginViewModel.kt
@@ -30,6 +30,7 @@ class LoginViewModel @AssistedInject constructor(
     @Assisted private val navController: NavHostController,
     savedState: SavedStateHandle
 ) : WearViewModel() {
+    @Suppress("ForbiddenComment")
     // TODO: Storing complete ViewState into SavedState can lead to TransactionTooLarge crashes. Only data that can't
     //  be easily recovered, such as user input, should be stored.
     private val _viewState = savedState.getStateFlow(

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/login/LoginViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/login/LoginViewModel.kt
@@ -30,6 +30,8 @@ class LoginViewModel @AssistedInject constructor(
     @Assisted private val navController: NavHostController,
     savedState: SavedStateHandle
 ) : WearViewModel() {
+    // TODO: Storing complete ViewState into SavedState can lead to TransactionTooLarge crashes. Only data that can't
+    //  be easily recovered, such as user input, should be stored.
     private val _viewState = savedState.getStateFlow(
         scope = this,
         initialValue = ViewState()

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/details/OrderDetailsViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/details/OrderDetailsViewModel.kt
@@ -41,6 +41,7 @@ class OrderDetailsViewModel @Inject constructor(
 ) : WearViewModel() {
     private val orderId = savedState.get<Long>(ORDER_ID.key) ?: 0
 
+    @Suppress("ForbiddenComment")
     // TODO: Storing complete ViewState into SavedState can lead to TransactionTooLarge crashes. Only data that can't
     //  be easily recovered, such as user input, should be stored.
     private val _viewState = savedState.getStateFlow(

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/details/OrderDetailsViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/details/OrderDetailsViewModel.kt
@@ -41,6 +41,8 @@ class OrderDetailsViewModel @Inject constructor(
 ) : WearViewModel() {
     private val orderId = savedState.get<Long>(ORDER_ID.key) ?: 0
 
+    // TODO: Storing complete ViewState into SavedState can lead to TransactionTooLarge crashes. Only data that can't
+    //  be easily recovered, such as user input, should be stored.
     private val _viewState = savedState.getStateFlow(
         scope = this,
         initialValue = ViewState()

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/list/OrdersListViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/list/OrdersListViewModel.kt
@@ -38,6 +38,8 @@ class OrdersListViewModel @AssistedInject constructor(
     private val analyticsTracker: AnalyticsTracker,
     savedState: SavedStateHandle
 ) : WearViewModel() {
+    // TODO: Storing complete ViewState into SavedState can lead to TransactionTooLarge crashes. Only data that can't
+    //  be easily recovered, such as user input, should be stored.
     private val _viewState = savedState.getStateFlow(
         scope = this,
         initialValue = ViewState()

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/list/OrdersListViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/orders/list/OrdersListViewModel.kt
@@ -38,6 +38,7 @@ class OrdersListViewModel @AssistedInject constructor(
     private val analyticsTracker: AnalyticsTracker,
     savedState: SavedStateHandle
 ) : WearViewModel() {
+    @Suppress("ForbiddenComment")
     // TODO: Storing complete ViewState into SavedState can lead to TransactionTooLarge crashes. Only data that can't
     //  be easily recovered, such as user input, should be stored.
     private val _viewState = savedState.getStateFlow(

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/StoreStatsViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/StoreStatsViewModel.kt
@@ -35,6 +35,8 @@ class StoreStatsViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTracker,
     savedState: SavedStateHandle
 ) : WearViewModel() {
+    // TODO: Storing complete ViewState into SavedState can lead to TransactionTooLarge crashes. Only data that can't
+    //  be easily recovered, such as user input, should be stored.
     private val _viewState = savedState.getStateFlow(
         scope = this,
         initialValue = ViewState()

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/StoreStatsViewModel.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/StoreStatsViewModel.kt
@@ -35,6 +35,7 @@ class StoreStatsViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTracker,
     savedState: SavedStateHandle
 ) : WearViewModel() {
+    @Suppress("ForbiddenComment")
     // TODO: Storing complete ViewState into SavedState can lead to TransactionTooLarge crashes. Only data that can't
     //  be easily recovered, such as user input, should be stored.
     private val _viewState = savedState.getStateFlow(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingsViewModel.kt
@@ -36,6 +36,12 @@ class AnalyticsHubSettingsViewModel @Inject constructor(
         const val MARKETPLACE = "https://woocommerce.com/products/"
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData: LiveDataDelegate<AnalyticsHubSettingsViewState> =
         LiveDataDelegate(savedState, AnalyticsHubSettingsViewState.Loading)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingsViewModel.kt
@@ -37,9 +37,9 @@ class AnalyticsHubSettingsViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData: LiveDataDelegate<AnalyticsHubSettingsViewState> =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModel.kt
@@ -29,6 +29,12 @@ class UserEligibilityErrorViewModel @Inject constructor(
         private const val ROLES_KEY = "current_roles"
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModel.kt
@@ -30,9 +30,9 @@ class UserEligibilityErrorViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackCPInstallViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackCPInstallViewModel.kt
@@ -43,9 +43,9 @@ class JetpackCPInstallViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, JetpackInstallProgressViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackCPInstallViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackCPInstallViewModel.kt
@@ -42,6 +42,12 @@ class JetpackCPInstallViewModel @Inject constructor(
         const val SYNC_CHECK_DELAY = 3000L
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, JetpackInstallProgressViewState())
     private var viewState by viewStateLiveData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListViewModel.kt
@@ -24,6 +24,12 @@ class MediaUploadErrorListViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     private val navArgs: MediaUploadErrorListFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/media/MediaUploadErrorListViewModel.kt
@@ -25,9 +25,9 @@ class MediaUploadErrorListViewModel @Inject constructor(
     private val navArgs: MediaUploadErrorListFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -228,9 +228,9 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -227,6 +227,12 @@ class OrderCreateEditViewModel @Inject constructor(
         const val DAYS_BEFORE_SHOWING_SHIPPING_FEEDBACK = 7
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreateEditFeeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreateEditFeeViewModel.kt
@@ -26,9 +26,9 @@ class OrderCreateEditFeeViewModel @Inject constructor(
     private val orderSubtotal = navArgs.orderSubTotal
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreateEditFeeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/fees/OrderCreateEditFeeViewModel.kt
@@ -25,6 +25,12 @@ class OrderCreateEditFeeViewModel @Inject constructor(
     private val navArgs: OrderCreateEditFeeFragmentArgs by savedState.navArgs()
     private val orderSubtotal = navArgs.orderSubTotal
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -141,9 +141,9 @@ class OrderDetailViewModel @Inject constructor(
     private var deletedOrderShipmentTrackingSet = mutableSetOf<String>()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, OrderDetailViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -140,6 +140,12 @@ class OrderDetailViewModel @Inject constructor(
     // and add the deleted tracking number back to the list
     private var deletedOrderShipmentTrackingSet = mutableSetOf<String>()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, OrderDetailViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -40,9 +40,9 @@ class OrderEditingViewModel @Inject constructor(
     private val navArgs by savedState.navArgs<OrderDetailFragmentArgs>()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModel.kt
@@ -39,6 +39,12 @@ class OrderEditingViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     private val navArgs by savedState.navArgs<OrderDetailFragmentArgs>()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -37,9 +37,9 @@ class AddressViewModel @Inject constructor(
     private val getLocations: GetLocations,
 ) : ScopedViewModel(savedState) {
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/editing/address/AddressViewModel.kt
@@ -36,6 +36,12 @@ class AddressViewModel @Inject constructor(
     private val dataStore: WCDataStore,
     private val getLocations: GetLocations,
 ) : ScopedViewModel(savedState) {
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesViewModel.kt
@@ -64,9 +64,9 @@ class OrderFilterCategoriesViewModel @Inject constructor(
         savedState[OLD_FILTER_SELECTION_KEY] ?: emptyList()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val categories = LiveDataDelegate(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesViewModel.kt
@@ -63,6 +63,12 @@ class OrderFilterCategoriesViewModel @Inject constructor(
     private var oldFilterSelection: List<OrderFilterCategoryUiModel> =
         savedState[OLD_FILTER_SELECTION_KEY] ?: emptyList()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val categories = LiveDataDelegate(
         savedState,
         OrderFilterCategories(emptyList())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsViewModel.kt
@@ -44,9 +44,9 @@ class OrderFilterOptionsViewModel @Inject constructor(
     private val categoryKey = arguments.filterCategory.categoryKey
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewState = LiveDataDelegate(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterOptionsViewModel.kt
@@ -43,6 +43,12 @@ class OrderFilterOptionsViewModel @Inject constructor(
     private val arguments: OrderFilterOptionsFragmentArgs by savedState.navArgs()
     private val categoryKey = arguments.filterCategory.categoryKey
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewState = LiveDataDelegate(
         savedState,
         ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
@@ -52,7 +52,7 @@ class OrderFulfillViewModel @Inject constructor(
 
     private val navArgs: OrderFulfillFragmentArgs by savedState.navArgs()
 
-    final /**
+    /**
      * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
      * with @OptIn(LiveDelegateSavedStateAPI::class).

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
@@ -53,9 +53,9 @@ class OrderFulfillViewModel @Inject constructor(
     private val navArgs: OrderFulfillFragmentArgs by savedState.navArgs()
 
     final /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/fulfill/OrderFulfillViewModel.kt
@@ -52,7 +52,13 @@ class OrderFulfillViewModel @Inject constructor(
 
     private val navArgs: OrderFulfillFragmentArgs by savedState.navArgs()
 
-    final val viewStateData = LiveDataDelegate(savedState, ViewState())
+    final /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
+    val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 
     private val _productList = MutableLiveData<List<Item>>()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -145,6 +145,12 @@ class OrderListViewModel @Inject constructor(
         )
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState(filterCount = getSelectedOrderFiltersCount()))
     internal var viewState by viewStateLiveData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -146,9 +146,9 @@ class OrderListViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState(filterCount = getSelectedOrderFiltersCount()))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModel.kt
@@ -28,9 +28,9 @@ class AddOrderNoteViewModel @Inject constructor(
     private val orderDetailRepository: OrderDetailRepository
 ) : ScopedViewModel(savedState) {
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val addOrderNoteViewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/notes/AddOrderNoteViewModel.kt
@@ -27,6 +27,12 @@ class AddOrderNoteViewModel @Inject constructor(
     private val networkStatus: NetworkStatus,
     private val orderDetailRepository: OrderDetailRepository
 ) : ScopedViewModel(savedState) {
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val addOrderNoteViewStateData = LiveDataDelegate(savedState, ViewState())
     private var addOrderNoteViewState by addOrderNoteViewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormViewModel.kt
@@ -30,6 +30,12 @@ class PrintShippingLabelCustomsFormViewModel @Inject constructor(
     private var printJob: Job? = null
     private val navArgs: PrintShippingLabelCustomsFormFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState(commercialInvoices = navArgs.invoices.toList()))
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelCustomsFormViewModel.kt
@@ -31,9 +31,9 @@ class PrintShippingLabelCustomsFormViewModel @Inject constructor(
     private val navArgs: PrintShippingLabelCustomsFormFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState(commercialInvoices = navArgs.invoices.toList()))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelViewModel.kt
@@ -47,6 +47,12 @@ class PrintShippingLabelViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(
         savedState,
         PrintShippingLabelViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/PrintShippingLabelViewModel.kt
@@ -48,9 +48,9 @@ class PrintShippingLabelViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundViewModel.kt
@@ -32,6 +32,12 @@ class ShippingLabelRefundViewModel @Inject constructor(
 
     private val arguments: ShippingLabelRefundFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val shippingLabelRefundViewStateData = LiveDataDelegate(savedState, ShippingLabelRefundViewState())
     private var shippingLabelRefundViewState by shippingLabelRefundViewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/ShippingLabelRefundViewModel.kt
@@ -33,9 +33,9 @@ class ShippingLabelRefundViewModel @Inject constructor(
     private val arguments: ShippingLabelRefundFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val shippingLabelRefundViewStateData = LiveDataDelegate(savedState, ShippingLabelRefundViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -170,9 +170,9 @@ class CreateShippingLabelViewModel @Inject constructor(
     private val arguments: CreateShippingLabelFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/CreateShippingLabelViewModel.kt
@@ -169,6 +169,12 @@ class CreateShippingLabelViewModel @Inject constructor(
 
     private val arguments: CreateShippingLabelFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -68,6 +68,12 @@ class EditShippingLabelAddressViewModel @Inject constructor(
 
     private val arguments: EditShippingLabelAddressFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState(arguments))
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelAddressViewModel.kt
@@ -69,9 +69,9 @@ class EditShippingLabelAddressViewModel @Inject constructor(
     private val arguments: EditShippingLabelAddressFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState(arguments))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -52,6 +52,12 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
 
     private val arguments: EditShippingLabelPackagesFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -53,9 +53,9 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
     private val arguments: EditShippingLabelPackagesFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
@@ -27,9 +27,9 @@ class EditShippingLabelPaymentViewModel @Inject constructor(
     private val shippingLabelRepository: ShippingLabelRepository
 ) : ScopedViewModel(savedState) {
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPaymentViewModel.kt
@@ -26,6 +26,12 @@ class EditShippingLabelPaymentViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val shippingLabelRepository: ShippingLabelRepository
 ) : ScopedViewModel(savedState) {
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
@@ -24,9 +24,9 @@ class MoveShippingItemViewModel @Inject constructor(
     private val navArgs: MoveShippingItemDialogArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/MoveShippingItemViewModel.kt
@@ -23,6 +23,12 @@ class MoveShippingItemViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     private val navArgs: MoveShippingItemDialogArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesViewModel.kt
@@ -55,9 +55,9 @@ class ShippingCarrierRatesViewModel @Inject constructor(
     private val arguments: ShippingCarrierRatesFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCarrierRatesViewModel.kt
@@ -54,6 +54,12 @@ class ShippingCarrierRatesViewModel @Inject constructor(
     }
     private val arguments: ShippingCarrierRatesFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -56,9 +56,9 @@ class ShippingCustomsViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingCustomsViewModel.kt
@@ -55,6 +55,12 @@ class ShippingCustomsViewModel @Inject constructor(
         private const val KEY_PARAMETERS = "key_parameters"
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionViewModel.kt
@@ -26,6 +26,12 @@ class ShippingLabelAddressSuggestionViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     private val arguments: ShippingLabelAddressSuggestionFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(
         savedState,
         ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelAddressSuggestionViewModel.kt
@@ -27,9 +27,9 @@ class ShippingLabelAddressSuggestionViewModel @Inject constructor(
     private val arguments: ShippingLabelAddressSuggestionFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageViewModel.kt
@@ -33,9 +33,9 @@ class ShippingLabelCreateCustomPackageViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ShippingLabelCreateCustomPackageViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateCustomPackageViewModel.kt
@@ -32,6 +32,12 @@ class ShippingLabelCreateCustomPackageViewModel @Inject constructor(
         private const val KEY_PARAMETERS = "key_parameters"
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ShippingLabelCreateCustomPackageViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreatePackageViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreatePackageViewModel.kt
@@ -46,9 +46,9 @@ class ShippingLabelCreatePackageViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ShippingLabelCreatePackageViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreatePackageViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreatePackageViewModel.kt
@@ -45,6 +45,12 @@ class ShippingLabelCreatePackageViewModel @Inject constructor(
         )
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ShippingLabelCreatePackageViewState())
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageViewModel.kt
@@ -29,6 +29,12 @@ class ShippingLabelCreateServicePackageViewModel @Inject constructor(
         private const val KEY_PARAMETERS = "key_parameters"
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingLabelCreateServicePackageViewModel.kt
@@ -30,9 +30,9 @@ class ShippingLabelCreateServicePackageViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorViewModel.kt
@@ -32,6 +32,12 @@ class ShippingPackageSelectorViewModel @Inject constructor(
 
     private val arguments: ShippingPackageSelectorFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/ShippingPackageSelectorViewModel.kt
@@ -33,9 +33,9 @@ class ShippingPackageSelectorViewModel @Inject constructor(
     private val arguments: ShippingPackageSelectorFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModel.kt
@@ -36,9 +36,9 @@ class AddOrderShipmentTrackingViewModel @Inject constructor(
     private val navArgs: AddOrderShipmentTrackingFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val addOrderShipmentTrackingViewStateData = LiveDataDelegate(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingViewModel.kt
@@ -35,6 +35,12 @@ class AddOrderShipmentTrackingViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     private val navArgs: AddOrderShipmentTrackingFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val addOrderShipmentTrackingViewStateData = LiveDataDelegate(
         savedState = savedState,
         initialValue = ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModel.kt
@@ -30,9 +30,9 @@ class AddOrderTrackingProviderListViewModel @Inject constructor(
     private val navArgs: AddOrderTrackingProviderListFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val trackingProviderListViewStateData = LiveDataDelegate(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListViewModel.kt
@@ -29,6 +29,12 @@ class AddOrderTrackingProviderListViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     private val navArgs: AddOrderTrackingProviderListFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val trackingProviderListViewStateData = LiveDataDelegate(
         savedState = savedState,
         initialValue = ViewState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
@@ -24,6 +24,12 @@ class CustomAmountsViewModel @Inject constructor(
     savedState: SavedStateHandle,
     tracker: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedState) {
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState())
     internal var viewState by viewStateLiveData
     var currentPrice: BigDecimal

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsViewModel.kt
@@ -25,9 +25,9 @@ class CustomAmountsViewModel @Inject constructor(
     tracker: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(savedState) {
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
@@ -120,6 +120,7 @@ class IssueRefundViewModel @Inject constructor(
      */
     @Suppress("OPT_IN_USAGE")
     val commonStateLiveData = LiveDataDelegate(savedState, CommonViewState())
+
     /**
      * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
@@ -127,6 +128,7 @@ class IssueRefundViewModel @Inject constructor(
      */
     @Suppress("OPT_IN_USAGE")
     val refundSummaryStateLiveData = LiveDataDelegate(savedState, RefundSummaryViewState())
+
     /**
      * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
@@ -140,6 +142,7 @@ class IssueRefundViewModel @Inject constructor(
             updateRefundTotal(new.grandTotalRefund)
         }
     )
+
     /**
      * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
@@ -153,6 +156,7 @@ class IssueRefundViewModel @Inject constructor(
             updateRefundTotal(new.enteredAmount)
         }
     )
+
     /**
      * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
@@ -113,8 +113,26 @@ class IssueRefundViewModel @Inject constructor(
     private val areAllItemsSelected: Boolean
         get() = refundItems.value?.all { it.quantity == it.availableRefundQuantity } ?: false
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val commonStateLiveData = LiveDataDelegate(savedState, CommonViewState())
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val refundSummaryStateLiveData = LiveDataDelegate(savedState, RefundSummaryViewState())
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val refundByItemsStateLiveData = LiveDataDelegate(
         savedState,
         RefundByItemsViewState(),
@@ -122,6 +140,12 @@ class IssueRefundViewModel @Inject constructor(
             updateRefundTotal(new.grandTotalRefund)
         }
     )
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val refundByAmountStateLiveData = LiveDataDelegate(
         savedState,
         RefundByAmountViewState(),
@@ -129,6 +153,12 @@ class IssueRefundViewModel @Inject constructor(
             updateRefundTotal(new.enteredAmount)
         }
     )
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     private val productsRefundLiveData = LiveDataDelegate(savedState, ProductsRefundViewState())
 
     private var commonState by commonStateLiveData

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModel.kt
@@ -114,23 +114,23 @@ class IssueRefundViewModel @Inject constructor(
         get() = refundItems.value?.all { it.quantity == it.availableRefundQuantity } ?: false
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val commonStateLiveData = LiveDataDelegate(savedState, CommonViewState())
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val refundSummaryStateLiveData = LiveDataDelegate(savedState, RefundSummaryViewState())
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val refundByItemsStateLiveData = LiveDataDelegate(
@@ -141,9 +141,9 @@ class IssueRefundViewModel @Inject constructor(
         }
     )
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val refundByAmountStateLiveData = LiveDataDelegate(
@@ -154,9 +154,9 @@ class IssueRefundViewModel @Inject constructor(
         }
     )
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     private val productsRefundLiveData = LiveDataDelegate(savedState, ProductsRefundViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundDetailViewModel.kt
@@ -44,6 +44,12 @@ class RefundDetailViewModel @Inject constructor(
     private val refundStore: WCRefundStore,
     private val orderMapper: OrderMapper,
 ) : ScopedViewModel(savedState) {
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundDetailViewModel.kt
@@ -45,9 +45,9 @@ class RefundDetailViewModel @Inject constructor(
     private val orderMapper: OrderMapper,
 ) : ScopedViewModel(savedState) {
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsViewModel.kt
@@ -34,9 +34,9 @@ class SimplePaymentsViewModel @Inject constructor(
     private val orderCreateEditRepository: OrderCreateEditRepository
 ) : ScopedViewModel(savedState) {
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/simplepayments/SimplePaymentsViewModel.kt
@@ -33,6 +33,12 @@ class SimplePaymentsViewModel @Inject constructor(
     private val networkStatus: NetworkStatus,
     private val orderCreateEditRepository: OrderCreateEditRepository
 ) : ScopedViewModel(savedState) {
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState())
     internal var viewState by viewStateLiveData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductBundleViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductBundleViewModel.kt
@@ -27,9 +27,9 @@ class ProductBundleViewModel @Inject constructor(
     val productList: LiveData<List<BundledProduct>> = _productList
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val productListViewStateData = LiveDataDelegate(savedState, BundledProductListViewState(isSkeletonShown = true))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductBundleViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductBundleViewModel.kt
@@ -26,6 +26,12 @@ class ProductBundleViewModel @Inject constructor(
     private val _productList = MutableLiveData<List<BundledProduct>>()
     val productList: LiveData<List<BundledProduct>> = _productList
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val productListViewStateData = LiveDataDelegate(savedState, BundledProductListViewState(isSkeletonShown = true))
     private var productListViewState by productListViewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModel.kt
@@ -34,6 +34,12 @@ class ProductInventoryViewModel @Inject constructor(
     private val navArgs: ProductInventoryFragmentArgs by savedState.navArgs()
     private val isProduct = navArgs.requestCode == RequestCodes.PRODUCT_DETAIL_INVENTORY
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(
         savedState,
         ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductInventoryViewModel.kt
@@ -35,9 +35,9 @@ class ProductInventoryViewModel @Inject constructor(
     private val isProduct = navArgs.requestCode == RequestCodes.PRODUCT_DETAIL_INVENTORY
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
@@ -38,9 +38,9 @@ class ProductSelectionListViewModel @Inject constructor(
     val productList: LiveData<List<Product>> = _productList
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val productSelectionListViewStateLiveData = LiveDataDelegate(savedState, ProductSelectionListViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductSelectionListViewModel.kt
@@ -37,6 +37,12 @@ class ProductSelectionListViewModel @Inject constructor(
     private val _productList = MutableLiveData<List<Product>>()
     val productList: LiveData<List<Product>> = _productList
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val productSelectionListViewStateLiveData = LiveDataDelegate(savedState, ProductSelectionListViewState())
     private var productSelectionListViewState by productSelectionListViewStateLiveData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -41,9 +41,9 @@ class OrderedAddonViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/addons/order/OrderedAddonViewModel.kt
@@ -40,6 +40,12 @@ class OrderedAddonViewModel @Inject constructor(
         private const val KEY_PRODUCT_PARAMETERS = "key_product_parameters"
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateLiveData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
@@ -43,8 +43,8 @@ class AddProductCategoryViewModel @Inject constructor(
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
      * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
-    @Suppress("OPT_IN_USAGE")
     // view state for the add category screen
+    @Suppress("OPT_IN_USAGE")
     val addProductCategoryViewStateLiveData = LiveDataDelegate(
         savedState,
         AddProductCategoryViewState(
@@ -60,8 +60,8 @@ class AddProductCategoryViewModel @Inject constructor(
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
      * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
-    @Suppress("OPT_IN_USAGE")
     // view state for the parent category list screen
+    @Suppress("OPT_IN_USAGE")
     val parentCategoryListViewStateData = LiveDataDelegate(savedState, ParentCategoryListViewState())
     private var parentCategoryListViewState by parentCategoryListViewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
@@ -39,9 +39,9 @@ class AddProductCategoryViewModel @Inject constructor(
     private val navArgs: AddProductCategoryFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     // view state for the add category screen
@@ -56,9 +56,9 @@ class AddProductCategoryViewModel @Inject constructor(
     private var addProductCategoryViewState by addProductCategoryViewStateLiveData
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     // view state for the parent category list screen

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/categories/AddProductCategoryViewModel.kt
@@ -38,6 +38,12 @@ class AddProductCategoryViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     private val navArgs: AddProductCategoryFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     // view state for the add category screen
     val addProductCategoryViewStateLiveData = LiveDataDelegate(
         savedState,
@@ -49,6 +55,12 @@ class AddProductCategoryViewModel @Inject constructor(
     )
     private var addProductCategoryViewState by addProductCategoryViewStateLiveData
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     // view state for the parent category list screen
     val parentCategoryListViewStateData = LiveDataDelegate(savedState, ParentCategoryListViewState())
     private var parentCategoryListViewState by parentCategoryListViewStateData

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/components/ComponentDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/components/ComponentDetailsViewModel.kt
@@ -29,9 +29,9 @@ class ComponentDetailsViewModel @Inject constructor(
     val componentOptions: LiveData<ComponentOptions> = _componentOptions
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val componentDetailsViewStateData = LiveDataDelegate(savedState, ComponentDetailsViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/components/ComponentDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/components/ComponentDetailsViewModel.kt
@@ -28,6 +28,12 @@ class ComponentDetailsViewModel @Inject constructor(
     private val _componentOptions = MutableLiveData<ComponentOptions>()
     val componentOptions: LiveData<ComponentOptions> = _componentOptions
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val componentDetailsViewStateData = LiveDataDelegate(savedState, ComponentDetailsViewState())
     private var componentDetailsViewState by componentDetailsViewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -172,6 +172,12 @@ class ProductDetailViewModel @Inject constructor(
         parameterRepository.getParameters(KEY_PRODUCT_PARAMETERS, savedState)
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     // view state for the product detail screen
     val productDetailViewStateData = LiveDataDelegate(
         savedState = savedState,
@@ -194,14 +200,32 @@ class ProductDetailViewModel @Inject constructor(
 
     private val storedProduct = MutableStateFlow<Product?>(null)
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     // view state for the product categories screen
     val productCategoriesViewStateData = LiveDataDelegate(savedState, ProductCategoriesViewState())
     private var productCategoriesViewState by productCategoriesViewStateData
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     // view state for the product tags screen
     val productTagsViewStateData = LiveDataDelegate(savedState, ProductTagsViewState())
     private var productTagsViewState by productTagsViewStateData
 
+        /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     // view state for the product downloads screen
     val productDownloadsViewStateData = LiveDataDelegate(savedState, ProductDownloadsViewState())
     private var productDownloadsViewState by productDownloadsViewStateData
@@ -218,9 +242,21 @@ class ProductDetailViewModel @Inject constructor(
     private val _attributeList = MutableLiveData<List<ProductAttribute>>()
     val attributeList: LiveData<List<ProductAttribute>> = _attributeList
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val globalAttributeViewStateData = LiveDataDelegate(savedState, GlobalAttributesViewState())
     private var globalAttributesViewState by globalAttributeViewStateData
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val attributeListViewStateData = LiveDataDelegate(savedState, AttributeListViewState())
     private var attributeListViewState by attributeListViewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -173,9 +173,9 @@ class ProductDetailViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     // view state for the product detail screen
@@ -201,9 +201,9 @@ class ProductDetailViewModel @Inject constructor(
     private val storedProduct = MutableStateFlow<Product?>(null)
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     // view state for the product categories screen
@@ -211,9 +211,9 @@ class ProductDetailViewModel @Inject constructor(
     private var productCategoriesViewState by productCategoriesViewStateData
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     // view state for the product tags screen
@@ -221,9 +221,9 @@ class ProductDetailViewModel @Inject constructor(
     private var productTagsViewState by productTagsViewStateData
 
         /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     // view state for the product downloads screen
@@ -243,18 +243,18 @@ class ProductDetailViewModel @Inject constructor(
     val attributeList: LiveData<List<ProductAttribute>> = _attributeList
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val globalAttributeViewStateData = LiveDataDelegate(savedState, GlobalAttributesViewState())
     private var globalAttributesViewState by globalAttributeViewStateData
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val attributeListViewStateData = LiveDataDelegate(savedState, AttributeListViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -177,8 +177,8 @@ class ProductDetailViewModel @Inject constructor(
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
      * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
-    @Suppress("OPT_IN_USAGE")
     // view state for the product detail screen
+    @Suppress("OPT_IN_USAGE")
     val productDetailViewStateData = LiveDataDelegate(
         savedState = savedState,
         initialValue = ProductDetailViewState(areImagesAvailable = !selectedSite.get().isPrivate)
@@ -205,8 +205,8 @@ class ProductDetailViewModel @Inject constructor(
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
      * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
-    @Suppress("OPT_IN_USAGE")
     // view state for the product categories screen
+    @Suppress("OPT_IN_USAGE")
     val productCategoriesViewStateData = LiveDataDelegate(savedState, ProductCategoriesViewState())
     private var productCategoriesViewState by productCategoriesViewStateData
 
@@ -215,18 +215,18 @@ class ProductDetailViewModel @Inject constructor(
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
      * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
-    @Suppress("OPT_IN_USAGE")
     // view state for the product tags screen
+    @Suppress("OPT_IN_USAGE")
     val productTagsViewStateData = LiveDataDelegate(savedState, ProductTagsViewState())
     private var productTagsViewState by productTagsViewStateData
 
-        /**
+    /**
      * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
      * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
-    @Suppress("OPT_IN_USAGE")
     // view state for the product downloads screen
+    @Suppress("OPT_IN_USAGE")
     val productDownloadsViewStateData = LiveDataDelegate(savedState, ProductDownloadsViewState())
     private var productDownloadsViewState by productDownloadsViewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModel.kt
@@ -29,6 +29,12 @@ class ProductDownloadDetailsViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     private val navArgs: ProductDownloadDetailsFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val productDownloadDetailsViewStateData = LiveDataDelegate(
         savedState,
         ProductDownloadDetailsViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/downloads/ProductDownloadDetailsViewModel.kt
@@ -30,9 +30,9 @@ class ProductDownloadDetailsViewModel @Inject constructor(
     private val navArgs: ProductDownloadDetailsFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val productDownloadDetailsViewStateData = LiveDataDelegate(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
@@ -68,9 +68,21 @@ class ProductFilterListViewModel @Inject constructor(
     private val _filterOptionListItems = MutableLiveData<List<FilterListOptionItemUiModel>>()
     val filterOptionListItems: LiveData<List<FilterListOptionItemUiModel>> = _filterOptionListItems
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val productFilterListViewStateData = LiveDataDelegate(savedState, ProductFilterListViewState())
     private var productFilterListViewState by productFilterListViewStateData
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val productFilterOptionListViewStateData =
         LiveDataDelegate(savedState, ProductFilterOptionListViewState())
     private var productFilterOptionListViewState by productFilterOptionListViewStateData

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
@@ -69,18 +69,18 @@ class ProductFilterListViewModel @Inject constructor(
     val filterOptionListItems: LiveData<List<FilterListOptionItemUiModel>> = _filterOptionListItems
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val productFilterListViewStateData = LiveDataDelegate(savedState, ProductFilterListViewState())
     private var productFilterListViewState by productFilterListViewStateData
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val productFilterOptionListViewStateData =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/grouped/GroupedProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/grouped/GroupedProductListViewModel.kt
@@ -32,6 +32,12 @@ class GroupedProductListViewModel @Inject constructor(
     private val _productList = MutableLiveData<List<Product>>()
     val productList: LiveData<List<Product>> = _productList
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val productListViewStateData = LiveDataDelegate(savedState, GroupedProductListViewState(originalProductIds))
     private var productListViewState by productListViewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/grouped/GroupedProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/grouped/GroupedProductListViewModel.kt
@@ -33,9 +33,9 @@ class GroupedProductListViewModel @Inject constructor(
     val productList: LiveData<List<Product>> = _productList
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val productListViewStateData = LiveDataDelegate(savedState, GroupedProductListViewState(originalProductIds))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/images/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/images/ProductImagesViewModel.kt
@@ -46,9 +46,9 @@ class ProductImagesViewModel @Inject constructor(
     private val isMultiSelectionAllowed = navArgs.requestCode == RequestCodes.PRODUCT_DETAIL_IMAGES
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/images/ProductImagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/images/ProductImagesViewModel.kt
@@ -45,6 +45,12 @@ class ProductImagesViewModel @Inject constructor(
 
     private val isMultiSelectionAllowed = navArgs.requestCode == RequestCodes.PRODUCT_DETAIL_IMAGES
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(
         savedState,
         ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
@@ -74,9 +74,9 @@ class ProductListViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
@@ -73,6 +73,12 @@ class ProductListViewModel @Inject constructor(
         it
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateLiveData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModel.kt
@@ -55,6 +55,12 @@ class ProductPricingViewModel @Inject constructor(
         parameterRepository.getParameters(KEY_PRODUCT_PARAMETERS, savedState)
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState(pricingData = navArgs.pricingData))
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/price/ProductPricingViewModel.kt
@@ -56,9 +56,9 @@ class ProductPricingViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState(pricingData = navArgs.pricingData))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/quantityRules/ProductQuantityRulesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/quantityRules/ProductQuantityRulesViewModel.kt
@@ -20,6 +20,7 @@ class ProductQuantityRulesViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
 
     private val navArgs: ProductQuantityRulesFragmentArgs by savedState.navArgs()
+
     /**
      * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/quantityRules/ProductQuantityRulesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/quantityRules/ProductQuantityRulesViewModel.kt
@@ -21,9 +21,9 @@ class ProductQuantityRulesViewModel @Inject constructor(
 
     private val navArgs: ProductQuantityRulesFragmentArgs by savedState.navArgs()
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/quantityRules/ProductQuantityRulesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/quantityRules/ProductQuantityRulesViewModel.kt
@@ -20,6 +20,12 @@ class ProductQuantityRulesViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
 
     private val navArgs: ProductQuantityRulesFragmentArgs by savedState.navArgs()
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(
         savedState,
         ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModel.kt
@@ -50,9 +50,9 @@ class ProductReviewsViewModel @Inject constructor(
         get() = _reviewList
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val productReviewsViewStateData = LiveDataDelegate(savedState, ProductReviewsViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModel.kt
@@ -49,6 +49,12 @@ class ProductReviewsViewModel @Inject constructor(
     override val ReviewModerationConsumer.rawReviewList: LiveData<List<ProductReview>>
         get() = _reviewList
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val productReviewsViewStateData = LiveDataDelegate(savedState, ProductReviewsViewState())
     private var productReviewsViewState by productReviewsViewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingClassViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingClassViewModel.kt
@@ -31,9 +31,9 @@ class ProductShippingClassViewModel @Inject constructor(
 
     // view state for the shipping class screen
     final /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingClassViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingClassViewModel.kt
@@ -30,7 +30,13 @@ class ProductShippingClassViewModel @Inject constructor(
     private var shippingClassLoadJob: Job? = null
 
     // view state for the shipping class screen
-    final val viewStateData = LiveDataDelegate(savedState, ViewState())
+    final /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
+    val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingClassViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingClassViewModel.kt
@@ -30,7 +30,7 @@ class ProductShippingClassViewModel @Inject constructor(
     private var shippingClassLoadJob: Job? = null
 
     // view state for the shipping class screen
-    final /**
+    /**
      * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
      * with @OptIn(LiveDelegateSavedStateAPI::class).

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingViewModel.kt
@@ -31,9 +31,9 @@ class ProductShippingViewModel @Inject constructor(
     private val navArgs: ProductShippingFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/shipping/ProductShippingViewModel.kt
@@ -30,6 +30,12 @@ class ProductShippingViewModel @Inject constructor(
     }
     private val navArgs: ProductShippingFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(
         savedState,
         ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -89,6 +89,12 @@ class VariationDetailViewModel @Inject constructor(
         parameterRepository.getParameters(KEY_VARIATION_PARAMETERS, savedState)
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     // view state for the variation detail screen
     val variationViewStateData = LiveDataDelegate(savedState, VariationViewState()) { old, new ->
         new.variation?.takeIf { it != old?.variation }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -90,9 +90,9 @@ class VariationDetailViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     // view state for the variation detail screen

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModel.kt
@@ -94,8 +94,8 @@ class VariationDetailViewModel @Inject constructor(
      * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
      * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
-    @Suppress("OPT_IN_USAGE")
     // view state for the variation detail screen
+    @Suppress("OPT_IN_USAGE")
     val variationViewStateData = LiveDataDelegate(savedState, VariationViewState()) { old, new ->
         new.variation?.takeIf { it != old?.variation }
             ?.let {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
@@ -93,6 +93,12 @@ class VariationListViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState(isAddVariationButtonVisible = isReadOnlyMode.not()))
     private var viewState by viewStateLiveData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
@@ -94,9 +94,9 @@ class VariationListViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState(isAddVariationButtonVisible = isReadOnlyMode.not()))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryViewModel.kt
@@ -22,6 +22,12 @@ class VariationsBulkUpdateInventoryViewModel @Inject constructor(
     private val data: InventoryUpdateData = args.inventoryUpdateData
     private val variationsToUpdate: List<ProductVariation> = args.inventoryUpdateData.variationsToUpdate
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdateInventoryViewModel.kt
@@ -23,9 +23,9 @@ class VariationsBulkUpdateInventoryViewModel @Inject constructor(
     private val variationsToUpdate: List<ProductVariation> = args.inventoryUpdateData.variationsToUpdate
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdatePriceViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdatePriceViewModel.kt
@@ -33,9 +33,9 @@ class VariationsBulkUpdatePriceViewModel @Inject constructor(
     }
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState(priceType = data.priceType))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdatePriceViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationsBulkUpdatePriceViewModel.kt
@@ -32,6 +32,12 @@ class VariationsBulkUpdatePriceViewModel @Inject constructor(
         parameterRepository.getParameters("key_product_parameters", savedState)
     }
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState(priceType = data.priceType))
     private var viewState: ViewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesViewModel.kt
@@ -33,6 +33,12 @@ class EditVariationAttributesViewModel @Inject constructor(
 
     val editableVariationAttributeList = _editableVariationAttributeList
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateLiveData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/attributes/edit/EditVariationAttributesViewModel.kt
@@ -34,9 +34,9 @@ class EditVariationAttributesViewModel @Inject constructor(
     val editableVariationAttributeList = _editableVariationAttributeList
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateLiveData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
@@ -39,9 +39,9 @@ class ReviewDetailViewModel @Inject constructor(
     private var remoteReviewId = 0L
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
@@ -38,6 +38,12 @@ class ReviewDetailViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     private var remoteReviewId = 0L
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
@@ -61,9 +61,9 @@ class ReviewListViewModel @Inject constructor(
         get() = this@ReviewListViewModel.reviewModerationHandler
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
@@ -60,6 +60,12 @@ class ReviewListViewModel @Inject constructor(
     override val ReviewModerationConsumer.reviewModerationHandler: ReviewModerationHandler
         get() = this@ReviewListViewModel.reviewModerationHandler
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, ViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -72,9 +72,9 @@ class SitePickerViewModel @Inject constructor(
     private val navArgs: SitePickerFragmentArgs by savedState.navArgs()
 
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val sitePickerViewStateData = LiveDataDelegate(savedState, SitePickerViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -71,6 +71,12 @@ class SitePickerViewModel @Inject constructor(
 
     private val navArgs: SitePickerFragmentArgs by savedState.navArgs()
 
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val sitePickerViewStateData = LiveDataDelegate(savedState, SitePickerViewState())
     private var sitePickerViewState by sitePickerViewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementViewModel.kt
@@ -17,6 +17,12 @@ class FeatureAnnouncementViewModel @Inject constructor(
     private val prefs: AppPrefs,
     private val buildConfigWrapper: BuildConfigWrapper,
 ) : ScopedViewModel(savedState) {
+    /**
+     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can
+     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     */
+    @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, FeatureAnnouncementViewState())
     private var viewState by viewStateData
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/whatsnew/FeatureAnnouncementViewModel.kt
@@ -18,9 +18,9 @@ class FeatureAnnouncementViewModel @Inject constructor(
     private val buildConfigWrapper: BuildConfigWrapper,
 ) : ScopedViewModel(savedState) {
     /**
-     * Saving more than necessary into the SavedState has associated risks which were not known at the time this
-     * field was implemented - after we ensure we don't save unnecessary data, we can
-     * replace @Suppress("OPT_IN_USAGE") with @OptIn(LiveDelegateSavedStateAPI::class).
+     * Saving more data than necessary into the SavedState has associated risks which were not known at the time this
+     * field was implemented - after we ensure we don't save unnecessary data, we can replace @Suppress("OPT_IN_USAGE")
+     * with @OptIn(LiveDelegateSavedStateAPI::class).
      */
     @Suppress("OPT_IN_USAGE")
     val viewStateData = LiveDataDelegate(savedState, FeatureAnnouncementViewState())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt
@@ -54,7 +54,7 @@ constructor(
 
     fun observe(owner: LifecycleOwner, observer: (T?, T) -> Unit) {
         if (_liveData.hasActiveObservers()) {
-            throw (IllegalStateException("Multiple observers registered but only one is supported."))
+            error("Multiple observers registered but only one is supported.")
         }
 
         previousValue = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt
@@ -25,12 +25,19 @@ import kotlin.reflect.KProperty
  *  being updated. If there is more than one, an [IllegalStateException] is thrown.
  *
  */
-class LiveDataDelegate<T : Parcelable> (
+class LiveDataDelegate<T : Parcelable>
+@Deprecated(
+    message = "Use the provided factory methods or secondary constructors instead.",
+    level = DeprecationLevel.WARNING
+)
+constructor(
     savedState: SavedStateHandle? = null,
     private val initialValue: T,
     savedStateKey: String = initialValue.javaClass.name,
     private val onChange: (T?, T) -> Unit = { _, _ -> }
 ) {
+    // This is a whitelisted usage of the primary constructor.
+    @Suppress("DEPRECATION")
     constructor(
         initialValue: T,
         onChange: (T?, T) -> Unit = { _, _ -> }
@@ -90,5 +97,6 @@ fun <T : Parcelable> createLiveDataDelegateWithSavedState(
     savedStateKey: String = initialValue.javaClass.name,
     onChange: (T?, T) -> Unit = { _, _ -> }
 ): LiveDataDelegate<T> {
+    @Suppress("DEPRECATION") // This is a whitelisted usage of the primary constructor.
     return LiveDataDelegate(savedState, initialValue, savedStateKey, onChange)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt
@@ -26,10 +26,7 @@ import kotlin.reflect.KProperty
  *
  */
 class LiveDataDelegate<T : Parcelable>
-@Deprecated(
-    message = "Use the provided factory methods or secondary constructors instead.",
-    level = DeprecationLevel.WARNING
-)
+@LiveDelegateSavedStateAPI
 constructor(
     savedState: SavedStateHandle? = null,
     private val initialValue: T,
@@ -37,7 +34,7 @@ constructor(
     private val onChange: (T?, T) -> Unit = { _, _ -> }
 ) {
     // This is a whitelisted usage of the primary constructor.
-    @Suppress("DEPRECATION")
+    @OptIn(LiveDelegateSavedStateAPI::class)
     constructor(
         initialValue: T,
         onChange: (T?, T) -> Unit = { _, _ -> }
@@ -80,23 +77,9 @@ constructor(
     operator fun getValue(ref: Any, p: KProperty<*>): T = _liveData.value!!
 }
 
-/**
- * !BEWARE! that only data that can't be easily recovered should be stored - e.g. user's input. Storing complete
- *  viewStates wastes device resources and often leads to issue such as TransactionTooLarge crashes.
- *
- *  Note: This method is technically not necessary, we could use the primary constructor. However, we are
- *  misusing the savedState in tons of places in the codebase. This approach will hopefully at least increase
- *  awareness of the associated risks and ensure developers who are using the saved state consider other options.
- *
- *  Note 2: We are intentionally not changing all the existing location to use this factory method as all these
- *  locations should be changed only after considering whether they truly store the minimal required data.
- */
-fun <T : Parcelable> createLiveDataDelegateWithSavedState(
-    savedState: SavedStateHandle,
-    initialValue: T,
-    savedStateKey: String = initialValue.javaClass.name,
-    onChange: (T?, T) -> Unit = { _, _ -> }
-): LiveDataDelegate<T> {
-    @Suppress("DEPRECATION") // This is a whitelisted usage of the primary constructor.
-    return LiveDataDelegate(savedState, initialValue, savedStateKey, onChange)
-}
+@RequiresOptIn(
+    message = "This API will cause the data to be saved to the SavedState, and should be used with caution.",
+    level = RequiresOptIn.Level.WARNING
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class LiveDelegateSavedStateAPI

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt
@@ -33,7 +33,6 @@ constructor(
     savedStateKey: String = initialValue.javaClass.name,
     private val onChange: (T?, T) -> Unit = { _, _ -> }
 ) {
-    // This is a whitelisted usage of the primary constructor.
     @OptIn(LiveDelegateSavedStateAPI::class)
     constructor(
         initialValue: T,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt
@@ -25,26 +25,19 @@ import kotlin.reflect.KProperty
  *  being updated. If there is more than one, an [IllegalStateException] is thrown.
  *
  */
-class LiveDataDelegate<T : Parcelable>
-@Deprecated(
-    message = "Use the provided factory methods or secondary constructors instead.",
-    level = DeprecationLevel.WARNING
-)
-constructor(
+class LiveDataDelegate<T : Parcelable> (
     savedState: SavedStateHandle? = null,
     private val initialValue: T,
     savedStateKey: String = initialValue.javaClass.name,
     private val onChange: (T?, T) -> Unit = { _, _ -> }
 ) {
-    // This is a whitelisted usage of the primary constructor.
-    @Suppress("DEPRECATION")
     constructor(
         initialValue: T,
         onChange: (T?, T) -> Unit = { _, _ -> }
     ) : this(savedState = null, initialValue = initialValue, onChange = onChange)
 
     private val _liveData: MutableLiveData<T> =
-        savedState?.getLiveData(savedStateKey, initialValue) ?: MutableLiveData<T>()
+        savedState?.getLiveData(savedStateKey, initialValue) ?: MutableLiveData<T>(initialValue)
     val liveData: LiveData<T> = _liveData
 
     private var previousValue: T? = null
@@ -97,6 +90,5 @@ fun <T : Parcelable> createLiveDataDelegateWithSavedState(
     savedStateKey: String = initialValue.javaClass.name,
     onChange: (T?, T) -> Unit = { _, _ -> }
 ): LiveDataDelegate<T> {
-    @Suppress("DEPRECATION") // This is a whitelisted usage of the primary constructor.
     return LiveDataDelegate(savedState, initialValue, savedStateKey, onChange)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/LiveDataDelegate.kt
@@ -87,6 +87,9 @@ constructor(
  *  Note: This method is technically not necessary, we could use the primary constructor. However, we are
  *  misusing the savedState in tons of places in the codebase. This approach will hopefully at least increase
  *  awareness of the associated risks and ensure developers who are using the saved state consider other options.
+ *
+ *  Note 2: We are intentionally not changing all the existing location to use this factory method as all these
+ *  locations should be changed only after considering whether they truly store the minimal required data.
  */
 fun <T : Parcelable> createLiveDataDelegateWithSavedState(
     savedState: SavedStateHandle,


### PR DESCRIPTION
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The codebase currently contains tens of ViewModels which are storing their complete ViewState into the SavedState bundle by using LiveDataDelegate. However, this approach isn't optimal - [the official documentation even states](https://developer.android.com/topic/libraries/architecture/viewmodel/viewmodel-savedstate) 

`
Note: State must be simple and lightweight. For complex or large data, you should use [local persistence](https://developer.android.com/topic/libraries/architecture/saving-states#local).
`

and

`
Key Point: Usually, data stored in saved instance state is transient state that depends on user input or navigation. Examples of this can be the scroll position of a list, the id of the item the user wants more detail about, the in-progress selection of user preferences, or input in text fields.
`

We are storing way more than that, which is wasting resources, leading to lower performance of the app as well as TransactionTooLarge crashes.

Fixing all these issues is way out of scope of this PR - it's an effort for weeks to implement properly. However, the goal of this PR is to change the API to increases awareness of the downsides of storing more than necessary, especially when creating new VMs.

The approach is deprecating the existing constructor and creating a new factory method which takes care of the creation. I'm intentionally not changing all the existing location to use this factory method as they should be changed only after carefully considering whether we truly store the minimal data.

P.S. I added `unit-tests-exemption` label since 95% of the code of this PR is only about increasing awareness, not actually changing the class.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
No repro steps.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Nothing to test since the production code is unchanged.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
