### PR TITLE
[Beta Fix] Fix navigation for "Collect payment" tap in order creation flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 - [*] [Internal] Fixed an issue with date formatting for the Blaze campaign creation API request [https://github.com/woocommerce/woocommerce-android/pull/12372]
 - [*] Fixed a rare crash in the order editing screen. [https://github.com/woocommerce/woocommerce-android/pull/12382]
 - [*] Fixed the blaze budget screens that are unusable on small screens. [https://github.com/woocommerce/woocommerce-android/pull/12402]
+- [**] Fixed navigation on "Collect payment" button tap in order creation flow [https://github.com/woocommerce/woocommerce-android/pull/12436]
 
 20.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderNavigator.kt
@@ -157,7 +157,7 @@ class OrderNavigator @Inject constructor() {
                 val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToCardReaderFlow(
                     CardReaderFlowParam.PaymentOrRefund.Payment(target.orderId, target.paymentTypeFlow)
                 )
-                fragment.findNavController().navigateSafely(action)
+                fragment.findNavController().navigateSafely(directions = action, skipThrottling = true)
             }
             is ViewPrintingInstructions -> {
                 val action = OrderDetailFragmentDirections


### PR DESCRIPTION
## [Beta Fix]  Tapping on "Collect Payment" in the order creation navigates to the order detail instead of the payment selection.

Closes: #12432
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
It turned out that navigating programmatically to the "Take payment" screen we should not employ the `CallThrottler` singleton because it can prevent navigation to `SelectPaymentMethodFragment` if the `OrderDetailViewModel` is instantiated before the `CallThrottler.DELAY` (200 ms) threshold.

Brainstorming: p1724752391339309-slack-C025A8VV728

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
To reproduce the bug:
1. On `trunk` manually set the `CallThrottler.DELAY` const to some bigger number, e.g. 1200 ms.
2. Create new order and add some product
3. Click "Collect payment" in the bottom sheet
4. Observe that "Order detail" is shown all the time instead of the "Take payment" screen

https://github.com/user-attachments/assets/f2546935-122c-46d6-b86d-28142b6c4344

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
It should be verified that during the order creation flow, every time "Collect payment" is tapped, the app redirects to the `SelectPaymentMethodFragment`.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I verified that this branch fixes the bug by testing the repro scenario on Pixel 7 Pro, Android 14.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
Fix:
https://github.com/user-attachments/assets/f4e7b17c-322d-491b-8ec1-921ba0338505

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->