### PR TITLE
[Tooling] Release-on-CI automation improvements

### DIFF
--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -35,4 +35,5 @@ steps:
       - slack: "#build-and-ship"
     retry:
       manual:
+        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -33,3 +33,6 @@ steps:
     if: build.env('INCLUDE_WEAR_APP') == "true"
     notify:
       - slack: "#build-and-ship"
+    retry:
+      manual:
+        allowed: false

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -20,4 +20,5 @@ steps:
         queue: "tumblr-metal"
     retry:
       manual:
+        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -18,3 +18,6 @@ steps:
       bundle exec fastlane complete_code_freeze skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
     agents:
         queue: "tumblr-metal"
+    retry:
+      manual:
+        allowed: false

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -20,4 +20,5 @@ steps:
         queue: "tumblr-metal"
     retry:
       manual:
+        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -18,3 +18,6 @@ steps:
       bundle exec fastlane finalize_hotfix_release skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
     agents:
         queue: "tumblr-metal"
+    retry:
+      manual:
+        allowed: false

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -20,4 +20,5 @@ steps:
         queue: "tumblr-metal"
     retry:
       manual:
+        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -18,3 +18,6 @@ steps:
       bundle exec fastlane finalize_release skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
     agents:
         queue: "tumblr-metal"
+    retry:
+      manual:
+        allowed: false

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -20,4 +20,5 @@ steps:
         queue: "tumblr-metal"
     retry:
       manual:
+        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -18,3 +18,6 @@ steps:
       bundle exec fastlane new_beta_release skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
     agents:
         queue: "tumblr-metal"
+    retry:
+      manual:
+        allowed: false

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -23,3 +23,6 @@ steps:
       bundle exec fastlane new_hotfix_release version_name:${VERSION} version_code:${VERSION_CODE} skip_confirm:true
     agents:
         queue: "tumblr-metal"
+    retry:
+      manual:
+        allowed: false

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -25,4 +25,5 @@ steps:
         queue: "tumblr-metal"
     retry:
       manual:
+        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -15,3 +15,6 @@ steps:
       bundle exec fastlane start_code_freeze skip_confirm:true
     agents:
         queue: "tumblr-metal"
+    retry:
+      manual:
+        allowed: false

--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -17,4 +17,5 @@ steps:
         queue: "tumblr-metal"
     retry:
       manual:
+        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -106,7 +106,7 @@ platform :android do
   # Release Lanes
   ########################################################################
 
-  # This lane executes the steps planned on code freeze, creating new release branch from the current trunk.
+  # This lane executes the steps planned on code freeze, creating a new release branch from the current trunk.
   #
   # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
   #
@@ -132,8 +132,11 @@ platform :android do
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
     # Create the release branch
+    new_release_branch = "release/#{release_version_next}"
+    ensure_branch_does_not_exist(new_release_branch)
+
     UI.message 'Creating release branch...'
-    Fastlane::Helper::GitHelper.create_branch("release/#{release_version_next}", from: DEFAULT_BRANCH)
+    Fastlane::Helper::GitHelper.create_branch(new_release_branch, from: DEFAULT_BRANCH)
     UI.success("Done! New release branch is: #{git_branch}")
 
     # Bump the version and build code
@@ -1307,6 +1310,17 @@ def ensure_git_branch_is_release_branch
   # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
   ensure_git_branch(branch: '^release/')
 end
+
+def ensure_branch_does_not_exist(branch_name)
+  return unless Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: branch_name)
+
+  error_message = "The branch `#{branch_name}` already exists. Please check first if there is an existing Pull Request that needs to be merged or closed first, " \
+                  'or delete the branch to then run again the release task.'
+
+  UI.user_error!(error_message)
+  buildkite_annotate(style: 'error', context: 'error-checking-branch', message: error_message) if is_ci
+end
+
 def report_milestone_error(error_title:)
   error_message = <<-MESSAGE
     #{error_title}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -133,7 +133,7 @@ platform :android do
 
     # Create the release branch
     new_release_branch = "release/#{release_version_next}"
-    ensure_branch_does_not_exist(new_release_branch)
+    ensure_branch_does_not_exist!(new_release_branch)
 
     UI.message 'Creating release branch...'
     Fastlane::Helper::GitHelper.create_branch(new_release_branch, from: DEFAULT_BRANCH)
