### PR TITLE
Track the number of words for the product prompt used

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 19.7
 -----
 - [*] Improve stability of the OrderDetail screen [https://github.com/woocommerce/woocommerce-android/pull/12106]
+- [*] Adds new advice box to product creation with AI prompt screen [https://github.com/woocommerce/woocommerce-android/pull/12129]
 
 19.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -639,6 +639,7 @@ class AnalyticsTracker private constructor(
         // -- AI product creation
         const val KEY_TONE = "tone"
         const val KEY_IS_FIRST_ATTEMPT = "is_first_attempt"
+        const val KEY_FEATURE_WORD_COUNT = "feature_word_count"
 
         // -- AI product from package photo
         const val KEY_SCANNED_TEXT_COUNT = "scanned_text_count"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModel.kt
@@ -217,7 +217,8 @@ class AiProductPreviewViewModel @Inject constructor(
         analyticsTracker.track(
             AnalyticsEvent.PRODUCT_CREATION_AI_GENERATE_DETAILS_TAPPED,
             mapOf(
-                AnalyticsTracker.KEY_IS_FIRST_ATTEMPT to false
+                AnalyticsTracker.KEY_IS_FIRST_ATTEMPT to false,
+                AnalyticsTracker.KEY_FEATURE_WORD_COUNT to navArgs.productFeatures.split(" ").size,
             )
         )
         generateProduct()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/productinfo/AiProductPromptViewModel.kt
@@ -142,7 +142,8 @@ class AiProductPromptViewModel @Inject constructor(
         tracker.track(
             AnalyticsEvent.PRODUCT_CREATION_AI_GENERATE_DETAILS_TAPPED,
             mapOf(
-                AnalyticsTracker.KEY_IS_FIRST_ATTEMPT to isFirstAttempt
+                AnalyticsTracker.KEY_IS_FIRST_ATTEMPT to isFirstAttempt,
+                AnalyticsTracker.KEY_FEATURE_WORD_COUNT to _state.value.productPrompt.split(" ").size,
             )
         )
         isFirstAttempt = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -33,8 +33,7 @@ enum class FeatureFlag {
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
             GOOGLE_ADS_M1,
-            BACKGROUND_TASKS,
-            PRODUCT_CREATION_WITH_AI_V2_M3 -> PackageUtils.isDebugBuild()
+            BACKGROUND_TASKS -> PackageUtils.isDebugBuild()
 
             PRODUCT_CREATION_WITH_AI_V2,
             CONNECTIVITY_TOOL,
@@ -42,7 +41,8 @@ enum class FeatureFlag {
             APP_PASSWORD_TUTORIAL,
             INBOX,
             GOOGLE_ADS_ANALYTICS_HUB_M1,
-            SHOW_INBOX_CTA -> true
+            SHOW_INBOX_CTA,
+            PRODUCT_CREATION_WITH_AI_V2_M3 -> true
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12128 and #12131
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Three things in this PR: 

- Adds tracking property `feature_word_count` to event `_product_creation_ai_generate_details_tapped`. 
- Enable product creation with ai M3
- Update release notes

### Testing information

**Tracking checks**

1. Trigger product creation with AI
2. Enter some words on the prompt text field
3. Click on "Generate Product Details"
4. Check in the logcat for the following event with `feature_word_count` property:
```
🔵 Tracked: product_creation_ai_generate_details_tapped, Properties: {"is_first_attempt":true,"feature_word_count":3
```
**Feature enabling**
No need to test anything. But if you want you can compile a `release` variant of the app and check that the advice box in product prompt screen is displayed. 
