### PR TITLE
Adds text recognition for Japanese, Korean, and Chinese

### DIFF
--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -325,6 +325,10 @@ dependencies {
     implementation 'com.google.android.gms:play-services-code-scanner:16.1.0'
 
     implementation "com.google.mlkit:text-recognition:$mlkitTextRecognitionVersion"
+    implementation "com.google.android.gms:play-services-mlkit-text-recognition-japanese:$mlkitTextRecognitionVersion"
+    implementation "com.google.android.gms:play-services-mlkit-text-recognition-chinese:$mlkitTextRecognitionVersion"
+    implementation "com.google.android.gms:play-services-mlkit-text-recognition-korean:$mlkitTextRecognitionVersion"
+
     implementation "com.google.mlkit:barcode-scanning:$mlkitBarcodeScanningVersion"
 
     implementation "com.google.zxing:core:3.5.3"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/TextRecognitionEngine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/TextRecognitionEngine.kt
@@ -27,11 +27,6 @@ class TextRecognitionEngine @Inject constructor(
         const val KOREAN_LANGUAGE_CODE = "ko"
     }
 
-    private val generalTextRecognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
-    private val japaneseTextRecognizer = TextRecognition.getClient(JapaneseTextRecognizerOptions.Builder().build())
-    private val chineseTextRecognizer = TextRecognition.getClient(ChineseTextRecognizerOptions.Builder().build())
-    private val koreanTextRecognizer = TextRecognition.getClient(KoreanTextRecognizerOptions.Builder().build())
-
     @Suppress("TooGenericExceptionCaught")
     suspend fun processImage(imageUrl: String): Result<List<String>> {
         return try {
@@ -39,10 +34,10 @@ class TextRecognitionEngine @Inject constructor(
             val image = InputImage.fromBitmap(requireNotNull(bitmap), 0)
             val deviceLocale = Locale.getDefault().language
             val result = when (deviceLocale) {
-                JAPANESE_LANGUAGE_CODE -> japaneseTextRecognizer
-                CHINESE_LANGUAGE_CODE -> chineseTextRecognizer
-                KOREAN_LANGUAGE_CODE -> koreanTextRecognizer
-                else -> generalTextRecognizer
+                JAPANESE_LANGUAGE_CODE -> TextRecognition.getClient(JapaneseTextRecognizerOptions.Builder().build())
+                CHINESE_LANGUAGE_CODE -> TextRecognition.getClient(ChineseTextRecognizerOptions.Builder().build())
+                KOREAN_LANGUAGE_CODE -> TextRecognition.getClient(KoreanTextRecognizerOptions.Builder().build())
+                else -> TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
             }.process(image).await()
             Result.success(result.textBlocks.map { it.text })
         } catch (e: Exception) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/TextRecognitionEngine.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/TextRecognitionEngine.kt
@@ -8,24 +8,42 @@ import coil.request.ImageRequest.Builder
 import coil.request.SuccessResult
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.chinese.ChineseTextRecognizerOptions
+import com.google.mlkit.vision.text.japanese.JapaneseTextRecognizerOptions
+import com.google.mlkit.vision.text.korean.KoreanTextRecognizerOptions
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.woocommerce.android.util.WooLog
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.tasks.await
+import java.util.Locale
 import javax.inject.Inject
 
 class TextRecognitionEngine @Inject constructor(
     @ApplicationContext private val appContext: Context
 ) {
-    private val textRecognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+    private companion object {
+        const val JAPANESE_LANGUAGE_CODE = "ja"
+        const val CHINESE_LANGUAGE_CODE = "zh"
+        const val KOREAN_LANGUAGE_CODE = "ko"
+    }
+
+    private val generalTextRecognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+    private val japaneseTextRecognizer = TextRecognition.getClient(JapaneseTextRecognizerOptions.Builder().build())
+    private val chineseTextRecognizer = TextRecognition.getClient(ChineseTextRecognizerOptions.Builder().build())
+    private val koreanTextRecognizer = TextRecognition.getClient(KoreanTextRecognizerOptions.Builder().build())
 
     @Suppress("TooGenericExceptionCaught")
     suspend fun processImage(imageUrl: String): Result<List<String>> {
         return try {
             val bitmap = loadBitmap(imageUrl)
             val image = InputImage.fromBitmap(requireNotNull(bitmap), 0)
-
-            val result = textRecognizer.process(image).await()
+            val deviceLocale = Locale.getDefault().language
+            val result = when (deviceLocale) {
+                JAPANESE_LANGUAGE_CODE -> japaneseTextRecognizer
+                CHINESE_LANGUAGE_CODE -> chineseTextRecognizer
+                KOREAN_LANGUAGE_CODE -> koreanTextRecognizer
+                else -> generalTextRecognizer
+            }.process(image).await()
             Result.success(result.textBlocks.map { it.text })
         } catch (e: Exception) {
             WooLog.d(WooLog.T.AI, "Failed to scan text from image: ${e.message}")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12242 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes issues with scanning images with text in Chinese, Korean and Japanese. It adds the dependencies to scan text for these images. The way the dependencies will work in such a way that are only downloaded when the feature is required. 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
1. Log into a site with product creation with AI enabled (Jetpack AI enables or WP.com sites) 
2. With the app language set to English scan an image with Japanese or Chinese text. You can use this Japanese image for example: 
<img width="200"  src="https://github.com/user-attachments/assets/2c2f2594-ddc7-4d51-95a6-1d9bbabade02"> 

3. Check how the scanned text doesn't make any sense 
4. Now switch the app language to Japanese and retry the steps above. Check how the Japanese text is now properly scanned. 
5. Follow the screen recording for reference: 

https://github.com/user-attachments/assets/f47cdab2-8e72-4b1d-b76e-016e5830affe

