### PR TITLE
Issue/12414 custom fields editor

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/CustomFieldModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/CustomFieldModels.kt
@@ -1,22 +1,27 @@
 package com.woocommerce.android.ui.customfields
 
+import android.os.Parcelable
 import androidx.core.util.PatternsCompat
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.metadata.WCMetaData
 import org.wordpress.android.util.HtmlUtils
 import java.util.regex.Pattern
 
 typealias CustomField = WCMetaData
 
+@Parcelize
 data class CustomFieldUiModel(
-    private val customField: CustomField
-) {
-    val key
-        get() = customField.key
-    val value
-        get() = customField.valueAsString
+    val key: String,
+    val value: String,
+    val id: Long? = null,
+) : Parcelable {
+    constructor(customField: CustomField) : this(customField.key, customField.valueAsString, customField.id)
+
     val valueStrippedHtml: String
         get() = HtmlUtils.fastStripHtml(value)
 
+    @IgnoredOnParcel
     val contentType: CustomFieldContentType = CustomFieldContentType.fromMetadataValue(value)
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/CustomFieldsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/CustomFieldsRepository.kt
@@ -38,4 +38,13 @@ class CustomFieldsRepository @Inject constructor(
     suspend fun hasDisplayableCustomFields(
         parentItemId: Long,
     ) = metaDataStore.hasDisplayableMetaData(selectedSite.get(), parentItemId)
+
+    suspend fun getCustomFieldById(
+        parentItemId: Long,
+        customFieldId: Long,
+    ): CustomField? = metaDataStore.getMetaDataById(
+        site = selectedSite.get(),
+        parentItemId = parentItemId,
+        metaDataId = customFieldId
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorFragment.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.ui.customfields.editor
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.composeView
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class CustomFieldsEditorFragment : BaseFragment() {
+    private val viewModel: CustomFieldsEditorViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return composeView {
+            CustomFieldsEditorScreen(viewModel)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorFragment.kt
@@ -7,10 +7,13 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class CustomFieldsEditorFragment : BaseFragment() {
+    override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
+
     private val viewModel: CustomFieldsEditorViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorFragment.kt
@@ -5,9 +5,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -19,6 +21,18 @@ class CustomFieldsEditorFragment : BaseFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {
             CustomFieldsEditorScreen(viewModel)
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        handleEvents()
+    }
+
+    private fun handleEvents() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
@@ -70,6 +70,7 @@ private fun CustomFieldsEditorScreen(
                 value = state.customField.key,
                 onValueChange = onKeyChanged,
                 label = stringResource(R.string.custom_fields_editor_key_label),
+                singleLine = true
             )
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
@@ -66,8 +66,7 @@ private fun CustomFieldsEditorScreen(
             WCOutlinedTextField(
                 value = state.customField.key,
                 onValueChange = onKeyChanged,
-                label = "Key",
-                placeholderText = "Enter key"
+                label = stringResource(R.string.custom_fields_editor_key_label),
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -75,8 +74,7 @@ private fun CustomFieldsEditorScreen(
             WCOutlinedTextField(
                 value = state.customField.value,
                 onValueChange = onValueChanged,
-                label = "Value",
-                placeholderText = "Enter value",
+                label = stringResource(R.string.custom_fields_editor_value_label),
                 minLines = 5
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
@@ -1,9 +1,101 @@
 package com.woocommerce.android.ui.customfields.editor
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.customfields.CustomFieldUiModel
 
 @Composable
 fun CustomFieldsEditorScreen(viewModel: CustomFieldsEditorViewModel) {
-    viewModel.toString()
-    TODO()
+    viewModel.state.observeAsState().value?.let { state ->
+        CustomFieldsEditorScreen(
+            state = state,
+            onKeyChanged = viewModel::onKeyChanged,
+            onValueChanged = viewModel::onValueChanged,
+            onDoneClicked = viewModel::onDoneClicked,
+            onBackButtonClick = viewModel::onBackClick,
+        )
+    }
+}
+
+@Composable
+private fun CustomFieldsEditorScreen(
+    state: CustomFieldsEditorViewModel.UiState,
+    onKeyChanged: (String) -> Unit,
+    onValueChanged: (String) -> Unit,
+    onDoneClicked: () -> Unit,
+    onBackButtonClick: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = "Custom Field",
+                onNavigationButtonClick = onBackButtonClick,
+                actions = {
+                    if (state.showDoneButton) {
+                        WCTextButton(
+                            onClick = onDoneClicked,
+                            text = stringResource(R.string.done)
+                        )
+                    }
+                }
+            )
+        },
+        backgroundColor = MaterialTheme.colors.surface
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            WCOutlinedTextField(
+                value = state.customField.key,
+                onValueChange = onKeyChanged,
+                label = "Key",
+                placeholderText = "Enter key"
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            WCOutlinedTextField(
+                value = state.customField.value,
+                onValueChange = onValueChanged,
+                label = "Value",
+                placeholderText = "Enter value",
+                minLines = 5
+            )
+        }
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun CustomFieldsEditorScreenPreview() {
+    WooThemeWithBackground {
+        CustomFieldsEditorScreen(
+            CustomFieldsEditorViewModel.UiState(
+                customField = CustomFieldUiModel("key", "value"),
+                showDoneButton = true,
+                isHtml = false
+            ),
+            onKeyChanged = {},
+            onValueChanged = {},
+            onDoneClicked = {},
+            onBackButtonClick = {}
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.DiscardChangesDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
@@ -77,6 +78,13 @@ private fun CustomFieldsEditorScreen(
                 label = "Value",
                 placeholderText = "Enter value",
                 minLines = 5
+            )
+        }
+
+        state.discardChangesDialogState?.let {
+            DiscardChangesDialog(
+                discardButton = it.onDiscard,
+                dismissButton = it.onCancel
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
@@ -60,6 +62,7 @@ private fun CustomFieldsEditorScreen(
     ) { paddingValues ->
         Column(
             modifier = Modifier
+                .verticalScroll(rememberScrollState())
                 .padding(paddingValues)
                 .padding(16.dp)
         ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
@@ -97,11 +97,7 @@ private fun CustomFieldsEditorScreen(
 private fun CustomFieldsEditorScreenPreview() {
     WooThemeWithBackground {
         CustomFieldsEditorScreen(
-            CustomFieldsEditorViewModel.UiState(
-                customField = CustomFieldUiModel("key", "value"),
-                showDoneButton = true,
-                isHtml = false
-            ),
+            CustomFieldsEditorViewModel.UiState(customField = CustomFieldUiModel("key", "value")),
             onKeyChanged = {},
             onValueChanged = {},
             onDoneClicked = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.ui.customfields.editor
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun CustomFieldsEditorScreen(viewModel: CustomFieldsEditorViewModel) {
+    viewModel.toString()
+    TODO()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -50,11 +50,7 @@ class CustomFieldsEditorViewModel @Inject constructor(
     ) { customField, storedValue, isHtml, discardChangesDialogState ->
         UiState(
             customField = customField,
-            showDoneButton = if (storedValue == null) {
-                customField.key.isNotBlank() && customField.value.isNotBlank()
-            } else {
-                customField.key != storedValue.key || customField.value != storedValue.valueAsString
-            },
+            showDoneButton = calculateShowButtonState(customField, storedValue),
             isHtml = isHtml,
             discardChangesDialogState = discardChangesDialogState
         )
@@ -116,6 +112,14 @@ class CustomFieldsEditorViewModel @Inject constructor(
         } else {
             null
         }
+    }
+
+    private fun calculateShowButtonState(draft: CustomFieldUiModel, stored: CustomField?): Boolean {
+        if (draft.key.isEmpty() || draft.value.isEmpty()) {
+            return false
+        }
+
+        return stored == null || stored.key != draft.key || stored.valueAsString != draft.value
     }
 
     data class UiState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -2,48 +2,81 @@ package com.woocommerce.android.ui.customfields.editor
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.ui.customfields.CustomField
 import com.woocommerce.android.ui.customfields.CustomFieldUiModel
+import com.woocommerce.android.ui.customfields.CustomFieldsRepository
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class CustomFieldsEditorViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val repository: CustomFieldsRepository
 ) : ScopedViewModel(savedStateHandle) {
-    val state = savedStateHandle.getStateFlow(viewModelScope, UiState(), "customField")
+    private val navArgs by savedStateHandle.navArgs<CustomFieldsEditorFragmentArgs>()
+
+    private val customFieldDraft = savedStateHandle.getStateFlow(
+        scope = viewModelScope,
+        initialValue = CustomFieldUiModel("", ""),
+        key = "customField"
+    )
+    private val storedValue = MutableStateFlow<CustomField?>(null)
+    private val isHtml = storedValue.map { it?.valueStrippedHtml != it?.valueAsString }
+
+    val state = combine(
+        customFieldDraft,
+        storedValue,
+        isHtml
+    ) { customField, storedValue, isHtml ->
+        UiState(
+            customField = customField,
+            showDoneButton = if (storedValue == null) {
+                customField.key.isNotBlank() && customField.value.isNotBlank()
+            } else {
+                customField.key != storedValue.key || customField.value != storedValue.valueAsString
+            },
+            isHtml = isHtml
+        )
+    }
 
     init {
-        if (!savedStateHandle.contains("customField")) {
-            initUiState()
-        }
+        loadStoreValue()
     }
 
     fun onKeyChanged(key: String) {
-        state.value = state.value.copy(customField = state.value.customField.copy(key = key))
+        customFieldDraft.update { it.copy(key = key) }
     }
 
     fun onValueChanged(value: String) {
-        state.value = state.value.copy(customField = state.value.customField.copy(value = value))
+        customFieldDraft.update { it.copy(value = value) }
     }
 
     fun onDoneClicked() {
         TODO()
     }
 
-    private fun initUiState() = launch {
-        // TODO: load the custom field from the repository if we have an id
-        val customField = CustomFieldUiModel("", "")
-        state.value = UiState(
-            customField = customField,
-            isHtml = customField.valueStrippedHtml != customField.value
-        )
+    private fun loadStoreValue() = launch {
+        navArgs.customFieldId.takeIf { it != -1L }?.let {
+            repository.getCustomFieldById(
+                parentItemId = navArgs.parentItemId,
+                customFieldId = it
+            )
+        }?.let {
+            storedValue.value = it
+        }
     }
 
     data class UiState(
         val customField: CustomFieldUiModel = CustomFieldUiModel("", ""),
+        val showDoneButton: Boolean = false,
         val isHtml: Boolean = false
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.customfields.editor
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.customfields.CustomField
 import com.woocommerce.android.ui.customfields.CustomFieldUiModel
 import com.woocommerce.android.ui.customfields.CustomFieldsRepository
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
@@ -45,7 +47,7 @@ class CustomFieldsEditorViewModel @Inject constructor(
             },
             isHtml = isHtml
         )
-    }
+    }.asLiveData()
 
     init {
         loadStoreValue()
@@ -69,9 +71,15 @@ class CustomFieldsEditorViewModel @Inject constructor(
                 parentItemId = navArgs.parentItemId,
                 customFieldId = it
             )
-        }?.let {
-            storedValue.value = it
+        }?.let { dbValue ->
+            storedValue.value = dbValue
+            customFieldDraft.update { it.copy(id = dbValue.id) }
         }
+    }
+
+    fun onBackClick() {
+        // TODO: show confirmation dialog if there are unsaved changes
+        triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
     data class UiState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -1,13 +1,49 @@
 package com.woocommerce.android.ui.customfields.editor
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.ui.customfields.CustomFieldUiModel
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class CustomFieldsEditorViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
+    val state = savedStateHandle.getStateFlow(viewModelScope, UiState(), "customField")
 
+    init {
+        if (!savedStateHandle.contains("customField")) {
+            initUiState()
+        }
+    }
+
+    fun onKeyChanged(key: String) {
+        state.value = state.value.copy(customField = state.value.customField.copy(key = key))
+    }
+
+    fun onValueChanged(value: String) {
+        state.value = state.value.copy(customField = state.value.customField.copy(value = value))
+    }
+
+    fun onDoneClicked() {
+        TODO()
+    }
+
+    private fun initUiState() = launch {
+        // TODO: load the custom field from the repository if we have an id
+        val customField = CustomFieldUiModel("", "")
+        state.value = UiState(
+            customField = customField,
+            isHtml = customField.valueStrippedHtml != customField.value
+        )
+    }
+
+    data class UiState(
+        val customField: CustomFieldUiModel = CustomFieldUiModel("", ""),
+        val isHtml: Boolean = false
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.customfields.editor
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class CustomFieldsEditorViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedStateHandle) {
+
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -50,7 +50,8 @@ class CustomFieldsEditorViewModel @Inject constructor(
     ) { customField, storedValue, isHtml, discardChangesDialogState ->
         UiState(
             customField = customField,
-            showDoneButton = calculateShowButtonState(customField, storedValue),
+            hasChanges = storedValue?.key.orEmpty() != customField.key ||
+                storedValue?.valueAsString.orEmpty() != customField.value,
             isHtml = isHtml,
             discardChangesDialogState = discardChangesDialogState
         )
@@ -96,7 +97,7 @@ class CustomFieldsEditorViewModel @Inject constructor(
     }
 
     fun onBackClick() {
-        if (state.value?.showDoneButton == true) {
+        if (state.value?.hasChanges == true) {
             showDiscardChangesDialog.value = true
         } else {
             triggerEvent(MultiLiveEvent.Event.Exit)
@@ -114,20 +115,15 @@ class CustomFieldsEditorViewModel @Inject constructor(
         }
     }
 
-    private fun calculateShowButtonState(draft: CustomFieldUiModel, stored: CustomField?): Boolean {
-        if (draft.key.isEmpty()) {
-            return false
-        }
-
-        return stored == null || stored.key != draft.key || stored.valueAsString != draft.value
-    }
-
     data class UiState(
         val customField: CustomFieldUiModel = CustomFieldUiModel("", ""),
-        val showDoneButton: Boolean = false,
+        val hasChanges: Boolean = false,
         val isHtml: Boolean = false,
         val discardChangesDialogState: DiscardChangesDialogState? = null
-    )
+    ) {
+        val showDoneButton
+            get() = customField.key.isNotEmpty() && hasChanges
+    }
 
     data class DiscardChangesDialogState(
         val onDiscard: () -> Unit,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -73,7 +73,7 @@ class CustomFieldsEditorViewModel @Inject constructor(
     }
 
     private fun initState() {
-        if (navArgs.customFieldId == -1L) {
+        if (navArgs.customFieldId == -1L && customFieldDraft.value == null) {
             customFieldDraft.value = CustomFieldUiModel("", "")
             return
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -115,7 +115,7 @@ class CustomFieldsEditorViewModel @Inject constructor(
     }
 
     private fun calculateShowButtonState(draft: CustomFieldUiModel, stored: CustomField?): Boolean {
-        if (draft.key.isEmpty() || draft.value.isEmpty()) {
+        if (draft.key.isEmpty()) {
             return false
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
@@ -42,6 +42,7 @@ class CustomFieldsFragment : BaseFragment() {
     private fun handleEvents() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
+                is CustomFieldsViewModel.OpenCustomFieldEditor -> openEditor(event.field)
                 is CustomFieldsViewModel.CustomFieldValueClicked -> handleValueClick(event.field)
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is MultiLiveEvent.Event.Exit -> {
@@ -49,6 +50,15 @@ class CustomFieldsFragment : BaseFragment() {
                 }
             }
         }
+    }
+
+    private fun openEditor(field: CustomFieldUiModel) {
+        findNavController().navigate(
+            CustomFieldsFragmentDirections.actionCustomFieldsFragmentToCustomFieldsEditorFragment(
+                customFieldId = field.id ?: -1,
+                parentItemId = viewModel.parentItemId,
+            )
+        )
     }
 
     private fun handleValueClick(field: CustomFieldUiModel) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.customfields.list
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -49,6 +50,7 @@ fun CustomFieldsScreen(viewModel: CustomFieldsViewModel) {
         CustomFieldsScreen(
             state = state,
             onPullToRefresh = viewModel::onPullToRefresh,
+            onCustomFieldClicked = viewModel::onCustomFieldClicked,
             onCustomFieldValueClicked = viewModel::onCustomFieldValueClicked,
             onBackClick = viewModel::onBackClick
         )
@@ -60,6 +62,7 @@ fun CustomFieldsScreen(viewModel: CustomFieldsViewModel) {
 private fun CustomFieldsScreen(
     state: CustomFieldsViewModel.UiState,
     onPullToRefresh: () -> Unit,
+    onCustomFieldClicked: (CustomFieldUiModel) -> Unit,
     onCustomFieldValueClicked: (CustomFieldUiModel) -> Unit,
     onBackClick: () -> Unit
 ) {
@@ -83,6 +86,7 @@ private fun CustomFieldsScreen(
                 items(state.customFields) { customField ->
                     CustomFieldItem(
                         customField = customField,
+                        onClicked = onCustomFieldClicked,
                         onValueClicked = onCustomFieldValueClicked,
                         modifier = Modifier.fillMaxWidth()
                     )
@@ -103,12 +107,15 @@ private fun CustomFieldsScreen(
 @Composable
 private fun CustomFieldItem(
     customField: CustomFieldUiModel,
+    onClicked: (CustomFieldUiModel) -> Unit,
     onValueClicked: (CustomFieldUiModel) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier.padding(16.dp)
+        modifier = modifier
+            .clickable(onClick = { onClicked(customField) })
+            .padding(16.dp)
     ) {
         Column(modifier = Modifier.weight(1f)) {
             Text(
@@ -177,6 +184,7 @@ private fun CustomFieldsScreenPreview() {
                 isLoading = false
             ),
             onPullToRefresh = {},
+            onCustomFieldClicked = {},
             onCustomFieldValueClicked = {},
             onBackClick = {}
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
@@ -24,6 +24,8 @@ class CustomFieldsViewModel @Inject constructor(
     private val isLoading = MutableStateFlow(false)
     private val customFields = repository.observeDisplayableCustomFields(args.parentItemId)
 
+    val parentItemId = args.parentItemId
+
     val state = combine(
         customFields,
         isLoading
@@ -48,6 +50,10 @@ class CustomFieldsViewModel @Inject constructor(
         }
     }
 
+    fun onCustomFieldClicked(field: CustomFieldUiModel) {
+        triggerEvent(OpenCustomFieldEditor(field))
+    }
+
     fun onCustomFieldValueClicked(field: CustomFieldUiModel) {
         triggerEvent(CustomFieldValueClicked(field))
     }
@@ -57,5 +63,6 @@ class CustomFieldsViewModel @Inject constructor(
         val isLoading: Boolean
     )
 
+    data class OpenCustomFieldEditor(val field: CustomFieldUiModel) : MultiLiveEvent.Event()
     data class CustomFieldValueClicked(val field: CustomFieldUiModel) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_custom_fields.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_custom_fields.xml
@@ -19,6 +19,20 @@
         <argument
             android:name="parentItemType"
             app:argType="org.wordpress.android.fluxc.model.metadata.MetaDataParentItemType" />
+        <action
+            android:id="@+id/action_customFieldsFragment_to_customFieldsEditorFragment"
+            app:destination="@id/customFieldsEditorFragment" />
     </fragment>
 
+    <fragment
+        android:id="@+id/customFieldsEditorFragment"
+        android:name="com.woocommerce.android.ui.customfields.editor.CustomFieldsEditorFragment">
+        <argument
+            android:name="customFieldId"
+            app:argType="long"
+            android:defaultValue="-1L" />
+        <argument
+            android:name="parentItemId"
+            app:argType="long" />
+    </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_custom_fields.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_custom_fields.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph_custom_fields"
+    app:startDestination="@id/customFieldsFragment">
+    <argument
+        android:name="parentItemId"
+        app:argType="long" />
+    <argument
+        android:name="parentItemType"
+        app:argType="org.wordpress.android.fluxc.model.metadata.MetaDataParentItemType" />
+
+    <fragment
+        android:id="@+id/customFieldsFragment"
+        android:name="com.woocommerce.android.ui.customfields.list.CustomFieldsFragment">
+        <argument
+            android:name="parentItemId"
+            app:argType="long" />
+        <argument
+            android:name="parentItemType"
+            app:argType="org.wordpress.android.fluxc.model.metadata.MetaDataParentItemType" />
+    </fragment>
+
+</navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -8,6 +8,7 @@
     <include app:graph="@navigation/nav_graph_payment_flow" />
     <include app:graph="@navigation/nav_graph_refunds" />
     <include app:graph="@navigation/nav_graph_order_creations" />
+    <include app:graph="@navigation/nav_graph_custom_fields" />
 
     <dialog
         android:id="@+id/itemSelectorDialog"
@@ -299,7 +300,15 @@
             app:destination="@id/AIThankYouNoteBottomSheetFragment" />
         <action
             android:id="@+id/action_orderDetailFragment_to_customFieldsFragment"
-            app:destination="@id/customFieldsFragment" />
+            app:destination="@id/nav_graph_custom_fields" >
+            <argument
+                android:name="parentItemId"
+                app:argType="long" />
+            <argument
+                android:name="parentItemType"
+                app:argType="org.wordpress.android.fluxc.model.metadata.MetaDataParentItemType"
+                android:defaultValue="ORDER" />
+        </action>
     </fragment>
     <dialog
         android:id="@+id/orderStatusSelectorDialog"
@@ -650,17 +659,6 @@
             android:name="remoteNoteId"
             android:defaultValue="0L"
             app:argType="long" />
-    </fragment>
-    <fragment
-        android:id="@+id/customFieldsFragment"
-        android:name="com.woocommerce.android.ui.customfields.list.CustomFieldsFragment">
-        <argument
-            android:name="parentItemId"
-            app:argType="long" />
-        <argument
-            android:name="parentItemType"
-            app:argType="org.wordpress.android.fluxc.model.metadata.MetaDataParentItemType"
-            android:defaultValue="ORDER" />
     </fragment>
     <action
         android:id="@+id/action_global_item_selector_dialog"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4271,4 +4271,6 @@
     -->
     <string name="custom_fields_list_title">Custom Fields</string>
     <string name="custom_fields_list_loading_error">Error while loading custom fields</string>
+    <string name="custom_fields_editor_key_label">Key</string>
+    <string name="custom_fields_editor_value_label">Value</string>
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
@@ -108,12 +108,11 @@ class CustomFieldsEditorViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given creating a new field, when the key and value are not empty, then show done button`() = testBlocking {
+    fun `given creating a new field, when the key is not empty, then show done button`() = testBlocking {
         setup(editing = false)
 
         val state = viewModel.state.runAndCaptureValues {
             viewModel.onKeyChanged("key")
-            viewModel.onValueChanged("value")
         }.last()
 
         assertThat(state.showDoneButton).isTrue()
@@ -125,17 +124,6 @@ class CustomFieldsEditorViewModelTest : BaseUnitTest() {
 
         val state = viewModel.state.runAndCaptureValues {
             viewModel.onKeyChanged("")
-        }.last()
-
-        assertThat(state.showDoneButton).isFalse()
-    }
-
-    @Test
-    fun `when value is empty, then hide done button`() = testBlocking {
-        setup(editing = false)
-
-        val state = viewModel.state.runAndCaptureValues {
-            viewModel.onValueChanged("")
         }.last()
 
         assertThat(state.showDoneButton).isFalse()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
@@ -1,0 +1,166 @@
+package com.woocommerce.android.ui.customfields.editor
+
+import com.woocommerce.android.ui.customfields.CustomField
+import com.woocommerce.android.ui.customfields.CustomFieldsRepository
+import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CustomFieldsEditorViewModelTest : BaseUnitTest() {
+    companion object {
+        private const val CUSTOM_FIELD_ID = 1L
+        private const val PARENT_ITEM_ID = 1L
+    }
+
+    private val repository: CustomFieldsRepository = mock {
+        onBlocking { getCustomFieldById(parentItemId = PARENT_ITEM_ID, customFieldId = CUSTOM_FIELD_ID) } doReturn
+            CustomField(
+                id = CUSTOM_FIELD_ID,
+                key = "key",
+                value = "value"
+            )
+    }
+
+    private lateinit var viewModel: CustomFieldsEditorViewModel
+
+    suspend fun setup(editing: Boolean, prepareMocks: suspend () -> Unit = {}) {
+        prepareMocks()
+        viewModel = CustomFieldsEditorViewModel(
+            savedStateHandle = CustomFieldsEditorFragmentArgs(
+                parentItemId = PARENT_ITEM_ID,
+                customFieldId = if (editing) CUSTOM_FIELD_ID else -1
+            ).toSavedStateHandle(),
+            repository = repository
+        )
+    }
+
+    @Test
+    fun `given editing an existing field, when the screen is opened, then load the existing field`() = testBlocking {
+        setup(editing = true)
+
+        val state = viewModel.state.getOrAwaitValue()
+
+        assertThat(state.customField.id).isEqualTo(CUSTOM_FIELD_ID)
+        assertThat(state.customField.key).isEqualTo("key")
+        assertThat(state.customField.value).isEqualTo("value")
+    }
+
+    @Test
+    fun `given creating a new field, when the screen is opened, then load an empty field`() = testBlocking {
+        setup(editing = false)
+
+        val state = viewModel.state.getOrAwaitValue()
+
+        assertThat(state.customField.id).isNull()
+        assertThat(state.customField.key).isEmpty()
+        assertThat(state.customField.value).isEmpty()
+    }
+
+    @Test
+    fun `when the key is changed, then update the key`() = testBlocking {
+        setup(editing = true)
+
+        val state = viewModel.state.runAndCaptureValues {
+            viewModel.onKeyChanged("new key")
+        }.last()
+
+        assertThat(state.customField.key).isEqualTo("new key")
+    }
+
+    @Test
+    fun `when the value is changed, then update the value`() = testBlocking {
+        setup(editing = true)
+
+        val state = viewModel.state.runAndCaptureValues {
+            viewModel.onValueChanged("new value")
+        }.last()
+
+        assertThat(state.customField.value).isEqualTo("new value")
+    }
+
+    @Test
+    fun `given editing an existing field, when key is changed, then show done button`() = testBlocking {
+        setup(editing = true)
+
+        val state = viewModel.state.runAndCaptureValues {
+            viewModel.onKeyChanged("new key")
+        }.last()
+
+        assertThat(state.showDoneButton).isTrue()
+    }
+
+    @Test
+    fun `given editing an existing field, when value is changed, then show done button`() = testBlocking {
+        setup(editing = true)
+
+        val state = viewModel.state.runAndCaptureValues {
+            viewModel.onValueChanged("new value")
+        }.last()
+
+        assertThat(state.showDoneButton).isTrue()
+    }
+
+    @Test
+    fun `given creating a new field, when the key and value are not empty, then show done button`() = testBlocking {
+        setup(editing = false)
+
+        val state = viewModel.state.runAndCaptureValues {
+            viewModel.onKeyChanged("key")
+            viewModel.onValueChanged("value")
+        }.last()
+
+        assertThat(state.showDoneButton).isTrue()
+    }
+
+    @Test
+    fun `when key is empty, then hide done button`() = testBlocking {
+        setup(editing = false)
+
+        val state = viewModel.state.runAndCaptureValues {
+            viewModel.onKeyChanged("")
+        }.last()
+
+        assertThat(state.showDoneButton).isFalse()
+    }
+
+    @Test
+    fun `when value is empty, then hide done button`() = testBlocking {
+        setup(editing = false)
+
+        val state = viewModel.state.runAndCaptureValues {
+            viewModel.onValueChanged("")
+        }.last()
+
+        assertThat(state.showDoneButton).isFalse()
+    }
+
+    @Test
+    fun `given no changes, when back is clicked, then exit`() = testBlocking {
+        setup(editing = true)
+
+        val events = viewModel.event.runAndCaptureValues {
+            viewModel.onBackClick()
+        }.last()
+
+        assertThat(events).isEqualTo(MultiLiveEvent.Event.Exit)
+    }
+
+    @Test
+    fun `given changes, when back is clicked, then show discard dialog`() = testBlocking {
+        setup(editing = true)
+
+        val state = viewModel.state.runAndCaptureValues {
+            viewModel.onKeyChanged("new key")
+            viewModel.onBackClick()
+        }.last()
+
+        assertThat(state.discardChangesDialogState).isNotNull
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
@@ -172,4 +172,23 @@ class CustomFieldsViewModelTest : BaseUnitTest() {
         assertThat(event).isEqualTo(CustomFieldsViewModel.CustomFieldValueClicked(uiModel))
         assertThat(uiModel.contentType).isEqualTo(CustomFieldContentType.PHONE)
     }
+
+    @Test
+    fun `when tapping on a custom field, then custom field editor is opened`() = testBlocking {
+        val customField = CustomField(
+            id = 1,
+            key = "key",
+            value = "value"
+        )
+        setup {
+            whenever(repository.observeDisplayableCustomFields(PARENT_ITEM_ID)).thenReturn(flowOf(listOf(customField)))
+        }
+
+        val uiModel = CustomFieldUiModel(customField)
+        val event = viewModel.event.runAndCaptureValues {
+            viewModel.onCustomFieldClicked(uiModel)
+        }.last()
+
+        assertThat(event).isEqualTo(CustomFieldsViewModel.OpenCustomFieldEditor(uiModel))
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12414
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR is the first part in implementing the custom fields editor, it adds a new screen to edit existing custom fields, the same screen will be used when adding new fields too, and that should be taken into consideration when reviewing the code.

Many parts are still missing to allow keeping the PR size manageable, this includes the following:
1. Saving changes.
2. Returning results to the list screen and updating its state.
3. Using Aztec when editing HTML values.

**While the PR seems large, a big part of the changes is just tests and XML file changes due to using a nested nav graph, so it should be still easy to review.**

### Testing information
1. Open an order in wp-admin.
2. Tap on the "Custom Fields" section is visible (from the screen options at the top of the page)
3. Add some custom fields (for a more comprehensive testing, add fields that contain a URL, an email and a phone number)
5. Open the order in the app.
6. Tap on "View custom fields"
7. Tap on a custom field.
8. Make some changes.
9. Tap on the back button
10. Confirm a dialog is shown.
11. Test the behavior of the dialog buttons.

### The tests that have been performed
The above steps in addition to the validation rules.

### Images/gif
<img src="https://github.com/user-attachments/assets/a2842e36-e47d-4350-80d7-319182d5aa1f" width=360 />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->