### PR TITLE
Woo POS: Skip Stripe Pending Error in POS Mode

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModel.kt
@@ -82,37 +82,47 @@ class CardReaderStatusCheckerViewModel
     private suspend fun handleOnboardingStatus(param: CardReaderFlowParam) {
         when (val state = cardReaderChecker.getOnboardingState()) {
             is CardReaderOnboardingState.OnboardingCompleted -> {
-                if (appPrefsWrapper.isCardReaderWelcomeDialogShown()) {
-                    triggerEvent(
-                        NavigateToConnection(
-                            param,
-                            arguments.cardReaderType
-                        )
-                    )
-                } else {
-                    triggerEvent(
-                        StatusCheckerEvent.NavigateToWelcome(
-                            param,
-                            arguments.cardReaderType
-                        )
-                    )
-                }
+                handleOnboardingCompletedState(param)
+            }
+            else -> {
+                handleOnboardingNotCompletedState(param, state)
+            }
+        }
+    }
+
+    private fun handleOnboardingCompletedState(param: CardReaderFlowParam) {
+        if (appPrefsWrapper.isCardReaderWelcomeDialogShown()) {
+            triggerEvent(
+                NavigateToConnection(
+                    param,
+                    arguments.cardReaderType
+                )
+            )
+        } else {
+            triggerEvent(
+                StatusCheckerEvent.NavigateToWelcome(
+                    param,
+                    arguments.cardReaderType
+                )
+            )
+        }
+    }
+
+    private fun handleOnboardingNotCompletedState(
+        param: CardReaderFlowParam,
+        state: CardReaderOnboardingState
+    ) {
+        when (param) {
+            is CardReaderFlowParam.CardReadersHub, is CardReaderFlowParam.PaymentOrRefund.Refund -> {
+                navigateToOnboardingFailed(param, state, arguments.cardReaderType)
             }
 
-            else -> {
-                when (param) {
-                    is CardReaderFlowParam.CardReadersHub, is CardReaderFlowParam.PaymentOrRefund.Refund -> {
-                        navigateToOnboardingFailed(param, state, arguments.cardReaderType)
-                    }
+            is CardReaderFlowParam.PaymentOrRefund.Payment -> {
+                handlePaymentType(param, arguments.cardReaderType, state)
+            }
 
-                    is CardReaderFlowParam.PaymentOrRefund.Payment -> {
-                        handlePaymentType(param, arguments.cardReaderType, state)
-                    }
-
-                    CardReaderFlowParam.WooPosConnection -> {
-                        handleCardReaderConnection(state, param)
-                    }
-                }
+            CardReaderFlowParam.WooPosConnection -> {
+                handleCardReaderConnection(state, param)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModel.kt
@@ -110,21 +110,28 @@ class CardReaderStatusCheckerViewModel
                     }
 
                     CardReaderFlowParam.WooPosConnection -> {
-                        if (state is CardReaderOnboardingState.StripeAccountPendingRequirement) {
-                            navigateToConnection(
-                                param,
-                                arguments.cardReaderType
-                            )
-                        } else {
-                            navigateToOnboardingFailed(
-                                param,
-                                state,
-                                arguments.cardReaderType
-                            )
-                        }
+                        handleCardReaderConnection(state, param)
                     }
                 }
             }
+        }
+    }
+
+    private fun handleCardReaderConnection(
+        state: CardReaderOnboardingState,
+        param: CardReaderFlowParam
+    ) {
+        if (state is CardReaderOnboardingState.StripeAccountPendingRequirement) {
+            navigateToConnection(
+                param,
+                arguments.cardReaderType
+            )
+        } else {
+            navigateToOnboardingFailed(
+                param,
+                state,
+                arguments.cardReaderType
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPosIsEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPosIsEnabled.kt
@@ -73,10 +73,10 @@ class WooPosIsEnabled @Inject constructor(
             is CardReaderOnboardingState.StripeAccountOverdueRequirement,
             is CardReaderOnboardingState.StripeAccountRejected,
             is CardReaderOnboardingState.StripeAccountUnderReview,
+            is CardReaderOnboardingState.StripeAccountPendingRequirement,
             CardReaderOnboardingState.WcpayNotActivated,
             CardReaderOnboardingState.WcpayNotInstalled -> false
 
-            is CardReaderOnboardingState.StripeAccountPendingRequirement,
             is CardReaderOnboardingState.OnboardingCompleted -> true
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.ReaderType
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.ORDER
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingParams
@@ -421,6 +422,37 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
                 countryCode
             )
             whenever(appPrefsWrapper.isCardReaderWelcomeDialogShown()).thenReturn(true)
+            whenever(cardReaderChecker.getOnboardingState()).thenReturn(onboardingState)
+
+            // WHEN
+            val vm = initViewModel(param)
+
+            // THEN
+            assertThat(vm.event.value)
+                .isEqualTo(
+                    CardReaderStatusCheckerViewModel.StatusCheckerEvent.NavigateToConnection(
+                        param,
+                        CardReaderType.EXTERNAL
+                    )
+                )
+        }
+
+    @Test
+    fun `given woo pos connection and onboarding failed with stripe pending requirements, when vm init, then navigates to connection`() =
+        testBlocking {
+            // GIVEN
+            val orderId = 1L
+            val param = CardReaderFlowParam.PaymentOrRefund.Payment(
+                orderId = orderId,
+                paymentType = PaymentType.WOO_POS
+            )
+            whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
+            val onboardingState = CardReaderOnboardingState.StripeAccountPendingRequirement(
+                dueDate = 0L,
+                preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
+                version = pluginVersion,
+                countryCode = countryCode
+            )
             whenever(cardReaderChecker.getOnboardingState()).thenReturn(onboardingState)
 
             // WHEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
@@ -559,7 +559,6 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             val param = CardReaderFlowParam.CardReadersHub()
-            whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
             val onboardingError = CardReaderOnboardingState.StripeAccountPendingRequirement(
                 dueDate = 0L,
                 preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.cardreader.connection.ReaderType
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.ORDER
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.WOO_POS
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingParams
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState
@@ -444,7 +445,7 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
             val orderId = 1L
             val param = CardReaderFlowParam.PaymentOrRefund.Payment(
                 orderId = orderId,
-                paymentType = PaymentType.WOO_POS
+                paymentType = WOO_POS
             )
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
             val onboardingState = CardReaderOnboardingState.StripeAccountPendingRequirement(
@@ -466,6 +467,26 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
                         CardReaderType.EXTERNAL
                     )
                 )
+        }
+
+    @Test
+    fun `given woo pos connection and onboarding failed with error other than stripe pending requirements, when vm init, then navigates to onboarding`() =
+        testBlocking {
+            // GIVEN
+            val orderId = 1L
+            val param = CardReaderFlowParam.PaymentOrRefund.Payment(orderId = orderId, paymentType = WOO_POS)
+            whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
+            val onboardingState = CardReaderOnboardingState.StripeAccountRejected(
+                preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
+            )
+            whenever(cardReaderChecker.getOnboardingState()).thenReturn(onboardingState)
+
+            // WHEN
+            val vm = initViewModel(param)
+
+            // THEN
+            assertThat(vm.event.value)
+                .isInstanceOf(CardReaderStatusCheckerViewModel.StatusCheckerEvent.NavigateToOnboarding::class.java)
         }
 
     private fun initViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
@@ -553,6 +553,30 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
                 )
         }
 
