### PR TITLE
[Woo POS] Update scrolling visualisation of the lists shadows

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosLazyColumn.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosLazyColumn.kt
@@ -1,0 +1,119 @@
+package com.woocommerce.android.ui.woopos.common.composeui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosTheme
+import com.woocommerce.android.ui.woopos.common.composeui.toAdaptivePadding
+
+@Composable
+fun WooPosLazyColumn(
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(8.dp),
+    state: LazyListState = rememberLazyListState(),
+    content: LazyListScope.() -> Unit
+) {
+    Box {
+        LazyColumn(
+            modifier = modifier,
+            contentPadding = contentPadding,
+            verticalArrangement = verticalArrangement,
+            state = state,
+            content = content
+        )
+
+        val showShadow = remember {
+            derivedStateOf {
+                state.firstVisibleItemIndex > 0 || state.firstVisibleItemScrollOffset > 0
+            }
+        }
+
+        if (showShadow.value) {
+            val height = 16.dp.toAdaptivePadding()
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(height)
+                    .align(Alignment.TopCenter)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(height)
+                        .background(
+                            brush = Brush.horizontalGradient(
+                                colors = listOf(
+                                    Color.Transparent,
+                                    MaterialTheme.colors.onSurface.copy(alpha = .03f),
+                                    MaterialTheme.colors.onSurface.copy(alpha = .03f),
+                                    MaterialTheme.colors.onSurface.copy(alpha = .03f),
+                                    MaterialTheme.colors.onSurface.copy(alpha = .03f),
+                                    Color.Transparent,
+                                ),
+                                startX = 0f,
+                                endX = Float.POSITIVE_INFINITY
+                            )
+                        )
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(height)
+                        .background(
+                            brush = Brush.verticalGradient(
+                                colors = listOf(
+                                    MaterialTheme.colors.onSurface.copy(alpha = .1f),
+                                    Color.Transparent,
+                                ),
+                                startY = 0f,
+                                endY = height.value
+                            )
+                        )
+                )
+            }
+        }
+    }
+}
+
+@WooPosPreview
+@Composable
+fun WooPosLazyColumnPreview() {
+    WooPosTheme
+    WooPosLazyColumn {
+        items(10) { i ->
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                elevation = 4.dp,
+            ) {
+                Text(
+                    "Item $i",
+                    modifier = Modifier
+                        .height(64.dp)
+                        .fillMaxWidth(),
+                    style = MaterialTheme.typography.h6,
+                    color = MaterialTheme.colors.onSurface,
+                )
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosLazyColumn.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosLazyColumn.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
@@ -28,6 +27,7 @@ fun WooPosLazyColumn(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(0.dp),
     verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(8.dp),
+    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     state: LazyListState = rememberLazyListState(),
     content: LazyListScope.() -> Unit
 ) {
@@ -36,6 +36,7 @@ fun WooPosLazyColumn(
             modifier = modifier,
             contentPadding = contentPadding,
             verticalArrangement = verticalArrangement,
+            horizontalAlignment = horizontalAlignment,
             state = state,
             content = content
         )
@@ -48,10 +49,9 @@ fun WooPosLazyColumn(
 
         if (showShadow.value) {
             Card(
-                modifier = Modifier
+                modifier = modifier
                     .fillMaxWidth()
                     .height(0.5.dp)
-                    .padding(horizontal = .5.dp)
                     .align(Alignment.TopCenter),
                 elevation = 4.dp.toAdaptivePadding(),
                 backgroundColor = MaterialTheme.colors.onBackground.copy(alpha = 0.1f)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosLazyColumn.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosLazyColumn.kt
@@ -1,11 +1,11 @@
 package com.woocommerce.android.ui.woopos.common.composeui.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
@@ -18,8 +18,6 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosTheme
@@ -49,48 +47,15 @@ fun WooPosLazyColumn(
         }
 
         if (showShadow.value) {
-            val height = 16.dp.toAdaptivePadding()
-            Box(
+            Card(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(height)
-                    .align(Alignment.TopCenter)
-            ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(height)
-                        .background(
-                            brush = Brush.horizontalGradient(
-                                colors = listOf(
-                                    Color.Transparent,
-                                    MaterialTheme.colors.onSurface.copy(alpha = .03f),
-                                    MaterialTheme.colors.onSurface.copy(alpha = .03f),
-                                    MaterialTheme.colors.onSurface.copy(alpha = .03f),
-                                    MaterialTheme.colors.onSurface.copy(alpha = .03f),
-                                    Color.Transparent,
-                                ),
-                                startX = 0f,
-                                endX = Float.POSITIVE_INFINITY
-                            )
-                        )
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(height)
-                        .background(
-                            brush = Brush.verticalGradient(
-                                colors = listOf(
-                                    MaterialTheme.colors.onSurface.copy(alpha = .1f),
-                                    Color.Transparent,
-                                ),
-                                startY = 0f,
-                                endY = height.value
-                            )
-                        )
-                )
-            }
+                    .height(0.5.dp)
+                    .padding(horizontal = .5.dp)
+                    .align(Alignment.TopCenter),
+                elevation = 4.dp.toAdaptivePadding(),
+                backgroundColor = MaterialTheme.colors.onBackground.copy(alpha = 0.1f)
+            ) {}
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -57,6 +56,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosLazyColumn
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.toAdaptivePadding
 
@@ -81,6 +81,7 @@ private fun WooPosCartScreen(
                 top = 40.dp.toAdaptivePadding(),
                 bottom = 16.dp.toAdaptivePadding()
             )
+            .fillMaxSize()
             .background(MaterialTheme.colors.surface)
     ) {
         Column {
@@ -151,9 +152,8 @@ private fun CartBodyWithItems(
     val listState = rememberLazyListState()
     ScrollToBottomHandler(items, listState)
 
-    LazyColumn(
+    WooPosLazyColumn(
         modifier = Modifier
-            .fillMaxSize()
             .padding(horizontal = 16.dp.toAdaptivePadding()),
         state = listState,
         verticalArrangement = Arrangement.spacedBy(8.dp.toAdaptivePadding()),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -277,7 +276,7 @@ private fun ProductsList(
 
 @Composable
 fun ProductsLoadingIndicator() {
-    LazyColumn(
+    WooPosLazyColumn(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         contentPadding = PaddingValues(2.dp),
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsScreen.kt
@@ -64,6 +64,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.component.Button
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorState
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosLazyColumn
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.home.products.WooPosProductsUIEvent.EndOfProductListReached
@@ -244,7 +245,7 @@ private fun ProductsList(
     onEndOfProductsListReached: () -> Unit,
 ) {
     val listState = rememberLazyListState()
-    LazyColumn(
+    WooPosLazyColumn(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         contentPadding = PaddingValues(2.dp),
         state = listState,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12113
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Add shadows to the lists:
* Products
* Loading products
* Carts

To show that we are not at the top of the list


TfaZ4LUkEwEGrxfnEFzvJj-fi-2967_78574

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Scroll the lists mentioned above. Notice the shadow 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/7d6afee2-d42c-4117-93e2-b82276862b92

https://github.com/user-attachments/assets/0d40437a-36af-4d6e-b21a-bd3db540da05



- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->