### PR TITLE
Fix TransactionTooLarge by not saving recoverable state

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 19.7
 -----
-
+- [*] Improve stability of the OrderDetail screen [https://github.com/woocommerce/woocommerce-android/pull/12106]
 
 19.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -140,7 +140,8 @@ class OrderDetailViewModel @Inject constructor(
     // and add the deleted tracking number back to the list
     private var deletedOrderShipmentTrackingSet = mutableSetOf<String>()
 
-    val viewStateData = LiveDataDelegate(savedState, OrderDetailViewState())
+    // Do NOT store the ViewState in SavedState bundle - it can be easily recreated on process death.
+    val viewStateData = LiveDataDelegate(OrderDetailViewState())
     private var viewState by viewStateData
 
     private val _orderNotes = MutableLiveData<List<OrderNote>>()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

~Do not merge label - the PR is dependant on [this PR](https://github.com/woocommerce/woocommerce-android/pull/12105) which needs to be merged first.~

Closes: #11308
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes TransactionTooLarge crashes that happen on the OrderDetail screen. Previously, viewState of the OrderDetailViewModel was stored into a Bundle in order to survive a process-death. However, this approach is highly inefficient, wastes users resources, and most importantly is not needed at all. All the data the app stores can be easily re-calculated/reloaded (from local DB) when a new processes is started leading to increased runtime performance of the app, completely avoiding the crash.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

We have not been able to reproduce this crash.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- Enable don't keep activities in OS Developer Settings.
- Test the order detail screen - put the app into the background and back to foreground to simulate a process-death.
- Ensure the behavior is consistent with the previous version of the app.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->