### PR TITLE
Fix sku ellipsize

### DIFF
--- a/WooCommerce/src/main/res/layout/order_detail_product_child_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_child_item.xml
@@ -67,13 +67,16 @@
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/productInfo_SKU"
         style="@style/Woo.ListItem.Body"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/orderdetail_product_lineitem_sku_value"
         app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
         app:layout_constraintTop_toBottomOf="@+id/productInfo_attributes"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/productInfo_total"
         tools:visibility="visible"
+        android:lines="1"
+        android:ellipsize="end"
         android:paddingBottom="@dimen/minor_100"/>
 
 

--- a/WooCommerce/src/main/res/layout/order_detail_product_item.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_product_item.xml
@@ -65,9 +65,12 @@
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/productInfo_SKU"
         style="@style/Woo.ListItem.Body"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/orderdetail_product_lineitem_sku_value"
+        app:layout_constraintEnd_toStartOf="@+id/productInfo_total"
+        android:lines="1"
+        android:ellipsize="end"
         app:layout_constraintStart_toEndOf="@+id/productInfo_iconFrame"
         app:layout_constraintTop_toBottomOf="@+id/productInfo_attributes"
         tools:visibility="visible" />


### PR DESCRIPTION
Closes: #12243

### Description
This PR addresses the issue of long SKU text overflowing the designated space on Android devices. To enhance user experience and readability, the SKU field will now be ellipsized if the text exceeds the available space. This implementation will ensure that the SKU is displayed clearly and concisely, preventing overlapping with other elements. These are visual changes, so the PR does not include unit tests

### Steps to reproduce

1. Create an order with an item having a long SKU name
2. Go to the Order Detail screen

### Testing information

1. Create an order with an item having a long SKU name
2. Go to the Order Detail screen

### The tests that have been performed

1. Create an order with an item having a long SKU name and check the order details


### Images/gif

| Before | After |
| ------------- | ------------- |
| <img width="300" src="https://github.com/user-attachments/assets/ed3e38f1-d2d9-4e36-a712-9d70215e50c2" />  | <img width="300" src="https://github.com/user-attachments/assets/4d422c75-d4d0-4c98-8af0-3d898509d148" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->