### PR TITLE
[Custom Fields] Use Aztec for editing HTML fields

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
@@ -33,6 +33,17 @@ import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.IAztecToolbar
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
 
+/**
+ * An Aztec editor that can be used in Compose, with an outlined style.
+ *
+ * @param content The content of the editor
+ * @param onContentChanged A callback that will be called when the content of the editor changes
+ * @param modifier The modifier to apply to the editor
+ * @param label The label to display above the editor
+ * @param minLines The minimum number of lines the editor should have
+ * @param maxLines The maximum number of lines the editor should have
+ * @param calypsoMode Whether the editor should be in calypso mode, for more information on calypso mode see https://github.com/wordpress-mobile/AztecEditor-Android/pull/309
+ */
 @Composable
 fun OutlinedAztecEditor(
     content: String,
@@ -67,6 +78,17 @@ fun OutlinedAztecEditor(
     )
 }
 
+/**
+ * An Aztec editor that can be used in Compose.
+ *
+ * @param content The content of the editor
+ * @param onContentChanged A callback that will be called when the content of the editor changes
+ * @param modifier The modifier to apply to the editor
+ * @param label The label to display above the editor
+ * @param minLines The minimum number of lines the editor should have
+ * @param maxLines The maximum number of lines the editor should have
+ * @param calypsoMode Whether the editor should be in calypso mode, for more information on calypso mode see https://github.com/wordpress-mobile/AztecEditor-Android/pull/309
+ */
 @Composable
 fun AztecEditor(
     content: String,
@@ -97,7 +119,6 @@ fun AztecEditor(
         calypsoMode = calypsoMode
     )
 }
-
 
 @Composable
 private fun InternalAztecEditor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
@@ -120,6 +121,8 @@ private fun InternalAztecEditor(
                 aztec.toolbar.toggleEditorMode()
             }
     }
