### PR TITLE
[Bug] LearnMore in Payments is cut-off

### DIFF
--- a/WooCommerce/src/main/res/layout/fragment_payments_hub.xml
+++ b/WooCommerce/src/main/res/layout/fragment_payments_hub.xml
@@ -35,6 +35,7 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/paymentsHubRv"
+        app:layout_constraintBottom_toBottomOf="parent"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:clipToPadding="false"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3740,7 +3740,7 @@
     <string name="more_menu_button_wc_admin_description">Manage more on admin</string>
 
     <string name="more_menu_button_payments">Payments</string>
-    <string name="more_menu_button_payments_description">Join the mobile payments</string>
+    <string name="more_menu_button_payments_description">Take payments on the go</string>
 
     <string name="more_menu_button_google">Google for WooCommerce</string>
     <string name="more_menu_button_google_description">Drive sales and generate more traffic with Google Ads</string>


### PR DESCRIPTION
Closes: #12241  
<!-- Id number of the GitHub issue this PR addresses. -->

### Description  
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Fixes the issue where the "Learn More" section in the Payments screen is cut off by the screen edge. The issue was caused by improper layout constraints which didn't account for different screen sizes, leading to the content being cut off. 

Also made a text change that had been suggested here:
pecCkj-15h-p2

### Steps to reproduce  
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to the More menu.
2. Click on Payments.
3. Scroll down.
4. Observe that the last section should not be cut off by the screen edge.

### Testing information  
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

#### Devices Used:
- Pixel 8 emulator (Android 14)
- small tablet emulator (Android 13

#### Test Cases:
- Navigating to the Payments screen and scrolling down to verify that the "Learn More" section is fully visible.
- Changing device orientation (portrait/landscape) and checking the "Learn More" section.
- Verifying on different screen sizes, including tablets, that the section is intact.
- Ensuring no other elements on the Payments screen are affected by the layout adjustments.

### The tests that have been performed  
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

- Verified that the "Learn More" section is fully visible on the Payments screen on multiple devices.
- Ensured that layout changes do not impact other elements on the screen.












- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.  
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.  
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->