### PR TITLE
Fix sync last update on background task

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateAnalyticsDataByRangeSelection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/background/UpdateAnalyticsDataByRangeSelection.kt
@@ -36,15 +36,14 @@ class UpdateAnalyticsDataByRangeSelection @Inject constructor(
                                 selectedRange,
                                 AnalyticsRepository.FetchStrategy.ForceNew
                             )
-                            if (result is AnalyticsRepository.RevenueResult.RevenueData) {
+                            val isSuccess = result is AnalyticsRepository.RevenueResult.RevenueData
+                            if (isSuccess) {
                                 analyticsUpdateDataStore.storeLastAnalyticsUpdate(
                                     selectedRange,
                                     AnalyticsUpdateDataStore.AnalyticData.REVENUE
                                 )
-                                true
-                            } else {
-                                false
                             }
+                            isSuccess
                         }
                     }
 
@@ -54,15 +53,14 @@ class UpdateAnalyticsDataByRangeSelection @Inject constructor(
                                 selectedRange,
                                 AnalyticsRepository.FetchStrategy.ForceNew
                             )
-                            if (result is AnalyticsRepository.OrdersResult.OrdersData) {
+                            val isSuccess = result is AnalyticsRepository.OrdersResult.OrdersData
+                            if (isSuccess) {
                                 analyticsUpdateDataStore.storeLastAnalyticsUpdate(
                                     selectedRange,
                                     AnalyticsUpdateDataStore.AnalyticData.ORDERS
                                 )
-                                true
-                            } else {
-                                false
                             }
+                            isSuccess
                         }
                     }
 
@@ -72,15 +70,14 @@ class UpdateAnalyticsDataByRangeSelection @Inject constructor(
                                 selectedRange,
                                 AnalyticsRepository.FetchStrategy.ForceNew
                             )
-                            if (result is AnalyticsRepository.ProductsResult.ProductsData) {
+                            val isSuccess = result is AnalyticsRepository.ProductsResult.ProductsData
+                            if (isSuccess) {
                                 analyticsUpdateDataStore.storeLastAnalyticsUpdate(
                                     selectedRange,
                                     AnalyticsUpdateDataStore.AnalyticData.TOP_PERFORMERS
                                 )
-                                true
-                            } else {
-                                false
                             }
+                            isSuccess
                         }
                     }
 


### PR DESCRIPTION
### Description
This PR fixes an issue detected in the Background Tasks beta testing: the last update timestamp does not sync after the data sync background task.

### Prerequisites

You can run this patch to Sync data when the app goes to the background (without waiting 4 hours)

<details>
  <summary>Patch</summary>

```
Subject: [PATCH] remove import
---
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt	(revision 1d8f79cb35b648dfb561b1e1e4a1ffabd69f7bdc)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt	(date 1722886015338)
@@ -476,10 +476,6 @@
             UpdateDataOnBackgroundWorker.REFRESH_TIME,
             TimeUnit.HOURS
         )
-            .setInitialDelay(
-                UpdateDataOnBackgroundWorker.REFRESH_TIME,
-                TimeUnit.HOURS
-            )
             .setConstraints(constraints)
             .build()
 
```
</details>

### Steps to reproduce
1. Run the app with the patch
2. Open the app
3. Send the app to background
4. Wait a few seconds (the background data synced event on LogCat `background_data_synced`)
5. Check that the last update timestamp was not synced.

### Testing information
1. Run the app with the patch
2. Open the app
3. Send the app to background
4. Wait a few seconds (the background data synced event on LogCat `background_data_synced`)
5. Check that the last update timestamp was synced.

- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->