### PR TITLE
[Woo POS] Open Zendesk support form from toolbar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpOrigin.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpOrigin.kt
@@ -32,7 +32,8 @@ enum class HelpOrigin(private val stringValue: String) {
     ORDERS_LIST("origin:orders-list"),
     BLAZE_CAMPAIGN_CREATION("origin:blaze-native-campaign-creation"),
     CONNECTIVITY_TOOL("origin:connectivity-tool"),
-    APPLICATION_PASSWORD_TUTORIAL("origin:application-password-tutorial");
+    APPLICATION_PASSWORD_TUTORIAL("origin:application-password-tutorial"),
+    POS("origin:point-of-sale");
 
     override fun toString(): String {
         return stringValue

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModel.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.woopos.home.toolbar.WooPosToolbarUIEvent.Conne
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosToolbarUIEvent.MenuItemClicked
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosToolbarUIEvent.OnOutsideOfToolbarMenuClicked
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosToolbarUIEvent.OnToolbarMenuClicked
+import com.woocommerce.android.ui.woopos.support.WooPosGetSupportFacade
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -26,6 +27,7 @@ import javax.inject.Inject
 class WooPosToolbarViewModel @Inject constructor(
     private val cardReaderFacade: WooPosCardReaderFacade,
     private val childrenToParentEventSender: WooPosChildrenToParentEventSender,
+    private val getSupportFacade: WooPosGetSupportFacade,
 ) : ViewModel() {
     private val _state = MutableStateFlow(
         WooPosToolbarState(
@@ -75,7 +77,7 @@ class WooPosToolbarViewModel @Inject constructor(
         hideMenu()
 
         when (event.menuItem.title) {
-            R.string.woopos_get_support_title -> TODO()
+            R.string.woopos_get_support_title -> getSupportFacade.openSupportForm()
             R.string.woopos_exit_confirmation_title ->
                 viewModelScope.launch {
                     childrenToParentEventSender.sendToParent(ChildToParentEvent.ExitPosClicked)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -25,6 +25,7 @@ import javax.inject.Inject
 class WooPosActivity : AppCompatActivity() {
     @Inject
     lateinit var wooPosCardReaderFacade: WooPosCardReaderFacade
+
     @Inject
     lateinit var wooPosGetSupportFacade: WooPosGetSupportFacade
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.core.view.WindowCompat
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosTheme
+import com.woocommerce.android.ui.woopos.support.WooPosGetSupportFacade
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -24,6 +25,8 @@ import javax.inject.Inject
 class WooPosActivity : AppCompatActivity() {
     @Inject
     lateinit var wooPosCardReaderFacade: WooPosCardReaderFacade
+    @Inject
+    lateinit var wooPosGetSupportFacade: WooPosGetSupportFacade
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,6 +34,7 @@ class WooPosActivity : AppCompatActivity() {
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
 
         lifecycle.addObserver(wooPosCardReaderFacade)
+        lifecycle.addObserver(wooPosGetSupportFacade)
 
         setContent {
             WooPosTheme {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/support/WooPosGetSupportFacade.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/support/WooPosGetSupportFacade.kt
@@ -9,7 +9,7 @@ import dagger.hilt.android.scopes.ActivityRetainedScoped
 import javax.inject.Inject
 
 @ActivityRetainedScoped
-class WooPosGetSupportFacade @Inject constructor(): DefaultLifecycleObserver {
+class WooPosGetSupportFacade @Inject constructor() : DefaultLifecycleObserver {
     private var activity: AppCompatActivity? = null
 
     override fun onCreate(owner: LifecycleOwner) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/support/WooPosGetSupportFacade.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/support/WooPosGetSupportFacade.kt
@@ -1,0 +1,31 @@
+package com.woocommerce.android.ui.woopos.support
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.support.requests.SupportRequestFormActivity
+import dagger.hilt.android.scopes.ActivityRetainedScoped
+import javax.inject.Inject
+
+@ActivityRetainedScoped
+class WooPosGetSupportFacade @Inject constructor(): DefaultLifecycleObserver {
+    private var activity: AppCompatActivity? = null
+
+    override fun onCreate(owner: LifecycleOwner) {
+        this.activity = owner as AppCompatActivity
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        this.activity = null
+    }
+
+    fun openSupportForm() {
+        val intent = SupportRequestFormActivity.createIntent(
+            context = activity!!,
+            origin = HelpOrigin.POS,
+            extraTags = ArrayList()
+        )
+        activity!!.startActivity(intent)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModelTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
+import com.woocommerce.android.ui.woopos.support.WooPosGetSupportFacade
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -26,6 +27,7 @@ class WooPosToolbarViewModelTest {
     private val cardReaderFacade: WooPosCardReaderFacade = mock {
         onBlocking { readerStatus }.thenReturn(flowOf(CardReaderStatus.NotConnected()))
     }
+    private val getSupportFacade: WooPosGetSupportFacade = mock()
     private val childrenToParentEventSender: WooPosChildrenToParentEventSender = mock()
 
     @Test
@@ -165,8 +167,21 @@ class WooPosToolbarViewModelTest {
         verify(cardReaderFacade, times(3)).connectToReader()
     }
 
+    @Test
+    fun `when get support clicked, then should open support form`() {
+        val viewModel = createViewModel()
+
+        viewModel.onUiEvent(WooPosToolbarUIEvent.MenuItemClicked(WooPosToolbarState.Menu.MenuItem(
+            title = R.string.woopos_get_support_title,
+            icon = R.drawable.woopos_ic_get_support,
+        )))
+
+        verify(getSupportFacade).openSupportForm()
+    }
+
     private fun createViewModel() = WooPosToolbarViewModel(
         cardReaderFacade,
-        childrenToParentEventSender
+        childrenToParentEventSender,
+        getSupportFacade,
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModelTest.kt
@@ -171,10 +171,14 @@ class WooPosToolbarViewModelTest {
     fun `when get support clicked, then should open support form`() {
         val viewModel = createViewModel()
 
-        viewModel.onUiEvent(WooPosToolbarUIEvent.MenuItemClicked(WooPosToolbarState.Menu.MenuItem(
-            title = R.string.woopos_get_support_title,
-            icon = R.drawable.woopos_ic_get_support,
-        )))
+        viewModel.onUiEvent(
+            WooPosToolbarUIEvent.MenuItemClicked(
+                WooPosToolbarState.Menu.MenuItem(
+                    title = R.string.woopos_get_support_title,
+                    icon = R.drawable.woopos_ic_get_support,
+                )
+            )
+        )
 
         verify(getSupportFacade).openSupportForm()
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12269
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds redirection to the Zendesk support form when user taps the "Get Support" item in the bottom floating menu, hidden under the 3-dots button. The support request sent from POS mode will include the following tag: `origin:point-of-sale`

Context and decision about tracking new tag: p1723445526122729-slack-C070SJRA8DP

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
1. Click on the "Get Support" button available in the floating menu in POS mode. 
2. Submit a test support request and verify it's visible in Zendesk

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="1132" alt="Screenshot 2024-08-12 at 18 51 57" src="https://github.com/user-attachments/assets/2b98e4b0-ec38-465a-85d8-c87907115268">

- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->