### PR TITLE
[Aztec in Compose] Few fixes and improvements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/aztec/AztecEditor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/aztec/AztecEditor.kt
@@ -345,9 +345,9 @@ private suspend fun handleFocus(
         // the session is closed and this hides the keyboard.
         // This behavior doesn't work well when focus moves to a non-Compose input field, like the Aztec editor.
         // see: https://issuetracker.google.com/issues/318530776 and https://issuetracker.google.com/issues/363544352
-        // To fix this, we are using the internal API to start/stop the input.
-        // This is safe to do because even if the API changes, we can remove the logic temporarily until we find a
-        // better solution, as this behavior is not critical for the editor.
+        // To get around the issue, we are using the internal API to start/stop the input session.
+        // This is safe to do because even if the API changes, we can remove the logic temporarily until the bug is
+        // fixed, as this bug is not critical for the editor.
         focusState.collect {
             if (it) {
                 textInputService?.startInput()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/aztec/AztecEditor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/aztec/AztecEditor.kt
@@ -19,8 +19,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -243,6 +246,7 @@ private fun InternalAztecEditor(
         Aztec.with(viewsHolder.visualEditor, viewsHolder.sourceEditor, viewsHolder.toolbar, listener)
             .setImageGetter(GlideImageLoader(localContext))
     }
+    var sourceEditorMinHeight by rememberSaveable { mutableStateOf(0) }
 
     // Toggle the editor mode when the state changes
     LaunchedEffect(Unit) {
@@ -281,7 +285,7 @@ private fun InternalAztecEditor(
             aztec.visualEditor.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
                 // Because the editors could have different number of lines, we don't set the minLines
                 // of the source editor, so we set the minHeight instead to match the visual editor
-                aztec.sourceEditor?.minHeight = aztec.visualEditor.height
+                sourceEditorMinHeight = aztec.visualEditor.height
             }
 
             aztec.visualEditor.doAfterTextChanged {
@@ -308,6 +312,9 @@ private fun InternalAztecEditor(
                 aztec.sourceEditor?.setCalypsoMode(calypsoMode)
             }
 
+            if (sourceEditorMinHeight != aztec.sourceEditor?.minHeight) {
+                aztec.sourceEditor?.minHeight = sourceEditorMinHeight
+            }
             if (minLines != -1 && minLines != aztec.visualEditor.minLines) {
                 aztec.visualEditor.minLines = minLines
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/aztec/AztecEditor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/aztec/AztecEditor.kt
@@ -282,6 +282,10 @@ private fun InternalAztecEditor(
 
     AndroidView(
         factory = {
+            // Set initial content
+            aztec.visualEditor.fromHtml(state.content)
+            aztec.sourceEditor?.displayStyledAndFormattedHtml(state.content)
+
             aztec.visualEditor.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
                 // Because the editors could have different number of lines, we don't set the minLines
                 // of the source editor, so we set the minHeight instead to match the visual editor
@@ -409,7 +413,7 @@ private data class AztecViewsHolder(
 @Composable
 @Preview
 private fun OutlinedAztecEditorPreview() {
-    val state = rememberAztecEditorState("")
+    val state = rememberAztecEditorState("something")
 
     WooThemeWithBackground {
         Column {

--- a/WooCommerce/src/main/res/values/styles_base.xml
+++ b/WooCommerce/src/main/res/values/styles_base.xml
@@ -777,6 +777,7 @@ theme across the entire app. Overridden versions should be added to the styles.x
     </style>
 
     <style name="Woo.AztecText.SourceEditor">
+        <item name="android:imeOptions">flagNoExtractUi</item>
         <item name="android:inputType">textNoSuggestions|textMultiLine</item>
         <item name="attributeColor">@color/editor_attribute_color</item>
         <item name="codeBackgroundColor">@color/editor_code_bg_color</item>


### PR DESCRIPTION
### Description
This PR is a cont to #12435, this PR adds some improvements and fixes to the Component:
- Make sure the screen is scrolled to show the component when it gains focus and also when the keyboard is shown if it already had focus.
- Fix an issue with keyboard getting hidden when focus moves from a Compose TextField to the component.
- Add the flag `flagNoExtractUi` to the source editor as well.
- Fix a bug where the source editor loses the minHeight value during config changes.

### Steps to reproduce
For the preparation steps, please check #12435 to get an HTML custom field on one of the orders.
##### TC 1
1. Open the app, and navigate to the HTML custom field.
2. Rotate the phone to landscape.
3. Tap on the Aztec editor.
4. Notice the screen doesn't scroll.

##### TC 2
1. On the same screen.
2. Tap on the Key field.
3. Tap now on the value field.
4. Notice the keyboard got hidden.

##### TC 3
1. On the same screen.
2. Switch to source mode on the HTML field.
3. Rotate the phone to landscape.
4. Notice the keyboard goes full screen and hides the toolbar.

##### TC 4
1. On the same screen.
2. Reduce the content of the HTML value field to be only a single line.
3. Switch to source mode on the HTML field.
4. Rotate the phone.
5. Notice the field gets smaller than expected.

### Testing information
Repeate all TCs above and confirm the issues have been fixed.

### The tests that have been performed
The above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->