### PR TITLE
Fix Rerty typo in POS

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4237,7 +4237,7 @@
     <string name="woopos_products_loading_error_title">Error loading products</string>
     <string name="woopos_products_loading_error_message">Give it another go?</string>
     <string name="woopos_error_icon_content_description">Error indication icon</string>
-    <string name="woopos_products_loading_error_retry_button">Rerty</string>
+    <string name="woopos_products_loading_error_retry_button">Retry</string>
     <string name="woopos_totals_order_creation_error">Couldn\'t create order</string>
     <string name="woopos_success_screen_total">A payment of %1$s was successfully made</string>
 


### PR DESCRIPTION
This PR fixes a typo in the strings.xml file. No tests are required.