+
+    val contentState by rememberUpdatedState(content)
 
     AndroidView(
         factory = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
@@ -105,12 +106,10 @@ private fun InternalAztecEditor(
     maxLines: Int = Int.MAX_VALUE
 ) {
     val localContext = LocalContext.current
-
-    var htmlMode by remember { mutableStateOf(true) }
-
-    val listener = remember { createToolbarListener { htmlMode = !htmlMode } }
+    var htmlMode by rememberSaveable { mutableStateOf(true) }
 
     val viewsHolder = remember(LocalContext.current) { aztecViewsProvider(localContext) }
+    val listener = remember { createToolbarListener { htmlMode = !htmlMode } }
     val aztec = remember(LocalContext.current) {
         Aztec.with(viewsHolder.visualEditor, viewsHolder.sourceEditor, viewsHolder.toolbar, listener)
             .setImageGetter(GlideImageLoader(localContext))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
@@ -149,16 +149,18 @@ private fun InternalAztecEditor(
             viewsHolder.layout
         },
         update = {
-            if (minLines != -1) {
+            if (minLines != -1 && minLines != aztec.visualEditor.minLines) {
                 aztec.visualEditor.minLines = minLines
             }
-            if (maxLines != Int.MAX_VALUE) {
+            if (maxLines != Int.MAX_VALUE && maxLines != aztec.visualEditor.maxLines) {
                 aztec.visualEditor.maxLines = maxLines
                 aztec.sourceEditor?.maxLines = maxLines
             }
 
-            aztec.visualEditor.label = label
-            aztec.sourceEditor?.label = label
+            if (aztec.visualEditor.label != label) {
+                aztec.visualEditor.label = label
+                aztec.sourceEditor?.label = label
+            }
 
             if (htmlMode) {
                 if (aztec.visualEditor.toHtml() != content) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.drop
 import org.wordpress.aztec.Aztec
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.ITextFormat
+import org.wordpress.aztec.glideloader.GlideImageLoader
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.IAztecToolbar
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
@@ -112,6 +113,7 @@ private fun InternalAztecEditor(
     val viewsHolder = remember(LocalContext.current) { aztecViewsProvider(localContext) }
     val aztec = remember(LocalContext.current) {
         Aztec.with(viewsHolder.visualEditor, viewsHolder.sourceEditor, viewsHolder.toolbar, listener)
+            .setImageGetter(GlideImageLoader(localContext))
     }
 
     LaunchedEffect(Unit) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.widget.doOnTextChanged
+import androidx.core.widget.doAfterTextChanged
 import com.google.android.material.textfield.TextInputLayout
 import com.woocommerce.android.databinding.ViewAztecBinding
 import com.woocommerce.android.databinding.ViewAztecOutlinedBinding
@@ -126,13 +126,15 @@ private fun InternalAztecEditor(
 
     AndroidView(
         factory = {
-            aztec.visualEditor.doOnTextChanged { _, _, _, _ ->
-                aztec.visualEditor.toHtml().takeIf { it != content }?.let {
+            aztec.visualEditor.doAfterTextChanged {
+                if (!htmlMode) return@doAfterTextChanged
+                aztec.visualEditor.toHtml().takeIf { it != contentState }?.let {
                     onContentChanged(it)
                 }
             }
-            aztec.sourceEditor?.doOnTextChanged { _, _, _, _ ->
-                aztec.sourceEditor?.getPureHtml()?.takeIf { it != content }?.let {
+            aztec.sourceEditor?.doAfterTextChanged {
+                if (htmlMode) return@doAfterTextChanged
+                aztec.sourceEditor?.getPureHtml()?.takeIf { it != contentState }?.let {
                     onContentChanged(it)
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
@@ -1,0 +1,165 @@
+package com.woocommerce.android.ui.compose.component
+
+import android.content.Context
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.view.updateLayoutParams
+import androidx.core.widget.doOnTextChanged
+import kotlinx.coroutines.flow.drop
+import org.wordpress.aztec.Aztec
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.ITextFormat
+import org.wordpress.aztec.source.SourceViewEditText
+import org.wordpress.aztec.toolbar.AztecToolbar
+import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
+
+@Composable
+fun AztecEditor(
+    content: String,
+    onContentChanged: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    minLines: Int = 1,
+    maxLines: Int = Int.MAX_VALUE
+) {
+    val localContext = LocalContext.current
+
+    var htmlMode by remember { mutableStateOf(true) }
+
+    val listener = remember { createToolbarListener { htmlMode = !htmlMode } }
+
+    val aztec = remember(LocalContext.current) { initAztec(localContext, listener) }
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { htmlMode }
+            .drop(1)
+            .collect {
+                aztec.toolbar.toggleEditorMode()
+            }
+    }
+
+    AndroidView(
+        factory = { context ->
+            aztec.visualEditor.doOnTextChanged { _, _, _, _ ->
+                aztec.visualEditor.toHtml().takeIf { it != content }?.let {
+                    onContentChanged(it)
+                }
+            }
+            aztec.sourceEditor?.doOnTextChanged { _, _, _, _ ->
+                aztec.sourceEditor?.getPureHtml()?.takeIf { it != content }?.let {
+                    onContentChanged(it)
+                }
+            }
+
+            createLayout(context, aztec)
+        },
+        update = {
+            if (minLines != -1) {
+                aztec.visualEditor.minLines = minLines
+                aztec.sourceEditor?.minLines = minLines
+            }
+            if (maxLines != Int.MAX_VALUE) {
+                aztec.visualEditor.maxLines = maxLines
+                aztec.sourceEditor?.maxLines = maxLines
+            }
+
+            if (htmlMode) {
+                if (aztec.visualEditor.toHtml() != content) {
+                    aztec.visualEditor.fromHtml(content)
+                }
+            } else {
+                if (aztec.sourceEditor?.getPureHtml() != content) {
+                    aztec.sourceEditor?.displayStyledAndFormattedHtml(content)
+                }
+            }
+        },
+        modifier = modifier
+    )
+}
+
+private fun initAztec(context: Context, listener: IAztecToolbarClickListener): Aztec {
+    val visualEditor = AztecText(context).apply {
+        gravity = android.view.Gravity.TOP
+    }
+    val sourceEditor = SourceViewEditText(context).apply {
+        gravity = android.view.Gravity.TOP
+        visibility = android.view.View.GONE
+    }
+    val toolbar = AztecToolbar(context)
+
+    return Aztec.with(visualEditor, sourceEditor, toolbar, listener)
+}
+
+private fun createLayout(context: Context, aztec: Aztec) = LinearLayout(context).apply {
+    orientation = LinearLayout.VERTICAL
+    val editorLayout = FrameLayout(context)
+    editorLayout.addView(aztec.visualEditor)
+    aztec.visualEditor.updateLayoutParams<FrameLayout.LayoutParams> {
+        width = FrameLayout.LayoutParams.MATCH_PARENT
+        height = FrameLayout.LayoutParams.MATCH_PARENT
+    }
+    editorLayout.addView(aztec.sourceEditor)
+    aztec.sourceEditor?.updateLayoutParams<FrameLayout.LayoutParams> {
+        width = FrameLayout.LayoutParams.MATCH_PARENT
+        height = FrameLayout.LayoutParams.MATCH_PARENT
+    }
+    addView(editorLayout)
+
+    val toolbar = aztec.toolbar as AztecToolbar
+    addView(toolbar)
+    toolbar.updateLayoutParams<LinearLayout.LayoutParams> {
+        width = FrameLayout.LayoutParams.MATCH_PARENT
+        height = FrameLayout.LayoutParams.WRAP_CONTENT
+    }
+}
+
+private fun createToolbarListener(onHtmlButtonClicked: () -> Unit) = object : IAztecToolbarClickListener {
+    override fun onToolbarCollapseButtonClicked() = Unit
+
+    override fun onToolbarExpandButtonClicked() = Unit
+
+    override fun onToolbarFormatButtonClicked(format: ITextFormat, isKeyboardShortcut: Boolean) = Unit
+
+    override fun onToolbarHeadingButtonClicked() = Unit
+
+    override fun onToolbarHtmlButtonClicked() {
+        onHtmlButtonClicked()
+    }
+
+    override fun onToolbarListButtonClicked() = Unit
+
+    override fun onToolbarMediaButtonClicked(): Boolean = false
+}
+
+@Composable
+@Preview
+private fun AztecEditorPreview() {
+    var content by remember { mutableStateOf("<h1>Heading</h1>") }
+    AztecEditor(
+        content = content,
+        onContentChanged = {
+            content = it
+        },
+        minLines = 5,
+        modifier = Modifier
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colors.onSurface,
+                shape = RoundedCornerShape(8.dp)
+            )
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
@@ -40,7 +40,8 @@ fun OutlinedAztecEditor(
     modifier: Modifier = Modifier,
     label: String? = null,
     minLines: Int = 1,
-    maxLines: Int = Int.MAX_VALUE
+    maxLines: Int = Int.MAX_VALUE,
+    calypsoMode: Boolean = false
 ) {
     InternalAztecEditor(
         content = content,
@@ -61,7 +62,8 @@ fun OutlinedAztecEditor(
         modifier = modifier,
         label = label,
         minLines = minLines,
-        maxLines = maxLines
+        maxLines = maxLines,
+        calypsoMode = calypsoMode
     )
 }
 
@@ -72,7 +74,8 @@ fun AztecEditor(
     modifier: Modifier = Modifier,
     label: String? = null,
     minLines: Int = 1,
-    maxLines: Int = Int.MAX_VALUE
+    maxLines: Int = Int.MAX_VALUE,
+    calypsoMode: Boolean = false
 ) {
     InternalAztecEditor(
         content = content,
@@ -90,7 +93,8 @@ fun AztecEditor(
         modifier = modifier,
         label = label,
         minLines = minLines,
-        maxLines = maxLines
+        maxLines = maxLines,
+        calypsoMode = calypsoMode
     )
 }
 
@@ -103,7 +107,8 @@ private fun InternalAztecEditor(
     modifier: Modifier = Modifier,
     label: String? = null,
     minLines: Int = 1,
-    maxLines: Int = Int.MAX_VALUE
+    maxLines: Int = Int.MAX_VALUE,
+    calypsoMode: Boolean = false
 ) {
     val localContext = LocalContext.current
     var htmlMode by rememberSaveable { mutableStateOf(true) }
@@ -149,6 +154,11 @@ private fun InternalAztecEditor(
             viewsHolder.layout
         },
         update = {
+            if (aztec.visualEditor.isInCalypsoMode != calypsoMode) {
+                aztec.visualEditor.isInCalypsoMode = calypsoMode
+                aztec.sourceEditor?.setCalypsoMode(calypsoMode)
+            }
+
             if (minLines != -1 && minLines != aztec.visualEditor.minLines) {
                 aztec.visualEditor.minLines = minLines
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/AztecEditor.kt
@@ -126,6 +126,12 @@ private fun InternalAztecEditor(
 
     AndroidView(
         factory = {
+            aztec.visualEditor.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                // Because the editors could have different number of lines, we don't set the minLines
+                // of the source editor, so we set the minHeight instead to match the visual editor
+                aztec.sourceEditor?.minHeight = aztec.visualEditor.height
+            }
+
             aztec.visualEditor.doAfterTextChanged {
                 if (!htmlMode) return@doAfterTextChanged
                 aztec.visualEditor.toHtml().takeIf { it != contentState }?.let {
@@ -144,7 +150,6 @@ private fun InternalAztecEditor(
         update = {
             if (minLines != -1) {
                 aztec.visualEditor.minLines = minLines
-                aztec.sourceEditor?.minLines = minLines
             }
             if (maxLines != Int.MAX_VALUE) {
                 aztec.visualEditor.maxLines = maxLines

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/aztec/AztecEditor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/aztec/AztecEditor.kt
@@ -10,7 +10,9 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -23,6 +25,8 @@ import com.woocommerce.android.databinding.ViewAztecBinding
 import com.woocommerce.android.databinding.ViewAztecOutlinedBinding
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import org.wordpress.aztec.Aztec
 import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.ITextFormat
@@ -30,6 +34,50 @@ import org.wordpress.aztec.glideloader.GlideImageLoader
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.IAztecToolbar
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener
+
+/**
+ * An Aztec editor that can be used in Compose, with an outlined style.
+ *
+ * @param content The content of the editor
+ * @param onContentChanged A callback that will be called when the content of the editor changes
+ * @param modifier The modifier to apply to the editor
+ * @param label The label to display above the editor
+ * @param minLines The minimum number of lines the editor should have
+ * @param maxLines The maximum number of lines the editor should have
+ * @param calypsoMode Whether the editor should be in calypso mode, for more information on calypso mode see https://github.com/wordpress-mobile/AztecEditor-Android/pull/309
+ */
+@Composable
+fun OutlinedAztecEditor(
+    content: String,
+    onContentChanged: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    label: String? = null,
+    minLines: Int = 1,
+    maxLines: Int = Int.MAX_VALUE,
+    calypsoMode: Boolean = false
+) {
+    val state = rememberAztecEditorState(initialContent = content)
+    val contentState by rememberUpdatedState(content)
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { contentState }
+            .onEach { state.updateContent(it) }
+            .launchIn(this)
+
+        snapshotFlow { state.content }
+            .onEach { onContentChanged(it) }
+            .launchIn(this)
+    }
+
+    OutlinedAztecEditor(
+        state = state,
+        modifier = modifier,
+        label = label,
+        minLines = minLines,
+        maxLines = maxLines,
+        calypsoMode = calypsoMode
+    )
+}
 
 /**
  * An Aztec editor that can be used in Compose, with an outlined style.
@@ -65,6 +113,50 @@ fun OutlinedAztecEditor(
                 toolbar = binding.toolbar
             )
         },
+        modifier = modifier,
+        label = label,
+        minLines = minLines,
+        maxLines = maxLines,
+        calypsoMode = calypsoMode
+    )
+}
+
+/**
+ * An Aztec editor that can be used in Compose.
+ *
+ * @param content The content of the editor
+ * @param onContentChanged A callback that will be called when the content of the editor changes
+ * @param modifier The modifier to apply to the editor
+ * @param label The label to display above the editor
+ * @param minLines The minimum number of lines the editor should have
+ * @param maxLines The maximum number of lines the editor should have
+ * @param calypsoMode Whether the editor should be in calypso mode, for more information on calypso mode see https://github.com/wordpress-mobile/AztecEditor-Android/pull/309
+ */
+@Composable
+fun AztecEditor(
+    content: String,
+    onContentChanged: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    label: String? = null,
+    minLines: Int = 1,
+    maxLines: Int = Int.MAX_VALUE,
+    calypsoMode: Boolean = false
+) {
+    val state = rememberAztecEditorState(initialContent = content)
+    val contentState by rememberUpdatedState(content)
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { contentState }
+            .onEach { state.updateContent(it) }
+            .launchIn(this)
+
+        snapshotFlow { state.content }
+            .onEach { onContentChanged(it) }
+            .launchIn(this)
+    }
+
+    AztecEditor(
+        state = state,
         modifier = modifier,
         label = label,
         minLines = minLines,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/aztec/AztecEditorState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/aztec/AztecEditorState.kt
@@ -25,7 +25,7 @@ class AztecEditorState(
     }
 
     companion object {
-        fun Saver() = Saver<AztecEditorState, Any>(
+        val Saver = Saver<AztecEditorState, Any>(
             save = { arrayListOf(it.content, it.isHtmlEditorEnabled) },
             restore = {
                 val list = it as List<*>
@@ -47,5 +47,5 @@ class AztecEditorState(
 fun rememberAztecEditorState(
     initialContent: String
 ): AztecEditorState {
-    return rememberSaveable(saver = AztecEditorState.Saver()) { AztecEditorState(initialContent) }
+    return rememberSaveable(saver = AztecEditorState.Saver) { AztecEditorState(initialContent) }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/aztec/AztecEditorState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/aztec/AztecEditorState.kt
@@ -1,0 +1,51 @@
+package com.woocommerce.android.ui.compose.component.aztec
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+
+class AztecEditorState(
+    initialContent: String
+) {
+    var content by mutableStateOf(initialContent)
+        private set
+
+    var isHtmlEditorEnabled by mutableStateOf(true)
+        private set
+
+    fun updateContent(newContent: String) {
+        content = newContent
+    }
+
+    fun toggleHtmlEditor() {
+        isHtmlEditorEnabled = !isHtmlEditorEnabled
+    }
+
+    companion object {
+        fun Saver() = Saver<AztecEditorState, Any>(
+            save = { arrayListOf(it.content, it.isHtmlEditorEnabled) },
+            restore = {
+                val list = it as List<*>
+                AztecEditorState(list[0] as String).apply {
+                    isHtmlEditorEnabled = list[1] as Boolean
+                }
+            }
+        )
+    }
+}
+
+/**
+ * Remember a [AztecEditorState] that can be used to manage the state of an Aztec editor.
+ * The state will be saved to the saved state to survive process death.
+ *
+ * @param initialContent The initial content of the editor
+ */
+@Composable
+fun rememberAztecEditorState(
+    initialContent: String
+): AztecEditorState {
+    return rememberSaveable(saver = AztecEditorState.Saver()) { AztecEditorState(initialContent) }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.compose.component.DiscardChangesDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.component.aztec.OutlinedAztecEditor
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.customfields.CustomFieldUiModel
@@ -74,12 +75,21 @@ private fun CustomFieldsEditorScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            WCOutlinedTextField(
-                value = state.customField.value,
-                onValueChange = onValueChanged,
-                label = stringResource(R.string.custom_fields_editor_value_label),
-                minLines = 5
-            )
+            if (state.isHtml) {
+                OutlinedAztecEditor(
+                    content = state.customField.value,
+                    onContentChanged = onValueChanged,
+                    label = stringResource(R.string.custom_fields_editor_value_label),
+                    minLines = 5
+                )
+            } else {
+                WCOutlinedTextField(
+                    value = state.customField.value,
+                    onValueChange = onValueChanged,
+                    label = stringResource(R.string.custom_fields_editor_value_label),
+                    minLines = 5
+                )
+            }
         }
 
         state.discardChangesDialogState?.let {

--- a/WooCommerce/src/main/res/layout/view_aztec.xml
+++ b/WooCommerce/src/main/res/layout/view_aztec.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/visual_editor_layout"
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
@@ -16,13 +15,6 @@
             android:layout_height="wrap_content"
             android:paddingBottom="52dp"
             android:scrollbars="vertical" />
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/source_editor_layout"
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
 
         <org.wordpress.aztec.source.SourceViewEditText
             android:id="@+id/sourceEditor"
@@ -32,12 +24,10 @@
             android:paddingBottom="52dp"
             android:scrollbars="vertical"
             android:visibility="gone" />
-    </com.google.android.material.textfield.TextInputLayout>
+    </FrameLayout>
 
     <org.wordpress.aztec.toolbar.AztecToolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="48dp"
-        android:layout_gravity="bottom"
-        android:layout_margin="2dp" />
-</FrameLayout>
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/WooCommerce/src/main/res/layout/view_aztec_outlined.xml
+++ b/WooCommerce/src/main/res/layout/view_aztec_outlined.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/visual_editor_layout"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <org.wordpress.aztec.AztecText
+            android:id="@+id/visual_editor"
+            style="@style/Woo.AztecText.VisualEditor"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="52dp"
+            android:scrollbars="vertical" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/source_editor_layout"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <org.wordpress.aztec.source.SourceViewEditText
+            android:id="@+id/sourceEditor"
+            style="@style/Woo.AztecText.SourceEditor"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="52dp"
+            android:scrollbars="vertical"
+            android:visibility="gone" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <org.wordpress.aztec.toolbar.AztecToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:layout_gravity="bottom"
+        android:layout_margin="2dp" />
+</FrameLayout>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12434 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds a Composable component that wraps the Aztec editor, it comes with two variants: regular one like the one we already use in the app, and a version with an Outlined border like the other text fields.

The PR seems large, but a lot of the lines come just from overloads that attempt to make the usage easier, and the main component code that needs proper review is in these [lines](https://github.com/woocommerce/woocommerce-android/blob/e0468f13dd589177947f2d9f2ff8965e4bb1080f/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/aztec/AztecEditor.kt#L208-L323).

I added the label `unit-tests-exemption` because the classes that the PR complains about are just basic classes with no business logic that can be tested.

**Note:** The component lacks some nice-to-have behaviors:
- The screen doesn't scroll to show it when it's focused, this is more important for when the phone is on landscape.
- The keyboard is sometimes not shown when you change focus from the key to the value field.

I'm planning to work on these two points on a separate PR to avoid making this PR larger.

### Testing information
#### Component
Launch the previews, and play around with the component.

#### Custom Fields integration
1. Open an order in wp-admin.
2. Tap on the "Custom Fields" section is visible (from the screen options at the top of the page)
3. Add a custom field that has some HTML content, it could be as simple as `<b>strong</b>`.
5. Open the order in the app.
6. Tap on "View custom fields"
7. Tap on a custom field.
8. Confirm the Aztec editor is used.
9. Make some changes and confirm it works as expected.
(Saving is not implemented yet, tapping on Done will just crash the app).

### The tests that have been performed
Exactly the above steps.

### Images/gif
[Screen_recording_20240828_172607.webm](https://github.com/user-attachments/assets/fd918c39-644c-4142-8c3d-f63a011fa7f1)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->