### PR TITLE
[Woo POS] Make bottom navigation bar transparent when its gesture based and keep it as it is in button based

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -1,20 +1,18 @@
 package com.woocommerce.android.ui.woopos.root
 
-import android.R
 import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -37,8 +35,7 @@ class WooPosActivity : AppCompatActivity() {
                 SystemBars()
 
                 WooPosRootScreen(
-                    modifier = Modifier
-                        .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())
+                    modifier = Modifier.gesturesOrButtonsNavigationPadding()
                 )
             }
         }
@@ -46,11 +43,31 @@ class WooPosActivity : AppCompatActivity() {
 
     @Composable
     private fun SystemBars() {
-        val colors = MaterialTheme.colors
-
         SideEffect {
-            window.statusBarColor = getColor(R.color.transparent)
-            window.navigationBarColor = colors.background.toArgb()
+            window.statusBarColor = getColor(android.R.color.transparent)
+            window.navigationBarColor = getColor(android.R.color.transparent)
         }
     }
 }
+
+@Composable
+private fun Modifier.gesturesOrButtonsNavigationPadding(): Modifier {
+    val view = LocalView.current
+    val insets = WindowInsetsCompat.toWindowInsetsCompat(view.rootWindowInsets)
+    val isGestureNavigation = insets.isGestureNavigation()
+
+    return if (isGestureNavigation) {
+        this.padding(bottom = 0.dp)
+    } else {
+        this.navigationBarsPadding()
+    }
+}
+
+private fun WindowInsetsCompat.isGestureNavigation(): Boolean {
+    val bottomInset = getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
+
+    // That seems to be different on different devices, but 48dp is a common upper value
+    val gestureNavigationBarHeight = 48
+    return bottomInset <= gestureNavigationBarHeight
+}
+

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -63,11 +63,10 @@ private fun Modifier.gesturesOrButtonsNavigationPadding(): Modifier {
     }
 }
 
+// That seems to be different on different devices, but 48dp is a common upper value
+private const val GESTURE_NAVIGATION_BAR_HEIGHT = 48
 private fun WindowInsetsCompat.isGestureNavigation(): Boolean {
     val bottomInset = getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
 
-    // That seems to be different on different devices, but 48dp is a common upper value
-    val gestureNavigationBarHeight = 48
-    return bottomInset <= gestureNavigationBarHeight
+    return bottomInset <= GESTURE_NAVIGATION_BAR_HEIGHT
 }
-


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12058
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR makes bottom navigation bar placed on top of the UI of the POS when it's in "gesture" mode, and places the UI on top of the "bottoms" when its in the buttons mode

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Using android systems settings try both navigation mode and notice how the POS activity behaves

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/6ebfbdbf-b027-4662-84c5-7a8cbd6f96b1


- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->