@@ -179,18 +179,18 @@ platform :android do
     )
 
     begin
-      # Add ❄️ marker to milestone title to indicate we entered code-freeze
-      set_milestone_frozen_marker(
-        repository: GITHUB_REPO,
-        milestone: new_version
-      )
-
       # Move PRs to next milestone
       moved_prs = update_assigned_milestone(
         repository: GITHUB_REPO,
         from_milestone: new_version,
         to_milestone: release_version_next,
         comment: "Version `#{new_version}` has now entered code-freeze, so the milestone of this PR has been updated to `#{release_version_next}`."
+      )
+
+      # Add ❄️ marker to milestone title to indicate we entered code-freeze
+      set_milestone_frozen_marker(
+        repository: GITHUB_REPO,
+        milestone: new_version
       )
     rescue StandardError => e
       moved_prs = []
@@ -222,10 +222,8 @@ platform :android do
   lane :complete_code_freeze do |skip_confirm: false, include_wear_app: false|
     check_for_toolkit_updates unless is_ci || ENV['FASTLANE_SKIP_TOOLKIT_UPDATE_CHECK']
 
-    # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
-
-    ensure_git_branch_is_release_branch
+    ensure_git_branch_is_release_branch!
 
     UI.important("Completing code freeze for: #{release_version_current}")
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
@@ -238,7 +236,7 @@ platform :android do
 
     trigger_release_build(branch_to_build: "release/#{release_version_current}", include_wear_app: include_wear_app)
 
-    create_backmerge_pr(version: release_version_current)
+    create_backmerge_pr
   end
 
   # Updates the `PlayStoreStrings.pot` file with the latest content from the `release_notes.txt` files and the other text sources.
@@ -297,10 +295,8 @@ platform :android do
   #
   desc 'Updates a release branch for a new beta release'
   lane :new_beta_release do |skip_confirm: false, include_wear_app: false|
-    # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
-
-    ensure_git_branch_is_release_branch
+    ensure_git_branch_is_release_branch!
 
     # Check versions
     message = <<-MESSAGE
@@ -318,7 +314,7 @@ platform :android do
 
     # Bump the release version and build code
     UI.message 'Bumping beta version and build code...'
