### PR TITLE
Google for WooCommerce: Update plugin checking

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [*] Disable QR code scanning from login flow [https://github.com/woocommerce/woocommerce-android/pull/12303]
 - [*] Fixed the hidden “Write with AI” issue that occurs when the keyboard is open. [https://github.com/woocommerce/woocommerce-android/pull/12311]
 - [*] Allowed collecting card-present payments for orders with `failed` status [https://github.com/woocommerce/woocommerce-android/pull/12349]
+- [*] Fix plugin check for Google for WooCommerce feature [https://github.com/woocommerce/woocommerce-android/pull/12398]
 - [*] [Internal] [Login] Switched back to using the `/token` endpoint for WordPress.com authentication, this fixes an issue where the SMS OTP is not triggered automatically after submitting the password [https://github.com/woocommerce/woocommerce-android/pull/12319]
 - [*] [Internal] [WEAR] Introduces Sentry support to the Wear app
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/IsGoogleForWooEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/IsGoogleForWooEnabled.kt
@@ -36,7 +36,7 @@ class IsGoogleForWooEnabled @Inject constructor(
             val plugin = activePlugins.getJSONObject(i)
             val currentPluginName = plugin.optString("plugin")
             val currentPluginVersion = plugin.optString("version")
-            if (currentPluginName == GOOGLE_FOR_WOO_PLUGIN_NAME &&
+            if (currentPluginName.contains(GOOGLE_FOR_WOO_PLUGIN_NAME) &&
                 currentPluginVersion.isVersionAtLeast(GOOGLE_FOR_WOO_PLUGIN_MIN_VERSION)
             ) {
                 return true


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12396
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->


Due to recent changes in either https://github.com/woocommerce/woocommerce/pull/48709 or https://github.com/woocommerce/woocommerce/pull/50417 , the `wc/v3/system_status response` endpoint now adds a prefix `/srv/htdocs/wp-content/plugins/` to the plugin name, and this causes the check for the Google for WooCommerce plugin's existence to fail.

This PR is quickly added and meant to be added in beta, so that it can get to users faster.

I tried adding unit tests but still could not figure out how to mock the use of `JSONArray` in the use case. As this fix is rather time sensitive, let's merge this first and I'll work on the unit test in a separate PR.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Start with a test site with the latest version of WooCommerce, active Google for WooCommerce plugin, existing active campaigns, and plugin version of 2.7.7 or above.
2. Start app, go to hub menu, ensure that the Google for WooCommerce button exists

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description. <-- pushed to another PR
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->