### PR TITLE
[Stats Widget] Handle widget battery saver mode

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/IsDeviceBatterySaverActive.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/IsDeviceBatterySaverActive.kt
@@ -4,11 +4,11 @@ import android.content.Context
 import android.os.PowerManager
 import javax.inject.Inject
 
-class IsDeviceBatterySaverActive @Inject constructor() {
-    operator fun invoke(
-        context: Context
-    ): Boolean {
-        return context.getSystemService(Context.POWER_SERVICE)
+class IsDeviceBatterySaverActive @Inject constructor(
+    private val appContext: Context
+) {
+    operator fun invoke(): Boolean {
+        return appContext.getSystemService(Context.POWER_SERVICE)
             .run { this as? PowerManager }
             ?.isPowerSaveMode
             ?: false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/IsDeviceBatterySaverActive.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/IsDeviceBatterySaverActive.kt
@@ -1,9 +1,18 @@
 package com.woocommerce.android.ui.appwidgets
 
+import android.content.Context
+import android.os.Build
+import android.os.PowerManager
+
 class IsDeviceBatterySaverActive(
 
 ) {
-    operator fun invoke() {
-
+    operator fun invoke(
+        context: Context
+    ): Boolean {
+        return context.getSystemService(Context.POWER_SERVICE)
+            .run { this as? PowerManager }
+            ?.isPowerSaveMode
+            ?: false
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/IsDeviceBatterySaverActive.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/IsDeviceBatterySaverActive.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.ui.appwidgets
+
+class IsDeviceBatterySaverActive(
+
+) {
+    operator fun invoke() {
+
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/IsDeviceBatterySaverActive.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/IsDeviceBatterySaverActive.kt
@@ -1,12 +1,10 @@
 package com.woocommerce.android.ui.appwidgets
 
 import android.content.Context
-import android.os.Build
 import android.os.PowerManager
+import javax.inject.Inject
 
-class IsDeviceBatterySaverActive(
-
-) {
+class IsDeviceBatterySaverActive @Inject constructor() {
     operator fun invoke(
         context: Context
     ): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/GetWidgetStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/GetWidgetStats.kt
@@ -70,7 +70,7 @@ class GetWidgetStats @Inject constructor(
     }
 
     sealed class WidgetStatsResult {
-        data object WidgetStatsBatterySaverActive: WidgetStatsResult()
+        data object WidgetStatsBatterySaverActive : WidgetStatsResult()
         data object WidgetStatsAuthFailure : WidgetStatsResult()
         data object WidgetStatsNetworkFailure : WidgetStatsResult()
         data object WidgetStatsAPINotSupportedFailure : WidgetStatsResult()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/UpdateTodayStatsWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/UpdateTodayStatsWorker.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
 import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats
+import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult
 import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStats
 import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStatsAPINotSupportedFailure
 import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStatsAuthFailure
@@ -74,7 +75,7 @@ class UpdateTodayStatsWorker @AssistedInject constructor(
         widgetId: Int,
         remoteViews: RemoteViews,
         site: SiteModel?,
-        todayStatsResult: GetWidgetStats.WidgetStatsResult
+        todayStatsResult: WidgetStatsResult
     ): Result {
         return when (todayStatsResult) {
             WidgetStatsBatterySaverActive -> {
@@ -123,22 +124,31 @@ class UpdateTodayStatsWorker @AssistedInject constructor(
                 Result.retry()
             }
             is WidgetStats -> {
-                if (site != null) {
-                    todayStatsWidgetUIHelper.displayInformation(
-                        stats = todayStatsResult,
-                        remoteViews = remoteViews
-                    )
-                    Result.success()
-                } else {
-                    todayStatsWidgetUIHelper.displayError(
-                        remoteViews = remoteViews,
-                        errorMessageRes = R.string.stats_widget_error_no_data,
-                        withRetryButton = true,
-                        widgetId = widgetId
-                    )
-                    Result.retry()
-                }
+                handleStatsAvailable(todayStatsResult, site, remoteViews, widgetId)
             }
+        }
+    }
+
+    private fun handleStatsAvailable(
+        todayStatsResult: WidgetStats,
+        site: SiteModel?,
+        remoteViews: RemoteViews,
+        widgetId: Int
+    ): Result {
+        if (site != null) {
+            todayStatsWidgetUIHelper.displayInformation(
+                stats = todayStatsResult,
+                remoteViews = remoteViews
+            )
+            return Result.success()
+        } else {
+            todayStatsWidgetUIHelper.displayError(
+                remoteViews = remoteViews,
+                errorMessageRes = R.string.stats_widget_error_no_data,
+                withRetryButton = true,
+                widgetId = widgetId
+            )
+            return Result.retry()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/UpdateTodayStatsWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/UpdateTodayStatsWorker.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats
 import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStats
 import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStatsAPINotSupportedFailure
 import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStatsAuthFailure
+import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStatsBatterySaverActive
 import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStatsFailure
 import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStatsNetworkFailure
 import com.woocommerce.android.util.DateUtils
@@ -76,6 +77,15 @@ class UpdateTodayStatsWorker @AssistedInject constructor(
         todayStatsResult: GetWidgetStats.WidgetStatsResult
     ): Result {
         return when (todayStatsResult) {
+            WidgetStatsBatterySaverActive -> {
+                todayStatsWidgetUIHelper.displayError(
+                    remoteViews = remoteViews,
+                    errorMessageRes = R.string.stats_widget_battery_saver_error,
+                    withRetryButton = false,
+                    widgetId = widgetId
+                )
+                Result.failure()
+            }
             WidgetStatsNetworkFailure -> {
                 todayStatsWidgetUIHelper.displayError(
                     remoteViews = remoteViews,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/UpdateTodayStatsWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/UpdateTodayStatsWorker.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.appwidgets.IsDeviceBatterySaverActive
 import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.locale.LocaleProvider

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/UpdateTodayStatsWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/appwidgets/stats/today/UpdateTodayStatsWorker.kt
@@ -10,8 +10,12 @@ import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
-import com.woocommerce.android.ui.appwidgets.IsDeviceBatterySaverActive
 import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats
+import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStats
+import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStatsAPINotSupportedFailure
+import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStatsAuthFailure
+import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStatsFailure
+import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStatsNetworkFailure
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.locale.LocaleProvider
 import dagger.assisted.Assisted
@@ -72,7 +76,7 @@ class UpdateTodayStatsWorker @AssistedInject constructor(
         todayStatsResult: GetWidgetStats.WidgetStatsResult
     ): Result {
         return when (todayStatsResult) {
-            GetWidgetStats.WidgetStatsResult.WidgetStatsNetworkFailure -> {
+            WidgetStatsNetworkFailure -> {
                 todayStatsWidgetUIHelper.displayError(
                     remoteViews = remoteViews,
                     errorMessageRes = R.string.stats_widget_offline_error,
@@ -81,7 +85,7 @@ class UpdateTodayStatsWorker @AssistedInject constructor(
                 )
                 Result.retry()
             }
-            GetWidgetStats.WidgetStatsResult.WidgetStatsAPINotSupportedFailure -> {
+            WidgetStatsAPINotSupportedFailure -> {
                 todayStatsWidgetUIHelper.displayError(
                     remoteViews = remoteViews,
                     errorMessageRes = R.string.stats_widget_availability_message,
@@ -90,7 +94,7 @@ class UpdateTodayStatsWorker @AssistedInject constructor(
                 )
                 Result.failure()
             }
-            GetWidgetStats.WidgetStatsResult.WidgetStatsAuthFailure -> {
+            WidgetStatsAuthFailure -> {
                 todayStatsWidgetUIHelper.displayError(
                     remoteViews = remoteViews,
                     errorMessageRes = R.string.stats_widget_log_in_message,
@@ -99,7 +103,7 @@ class UpdateTodayStatsWorker @AssistedInject constructor(
                 )
                 Result.failure()
             }
-            is GetWidgetStats.WidgetStatsResult.WidgetStatsFailure -> {
+            is WidgetStatsFailure -> {
                 todayStatsWidgetUIHelper.displayError(
                     remoteViews = remoteViews,
                     errorMessageRes = R.string.stats_widget_error_no_data,
@@ -108,7 +112,7 @@ class UpdateTodayStatsWorker @AssistedInject constructor(
                 )
                 Result.retry()
             }
-            is GetWidgetStats.WidgetStatsResult.WidgetStats -> {
+            is WidgetStats -> {
                 if (site != null) {
                     todayStatsWidgetUIHelper.displayInformation(
                         stats = todayStatsResult,

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3485,6 +3485,7 @@
     -->
     <string name="stats_widget_log_in_message">Please log in to the WooCommerce app</string>
     <string name="stats_widget_offline_error">Your network is unavailable.\nCheck your data or wifi connection.</string>
+    <string name="stats_widget_battery_saver_error">Looks like your device is in Battery Saver mode. \nWe can\'t provide your store information while it\'s active</string>
     <string name="stats_widget_availability_message">Store analytics not available! Please upgrade to the latest version of WooCommerce to view your store analytics.</string>
     <string name="stats_today_widget_configure_title">Today\'s store stats</string>
     <string name="stats_today_widget_description">WooCommerce Stats Today</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/appwidgets/IsDeviceBatterySaverActiveTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/appwidgets/IsDeviceBatterySaverActiveTest.kt
@@ -3,12 +3,12 @@ package com.woocommerce.android.ui.appwidgets
 import android.content.Context
 import android.os.PowerManager
 import com.woocommerce.android.viewmodel.BaseUnitTest
-import kotlin.test.Test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class IsDeviceBatterySaverActiveTest : BaseUnitTest() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/appwidgets/IsDeviceBatterySaverActiveTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/appwidgets/IsDeviceBatterySaverActiveTest.kt
@@ -1,0 +1,51 @@
+package com.woocommerce.android.ui.appwidgets
+
+import android.content.Context
+import android.os.PowerManager
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class IsDeviceBatterySaverActiveTest : BaseUnitTest() {
+    private lateinit var sut: IsDeviceBatterySaverActive
+    private val appContext: Context = mock()
+    private val powerManager: PowerManager = mock()
+
+    @Before
+    fun setUp() {
+        whenever(appContext.getSystemService(Context.POWER_SERVICE)).thenReturn(powerManager)
+        sut = IsDeviceBatterySaverActive(appContext)
+    }
+
+    @Test
+    fun `returns true when power save mode is active`() = testBlocking {
+        whenever(powerManager.isPowerSaveMode).thenReturn(true)
+
+        val result = sut.invoke()
+
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `returns false when power save mode is not active`() = testBlocking {
+        whenever(powerManager.isPowerSaveMode).thenReturn(false)
+
+        val result = sut.invoke()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `returns false when power manager is null`() = testBlocking {
+        whenever(appContext.getSystemService(Context.POWER_SERVICE)).thenReturn(null)
+
+        val result = sut.invoke()
+
+        assertThat(result).isFalse
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/appwidgets/stats/GetWidgetStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/appwidgets/stats/GetWidgetStatsTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
 import com.woocommerce.android.ui.appwidgets.IsDeviceBatterySaverActive
+import com.woocommerce.android.ui.appwidgets.stats.GetWidgetStats.WidgetStatsResult.WidgetStatsBatterySaverActive
 import com.woocommerce.android.ui.dashboard.data.StatsRepository
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -156,5 +157,21 @@ class GetWidgetStatsTest : BaseUnitTest() {
 
             // Then the result is WidgetStatsFailure
             assertThat(result).isEqualTo(expected)
+        }
+
+    @Test
+    fun `when the device is in battery saver mode then get stats respond with WidgetStatsBatterySaverActive`() =
+        testBlocking {
+            // Given the user is logged, v4 stats is supported and network is working fine
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+            whenever(appPrefsWrapper.isV4StatsSupported()).thenReturn(true)
+            whenever(networkStatus.isConnected()).thenReturn(true)
+            whenever(isDeviceBatterySaverActive()).thenReturn(true)
+
+            // When GetWidgetStats is invoked
+            val result = sut.invoke(defaultRange, defaultSiteModel)
+
+            // Then the result is WidgetStatsBatterySaverActive
+            assertThat(result).isEqualTo(WidgetStatsBatterySaverActive)
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/appwidgets/stats/GetWidgetStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/appwidgets/stats/GetWidgetStatsTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.appwidgets.IsDeviceBatterySaverActive
 import com.woocommerce.android.ui.dashboard.data.StatsRepository
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -27,6 +28,7 @@ class GetWidgetStatsTest : BaseUnitTest() {
     private val appPrefsWrapper: AppPrefsWrapper = mock()
     private val statsRepository: StatsRepository = mock()
     private val networkStatus: NetworkStatus = mock()
+    private val isDeviceBatterySaverActive: IsDeviceBatterySaverActive = mock()
 
     private val defaultRange = StatsTimeRangeSelection.build(
         selectionType = SelectionType.TODAY,
@@ -55,7 +57,8 @@ class GetWidgetStatsTest : BaseUnitTest() {
         appPrefsWrapper = appPrefsWrapper,
         statsRepository = statsRepository,
         networkStatus = networkStatus,
-        coroutineDispatchers = coroutinesTestRule.testDispatchers
+        coroutineDispatchers = coroutinesTestRule.testDispatchers,
+        isDeviceBatterySaverActive = isDeviceBatterySaverActive
     )
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/appwidgets/stats/GetWidgetStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/appwidgets/stats/GetWidgetStatsTest.kt
@@ -163,9 +163,6 @@ class GetWidgetStatsTest : BaseUnitTest() {
     fun `when the device is in battery saver mode then get stats respond with WidgetStatsBatterySaverActive`() =
         testBlocking {
             // Given the user is logged, v4 stats is supported and network is working fine
-            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
-            whenever(appPrefsWrapper.isV4StatsSupported()).thenReturn(true)
-            whenever(networkStatus.isConnected()).thenReturn(true)
             whenever(isDeviceBatterySaverActive()).thenReturn(true)
 
             // When GetWidgetStats is invoked


### PR DESCRIPTION
Summary
==========
Fix issue #12096 by introducing a text warning into the Widget UI when the device is using Battery Saver mode.

Ever since Android 9, whenever a Android device activates the Battery Saver mode, all Background tasks from any app gets deactivated until the mode is switched off. This directly afects the Widget ability to fetch data, but it's internal error handling ends up giving a Network error output instead of the correct information, misleading the user.

How
==========
The Widget code now verifies if the Battery Saver mode is activated in the device before any attempt of requesting Store Stats for the Widget, and immeadiately throws an UI error with the correct message.

Screenshots
==========
<img src="https://github.com/user-attachments/assets/b2656bbd-8f0a-40e4-bf5b-7de4c2e79479" width="270" height="570" />


How to Test
==========
1. Install the Woo app in your device
2. Go to the Device control center and activate the standard `Battery Saver` mode. The extreme mode even deactivate widget UIs, there are nothing we can do for those scenarios.
3. Set the Woo Widget into the device main app dashboard
4. Verify the Widget is displayed with a Battery Saver text with details of why it can't display any data.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