-    ensure_git_branch_is_release_branch
+    ensure_git_branch_is_release_branch!
     VERSION_FILE.write_version(
       version_name: beta_version_next,
       version_code: build_code_next
@@ -333,7 +329,7 @@ platform :android do
 
     trigger_release_build(branch_to_build: "release/#{release_version_current}", include_wear_app: include_wear_app)
 
-    create_backmerge_pr(version: release_version_current)
+    create_backmerge_pr
   end
 
   #####################################################################################
@@ -347,7 +343,6 @@ platform :android do
   #
   desc 'Prepare a new hotfix branch cut from the previous tag, and bump the version'
   lane :new_hotfix_release do |version_name:, version_code:, skip_confirm: false|
-    # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
 
     # Parse the provided version into an AppVersion object
@@ -403,8 +398,7 @@ platform :android do
   #
   lane :finalize_hotfix_release do |skip_confirm: false, include_wear_app: false|
     ensure_git_status_clean
-
-    ensure_git_branch_is_release_branch
+    ensure_git_branch_is_release_branch!
 
     hotfix_version = release_version_current
 
@@ -413,7 +407,7 @@ platform :android do
 
     trigger_release_build(branch_to_build: "release/#{hotfix_version}", include_wear_app: include_wear_app)
 
-    create_backmerge_pr(version: hotfix_version)
+    create_backmerge_pr
 
     # Close hotfix milestone
     begin
@@ -454,10 +448,8 @@ platform :android do
   lane :finalize_release do |skip_confirm: false, include_wear_app: false|
     UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if android_current_branch_is_hotfix(version_properties_path: VERSION_PROPERTIES_PATH)
 
-    # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
-
-    ensure_git_branch_is_release_branch
+    ensure_git_branch_is_release_branch!
 
     UI.important("Finalizing release: #{release_version_current}")
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
@@ -490,7 +482,7 @@ platform :android do
 
     trigger_release_build(branch_to_build: "release/#{version}", include_wear_app: include_wear_app)
 
-    create_backmerge_pr(version: version)
+    create_backmerge_pr
 
     remove_branch_protection(
       repository: GITHUB_REPO,
@@ -574,11 +566,10 @@ platform :android do
   #
   desc 'Builds and uploads release for distribution'
   lane :build_and_upload_release do |options|
-    ensure_git_branch_is_release_branch unless is_ci
+    ensure_git_branch_is_release_branch! unless is_ci
+    ensure_git_status_clean unless is_ci
 
     UI.user_error!("Can't build a final release out of this branch because it's configured as a beta release!") if beta_version?(version_name_current)
-
-    ensure_git_status_clean unless is_ci
 
     app = get_app_param!(options)
     message = "Building `#{app}` version #{release_version_current} (#{build_code_current}) for upload to Release Channel"
@@ -628,8 +619,7 @@ platform :android do
   #
   desc 'Builds and uploads a new beta build to Google Play (without releasing it)'
   lane :build_and_upload_beta do |options|
-    ensure_git_branch_is_release_branch unless is_ci
-
+    ensure_git_branch_is_release_branch! unless is_ci
     ensure_git_status_clean unless is_ci
 
     app = get_app_param!(options)
@@ -1287,38 +1277,41 @@ end
 # -----------------------------------------------------------------------------------
 # Release Management Utils
 # -----------------------------------------------------------------------------------
-def create_backmerge_pr(version:)
+def create_backmerge_pr
+  version = release_version_current
+
   create_release_backmerge_pull_request(
     repository: GITHUB_REPO,
     source_branch: "release/#{version}",
     labels: ['Releases'],
-    milestone_title: version
+    milestone_title: release_version_next
   )
 rescue StandardError => e
   error_message = <<-MESSAGE
       Error creating backmerge pull request: #{e.message}
-      - If this is a retry of the lane, the backmerge PR for the version `#{version}` might have already been previously created.
-      Please close any previous backmerge PR for `#{version}`, also deleting the merge branch, and then run again the release task.
+      - If you are running the release task again, the backmerge PR for the version `#{version}` might have already been previously created.
+      Please close any previous backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.
   MESSAGE
 
-  UI.user_error!(error_message)
-
   buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: error_message) if is_ci
+
+  UI.user_error!(error_message)
 end
 
-def ensure_git_branch_is_release_branch
+def ensure_git_branch_is_release_branch!
   # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
   ensure_git_branch(branch: '^release/')
 end
 
-def ensure_branch_does_not_exist(branch_name)
+def ensure_branch_does_not_exist!(branch_name)
   return unless Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: branch_name)
 
   error_message = "The branch `#{branch_name}` already exists. Please check first if there is an existing Pull Request that needs to be merged or closed first, " \
                   'or delete the branch to then run again the release task.'
 
-  UI.user_error!(error_message)
   buildkite_annotate(style: 'error', context: 'error-checking-branch', message: error_message) if is_ci
+
+  UI.user_error!(error_message)
 end
 
 def report_milestone_error(error_title:)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1292,12 +1292,12 @@ end
 # Release Management Utils
 # -----------------------------------------------------------------------------------
 def create_backmerge_pr(version:)
-    create_release_backmerge_pull_request(
-      repository: GITHUB_REPO,
-      source_branch: "release/#{version}",
-      labels: ['Releases'],
-      milestone_title: version
-    )
+  create_release_backmerge_pull_request(
+    repository: GITHUB_REPO,
+    source_branch: "release/#{version}",
+    labels: ['Releases'],
+    milestone_title: version
+  )
 end
 
 def ensure_git_branch_is_release_branch

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1288,9 +1288,9 @@ def create_backmerge_pr
   )
 rescue StandardError => e
   error_message = <<-MESSAGE
-      Error creating backmerge pull request: #{e.message}
-      - If you are running the release task again, the backmerge PR for the version `#{version}` might have already been previously created.
-      Please close any previous backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.
+    Error creating backmerge pull request: #{e.message}
+    - If this is not the first time you are running the release task, the backmerge PR for the version `#{version}` might have already been previously created.
+    Please close any previous backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.
   MESSAGE
 
   buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: error_message) if is_ci

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -168,16 +168,36 @@ platform :android do
 
     push_to_git_remote(tags: false)
 
-    # Update GitHub branch protection and milestone name
+    # Protect release/* branch
     copy_branch_protection(
       repository: GITHUB_REPO,
       from_branch: DEFAULT_BRANCH,
       to_branch: "release/#{new_version}"
     )
