### PR TITLE
Manually update version.properties for 20.1.1

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
 versionName=20.1.1
-versionCode=
+versionCode=598


### PR DESCRIPTION
The CI automation contains a bug which incorrectly read the version code and therefore the version code ended up being empty. This PR manually fixes this issue. A separate PR which fixes the automation will be created independently of this to ensure we don't block the release.