### PR TITLE
Add new suspended status to Blaze campaigns

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
@@ -54,6 +54,11 @@ enum class CampaignStatusUi(
         statusDisplayText = R.string.blaze_campaign_status_canceled,
         textColor = R.color.blaze_campaign_status_rejected_text,
         backgroundColor = R.color.blaze_campaign_status_rejected_background
+    ),
+    Suspended(
+        statusDisplayText = R.string.blaze_campaign_status_suspended,
+        textColor = R.color.blaze_campaign_status_suspended_text,
+        backgroundColor = R.color.blaze_campaign_status_suspended_background
     );
 
     companion object {
@@ -63,6 +68,7 @@ enum class CampaignStatusUi(
                 "scheduled" -> Scheduled
                 "active" -> Active
                 "rejected" -> Rejected
+                "suspended" -> Suspended
                 "canceled" -> Canceled
                 "finished" -> Completed
                 else -> null

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -297,6 +297,8 @@
     <color name="blaze_campaign_status_completed_text">@color/blaze_blue_60</color>
     <color name="blaze_campaign_status_rejected_background">@color/blaze_red_5</color>
     <color name="blaze_campaign_status_rejected_text">@color/blaze_red_6</color>
+    <color name="blaze_campaign_status_suspended_background">@color/blaze_red_6</color>
+    <color name="blaze_campaign_status_suspended_text">@color/white</color>
     <color name="blaze_campaign_bottom_sheet_highlight_background">@color/woo_gray_6</color>
     <color name="blaze_campaign_preview_header_background">@color/woo_gray_0</color>
     <color name="blaze_campaign_preview_shop_now_button">@color/woo_gray_0</color>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3875,6 +3875,7 @@
     <string name="blaze_campaign_status_scheduled">Scheduled</string>
     <string name="blaze_campaign_status_rejected">Rejected</string>
     <string name="blaze_campaign_status_canceled">Canceled</string>
+    <string name="blaze_campaign_status_suspended">Suspended</string>
     <string name="blaze_campaign_status_impressions">Impressions</string>
     <string name="blaze_campaign_status_clicks">Clicks</string>
     <string name="blaze_campaign_status_budget">Budget</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12326 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Adds new `suspended` status to Blaze campaigns

### Testing information
We are releasing the support for this new status asap, because it will be deployed on the backend soon, and older versions of the app will display this new status as `Unknown`
For now, there's no way to test this using real values from the API. But applying this patch we can convert any `canceled` campaign into `suspended`, which should be enough to test. 

```diff
Subject: [PATCH] Add new suspended status to Blaze campaigns
---
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt	(revision 6c3aedfa04fd655ba4d466375633f63854fccd93)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt	(date 1723642911797)
@@ -69,7 +69,7 @@
                 "active" -> Active
                 "rejected" -> Rejected
                 "suspended" -> Suspended
-                "canceled" -> Canceled
+                "canceled" -> Suspended
                 "finished" -> Completed
                 else -> null
             }

```

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="335" alt="Screenshot 2024-08-14 at 15 44 42" src="https://github.com/user-attachments/assets/6817666e-3b1b-484e-8730-850cc4e2460d">


- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->