+    # Add ❄️ marker to milestone title to indicate we entered code-freeze
     set_milestone_frozen_marker(
       repository: GITHUB_REPO,
       milestone: new_version
     )
+
+    # Move PRs to next milestone
+    moved_prs = update_assigned_milestone(
+      repository: GITHUB_REPO,
+      from_milestone: new_version,
+      to_milestone: release_version_next,
+      comment: "Version `#{new_version}` has now entered code-freeze, so the milestone of this PR has been updated to `#{release_version_next}`."
+    )
+    UI.message("Moved the following PRs to milestone #{release_version_next}: #{moved_prs.join(', ')}")
+
+    # Annotate the build with the moved PRs
+    moved_prs_info = if moved_prs.empty?
+                       "👍 No open PR were targeting `#{new_version}` at the time of code-freeze"
+                     else
+                       "#{moved_prs.count} PRs targeting `#{new_version}` were still open and thus moved to `#{release_version_next}`:\n" \
+                         + moved_prs.map { |pr_num| "[##{pr_num}](https://github.com/#{GITHUB_REPO}/pull/#{pr_num})" }.join(', ')
+                     end
+
+    buildkite_annotate(style: moved_prs.empty? ? 'success' : 'warning', context: 'start-code-freeze-wcios', message: moved_prs_info) if is_ci
   end
 
   # This lane executes the last steps planned on code freeze, creating a new release branch from the current trunk

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -174,19 +174,27 @@ platform :android do
       from_branch: DEFAULT_BRANCH,
       to_branch: "release/#{new_version}"
     )
-    # Add ❄️ marker to milestone title to indicate we entered code-freeze
-    set_milestone_frozen_marker(
-      repository: GITHUB_REPO,
-      milestone: new_version
-    )
 
-    # Move PRs to next milestone
-    moved_prs = update_assigned_milestone(
-      repository: GITHUB_REPO,
-      from_milestone: new_version,
-      to_milestone: release_version_next,
-      comment: "Version `#{new_version}` has now entered code-freeze, so the milestone of this PR has been updated to `#{release_version_next}`."
-    )
+    begin
+      # Add ❄️ marker to milestone title to indicate we entered code-freeze
+      set_milestone_frozen_marker(
+        repository: GITHUB_REPO,
+        milestone: new_version
+      )
+
+      # Move PRs to next milestone
+      moved_prs = update_assigned_milestone(
+        repository: GITHUB_REPO,
+        from_milestone: new_version,
+        to_milestone: release_version_next,
+        comment: "Version `#{new_version}` has now entered code-freeze, so the milestone of this PR has been updated to `#{release_version_next}`."
+      )
+    rescue StandardError => e
+      moved_prs = []
+
+      report_milestone_error(error_title: "Error freezing milestone `#{new_version}`: #{e.message}")
+    end
+
     UI.message("Moved the following PRs to milestone #{release_version_next}: #{moved_prs.join(', ')}")
 
     # Annotate the build with the moved PRs
@@ -411,15 +419,7 @@ platform :android do
         milestone: hotfix_version
       )
     rescue StandardError => e
-      error_message = <<-MESSAGE
-        Error closing milestone `#{hotfix_version}`: #{e.message}
-        - If this is a retry of the lane, the milestone might have already been closed and this error is expected.
-        - If this is the first run of the lane, please investigate the error.
-      MESSAGE
-
-      UI.error(error_message)
-
-      buildkite_annotate(style: 'warning', context: 'finalize-hotfix-error-closing-milestone', message: error_message) if is_ci
+      report_milestone_error(error_title: "Error closing milestone `#{hotfix_version}`: #{e.message}")
     end
   end
 
@@ -489,12 +489,13 @@ platform :android do
 
     create_backmerge_pr(version: version)
 
+    remove_branch_protection(
+      repository: GITHUB_REPO,
+      branch: "release/#{version}"
+    )
+
     # Close milestone
     begin
-      remove_branch_protection(
-        repository: GITHUB_REPO,
-        branch: "release/#{version}"
-      )
       set_milestone_frozen_marker(
         repository: GITHUB_REPO,
         milestone: version,
@@ -505,15 +506,7 @@ platform :android do
         milestone: version
       )
     rescue StandardError => e
