### PR TITLE
[Woo POS] Polish transition between splash and home screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.home
 
-import androidx.compose.animation.fadeOut
+import android.view.animation.OvershootInterpolator
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -18,10 +19,17 @@ fun NavGraphBuilder.homeScreen(
 ) {
     composable(
         route = HOME_ROUTE,
-        enterTransition = { slideInVertically(initialOffsetY = { -it }) },
-        exitTransition = { fadeOut() },
-        popEnterTransition = { slideInVertically(initialOffsetY = { -it }) },
-        popExitTransition = { fadeOut() }
+        enterTransition = {
+            slideInVertically(
+                initialOffsetY = { -it },
+                animationSpec = tween(
+                    durationMillis = 1000,
+                    easing = {
+                        OvershootInterpolator(2f).getInterpolation(it)
+                    }
+                )
+            )
+        }
     ) {
         WooPosHomeScreen(onNavigationEvent)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
@@ -7,7 +7,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 
-const val HOME_ROUTE = "home"
+private const val HOME_ROUTE = "home"
 
 fun NavController.navigateToHomeScreen() {
     navigate(HOME_ROUTE)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.home
 
+import android.view.animation.AccelerateDecelerateInterpolator
 import android.view.animation.OvershootInterpolator
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
@@ -23,9 +24,10 @@ fun NavGraphBuilder.homeScreen(
             slideInVertically(
                 initialOffsetY = { -it },
                 animationSpec = tween(
-                    durationMillis = 1000,
-                    easing = {
-                        OvershootInterpolator(2f).getInterpolation(it)
+                    durationMillis = 800,
+                    easing = { time ->
+                        val accelerateDecelerate = AccelerateDecelerateInterpolator().getInterpolation(time)
+                        OvershootInterpolator(1.5f).getInterpolation(accelerateDecelerate)
                     }
                 )
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
@@ -27,6 +27,7 @@ fun NavGraphBuilder.homeScreen(
                     durationMillis = 800,
                     easing = { time ->
                         val accelerateDecelerate = AccelerateDecelerateInterpolator().getInterpolation(time)
+                        @Suppress("MagicNumber")
                         OvershootInterpolator(1.5f).getInterpolation(accelerateDecelerate)
                     }
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -135,7 +135,11 @@ private fun WooPosHomeScreen(
     totalsWidthDp: Dp,
     onHomeUIEvent: (WooPosHomeUIEvent) -> Unit,
 ) {
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colors.surface)
+    ) {
         Row(
             modifier = Modifier
                 .horizontalScroll(scrollState, enabled = false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -20,7 +20,7 @@ class WooPosHomeViewModel @Inject constructor(
         scope = viewModelScope,
         key = "home_state",
         initialValue = WooPosHomeState(
-            screenPositionState = WooPosHomeState.ScreenPositionState.Cart.Hidden,
+            screenPositionState = WooPosHomeState.ScreenPositionState.Cart.Visible.Empty,
             productsInfoDialog = WooPosHomeState.ProductsInfoDialog.Hidden,
             exitConfirmationDialog = null
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsScreen.kt
@@ -527,7 +527,12 @@ fun WooPosProductsScreenPreview(modifier: Modifier = Modifier) {
 @Composable
 @WooPosPreview
 fun WooPosProductsScreenLoadingPreview() {
-    val productState = MutableStateFlow(WooPosProductsViewState.Loading(true))
+    val productState = MutableStateFlow(
+        WooPosProductsViewState.Loading(
+            reloadingProductsWithPullToRefresh = true,
+            withCart = false
+        )
+    )
     WooPosTheme {
         WooPosProductsScreen(
             productsStateFlow = productState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsViewModel.kt
@@ -29,7 +29,7 @@ class WooPosProductsViewModel @Inject constructor(
     private var loadMoreProductsJob: Job? = null
 
     private val _viewState =
-        MutableStateFlow<WooPosProductsViewState>(WooPosProductsViewState.Loading())
+        MutableStateFlow<WooPosProductsViewState>(WooPosProductsViewState.Loading(withCart = true))
     val viewState: StateFlow<WooPosProductsViewState> = _viewState
         .onEach { notifyParentAboutStatusChange(it) }
         .stateIn(
@@ -41,7 +41,8 @@ class WooPosProductsViewModel @Inject constructor(
     init {
         loadProducts(
             forceRefreshProducts = false,
-            withPullToRefresh = false
+            withPullToRefresh = false,
+            withCart = true,
         )
     }
 
@@ -58,14 +59,16 @@ class WooPosProductsViewModel @Inject constructor(
             WooPosProductsUIEvent.PullToRefreshTriggered -> {
                 loadProducts(
                     forceRefreshProducts = true,
-                    withPullToRefresh = true
+                    withPullToRefresh = true,
+                    withCart = true,
                 )
             }
 
             WooPosProductsUIEvent.ProductsLoadingErrorRetryButtonClicked -> {
                 loadProducts(
                     forceRefreshProducts = false,
-                    withPullToRefresh = false
+                    withPullToRefresh = false,
+                    withCart = false,
                 )
             }
 
@@ -106,13 +109,14 @@ class WooPosProductsViewModel @Inject constructor(
 
     private fun loadProducts(
         forceRefreshProducts: Boolean,
-        withPullToRefresh: Boolean
+        withPullToRefresh: Boolean,
+        withCart: Boolean
     ) {
         viewModelScope.launch {
             _viewState.value = if (withPullToRefresh) {
                 buildProductsReloadingState()
             } else {
-                WooPosProductsViewState.Loading()
+                WooPosProductsViewState.Loading(withCart = withCart)
             }
 
             productsDataSource.loadSimpleProducts(forceRefreshProducts = forceRefreshProducts).collect { result ->
@@ -198,8 +202,14 @@ class WooPosProductsViewModel @Inject constructor(
                 is WooPosProductsViewState.Content -> ChildToParentEvent.ProductsStatusChanged.WithCart
 
                 is WooPosProductsViewState.Empty,
-                is WooPosProductsViewState.Error,
-                is WooPosProductsViewState.Loading -> ChildToParentEvent.ProductsStatusChanged.FullScreen
+                is WooPosProductsViewState.Error -> ChildToParentEvent.ProductsStatusChanged.FullScreen
+                is WooPosProductsViewState.Loading -> {
+                    if (newState.withCart) {
+                        ChildToParentEvent.ProductsStatusChanged.WithCart
+                    } else {
+                        ChildToParentEvent.ProductsStatusChanged.FullScreen
+                    }
+                }
             }
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsViewState.kt
@@ -20,7 +20,10 @@ sealed class WooPosProductsViewState(
         )
     }
 
-    data class Loading(override val reloadingProductsWithPullToRefresh: Boolean = false) :
+    data class Loading(
+        override val reloadingProductsWithPullToRefresh: Boolean = false,
+        val withCart: Boolean,
+    ) :
         WooPosProductsViewState(reloadingProductsWithPullToRefresh)
 
     data class Error(override val reloadingProductsWithPullToRefresh: Boolean = false) :

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
@@ -33,11 +33,12 @@ fun WooPosSplashScreen(onNavigationEvent: (WooPosNavigationEvent) -> Unit) {
         onNavigationEvent(WooPosNavigationEvent.BackFromSplashClicked)
     }
 
+    Loading()
+
     when (state.value) {
-        is WooPosSplashState.Loading -> Loading()
+        is WooPosSplashState.Loading -> {}
         is WooPosSplashState.Loaded -> {
             onNavigationEvent(WooPosNavigationEvent.OpenHomeFromSplash)
-            Loading()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
@@ -35,7 +35,10 @@ fun WooPosSplashScreen(onNavigationEvent: (WooPosNavigationEvent) -> Unit) {
 
     when (state.value) {
         is WooPosSplashState.Loading -> Loading()
-        is WooPosSplashState.Loaded -> onNavigationEvent(WooPosNavigationEvent.OpenHomeFromSplash)
+        is WooPosSplashState.Loaded -> {
+            onNavigationEvent(WooPosNavigationEvent.OpenHomeFromSplash)
+            Loading()
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12078
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR improves the transition between splash and home screen. To do that, it slightly changes the flow and we show the cart on initial products display


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Just open the POS and notice the new transition. Remember that in debug mode compose is not optiomised so to see how that looks like on production release build is needed.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/d277a5ab-aaed-4c0e-be33-6e33a7d3a5f6




- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->