### PR TITLE
[Tooling] Add Release Publishing automation

### DIFF
--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -1,0 +1,25 @@
+agents:
+  queue: "android"
+
+steps:
+  - label: "Publish Release"
+    plugins:
+      - $CI_TOOLKIT
+    command: |
+      echo '--- :robot_face: Use bot for git operations'
+      source use-bot-for-git
+
+      echo '--- :git: Checkout Release Branch'
+      .buildkite/commands/checkout-release-branch.sh
+
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
+
+      echo '--- :package: Publish Release'
+      bundle exec fastlane publish_release_and_cleanup skip_confirm:true
+    agents:
+      queue: "tumblr-metal"
+    retry:
+      manual:
+        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        allowed: false

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -1,6 +1,3 @@
-agents:
-  queue: "android"
-
 steps:
   - label: "Publish Release"
     plugins:

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -16,7 +16,7 @@ steps:
       install_gems
 
       echo '--- :package: Publish Release'
-      bundle exec fastlane publish_release_and_cleanup skip_confirm:true
+      bundle exec fastlane publish_release skip_confirm:true
     agents:
       queue: "tumblr-metal"
     retry:

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -13,7 +13,7 @@ steps:
       install_gems
 
       echo '--- :package: Publish Release'
-      bundle exec fastlane publish_release skip_confirm:true
+      bundle exec fastlane publish_release skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
     agents:
       queue: "tumblr-metal"
     retry:

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rubocop', '~> 1.65'
 
 ### Fastlane Plugins
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 11.0', git: 'https://github.com/wordpress-mobile/release-toolkit.git', branch: 'iangmaia/publish-release'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 12.0'
 # gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
 # gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: ''
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ source 'https://rubygems.org'
 gem 'danger-dangermattic', '~> 1.1'
 gem 'fastlane', '~> 2.216'
 gem 'nokogiri'
-gem 'rubocop', '~> 1.60'
+gem 'rubocop', '~> 1.65'
 
 ### Fastlane Plugins
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 11.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 11.0', git: 'https://github.com/wordpress-mobile/release-toolkit.git', branch: 'iangmaia/publish-release'
 # gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
 # gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: ''
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,3 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit.git
-  revision: 508006d08eda60aa2bf07de2278855469be08e54
-  branch: iangmaia/publish-release
-  specs:
-    fastlane-plugin-wpmreleasetoolkit (11.1.0)
-      activesupport (>= 6.1.7.1)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      fastlane (~> 2.213)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      java-properties (~> 0.3.0)
-      nokogiri (~> 1.11)
-      octokit (~> 6.1)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-      xcodeproj (~> 1.22)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -182,6 +159,23 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
+    fastlane-plugin-wpmreleasetoolkit (12.0.0)
+      activesupport (>= 6.1.7.1)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      fastlane (~> 2.213)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      java-properties (~> 0.3.0)
+      nokogiri (~> 1.11)
+      octokit (~> 6.1)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
+      xcodeproj (~> 1.22)
     gh_inspector (1.1.3)
     git (1.19.1)
       addressable (~> 2.8)
@@ -238,7 +232,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
-    logger (1.6.0)
+    logger (1.6.1)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
@@ -345,7 +339,7 @@ PLATFORMS
 DEPENDENCIES
   danger-dangermattic (~> 1.1)
   fastlane (~> 2.216)
-  fastlane-plugin-wpmreleasetoolkit (~> 11.0)!
+  fastlane-plugin-wpmreleasetoolkit (~> 12.0)
   nokogiri
   rmagick (~> 4.1)
   rubocop (~> 1.65)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,26 @@
+GIT
+  remote: https://github.com/wordpress-mobile/release-toolkit.git
+  revision: 508006d08eda60aa2bf07de2278855469be08e54
+  branch: iangmaia/publish-release
+  specs:
+    fastlane-plugin-wpmreleasetoolkit (11.1.0)
+      activesupport (>= 6.1.7.1)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      fastlane (~> 2.213)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      java-properties (~> 0.3.0)
+      nokogiri (~> 1.11)
+      octokit (~> 6.1)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
+      xcodeproj (~> 1.22)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -5,16 +28,17 @@ GEM
       base64
       nkf
       rexml