-      error_message = <<-MESSAGE
-        Error closing milestone `#{app_version}`: #{e.message}
-        - If this is a retry of the lane, the milestone might have already been closed and this error is expected.
-        - If this is the first run of the lane, please investigate the error.
-      MESSAGE
-
-      UI.error(error_message)
-
-      buildkite_annotate(style: 'warning', context: 'finalize-release-error-milestone', message: error_message) if is_ci
+      report_milestone_error(error_title: "Error closing milestone `#{version}`: #{e.message}")
     end
   end
 
@@ -1298,9 +1291,30 @@ def create_backmerge_pr(version:)
     labels: ['Releases'],
     milestone_title: version
   )
+rescue StandardError => e
+  error_message = <<-MESSAGE
+      Error creating backmerge pull request: #{e.message}
+      - If this is a retry of the lane, the backmerge PR for the version `#{version}` might have already been previously created.
+      Please close any previous backmerge PR for `#{version}`, also deleting the merge branch, and then run again the release task.
+  MESSAGE
+
+  UI.user_error!(error_message)
+
+  buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: error_message) if is_ci
 end
 
 def ensure_git_branch_is_release_branch
   # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
   ensure_git_branch(branch: '^release/')
+end
+def report_milestone_error(error_title:)
+  error_message = <<-MESSAGE
+    #{error_title}
+    - If this is a retry of the lane, the milestone might have already been closed and this error is expected.
+    - If this is the first run of the lane, please investigate the error.
+  MESSAGE
+
+  UI.error(error_message)
+
+  buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -689,7 +689,7 @@ platform :android do
     )
 
     message = "This build triggered a release build on <code>#{branch}</code>:<br>- #{build_url}"
-    buildkite_annotate(style: 'info', context: 'trigger-release-build-doandroid', message: message) if is_ci
+    buildkite_annotate(style: 'info', context: 'trigger-release-build', message: message) if is_ci
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -207,17 +207,7 @@ platform :android do
 
     trigger_release_build(branch_to_build: "release/#{release_version_current}", include_wear_app: include_wear_app)
 
-    # Create an intermediate branch
-    new_intermediate_branch_name = "merge/#{release_version_current}-code-freeze-into-#{DEFAULT_BRANCH}"
-    Fastlane::Helper::GitHelper.create_branch(new_intermediate_branch_name)
-
-    # Push up the intermediate branch
-    push_to_git_remote(tags: false)
-
-    create_release_management_pull_request(
-      base_branch: DEFAULT_BRANCH,
-      title: "Merge #{release_version_current} code freeze to #{DEFAULT_BRANCH}"
-    )
+    create_backmerge_pr(version: release_version_current)
   end
 
   # Updates the `PlayStoreStrings.pot` file with the latest content from the `release_notes.txt` files and the other text sources.
@@ -312,17 +302,7 @@ platform :android do
 
     trigger_release_build(branch_to_build: "release/#{release_version_current}", include_wear_app: include_wear_app)
 
-    # Create an intermediate branch
-    new_intermediate_branch_name = "merge/#{version_name_current}-into-#{DEFAULT_BRANCH}"
-    Fastlane::Helper::GitHelper.create_branch(new_intermediate_branch_name)
-
-    # Push up the intermediate branch
-    push_to_git_remote(tags: false)
-
-    create_release_management_pull_request(
-      base_branch: DEFAULT_BRANCH,
-      title: "Merge #{version_name_current} into #{DEFAULT_BRANCH}"
-    )
+    create_backmerge_pr(version: release_version_current)
   end
 
   #####################################################################################
@@ -402,22 +382,25 @@ platform :android do
 
     trigger_release_build(branch_to_build: "release/#{hotfix_version}", include_wear_app: include_wear_app)
 
-    # Retrieve the current non-hotfix release version
-    Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
-    non_hotfix_release_version = release_version_current
+    create_backmerge_pr(version: hotfix_version)
 
-    # Create an intermediate branch
-    Fastlane::Helper::GitHelper.checkout_and_pull("release/#{hotfix_version}")
-    new_intermediate_branch_name = "merge/#{hotfix_version}-hotfix-into-release-#{non_hotfix_release_version}"
-    Fastlane::Helper::GitHelper.create_branch(new_intermediate_branch_name)
+    # Close hotfix milestone
+    begin
+      close_milestone(
+        repository: GITHUB_REPO,
+        milestone: hotfix_version
+      )
+    rescue StandardError => e
+      error_message = <<-MESSAGE
+        Error closing milestone `#{hotfix_version}`: #{e.message}
+        - If this is a retry of the lane, the milestone might have already been closed and this error is expected.
+        - If this is the first run of the lane, please investigate the error.
+      MESSAGE
 
