### PR TITLE
[Crash] `IllegalArgumentException` when navigating to Filters in Orders list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 20.3
 -----
-
+- [**] Stopped potential crash in the orders list screen when tapping "Filters" button [https://github.com/woocommerce/woocommerce-android/pull/12482]
 
 20.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -709,7 +709,7 @@ class OrderListFragment :
     }
 
     private fun showOrderFilters() {
-        findNavController().navigateSafely(R.id.action_orderListFragment_to_orderFilterListFragment)
+        findNavController().navigateSafely(OrderListFragmentDirections.actionOrderListFragmentToOrderFilterListFragment())
     }
 
     private fun navigateToTryTestOrderScreen() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -709,7 +709,9 @@ class OrderListFragment :
     }
 
     private fun showOrderFilters() {
-        findNavController().navigateSafely(OrderListFragmentDirections.actionOrderListFragmentToOrderFilterListFragment())
+        findNavController().navigateSafely(
+            OrderListFragmentDirections.actionOrderListFragmentToOrderFilterListFragment()
+        )
     }
 
     private fun navigateToTryTestOrderScreen() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
## [Crash] IllegalArgumentException when navigating to Filters in Orders list

Closes: #12480 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Sentry [logs](https://a8c.sentry.io/issues/5078779302/?referrer=github_integration) revealed crash happening in the Orders screen when tapping the "Filters" button. 

As shared (p1725275700876619-slack-C6H8C3G23), I couldn't reproduce the crash. However, in this case, I think swallowing the exception, preventing the app from crashing and logging the error instead makes sense. For that, I just switched to the `navigateSafely` function that calls the navigation action in a try-catch block.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
—
### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
It's crucial to test against regression. The Filters screen/dialog should appear when tapping the "Filters" button in the Orders screen.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I verified the Filters screen/dialog is displayed correctly and filtering works in the Orders screen. Devices: Pixel 7 pro, Galaxy Tab, Android 14

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->