+    @Test
+    fun `given card reader hub flow and not connected and error, when vm init, then navigates to onboarding with fail`() =
+        testBlocking {
+            // GIVEN
+            val param = CardReaderFlowParam.CardReadersHub()
+            whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
+            val onboardingError = CardReaderOnboardingState.StripeAccountPendingRequirement(
+                dueDate = 0L,
+                preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
+                version = pluginVersion,
+                countryCode = countryCode
+            )
+            whenever(cardReaderChecker.getOnboardingState()).thenReturn(onboardingError)
+
+            // WHEN
+            val vm = initViewModel(param)
+
+            // THEN
+            assertThat(vm.event.value)
+                .isInstanceOf(
+                    CardReaderStatusCheckerViewModel.StatusCheckerEvent.NavigateToOnboarding::class.java
+                )
+        }
+
     private fun initViewModel(
         param: CardReaderFlowParam,
         cardReaderType: CardReaderType = CardReaderType.EXTERNAL

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.ReaderType
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
-import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.ORDER
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.WOO_POS
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
@@ -487,6 +486,29 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
             // THEN
             assertThat(vm.event.value)
                 .isInstanceOf(CardReaderStatusCheckerViewModel.StatusCheckerEvent.NavigateToOnboarding::class.java)
+        }
+
+    @Test
+    fun `given payment flow for woo pos and onboarding failed with stripe pending requirements, when vm init, then navigates to connection`() =
+        testBlocking {
+            // GIVEN
+            val orderId = 1L
+            val param = CardReaderFlowParam.PaymentOrRefund.Payment(orderId = orderId, paymentType = WOO_POS)
+            whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
+            val onboardingState = CardReaderOnboardingState.StripeAccountPendingRequirement(
+                dueDate = 0L,
+                preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
+                version = pluginVersion,
+                countryCode = countryCode
+            )
+            whenever(cardReaderChecker.getOnboardingState()).thenReturn(onboardingState)
+
+            // WHEN
+            val vm = initViewModel(param)
+
+            // THEN
+            assertThat(vm.event.value)
+                .isInstanceOf(CardReaderStatusCheckerViewModel.StatusCheckerEvent.NavigateToConnection::class.java)
         }
 
     private fun initViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.ReaderType
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.ORDER
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.SIMPLE
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.WOO_POS
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingParams
@@ -558,6 +559,31 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             val param = CardReaderFlowParam.CardReadersHub()
+            whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
+            val onboardingError = CardReaderOnboardingState.StripeAccountPendingRequirement(
+                dueDate = 0L,
+                preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
+                version = pluginVersion,
+                countryCode = countryCode
+            )
+            whenever(cardReaderChecker.getOnboardingState()).thenReturn(onboardingError)
+
+            // WHEN
+            val vm = initViewModel(param)
+
+            // THEN
+            assertThat(vm.event.value)
+                .isInstanceOf(
+                    CardReaderStatusCheckerViewModel.StatusCheckerEvent.NavigateToOnboarding::class.java
+                )
+        }
+
+    @Test
+    fun `given payment flow during IPP and not connected and error, when vm init, then navigates to onboarding with fail`() =
+        testBlocking {
+            // GIVEN
+            val orderId = 1L
+            val param = CardReaderFlowParam.PaymentOrRefund.Payment(orderId = orderId, paymentType = SIMPLE)
             whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
             val onboardingError = CardReaderOnboardingState.StripeAccountPendingRequirement(
                 dueDate = 0L,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
@@ -7,8 +7,6 @@ import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.ReaderType
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.ORDER
-import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.SIMPLE
-import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.WOO_POS
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingParams
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState
@@ -440,79 +438,10 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given woo pos connection and onboarding failed with stripe pending requirements, when vm init, then navigates to connection`() =
+    fun `given woo pos connection and onboarding failed with error, when vm init, then navigates to onboarding`() =
         testBlocking {
             // GIVEN
             val param = CardReaderFlowParam.WooPosConnection
-            val onboardingState = CardReaderOnboardingState.StripeAccountPendingRequirement(
-                dueDate = 0L,
-                preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
-                version = pluginVersion,
-                countryCode = countryCode
-            )
-            whenever(cardReaderChecker.getOnboardingState()).thenReturn(onboardingState)
-
-            // WHEN
-            val vm = initViewModel(param)
-
-            // THEN
-            assertThat(vm.event.value)
-                .isEqualTo(
-                    CardReaderStatusCheckerViewModel.StatusCheckerEvent.NavigateToConnection(
-                        param,
-                        CardReaderType.EXTERNAL
-                    )
-                )
-        }
-
-    @Test
-    fun `given woo pos connection and onboarding failed with error other than stripe pending requirements, when vm init, then navigates to onboarding`() =
-        testBlocking {
-            // GIVEN
-            val param = CardReaderFlowParam.WooPosConnection
-            val onboardingState = CardReaderOnboardingState.StripeAccountRejected(
-                preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
-            )
-            whenever(cardReaderChecker.getOnboardingState()).thenReturn(onboardingState)
-
-            // WHEN
-            val vm = initViewModel(param)
-
-            // THEN
-            assertThat(vm.event.value)
-                .isInstanceOf(CardReaderStatusCheckerViewModel.StatusCheckerEvent.NavigateToOnboarding::class.java)
-        }
-
-    @Test
-    fun `given payment flow for woo pos and onboarding failed with stripe pending requirements, when vm init, then navigates to connection`() =
-        testBlocking {
-            // GIVEN
-            val orderId = 1L
-            val param = CardReaderFlowParam.PaymentOrRefund.Payment(orderId = orderId, paymentType = WOO_POS)
-            whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
-            val onboardingState = CardReaderOnboardingState.StripeAccountPendingRequirement(
-                dueDate = 0L,
-                preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
-                version = pluginVersion,
-                countryCode = countryCode
-            )
-            whenever(cardReaderChecker.getOnboardingState()).thenReturn(onboardingState)
-
-            // WHEN
-            val vm = initViewModel(param)
-
-            // THEN
-            assertThat(vm.event.value)
-                .isInstanceOf(CardReaderStatusCheckerViewModel.StatusCheckerEvent.NavigateToConnection::class.java)
-        }
-
-    @Test
-    fun `given payment flow for woo pos and onboarding failed with error other than stripe pending requirements, when vm init, then navigates to onboarding`() =
-        testBlocking {
-            // GIVEN
-            val orderId = 1L
-            val param = CardReaderFlowParam.PaymentOrRefund.Payment(orderId = orderId, paymentType = WOO_POS)
-            whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
             val onboardingState = CardReaderOnboardingState.StripeAccountRejected(
                 preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
             )
@@ -559,31 +488,6 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             val param = CardReaderFlowParam.CardReadersHub()
-            val onboardingError = CardReaderOnboardingState.StripeAccountPendingRequirement(
-                dueDate = 0L,
-                preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
-                version = pluginVersion,
-                countryCode = countryCode
-            )
-            whenever(cardReaderChecker.getOnboardingState()).thenReturn(onboardingError)
-
-            // WHEN
-            val vm = initViewModel(param)
-
-            // THEN
-            assertThat(vm.event.value)
-                .isInstanceOf(
-                    CardReaderStatusCheckerViewModel.StatusCheckerEvent.NavigateToOnboarding::class.java
-                )
-        }
-
-    @Test
-    fun `given payment flow during IPP and not connected and error, when vm init, then navigates to onboarding with fail`() =
-        testBlocking {
-            // GIVEN
-            val orderId = 1L
-            val param = CardReaderFlowParam.PaymentOrRefund.Payment(orderId = orderId, paymentType = SIMPLE)
-            whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
             val onboardingError = CardReaderOnboardingState.StripeAccountPendingRequirement(
                 dueDate = 0L,
                 preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
@@ -441,12 +441,7 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
     fun `given woo pos connection and onboarding failed with stripe pending requirements, when vm init, then navigates to connection`() =
         testBlocking {
             // GIVEN
-            val orderId = 1L
-            val param = CardReaderFlowParam.PaymentOrRefund.Payment(
-                orderId = orderId,
-                paymentType = WOO_POS
-            )
-            whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
+            val param = CardReaderFlowParam.WooPosConnection
             val onboardingState = CardReaderOnboardingState.StripeAccountPendingRequirement(
                 dueDate = 0L,
                 preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
@@ -472,9 +467,7 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
     fun `given woo pos connection and onboarding failed with error other than stripe pending requirements, when vm init, then navigates to onboarding`() =
         testBlocking {
             // GIVEN
-            val orderId = 1L
-            val param = CardReaderFlowParam.PaymentOrRefund.Payment(orderId = orderId, paymentType = WOO_POS)
-            whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
+            val param = CardReaderFlowParam.WooPosConnection
             val onboardingState = CardReaderOnboardingState.StripeAccountRejected(
                 preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/statuschecker/CardReaderStatusCheckerViewModelTest.kt
@@ -511,6 +511,26 @@ class CardReaderStatusCheckerViewModelTest : BaseUnitTest() {
                 .isInstanceOf(CardReaderStatusCheckerViewModel.StatusCheckerEvent.NavigateToConnection::class.java)
         }
 
+    @Test
+    fun `given payment flow for woo pos and onboarding failed with error other than stripe pending requirements, when vm init, then navigates to onboarding`() =
+        testBlocking {
+            // GIVEN
+            val orderId = 1L
+            val param = CardReaderFlowParam.PaymentOrRefund.Payment(orderId = orderId, paymentType = WOO_POS)
+            whenever(cardReaderManager.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
+            val onboardingState = CardReaderOnboardingState.StripeAccountRejected(
+                preferredPlugin = PluginType.WOOCOMMERCE_PAYMENTS,
+            )
+            whenever(cardReaderChecker.getOnboardingState()).thenReturn(onboardingState)
+
+            // WHEN
+            val vm = initViewModel(param)
+
+            // THEN
+            assertThat(vm.event.value)
+                .isInstanceOf(CardReaderStatusCheckerViewModel.StatusCheckerEvent.NavigateToOnboarding::class.java)
+        }
+
     private fun initViewModel(
         param: CardReaderFlowParam,
         cardReaderType: CardReaderType = CardReaderType.EXTERNAL

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/WooPosIsEnabledTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/WooPosIsEnabledTest.kt
@@ -102,12 +102,12 @@ class WooPosIsEnabledTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given ipp onboarding is Pending Requirements, then return true`() = testBlocking {
+    fun `given ipp onboarding is Pending Requirements, then return false`() = testBlocking {
         val onboardingCompleted = mock<CardReaderOnboardingState.StripeAccountPendingRequirement>()
         whenever(onboardingCompleted.preferredPlugin).thenReturn(PluginType.WOOCOMMERCE_PAYMENTS)
         whenever(cardReaderOnboardingChecker.getOnboardingState()).thenReturn(onboardingCompleted)
 
-        assertTrue(sut())
+        assertFalse(sut())
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11612 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR addresses the issue of handling Stripe account pending errors in POS mode. Since onboarding flows are not supported in POS mode, the changes ensure that this error is skipped to improve user experience.

Note that the same Stripe pending error is handled manually on IPP(non-pos mode). Merchant will be taken to onboarding flow with an option to skip the step and continues the flow when they skip it.

For more context: p91TBi-bje-p2

### Key Changes:

1. Added logic to bypass Stripe account pending errors during the onboarding process in POS mode.
2. Included comprehensive tests to verify the new behaviour for various error scenarios.

### Testing:

1. Added unit tests to verify that Stripe account pending errors are skipped in POS mode.
2. Ensured other errors still trigger the onboarding flow as expected in POS Mode.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
####  NOTE to Reviewer: For easier testing, return `StripePendingError` from `CardReaderOnboardingChecker` class
#### POS mode
1. Try to connect to card reader and ensure the connection succeeds.
2. Try taking payment and ensure the entire process proceeds smoothly.

#### Non-POS mode
1. Try to connect to card reader and ensure you see onboarding error with all the details.
2. Try to take payment and ensure you see onboarding error with all the details.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/4cb48e20-85c6-4cd1-b15d-0d9529c11cf9



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->