### PR TITLE
Allow signing in to duplicated Jetpack websites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Fix broken in-person payments illustrations in landscape mode. [https://github.com/woocommerce/woocommerce-android/pull/12179]
 - [*] [Internal] Fixed an ANR related to the Zendesk SDK initialization [https://github.com/woocommerce/woocommerce-android/pull/12153]
 - [*] Contact Support Form: Added a field to enter the Site Address. [https://github.com/woocommerce/woocommerce-android/pull/12180]
+- [*] [Internal] Improved login flow to allow signing-in when one of the user's websites is duplicated on WPCom [https://github.com/woocommerce/woocommerce-android/pull/12143]
 
 19.7
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-cc6b2f85546a844b13d99bc0ad6ceabd1af131d3'
+    fluxCVersion = 'trunk-ca5091574709c6d8eda8dfe1c905d93a5e204984'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12037 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates FluxC to include the changes of https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3066, this FluxC change updates the logic of detecting duplicate websites to allow signing in when a website was duplicated on the WPCom API side, since this a possible situation (when an Identity Crisis occurs), the app shouldn't lock the user out of their websites, and this also aligns with what the other clients do (Calypso and the iOS apps).

### Steps to reproduce
1. Use `trunk`.
2. Send me a DM and I'll share with you the credentials of an account with a site with IDC.
3. Open the app and enter the URL of this IDCed website.
4. Continue the login using WordPress.com
5. Notice an error about duplicate websites, the login also will fail as the inserted website is the broken one.
6. Confirm that the site picker has only a single website exists (for the URL used during the login).

### Testing information
1. Use this branch.
2. Using the same credentials.
3. Open the app and enter the URL of this IDCed website.
4. Continue the login using WordPress.com
5. Notice that the login works without issues.
7. Open the site picker and confirm that two websites with the same URL exists.

**PS: if you are curious about how to trigger IDC, I can share the details, but it's outside of the scope of this PR.**

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->