### PR TITLE
[Google for Woo] Update `CanUseAutoLoginWebview` only to support WordPress.com sites.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/CanUseAutoLoginWebview.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/CanUseAutoLoginWebview.kt
@@ -1,18 +1,12 @@
 package com.woocommerce.android.ui.google
 
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.tools.SiteConnectionType
-import com.woocommerce.android.tools.connectionType
 import javax.inject.Inject
 
-// The Google Ads feature (available for Jetpack and Jetpack Connection Package sites) needs to open non-WordPress.com
-// wp-admin URLs. To do so, it has to pick whether to use `WPComWebView` (which includes automatic login) or
-// `ExitAwareWebView` (which doesn't).
-// While technically Jetpack Connection Package sites can automatically login with `WPComWebView` too, there's a
-// behavior where the login redirect does not work properly (it redirects to WordPress.com instead), so it has to use
-// `ExitAwareWebView` instead.
-class CanUseAutoLoginWebview @Inject constructor(
-    private val selectedSite: SelectedSite
-) {
-    operator fun invoke(): Boolean = selectedSite.get().connectionType == SiteConnectionType.Jetpack
+// The Google for WooCommerce feature uses a webview to display campaign creation or dashboard. When first opened, the
+// webview can automatically logs user in (thus saving them some steps) if the site is a WordPress.com site.
+// For .org Jetpack or Jetpack Connection Package sites, the redirection does not work correctly
+// (it logs in then redirects to WordPress.com instead), so we should not use automatic login for these sites.
+class CanUseAutoLoginWebview @Inject constructor(private val selectedSite: SelectedSite) {
+    operator fun invoke(): Boolean = selectedSite.get().isWPCom
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/CanUseAutoLoginWebview.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/CanUseAutoLoginWebview.kt
@@ -4,9 +4,9 @@ import com.woocommerce.android.tools.SelectedSite
 import javax.inject.Inject
 
 // The Google for WooCommerce feature uses a webview to display campaign creation or dashboard. When first opened, the
-// webview can automatically logs user in (thus saving them some steps) if the site is a WordPress.com site.
+// webview can automatically logs user in (thus saving them some steps) if the site is a WordPress.com Atomic site.
 // For .org Jetpack or Jetpack Connection Package sites, the redirection does not work correctly
 // (it logs in then redirects to WordPress.com instead), so we should not use automatic login for these sites.
 class CanUseAutoLoginWebview @Inject constructor(private val selectedSite: SelectedSite) {
-    operator fun invoke(): Boolean = selectedSite.get().isWPCom
+    operator fun invoke(): Boolean = selectedSite.get().isWPComAtomic
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

During beta testing, @selanthiraiyan found that Jetpack-connected sites redirected incorrectly to WordPress.com, instead of to the campaign form URL.

During development, I had assumed that Jetpack-connected .org sites would behave similarly to WordPress.com sites, so it was set to autologin, but it turned out it had the same redirect issue as Jetpack CP sites. 

This PR fixes the issue so that only WordPress.com sites are able to have autologin. Everything else needs an initial manual login first.

### Testing steps:

1. This will require a few different test sites: a WordPress.com site, a .org site with full Jetpack connection, a .org site with Jetpack Connection Package (can be done by not installing Jetpack, and connecting using the Google Listings and Ads plugin itself). Setup guide is available at pe5sF9-2Qo-p2
2. Start with a logged out state,
3. Start app, log into the WordPress.com site, 
4. Go to More Menu, tap Google for WooCommerce,
5. The webview should not show any login form, and instead show either the campaign creation form or campaign dashboard (depending on whether the test site already has campaigns or not)
6. Log in to the .org Jetpack-connected site,
7. Go to More Menu, tap Google for WooCommerce,
8. The webview should show the .org login form at the beginning,
9. Log in, and the webview should redirect correctly and show either the campaign creation form or campaign dashboard (depending on whether the test site already has campaigns or not)
10. Log in to the .org Jetpack Connection Package site,
11. Go to More Menu, tap Google for WooCommerce,
12. The webview should show the .org login form at the beginning,
13. Log in, and the webview should redirect correctly and show either the campaign creation form or campaign dashboard (depending on whether the test site already has campaigns or not)
