### PR TITLE
Hotfix: Fix broken TTP on Android 14

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,10 @@
 -----
 
 
+19.6.1
+-----
+- [***] Fixed a critical bug causing Tap to Pay to crash on Android 14. [https://github.com/woocommerce/woocommerce-android/pull/12184]
+
 19.6
 -----
 - [**] Stats: The Analytics Hub (accessed by tapping "View all store analytics" on the My Store dashboard) now includes analytics for Google Ads campaigns, when the Google Listings & Ads extension is active and connected to Google. [https://github.com/woocommerce/woocommerce-android/pull/12084]

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -199,7 +199,6 @@
         <service
             android:name="org.wordpress.android.login.LoginWpcomService"
             android:exported="false"
-            android:foregroundServiceType="shortService"
             android:label="Login to WPCOM Service" />
 
         <meta-data

--- a/settings.gradle
+++ b/settings.gradle
@@ -73,7 +73,7 @@ gradle.ext.mediaPickerSourceWordPressBinaryPath = "org.wordpress.mediapicker:sou
 
 gradle.ext {
     compileSdkVersion = 34
-    targetSdkVersion = 34
+    targetSdkVersion = 33
     minSdkVersion = 26
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12182 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes an issue in the Stripe SDK when `targetSdkVersion` is set to 34 and the app runs on Android 14 - [issue in Stripe's repo](https://github.com/stripe/stripe-terminal-android/issues/387).

The issue is fixed in Stripe's Terminal Sdk 3.2.1, however, the update also updates some transitive dependencies - kotlin reflection and android material, which makes it a too risky change to merge as a hotfix.

Therefore, we decided to downgrade the `targetSdkversion` as a hotfix instead and update the Stripe dependency as part of the regular release cycle.

We also decided to revert the explicit definition of `android:foregroundServiceType="shortService"` which was introduced as part of the update to version 34 [here](https://github.com/woocommerce/woocommerce-android/pull/11970). This is likely not necessary, but it feels safer to revert this change since the `shortService` type was introduced in Android 14 => it'll likely ignored it the targetSdk is lower then 34, but it still feels safer to revert this change as well.

We plan to re-introduce all these changes in the regular release cycle including the update of the Stripe SDK.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Run the app on Android 14 on a TTP compatible device.
- **Make sure to use the release build variant - minify needs to be enabled.**
1. Open an unpaid order
2. Tap on Collect Payment
3. Select TTP
4. Notice the app crashes

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Testing TTP on Android 14 should be enough.

Question: I don't recall how release notes work with hotfixes - do I need to add them?

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->