### PR TITLE
Update orders task

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateAnalyticsDashboardRangeSelections.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateAnalyticsDashboardRangeSelections.kt
@@ -19,7 +19,7 @@ class UpdateAnalyticsDashboardRangeSelections @Inject constructor(
             getSelectedRangeForTopPerformers.invoke().first().let { add(it) }
             getSelectedRangeForDashboardStats.invoke().first().let { add(it) }
         }
-        val forceCardUpdates = listOf(AnalyticsCards.Products, AnalyticsCards.Revenue)
+        val forceCardUpdates = listOf(AnalyticsCards.Products, AnalyticsCards.Revenue, AnalyticsCards.Session)
         return coroutineScope {
             val asyncCalls = dashboardRangeSelections.map { selectedRange ->
                 async {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateDataOnBackgroundWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateDataOnBackgroundWorker.kt
@@ -14,6 +14,7 @@ class UpdateDataOnBackgroundWorker @AssistedInject constructor(
     @Assisted workerParams: WorkerParameters,
     private val accountRepository: AccountRepository,
     private val updateAnalyticsDashboardRangeSelections: UpdateAnalyticsDashboardRangeSelections,
+    private val updateOrdersList: UpdateOrdersList
 ) : CoroutineWorker(appContext, workerParams) {
     companion object {
         const val REFRESH_TIME = 4L
@@ -23,7 +24,7 @@ class UpdateDataOnBackgroundWorker @AssistedInject constructor(
     override suspend fun doWork(): Result {
         return when {
             accountRepository.isUserLoggedIn().not() -> Result.success()
-            updateAnalyticsDashboardRangeSelections() -> Result.success()
+            updateAnalyticsDashboardRangeSelections() && updateOrdersList() -> Result.success()
             else -> Result.retry()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateOrdersList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateOrdersList.kt
@@ -15,7 +15,7 @@ class UpdateOrdersList @Inject constructor(
         val response = ordersStore.fetchOrdersListFirstPage(listDescriptor)
         val orders = response.model
 
-        if (response.isError || orders.isNullOrEmpty()) return false
+        if (response.isError || orders == null) return false
 
         orders.map { it.orderId }.let { remoteIds ->
             listStore.saveListFetched(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateOrdersList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateOrdersList.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.background
+
+import com.woocommerce.android.ui.orders.filters.domain.GetWCOrderListDescriptorWithFilters
+import org.wordpress.android.fluxc.store.ListStore
+import org.wordpress.android.fluxc.store.WCOrderStore
+import javax.inject.Inject
+
+class UpdateOrdersList @Inject constructor(
+    private val getWCOrderListDescriptorWithFilters: GetWCOrderListDescriptorWithFilters,
+    private val listStore: ListStore,
+    private val ordersStore: WCOrderStore
+) {
+    suspend operator fun invoke(): Boolean {
+        val listDescriptor = getWCOrderListDescriptorWithFilters()
+        val response = ordersStore.fetchOrdersListFirstPage(listDescriptor)
+        val orders = response.model
+
+        if (response.isError || orders.isNullOrEmpty()) return false
+
+        orders.map { it.orderId }.let { remoteIds ->
+            listStore.saveListFetched(
+                listDescriptor = listDescriptor,
+                remoteItemIds = remoteIds,
+                canLoadMore = remoteIds.size == listDescriptor.config.networkPageSize
+            )
+        }
+
+        return true
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/background/UpdateAnalyticsDashboardRangeSelectionsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/background/UpdateAnalyticsDashboardRangeSelectionsTest.kt
@@ -47,7 +47,7 @@ class UpdateAnalyticsDashboardRangeSelectionsTest : BaseUnitTest() {
 
     @Test
     fun `when there are two different range selected then update data for both ranges`() = runTest {
-        val forceCardUpdates = listOf(AnalyticsCards.Products, AnalyticsCards.Revenue)
+        val forceCardUpdates = listOf(AnalyticsCards.Products, AnalyticsCards.Revenue, AnalyticsCards.Session)
 
         whenever(getSelectedRangeForTopPerformers.invoke()).doReturn(flowOf(today))
         whenever(getSelectedRangeForDashboardStats.invoke()).doReturn(flowOf(yesterday))
@@ -78,7 +78,7 @@ class UpdateAnalyticsDashboardRangeSelectionsTest : BaseUnitTest() {
 
     @Test
     fun `when the same range is selected then update for the selected ranges once`() = runTest {
-        val forceCardUpdates = listOf(AnalyticsCards.Products, AnalyticsCards.Revenue)
+        val forceCardUpdates = listOf(AnalyticsCards.Products, AnalyticsCards.Revenue, AnalyticsCards.Session)
 
         whenever(getSelectedRangeForTopPerformers.invoke()).doReturn(flowOf(today))
         whenever(getSelectedRangeForDashboardStats.invoke()).doReturn(flowOf(today))
@@ -100,7 +100,7 @@ class UpdateAnalyticsDashboardRangeSelectionsTest : BaseUnitTest() {
 
     @Test
     fun `when one update fails then return false`() = runTest {
-        val forceCardUpdates = listOf(AnalyticsCards.Products, AnalyticsCards.Revenue)
+        val forceCardUpdates = listOf(AnalyticsCards.Products, AnalyticsCards.Revenue, AnalyticsCards.Session)
 
         whenever(getSelectedRangeForTopPerformers.invoke()).doReturn(flowOf(today))
         whenever(getSelectedRangeForDashboardStats.invoke()).doReturn(flowOf(yesterday))
@@ -126,7 +126,7 @@ class UpdateAnalyticsDashboardRangeSelectionsTest : BaseUnitTest() {
 
     @Test
     fun `when all updates succeed then return true`() = runTest {
-        val forceCardUpdates = listOf(AnalyticsCards.Products, AnalyticsCards.Revenue)
+        val forceCardUpdates = listOf(AnalyticsCards.Products, AnalyticsCards.Revenue, AnalyticsCards.Session)
 
         whenever(getSelectedRangeForTopPerformers.invoke()).doReturn(flowOf(today))
         whenever(getSelectedRangeForDashboardStats.invoke()).doReturn(flowOf(yesterday))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/background/UpdateOrdersListTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/background/UpdateOrdersListTest.kt
@@ -1,0 +1,103 @@
+package com.woocommerce.android.background
+
+import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.orders.filters.domain.GetWCOrderListDescriptorWithFilters
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCOrderListDescriptor
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.ListStore
+import org.wordpress.android.fluxc.store.WCOrderStore
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpdateOrdersListTest : BaseUnitTest() {
+    private val defaultListDescriptor = WCOrderListDescriptor(SiteModel().apply { id = 1 })
+    private val defaultOrderResponse = List(5) { i ->
+        OrderTestUtils.generateOrder().copy(orderId = i.toLong())
+    }
+
+    private val getWCOrderListDescriptorWithFilters: GetWCOrderListDescriptorWithFilters = mock()
+    private val listStore: ListStore = mock()
+    private val ordersStore: WCOrderStore = mock()
+
+    val sut = UpdateOrdersList(
+        getWCOrderListDescriptorWithFilters = getWCOrderListDescriptorWithFilters,
+        listStore = listStore,
+        ordersStore = ordersStore
+    )
+
+    @Test
+    fun `when fetch orders succeed then persist data and return true`() = testBlocking {
+        // Mock dependencies
+        whenever(getWCOrderListDescriptorWithFilters.invoke()).thenReturn(defaultListDescriptor)
+        whenever(ordersStore.fetchOrdersListFirstPage(defaultListDescriptor))
+            .thenReturn(WooResult(defaultOrderResponse))
+
+        val result = sut()
+
+        // Assertions
+        val expectedIds = defaultOrderResponse.map { it.orderId }
+        verify(listStore).saveListFetched(defaultListDescriptor, expectedIds, false)
+        assertTrue(result)
+    }
+
+    @Test
+    fun `when fetch orders fails then DON'T persist data and return false`() = testBlocking {
+        // Mock dependencies
+        whenever(getWCOrderListDescriptorWithFilters.invoke()).thenReturn(defaultListDescriptor)
+        whenever(ordersStore.fetchOrdersListFirstPage(defaultListDescriptor))
+            .thenReturn(
+                WooResult(
+                    WooError(WooErrorType.INVALID_RESPONSE, BaseRequest.GenericErrorType.INVALID_RESPONSE)
+                )
+            )
+
+        val result = sut()
+
+        // Assertions
+        val expectedIds = defaultOrderResponse.map { it.orderId }
+        verify(listStore, never()).saveListFetched(defaultListDescriptor, expectedIds, false)
+        assertFalse(result)
+    }
+
+    @Test
+    fun `when fetch orders succeed but result is null then DON'T persist data and return false`() = testBlocking {
+        // Mock dependencies
+        whenever(getWCOrderListDescriptorWithFilters.invoke()).thenReturn(defaultListDescriptor)
+        whenever(ordersStore.fetchOrdersListFirstPage(defaultListDescriptor))
+            .thenReturn(WooResult(null))
+
+        val result = sut()
+
+        // Assertions
+        val expectedIds = defaultOrderResponse.map { it.orderId }
+        verify(listStore, never()).saveListFetched(defaultListDescriptor, expectedIds, false)
+        assertFalse(result)
+    }
+
+    @Test
+    fun `when fetch orders succeed but result is empty then DON'T persist data and return true`() = testBlocking {
+        // Mock dependencies
+        whenever(getWCOrderListDescriptorWithFilters.invoke()).thenReturn(defaultListDescriptor)
+        whenever(ordersStore.fetchOrdersListFirstPage(defaultListDescriptor))
+            .thenReturn(WooResult(emptyList()))
+
+        val result = sut()
+
+        // Assertions
+        val expectedIds = defaultOrderResponse.map { it.orderId }
+        verify(listStore, never()).saveListFetched(defaultListDescriptor, expectedIds, false)
+        assertTrue(result)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '3061-f06404689336398881bde4d3563c98aedd473b37'
+    fluxCVersion = 'trunk-6b6ef2da5e745f4ef7420d458b0d5bb4b50be863'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-53b346d2231b8a836e0502fe58b13d70e7d57de4'
+    fluxCVersion = '3061-f06404689336398881bde4d3563c98aedd473b37'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Closes: #11792 

### Description
This PR updates the `UpdateDataOnBackgroundWorker` task to periodically refresh the first page of the orders list.

##### UpdateOrderList
- Retrieves the first page of orders, extracts relevant data, and uses it to update the list model and its associated items

### Testing
Unit tests should cover all major scenarios


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->