### PR TITLE
[GLA Analytics] Introduce Google Ads CTA into Analytics Hub

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 19.8
 -----
-
+- [*] Stats: The Google Campaign analytics card now has a call to action to create a paid campaign if there are no campaign analytics for the selected time period. [https://github.com/woocommerce/woocommerce-android/pull/12161]
 
 19.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -678,6 +678,7 @@ class AnalyticsTracker private constructor(
         const val VALUE_GOOGLEADS_ENTRY_POINT_SOURCE_MOREMENU = "more_menu"
         const val VALUE_GOOGLEADS_ENTRY_POINT_TYPE_CREATION = "creation"
         const val VALUE_GOOGLEADS_ENTRY_POINT_TYPE_DASHBOARD = "dashboard"
+        const val VALUE_GOOGLEADS_ENTRY_POINT_TYPE_ANALYTICS_HUB = "analytics_hub"
 
         var sendUsageStats: Boolean = true
             set(value) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/GoogleAdsStat.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/GoogleAdsStat.kt
@@ -1,17 +1,16 @@
 package com.woocommerce.android.model
 
 data class GoogleAdsStat(
-    val googleAdsCampaigns: List<GoogleAdsCampaign>,
+    val googleAdsCampaigns: List<GoogleAdsCampaign>?,
     val totals: GoogleAdsTotals,
-    val totalsDeltaPercentage: GoogleAdsTotalsDeltaPercentage,
-    val isFetchedData: Boolean
+    val totalsDeltaPercentage: GoogleAdsTotalsDeltaPercentage
 ) {
     val noCampaignsAvailable
-        get() = googleAdsCampaigns.isEmpty() && isFetchedData
+        get() = googleAdsCampaigns?.isEmpty() ?: false
 
     companion object {
         val EMPTY = GoogleAdsStat(
-            googleAdsCampaigns = emptyList(),
+            googleAdsCampaigns = null,
             totals = GoogleAdsTotals(
                 sales = 0.0,
                 spend = 0.0,
@@ -25,8 +24,7 @@ data class GoogleAdsStat(
                 clicksDelta = DeltaPercentage.NotExist,
                 impressionsDelta = DeltaPercentage.NotExist,
                 conversionsDelta = DeltaPercentage.NotExist
-            ),
-            isFetchedData = false
+            )
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/GoogleAdsStat.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/GoogleAdsStat.kt
@@ -3,8 +3,12 @@ package com.woocommerce.android.model
 data class GoogleAdsStat(
     val googleAdsCampaigns: List<GoogleAdsCampaign>,
     val totals: GoogleAdsTotals,
-    val totalsDeltaPercentage: GoogleAdsTotalsDeltaPercentage
+    val totalsDeltaPercentage: GoogleAdsTotalsDeltaPercentage,
+    val isFetchedData: Boolean
 ) {
+    val noCampaignsAvailable
+        get() = googleAdsCampaigns.isEmpty() && isFetchedData
+
     companion object {
         val EMPTY = GoogleAdsStat(
             googleAdsCampaigns = emptyList(),
@@ -21,7 +25,8 @@ data class GoogleAdsStat(
                 clicksDelta = DeltaPercentage.NotExist,
                 impressionsDelta = DeltaPercentage.NotExist,
                 conversionsDelta = DeltaPercentage.NotExist
-            )
+            ),
+            isFetchedData = false
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/GoogleAdsStatUIData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/GoogleAdsStatUIData.kt
@@ -23,7 +23,7 @@ class GoogleAdsStatUIData(
             StatType.TOTAL_SALES -> {
                 mainTotalStatTitle = resourceProvider.getString(R.string.analytics_google_ads_filter_total_sales)
                 mainTotalStat = currencyFormatter.formatCurrency(rawStats.totals.sales.toString())
-                statItems = rawStats.googleAdsCampaigns.map { campaign ->
+                statItems = rawStats.googleAdsCampaigns?.map { campaign ->
                     GoogleAdsStatUIDataItem(
                         name = campaign.name,
                         mainStat = currencyFormatter.formatCurrency(campaign.subtotal.sales.toString()),
@@ -32,13 +32,13 @@ class GoogleAdsStatUIData(
                             currencyFormatter.formatCurrency(campaign.subtotal.spend.toString())
                         )
                     )
-                }
+                }.orEmpty()
             }
 
             StatType.SPEND -> {
                 mainTotalStatTitle = resourceProvider.getString(R.string.analytics_google_ads_filter_spend)
                 mainTotalStat = currencyFormatter.formatCurrency(rawStats.totals.spend.toString())
-                statItems = rawStats.googleAdsCampaigns.map { campaign ->
+                statItems = rawStats.googleAdsCampaigns?.map { campaign ->
                     GoogleAdsStatUIDataItem(
                         name = campaign.name,
                         mainStat = currencyFormatter.formatCurrency(campaign.subtotal.spend.toString()),
@@ -47,13 +47,13 @@ class GoogleAdsStatUIData(
                             currencyFormatter.formatCurrency(campaign.subtotal.sales.toString())
                         )
                     )
-                }
+                }.orEmpty()
             }
 
             StatType.CLICKS -> {
                 mainTotalStatTitle = resourceProvider.getString(R.string.analytics_google_ads_filter_clicks)
                 mainTotalStat = rawStats.totals.clicks.toString()
-                statItems = rawStats.googleAdsCampaigns.map { campaign ->
+                statItems = rawStats.googleAdsCampaigns?.map { campaign ->
                     GoogleAdsStatUIDataItem(
                         name = campaign.name,
                         mainStat = campaign.subtotal.clicks.toString(),
@@ -62,13 +62,13 @@ class GoogleAdsStatUIData(
                             currencyFormatter.formatCurrency(campaign.subtotal.spend.toString())
                         )
                     )
-                }
+                }.orEmpty()
             }
 
             StatType.IMPRESSIONS -> {
                 mainTotalStatTitle = resourceProvider.getString(R.string.analytics_google_ads_filter_impressions)
                 mainTotalStat = rawStats.totals.impressions.toString()
-                statItems = rawStats.googleAdsCampaigns.map { campaign ->
+                statItems = rawStats.googleAdsCampaigns?.map { campaign ->
                     GoogleAdsStatUIDataItem(
                         name = campaign.name,
                         mainStat = campaign.subtotal.impressions.toString(),
@@ -77,13 +77,13 @@ class GoogleAdsStatUIData(
                             currencyFormatter.formatCurrency(campaign.subtotal.spend.toString())
                         )
                     )
-                }
+                }.orEmpty()
             }
 
             StatType.CONVERSIONS -> {
                 mainTotalStatTitle = resourceProvider.getString(R.string.analytics_google_ads_filter_conversion)
                 mainTotalStat = rawStats.totals.conversions.toString()
-                statItems = rawStats.googleAdsCampaigns.map { campaign ->
+                statItems = rawStats.googleAdsCampaigns?.map { campaign ->
                     GoogleAdsStatUIDataItem(
                         name = campaign.name,
                         mainStat = campaign.subtotal.conversions.toString(),
@@ -92,7 +92,7 @@ class GoogleAdsStatUIData(
                             currencyFormatter.formatCurrency(campaign.subtotal.spend.toString())
                         )
                     )
-                }
+                }.orEmpty()
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubCardState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubCardState.kt
@@ -56,10 +56,12 @@ sealed class AnalyticsHubListViewState : AnalyticsCardViewState {
 
 sealed class AnalyticsHubCustomSelectionListViewState : AnalyticsCardViewState {
     data class LoadingAdsViewState(override val card: AnalyticsCards) : AnalyticsHubCustomSelectionListViewState()
+
     data class NoAdsState(
         override val card: AnalyticsCards,
         val message: String
     ) : AnalyticsHubCustomSelectionListViewState()
+
     data class CustomListViewState(
         override val card: AnalyticsCards,
         val title: String,
@@ -81,5 +83,27 @@ sealed class AnalyticsHubCustomSelectionListViewState : AnalyticsCardViewState {
                 delta > 0 -> "+"
                 else -> "-"
             }
+    }
+
+    data class HiddenState(
+        override val card: AnalyticsCards
+    ) : AnalyticsHubCustomSelectionListViewState()
+}
+
+data class AnalyticsHubUserCallToActionViewState(
+    val title: String,
+    val description: String,
+    val callToActionText: String,
+    val isVisible: Boolean,
+    val onCallToActionClickListener: () -> Unit
+) {
+    companion object {
+        val EMPTY = AnalyticsHubUserCallToActionViewState(
+            title = "",
+            description = "",
+            callToActionText = "",
+            isVisible = false,
+            onCallToActionClickListener = {}
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubCardViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubCardViewState.kt
@@ -6,8 +6,8 @@ sealed class AnalyticsHubCardViewState(
     open val cardsState: List<AnalyticsCardViewState>
 ) {
     /**
-    A default Loading configuration for when the Analytics Hub has started
-    but the AnalyticCardConfiguration list is still unknown.
+     A default Loading configuration for when the Analytics Hub has started
+     but the AnalyticCardConfiguration list is still unknown.
      */
     data object LoadingCardsConfiguration : AnalyticsHubCardViewState(
         cardsState = listOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubCardViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubCardViewState.kt
@@ -1,6 +1,22 @@
 package com.woocommerce.android.ui.analytics.hub
 
-sealed class AnalyticsHubCardViewState {
-    data object LoadingCardsConfiguration : AnalyticsHubCardViewState()
-    data class CardsState(val cardsState: List<AnalyticsCardViewState>) : AnalyticsHubCardViewState()
+import com.woocommerce.android.model.AnalyticsCards
+
+sealed class AnalyticsHubCardViewState(
+    open val cardsState: List<AnalyticsCardViewState>
+) {
+    /**
+    A default Loading configuration for when the Analytics Hub has started
+    but the AnalyticCardConfiguration list is still unknown.
+     */
+    data object LoadingCardsConfiguration : AnalyticsHubCardViewState(
+        cardsState = listOf(
+            AnalyticsHubInformationViewState.LoadingViewState(AnalyticsCards.Revenue),
+            AnalyticsHubInformationViewState.LoadingViewState(AnalyticsCards.Orders),
+            AnalyticsHubListViewState.LoadingViewState(AnalyticsCards.Products),
+        )
+    )
+    data class CardsState(
+        override val cardsState: List<AnalyticsCardViewState>
+    ) : AnalyticsHubCardViewState(cardsState)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
@@ -134,8 +134,8 @@ class AnalyticsHubFragment : BaseFragment(R.layout.fragment_analytics) {
                 ?.let { viewModel.onNewRangeSelection(it) }
                 ?: viewModel.onCustomDateRangeClicked()
         }
+
         handleNotice(WEBVIEW_RESULT) {
-            viewModel.onGoogleAdsCreationSuccess()
             findNavController().navigateSafely(
                 NavGraphMainDirections.actionGlobalGoogleAdsCampaignSuccessBottomSheet()
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
@@ -28,7 +28,8 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.MarginBottomItemDecoration
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.google.webview.GoogleAdsWebViewFragment.Companion.WEBVIEW_RESULT
-import com.woocommerce.android.ui.google.webview.GoogleAdsWebViewViewModel
+import com.woocommerce.android.ui.google.webview.GoogleAdsWebViewViewModel.EntryPointSource.ANALYTICS_HUB
+import com.woocommerce.android.ui.google.webview.GoogleAdsWebViewViewModel.UrlComparisonMode.PARTIAL
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
@@ -218,9 +219,9 @@ class AnalyticsHubFragment : BaseFragment(R.layout.fragment_analytics) {
         val direction = NavGraphMainDirections.actionGlobalGoogleAdsWebViewFragment(
             urlToLoad = url,
             title = title,
-            urlComparisonMode = GoogleAdsWebViewViewModel.UrlComparisonMode.PARTIAL,
+            urlComparisonMode = PARTIAL,
             isCreationFlow = isCreationFlow,
-            entryPointSource = GoogleAdsWebViewViewModel.EntryPointSource.MYSTORE
+            entryPointSource = ANALYTICS_HUB
         )
 
         findNavController().navigateSafely(direction)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
@@ -162,15 +162,12 @@ class AnalyticsHubFragment : BaseFragment(R.layout.fragment_analytics) {
         binding.analyticsDateSelectorCard.updateCurrentRange(viewState.analyticsDateRangeSelectorState.currentRange)
         binding.analyticsDateSelectorCard.updateLastUpdateTimestamp(viewState.lastUpdateTimestamp)
         binding.analyticsCallToActionCard.updateInformation(viewState.ctaState)
-        when (viewState.cards) {
-            is AnalyticsHubCardViewState.CardsState -> {
-                (binding.cards.adapter as AnalyticsHubCardsAdapter).cardList = viewState.cards.cardsState
-            }
-
-            else -> {}
-        }
         binding.analyticsRefreshLayout.isRefreshing = viewState.refreshIndicator == ShowIndicator
         displayFeedbackBanner(viewState.showFeedBackBanner)
+
+        binding.cards.adapter
+            .run { this as? AnalyticsHubCardsAdapter }
+            ?.cardList = viewState.cards.cardsState
     }
 
     private fun getDateRangeSelectorViewState() = viewModel.viewState.value.analyticsDateRangeSelectorState

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubFragment.kt
@@ -136,6 +136,7 @@ class AnalyticsHubFragment : BaseFragment(R.layout.fragment_analytics) {
         }
 
         handleNotice(WEBVIEW_RESULT) {
+            viewModel.onRefreshRequested()
             findNavController().navigateSafely(
                 NavGraphMainDirections.actionGlobalGoogleAdsCampaignSuccessBottomSheet()
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -833,7 +833,7 @@ class AnalyticsHubViewModel @Inject constructor(
                 OpenGoogleAdsCreation(
                     url = url,
                     isCreationFlow = true,
-                    title = resourceProvider.getString(R.string.analytics_google_ads_cta_action)
+                    title = resourceProvider.getString(R.string.analytics_google_ads_cta_web_view_title)
                 )
             )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -848,10 +848,6 @@ class AnalyticsHubViewModel @Inject constructor(
         tracker.track(AnalyticsEvent.ANALYTICS_HUB_SETTINGS_OPENED)
         triggerEvent(AnalyticsViewEvent.OpenSettings)
     }
-
-    fun onGoogleAdsCreationSuccess() {
-        TODO("Not yet implemented")
-    }
 }
 
 enum class ReportCard { Revenue, Orders, Products, Bundles, GiftCard, GoogleCampaigns }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -486,16 +486,16 @@ class AnalyticsHubViewModel @Inject constructor(
 
     private fun observeGoogleAdsChanges() {
         googleAdsObservationJob = updateStats.googleAdsState.onEach { state ->
+            updateGoogleAdsCTAVisibility(isVisible = false)
+
             when (state) {
                 is GoogleAdsState.Available -> {
-                    val stats = state.googleAdsStat
-                    if (stats.noCampaignsAvailable) {
-                        updateGoogleAdsCTAVisibility(isVisible = true)
-                        updateCardStatus(AnalyticsCards.GoogleAds, HiddenState(AnalyticsCards.GoogleAds))
-                    } else {
-                        updateGoogleAdsCTAVisibility(isVisible = false)
-                        updateCardStatus(AnalyticsCards.GoogleAds, buildGoogleAdsDataViewState(stats))
-                    }
+                    updateCardStatus(AnalyticsCards.GoogleAds, buildGoogleAdsDataViewState(state.googleAdsStat))
+                }
+
+                is GoogleAdsState.Empty -> {
+                    updateGoogleAdsCTAVisibility(isVisible = true)
+                    updateCardStatus(AnalyticsCards.GoogleAds, HiddenState(AnalyticsCards.GoogleAds))
                 }
 
                 is GoogleAdsState.Error -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -814,6 +814,15 @@ class AnalyticsHubViewModel @Inject constructor(
         ).let { newState ->
             mutableState.update { it.copy(ctaState = newState) }
         }
+
+        if (isVisible) {
+            tracker.track(
+                stat = AnalyticsEvent.GOOGLEADS_ENTRY_POINT_DISPLAYED,
+                properties = mapOf(
+                    KEY_GOOGLEADS_SOURCE to VALUE_GOOGLEADS_ENTRY_POINT_TYPE_ANALYTICS_HUB
+                )
+            )
+        }
     }
 
     private fun onGoogleAdsCTAClicked() {
@@ -827,7 +836,7 @@ class AnalyticsHubViewModel @Inject constructor(
             ))
 
             tracker.track(
-                stat = AnalyticsEvent.GOOGLEADS_ENTRY_POINT_DISPLAYED,
+                stat = AnalyticsEvent.GOOGLEADS_ENTRY_POINT_TAPPED,
                 properties = mapOf(
                     KEY_GOOGLEADS_SOURCE to VALUE_GOOGLEADS_ENTRY_POINT_TYPE_ANALYTICS_HUB
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewModel.kt
@@ -4,10 +4,14 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppUrls.GOOGLE_ADMIN_CAMPAIGN_CREATION_SUFFIX
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_GOOGLEADS_SOURCE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_GOOGLEADS_ENTRY_POINT_TYPE_ANALYTICS_HUB
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.adminUrlOrDefault
 import com.woocommerce.android.model.AnalyticCardConfiguration
 import com.woocommerce.android.model.AnalyticsCards
 import com.woocommerce.android.model.BundleStat
@@ -24,11 +28,13 @@ import com.woocommerce.android.model.SessionStat
 import com.woocommerce.android.model.StatType
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubCustomSelectionListViewState.CustomListViewState
+import com.woocommerce.android.ui.analytics.hub.AnalyticsHubCustomSelectionListViewState.HiddenState
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubCustomSelectionListViewState.LoadingAdsViewState
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubInformationViewState.DataViewState
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubInformationViewState.LoadingViewState
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubInformationViewState.NoDataState
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubInformationViewState.NoSupportedState
+import com.woocommerce.android.ui.analytics.hub.AnalyticsViewEvent.OpenGoogleAdsCreation
 import com.woocommerce.android.ui.analytics.hub.RefreshIndicator.NotShowIndicator
 import com.woocommerce.android.ui.analytics.hub.RefreshIndicator.ShowIndicator
 import com.woocommerce.android.ui.analytics.hub.daterangeselector.AnalyticsHubDateRangeSelectorViewState
@@ -78,12 +84,6 @@ import javax.inject.Inject
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubListViewState as ListViewState
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubListViewState.LoadingViewState as LoadingListViewState
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubListViewState.NoDataState as ListNoDataState
-import com.woocommerce.android.AppUrls.GOOGLE_ADMIN_CAMPAIGN_CREATION_SUFFIX
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_GOOGLEADS_SOURCE
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_GOOGLEADS_ENTRY_POINT_TYPE_ANALYTICS_HUB
-import com.woocommerce.android.extensions.adminUrlOrDefault
-import com.woocommerce.android.ui.analytics.hub.AnalyticsHubCustomSelectionListViewState.HiddenState
-import com.woocommerce.android.ui.analytics.hub.AnalyticsViewEvent.OpenGoogleAdsCreation
 
 @HiltViewModel
 @SuppressWarnings("LargeClass")
@@ -829,11 +829,13 @@ class AnalyticsHubViewModel @Inject constructor(
         selectedSite.getOrNull()?.let {
             it.adminUrlOrDefault + GOOGLE_ADMIN_CAMPAIGN_CREATION_SUFFIX
         }?.let { url ->
-            triggerEvent(OpenGoogleAdsCreation(
-                url = url,
-                isCreationFlow = true,
-                title = resourceProvider.getString(R.string.analytics_google_ads_cta_action)
-            ))
+            triggerEvent(
+                OpenGoogleAdsCreation(
+                    url = url,
+                    isCreationFlow = true,
+                    title = resourceProvider.getString(R.string.analytics_google_ads_cta_action)
+                )
+            )
 
             tracker.track(
                 stat = AnalyticsEvent.GOOGLEADS_ENTRY_POINT_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/AnalyticsHubViewState.kt
@@ -7,6 +7,7 @@ data class AnalyticsViewState(
     val refreshIndicator: RefreshIndicator,
     val analyticsDateRangeSelectorState: AnalyticsHubDateRangeSelectorViewState,
     val cards: AnalyticsHubCardViewState,
+    val ctaState: AnalyticsHubUserCallToActionViewState,
     val showFeedBackBanner: Boolean,
     val lastUpdateTimestamp: String
 )
@@ -18,6 +19,11 @@ sealed class AnalyticsViewEvent : MultiLiveEvent.Event() {
     object OpenDateRangeSelector : AnalyticsViewEvent()
     object SendFeedback : AnalyticsViewEvent()
     object OpenSettings : AnalyticsViewEvent()
+    data class OpenGoogleAdsCreation(
+        val url: String,
+        val isCreationFlow: Boolean,
+        val title: String
+    ) : AnalyticsViewEvent()
 }
 
 sealed class RefreshIndicator {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/cta/AnalyticsHubUserCallToActionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/cta/AnalyticsHubUserCallToActionView.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.ui.analytics.hub.cta
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import com.google.android.material.card.MaterialCardView
+import com.woocommerce.android.databinding.AnalyticsCallToActionViewBinding
+import com.woocommerce.android.ui.analytics.hub.AnalyticsHubUserCallToActionViewState
+
+class AnalyticsHubUserCallToActionView @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(ctx, attrs, defStyleAttr) {
+    val binding = AnalyticsCallToActionViewBinding.inflate(LayoutInflater.from(ctx), this)
+
+    fun updateInformation(viewState: AnalyticsHubUserCallToActionViewState) {
+        if (viewState.isVisible) {
+            binding.ctaTitle.text = viewState.title
+            binding.ctaDescription.text = viewState.description
+            binding.buttonCtaAction.text = viewState.callToActionText
+            binding.buttonCtaAction.setOnClickListener {
+                viewState.onCallToActionClickListener()
+            }
+            binding.analyticsCallToActionCard.visibility = VISIBLE
+        } else {
+            binding.analyticsCallToActionCard.visibility = GONE
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/cta/AnalyticsHubUserCallToActionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/cta/AnalyticsHubUserCallToActionView.kt
@@ -22,9 +22,9 @@ class AnalyticsHubUserCallToActionView @JvmOverloads constructor(
             binding.buttonCtaAction.setOnClickListener {
                 viewState.onCallToActionClickListener()
             }
-            binding.analyticsCallToActionCard.visibility = VISIBLE
+            binding.root.visibility = VISIBLE
         } else {
-            binding.analyticsCallToActionCard.visibility = GONE
+            binding.root.visibility = GONE
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/cta/AnalyticsHubUserCallToActionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/cta/AnalyticsHubUserCallToActionView.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.databinding.AnalyticsCallToActionViewBinding
+import com.woocommerce.android.extensions.expand
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubUserCallToActionViewState
 
 class AnalyticsHubUserCallToActionView @JvmOverloads constructor(
@@ -22,7 +23,7 @@ class AnalyticsHubUserCallToActionView @JvmOverloads constructor(
             binding.buttonCtaAction.setOnClickListener {
                 viewState.onCallToActionClickListener()
             }
-            binding.root.visibility = VISIBLE
+            binding.root.expand()
         } else {
             binding.root.visibility = GONE
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/customlistcard/AnalyticsHubCustomSelectionCardView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/customlistcard/AnalyticsHubCustomSelectionCardView.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.AnalyticsCustomSelectionCardViewBinding
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubCustomSelectionListViewState
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubCustomSelectionListViewState.CustomListViewState
+import com.woocommerce.android.ui.analytics.hub.AnalyticsHubCustomSelectionListViewState.HiddenState
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubCustomSelectionListViewState.LoadingAdsViewState
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubCustomSelectionListViewState.NoAdsState
 import com.woocommerce.android.ui.analytics.hub.informationcard.SeeReportClickListener
@@ -36,7 +37,13 @@ class AnalyticsHubCustomSelectionCardView @JvmOverloads constructor(
             is LoadingAdsViewState -> setSkeleton()
             is NoAdsState -> setNoAdsViewState(viewState)
             is CustomListViewState -> setDataViewState(viewState)
+            is HiddenState -> setHiddenState()
         }
+    }
+
+    private fun setHiddenState() {
+        skeletonView.hide()
+        binding.analyticsCustomCardListContainer.visibility = GONE
     }
 
     private fun setDataViewState(viewState: CustomListViewState) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsRepository.kt
@@ -519,7 +519,8 @@ class AnalyticsRepository @Inject constructor(
             totalsDeltaPercentage = mapGoogleAdsDeltaPercentages(
                 previousRangeResponse,
                 currentRangeResponse
-            )
+            ),
+            isFetchedData = true
         )
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsRepository.kt
@@ -519,8 +519,7 @@ class AnalyticsRepository @Inject constructor(
             totalsDeltaPercentage = mapGoogleAdsDeltaPercentages(
                 previousRangeResponse,
                 currentRangeResponse
-            ),
-            isFetchedData = true
+            )
         )
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateAnalyticsHubStats.kt
@@ -229,7 +229,12 @@ class UpdateAnalyticsHubStats @Inject constructor(
     ) = async {
         analyticsRepository.fetchGoogleAdsStats(rangeSelection)
             .run { this as? AnalyticsRepository.GoogleAdsResult.GoogleAdsData }
-            ?.let { _googleAdsState.value = GoogleAdsState.Available(it.googleAdsStat) }
-            ?: _googleAdsState.update { GoogleAdsState.Error }
+            ?.let {
+                if (it.googleAdsStat.noCampaignsAvailable) {
+                    _googleAdsState.value = GoogleAdsState.Empty
+                } else {
+                    _googleAdsState.value = GoogleAdsState.Available(it.googleAdsStat)
+                }
+            } ?: _googleAdsState.update { GoogleAdsState.Error }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateStates.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/UpdateStates.kt
@@ -68,6 +68,7 @@ sealed class GiftCardsState {
 
 sealed class GoogleAdsState {
     data class Available(val googleAdsStat: GoogleAdsStat) : GoogleAdsState()
+    data object Empty : GoogleAdsState()
     data object Loading : GoogleAdsState()
     data object Error : GoogleAdsState()
     val isIdle get() = this !is Loading

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/webview/GoogleAdsWebViewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/webview/GoogleAdsWebViewViewModel.kt
@@ -56,10 +56,10 @@ class GoogleAdsWebViewViewModel @Inject constructor(
         )
     }
 
-    private val sourceValue = if (viewState.source == EntryPointSource.MORE_MENU) {
-        AnalyticsTracker.VALUE_GOOGLEADS_ENTRY_POINT_SOURCE_MOREMENU
-    } else {
-        AnalyticsTracker.VALUE_GOOGLEADS_ENTRY_POINT_SOURCE_MYSTORE
+    private val sourceValue = when (viewState.source) {
+        EntryPointSource.MORE_MENU -> AnalyticsTracker.VALUE_GOOGLEADS_ENTRY_POINT_SOURCE_MOREMENU
+        EntryPointSource.MYSTORE -> AnalyticsTracker.VALUE_GOOGLEADS_ENTRY_POINT_SOURCE_MYSTORE
+        EntryPointSource.ANALYTICS_HUB -> AnalyticsTracker.VALUE_GOOGLEADS_ENTRY_POINT_TYPE_ANALYTICS_HUB
     }
 
     fun onUrlLoaded(url: String) {
@@ -148,6 +148,6 @@ class GoogleAdsWebViewViewModel @Inject constructor(
     }
 
     enum class EntryPointSource {
-        MORE_MENU, MYSTORE
+        MORE_MENU, MYSTORE, ANALYTICS_HUB
     }
 }

--- a/WooCommerce/src/main/res/layout/analytics_call_to_action_view.xml
+++ b/WooCommerce/src/main/res/layout/analytics_call_to_action_view.xml
@@ -1,0 +1,57 @@
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:context=".ui.analytics.hub.cta.AnalyticsHubUserCallToActionView">
+
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:id="@+id/analyticsCallToActionCard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/major_75"
+        android:orientation="vertical">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/cta_title"
+            style="@style/Woo.Card.Title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxLines="1"
+            android:layout_marginTop="@dimen/minor_00"
+            android:layout_marginBottom="@dimen/major_75"
+            android:textSize="@dimen/text_minor_125"
+            app:layout_constraintBottom_toTopOf="@+id/cta_description"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Google Campaigns" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/cta_description"
+            style="@style/Woo.Card.Body"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/major_75"
+            android:textStyle="bold"
+            android:maxLines="1"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="@id/cta_title"
+            app:layout_constraintTop_toBottomOf="@id/cta_title"
+            tools:text="Drive sales and generate more traffic with Google Ads." />
+
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/button_cta_action"
+            style="@style/Woo.Button.Colored.Circle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/major_100"
+            android:layout_marginEnd="@dimen/major_100"
+            android:layout_weight="1"
+            android:textAllCaps="false"
+            tools:visibility="visible"
+            tools:text="Add paid campaign"/>
+
+    </androidx.appcompat.widget.LinearLayoutCompat>
+
+</merge>

--- a/WooCommerce/src/main/res/layout/fragment_analytics.xml
+++ b/WooCommerce/src/main/res/layout/fragment_analytics.xml
@@ -50,14 +50,26 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/divider" />
 
+            <com.woocommerce.android.ui.analytics.hub.cta.AnalyticsHubUserCallToActionView
+                android:id="@+id/analyticsCallToActionCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/major_100"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/analyticsDateSelectorCard" />
+
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/cards"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:layout_constraintStart_toStartOf="parent"
+                android:layout_marginTop="@dimen/major_100"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/analyticsDateSelectorCard"
-                android:layout_marginTop="@dimen/major_100"/>
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/analyticsCallToActionCard" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
+
     </androidx.core.widget.NestedScrollView>
+
 </com.woocommerce.android.widgets.ScrollChildSwipeRefreshLayout>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -540,6 +540,9 @@
     <string name="analytics_item">item</string>
     <string name="analytics_items">items</string>
     <string name="analytics_list_item_products_sold">%1$s, %2$s, %3$s, %4$s sold</string>
+    <string name="analytics_google_ads_cta_title">Google Campaigns</string>
+    <string name="analytics_google_ads_cta_description">Drive sales and generate more traffic with Google Ads.</string>
+    <string name="analytics_google_ads_cta_action">Add paid campaign</string>
 
     <string name="analytics_wip_title">See your stats, revenue and more from your device!</string>
     <string name="analytics_wip_message">We\'ve been working on making it possible to display significant store information from your device! Could it be better? Please help us improve this feature by sharing your feedback with us</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -543,6 +543,7 @@
     <string name="analytics_google_ads_cta_title">Google Campaigns</string>
     <string name="analytics_google_ads_cta_description">Drive sales and generate more traffic with Google Ads.</string>
     <string name="analytics_google_ads_cta_action">Add paid campaign</string>
+    <string name="analytics_google_ads_cta_web_view_title">Google for WooCommerce</string>
 
     <string name="analytics_wip_title">See your stats, revenue and more from your device!</string>
     <string name="analytics_wip_message">We\'ve been working on making it possible to display significant store information from your device! Could it be better? Please help us improve this feature by sharing your feedback with us</string>


### PR DESCRIPTION
Summary
==========
Fix issues #12151, #12159 and #12160 by introducing the required Call to Action view handling to the Analytics Hub, while taking advantage of the implementation of the `GoogleAdsWebView` introduced through Google for Woo project.

Scren Captures
==========
### Feature
https://github.com/user-attachments/assets/38023e34-76f0-4135-acb2-4e76cc475de9

### Tracks
<img width="904" alt="image" src="https://github.com/user-attachments/assets/409cc31d-d21c-41a8-be66-8191fe3a4cb9">


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
