### PR TITLE
Fix low stock in filter options

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
@@ -366,7 +366,7 @@ class ProductFilterListViewModel @Inject constructor(
                 STOCK_STATUS,
                 resourceProvider.getString(R.string.product_stock_status),
                 addDefaultFilterOption(
-                    CoreProductStockStatus.values().map {
+                    CoreProductStockStatus.FILTERABLE_VALUES.map {
                         FilterListOptionItemUiModel.DefaultFilterListOptionItemUiModel(
                             resourceProvider.getString(ProductStockStatus.fromString(it.value).stringResource),
                             filterOptionItemValue = it.value,

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-863f213e0e3a7a4322032e8e8c57a99f77bb48ec'
+    fluxCVersion = 'trunk-67b716889eb864763d703eb6d8c7519f73ad3157'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Closes: #12296 

### Description
> Filtering: When I try to filter for “Low Stock” products, I get an error. The app logs show an error: Fetching products failed, error: INVALID_PARAM: Invalid parameter(s): stock_status.

This PR fixes the error when filtering products with low stock stock status. It fix the issue by removing the Low Stock option from the filter section, this will match the iOS behavior and the [API documentation](https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-products). These changes just updated the filter source, so there is no need for unit tests

> `stock_status` | `string` | Limit result set to products with specified stock status. Options: `instock`, `outofstock` and `onbackorder`.

### Steps to reproduce

1. Go to the Products tab.
2. Select Filter.
3. Select Stock status.
4. Select Low stock.
5. Tap the Show products button.
6. Notice the error on the Products list.

### Testing information
1. Go to the Products tab.
2. Select Filter.
3. Select Stock status.
4. Check that there is no Low stock option & that all remaining options work as expected

### Images/gif

https://github.com/user-attachments/assets/3277e3c8-8438-44c5-a5ee-d3850bf0d427


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->