### PR TITLE
[Tooling] Fix hotfix pipeline

### DIFF
--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -2,7 +2,7 @@
 ---
 
 steps:
-  - input: "What version code do you want to use for the new hotfix release?"
+  - block: "What version code do you want to use for the new hotfix release?"
     fields:
       - text: "Version Code"
         key: "version_code"


### PR DESCRIPTION
The pipeline needs to wait for the Release Manager to enter the version code in the prompt before running the next step using the value, otherwise the "New Hotfix Release" step would run too soon and try to read the value before it got entered.

Ref: p1725266979981439/1725028369.820509-slack-C6H8C3G23
Example failing build: https://buildkite.com/automattic/woocommerce-android/builds/23784

PS: Targeting `trunk` should be ok because that's also the branch from which the `new_hotfix_release` lane and scenario step is triggered from.