### PR TITLE
Merge 20.1 into 20.1.1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStore.kt
@@ -122,7 +122,7 @@ class AnalyticsUpdateDataStore @Inject constructor(
                     true
                 }
             }
-            .map { lastUpdateValues -> lastUpdateValues.min() }
+            .map { lastUpdateValues -> lastUpdateValues.minOrNull() }
     }
 
     private fun observeLastUpdate(timestampKey: String): Flow<Long?> {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/hub/sync/AnalyticsUpdateDataStoreTest.kt
@@ -273,6 +273,32 @@ class AnalyticsUpdateDataStoreTest : BaseUnitTest() {
         assertThat(timestampUpdate).isEqualTo(lastUpdateTimestamp)
     }
 
+    @Test
+    fun `given observe should emit last update, when all data sources are not required, if all data sources are missing then return null`() = testBlocking {
+        // Given
+        val selectedSiteId = 1
+
+        val analyticsPreferences = mock<Preferences>()
+
+        createAnalyticsUpdateScenarioWith(analyticsPreferences, selectedSiteId)
+
+        // When
+        var timestampUpdate: Long? = null
+        sut.observeLastUpdate(
+            rangeSelection = defaultSelectionData,
+            analyticData = listOf(
+                AnalyticsUpdateDataStore.AnalyticData.REVENUE,
+                AnalyticsUpdateDataStore.AnalyticData.VISITORS
+            ),
+            shouldAllDataBePresent = false
+        ).onEach {
+            timestampUpdate = it
+        }.launchIn(this)
+
+        // Then
+        assertThat(timestampUpdate).isNull()
+    }
+
     private fun createAnalyticsUpdateScenarioWith(
         analyticsPreferences: Preferences,
         selectedSiteId: Int


### PR DESCRIPTION
This PR merges 20.1 into 20.1.1. It doesn't use the 20.1 branch directly, since that branch is in an inconsistent state - string.xml translations contain changes which it shouldn't contain. More info on the original PR https://github.com/woocommerce/woocommerce-android/pull/12474.


The changes in this PR were tested and reviewed [here](https://github.com/woocommerce/woocommerce-android/pull/12466).