### PR TITLE
[Woo POS] M2: Fix Pagination Issue on Pull-to-Refresh in POS Mode

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsScreen.kt
@@ -205,6 +205,7 @@ private fun ProductsToolbar(
                     }
                 }
             }
+
             else -> {
                 // no op
             }
@@ -269,7 +270,7 @@ private fun ProductsList(
             Spacer(modifier = Modifier.height(104.dp))
         }
     }
-    InfiniteListHandler(listState) {
+    InfiniteListHandler(listState, state) {
         onEndOfProductsListReached()
     }
 }
@@ -447,6 +448,7 @@ fun ProductsError(onRetryClicked: () -> Unit) {
 @Composable
 private fun InfiniteListHandler(
     listState: LazyListState,
+    state: WooPosProductsViewState.Content,
     onEndOfProductsListReached: () -> Unit
 ) {
     val buffer = 5
@@ -460,7 +462,7 @@ private fun InfiniteListHandler(
         }
     }
 
-    LaunchedEffect(loadMore) {
+    LaunchedEffect(state.reloadingProductsWithPullToRefresh) {
         snapshotFlow { loadMore.value }
             .distinctUntilChanged()
             .filter { it }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12240 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR addresses a bug where pagination was broken on the products screen in POS mode when performing a pull-to-refresh (PTR). Previously, the list would only load the first page of products after a PTR, causing issues with loading additional pages. The fix ensures that pagination functions correctly after a PTR, allowing all products to be loaded as expected.

Key Changes:

Updated the handling of the pagination logic to correctly re-evaluate after PTR.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
**Before this PR**
1. Navigate to POS mode from settings
2. Scroll the products list down and observe pagination works as expected
3. Pull-to-refresh the products list
4. Scroll the product list down again and observe that pagination breaks. Only first page products will be loaded

**After this PR**
1. Navigate to POS mode from settings
2. Scroll the products list down and observe pagination works as expected
3. Pull-to-refresh the products list
4. Scroll the product list down again and observe that pagination works as expected.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/05d70044-336e-49cf-85cc-31440deedfe3



- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
The changes are just in the UI. No unit tests are required
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