-    # Push up the intermediate branch
-    push_to_git_remote(tags: false)
+      UI.error(error_message)
 
-    create_release_management_pull_request(
-      base_branch: "release/#{non_hotfix_release_version}",
-      title: "Merge #{hotfix_version} hotfix into release/#{non_hotfix_release_version}"
-    )
+      buildkite_annotate(style: 'warning', context: 'finalize-hotfix-error-closing-milestone', message: error_message) if is_ci
+    end
   end
 
   #####################################################################################
@@ -476,7 +459,17 @@ platform :android do
     download_metadata_strings(version: version, app: MOBILE_APP)
     download_metadata_strings(version: version, app: WEAR_APP) if include_wear_app
 
-    # Wrap up
+    # Start the build
+    UI.important('Pushing changes to remote and triggering the release build')
+    UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
+
+    push_to_git_remote(tags: false)
+
+    trigger_release_build(branch_to_build: "release/#{version}", include_wear_app: include_wear_app)
+
+    create_backmerge_pr(version: version)
+
+    # Close milestone
     begin
       remove_branch_protection(
         repository: GITHUB_REPO,
@@ -502,26 +495,6 @@ platform :android do
 
       buildkite_annotate(style: 'warning', context: 'finalize-release-error-milestone', message: error_message) if is_ci
     end
-
-    # Start the build
-    UI.important('Pushing changes to remote and triggering the release build')
-    UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
-
-    push_to_git_remote(tags: false)
-
-    trigger_release_build(branch_to_build: "release/#{version}", include_wear_app: include_wear_app)
-
-    # Create an intermediate branch
-    new_intermediate_branch_name = "merge/#{release_version_current}-final-into-#{DEFAULT_BRANCH}"
-    Fastlane::Helper::GitHelper.create_branch(new_intermediate_branch_name)
-
-    # Push up the intermediate branch
-    push_to_git_remote(tags: false)
-
-    create_release_management_pull_request(
-      base_branch: DEFAULT_BRANCH,
-      title: "Merge #{release_version_current} final into #{DEFAULT_BRANCH}"
-    )
   end
 
   lane :check_translation_progress_all do
@@ -1298,15 +1271,13 @@ end
 # -----------------------------------------------------------------------------------
 # Release Management Utils
 # -----------------------------------------------------------------------------------
-def create_release_management_pull_request(base_branch:, title:)
-  create_pull_request(
-    api_token: ENV.fetch('GITHUB_TOKEN', nil),
-    repo: GITHUB_REPO,
-    title: title,
-    head: Fastlane::Helper::GitHelper.current_git_branch,
-    base: base_branch,
-    labels: 'Releases'
-  )
+def create_backmerge_pr(version:)
+    create_release_backmerge_pull_request(
+      repository: GITHUB_REPO,
+      source_branch: "release/#{version}",
+      labels: ['Releases'],
+      milestone_title: version
+    )
 end
 
 def ensure_git_branch_is_release_branch

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1317,8 +1317,8 @@ end
 def report_milestone_error(error_title:)
   error_message = <<-MESSAGE
     #{error_title}
-    - If this is a retry of the lane, the milestone might have already been closed and this error is expected.
-    - If this is the first run of the lane, please investigate the error.
+    - If this is not the first time you are running the release task (e.g. retrying because it failed on first attempt), the milestone might have already been closed and this error is expected.
+    - Otherwise if this is the first you are running the release task for this version, please investigate the error.
   MESSAGE
 
   UI.error(error_message)


### PR DESCRIPTION
This PR implements a few additions for our release automation on CI:
- Automatically move PRs from the current release milestone to the next one
- Uses the shared `create_release_backmerge_pull_request` Action from [release-toolkit](https://github.com/wordpress-mobile/release-toolkit), assigning a milestone to the backmerge PR.
- Make sure release tasks won't fail due to milestones already being closed
- Close hotfix milestone
- Updated release pipelines to not allow manual retry
- Added `ensure_branch_does_not_exist` in the beginning of `start_code_freeze`, to avoid unexpected behavior and errors.
- Added a rescue when creating the backmerge PR, since it can fail when re-running a release task and there already is a backmerge PR;