### PR TITLE
Resolve `androidx.navigation.safeargs.kotlin` in root module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
     id 'com.android.application' apply false
     id 'org.jetbrains.kotlin.android' apply false
     id 'com.google.dagger.hilt.android' apply false
+    id 'androidx.navigation.safeargs.kotlin' apply false
     id 'com.google.gms.google-services' apply false
     id 'com.google.devtools.ksp' apply false
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes 
- https://github.com/woocommerce/woocommerce-android/security/dependabot/48
- https://github.com/woocommerce/woocommerce-android/security/dependabot/45
- https://github.com/woocommerce/woocommerce-android/security/dependabot/42
- https://github.com/woocommerce/woocommerce-android/security/dependabot/53
- https://github.com/woocommerce/woocommerce-android/security/dependabot/54
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR moves resolving of `androidx.navigation.safeargs.kotlin` plugin to the root module.

This way, `androidx.navigation.safeargs.kotlin` applied in `WooCommerce` module isn't resolved in isolation, causing resolution in module-specific classpath.

In this particular example, applying this plugin in `WooCommerce` caused `protobuf-java` in version `3.17.2` to be applied. This dependency is already on classpath on root module in version `3.22.3` so resolving `safeargs` in root module classpath will bump `protobuf` to higher version.

### Testing information
Not necessary: 🟢 from CI checks should be just fine.


- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
