### PR TITLE
Fix/12470 display click through rate correctly

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignItem.kt
@@ -75,8 +75,8 @@ fun BlazeCampaignItem(
                         statName = stringResource(R.string.blaze_campaign_status_ctr_label),
                         statValue = stringResource(
                             id = R.string.blaze_campaign_status_ctr_valur,
-                            campaign.clicks,
-                            campaign.impressions
+                            campaign.impressions,
+                            campaign.clicks
                         )
                     )
                     Spacer(modifier = Modifier.width(42.dp))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignItem.kt
@@ -74,7 +74,7 @@ fun BlazeCampaignItem(
                     CampaignStat(
                         statName = stringResource(R.string.blaze_campaign_status_ctr_label),
                         statValue = stringResource(
-                            id = R.string.blaze_campaign_status_ctr_valur,
+                            id = R.string.blaze_campaign_status_ctr_value,
                             campaign.impressions,
                             campaign.clicks
                         )

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3856,7 +3856,7 @@
     <string name="blaze_campaign_status_canceled">Canceled</string>
     <string name="blaze_campaign_status_suspended">Suspended</string>
     <string name="blaze_campaign_status_ctr_label">Click-throughs</string>
-    <string name="blaze_campaign_status_ctr_valur">%1$d ➔ %2$d</string>
+    <string name="blaze_campaign_status_ctr_value">%1$d ➔ %2$d</string>
     <string name="blaze_campaign_status_budget_total">Total</string>
     <string name="blaze_campaign_status_budget_remaining">Remaining</string>
     <string name="blaze_campaign_status_budget_weekly">Weekly</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12470
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We currently updated the UI for Blaze campaigns to display the click-though rate [here](https://github.com/woocommerce/woocommerce-android/issues/12389). However, in that liked PR I applied some changes coming from feedback suggestions. In those changes I accidentally introduced a bug: https://github.com/woocommerce/woocommerce-android/pull/12433/commits/ee27a142b1c15ed3a74b31ad0b420752e7897997 and now clicks are displayed before impressions, when it should be the other way around: 

 <img width="300"  src="https://github.com/user-attachments/assets/97dcaaf2-ceac-4d99-9cfe-9b3d72d0ebe0"> 
 <img width="300"  src="https://github.com/user-attachments/assets/95b2f57f-4cc4-403d-aa3b-eef1be1a7cdf"> 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
1. Check the campaign list and verify that impressions are displayed before clicks in the Click through column

If you don't have any campaign with non-zero impressions and clicks, you have 2 options: 
- Trust the change works, as it is super straightforward and clear. And trust I tested it and works. 
- Ask me and I can invite you to a site with Blaze campaigns with non zero values. 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Loaded Blaze campaigns and checked that the stats are displayed correctly. 

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->12470