### PR TITLE
Check changes before exiting

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailsToolbarHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailsToolbarHelper.kt
@@ -91,6 +91,8 @@ class ProductDetailsToolbarHelper @Inject constructor(
             }
 
         toolbar.setNavigationOnClickListener {
+            if (viewModel?.onBackButtonClickedProductDetail() == false) return@setNavigationOnClickListener
+
             if (fragment?.findNavController()?.popBackStack(R.id.products, false) == false) {
                 // in case the back stack is empty, indicating that the ProductDetailsFragment is shown in details pane
                 // of the ProductListFragment, we need to propagate back press to the parent fragment manually.


### PR DESCRIPTION
Closes: #12298

### Description
There was no discard confirmation when exiting the product details with unsaved changes using the toolbar navigation icon. The changes were just discarded without warning. This PR fixes that by checking if there was any change before exiting the screen and displaying the discard confirmation dialog if some changes were made. The changes in this PR don't require unit tests.

### Steps to reproduce

1. Go to the Products tab.
2. Select an existing product.
3. Change or add product details.
4. Tap the back button to exit the product details and notice there is no confirmation before the changes are discarded.

### Testing information
TC1 
1. Go to the Products tab.
2. Select an existing product.
3. Change or add product details.
4. Tap the back button to exit the product details and notice there is a confirmation dialog before the changes are discarded.

TC2
1. Go to the Products tab.
2. Select an existing product.
4. Tap the back button to exit the product details and check there is NO confirmation dialog.

### The tests that have been performed
I have executed TC1 and TC2.

### Images/gif

https://github.com/user-attachments/assets/cde2eaad-066c-4b5e-b0ab-03f072d665f1

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->