### PR TITLE
Issue/12141 hide illustration in phone landscape

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 19.8
 -----
 - [*] Stats: The Google Campaign analytics card now has a call to action to create a paid campaign if there are no campaign analytics for the selected time period. [https://github.com/woocommerce/woocommerce-android/pull/12161]
+- [*] Fix broken in-person payments illustrations in landscape mode. [https://github.com/woocommerce/woocommerce-android/pull/12179]
 
 19.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ContextExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ContextExt.kt
@@ -15,12 +15,25 @@ import com.woocommerce.android.util.SystemVersionUtils
 import kotlinx.parcelize.Parcelize
 
 val Context.windowSizeClass: WindowSizeClass
-    get() = determineWindowSizeClassByGivenSize(resources.configuration.screenWidthDp)
+    get() = determineWindowWidthSizeClassByGivenSize(resources.configuration.screenWidthDp)
 
-private fun determineWindowSizeClassByGivenSize(sizeDp: Int): WindowSizeClass {
+val Context.windowHeightSizeClass: WindowSizeClass
+    get() = determineWindowHeightSizeClassByGivenSize(resources.configuration.screenHeightDp)
+
+
+
+private fun determineWindowWidthSizeClassByGivenSize(sizeDp: Int): WindowSizeClass {
     return when {
         sizeDp < WindowSizeClass.Compact.maxWidthDp -> WindowSizeClass.Compact
         sizeDp < WindowSizeClass.Medium.maxWidthDp -> WindowSizeClass.Medium
+        else -> WindowSizeClass.ExpandedAndBigger
+    }
+}
+
+private fun determineWindowHeightSizeClassByGivenSize(sizeDp: Int): WindowSizeClass {
+    return when {
+        sizeDp < WindowSizeClass.Compact.maxHeightDp -> WindowSizeClass.Compact
+        sizeDp < WindowSizeClass.Medium.maxHeightDp -> WindowSizeClass.Medium
         else -> WindowSizeClass.ExpandedAndBigger
     }
 }
@@ -30,26 +43,33 @@ private fun determineWindowSizeClassByGivenSize(sizeDp: Int): WindowSizeClass {
  * [guidelines](https://m3.material.io/foundations/layout/applying-layout/window-size-classes)
  */
 @Parcelize
-sealed class WindowSizeClass(val maxWidthDp: Int) : Parcelable, Comparable<WindowSizeClass> {
+sealed class WindowSizeClass(val maxWidthDp: Int, val maxHeightDp: Int) : Parcelable, Comparable<WindowSizeClass> {
     /**
-     * Phone in portrait
+     * Width: 99.96% of phones in portrait.
+     * Height: 99.78% of phones in landscape.
      */
-    data object Compact : WindowSizeClass(COMPACT_SCREEN_MAX_WIDTH)
+    data object Compact : WindowSizeClass(COMPACT_SCREEN_MAX_WIDTH, COMPACT_SCREEN_MAX_HEIGHT)
 
     /**
-     * Small tablet, tablet in portrait or foldable in portrait (unfolded).
+     * Width: 93.73% of tablets in portrait, most large unfolded inner displays in portrait.
+     * Height: 96.56% of tablets in landscape, 97.59% of phones in portrait.
      */
-    data object Medium : WindowSizeClass(MEDIUM_SCREEN_MAX_WIDTH)
+    data object Medium : WindowSizeClass(MEDIUM_SCREEN_MAX_WIDTH, MEDIUM_SCREEN_MAX_HEIGHT)
 
     /**
-     * Phone in landscape, tablet in landscape, foldable in landscape, desktop and ultra-wide.
+     * Width: 97.22% of tablets in landscape, most large unfolded inner displays in landscape.
+     * Height: 94.25% of tablets in portrait.
      */
-    data object ExpandedAndBigger : WindowSizeClass(EXPANDED_SCREEN_MAX_WIDTH)
+    data object ExpandedAndBigger : WindowSizeClass(EXPANDED_SCREEN_MAX_WIDTH, EXPANDED_SCREEN_MAX_HEIGHT)
 
     companion object {
         private const val COMPACT_SCREEN_MAX_WIDTH = 600
         private const val MEDIUM_SCREEN_MAX_WIDTH = 840
         private const val EXPANDED_SCREEN_MAX_WIDTH = 1200
+
+        private const val COMPACT_SCREEN_MAX_HEIGHT = 480
+        private const val MEDIUM_SCREEN_MAX_HEIGHT = 900
+        private const val EXPANDED_SCREEN_MAX_HEIGHT = 2000
     }
 
     override fun compareTo(other: WindowSizeClass): Int {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ContextExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/ContextExt.kt
@@ -20,8 +20,6 @@ val Context.windowSizeClass: WindowSizeClass
 val Context.windowHeightSizeClass: WindowSizeClass
     get() = determineWindowHeightSizeClassByGivenSize(resources.configuration.screenHeightDp)
 
-
-
 private fun determineWindowWidthSizeClassByGivenSize(sizeDp: Int): WindowSizeClass {
     return when {
         sizeDp < WindowSizeClass.Compact.maxWidthDp -> WindowSizeClass.Compact

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectDialogFragment.kt
@@ -152,7 +152,7 @@ class CardReaderConnectDialogFragment : PaymentsBaseDialogFragment(R.layout.card
 
     private fun moveToState(binding: CardReaderConnectDialogBinding, viewState: CardReaderConnectViewState) {
         UiHelpers.setTextOrHide(binding.headerLabel, viewState.headerLabel)
-        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, viewState.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, viewState.illustration)
         UiHelpers.setTextOrHide(binding.hintLabel, viewState.hintLabel)
         UiHelpers.setTextOrHide(binding.primaryActionBtn, viewState.primaryActionLabel)
         UiHelpers.setTextOrHide(binding.secondaryActionBtn, viewState.secondaryActionLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/adapter/MultipleCardReadersFoundViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/adapter/MultipleCardReadersFoundViewHolder.kt
@@ -47,7 +47,7 @@ sealed class MultipleCardReadersFoundViewHolder(
         override fun onBind(uiState: ListItemViewState) {
             uiState as ScanningInProgressListItem
             UiHelpers.setTextOrHide(binding.cardReaderConnectProgressLabel, uiState.label)
-            UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(
+            UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(
                 binding.cardReaderConnectProgressIndicator,
                 uiState.scanningIcon
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailFragment.kt
@@ -135,7 +135,7 @@ class CardReaderDetailFragment : BaseFragment(R.layout.fragment_card_reader_deta
                 is NotConnectedState -> {
                     with(binding.readerDisconnectedState) {
                         UiHelpers.setTextOrHide(cardReaderDetailConnectHeaderLabel, state.headerLabel)
-                        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(
+                        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(
                             cardReaderDetailIllustration,
                             state.illustration
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -165,7 +165,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         UiHelpers.setTextOrHide(binding.enableCashOnDelivery, state.enableCashOnDeliveryButtonLabel)
         UiHelpers.setTextOrHide(binding.textSupport, state.contactSupportLabel)
         UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreLabel)
-        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, state.cardIllustration)
+        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, state.cardIllustration)
 
         if (state.shouldShowProgress) {
             binding.enableCashOnDelivery.isEnabled = false
@@ -245,7 +245,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingLoadingBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeaderTv, state.headerLabel)
         UiHelpers.setTextOrHide(binding.hintTv, state.hintLabel)
-        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustrationIv, state.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustrationIv, state.illustration)
     }
 
     private fun showGenericErrorState(
@@ -255,7 +255,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingGenericErrorBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textSupport, state.contactSupportLabel)
         UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreLabel)
-        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
         binding.textSupport.setOnClickListener {
             state.onContactSupportActionClicked.invoke()
         }
@@ -269,7 +269,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         state: CardReaderOnboardingViewState.NoConnectionErrorState
     ) {
         val binding = FragmentCardReaderOnboardingNetworkErrorBinding.bind(view)
-        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
         binding.buttonRetry.setOnClickListener {
             state.onRetryButtonActionClicked.invoke()
         }
@@ -282,7 +282,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingStripeBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeader, state.headerLabel)
         UiHelpers.setTextOrHide(binding.textLabel, state.hintLabel)
-        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
 
         UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreButton.label)
         binding.learnMoreContainer.learnMore.setOnClickListener {
@@ -318,7 +318,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingWcpayBinding.bind(view)
         UiHelpers.setTextOrHide(binding.textHeader, state.headerLabel)
         UiHelpers.setTextOrHide(binding.textLabel, state.hintLabel)
-        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
 
         UiHelpers.setTextOrHide(binding.primaryButton, state.actionButtonPrimary.label)
         binding.primaryButton.setWhiteIcon(state.actionButtonPrimary.icon)
@@ -348,7 +348,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         binding.primaryButton.visibility = View.GONE
         UiHelpers.setTextOrHide(binding.secondaryButton, state.refreshButtonLabel)
         UiHelpers.setTextOrHide(binding.learnMoreContainer.learnMore, state.learnMoreLabel)
-        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, state.illustration)
+        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, state.illustration)
         binding.secondaryButton.setOnClickListener {
             state.refreshButtonAction.invoke()
         }
@@ -363,7 +363,7 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
     ) {
         val binding = FragmentCardReaderOnboardingUnsupportedBinding.bind(view)
         UiHelpers.setTextOrHide(binding.unsupportedCountryHeader, state.headerLabel)
-        UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(
+        UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(
             binding.unsupportedCountryIllustration,
             state.illustration
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderWelcomeDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderWelcomeDialogFragment.kt
@@ -23,7 +23,7 @@ class CardReaderWelcomeDialogFragment : PaymentsBaseDialogFragment(R.layout.card
 
     private fun initObservers(binding: CardReaderWelcomeDialogBinding) {
         viewModel.viewState.observe(viewLifecycleOwner) { viewState ->
-            UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, viewState.img)
+            UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, viewState.img)
             UiHelpers.setTextOrHide(binding.headerLabel, viewState.header)
             UiHelpers.setTextOrHide(binding.text, viewState.text)
             UiHelpers.setTextOrHide(binding.actionBtn, viewState.buttonLabel)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
@@ -104,7 +104,10 @@ class CardReaderPaymentDialogFragment : PaymentsBaseDialogFragment(R.layout.card
             announceForAccessibility(binding, viewState)
             UiHelpers.setTextOrHide(binding.headerLabel, viewState.headerLabel)
             UiHelpers.setTextOrHide(binding.amountLabel, viewState.amountWithCurrencyLabel)
-            UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, viewState.illustration)
+            UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(
+                binding.illustration,
+                viewState.illustration
+            )
             UiHelpers.setTextOrHide(binding.paymentStateLabel, viewState.paymentStateLabel)
             (binding.paymentStateLabel.layoutParams as ViewGroup.MarginLayoutParams)
                 .topMargin = resources.getDimensionPixelSize(viewState.paymentStateLabelTopMargin)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentDialogFragment.kt
@@ -104,7 +104,7 @@ class CardReaderPaymentDialogFragment : PaymentsBaseDialogFragment(R.layout.card
             announceForAccessibility(binding, viewState)
             UiHelpers.setTextOrHide(binding.headerLabel, viewState.headerLabel)
             UiHelpers.setTextOrHide(binding.amountLabel, viewState.amountWithCurrencyLabel)
-            UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(binding.illustration, viewState.illustration)
+            UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(binding.illustration, viewState.illustration)
             UiHelpers.setTextOrHide(binding.paymentStateLabel, viewState.paymentStateLabel)
             (binding.paymentStateLabel.layoutParams as ViewGroup.MarginLayoutParams)
                 .topMargin = resources.getDimensionPixelSize(viewState.paymentStateLabelTopMargin)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/update/CardReaderUpdateDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/update/CardReaderUpdateDialogFragment.kt
@@ -76,7 +76,7 @@ class CardReaderUpdateDialogFragment : PaymentsBaseDialogFragment(R.layout.card_
                     UiHelpers.updateVisibility(this, state.progress != null)
                     currentProgressPercentage = state.progress ?: 0
                 }
-                UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(progressImageView, state.illustration)
+                UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(progressImageView, state.illustration)
                 actionButton.setOnClickListener { state.button?.onActionClicked?.invoke() }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsToggleOptionView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/WCSettingsToggleOptionView.kt
@@ -58,7 +58,7 @@ class WCSettingsToggleOptionView @JvmOverloads constructor(
                     R.styleable.WCSettingsToggleOptionView_toggleOptionIcon,
                     R.styleable.WCSettingsToggleOptionView_tools_toggleOptionIcon
                 ).let {
-                    UiHelpers.setImageOrHideInLandscapeOnNonExpandedScreenSizes(
+                    UiHelpers.setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(
                         binding.toggleSettingIcon,
                         it,
                         setInvisible = true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UiHelpers.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UiHelpers.kt
@@ -9,6 +9,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.core.text.HtmlCompat
 import com.woocommerce.android.extensions.WindowSizeClass
+import com.woocommerce.android.extensions.windowHeightSizeClass
 import com.woocommerce.android.extensions.windowSizeClass
 import com.woocommerce.android.model.UiDimen
 import com.woocommerce.android.model.UiDimen.UiDimenDPInt
@@ -72,14 +73,14 @@ object UiHelpers {
         }
     }
 
-    fun setImageOrHideInLandscapeOnNonExpandedScreenSizes(
+    fun setImageOrHideInLandscapeOnCompactScreenHeightSizeClass(
         imageView: ImageView,
         @DrawableRes resId: Int?,
         setInvisible: Boolean = false
     ) {
         val isLandscape = DisplayUtils.isLandscape(imageView.context)
-        val isExpandedOrBigger = imageView.context.windowSizeClass >= WindowSizeClass.ExpandedAndBigger
-        val shouldShowBasedOnOrientationAndSize = !isLandscape || isExpandedOrBigger
+        val isNotCompact = imageView.context.windowHeightSizeClass >= WindowSizeClass.Medium
+        val shouldShowBasedOnOrientationAndSize = !isLandscape || isNotCompact
         val showImage = resId != null && shouldShowBasedOnOrientationAndSize
         updateVisibility(imageView, showImage, setInvisible)
         resId?.let {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12141 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes an issue in which illustrations in the IPP flows were not automatically hidden in landscape mode on phones.

The root cause of the issue was that the app was determining whether to show/hide the illustration based on device's screen height instead of width (which is technically height in landscape). This PR fixes this issue by introducing Screen Width Size Class and using it instead.

There might be some obscure devices which don't belong to the Compact Screen width Size in landscape, but according to the official documentation this should affect less then 0.25% of all devices => likely significantly less users, since these devices are likely extremely rare to be used for regular apps such as WooCommerce - considering the illustration doesn't block the flow, it's just an UI issue, this is not IMO worth fixing (we could fix it by resizing the illustration but that's a too risky change not worth the risk).

[The screen sizes are copied from the official documentation.](https://developer.android.com/develop/ui/compose/layouts/adaptive/window-size-classes)

P.S. I intentionally left the original field `windowSizeClass` named `windowSizeClass` since it's the class that should be used in vast majority of the cases. If you believe it'd be better to rename it to `windowWidthSizeClass` let me know.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Test on a phone:
1. Go to More -> Payments section
2. Tap on Manager Card Reader
3. Initiate the connection and rotate your device into landscape
4. Notice the UI is broken

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Test the illustration is visible on tablets and phones in portrait but hidden on phones in landscape. This change affects all the IPP flows, but considering the logic is shared I believe testing just one of these is fine.

1. Open an unpaid order
2. Tap on Collect Payment
3. Select Card Reader
4. Notice the UI is NOT broken - in either portrait or landscape.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
| Before | After |
| -- | -- |
| <img src="https://private-user-images.githubusercontent.com/2261188/352049090-ae884f18-ce3f-4e57-97d1-c1458935776e.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjI0MTkxMzEsIm5iZiI6MTcyMjQxODgzMSwicGF0aCI6Ii8yMjYxMTg4LzM1MjA0OTA5MC1hZTg4NGYxOC1jZTNmLTRlNTctOTdkMS1jMTQ1ODkzNTc3NmUucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDczMSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA3MzFUMDk0MDMxWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NGI0NzA1MmQxYzE3ZjI1MTE1Y2RjOGI2ZmM5M2I3YjBjNmU4YzMyN2FlZmQzNjRiNTBjNGQzZTI2OGZkY2YyNyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.Nb6kkY_pwzzNce-rceclg96IW11etU9sv97sGaz67GU" width="250px" /> | <img src="https://github.com/user-attachments/assets/41397939-c985-4bf9-9f76-4148e2ea23fb" width="250px" /> |



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->