-    activesupport (7.1.3.4)
+    activesupport (7.2.1)
       base64
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     artifactory (3.0.17)
@@ -51,7 +75,7 @@ GEM
     colored2 (3.1.2)
     commander (4.6.0)
       highline (~> 2.0.0)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     cork (0.3.0)
       colored2 (~> 3.1)
@@ -158,23 +182,6 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    fastlane-plugin-wpmreleasetoolkit (11.1.0)
-      activesupport (>= 6.1.7.1)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      fastlane (~> 2.213)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      java-properties (~> 0.3.0)
-      nokogiri (~> 1.11, < 1.17)
-      octokit (~> 6.1)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-      xcodeproj (~> 1.22)
     gh_inspector (1.1.3)
     git (1.19.1)
       addressable (~> 2.8)
@@ -231,13 +238,13 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
+    logger (1.6.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
-    minitest (5.24.1)
+    minitest (5.25.1)
     multi_json (1.15.0)
     multipart-post (2.4.1)
-    mutex_m (0.2.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     naturally (2.2.1)
@@ -296,6 +303,7 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
+    securerandom (0.3.1)
     security (0.1.5)
     signet (0.19.0)
       addressable (~> 2.8)
@@ -337,10 +345,10 @@ PLATFORMS
 DEPENDENCIES
   danger-dangermattic (~> 1.1)
   fastlane (~> 2.216)
-  fastlane-plugin-wpmreleasetoolkit (~> 11.0)
+  fastlane-plugin-wpmreleasetoolkit (~> 11.0)!
   nokogiri
   rmagick (~> 4.1)
-  rubocop (~> 1.60)
+  rubocop (~> 1.65)
 
 BUNDLED WITH
    2.4.19

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -508,11 +508,12 @@ platform :android do
   # This lane publishes a release on GitHub, tagging it on git, and backmerges the current release branch into the next release/ branch
   #
   # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
+  # @param [Boolean] include_wear_app (default: false) If true, the CI build will also include a job to build the WEAR_APP
   #
   # @example Running the lane
-  #          bundle exec fastlane publish_release skip_confirm:true
+  #          bundle exec fastlane publish_release skip_confirm:true include_wear_app:true
   #
-  lane :publish_release do |skip_confirm: false|
+  lane :publish_release do |skip_confirm: false, include_wear_app: false|
     ensure_git_status_clean
     ensure_git_branch_is_release_branch
 
@@ -533,10 +534,14 @@ platform :android do
 
     UI.important "Publishing release #{version_number} on GitHub"
 
-    publish_github_release(
-      repository: GITHUB_REPO,
-      name: version_number
-    )
+    apps = [MOBILE_APP]
+    apps << WEAR_APP if include_wear_app
+    apps.each do |app|
+      publish_github_release(
+        repository: GITHUB_REPO,
+        name: app == WEAR_APP ? "#{version_number}w" : version_number
+      )
+    end
 
     create_backmerge_pr
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1328,6 +1328,7 @@ def create_backmerge_pr
 rescue StandardError => e
   error_message = <<-MESSAGE
     Error creating backmerge pull request:
+
     ```
     #{e.message}
     ```

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -505,6 +505,45 @@ platform :android do
     end
   end
 
+  # This lane publishes a release on GitHub, tagging it on git, and backmerges the current release branch into the next release/ branch
+  #
+  # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
+  #
+  # @example Running the lane
+  #          bundle exec fastlane publish_release_and_cleanup skip_confirm:true
+  #
+  lane :publish_release_and_cleanup do |skip_confirm: false|
+    ensure_git_status_clean
+    ensure_git_branch_is_release_branch
+
+    version_number = release_version_current
+
+    current_branch = "release/#{version_number}"
+    next_release_branch = "release/#{release_version_next}"
+
+    UI.important <<~PROMPT
+      Publish the #{version_number} release. This will:
+      - Publish the existing draft `#{version_number}` release on GitHub
+      - Which will also have GitHub create the associated git tag, pointing to the tip of the branch
+      - If the release branch for the next version `#{next_release_branch}` already exists, backmerge `#{current_branch}` into it
+      - If needed, backmerge `#{current_branch}` back into `#{DEFAULT_BRANCH}`
+      - Delete the `#{current_branch}` branch
+    PROMPT
+    UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
+
+    UI.important "Publishing release #{version_number} on GitHub"
+
+    publish_release(
+      repository: GITHUB_REPO,
+      name: version_number
+    )
+
+    create_backmerge_pr
+
+    # Now that an eventual backmerge PR has created an intermediate branch, we can delete the `release/*` branch
+    delete_remote_git_branch!(current_branch)
+  end
+
   lane :check_translation_progress_all do
     check_translation_progress_strings
     check_translation_progress_release_notes
@@ -1312,6 +1351,14 @@ def ensure_branch_does_not_exist!(branch_name)
   buildkite_annotate(style: 'error', context: 'error-checking-branch', message: error_message) if is_ci
 
   UI.user_error!(error_message)
+end
+
+# Delete a branch remotely, after having removed any GitHub branch protection
+#
+def delete_remote_git_branch!(branch_name)
+  remove_branch_protection(repository: GITHUB_REPO, branch: branch_name)
+
+  Git.open('.').push('origin', branch_name, delete: true)
 end
 
 def report_milestone_error(error_title:)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -540,7 +540,9 @@ platform :android do
 
     create_backmerge_pr
 
-    # Now that an eventual backmerge PR has created an intermediate branch, we can delete the `release/*` branch
+    # At this point, an intermediate branch has been created by creating a backmerge PR to a hotfix or the next version release branch.
+    # This allows us to safely delete the `release/*` branch.
+    # Note that if a hotfix or new release branches haven't been created, the backmerge PR won't be created as well.
     delete_remote_git_branch!(current_branch)
   end
 
@@ -1363,7 +1365,7 @@ end
 def delete_remote_git_branch!(branch_name)
   remove_branch_protection(repository: GITHUB_REPO, branch: branch_name)
 
-  Git.open('.').push('origin', branch_name, delete: true)
+  Git.open(Dir.pwd).push('origin', branch_name, delete: true)
 end
 
 def report_milestone_error(error_title:)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1128,7 +1128,7 @@ platform :android do
     aab_file_path = File.join(PROJECT_ROOT_FOLDER, 'artifacts', aab_file_name(app, version))
     release_assets = [universal_apk_path, aab_file_path].compact
 
-    create_release(
+    create_github_release(
       repository: GITHUB_REPO,
       # 'version' is used for the release name as well as the tag that's going to be created for the release
       version: app == WEAR_APP ? "#{version}w" : version,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1327,8 +1327,12 @@ def create_backmerge_pr
   )
 rescue StandardError => e
   error_message = <<-MESSAGE
-    Error creating backmerge pull request: #{e.message}
-    - If this is not the first time you are running the release task, the backmerge PR for the version `#{version}` might have already been previously created.
+    Error creating backmerge pull request:
+    ```
+    #{e.message}
+    ```
+
+    If this is not the first time you are running the release task, the backmerge PR for the version `#{version}` might have already been previously created.
     Please close any previous backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.
   MESSAGE
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -505,7 +505,7 @@ platform :android do
     end
   end
 
-  # This lane publishes a release on GitHub, tagging it on git, and backmerges the current release branch into the next release/ branch
+  # This lane publishes a release on GitHub and creates a PR to backmerge the current release branch into the next release/ branch
   #
   # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
   # @param [Boolean] include_wear_app (default: false) If true, the CI build will also include a job to build the WEAR_APP

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -510,9 +510,9 @@ platform :android do
   # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
   #
   # @example Running the lane
-  #          bundle exec fastlane publish_release_and_cleanup skip_confirm:true
+  #          bundle exec fastlane publish_release skip_confirm:true
   #
-  lane :publish_release_and_cleanup do |skip_confirm: false|
+  lane :publish_release do |skip_confirm: false|
     ensure_git_status_clean
     ensure_git_branch_is_release_branch
 
@@ -533,7 +533,7 @@ platform :android do
 
     UI.important "Publishing release #{version_number} on GitHub"
 
-    publish_release(
+    publish_github_release(
       repository: GITHUB_REPO,
       name: version_number
     )


### PR DESCRIPTION
This PR automates the release publishing, which means to:

- Publish the existing draft release on GitHub (which will also have GitHub create the associated git tag, pointing to the tip of the branch)
- If the release branch for the next version already exists, backmerge the current release into it
- Delete the current release branch

This PR will be followed by updates to the Releases V2 tool.