### PR TITLE
Bring back instrumented tests annotations

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -489,7 +489,7 @@ class AppPrefsTest {
                 remoteSiteId = 0L,
                 selfHostedSiteId = 0L,
             )
-        ).isFalse
+        ).isTrue()
     }
 
     @Test

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -489,7 +489,7 @@ class AppPrefsTest {
                 remoteSiteId = 0L,
                 selfHostedSiteId = 0L,
             )
-        ).isTrue()
+        ).isFalse
     }
 
     @Test

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -950,7 +950,16 @@ platform :android do
   lane :build_and_instrumented_test do
     gradle(tasks: %w[assembleVanillaDebug assembleVanillaDebugAndroidTest])
 
-    gradle(task: 'runFlank')
+    annotation_ctx = 'firebase-test-woocommerce-vanilla-debug'
+    begin
+      gradle(task: 'runFlank')
+      sh("buildkite-agent annotation remove --context '#{annotation_ctx}' || true") if is_ci?
+    rescue StandardError
+      details_url = sh('jq', '.[].webLink', '../build/instrumented-tests/matrix_ids.json', '-r')
+      message = "Firebase Tests failed. Failure details can be seen [here in Firebase Console](#{details_url})"
+      sh('buildkite-agent', 'annotate', message, '--style', 'error', '--context', annotation_ctx) if is_ci?
+      UI.test_failure!(message)
+    end
   end
 
   #####################################################################################


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12060 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR brings back behavior of annotating failed instrumentation tests on Buildkite job details. It works the same as the twin Fastlane action in WordPress/Jetpack

### Testing information
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Not needed: see the screenshot below or Buildkite build from c3b2e7ad9604ece29e27eedea570f7379f25880a commit.

### Images/gif
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/1187aefb-236b-457d-a9c8-7d7297534a44">
