### PR TITLE
Fix for payment selection screen shown after successful payment

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 20.2
 -----
-
+- [**] Fixed navigation in tablet mode: after order is paid, the app should redirect to order details screen. [https://github.com/woocommerce/woocommerce-android/pull/12415]
 
 20.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -231,14 +231,13 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
                 }
 
                 is NavigateBackToOrderList -> {
-                    val action = if (requireContext().windowSizeClass != WindowSizeClass.Compact) {
-                        SelectPaymentMethodFragmentDirections.actionSelectPaymentMethodFragmentToOrderDetailFragment(
-                            orderId = event.order.id
-                        )
+                    if (requireContext().windowSizeClass > WindowSizeClass.Compact) {
+                        findNavController().popBackStack()
                     } else {
-                        SelectPaymentMethodFragmentDirections.actionSelectPaymentMethodFragmentToOrderList()
+                        SelectPaymentMethodFragmentDirections.actionSelectPaymentMethodFragmentToOrderList().run {
+                            findNavController().navigateSafely(this)
+                        }
                     }
-                    findNavController().navigateSafely(action)
                 }
 
                 is NavigateBackToHub -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -232,6 +232,8 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
 
                 is NavigateBackToOrderList -> {
                     if (requireContext().windowSizeClass > WindowSizeClass.Compact) {
+                        // in tablet mode the [SelectPaymentMethodFragment] is shown in the details pane.
+                        // We should pop the back stack to show the [OrderDetailsFragment].
                         findNavController().popBackStack()
                     } else {
                         SelectPaymentMethodFragmentDirections.actionSelectPaymentMethodFragmentToOrderList().run {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10920
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
There was a bug in navigation resulting in showing "Take payment" screen again after the payment was successfully collected (e.g. cash payment) after creating an order. The issue was present on large screens in tablet mode.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Steps to reproduce the bug:
1. Go to order list
2. Start the order creation flow
3. Add a product or a custom amount
4. Tap on Collect Payment
5. Select Cash
6. Confirm
7. Press back
8. Notice the app navigates you back to the Payment Selection screen

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
The tests should verify that after collecting the payment the app redirects to the order list screen (in phone mode) and to the orders with order details (in tablet mode). Pressing "back" should redirect to the "My store" screen.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I tested the above scenario on phone and tablet physical devices: Pixel 8 and Galaxy Tab, Android 14.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/b6467c65-4178-48fc-8fb6-04f33ca84b77

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->