### PR TITLE
[Woo POS] 24dp as cut off for determining the gesture way of navigation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.woopos.root
 
+import android.content.Context
 import android.content.pm.ActivityInfo
 import android.os.Bundle
+import android.util.TypedValue
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -54,7 +56,7 @@ class WooPosActivity : AppCompatActivity() {
 private fun Modifier.gesturesOrButtonsNavigationPadding(): Modifier {
     val view = LocalView.current
     val insets = WindowInsetsCompat.toWindowInsetsCompat(view.rootWindowInsets)
-    val isGestureNavigation = insets.isGestureNavigation()
+    val isGestureNavigation = insets.isGestureNavigation(view.context)
 
     return if (isGestureNavigation) {
         this.padding(bottom = 0.dp)
@@ -63,10 +65,16 @@ private fun Modifier.gesturesOrButtonsNavigationPadding(): Modifier {
     }
 }
 
-// That seems to be different on different devices, but 48dp is a common upper value
-private const val GESTURE_NAVIGATION_BAR_HEIGHT = 48
-private fun WindowInsetsCompat.isGestureNavigation(): Boolean {
+// That seems to be different on different devices, but 24dp is a common upper value
+private const val GESTURE_NAVIGATION_BAR_HEIGHT_DP = 24
+private fun WindowInsetsCompat.isGestureNavigation(context: Context): Boolean {
     val bottomInset = getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
 
-    return bottomInset <= GESTURE_NAVIGATION_BAR_HEIGHT
+    val gestureNavigationBarHeightPx = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP,
+        GESTURE_NAVIGATION_BAR_HEIGHT_DP.toFloat(),
+        context.resources.displayMetrics
+    ).toInt()
+
+    return bottomInset in 1..gestureNavigationBarHeightPx
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12314 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As @AnirudhBhat noticed I made a mistake and was comparing pixels with dp to determine if gesture navigation is used. This PR fixes that

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
* Try gesture and buttons navigation
* Notice that the UI placed underneath in case of the gesture navigation and on top if it's buttons navigation


- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->4