### PR TITLE
Product Creation with AI: Fix the visibility of “Write with AI” button 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 20.0
 -----
-
+- [*] Fixed the hidden “Write with AI” issue that occurs when the keyboard is open. [https://github.com/woocommerce/woocommerce-android/pull/12311]
 
 19.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/description/AIProductDescriptionBottomSheetFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ai/description/AIProductDescriptionBottomSheetFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.copyToClipboard
@@ -25,6 +26,11 @@ class AIProductDescriptionBottomSheetFragment : WCBottomSheetDialogFragment() {
     }
 
     private val viewModel: AIProductDescriptionViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(DialogFragment.STYLE_NORMAL, R.style.Woo_Theme_BottomSheetDialog_Resizeable)
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -811,4 +811,8 @@ theme across the entire app. Overridden versions should be added to the styles.x
     <style name="Theme.Woo.BottomSheet" parent="Widget.Design.BottomSheet.Modal">
         <item name="android:background">@drawable/bottomsheet_rounded</item>
     </style>
+
+    <style name="Woo.Theme.BottomSheetDialog.Resizeable" parent="Woo.Theme.BottomSheetDialog">
+        <item name="android:windowSoftInputMode">adjustResize</item>
+    </style>
 </resources>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12294 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes the hidden “Write with AI” issue that occurs when the keyboard is open.
This adds a new style variation for the bottom sheet and applied it to the `AIProductDescriptionBottomSheetFragment` 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the "Products" tab.
2. Tap "+" button to add a product manually, then select any option to create a product.
3. Tap the "Write with AI" button.
4. Tap any text field to start typing.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Test in both portrait and landscape orientation. In landscape orientation, the button won't appear initially, but the bottom sheet will be scrollable.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|before|after|
|-|-|
|<img src="https://github.com/user-attachments/assets/6abfda26-3f54-4cea-be95-2c943225efeb" width=300>|<img src="https://github.com/user-attachments/assets/decfff7a-8663-43b0-aa52-b581cb6a99c9" width=300>|


- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->