### PR TITLE
Update material and transition dependencies

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] [Internal] Update Android-core from 1.12.0 to 1.13.1 [https://github.com/woocommerce/woocommerce-android/pull/12229]
 - [*] [Internal] Update Android-lifecycle from 2.6.2 to 2.7.0 [https://github.com/woocommerce/woocommerce-android/pull/12230]
 - [*] [Internal] Update Androidx-fragment from 1.6.2 to 1.8.2 [https://github.com/woocommerce/woocommerce-android/pull/12231]
+- [*] [Internal] Update Material to 1.12.0 and Transition to 1.5.1 [https://github.com/woocommerce/woocommerce-android/pull/12237]
 
 19.8
 -----

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -240,6 +240,7 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview-selection:1.1.0"
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
     implementation "com.google.android.material:material:$materialVersion"
+    implementation "androidx.transition:transition:$transitionVersion"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation("androidx.browser:browser:1.5.0") {
         exclude group: 'com.google.guava', module: 'listenablefuture'

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -240,7 +240,7 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview-selection:1.1.0"
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
     implementation "com.google.android.material:material:$materialVersion"
-    implementation "androidx.transition:transition:$transitionVersion"
+    implementation "androidx.transition:transition-ktx:$transitionVersion"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation("androidx.browser:browser:1.5.0") {
         exclude group: 'com.google.guava', module: 'listenablefuture'

--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ ext {
     stateMachineVersion = '0.2.0'
     coreKtxVersion = '1.13.1'
     appCompatVersion = '1.4.2'
-    materialVersion = '1.10.0'
+    materialVersion = '1.12.0'
     transitionVersion = '1.5.0'
     hiltJetpackVersion = '1.1.0'
     wordPressUtilsVersion = '3.5.0'

--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ ext {
     coreKtxVersion = '1.13.1'
     appCompatVersion = '1.4.2'
     materialVersion = '1.12.0'
-    transitionVersion = '1.5.0'
+    transitionVersion = '1.5.1'
     hiltJetpackVersion = '1.1.0'
     wordPressUtilsVersion = '3.5.0'
     mediapickerVersion = '0.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,7 @@ ext {
     coreKtxVersion = '1.13.1'
     appCompatVersion = '1.4.2'
     materialVersion = '1.10.0'
+    transitionVersion = '1.5.0'
     hiltJetpackVersion = '1.1.0'
     wordPressUtilsVersion = '3.5.0'
     mediapickerVersion = '0.3.1'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

**Do not merge label - https://github.com/woocommerce/woocommerce-android/pull/12230 needs to be merged first.**

Fourth in the chain of dependency udpates, parents are:
- https://github.com/woocommerce/woocommerce-android/pull/12229
- https://github.com/woocommerce/woocommerce-android/pull/12230
- https://github.com/woocommerce/woocommerce-android/pull/12231

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR explicitly declares androidx.transition-ktx dependency since it's used explicitly by our codebase but isn't declared in our build.gradle files. I also took the opportunity to update it as it's required for the Stripe migration.
[- Changelog 1.4.0 -> 1.5.1](https://developer.android.com/jetpack/androidx/releases/transition#version_15_2)

It also updates android material from 1.10.0 to 1.12.0 as that's another prerequisite for the Stripe migration.
- [Changelog 1.11.0](https://github.com/material-components/material-components-android/releases/tag/1.11.0)
- [Changelog 1.12.0](https://github.com/material-components/material-components-android/releases/tag/1.12.0)



### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

This is not a bug so there are no repro steps.



### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

We should smoke test the above changes just to be sure. Having said that, considering we are going to update other libraries this week, we need to perform more thorough smoke testing anyway, I suggest limiting testing of this PR to 10 minutes or so.

I smoke tested the following sections (Pixel 8 with Android 14):
- Order Creation
- Order Edit
- Product Detail + Image upload
- Blaze - haven't taken a payment as I don't have the proper setup.
- Reviews
- Inbox
- Customers


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No user facing changes

- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional): This is a dependency update so unit tests are irrelevant.
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->