### PR TITLE
Update ci toolkit to `3.5.1`

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
  # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
  # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
- export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.4.2"
+ export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.5.1"
  export TEST_COLLECTOR="test-collector#v1.10.1"


### PR DESCRIPTION
Tests with apostrophes, in case of failure, will be now annotated successfully by `annotate_test_failures`