### PR TITLE
[Edit Orders] Show a back button in the Order Edit Screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,9 +1,10 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final APK before release (e.g. major library or targetSdk updates).
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
+
 20.2
 -----
-
+- [*] Show the back button on the Order Edit Screen for phones [https://github.com/woocommerce/woocommerce-android/pull/12421]
 
 20.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -243,11 +243,7 @@ class OrderCreateEditFormFragment :
             twoPaneModeToolbar.title = getTitle()
             twoPaneModeToolbar.setNavigationIcon(R.drawable.ic_back_24dp)
         } else {
-            val navigationIcon = when (viewModel.mode) {
-                is Creation -> ContextCompat.getDrawable(requireContext(), R.drawable.ic_back_24dp)
-                is Edit -> null
-            }
-            mainToolbar.navigationIcon = navigationIcon
+            mainToolbar.navigationIcon = ContextCompat.getDrawable(requireContext(), R.drawable.ic_back_24dp)
             mainToolbar.title = getTitle()
         }
         mainToolbar.setNavigationOnClickListener { viewModel.onBackButtonClicked() }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12420 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we add a back button on the edit order screen for phones.

### Notes
I see that the back button was explicitly hidden for the edit mode on non tablets [here](https://github.com/woocommerce/woocommerce-android/commit/3bc60582db40566c2c6153d1ed084fd7cafa1d17) @samiuelson please let me know if it's ok to change that behavior.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to Orders
2. Tap on an Order
3. Tap on Edit
4. There was no back button on the phone (there was on the tablet). Fixed

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I tested the above steps on a phone (Samsung Galaxy S21) and tablet (Samsung Galaxy A8), for order creation and edition modes.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/user-attachments/assets/278ac9ad-7a2b-497e-9d40-41d71316e679" width="375">


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->