### PR TITLE
Fix last update always empty

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -122,7 +122,7 @@ class AnalyticsUpdateDataStore @Inject constructor(
                     true
                 }
             }
-            .map { lastUpdateValues -> lastUpdateValues.min() }
+            .map { lastUpdateValues -> lastUpdateValues.minOrNull() }
     }
 
     private fun observeLastUpdate(timestampKey: String): Flow<Long?> {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
@@ -273,6 +273,32 @@ class AnalyticsUpdateDataStoreTest : BaseUnitTest() {
         assertThat(timestampUpdate).isEqualTo(lastUpdateTimestamp)
     }
 
+    @Test
+    fun `given observe should emit last update, when all data sources are not required, if all data sources are missing then return null`() = testBlocking {
+        // Given
+        val selectedSiteId = 1
+
+        val analyticsPreferences = mock<Preferences>()
+
+        createAnalyticsUpdateScenarioWith(analyticsPreferences, selectedSiteId)
+
+        // When
+        var timestampUpdate: Long? = null
+        sut.observeLastUpdate(
+            rangeSelection = defaultSelectionData,
+            analyticData = listOf(
+                AnalyticsUpdateDataStore.AnalyticData.REVENUE,
+                AnalyticsUpdateDataStore.AnalyticData.VISITORS
+            ),
+            shouldAllDataBePresent = false
+        ).onEach {
+            timestampUpdate = it
+        }.launchIn(this)
+
+        // Then
+        assertThat(timestampUpdate).isNull()
+    }
+
     private fun createAnalyticsUpdateScenarioWith(
         analyticsPreferences: Preferences,
         selectedSiteId: Int


### PR DESCRIPTION
### Description
This PR fixes an issue causing the app to crash when it never has information about the last update timestamp. It was always possible that all the sources for the last update could return `null,` but with the previous implementation, we were filtering results where the number of sources to observe didn't match the number of results. With the introduction of the `shouldAllDataBePresent` param, this filter changed and allowed differences between sources and results when the flag was `false` (not all data needs to be present). 
The crash was caused by using the `min()` function for checking the min last update value on an empty list. The fix is to use the `minOrNull()` version that will not crash the app when the list is empty.

### Testing information
1. Open the app on a store without the stats module

### The tests that have been performed
1. Open the app on a store without the stats module
2. I added a [unit test](https://github.com/woocommerce/woocommerce-android/commit/df225b8fd94fbff91d7d4c2787557dea305c128a) to cover this edge case

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->