### PR TITLE
[Blaze i4] Logic of blaze reminder notification

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -39,6 +39,7 @@ import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.tracker.SendTelemetry
 import com.woocommerce.android.tracker.TrackStoreSnapshot
 import com.woocommerce.android.ui.appwidgets.getWidgetName
+import com.woocommerce.android.ui.blaze.notification.BlazeCampaignsObserver
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
 import com.woocommerce.android.ui.jitm.JitmStoreInMemoryCache
 import com.woocommerce.android.ui.login.AccountRepository
@@ -126,6 +127,9 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     @Inject lateinit var sendTelemetry: SendTelemetry
 
     @Inject lateinit var siteObserver: SiteObserver
+
+    @Inject
+    lateinit var blazeCampaignsObserver: BlazeCampaignsObserver
 
     @Inject lateinit var wooLog: WooLogWrapper
 
@@ -232,6 +236,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         appCoroutineScope.launch {
             siteObserver.observeAndUpdateSelectedSiteData()
         }
+        appCoroutineScope.launch { blazeCampaignsObserver.observeAndScheduleNotifications() }
         appCoroutineScope.launch {
             featureFlagRepository.fetchFeatureFlags(PackageUtils.getVersionName(application.applicationContext))
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -101,11 +101,12 @@ val Date.pastTimeDeltaFromNowInDays
         ?.let { TimeUnit.DAYS.convert(it, MILLISECONDS) }
         ?.toInt()
 
-fun Date.daysAgo(daysAgo: Int) =
-    Calendar.getInstance()
-        .apply { time = this@daysAgo }
-        .apply { add(Calendar.DATE, -daysAgo) }
-        .time
+fun Date.daysLater(daysLater: Int): Date = Calendar.getInstance()
+    .apply { time = this@daysLater }
+    .apply { add(Calendar.DATE, daysLater) }
+    .time
+
+fun Date.daysAgo(daysAgo: Int) = daysLater(-daysAgo)
 
 fun Date.oneDayAgo(): Date =
     Calendar.getInstance().apply {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -16,6 +16,9 @@ sealed class LocalNotification(
     open val data: String? = null
     val id = type.hashCode()
 
+    val tag
+        get() = "$type:$siteId"
+
     open fun getTitleString(resourceProvider: ResourceProvider) = resourceProvider.getString(title)
 
     open fun getDescriptionString(resourceProvider: ResourceProvider) = resourceProvider.getString(description)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotification.kt
@@ -10,7 +10,7 @@ sealed class LocalNotification(
     @StringRes val title: Int,
     @StringRes val description: Int,
     val type: LocalNotificationType,
-    val delay: Long,
+    open val delay: Long,
     val delayUnit: TimeUnit
 ) {
     open val data: String? = null
@@ -25,13 +25,13 @@ sealed class LocalNotification(
 
     data class BlazeNoCampaignReminderNotification(
         override val siteId: Long,
-        val daysToCampaignEnd: Int
+        override val delay: Long,
     ) : LocalNotification(
         siteId = siteId,
         title = R.string.local_notification_blaze_no_campaign_reminder_title,
         description = R.string.local_notification_blaze_no_campaign_reminder_description,
         type = LocalNotificationType.BLAZE_NO_CAMPAIGN_REMINDER,
-        delay = daysToCampaignEnd.toLong() + 30,
-        delayUnit = TimeUnit.DAYS
+        delay = delay,
+        delayUnit = TimeUnit.MILLISECONDS
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
@@ -33,7 +33,7 @@ class LocalNotificationScheduler @Inject constructor(
 
         workManager
             .beginUniqueWork(
-                LOCAL_NOTIFICATION_WORK_NAME + notification.type.value + notification.siteId,
+                LOCAL_NOTIFICATION_WORK_NAME + notification.tag,
                 REPLACE,
                 buildPreconditionCheckWorkRequest(notification)
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
@@ -29,11 +29,11 @@ class LocalNotificationScheduler @Inject constructor(
     private val workManager = WorkManager.getInstance(appContext)
 
     fun scheduleNotification(notification: LocalNotification) {
-        cancelScheduledNotification(notification.type)
+        cancelScheduledNotification(notification.tag)
 
         workManager
             .beginUniqueWork(
-                LOCAL_NOTIFICATION_WORK_NAME + notification.type.value,
+                LOCAL_NOTIFICATION_WORK_NAME + notification.type.value + notification.siteId,
                 REPLACE,
                 buildPreconditionCheckWorkRequest(notification)
             )
@@ -57,7 +57,7 @@ class LocalNotificationScheduler @Inject constructor(
         )
         return OneTimeWorkRequestBuilder<PreconditionCheckWorker>()
             .setInputData(conditionData)
-            .addTag(notification.type.value)
+            .addTag(notification.tag)
             .setInitialDelay(notification.delay, notification.delayUnit)
             .build()
     }
@@ -72,12 +72,12 @@ class LocalNotificationScheduler @Inject constructor(
             LOCAL_NOTIFICATION_SITE_ID to notification.siteId
         )
         return OneTimeWorkRequestBuilder<LocalNotificationWorker>()
-            .addTag(notification.type.value)
+            .addTag(notification.tag)
             .setInputData(notificationData)
             .build()
     }
 
-    fun cancelScheduledNotification(type: LocalNotificationType) {
-        workManager.cancelAllWorkByTag(type.value)
+    private fun cancelScheduledNotification(tag: String) {
+        workManager.cancelAllWorkByTag(tag)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/PreconditionCheckWorker.kt
@@ -4,17 +4,20 @@ import android.content.Context
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
 import androidx.work.WorkManager
-import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.automattic.android.tracks.crashlogging.CrashLogging
+import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_SITE_ID
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_TYPE
+import com.woocommerce.android.ui.dashboard.data.ObserveBlazeWidgetStatus
 import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
 import com.woocommerce.android.util.WooLogWrapper
 import com.woocommerce.android.util.WooPermissionUtils
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.first
 import org.wordpress.android.fluxc.store.SiteStore
 
 @HiltWorker
@@ -23,36 +26,40 @@ class PreconditionCheckWorker @AssistedInject constructor(
     @Assisted workerParams: WorkerParameters,
     private val wooLogWrapper: WooLogWrapper,
     private val siteStore: SiteStore,
+    private val observeBlazeWidgetStatus: ObserveBlazeWidgetStatus,
     private val crashLogging: CrashLogging,
-) : Worker(appContext, workerParams) {
-    override fun doWork(): Result {
+) : CoroutineWorker(appContext, workerParams) {
+    override suspend fun doWork(): Result {
         if (!canDisplayNotifications) cancelWork("Notifications permission not granted. Cancelling work.")
 
         val type = LocalNotificationType.fromString(inputData.getString(LOCAL_NOTIFICATION_TYPE))
         val siteId = inputData.getLong(LOCAL_NOTIFICATION_SITE_ID, 0L)
         return when (type) {
-            LocalNotificationType.BLAZE_NO_CAMPAIGN_REMINDER -> proceedIfValidSite(siteId)
+            LocalNotificationType.BLAZE_NO_CAMPAIGN_REMINDER -> proceedIfValidSiteAndBlazeAvailable(siteId)
 
             null -> cancelWork("Notification type is null. Cancelling work.")
         }
     }
 
-    private fun proceedIfValidSite(siteId: Long): Result {
-        if (siteId == 0L) {
+    private suspend fun proceedIfValidSiteAndBlazeAvailable(siteId: Long) = when {
+        siteId == 0L -> {
             val message = "Site id is missing. Cancelling local notification work."
             crashLogging.sendReport(
                 exception = Exception(message),
                 message = "PreconditionCheckWorker: cancelling work"
             )
-            return cancelWork(message)
+            cancelWork(message)
         }
 
-        val notificationLinkedSite = siteStore.getSiteBySiteId(siteId)
-        return if (notificationLinkedSite == null) {
-            cancelWork("The site linked to the notifications doesn't exist in the db. Cancelling work.")
-        } else {
-            Result.success()
+        observeBlazeWidgetStatus().first() != DashboardWidget.Status.Available -> {
+            cancelWork("Blaze is not available. Cancelling local notification work.")
         }
+
+        siteStore.getSiteBySiteId(siteId) == null -> {
+            cancelWork("The site linked to the notifications doesn't exist in the db. Cancelling work.")
+        }
+
+        else -> Result.success()
     }
 
     private val canDisplayNotifications: Boolean

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/notification/BlazeCampaignsObserver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/notification/BlazeCampaignsObserver.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.extensions.daysLater
 import com.woocommerce.android.notifications.local.LocalNotification.BlazeNoCampaignReminderNotification
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.blaze.CampaignStatusUi
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -41,19 +40,12 @@ class BlazeCampaignsObserver @Inject constructor(
     }
 
     private fun scheduleNotification(campaigns: List<BlazeCampaignsDao.BlazeCampaignEntity>) {
-        val activeCampaigns = campaigns.filter { campaign ->
-            CampaignStatusUi.fromString(campaign.uiStatus).let { status ->
-                status == CampaignStatusUi.Active ||
-                    status == CampaignStatusUi.Completed ||
-                    (status == CampaignStatusUi.Canceled && campaign.impressions > 0)
-            }
-        }
-        if (activeCampaigns.isEmpty()) {
-            // There are no campaigns that were successfully created and started. Skip scheduling the notification.
+        if (campaigns.isEmpty()) {
+            // There are no campaigns. Skip scheduling the notification.
             return
         }
 
-        val delayForNotification = calculateDelayForNotification(activeCampaigns)
+        val delayForNotification = calculateDelayForNotification(campaigns)
 
         localNotificationScheduler.scheduleNotification(
             BlazeNoCampaignReminderNotification(selectedSite.get().siteId, delayForNotification)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/notification/BlazeCampaignsObserver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/notification/BlazeCampaignsObserver.kt
@@ -1,0 +1,72 @@
+package com.woocommerce.android.ui.blaze.notification
+
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.extensions.daysLater
+import com.woocommerce.android.notifications.local.LocalNotification.BlazeNoCampaignReminderNotification
+import com.woocommerce.android.notifications.local.LocalNotificationScheduler
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.blaze.CampaignStatusUi
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.persistence.blaze.BlazeCampaignsDao
+import org.wordpress.android.fluxc.store.blaze.BlazeCampaignsStore
+import java.util.Calendar
+import javax.inject.Inject
+
+/**
+ * A utility class that can observe changes in Blaze campaigns for the selected site and schedule local notifications
+ * for Blaze.
+ */
+class BlazeCampaignsObserver @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val blazeCampaignsStore: BlazeCampaignsStore,
+    private val localNotificationScheduler: LocalNotificationScheduler,
+) {
+    suspend fun observeAndScheduleNotifications() {
+        selectedSite.observe()
+            .filterNotNull()
+            .filter { !appPrefsWrapper.getBlazeNoCampaignReminderShown(it.siteId) }
+            .distinctUntilChanged { old, new -> new.id == old.id }
+            .collectLatest { observeBlazeCampaigns(it) }
+    }
+
+    private suspend fun observeBlazeCampaigns(site: SiteModel) {
+        blazeCampaignsStore.observeBlazeCampaigns(site)
+            .filter { it.isNotEmpty() }
+            .collectLatest { scheduleNotification(it) }
+    }
+
+    private fun scheduleNotification(campaigns: List<BlazeCampaignsDao.BlazeCampaignEntity>) {
+        val activeCampaigns = campaigns.filter { campaign ->
+            CampaignStatusUi.fromString(campaign.uiStatus).let { status ->
+                status == CampaignStatusUi.Active ||
+                    status == CampaignStatusUi.Completed ||
+                    (status == CampaignStatusUi.Canceled && campaign.impressions > 0)
+            }
+        }
+        if (activeCampaigns.isEmpty()) {
+            // There are no campaigns that were successfully created and started. Skip scheduling the notification.
+            return
+        }
+
+        val delayForNotification = calculateDelayForNotification(activeCampaigns)
+
+        localNotificationScheduler.scheduleNotification(
+            BlazeNoCampaignReminderNotification(selectedSite.get().siteId, delayForNotification)
+        )
+    }
+
+    private fun calculateDelayForNotification(campaigns: List<BlazeCampaignsDao.BlazeCampaignEntity>): Long {
+        val latestEndTime = campaigns.maxOf { it.startTime.daysLater(it.durationInDays) }
+        val notificationTime = latestEndTime.daysLater(DAYS_DURATION_NO_CAMPAIGN_REMINDER_NOTIFICATION)
+        return notificationTime.time - Calendar.getInstance().time.time
+    }
+
+    companion object {
+        const val DAYS_DURATION_NO_CAMPAIGN_REMINDER_NOTIFICATION = 30
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/notification/BlazeCampaignsObserverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/notification/BlazeCampaignsObserverTest.kt
@@ -1,0 +1,112 @@
+package com.woocommerce.android.ui.blaze.notification
+
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.extensions.daysLater
+import com.woocommerce.android.notifications.local.LocalNotificationScheduler
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.persistence.blaze.BlazeCampaignsDao.BlazeCampaignEntity
+import org.wordpress.android.fluxc.store.blaze.BlazeCampaignsStore
+import java.util.Date
+
+class BlazeCampaignsObserverTest {
+    private val site = SiteModel().apply { siteId = 1 }
+    private val selectedSite = mock<SelectedSite>()
+    private val appPrefsWrapper = mock<AppPrefsWrapper>()
+    private val blazeCampaignsStore = mock<BlazeCampaignsStore>()
+    private val localNotificationScheduler = mock<LocalNotificationScheduler>()
+
+    private lateinit var blazeCampaignsObserver: BlazeCampaignsObserver
+
+    private fun initBlazeCampaignsObserver(
+        notificationShownBefore: Boolean = false,
+        campaigns: List<BlazeCampaignEntity> = listOf(BLAZE_CAMPAIGN_ENTITY)
+    ) {
+        whenever(selectedSite.observe()).thenReturn(flowOf(site))
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(appPrefsWrapper.getBlazeNoCampaignReminderShown(site.siteId)).thenReturn(notificationShownBefore)
+        whenever(blazeCampaignsStore.observeBlazeCampaigns(site)).thenReturn(flowOf(campaigns))
+        blazeCampaignsObserver = BlazeCampaignsObserver(
+            selectedSite,
+            appPrefsWrapper,
+            blazeCampaignsStore,
+            localNotificationScheduler
+        )
+    }
+
+    @Test
+    fun whenNotificationShownBefore_notificationIsNotScheduled() = runTest {
+        initBlazeCampaignsObserver(notificationShownBefore = true)
+
+        blazeCampaignsObserver.observeAndScheduleNotifications()
+
+        verifyNoInteractions(localNotificationScheduler)
+    }
+
+    @Test
+    fun whenNoCampaign_notificationIsNotScheduled() = runTest {
+        initBlazeCampaignsObserver(campaigns = emptyList())
+
+        blazeCampaignsObserver.observeAndScheduleNotifications()
+
+        verifyNoInteractions(localNotificationScheduler)
+    }
+
+    @Test
+    fun whenNoActiveCampaign_notificationIsNotScheduled() = runTest {
+        initBlazeCampaignsObserver(campaigns = listOf(BLAZE_CAMPAIGN_ENTITY.copy(uiStatus = "rejected")))
+
+        blazeCampaignsObserver.observeAndScheduleNotifications()
+
+        verifyNoInteractions(localNotificationScheduler)
+    }
+
+    @Test
+    fun whenCanceledWithZeroImpressionCampaign_notificationIsNotScheduled() = runTest {
+        initBlazeCampaignsObserver(
+            campaigns = listOf(BLAZE_CAMPAIGN_ENTITY.copy(uiStatus = "canceled", impressions = 0))
+        )
+
+        blazeCampaignsObserver.observeAndScheduleNotifications()
+
+        verifyNoInteractions(localNotificationScheduler)
+    }
+
+    @Test
+    fun whenActiveCampaign_notificationIsScheduled() = runTest {
+        val campaign1 = BLAZE_CAMPAIGN_ENTITY
+        val campaign2 = BLAZE_CAMPAIGN_ENTITY.copy(durationInDays = 8)
+        val campaign3 = BLAZE_CAMPAIGN_ENTITY.copy(uiStatus = "completed")
+        val campaignList = listOf(campaign1, campaign2, campaign3)
+        initBlazeCampaignsObserver(campaigns = campaignList)
+
+        blazeCampaignsObserver.observeAndScheduleNotifications()
+
+        verify(localNotificationScheduler).scheduleNotification(any())
+    }
+
+    companion object {
+        private val BLAZE_CAMPAIGN_ENTITY = BlazeCampaignEntity(
+            siteId = 1,
+            campaignId = "2",
+            title = "title",
+            imageUrl = "image_url",
+            startTime = Date().daysLater(1),
+            durationInDays = 7,
+            uiStatus = "active",
+            impressions = 2,
+            clicks = 1,
+            targetUrn = "urn:wpcom:post:1:1",
+            totalBudget = 100.0,
+            spentBudget = 1.0
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/notification/BlazeCampaignsObserverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/notification/BlazeCampaignsObserverTest.kt
@@ -43,7 +43,7 @@ class BlazeCampaignsObserverTest {
     }
 
     @Test
-    fun whenNotificationShownBefore_notificationIsNotScheduled() = runTest {
+    fun `when notification shown before, then don't schedule notification`() = runTest {
         initBlazeCampaignsObserver(notificationShownBefore = true)
 
         blazeCampaignsObserver.observeAndScheduleNotifications()
@@ -52,7 +52,7 @@ class BlazeCampaignsObserverTest {
     }
 
     @Test
-    fun whenNoCampaign_notificationIsNotScheduled() = runTest {
+    fun `when no campaign, then don't schedule notification`() = runTest {
         initBlazeCampaignsObserver(campaigns = emptyList())
 
         blazeCampaignsObserver.observeAndScheduleNotifications()
@@ -61,7 +61,7 @@ class BlazeCampaignsObserverTest {
     }
 
     @Test
-    fun whenNoActiveCampaign_notificationIsNotScheduled() = runTest {
+    fun `when no active campaign, then don't schedule notification`() = runTest {
         initBlazeCampaignsObserver(campaigns = listOf(BLAZE_CAMPAIGN_ENTITY.copy(uiStatus = "rejected")))
 
         blazeCampaignsObserver.observeAndScheduleNotifications()
@@ -70,7 +70,7 @@ class BlazeCampaignsObserverTest {
     }
 
     @Test
-    fun whenCanceledWithZeroImpressionCampaign_notificationIsNotScheduled() = runTest {
+    fun `when canceled with zero Impression campaign, then don't schedule the notification`() = runTest {
         initBlazeCampaignsObserver(
             campaigns = listOf(BLAZE_CAMPAIGN_ENTITY.copy(uiStatus = "canceled", impressions = 0))
         )
@@ -81,7 +81,7 @@ class BlazeCampaignsObserverTest {
     }
 
     @Test
-    fun whenActiveCampaign_notificationIsScheduled() = runTest {
+    fun `when active campaign, schedule the notification`() = runTest {
         val campaign1 = BLAZE_CAMPAIGN_ENTITY
         val campaign2 = BLAZE_CAMPAIGN_ENTITY.copy(durationInDays = 8)
         val campaign3 = BLAZE_CAMPAIGN_ENTITY.copy(uiStatus = "completed")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/notification/BlazeCampaignsObserverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/notification/BlazeCampaignsObserverTest.kt
@@ -61,27 +61,7 @@ class BlazeCampaignsObserverTest {
     }
 
     @Test
-    fun `when no active campaign, then don't schedule notification`() = runTest {
-        initBlazeCampaignsObserver(campaigns = listOf(BLAZE_CAMPAIGN_ENTITY.copy(uiStatus = "rejected")))
-
-        blazeCampaignsObserver.observeAndScheduleNotifications()
-
-        verifyNoInteractions(localNotificationScheduler)
-    }
-
-    @Test
-    fun `when canceled with zero Impression campaign, then don't schedule the notification`() = runTest {
-        initBlazeCampaignsObserver(
-            campaigns = listOf(BLAZE_CAMPAIGN_ENTITY.copy(uiStatus = "canceled", impressions = 0))
-        )
-
-        blazeCampaignsObserver.observeAndScheduleNotifications()
-
-        verifyNoInteractions(localNotificationScheduler)
-    }
-
-    @Test
-    fun `when active campaign, schedule the notification`() = runTest {
+    fun `when there are campaigns, schedule the notification`() = runTest {
         val campaign1 = BLAZE_CAMPAIGN_ENTITY
         val campaign2 = BLAZE_CAMPAIGN_ENTITY.copy(durationInDays = 8)
         val campaign3 = BLAZE_CAMPAIGN_ENTITY.copy(uiStatus = "completed")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12290 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This completes the missing logic part of the Blaze reminder notification. The notification will be shown 30 days after the last active campaign has ended. It will be shown only once for each site.

`BlazeCampaignsObserver` will begin monitoring all changes to the site's campaigns and will schedule a notification after each change.

The notification won't be shown
- If the Blaze is not enabled for the site,
- or the notification has already been shown for the selected site, 
- or there isn't any campaign that started to run and received an impression.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Since the notification will be shown at least 30 days later, it's not possible to test the actual behavior. I tested this PR by manipulating the code.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
To change the code to trigger the notification in 30 seconds, you can this patch:
[Trigger_blaze_reminder_notification_for_testing.patch](https://github.com/user-attachments/files/16665165/Trigger_blaze_reminder_notification_for_testing.patch)
Testing with this patch does not guarantee the feature has no issue. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/6574a3bf-45f3-453a-aa9c-eb18ef91cfa5" width=300>

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->