### PR TITLE
Fix refresh last update on resume

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -275,6 +275,7 @@ class DashboardFragment :
             usageTracksEventEmitter.interacted()
             wasPreviouslyStopped = false
         }
+        dashboardViewModel.onResume()
     }
 
     override fun onStop() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -168,6 +168,10 @@ class DashboardViewModel @Inject constructor(
         _refreshTrigger.tryEmit(RefreshEvent(isForced = true))
     }
 
+    fun onResume(){
+        _refreshTrigger.tryEmit(RefreshEvent())
+    }
+
     fun onShareStoreClicked() {
         AnalyticsTracker.track(AnalyticsEvent.DASHBOARD_SHARE_YOUR_STORE_BUTTON_TAPPED)
         triggerEvent(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -168,7 +168,7 @@ class DashboardViewModel @Inject constructor(
         _refreshTrigger.tryEmit(RefreshEvent(isForced = true))
     }
 
-    fun onResume(){
+    fun onResume() {
         _refreshTrigger.tryEmit(RefreshEvent())
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -344,6 +344,7 @@ class OrderListFragment :
     override fun onResume() {
         super.onResume()
         AnalyticsTracker.trackViewShown(this)
+        viewModel.loadOrders()
         if (requireContext().windowSizeClass != WindowSizeClass.Compact) {
             refreshOrders()
         }


### PR DESCRIPTION
### Description
This PR implements forced data refresh upon app resume from the background on the dashboard and order list screens. Previously, cached data older than 30 minutes was displayed if the app was backgrounded and reopened, leading to stale information. By enforcing a data refresh, we ensure users always view the latest data.

### Testing information

For testing, it's better to apply the following patch and force data to always be stale.
<details>
  <summary>Patch</summary>

```
Subject: [PATCH] fix detekt issues
---
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt	(revision b9a5f6ae497cd0dd5b6ee7c8454a3bee281f3b81)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt	(date 1722565498270)
@@ -39,7 +39,7 @@
         maxOutdatedTime: Long = defaultMaxOutdatedTime,
     ) = dataStore.data
         .map { prefs -> prefs[longPreferencesKey(getTimeStampKey(rangeSelection.identifier, analyticData))] }
-        .map { lastUpdateTime -> isElapsedTimeExpired(lastUpdateTime, maxOutdatedTime) }
+        .map { lastUpdateTime -> isElapsedTimeExpired(lastUpdateTime, maxOutdatedTime) || true }
 
     fun shouldUpdateAnalytics(
         rangeSelection: StatsTimeRangeSelection,
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/background/LastUpdateDataStore.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/background/LastUpdateDataStore.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/background/LastUpdateDataStore.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/background/LastUpdateDataStore.kt	(revision b9a5f6ae497cd0dd5b6ee7c8454a3bee281f3b81)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/background/LastUpdateDataStore.kt	(date 1722565498275)
@@ -26,7 +26,7 @@
         maxOutdatedTime: Long = DEFAULT_MAX_OUTDATED_TIME,
     ) = dataStore.data
         .map { prefs -> prefs[longPreferencesKey(key)] }
-        .map { lastUpdateTime -> isElapsedTimeExpired(lastUpdateTime, maxOutdatedTime) }
+        .map { lastUpdateTime -> isElapsedTimeExpired(lastUpdateTime, maxOutdatedTime) || true }
 
     suspend fun storeLastUpdate(key: String) {
         dataStore.edit { preferences ->

```
</details>

#### TC1
1. Open the app
2. Go to the Dashboard screen
3. Minimize the app 
4. Re-open the app
5. Check that the app refreshes the data when the data is stale

#### TC2
1. Open the app
2. Go to the Order list screen
3. Minimize the app 
4. Re-open the app
5. Check that the app refreshes the data when the data is stale

### Images/gif

https://github.com/user-attachments/assets/4c094e77-8634-4e67-b9c3-0ff8276cb876


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->