### PR TITLE
Issue/12126 fix image upload issues

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [**] Product Creation AI V2: Milestone 1 which simplifies package photo flow and revamps UI. [https://github.com/woocommerce/woocommerce-android/issues/11800]
 - [*] The more screen shows proper loading button statuses [https://github.com/woocommerce/woocommerce-android/pull/11968]
 - [*] [Login] Improved login reliability by addressing some edge-case issues [https://github.com/woocommerce/woocommerce-android/pull/12033]
+- [*] Fix an issue with image upload on devices running Android 8 and 9 [https://github.com/woocommerce/woocommerce-android/pull/12127]
 
 19.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/media/FileUploadUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/media/FileUploadUtils.kt
@@ -135,10 +135,6 @@ object FileUploadUtils {
      * @return A local {@link Uri} or null if the download failed
      */
     private fun fetchMedia(context: Context, mediaUri: Uri): Uri? {
-        if (MediaUtils.isInMediaStore(mediaUri)) {
-            return mediaUri
-        }
-
         return try {
             MediaUtils.downloadExternalMedia(context.applicationContext, mediaUri)
         } catch (e: IllegalStateException) {

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ ext {
     materialVersion = '1.6.1'
     hiltJetpackVersion = '1.1.0'
     wordPressUtilsVersion = '3.5.0'
-    mediapickerVersion = '0.3.0'
+    mediapickerVersion = '0.3.1'
     wordPressLoginVersion = '1.17.0'
     aboutAutomatticVersion = '0.0.6'
     automatticTracksVersion = '5.0.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12126 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes two issues regarding media upload:
1. Fixes an issue where the lack fo the permission to read external storage broke media upload from local files on devices with Android 9 and lower.
The issue happens because we [don't `fetch` media](https://github.com/woocommerce/woocommerce-android/blob/8dba5e3e49b94b3c0111768e6d049c64facf0deb/WooCommerce/src/main/kotlin/com/woocommerce/android/media/FileUploadUtils.kt#L138-L140) when the Uri is in the media store `content:://media`, then later when we try to read it directly in FluxC, it causes an issue.
This wasn't happening on devices running on Android 10 and above, as we still had to [copy](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/blob/62b29b9ce9c79f52743193b3e385baa0440d89ca/mediapicker/src/main/java/org/wordpress/android/mediapicker/MediaPickerUtils.kt#L118-L140) the file to internal storage later on, so accidentally the issue wasn't caught when we removed the permissions.
The fix I applied here is to remove the check, and proceed to `fetch` the external media in all cases: meaning the external file will be copied to app's internal cache before the upload, this will align the behavior for all platforms, and it was already happening for newer Android versions.

2. Fixes an issue with Camera flow, the issue was also caused by the lack of the external storage permissions, mainly the `WRITE_EXTERNAL_STORAGE` one, and I believe this was caused by a misinterpretation of the documentation, the library [requires](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/blob/62b29b9ce9c79f52743193b3e385baa0440d89ca/mediapicker/src/main/java/org/wordpress/android/mediapicker/util/MediaPickerPermissionUtils.kt#L58) the permission `WRITE_EXTERNAL_STORAGE` for devices running on API lower than 29, where the documentation [states](https://developer.android.com/media/camera/camera-deprecated/photobasics#TaskPath) (in a non-clear way TBH) that this permission is needed only for devices with API lower than 19.
This fix comes from the MediaPicker library [PR](https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/pull/82).

### Steps to reproduce
##### Preparation
1. **Use `trunk` or the `release/19.6` branch**
2. Apply the following patch (the patch is needed because we still have the needed permissions on debug builds, so the issue is not reproducible on them without this change)
```patch
Index: WooCommerce/src/debug/AndroidManifest.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/debug/AndroidManifest.xml b/WooCommerce/src/debug/AndroidManifest.xml
--- a/WooCommerce/src/debug/AndroidManifest.xml	(revision 4c39a709bfd15241392554ecc9e17cf1e21d268c)
+++ b/WooCommerce/src/debug/AndroidManifest.xml	(date 1721823754943)
@@ -8,10 +8,10 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <!-- Allows for storing and retrieving screenshots -->
-    <uses-permission
-        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="28" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+<!--    <uses-permission-->
+<!--        android:name="android.permission.WRITE_EXTERNAL_STORAGE"-->
+<!--        android:maxSdkVersion="28" />-->
+<!--    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />-->
 
     <!-- Allows changing locales -->
     <uses-permission
```

##### Local files
1. Use a device with Android 9 or 8
2. Open the app
3. Add a file to a new or existing product from the device
4. Notice the upload failure.

##### Camera
1. Use a device with Android 9 or 8
2. Open the app
3. Add a file to a new or existing product from the camera
4. Notice the camera complaints about the lack of the storage permission

### Testing information
1. Switch to this branch.
2. Confirm the two above cases are now working without issues.
3. Test on a newer device too and confirm there is no regression.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->