### PR TITLE
Proper fix for broken TTP - Update Stripe Terminal SDK to 3.7.1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,11 +3,12 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 19.9
 -----
-- [*] [Internal] Update Android material from 1.9.0 to 1.10.0 [https://github.com/woocommerce/woocommerce-android/pull/12186]
-- [*] [Internal] Update Android-core from 1.12.0 to 1.13.1 [https://github.com/woocommerce/woocommerce-android/pull/12229]
-- [*] [Internal] Update Android-lifecycle from 2.6.2 to 2.7.0 [https://github.com/woocommerce/woocommerce-android/pull/12230]
-- [*] [Internal] Update Androidx-fragment from 1.6.2 to 1.8.2 [https://github.com/woocommerce/woocommerce-android/pull/12231]
-- [*] [Internal] Update Material to 1.12.0 and Transition to 1.5.1 [https://github.com/woocommerce/woocommerce-android/pull/12237]
+- [*****] [Internal] Update Android material from 1.9.0 to 1.10.0 [https://github.com/woocommerce/woocommerce-android/pull/12186]
+- [*****] [Internal] Update Android-core from 1.12.0 to 1.13.1 [https://github.com/woocommerce/woocommerce-android/pull/12229]
+- [*****] [Internal] Update Android-lifecycle from 2.6.2 to 2.7.0 [https://github.com/woocommerce/woocommerce-android/pull/12230]
+- [*****] [Internal] Update Androidx-fragment from 1.6.2 to 1.8.2 [https://github.com/woocommerce/woocommerce-android/pull/12231]
+- [*****] [Internal] Update Material to 1.12.0 and Transition to 1.5.1 [https://github.com/woocommerce/woocommerce-android/pull/12237]
+- [*****] [Internal] Update Stripe Terminal SDK from 3.1.1 to 3.7.1 [https://github.com/woocommerce/woocommerce-android/pull/12239]
 
 19.8
 -----

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -199,6 +199,7 @@
         <service
             android:name="org.wordpress.android.login.LoginWpcomService"
             android:exported="false"
+            android:foregroundServiceType="shortService"
             android:label="Login to WPCOM Service" />
 
         <meta-data

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -55,6 +55,6 @@ open class WooCommerce : Application(), HasAndroidInjector, Configuration.Provid
     override fun androidInjector(): AndroidInjector<Any> = androidInjector
 
     companion object {
-        private const val TAP_TO_PAY_STRIPE_PROCESS_NAME = "com.stripe.cots.aidlservice"
+        private const val TAP_TO_PAY_STRIPE_PROCESS_NAME = "com.woocommerce.android:stripelocalmobile"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -30,7 +30,7 @@ open class WooCommerce : Application(), HasAndroidInjector, Configuration.Provid
         //  > Caused by: java.lang.IllegalStateException: Default FirebaseApp is not initialized in this process
         //  > com.woocommerce.android:stripelocalmobile Make sure to call FirebaseApp.initializeApp(Context) first.
         // In this case we don't want to initialize any Firebase (or any at all) features of the app in their process.
-        if (getCurrentProcessName() == "$packageName:$TAP_TO_PAY_STRIPE_PROCESS_NAME_SUFFIX") return
+        if (getCurrentProcessName() == "${BuildConfig.APPLICATION_ID}:$TAP_TO_PAY_STRIPE_PROCESS_NAME_SUFFIX") return
 
         // Disables Volley debug logging on release build and prevents the "Marker added to finished log" crash
         // https://github.com/woocommerce/woocommerce-android/issues/817

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -30,7 +30,7 @@ open class WooCommerce : Application(), HasAndroidInjector, Configuration.Provid
         //  > Caused by: java.lang.IllegalStateException: Default FirebaseApp is not initialized in this process
         //  > com.stripe.cots.aidlservice. Make sure to call FirebaseApp.initializeApp(Context) first.
         // In this case we don't want to initialize any Firebase (or any at all) features of the app in their process.
-        if (getCurrentProcessName() == TAP_TO_PAY_STRIPE_PROCESS_NAME) return
+        if (getCurrentProcessName() == "$packageName:$TAP_TO_PAY_STRIPE_PROCESS_NAME_SUFFIX") return
 
         // Disables Volley debug logging on release build and prevents the "Marker added to finished log" crash
         // https://github.com/woocommerce/woocommerce-android/issues/817
@@ -55,6 +55,6 @@ open class WooCommerce : Application(), HasAndroidInjector, Configuration.Provid
     override fun androidInjector(): AndroidInjector<Any> = androidInjector
 
     companion object {
-        private const val TAP_TO_PAY_STRIPE_PROCESS_NAME = "com.woocommerce.android:stripelocalmobile"
+        private const val TAP_TO_PAY_STRIPE_PROCESS_NAME_SUFFIX = "stripelocalmobile"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/WooCommerce.kt
@@ -28,7 +28,7 @@ open class WooCommerce : Application(), HasAndroidInjector, Configuration.Provid
 
         // Stripe Tap to Pay library starts it's own process. That causes the crash:
         //  > Caused by: java.lang.IllegalStateException: Default FirebaseApp is not initialized in this process
-        //  > com.stripe.cots.aidlservice. Make sure to call FirebaseApp.initializeApp(Context) first.
+        //  > com.woocommerce.android:stripelocalmobile Make sure to call FirebaseApp.initializeApp(Context) first.
         // In this case we don't want to initialize any Firebase (or any at all) features of the app in their process.
         if (getCurrentProcessName() == "$packageName:$TAP_TO_PAY_STRIPE_PROCESS_NAME_SUFFIX") return
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatus.kt
@@ -19,7 +19,7 @@ class TapToPayAvailabilityStatus @Inject constructor(
 ) {
     operator fun invoke() =
         when {
-            !systemVersionUtilsWrapper.isAtLeastQ() -> Result.NotAvailable.SystemVersionNotSupported
+            !systemVersionUtilsWrapper.isAtLeastR() -> Result.NotAvailable.SystemVersionNotSupported
             !deviceFeatures.isGooglePlayServicesAvailable() -> Result.NotAvailable.GooglePlayServicesNotAvailable
             !deviceFeatures.isNFCAvailable() -> Result.NotAvailable.NfcNotAvailable
             !isTppSupportedInCountry() -> Result.NotAvailable.CountryNotSupported

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
@@ -64,10 +64,10 @@ class TapToPayAvailabilityStatusTest {
     }
 
     @Test
-    fun `given device has os less than Android 9, when invoking, then system is not supported returned`() {
+    fun `given device has os less than Android 10, when invoking, then system is not supported returned`() {
         whenever(deviceFeatures.isNFCAvailable()).thenReturn(true)
         whenever(deviceFeatures.isGooglePlayServicesAvailable()).thenReturn(true)
-        whenever(systemVersionUtilsWrapper.isAtLeastQ()).thenReturn(false)
+        whenever(systemVersionUtilsWrapper.isAtLeastR()).thenReturn(false)
 
         val result = availabilityStatus.invoke()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/taptopay/TapToPayAvailabilityStatusTest.kt
@@ -16,7 +16,7 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 
 class TapToPayAvailabilityStatusTest {
     private val systemVersionUtilsWrapper = mock<SystemVersionUtilsWrapper> {
-        on { isAtLeastQ() }.thenReturn(true)
+        on { isAtLeastR() }.thenReturn(true)
     }
     private val cardReaderCountryConfigProvider: CardReaderCountryConfigProvider = mock {
         on { provideCountryConfigFor("US") }.thenReturn(CardReaderConfigForUSA)
@@ -45,7 +45,7 @@ class TapToPayAvailabilityStatusTest {
     fun `given device has no NFC, when invoking, then nfc disabled returned`() {
         whenever(deviceFeatures.isNFCAvailable()).thenReturn(false)
         whenever(deviceFeatures.isGooglePlayServicesAvailable()).thenReturn(true)
-        whenever(systemVersionUtilsWrapper.isAtLeastQ()).thenReturn(true)
+        whenever(systemVersionUtilsWrapper.isAtLeastR()).thenReturn(true)
 
         val result = availabilityStatus.invoke()
 
@@ -56,7 +56,7 @@ class TapToPayAvailabilityStatusTest {
     fun `given device has no Google Play Services, when invoking, then GPS not available`() {
         whenever(deviceFeatures.isNFCAvailable()).thenReturn(true)
         whenever(deviceFeatures.isGooglePlayServicesAvailable()).thenReturn(false)
-        whenever(systemVersionUtilsWrapper.isAtLeastQ()).thenReturn(true)
+        whenever(systemVersionUtilsWrapper.isAtLeastR()).thenReturn(true)
 
         val result = availabilityStatus.invoke()
 
@@ -78,7 +78,7 @@ class TapToPayAvailabilityStatusTest {
     fun `given country other than US, when invoking, then country is not supported returned`() {
         whenever(deviceFeatures.isNFCAvailable()).thenReturn(true)
         whenever(deviceFeatures.isGooglePlayServicesAvailable()).thenReturn(true)
-        whenever(systemVersionUtilsWrapper.isAtLeastQ()).thenReturn(true)
+        whenever(systemVersionUtilsWrapper.isAtLeastR()).thenReturn(true)
         whenever(wooStore.getStoreCountryCode(siteModel)).thenReturn("RU")
 
         val result = availabilityStatus.invoke()
@@ -90,7 +90,7 @@ class TapToPayAvailabilityStatusTest {
     fun `given device satisfies all the requirements, when invoking, then tpp available returned`() {
         whenever(deviceFeatures.isNFCAvailable()).thenReturn(true)
         whenever(deviceFeatures.isGooglePlayServicesAvailable()).thenReturn(true)
-        whenever(systemVersionUtilsWrapper.isAtLeastQ()).thenReturn(true)
+        whenever(systemVersionUtilsWrapper.isAtLeastR()).thenReturn(true)
 
         val result = availabilityStatus.invoke()
 

--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ ext {
     automatticTracksVersion = '5.0.0'
     workManagerVersion = '2.7.1'
     billingVersion = '5.0.0'
-    stripeTerminalVersion = '3.1.1'
+    stripeTerminalVersion = '3.7.1'
     mlkitBarcodeScanningVersion = '17.2.0'
     mlkitTextRecognitionVersion = '16.0.0'
     androidxCameraVersion = '1.2.3'

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/RefundParams.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/RefundParams.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.cardreader.payments
 
 import com.stripe.stripeterminal.external.models.RefundParameters
+import com.stripe.stripeterminal.external.models.RefundParameters.Id
 import com.woocommerce.android.cardreader.internal.payments.PaymentUtils
 import java.math.BigDecimal
 
@@ -12,7 +13,7 @@ data class RefundParams(
 
 internal fun RefundParams.toStripeRefundParameters(paymentUtils: PaymentUtils): RefundParameters {
     return RefundParameters.Builder(
-        chargeId = this.chargeId,
+        Id.Charge(id = this.chargeId),
         amount = paymentUtils.convertToSmallestCurrencyUnit(this.amount, this.currency),
         currency = this.currency
     ).build()

--- a/settings.gradle
+++ b/settings.gradle
@@ -73,7 +73,7 @@ gradle.ext.mediaPickerSourceWordPressBinaryPath = "org.wordpress.mediapicker:sou
 
 gradle.ext {
     compileSdkVersion = 34
-    targetSdkVersion = 33
+    targetSdkVersion = 34
     minSdkVersion = 26
 }
 


### PR DESCRIPTION
### **This PR should be tested by at least two reviewers!**

<!-- Remember about a good descriptive title. -->
**Do not merge label - https://github.com/woocommerce/woocommerce-android/pull/12237 needs to be merged first.**

Fifth and final in the chain of dependency udpates, parents are:
- https://github.com/woocommerce/woocommerce-android/pull/12229
- https://github.com/woocommerce/woocommerce-android/pull/12230
- https://github.com/woocommerce/woocommerce-android/pull/12231
- https://github.com/woocommerce/woocommerce-android/pull/12237

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is the final PR in the chain of library updates 🥳.

We found out that TTP was broken on Android 14 since we updated targetSdkVersion to 34. As it turned out, this was an issue in the version of Stripe Terminal SDK we were using. We decided to downgrade back to targetSdkVersion 33 as a hotfix, since it felt safer then updating several dependencies in a hotfix. This PR reverts changes made in [the hotfix](https://github.com/woocommerce/woocommerce-android/pull/12184) and implements a proper fix - updates Stripe Terminal SDK to version 3.7.1 which contains a fix for this issue.

I'm intentionally not updating to Stripe Terminal SDK version 3.8.0 as it was released recently and doesn't seem to contain any critical updates. It feels safer to wait a few weeks.

Changelog can be found here
- [3.7.1](https://github.com/stripe/stripe-terminal-android/blob/master/CHANGELOG.md#371---2024-07-05)
- All changes between 3.1.1 and 3.7.1 need to be reviewed.

I haven't noticed any behavioral changes. One thing I updated was minimal supported Android version for TTP as it was upgraded by Stripe in version 3.3.0 - however,  TTP payments on Android 10 were disabled server-side by Stripe in April so this doesn't impact the users. They simply don't even see the TTP row anymore.

Update: I noticed Stripe updated the name of the TTP process they start in 3.7.0 => this was causing a crash, which is fixed in 512c0dcadd4e51782ebf7efa44a0a64180bdb713 and 54b3dccc1ba8e57bd0bd67f2dabf723c551ae24c and 590cd660c3e7ab03a8c76e277434dde6ad243cc5.



### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->


- Run the app on Android 14 on a TTP compatible device.
- Make sure to use the **release** build variant - minify needs to be enabled.

1. Open an unpaid order
2. Tap on Collect Payment
3. Select TTP
4. Notice the payment succeeds


- Run the app on Android 10
1. Open an unpaid order
2. Tap on Collect Payment
3. Notice TTP is not even available


### **Thoroughly test the app - focus on IPP and critical flows. This is the last PR in the chain of dependency updates and should be carefully tested before we proceed with the merge! We should test various devices, tablets/phones, RTL, ... .**


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
No user facing changes

- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional): This is a dependency update so unit tests are irrelevant.
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->