### PR TITLE
[Tooling] Fix too-early interpolation of `${VERSION_CODE}` in inline script of `new-hotfix-release`

### DIFF
--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -21,7 +21,7 @@ steps:
 
       echo '--- :fire: Start New Hotfix Release'
       # Note: we need to double the dollar sign in front of `{VERSION_CODE}` below, so that the env var is interpreted *at runtime*, instead of too soon during `pipeline upload`
-      bundle exec fastlane new_hotfix_release version_name:$${VERSION} version_code:$${VERSION_CODE} skip_confirm:true
+      echo bundle exec fastlane new_hotfix_release version_name:$${VERSION} version_code:$${VERSION_CODE} skip_confirm:true
     agents:
         queue: "tumblr-metal"
     retry:

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -21,7 +21,7 @@ steps:
 
       echo '--- :fire: Start New Hotfix Release'
       # Note: we need to double the dollar sign in front of `{VERSION_CODE}` below, so that the env var is interpreted *at runtime*, instead of too soon during `pipeline upload`
-      echo bundle exec fastlane new_hotfix_release version_name:$${VERSION} version_code:$${VERSION_CODE} skip_confirm:true
+      bundle exec fastlane new_hotfix_release version_name:$${VERSION} version_code:$${VERSION_CODE} skip_confirm:true
     agents:
         queue: "tumblr-metal"
     retry:

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -16,11 +16,12 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      # Get the version code from the Buildkite 'input' step
+      # Get the version code from the Buildkite 'block' step
       VERSION_CODE=$(buildkite-agent meta-data get version_code)
 
       echo '--- :fire: Start New Hotfix Release'
-      bundle exec fastlane new_hotfix_release version_name:${VERSION} version_code:${VERSION_CODE} skip_confirm:true
+      # Note: we need to double the dollar sign in front of `{VERSION_CODE}` below, so that the env var is interpreted *at runtime*, instead of too soon during `pipeline upload`
+      bundle exec fastlane new_hotfix_release version_name:$${VERSION} version_code:$${VERSION_CODE} skip_confirm:true
     agents:
         queue: "tumblr-metal"
     retry:


### PR DESCRIPTION
Ref: p1725269377791449/1725268293.805049-slack-C02KLTL3MKM 

## Why?

This is necessary in this case because we're writing the shell script commands inline direclty within the YAML body, and the env vars in the YAML are interpolated during `buildkite-agent pipeline upload`.

See https://buildkite.com/docs/pipelines/environment-variables\#runtime-variable-interpolation

 - Note that this change was not strictly necessary to apply _also_ for the case of `$${VERSION}` (unlike for `VERSION_CODE`) because the value of that `VERSION` env var already has its final value (provided by ReleaseV2 when it triggered the pipeline) at the time `pipeline upload` is run; so it was not a problem for this one to be interpolated that early. Still, for consistency with the rest of the script, I decided to escape it as `$${VERSION}` anyway, mostly for consistency with the rest of the script, as it should still work when only resolving it at runtime of the script just like `$${VERSION_CODE}` now is.

 - Also note that this double-escape is only necessary when we're writing the bash script inline within the YAML, as opposed to writing the script in a separate `.sh` and invoking that `.sh` from the YAML, as only the content of the `.yml` (not the content of the `.sh` is interpolated during `pipeline upload`. That's why we usually don't need that double-escape in other pipelines that use a separate `.sh` instead of inline commands, and why we missed it in this rare occasion when we write the script directly in the YAML.

## Testing

 - I pushed a test commit d04203f8d07dae5fb249d11803a0f963982daf9e to add an `echo` in front of the `bundle exec` command
 - Then I [manually triggered a build for that pipeline from the Buildkite web UI](https://buildkite.com/automattic/woocommerce-android/builds/23821), which allowed me to [validate the command being run would be the right one and now include the version code too](https://buildkite.com/automattic/woocommerce-android/builds/23821#0191b2a7-c2fc-4326-8c23-c2253bd20297/156-157).
 - I then reverted the test commit (via 23e0245b8b0d1fb31f7fc83fbe8fb895393ce5dd) before marking this PR as ready for review.