### PR TITLE
[Bug] Disallow applying coupons and discounts together

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*****] [Internal] Update Androidx-fragment from 1.6.2 to 1.8.2 [https://github.com/woocommerce/woocommerce-android/pull/12231]
 - [*****] [Internal] Update Material to 1.12.0 and Transition to 1.5.1 [https://github.com/woocommerce/woocommerce-android/pull/12237]
 - [*****] [Internal] Update Stripe Terminal SDK from 3.1.1 to 3.7.1 [https://github.com/woocommerce/woocommerce-android/pull/12239]
+- [***] Fix logic behind handling enabled/disabled states of "+ Add coupon" and "+ Add discount" buttons in the Order creation/edition flow [https://github.com/woocommerce/woocommerce-android/pull/12263].
 
 19.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -853,7 +853,6 @@ class OrderCreateEditViewModel @Inject constructor(
 
     private fun Order.containsDiscounts(): Boolean = items.any { it.discount > BigDecimal.ZERO }
 
-
     private fun updateAddShippingButtonVisibility(order: Order) {
         viewState = viewState.copy(isAddShippingButtonEnabled = order.hasProducts() && order.isEditable)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -467,7 +467,7 @@ class OrderCreateEditViewModel @Inject constructor(
                             isEditable = order.isEditable
                         )
                         monitorOrderChanges()
-                        updateCouponButtonVisibility(order)
+                        updateCouponAndDiscountButtonsState(order)
                         updateAddShippingButtonVisibility(order)
                         updateAddGiftCardButtonVisibility(order)
                         handleCouponEditResult()
@@ -844,7 +844,7 @@ class OrderCreateEditViewModel @Inject constructor(
         }
     }
 
-    private fun updateCouponButtonVisibility(order: Order) {
+    private fun updateCouponAndDiscountButtonsState(order: Order) {
         viewState = viewState.copy(
             isCouponButtonEnabled = order.hasProducts() && order.isEditable && !order.containsDiscounts(),
             areDiscountButtonsEnabled = order.hasProducts() && order.isEditable && order.couponLines.isEmpty()
@@ -1514,7 +1514,7 @@ class OrderCreateEditViewModel @Inject constructor(
                                     updateStatus.order
                                 }
                             }.also {
-                                updateCouponButtonVisibility(it)
+                                updateCouponAndDiscountButtonsState(it)
                                 updateAddShippingButtonVisibility(it)
                                 updateAddGiftCardButtonVisibility(it)
                             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -845,8 +845,14 @@ class OrderCreateEditViewModel @Inject constructor(
     }
 
     private fun updateCouponButtonVisibility(order: Order) {
-        viewState = viewState.copy(isCouponButtonEnabled = order.hasProducts() && order.isEditable)
+        viewState = viewState.copy(
+            isCouponButtonEnabled = order.hasProducts() && order.isEditable && !order.containsDiscounts(),
+            areDiscountButtonsEnabled = order.hasProducts() && order.isEditable && order.couponLines.isEmpty()
+        )
     }
+
+    private fun Order.containsDiscounts(): Boolean = items.any { it.discount > BigDecimal.ZERO }
+
 
     private fun updateAddShippingButtonVisibility(order: Order) {
         viewState = viewState.copy(isAddShippingButtonEnabled = order.hasProducts() && order.isEditable)
@@ -2040,6 +2046,7 @@ class OrderCreateEditViewModel @Inject constructor(
         val isUpdatingOrderDraft: Boolean = false,
         val showOrderUpdateSnackbar: Boolean = false,
         val isCouponButtonEnabled: Boolean = false,
+        val areDiscountButtonsEnabled: Boolean = false,
         val isAddShippingButtonEnabled: Boolean = false,
         val isAddGiftCardButtonEnabled: Boolean = false,
         val shouldDisplayAddGiftCardButton: Boolean = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -846,12 +846,14 @@ class OrderCreateEditViewModel @Inject constructor(
 
     private fun updateCouponAndDiscountButtonsState(order: Order) {
         viewState = viewState.copy(
-            isCouponButtonEnabled = order.hasProducts() && order.isEditable && !order.containsDiscounts(),
-            areDiscountButtonsEnabled = order.hasProducts() && order.isEditable && order.couponLines.isEmpty()
+            isCouponButtonEnabled = order.hasProducts() && order.isEditable && order.doesNotContainManualDiscounts(),
+            areDiscountButtonsEnabled = order.hasProducts() && order.isEditable && !order.containsCoupons()
         )
     }
 
     private fun Order.containsDiscounts(): Boolean = items.any { it.discount > BigDecimal.ZERO }
+    private fun Order.containsCoupons(): Boolean = couponLines.isNotEmpty()
+    private fun Order.doesNotContainManualDiscounts() = (!containsDiscounts() || containsCoupons())
 
     private fun updateAddShippingButtonVisibility(order: Order) {
         viewState = viewState.copy(isAddShippingButtonEnabled = order.hasProducts() && order.isEditable)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -290,6 +290,7 @@ fun ExpandableProductCard(
     }
 }
 
+@Suppress("DestructuringDeclarationWithTooManyEntries")
 @Composable
 fun ExtendedProductCardContent(
     state: State<OrderCreateEditViewModel.ViewState?>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -307,7 +307,7 @@ fun ExtendedProductCardContent(
             bottomDivider,
             orderCount,
             price,
-            discountButton,
+            addDiscountButton,
             discountAmount,
             priceAfterDiscountLabel,
             priceAfterDiscountValue,
@@ -322,6 +322,7 @@ fun ExtendedProductCardContent(
         // The logic to update bundled products quantity is complex so we need to prevent any change while we are
         // updating the bundle and inner products quantity
         val isBundledProduct = product.productInfo.productType == ProductType.BUNDLE
+        val discountButtonsEnabled = state.value?.areDiscountButtonsEnabled == true
 
         Divider(
             modifier = Modifier
@@ -399,11 +400,11 @@ fun ExtendedProductCardContent(
         }
         if (product.productInfo.hasDiscount) {
             WCTextButton(
-                modifier = Modifier.constrainAs(discountButton) {
+                modifier = Modifier.constrainAs(addDiscountButton) {
                     top.linkTo(price.bottom)
                 },
                 onClick = onDiscountButtonClicked,
-                enabled = editableControlsEnabled
+                enabled = editableControlsEnabled && discountButtonsEnabled
             ) {
                 Text(
                     text = stringResource(id = R.string.discount),
@@ -421,8 +422,8 @@ fun ExtendedProductCardContent(
                     .padding(horizontal = dimensionResource(id = R.dimen.minor_100))
                     .constrainAs(discountAmount) {
                         end.linkTo(parent.end)
-                        top.linkTo(discountButton.top)
-                        bottom.linkTo(discountButton.bottom)
+                        top.linkTo(addDiscountButton.top)
+                        bottom.linkTo(addDiscountButton.bottom)
                     },
                 text = "-${product.productInfo.discountAmount}",
                 color = colorResource(id = R.color.woo_green_50)
@@ -430,7 +431,7 @@ fun ExtendedProductCardContent(
             Text(
                 modifier = Modifier
                     .constrainAs(priceAfterDiscountLabel) {
-                        top.linkTo(discountButton.bottom)
+                        top.linkTo(addDiscountButton.bottom)
                         start.linkTo(parent.start)
                         bottom.linkTo(bottomDivider.top)
                     }
@@ -451,12 +452,12 @@ fun ExtendedProductCardContent(
             )
         } else {
             WCTextButton(
-                modifier = Modifier.constrainAs(discountButton) {
+                modifier = Modifier.constrainAs(addDiscountButton) {
                     top.linkTo(price.bottom)
                     bottom.linkTo(bottomDivider.top)
                 },
                 onClick = onDiscountButtonClicked,
-                enabled = editableControlsEnabled
+                enabled = editableControlsEnabled && discountButtonsEnabled,
             ) {
                 Icon(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_add),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
@@ -337,6 +337,157 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
     }
 
     @Test
+    fun `given coupon applied to order, then should disable adding discount to a product`() {
+        initMocksForAnalyticsWithOrder(defaultOrderValue)
+        val order = defaultOrderValue.copy(
+            isEditable = true,
+            items = listOf(
+                Order.Item(
+                    1L,
+                    1L,
+                    "name",
+                    BigDecimal(1),
+                    "",
+                    1f,
+                    BigDecimal(1),
+                    BigDecimal(1),
+                    BigDecimal(1),
+                    1L,
+                    listOf()
+                )
+            ),
+            couponLines = listOf(Order.CouponLine("code", 1L, ""))
+        )
+        orderDetailRepository.stub {
+            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+        }
+        createUpdateOrderUseCase = mock {
+            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+        }
+        createSut()
+        var orderDraft: Order? = null
+        sut.orderDraft.observeForever {
+            orderDraft = it
+        }
+        assertTrue(orderDraft!!.couponLines.isNotEmpty())
+        var lastReceivedState: OrderCreateEditViewModel.ViewState? = null
+        sut.viewStateData.liveData.observeForever {
+            lastReceivedState = it
+        }
+        assertFalse(lastReceivedState!!.areDiscountButtonsEnabled)
+    }
+
+    @Test
+    fun `given no coupons applied to order, then should enable adding discount to a product`() {
+        initMocksForAnalyticsWithOrder(defaultOrderValue)
+        val order = defaultOrderValue.copy(
+            isEditable = true,
+            items = listOf(
+                Order.Item(
+                    1L,
+                    1L,
+                    "name",
+                    BigDecimal(1),
+                    "",
+                    1f,
+                    BigDecimal(1),
+                    BigDecimal(1),
+                    BigDecimal(1),
+                    1L,
+                    listOf()
+                )
+            ),
+        )
+        orderDetailRepository.stub {
+            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+        }
+        createUpdateOrderUseCase = mock {
+            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+        }
+        createSut()
+        var orderDraft: Order? = null
+        sut.orderDraft.observeForever {
+            orderDraft = it
+        }
+        assertTrue(orderDraft!!.couponLines.isEmpty())
+        var lastReceivedState: OrderCreateEditViewModel.ViewState? = null
+        sut.viewStateData.liveData.observeForever {
+            lastReceivedState = it
+        }
+        assertTrue(lastReceivedState!!.areDiscountButtonsEnabled)
+    }
+
+    @Test
+    fun `given discount applied to at least item, then should disable adding coupon to the order`() {
+        initMocksForAnalyticsWithOrder(defaultOrderValue)
+        val item = Order.Item(
+            itemId = 1L,
+            productId = 1L,
+            name = "name",
+            price = BigDecimal(1),
+            sku = "",
+            quantity = 1f,
+            subtotal = BigDecimal(10),
+            totalTax = BigDecimal(5),
+            total = BigDecimal(1),
+            variationId = 1L,
+            attributesList = listOf()
+        )
+        val order = defaultOrderValue.copy(
+            isEditable = true,
+            items = listOf(item),
+        )
+        orderDetailRepository.stub {
+            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+        }
+        createUpdateOrderUseCase = mock {
+            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+        }
+        createSut()
+        var lastReceivedState: OrderCreateEditViewModel.ViewState? = null
+        sut.viewStateData.liveData.observeForever {
+            lastReceivedState = it
+        }
+        assertTrue(item.discount > BigDecimal.ZERO)
+        assertFalse(lastReceivedState!!.isCouponButtonEnabled)
+    }
+
+    @Test
+    fun `given no discounts applied to order items, then should disable adding coupon to the order`() {
+        initMocksForAnalyticsWithOrder(defaultOrderValue)
+        val item = Order.Item(
+            itemId = 1L,
+            productId = 1L,
+            name = "name",
+            price = BigDecimal(1),
+            sku = "",
+            quantity = 1f,
+            subtotal = BigDecimal(10),
+            totalTax = BigDecimal(1),
+            total = BigDecimal(10),
+            variationId = 1L,
+            attributesList = listOf()
+        )
+        val order = defaultOrderValue.copy(
+            isEditable = true,
+            items = listOf(item),
+        )
+        orderDetailRepository.stub {
+            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+        }
+        createUpdateOrderUseCase = mock {
+            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+        }
+        createSut()
+        var lastReceivedState: OrderCreateEditViewModel.ViewState? = null
+        sut.viewStateData.liveData.observeForever {
+            lastReceivedState = it
+        }
+        assertTrue(item.discount == BigDecimal.ZERO)
+        assertTrue(lastReceivedState!!.isCouponButtonEnabled)
+    }
+
+    @Test
     fun `given editable order and order paid, then set tax rate button should be disabled`() {
         testBlocking {
             initMocksForAnalyticsWithOrder(defaultOrderValue)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
@@ -338,6 +338,7 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
 
     @Test
     fun `given coupon applied to order, then should disable adding discount to a product`() {
+        // given
         initMocksForAnalyticsWithOrder(defaultOrderValue)
         val order = defaultOrderValue.copy(
             isEditable = true,
@@ -374,11 +375,13 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
         sut.viewStateData.liveData.observeForever {
             lastReceivedState = it
         }
+        // then
         assertFalse(lastReceivedState!!.areDiscountButtonsEnabled)
     }
 
     @Test
     fun `given no coupons applied to order, then should enable adding discount to a product`() {
+        // given
         initMocksForAnalyticsWithOrder(defaultOrderValue)
         val order = defaultOrderValue.copy(
             isEditable = true,
@@ -414,11 +417,13 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
         sut.viewStateData.liveData.observeForever {
             lastReceivedState = it
         }
+        // then
         assertTrue(lastReceivedState!!.areDiscountButtonsEnabled)
     }
 
     @Test
-    fun `given discount applied to at least item, then should disable adding coupon to the order`() {
+    fun `given discount applied to at least one item, then should disable adding coupon to the order`() {
+        // given
         initMocksForAnalyticsWithOrder(defaultOrderValue)
         val item = Order.Item(
             itemId = 1L,
@@ -448,12 +453,14 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
         sut.viewStateData.liveData.observeForever {
             lastReceivedState = it
         }
+        // then
         assertTrue(item.discount > BigDecimal.ZERO)
         assertFalse(lastReceivedState!!.isCouponButtonEnabled)
     }
 
     @Test
     fun `given no discounts applied to order items, then should disable adding coupon to the order`() {
+        // given
         initMocksForAnalyticsWithOrder(defaultOrderValue)
         val item = Order.Item(
             itemId = 1L,
@@ -483,6 +490,7 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
         sut.viewStateData.liveData.observeForever {
             lastReceivedState = it
         }
+        // then
         assertTrue(item.discount == BigDecimal.ZERO)
         assertTrue(lastReceivedState!!.isCouponButtonEnabled)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
# Disallow applying coupons and discounts together 

Closes: #12259 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR intends to fix the logic behind the enabled/disabled states of "+ Add coupon" and "+ Add discount" buttons in the Order creation/edition flow.

The intended behavior is that only a manual product discount or a coupon discount can be applied at the same time. We can't mix both of them because the backend will take into account only the coupon (if applied to the order) and ignore the manual discounts.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Steps to reproduce the misbehavior:

1. Create an order
2. Add a product
3. Apply an item discount
4. Apply a coupon
5. Notice only the coupon is taken into account.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Verify that:
* Whenever a discount is applied to the item, the "+ Add coupon" button is disabled.
* Whenever a coupon is applied to the order, all "+ Add discount" buttons are disabled.
* If no coupon is applied to the order, it is possible to add discounts to multiple products.
* If no manual discount is applied to order items, it is possible to add one or more coupons to the order.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/baee8e7d-7923-4d28-94b1-ca15e406e567

- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->