### PR TITLE
Issue/12453 enable evergreen campaigns feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 -----
 - [**] Fixed navigation in tablet mode: after order is paid, the app should redirect to order details screen. [https://github.com/woocommerce/woocommerce-android/pull/12415]
 - [*] Show the back button on the Order Edit Screen for phones [https://github.com/woocommerce/woocommerce-android/pull/12421]
-
+- [**] Enables support to create Blaze Evergreen campaigns [https://github.com/woocommerce/woocommerce-android/issues/12176]
 
 20.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -28,13 +28,13 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
-            ENDLESS_CAMPAIGNS_SUPPORT,
             CUSTOM_FIELDS -> PackageUtils.isDebugBuild()
 
             NEW_SHIPPING_SUPPORT,
             INBOX,
             SHOW_INBOX_CTA,
-            GOOGLE_ADS_M1 -> true
+            GOOGLE_ADS_M1,
+            ENDLESS_CAMPAIGNS_SUPPORT -> true
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12453 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR enables support for creating Blaze Evergreen campaigns and updates release notes. 


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

The feature has already been tested in all the PRs: https://github.com/woocommerce/woocommerce-android/issues/12176#issue-2438214127 leading to this one, so there's no need for extra testing. Also the feature will be re tested thoroughly during beta testing phase. 
However, if you still want to try out the feature, follow these steps: 
1. Compile a `release` version of the app. 
2. Log into a site with Blaze enabled: Atomic site/ Selfhosted with Jetpack connected. The site must be public and have at least one product published. 
3. Enable the Blaze card on the dashboard.
4. Click Create campaign and follow the steps from the screen recording : 


https://github.com/user-attachments/assets/b18d7f64-668e-4475-8cee-fc1dacaab95e

Note you won't be charged anything at the moment of creating the campaign. Charging starts when the campaign starts serving ads, which by default is 24h after creation.  I suggest canceling the campaign right away after creating it to avoid any future charges

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->