### PR TITLE
[Woo POS] Crash when multiple connection flows are started and cancelled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -26,8 +26,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -45,10 +43,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorS
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.home.totals.payment.success.WooPosPaymentSuccessScreen
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 @Composable
 fun WooPosTotalsScreen(modifier: Modifier = Modifier) {
@@ -111,11 +105,6 @@ private fun TotalsLoaded(
     state: WooPosTotalsViewState.Totals,
     onUIEvent: (WooPosTotalsUIEvent) -> Unit
 ) {
-    val uiScope = rememberCoroutineScope()
-    val debouncedCollectPaymentClick = rememberDebouncedClickHandler(uiScope, 3000L) {
-        onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked)
-    }
-
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -144,7 +133,7 @@ private fun TotalsLoaded(
 
         WooPosButtonLarge(
             text = stringResource(R.string.woopos_payment_collect_payment_label),
-            onClick = { debouncedCollectPaymentClick(Unit) },
+            onClick = { onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked) },
         )
     }
 }
@@ -308,23 +297,5 @@ fun WooPosTotalsErrorScreenPreview() {
             errorMessage = "An error occurred. Please try again.",
             onUIEvent = {}
         )
-    }
-}
-
-@Composable
-fun rememberDebouncedClickHandler(scope: CoroutineScope, debounceTime: Long, action: (Unit) -> Unit): (Unit) -> Unit {
-    return remember(scope, debounceTime) {
-        debounce(debounceTime, scope, action)
-    }
-}
-
-fun <T> debounce(waitMs: Long, scope: CoroutineScope, destinationFunction: (T) -> Unit): (T) -> Unit {
-    var debounceJob: Job? = null
-    return { param: T ->
-        debounceJob?.cancel()
-        debounceJob = scope.launch {
-            delay(waitMs)
-            destinationFunction(param)
-        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -42,7 +42,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimme
 import com.woocommerce.android.ui.woopos.common.composeui.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.home.totals.payment.success.WooPosPaymentSuccessScreen
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -163,7 +163,7 @@ class WooPosTotalsViewModel @Inject constructor(
         val productIds: List<Long> = emptyList()
     ) : Parcelable
 
-    private fun debounce(destinationFunction: () -> Unit) {
+    private fun debounce(destinationFunction: suspend () -> Unit) {
         if (debounceJob?.isActive == true) {
             return
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -67,7 +67,7 @@ class WooPosTotalsViewModel @Inject constructor(
     fun onUIEvent(event: WooPosTotalsUIEvent) {
         when (event) {
             is WooPosTotalsUIEvent.CollectPaymentClicked -> {
-                debounce(DEBOUNCE_TIME_MS) {
+                debounce {
                     viewModelScope.launch {
                         collectPayment()
                     }
@@ -84,14 +84,6 @@ class WooPosTotalsViewModel @Inject constructor(
             is WooPosTotalsUIEvent.RetryOrderCreationClicked -> {
                 createOrderDraft(dataState.value.productIds)
             }
-        }
-    }
-
-    private fun debounce(waitMs: Long, destinationFunction: () -> Unit) {
-        debounceJob?.cancel()
-        debounceJob = viewModelScope.launch {
-            delay(waitMs)
-            destinationFunction()
         }
     }
 
@@ -170,4 +162,12 @@ class WooPosTotalsViewModel @Inject constructor(
         val orderId: Long = EMPTY_ORDER_ID,
         val productIds: List<Long> = emptyList()
     ) : Parcelable
+
+    private fun debounce(destinationFunction: () -> Unit) {
+        debounceJob?.cancel()
+        debounceJob = viewModelScope.launch {
+            delay(DEBOUNCE_TIME_MS)
+            destinationFunction()
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -39,7 +39,7 @@ class WooPosTotalsViewModel @Inject constructor(
 
     private companion object {
         private const val EMPTY_ORDER_ID = -1L
-        private const val DEBOUNCE_TIME_MS = 3000L
+        private const val DEBOUNCE_TIME_MS = 800L
         private const val KEY_STATE = "woo_pos_totals_data_state"
         private val InitialState = WooPosTotalsViewState.Loading
     }
@@ -164,10 +164,12 @@ class WooPosTotalsViewModel @Inject constructor(
     ) : Parcelable
 
     private fun debounce(destinationFunction: () -> Unit) {
-        debounceJob?.cancel()
+        if (debounceJob?.isActive == true) {
+            return
+        }
         debounceJob = viewModelScope.launch {
-            delay(DEBOUNCE_TIME_MS)
             destinationFunction()
+            delay(DEBOUNCE_TIME_MS)
         }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderPaymentResult
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
@@ -13,11 +14,14 @@ import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
@@ -43,6 +47,8 @@ class WooPosTotalsViewModelTest {
             )
         )
     }
+
+    private val cardReaderFacade: WooPosCardReaderFacade = mock()
 
     private companion object {
         private const val EMPTY_ORDER_ID = -1L
@@ -298,11 +304,130 @@ class WooPosTotalsViewModelTest {
         assertThat(state.orderSubtotalText).isEqualTo("$3.00")
     }
 
+    @Test
+    fun `given vm created, when collect payment clicked multiple times within delay, then debounce prevents it`() =
+        runTest {
+            // GIVEN
+            val productIds = listOf(1L, 2L, 3L)
+            val parentToChildrenEventFlow = MutableStateFlow(ParentToChildrenEvent.CheckoutClicked(productIds))
+            val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock {
+                on { events }.thenReturn(parentToChildrenEventFlow)
+            }
+            val order = Order.getEmptyOrder(
+                dateCreated = Date(),
+                dateModified = Date()
+            ).copy(
+                totalTax = BigDecimal("2.00"),
+                items = listOf(
+                    Order.Item.EMPTY.copy(
+                        subtotal = BigDecimal("1.00"),
+                    ),
+                    Order.Item.EMPTY.copy(
+                        subtotal = BigDecimal("1.00"),
+                    ),
+                    Order.Item.EMPTY.copy(
+                        subtotal = BigDecimal("1.00"),
+                    )
+                )
+            )
+            val totalsRepository: WooPosTotalsRepository = mock {
+                onBlocking { createOrderWithProducts(productIds = productIds) }.thenReturn(
+                    Result.success(order)
+                )
+            }
+            val priceFormat: WooPosFormatPrice = mock {
+                onBlocking { invoke(BigDecimal("2.00")) }.thenReturn("2.00$")
+                onBlocking { invoke(BigDecimal("3.00")) }.thenReturn("3.00$")
+                onBlocking { invoke(BigDecimal("5.00")) }.thenReturn("5.00$")
+            }
+            whenever(cardReaderFacade.collectPayment(any())).thenReturn(
+                WooPosCardReaderPaymentResult.Success
+            )
+
+            // WHEN
+            val viewModel = createViewModel(
+                parentToChildrenEventReceiver = parentToChildrenEventReceiver,
+                totalsRepository = totalsRepository,
+                priceFormat = priceFormat,
+            )
+            viewModel.onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked)
+            viewModel.onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked)
+            viewModel.onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked)
+            viewModel.onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked)
+            viewModel.onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked)
+
+            // THEN
+            // Advance time by less than the debounce delay
+            advanceTimeBy(800 / 2)
+            verify(cardReaderFacade, times(1)).collectPayment(any())
+            advanceUntilIdle()
+            verify(cardReaderFacade, times(1)).collectPayment(any())
+        }
+
+    @Test
+    fun `given vm created, when collect payment clicked multiple times after delay, then click event is handled for all of it`() =
+        runTest {
+            // GIVEN
+            val productIds = listOf(1L, 2L, 3L)
+            val parentToChildrenEventFlow = MutableStateFlow(ParentToChildrenEvent.CheckoutClicked(productIds))
+            val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock {
+                on { events }.thenReturn(parentToChildrenEventFlow)
+            }
+            val order = Order.getEmptyOrder(
+                dateCreated = Date(),
+                dateModified = Date()
+            ).copy(
+                totalTax = BigDecimal("2.00"),
+                items = listOf(
+                    Order.Item.EMPTY.copy(
+                        subtotal = BigDecimal("1.00"),
+                    ),
+                    Order.Item.EMPTY.copy(
+                        subtotal = BigDecimal("1.00"),
+                    ),
+                    Order.Item.EMPTY.copy(
+                        subtotal = BigDecimal("1.00"),
+                    )
+                )
+            )
+            val totalsRepository: WooPosTotalsRepository = mock {
+                onBlocking { createOrderWithProducts(productIds = productIds) }.thenReturn(
+                    Result.success(order)
+                )
+            }
+            val priceFormat: WooPosFormatPrice = mock {
+                onBlocking { invoke(BigDecimal("2.00")) }.thenReturn("2.00$")
+                onBlocking { invoke(BigDecimal("3.00")) }.thenReturn("3.00$")
+                onBlocking { invoke(BigDecimal("5.00")) }.thenReturn("5.00$")
+            }
+            whenever(cardReaderFacade.collectPayment(any())).thenReturn(
+                WooPosCardReaderPaymentResult.Failure
+            )
+
+            // WHEN
+            val viewModel = createViewModel(
+                parentToChildrenEventReceiver = parentToChildrenEventReceiver,
+                totalsRepository = totalsRepository,
+                priceFormat = priceFormat,
+            )
+            viewModel.onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked)
+            advanceUntilIdle()
+            verify(cardReaderFacade, times(1)).collectPayment(any())
+            viewModel.onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked)
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked)
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked)
+            advanceUntilIdle()
+            viewModel.onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked)
+            advanceUntilIdle()
+            verify(cardReaderFacade, times(5)).collectPayment(any())
+        }
+
     private fun createViewModel(
         resourceProvider: ResourceProvider = mock(),
         parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock(),
         childrenToParentEventSender: WooPosChildrenToParentEventSender = mock(),
-        cardReaderFacade: WooPosCardReaderFacade = mock(),
         totalsRepository: WooPosTotalsRepository = mock(),
         priceFormat: WooPosFormatPrice = mock(),
         savedState: SavedStateHandle = SavedStateHandle(),


### PR DESCRIPTION

**Closes:** #12028

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR addresses the issue where clicking the 'Collect Payment' button multiple times quickly initiates multiple card reader connection flows. This can cause the app to crash when attempting to cancel these connections. This update ensures that multiple clicks on the 'Collect Payment' button will still start only a single connection flow, thus preventing such crashes.

### Steps to Reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to More Menu -> POS.
2. Add a product.
3. Tap on 'Checkout'.
4. Tap on 'Collect Payment' multiple times quickly.
5. Tap on cancel.
6. Notice that the app sometimes crashes.

**Expected Behavior:**
- Multiple clicks on the 'Collect Payment' button should start only a single connection flow.

### Testing Information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- **Device Testing:** Test on various devices to ensure consistent behavior.



### Release Notes
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->

