### PR TITLE
[Login] Fix "send SMS" button during 2FA login

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,7 @@
 - [*****] [Internal] Update Androidx-fragment from 1.6.2 to 1.8.2 [https://github.com/woocommerce/woocommerce-android/pull/12231]
 - [*****] [Internal] Update Material to 1.12.0 and Transition to 1.5.1 [https://github.com/woocommerce/woocommerce-android/pull/12237]
 - [*****] [Internal] Update Stripe Terminal SDK from 3.1.1 to 3.7.1 [https://github.com/woocommerce/woocommerce-android/pull/12239]
+- [*] [Login] Fixed an issue with the "send SMS" button during the 2FA login [https://github.com/woocommerce/woocommerce-android/pull/12306]
 
 19.8
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.92.1'
+    fluxCVersion = '2.92.2'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12304 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR updates FluxC to bring the changes of https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3078 that fixes one of the SMS 2FA issues: the broken "Send SMS" button.

### Steps to reproduce
1. Using `trunk`
2. Signing in using a WordPress.com with SMS 2FA doesn't work.

### Testing information
1. Open the app.
2. Proceed to WordPress.com login.
3. Use a WordPress.com account with SMS 2FA.
4. Enter the email/username and proceed.
5. Tap on "Text me a code instead"
7. Confirm a new SMS was triggered.
8. Continue the login and confirm it works as expected.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->