### PR TITLE
Remove unused Feature Flags from past Eagle projects

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/GetAnalyticPluginsCardActive.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/GetAnalyticPluginsCardActive.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.analytics.hub
 import com.woocommerce.android.model.AnalyticsCards
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.google.IsGoogleForWooEnabled
-import com.woocommerce.android.util.FeatureFlag
 import org.wordpress.android.fluxc.model.plugin.SitePluginModel
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WooCommerceStore.WooPlugin.GOOGLE_ADS

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/GetAnalyticPluginsCardActive.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/GetAnalyticPluginsCardActive.kt
@@ -46,7 +46,5 @@ class GetAnalyticPluginsCardActive @Inject constructor(
      * We need a different validation for Google Ads plugin, not only checking if it's active
      */
     private fun SitePluginModel.isValidGoogleAdsPlugin(isGoogleForWooEnabled: Boolean) =
-        name == GOOGLE_ADS.pluginName &&
-            FeatureFlag.GOOGLE_ADS_ANALYTICS_HUB_M1.isEnabled() &&
-            isGoogleForWooEnabled
+        name == GOOGLE_ADS.pluginName && isGoogleForWooEnabled
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/settings/AnalyticsHubSettingsViewModel.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.model.PluginUrls
 import com.woocommerce.android.ui.analytics.hub.GetAnalyticPluginsCardActive
 import com.woocommerce.android.ui.analytics.hub.ObserveAnalyticsCardsConfiguration
 import com.woocommerce.android.ui.analytics.hub.settings.AnalyticsHubSettingsViewModel.Companion.MARKETPLACE
-import com.woocommerce.android.util.FeatureFlag.GOOGLE_ADS_ANALYTICS_HUB_M1
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -57,7 +56,7 @@ class AnalyticsHubSettingsViewModel @Inject constructor(
             activePluginCards = getAnalyticPluginsCardActive()
             observeAnalyticsCardsConfiguration().first().let { configuration ->
                 currentConfiguration = configuration
-                    .filterNot { it.card == AnalyticsCards.GoogleAds && GOOGLE_ADS_ANALYTICS_HUB_M1.isEnabled().not() }
+                    .filterNot { it.card == AnalyticsCards.GoogleAds }
                     .map { it.toConfigurationUI(activePluginCards) }
                     .sortedByDescending { it is AnalyticCardConfigurationUI.SelectableCardConfigurationUI }
                 draftConfiguration = currentConfiguration

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -267,21 +267,16 @@ class LoginSiteCredentialsViewModel @Inject constructor(
             onFailure = { exception ->
                 val authenticationError = exception as? CookieNonceAuthenticationException
 
-                if (FeatureFlag.APP_PASSWORD_TUTORIAL.isEnabled()) {
-                    when (authenticationError?.errorType) {
-                        INVALID_CREDENTIALS -> errorDialogMessage.value = authenticationError.errorMessage
-                        else -> {
-                            fetchSiteForTutorial(
-                                username = state.username,
-                                password = state.password,
-                                detectedErrorMessage = authenticationError?.errorMessage
-                            )
-                            analyticsTracker.track(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_INVALID_LOGIN_PAGE_DETECTED)
-                        }
+                when (authenticationError?.errorType) {
+                    INVALID_CREDENTIALS -> errorDialogMessage.value = authenticationError.errorMessage
+                    else -> {
+                        fetchSiteForTutorial(
+                            username = state.username,
+                            password = state.password,
+                            detectedErrorMessage = authenticationError?.errorMessage
+                        )
+                        analyticsTracker.track(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_INVALID_LOGIN_PAGE_DETECTED)
                     }
-                } else {
-                    this.errorDialogMessage.value = authenticationError?.errorMessage
-                        ?: UiStringRes(R.string.error_generic)
                 }
 
                 trackLoginFailure(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -21,7 +21,6 @@ import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -997,22 +997,20 @@ class OrderListFragment :
     }
 
     private fun displayTimeoutErrorCard(show: Boolean) {
-        if (FeatureFlag.CONNECTIVITY_TOOL.isEnabled()) {
-            displayErrorTroubleshootingCard(
-                show = show,
-                title = getString(R.string.orderlist_timeout_error_title),
-                message = getString(R.string.orderlist_timeout_error_message),
-                supportContactClick = {
-                    viewModel.changeTroubleshootingBannerVisibility(show = false)
-                    openSupportRequestScreen()
-                },
-                troubleshootingClick = {
-                    viewModel.changeTroubleshootingBannerVisibility(show = false)
-                    viewModel.trackConnectivityTroubleshootClicked()
-                    openConnectivityTool()
-                }
-            )
-        }
+        displayErrorTroubleshootingCard(
+            show = show,
+            title = getString(R.string.orderlist_timeout_error_title),
+            message = getString(R.string.orderlist_timeout_error_message),
+            supportContactClick = {
+                viewModel.changeTroubleshootingBannerVisibility(show = false)
+                openSupportRequestScreen()
+            },
+            troubleshootingClick = {
+                viewModel.changeTroubleshootingBannerVisibility(show = false)
+                viewModel.trackConnectivityTroubleshootClicked()
+                openConnectivityTool()
+            }
+        )
     }
 
     private fun displayErrorTroubleshootingCard(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -67,7 +67,6 @@ import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.
 import com.woocommerce.android.ui.orders.list.OrderListViewModel.OrderListEvent.ShowOrderFilters
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.widgets.WCEmptyView.EmptyViewType
 import dagger.hilt.android.AndroidEntryPoint

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -12,11 +12,8 @@ enum class FeatureFlag {
     WC_SHIPPING_BANNER,
     BETTER_CUSTOMER_SEARCH_M2,
     ORDER_CREATION_AUTO_TAX_RATE,
-    CONNECTIVITY_TOOL,
     NEW_SHIPPING_SUPPORT,
-    APP_PASSWORD_TUTORIAL,
     GOOGLE_ADS_M1,
-    GOOGLE_ADS_ANALYTICS_HUB_M1,
     SHOW_INBOX_CTA;
 
     fun isEnabled(context: Context? = null): Boolean {
@@ -30,11 +27,8 @@ enum class FeatureFlag {
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE -> PackageUtils.isDebugBuild()
 
-            CONNECTIVITY_TOOL,
             NEW_SHIPPING_SUPPORT,
-            APP_PASSWORD_TUTORIAL,
             INBOX,
-            GOOGLE_ADS_ANALYTICS_HUB_M1,
             SHOW_INBOX_CTA,
             GOOGLE_ADS_M1 -> true
         }


### PR DESCRIPTION
Summary
==========
As a recently highlighted good practice, we should remove Feature Flags hanging for too long without incidents after the feature release. This PR remove three of them introduced by the Eagle team projects in the past few months.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
