### PR TITLE
[WOO POS]M2: Prevent Multiple Instances of Card Reader Connect Dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModel.kt
@@ -128,7 +128,6 @@ class WooPosToolbarViewModel @Inject constructor(
     }
 
     override fun onCleared() {
-        super.onCleared()
         debounceJob?.cancel()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModelTest.kt
@@ -147,6 +147,24 @@ class WooPosToolbarViewModelTest {
         verify(cardReaderFacade, times(1)).connectToReader()
     }
 
+    @Test
+    fun `when connect to card reader clicked multiple times after delay, then debounce handles all clicks`() = runTest {
+        // GIVEN
+        whenever(cardReaderFacade.readerStatus).thenReturn(flowOf(CardReaderStatus.NotConnected()))
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUiEvent(WooPosToolbarUIEvent.ConnectToAReaderClicked)
+        advanceUntilIdle()
+        viewModel.onUiEvent(WooPosToolbarUIEvent.ConnectToAReaderClicked)
+        advanceUntilIdle()
+        viewModel.onUiEvent(WooPosToolbarUIEvent.ConnectToAReaderClicked)
+        advanceUntilIdle()
+
+        // THEN
+        verify(cardReaderFacade, times(3)).connectToReader()
+    }
+
     private fun createViewModel() = WooPosToolbarViewModel(
         cardReaderFacade,
         childrenToParentEventSender


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12203 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR addresses an issue where multiple successive clicks on the connect card reader button could create multiple instances of the card reader connect dialog. The solution ensures that only one instance of the dialog is created, preventing redundancy and improving the user experience.

Key Changes:

Implemented a mechanism to block multiple successive clicks that could trigger the dialog.
Ensured that only a single instance of the card reader connect dialog is displayed at a time.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Navigate to the POS mode from settings
2. Continuously click on the "Connect to card reader" button
3. Notice multiple instances of Card reader connect dialog appears on the screen

<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->


### Before
[Watch the before video](https://github.com/user-attachments/assets/994891a9-9690-46a4-b885-5491ab6f851a)

### After
[Watch the after video](https://github.com/user-attachments/assets/ce1e054a-4c16-4cce-947b-a0cef7a690f8)




- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->