### PR TITLE
Issue/12108 fix crash on stats card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -197,10 +197,17 @@ private fun StatsChart(
     // is applying all properties on each composition (even the unchanged ones) which creates issues with the legacy
     // view.
 
+    LaunchedEffect(dateRange?.rangeSelection) {
+        dateRange?.rangeSelection?.let { statsView.loadDashboardStats(it) }
+    }
+
+    LaunchedEffect(lastUpdateState) {
+        statsView.showLastUpdate(lastUpdateState)
+    }
+
     LaunchedEffect(revenueStatsState) {
         when (revenueStatsState) {
             is DashboardStatsViewModel.RevenueStatsViewState.Content -> {
-                dateRange?.rangeSelection?.let { statsView.loadDashboardStats(it) }
                 statsView.showErrorView(false)
                 statsView.showSkeleton(false)
                 statsView.updateView(revenueStatsState.revenueStats)
@@ -226,15 +233,8 @@ private fun StatsChart(
 
     LaunchedEffect(visitorsStatsState) {
         visitorsStatsState?.let {
-            statsView.showVisitorStats(
-                it,
-                dateRange?.rangeSelection
-            )
+            statsView.showVisitorStats(it)
         }
-    }
-
-    LaunchedEffect(lastUpdateState) {
-        statsView.showLastUpdate(lastUpdateState)
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
@@ -49,7 +49,7 @@ fun DashboardStatsCard(
         }
     )
 ) {
-    val dateRange by viewModel.dateRangeState.observeAsState()
+    val dateRange = viewModel.dateRangeState.observeAsState().value ?: return
     val revenueStatsState by viewModel.revenueStatsState.observeAsState()
     val visitorsStatsState by viewModel.visitorStatsState.observeAsState()
     val lastUpdateState by viewModel.lastUpdateStats.observeAsState()
@@ -115,7 +115,7 @@ fun DashboardStatsCard(
 
 @Composable
 private fun DashboardStatsContent(
-    dateRange: DashboardStatsViewModel.DateRangeState?,
+    dateRange: DashboardStatsViewModel.DateRangeState,
     revenueStatsState: DashboardStatsViewModel.RevenueStatsViewState?,
     visitorsStatsState: DashboardStatsViewModel.VisitorStatsViewState?,
     lastUpdateState: Long?,
@@ -127,15 +127,13 @@ private fun DashboardStatsContent(
     onChartDateSelected: (String?) -> Unit,
 ) {
     Column {
-        dateRange?.let {
-            DashboardDateRangeHeader(
-                rangeSelection = it.rangeSelection,
-                dateFormatted = dateRange.selectedDateFormatted ?: dateRange.rangeFormatted,
-                onCustomRangeClick = onAddCustomRangeClick,
-                onTabSelected = onTabSelected,
-                modifier = Modifier.fillMaxWidth()
-            )
-        }
+        DashboardDateRangeHeader(
+            rangeSelection = dateRange.rangeSelection,
+            dateFormatted = dateRange.selectedDateFormatted ?: dateRange.rangeFormatted,
+            onCustomRangeClick = onAddCustomRangeClick,
+            onTabSelected = onTabSelected,
+            modifier = Modifier.fillMaxWidth()
+        )
 
         Divider()
         StatsChart(
@@ -155,7 +153,7 @@ private fun DashboardStatsContent(
 
 @Composable
 private fun StatsChart(
-    dateRange: DashboardStatsViewModel.DateRangeState?,
+    dateRange: DashboardStatsViewModel.DateRangeState,
     revenueStatsState: DashboardStatsViewModel.RevenueStatsViewState?,
     visitorsStatsState: DashboardStatsViewModel.VisitorStatsViewState?,
     lastUpdateState: Long?,
@@ -197,8 +195,8 @@ private fun StatsChart(
     // is applying all properties on each composition (even the unchanged ones) which creates issues with the legacy
     // view.
 
-    LaunchedEffect(dateRange?.rangeSelection) {
-        dateRange?.rangeSelection?.let { statsView.loadDashboardStats(it) }
+    LaunchedEffect(dateRange.rangeSelection) {
+        statsView.loadDashboardStats(dateRange.rangeSelection)
     }
 
     LaunchedEffect(lastUpdateState) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
@@ -92,6 +92,7 @@ class DashboardStatsView @JvmOverloads constructor(
             // to appear, and we remove the chart's empty string so it doesn't briefly show
             // up before the chart data is added once the request completes
             if (value) {
+                clearStatsHeaderValues()
                 binding.chart.setNoDataText(null)
                 binding.chart.clear()
             } else {
@@ -398,8 +399,7 @@ class DashboardStatsView @JvmOverloads constructor(
         binding.chart.isVisible = !show
     }
 
-    fun showVisitorStats(statsViewState: VisitorStatsViewState, rangeSelection: StatsTimeRangeSelection?) {
-        rangeSelection?.let { statsTimeRangeSelection = it }
+    fun showVisitorStats(statsViewState: VisitorStatsViewState) {
         // Reset click listeners
         binding.statsViewRow.emptyVisitorStatsIcon.setOnClickListener(null)
         binding.statsViewRow.emptyVisitorStatsIndicator.setOnClickListener(null)
@@ -726,7 +726,6 @@ class DashboardStatsView @JvmOverloads constructor(
                     dateString,
                     statsTimeRangeSelection.revenueStatsGranularity
                 )
-
                 else -> error("Unsupported range value used in my store tab: ${statsTimeRangeSelection.selectionType}")
             }.also { result -> trackUnexpectedFormat(result, dateString) }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12108 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This crash happens when we try to access the property `DashboardStatsView#statsTimeRangeSelection` before it gets initialized.

In the past, there was an [attempt](https://github.com/woocommerce/woocommerce-android/pull/11824) to fix this crash, but it didn't work well, it just resulted in a change of the stacktrace that leaded to a new Sentry issue being created.

In this PR, I'm attempting a new fix, my theory is that the cause of the crash is that we are passing a nullable `dateRange` argument to the `Composable` function, this nullable value comes from a call to `observeAsState`, the value would be `null` when we read it before the `LiveData` was initialized, and this can happen when the `dateRangeState` initialization takes longer than the time reading the stats takes, and here we have a race between two flows:
1. The stats are [read](https://github.com/woocommerce/woocommerce-android/blob/01ed20fb72073d2054f89e6141ced69da33ff4ac/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/StatsRepository.kt#L118) from the DB when we have a cache.
2. The `dateRangeState` will need data from both the `DataStore` and the `SharedPrefs`.

Now when `2` takes longer than `1`, we end up with the crash.

### Steps to reproduce
1. Apply the following patch on `trunk`:
```patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt	(revision b232ce7bfab904abf2dabab7b2aed18d858aacf4)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt	(date 1721751399851)
@@ -38,6 +38,7 @@
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -91,6 +92,7 @@
         customDateRangeDataStore.dateRange,
         selectedChartDate
     ) { selectedRange, custom, selectedDate ->
+        delay(500)
         DateRangeState(
             rangeSelection = selectedRange,
             customRange = custom,
```
2. Launch the dashboard multiple times.
3. The app should crash.

### Testing information
1. Switch to the branch of this PR.
2. Apply the same patch from above.
3. Confirm the app doesn't crash.


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->