### PR TITLE
Update endpoint used to fetch site status after activating Jetpack

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 20.3
 -----
-
+- [*] Fixes error when installing Jetpack plugin from the app [https://github.com/woocommerce/woocommerce-android/issues/12364]
 
 20.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackCPInstallViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackCPInstallViewModel.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.store.SiteStore
-import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
 @HiltViewModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackCPInstallViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackCPInstallViewModel.kt
@@ -115,8 +115,8 @@ class JetpackCPInstallViewModel @Inject constructor(
         var attempt = 0
         while (attempt < ATTEMPT_LIMIT) {
             val siteId = selectedSite.get().siteId
-            val result = siteStore.fetchSite(selectedSite.get()).let { !it.isError }
-            if (result) {
+            val resultIsNotError = siteStore.fetchSite(selectedSite.get()).let { !it.isError }
+            if (resultIsNotError) {
                 val syncedSite = siteStore.getSiteBySiteId(siteId)
                 if (syncedSite?.isJetpackConnected == true && syncedSite.hasWooCommerce) {
                     selectedSite.set(syncedSite)
@@ -125,6 +125,8 @@ class JetpackCPInstallViewModel @Inject constructor(
                     attempt++
                     delay(SYNC_CHECK_DELAY)
                 }
+            } else {
+                attempt++
             }
         }
         return false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackCPInstallViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/JetpackCPInstallViewModel.kt
@@ -24,6 +24,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
 
@@ -32,7 +33,7 @@ class JetpackCPInstallViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val repository: PluginRepository,
     private val selectedSite: SelectedSite,
-    private val wooCommerceStore: WooCommerceStore
+    private val siteStore: SiteStore
 ) : ScopedViewModel(savedState) {
     companion object {
         const val JETPACK_SLUG = "jetpack"
@@ -114,10 +115,10 @@ class JetpackCPInstallViewModel @Inject constructor(
     private suspend fun isJetpackConnectedAfterInstallation(): Boolean {
         var attempt = 0
         while (attempt < ATTEMPT_LIMIT) {
-            val result = wooCommerceStore.fetchWooCommerceSites()
-            val sites = result.model
-            if (sites != null) {
-                val syncedSite = sites.firstOrNull { it.siteId == selectedSite.get().siteId }
+            val siteId = selectedSite.get().siteId
+            val result = siteStore.fetchSite(selectedSite.get()).let { !it.isError }
+            if (result) {
+                val syncedSite = siteStore.getSiteBySiteId(siteId)
                 if (syncedSite?.isJetpackConnected == true && syncedSite.hasWooCommerce) {
                     selectedSite.set(syncedSite)
                     return true

--- a/WooCommerce/src/main/res/layout/dialog_jetpack_install_progress.xml
+++ b/WooCommerce/src/main/res/layout/dialog_jetpack_install_progress.xml
@@ -238,7 +238,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/jetpackProgressActionButton"
-        style="@style/Woo.JetpackButton"
+        style="@style/Woo.Button.Colored"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/done" />

--- a/WooCommerce/src/main/res/layout/dialog_jetpack_install_start.xml
+++ b/WooCommerce/src/main/res/layout/dialog_jetpack_install_start.xml
@@ -73,7 +73,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/install_jetpack_button"
-        style="@style/Woo.JetpackButton"
+        style="@style/Woo.Button.Colored"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/get_started" />

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -131,7 +131,6 @@
     <!--
     Jetpack plugin installation dialog
     -->
-    <color name="jetpack_button_color">@color/woo_white</color>
     <color name="jetpack_install_progressbar">@color/woo_white</color>
 
     <color name="reader_update_progress_color">@color/woo_purple_40</color>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -195,7 +195,6 @@
     <!--
         Jetpack plugin installation dialog
     -->
-    <color name="jetpack_button_color">@color/color_secondary</color>
     <color name="jetpack_install_progressbar">@color/jetpack_green_40</color>
 
     <color name="reader_update_progress_color">@color/woo_purple_50</color>

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -533,16 +533,6 @@ theme across the entire app. Overridden versions should be added to the styles.x
         <item name="backgroundTint">?colorPrimary</item>
     </style>
 
-    <!--  Button used in Jetpack Installation dialogs   -->
-    <style name="Woo.JetpackButton" parent="Widget.MaterialComponents.Button.UnelevatedButton">
-        <item name="android:textAppearance">?attr/textAppearanceSubtitle2</item>
-        <item name="android:paddingStart">@dimen/major_100</item>
-        <item name="android:paddingEnd">@dimen/major_100</item>
-        <item name="backgroundTint">@color/jetpack_button_color</item>
-    </style>
-
-
-
     <!-- Set at the theme level so no need to set directly on the component -->
     <style name="Widget.Woo.WCToggleOutlinedButton" parent="Widget.MaterialComponents.Button.OutlinedButton">
         <item name="android:paddingStart">@dimen/major_100</item>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/JetpackCPInstallViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/JetpackCPInstallViewModelTest.kt
@@ -29,8 +29,8 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 
 @ExperimentalCoroutinesApi
 class JetpackCPInstallViewModelTest : BaseUnitTest() {
@@ -47,7 +47,7 @@ class JetpackCPInstallViewModelTest : BaseUnitTest() {
         on { get() }.doReturn(siteModelMock)
     }
     private val siteStore: SiteStore = mock()
-    private val exampleResult = WooResult(model = listOf(siteModelMock))
+    private val successResult = OnSiteChanged(rowsAffected = 1)
     private lateinit var viewModel: JetpackCPInstallViewModel
 
     companion object {
@@ -73,7 +73,8 @@ class JetpackCPInstallViewModelTest : BaseUnitTest() {
     fun `when installation is successful, then set proper install states`() = testBlocking {
         val installStates = mutableListOf<JetpackCPInstallViewModel.InstallStatus>()
         doReturn(true).whenever(siteModelMock).hasWooCommerce
-        doReturn(exampleResult).whenever(siteStore).fetchSite(selectedSiteMock.get())
+        doReturn(successResult).whenever(siteStore).fetchSite(siteModelMock)
+        doReturn(siteModelMock).whenever(siteStore).getSiteBySiteId(SITE_ID)
 
         viewModel.viewStateLiveData.observeForever { old, new ->
             new.installStatus?.takeIfNotEqualTo(old?.installStatus) { installStates.add(it) }
@@ -143,8 +144,7 @@ class JetpackCPInstallViewModelTest : BaseUnitTest() {
     @Test
     fun `when connecting is failed, then set failed state`() = testBlocking {
         val installStates = mutableListOf<JetpackCPInstallViewModel.InstallStatus>()
-        doReturn(false).whenever(siteModelMock).hasWooCommerce
-        doReturn(exampleResult).whenever(siteStore).fetchSite(selectedSiteMock.get())
+        doReturn(successResult).whenever(siteStore).fetchSite(siteModelMock)
 
         viewModel.viewStateLiveData.observeForever { old, new ->
             new.installStatus?.takeIfNotEqualTo(old?.installStatus) { installStates.add(it) }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/JetpackCPInstallViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/JetpackCPInstallViewModelTest.kt
@@ -30,7 +30,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.fluxc.store.SiteStore
 
 @ExperimentalCoroutinesApi
 class JetpackCPInstallViewModelTest : BaseUnitTest() {
@@ -46,7 +46,7 @@ class JetpackCPInstallViewModelTest : BaseUnitTest() {
     private val selectedSiteMock: SelectedSite = mock {
         on { get() }.doReturn(siteModelMock)
     }
-    private val wooCommerceStore: WooCommerceStore = mock()
+    private val siteStore: SiteStore = mock()
     private val exampleResult = WooResult(model = listOf(siteModelMock))
     private lateinit var viewModel: JetpackCPInstallViewModel
 
@@ -65,7 +65,7 @@ class JetpackCPInstallViewModelTest : BaseUnitTest() {
             savedState,
             pluginRepository,
             selectedSiteMock,
-            wooCommerceStore
+            siteStore
         )
     }
 
@@ -73,7 +73,7 @@ class JetpackCPInstallViewModelTest : BaseUnitTest() {
     fun `when installation is successful, then set proper install states`() = testBlocking {
         val installStates = mutableListOf<JetpackCPInstallViewModel.InstallStatus>()
         doReturn(true).whenever(siteModelMock).hasWooCommerce
-        doReturn(exampleResult).whenever(wooCommerceStore).fetchWooCommerceSites()
+        doReturn(exampleResult).whenever(siteStore).fetchSite(selectedSiteMock.get())
 
         viewModel.viewStateLiveData.observeForever { old, new ->
             new.installStatus?.takeIfNotEqualTo(old?.installStatus) { installStates.add(it) }
@@ -144,7 +144,7 @@ class JetpackCPInstallViewModelTest : BaseUnitTest() {
     fun `when connecting is failed, then set failed state`() = testBlocking {
         val installStates = mutableListOf<JetpackCPInstallViewModel.InstallStatus>()
         doReturn(false).whenever(siteModelMock).hasWooCommerce
-        doReturn(exampleResult).whenever(wooCommerceStore).fetchWooCommerceSites()
+        doReturn(exampleResult).whenever(siteStore).fetchSite(selectedSiteMock.get())
 
         viewModel.viewStateLiveData.observeForever { old, new ->
             new.installStatus?.takeIfNotEqualTo(old?.installStatus) { installStates.add(it) }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12364
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Coming from a CUW issue: peaMlT-Om-p2

When attempting to install and connect Jetpack, if the site is Jetpack CP connected and it the user had previously Jetpack the plugin enabled on the site, the installation flow will fail with an error and the user will be stuck there. 

https://github.com/user-attachments/assets/ef7a09b4-eabd-4608-81f6-eb1bf48d14fd

**Extra fix:** The current flow is showing 2 of the main CTAs with the old pink/fuchsia color. The buttons should be updated to the primary color Woo purple. This PR also addresses that. 


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Run the app from `trunk`

1. From a self hosted site install any plugin that uses Jetpack CP and connect it
2. From `wp-admin` install and activate Jetpack the plugin
3. Now from same `wp-admin` plugins sections click on deactivate Jetpack the plugin
4. Log into the site from Woo app using WP.com creds 
5. The "Install Jetpack" banner should be shown at the bottom of the screen after logging in. Click on it. 
6. Complete the Jetpack installation flow until reaching the error screen shown in the screen recording above. 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Repeat the steps described above, running the app from this branch. The Jetpack installation flow should be completed successfully. 
Also, review that all the CTAs displayed during the flow have the Woo primary purple color. 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I tested the Jetpack installation flow 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/57b3c834-1b81-4b05-a0af-ea5ff40c80c5

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->12364