### PR TITLE
Update android-core from 1.12.0 to 1.13.1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 19.9
 -----
 - [*] [Internal] Update Android material from 1.9.0 to 1.10.0 [https://github.com/woocommerce/woocommerce-android/pull/12186]
+- [*] [Internal] Update Android-core from 1.12.0 to 1.13.1 [https://github.com/woocommerce/woocommerce-android/pull/12229]
 
 19.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/AlignedDividerDecoration.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/AlignedDividerDecoration.kt
@@ -6,7 +6,6 @@ import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.view.ViewCompat
 import androidx.recyclerview.widget.RecyclerView
 
 /**
@@ -95,7 +94,7 @@ class AlignedDividerDecoration @JvmOverloads constructor(
 
     private fun drawForVertical(canvas: Canvas, parent: RecyclerView) {
         val adjustedChildCount = parent.childCount - 2
-        val isRtl = ViewCompat.getLayoutDirection(parent) == ViewCompat.LAYOUT_DIRECTION_RTL
+        val isRtl = parent.getLayoutDirection() == View.LAYOUT_DIRECTION_RTL
         (0..adjustedChildCount)
             .map { parent.getChildAt(it) }
             .forEach {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/FlowLayout.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/FlowLayout.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.ViewGroup
-import androidx.core.view.ViewCompat
 import com.woocommerce.android.R
 
 /**
@@ -36,13 +35,13 @@ open class FlowLayout @JvmOverloads constructor(
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        val widthSize = MeasureSpec.getSize(widthMeasureSpec) - ViewCompat.getPaddingEnd(this) -
-            ViewCompat.getPaddingStart(this)
+        val widthSize = MeasureSpec.getSize(widthMeasureSpec) - this.getPaddingEnd() -
+            this.getPaddingStart()
         val widthMode = MeasureSpec.getMode(widthMeasureSpec)
         val growHeight = widthMode != MeasureSpec.UNSPECIFIED
         var width = 0
         var height = paddingTop
-        var currentWidth = ViewCompat.getPaddingStart(this)
+        var currentWidth = this.getPaddingStart()
         var currentHeight = 0
         var newLine = false
         var spacing = 0
@@ -62,7 +61,7 @@ open class FlowLayout @JvmOverloads constructor(
                 height += currentHeight + mVerticalSpacing
                 currentHeight = 0
                 width = Math.max(width, currentWidth - spacing)
-                currentWidth = ViewCompat.getPaddingStart(this)
+                currentWidth = this.getPaddingStart()
                 newLine = true
             } else {
                 newLine = false
@@ -77,7 +76,7 @@ open class FlowLayout @JvmOverloads constructor(
         if (!newLine) {
             width = Math.max(width, currentWidth - spacing)
         }
-        width += ViewCompat.getPaddingEnd(this)
+        width += this.getPaddingEnd()
         height += currentHeight + paddingBottom
         setMeasuredDimension(resolveSize(width, widthMeasureSpec), resolveSize(height, heightMeasureSpec))
     }
@@ -106,7 +105,7 @@ open class FlowLayout @JvmOverloads constructor(
     override fun generateLayoutParams(p: ViewGroup.LayoutParams): LayoutParams {
         return LayoutParams(p.width, p.height)
     }
-    class LayoutParams : ViewGroup.MarginLayoutParams {
+    class LayoutParams : MarginLayoutParams {
         internal var x: Int = 0
         internal var y: Int = 0
         var horizontalSpacing: Int = -1

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCSelectableTextView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCSelectableTextView.kt
@@ -7,7 +7,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
-import androidx.core.view.GestureDetectorCompat
 import com.google.android.material.textview.MaterialTextView
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.selectAllText
@@ -24,7 +23,7 @@ class WCSelectableTextView @JvmOverloads constructor(
 ) : MaterialTextView(context, attrs, defStyleAttr),
     android.view.ActionMode.Callback,
     GestureDetector.OnDoubleTapListener {
-    private val detector = GestureDetectorCompat(context, GestureDetector.SimpleOnGestureListener())
+    private val detector = GestureDetector(context, GestureDetector.SimpleOnGestureListener())
 
     // when text is selectable, TextView intercepts the click event even if there's no OnClickListener,
     // requiring this workaround to pass the click to a parent view

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ def detektAutoCorrectPrompt = tasks.register("detektAutoCorrectPrompt") {
     }
 }
 
-detektAll.configure{
+detektAll.configure {
     finalizedBy detektAutoCorrectPrompt
 }
 
@@ -112,7 +112,7 @@ ext {
     aztecVersion = 'v1.3.45'
     flipperVersion = '0.176.1'
     stateMachineVersion = '0.2.0'
-    coreKtxVersion = '1.12.0'
+    coreKtxVersion = '1.13.1'
     appCompatVersion = '1.4.2'
     materialVersion = '1.10.0'
     hiltJetpackVersion = '1.1.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
**Do not merge label - let's merge it only after we review the whole chain of PRs and are confident they don't cause any regressions.**

First in the chain of dependency udpates.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates `android-core` dependency from 1.12.0 to 1.13.1. . This is a pre-requisite for updating Stripe Terminal SDK to version 3.8.0.

The release notes for this update are here
- [1.13.0](https://developer.android.com/jetpack/androidx/releases/core#1.13.0)
- [1.13.1](https://developer.android.com/jetpack/androidx/releases/core#1.13.1)

The following change is the only one that is affecting our codebase AFAICT but please review it!
`The library’s minSdkVersion has been raised to 19. Many compatibility APIs have been marked deprecated since they were only needed prior to API level 19.`

I updated the deprecated methods with their non-appCompat counter parts. This seems like a safe change since the AppCompat library was using a different API only on API below 19 => which means it was simply delegating the calls to `View` on 19+ and we are now invoking the methods on `View` directly.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
This PR is not about any bugs - so nothing to reproduce.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

We should smoke test the above changes just to be sure. Having said that, considering we are going to update other libraries this week, we need to perform more thorough smoke testing anyway, I suggest limiting testing of this PR to 10 minutes or so.


Things I tested on Pixel 8 with Android 14:

1. I verified `AlignedDividerDecoration` is properly rendered with the correct alignment on the ProductList and Product-CategoryList screen.
- Open Product List.
- Verify the divider between each item is rendered and it starts aligned with the Product name.
- Open a product.
- Tap on Categories.
- Verify the divider between each item is rendered and it starts aligned with the category name.
<img src="https://github.com/user-attachments/assets/fa872aef-86a8-4824-acf9-6c488f93080e" width="250px" />
<img src="https://github.com/user-attachments/assets/8e02eb86-5bbf-49d7-8395-40e98e428ac8" width="250px" />




2. I verified `FlowLayout` is properly rendered on the `OrderList` - it's used to render Order Status. However, considering we always render just one status I believe the `FlowLayout` isn't needed at all. However, such improvement is out of the scope of this PR.
- Open Order List.
- Verify Order Status is rendered correctly.
<img src="https://github.com/user-attachments/assets/fdf52128-13e7-4a2f-833c-fe56f0cc2433" width="250px" />





3. I verified `WCSelectableTextView` works as expected on Order Detail - Copying Billing Phone using long press.
- Open Order List
- Open an Order
- Make sure the order has phone set on the billing address (or add it)
- Long press on the phone number and make sure the whole number including `+` prefix is automatically selected.

<img src="https://github.com/user-attachments/assets/b0bed690-5866-4598-aa63-f78962da15ec" width="250px" />



### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional): This is a dependency update so unit tests are irrelevant.
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->