### PR TITLE
Update androidx-fragment from 1.6.2 to 1.8.2

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] [Internal] Update Android material from 1.9.0 to 1.10.0 [https://github.com/woocommerce/woocommerce-android/pull/12186]
 - [*] [Internal] Update Android-core from 1.12.0 to 1.13.1 [https://github.com/woocommerce/woocommerce-android/pull/12229]
 - [*] [Internal] Update Android-lifecycle from 2.6.2 to 2.7.0 [https://github.com/woocommerce/woocommerce-android/pull/12230]
+- [*] [Internal] Update Androidx-fragment from 1.6.2 to 1.8.2 [https://github.com/woocommerce/woocommerce-android/pull/12231]
 
 19.8
 -----

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -400,7 +400,7 @@ dependencies {
     }
 
     // ViewModel and LiveData
-    implementation "androidx.fragment:fragment-ktx:1.6.1"
+    implementation "androidx.fragment:fragment-ktx:1.8.2"
     implementation "androidx.activity:activity-ktx:1.8.0"
     implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

**Do not merge label - https://github.com/woocommerce/woocommerce-android/pull/12230/files needs to be merged first.**

Third in the chain of dependency udpates, parents are:
- https://github.com/woocommerce/woocommerce-android/pull/12229
- https://github.com/woocommerce/woocommerce-android/pull/12230

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates Androidx-fragment from 1.6.2 to 1.8.2. This is a pre-requisite for Stripe SDK update.

[The changelog can be found here](https://developer.android.com/jetpack/androidx/releases/fragment#1.8.2) - we need to check all stable versions between 1.6.2 and 1.8.2.

 I didn't notice anything in particular we need to handle. Having said that, there are a lot of changes which might potentially affect our app.

This also transitively updates - https://developer.android.com/jetpack/androidx/releases/profileinstaller#1.3.1, however, the changelog seems fine as it contains only bug fixes.



### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

This is not a bug so there are no repro steps.



### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

We should smoke test the above changes just to be sure. Having said that, considering we are going to update other libraries this week, we need to perform more thorough smoke testing anyway, I suggest limiting testing of this PR to 10 minutes or so.

I smoke tested (Pixel 8 with Android 14):
- Google SSO login (it asked me for my password not sure if that's expected)
- Analytics
- Refund
- IPP
- Coupons

Focus on screen transitions and fragment transactions (back behavior etc)


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No UI changes

- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional): This is a dependency update so unit tests are irrelevant.
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->