### PR TITLE
[Custom Fields] Handle saving changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/CustomFieldModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/CustomFieldModels.kt
@@ -5,6 +5,7 @@ import androidx.core.util.PatternsCompat
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.metadata.WCMetaData
+import org.wordpress.android.fluxc.model.metadata.WCMetaDataValue
 import org.wordpress.android.util.HtmlUtils
 import java.util.regex.Pattern
 
@@ -23,6 +24,12 @@ data class CustomFieldUiModel(
 
     @IgnoredOnParcel
     val contentType: CustomFieldContentType = CustomFieldContentType.fromMetadataValue(value)
+
+    fun toDomainModel() = CustomField(
+        id = id ?: 0, // Use 0 for new custom fields
+        key = key,
+        value = WCMetaDataValue.StringValue(value) // Treat all updates as string values
+    )
 }
 
 enum class CustomFieldContentType {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/CustomFieldsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/CustomFieldsRepository.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.model.metadata.MetaDataParentItemType
+import org.wordpress.android.fluxc.model.metadata.UpdateMetadataRequest
 import org.wordpress.android.fluxc.store.MetaDataStore
 import javax.inject.Inject
 
@@ -30,6 +31,18 @@ class CustomFieldsRepository @Inject constructor(
                 Result.failure(WooException(it.error))
             } else {
                 WooLog.d(WooLog.T.CUSTOM_FIELDS, "Successfully refreshed custom fields")
+                Result.success(Unit)
+            }
+        }
+    }
+
+    suspend fun updateCustomFields(request: UpdateMetadataRequest): Result<Unit> {
+        return metaDataStore.updateMetaData(selectedSite.get(), request).let {
+            if (it.isError) {
+                WooLog.w(WooLog.T.CUSTOM_FIELDS, "Failed to update custom fields: ${it.error}")
+                Result.failure(WooException(it.error))
+            } else {
+                WooLog.d(WooLog.T.CUSTOM_FIELDS, "Successfully updated custom fields")
                 Result.success(Unit)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -14,6 +15,10 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class CustomFieldsEditorFragment : BaseFragment() {
+    companion object {
+        const val RESULT_KEY = "custom_field_result"
+    }
+
     override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
 
     private val viewModel: CustomFieldsEditorViewModel by viewModels()
@@ -31,6 +36,7 @@ class CustomFieldsEditorFragment : BaseFragment() {
     private fun handleEvents() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
+                is MultiLiveEvent.Event.ExitWithResult<*> -> navigateBackWithResult(RESULT_KEY, event.data)
                 MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.customfields.editor
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -43,6 +44,8 @@ private fun CustomFieldsEditorScreen(
     onDoneClicked: () -> Unit,
     onBackButtonClick: () -> Unit,
 ) {
+    BackHandler { onBackButtonClick() }
+
     Scaffold(
         topBar = {
             Toolbar(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -70,7 +70,8 @@ class CustomFieldsEditorViewModel @Inject constructor(
     }
 
     fun onDoneClicked() {
-        TODO()
+        val value = requireNotNull(customFieldDraft.value)
+        triggerEvent(MultiLiveEvent.Event.ExitWithResult(value))
     }
 
     private fun initState() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -3,98 +3,61 @@ package com.woocommerce.android.ui.customfields.editor
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.ui.customfields.CustomField
 import com.woocommerce.android.ui.customfields.CustomFieldUiModel
-import com.woocommerce.android.ui.customfields.CustomFieldsRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
-import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class CustomFieldsEditorViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle,
-    private val repository: CustomFieldsRepository
+    savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs by savedStateHandle.navArgs<CustomFieldsEditorFragmentArgs>()
 
-    private val customFieldDraft = savedStateHandle.getNullableStateFlow(
+    private val customFieldDraft = savedStateHandle.getStateFlow(
         scope = viewModelScope,
-        initialValue = null,
-        key = "customField",
-        clazz = CustomFieldUiModel::class.java
+        initialValue = navArgs.customField ?: CustomFieldUiModel("", ""),
+        key = "customField"
     )
     private val showDiscardChangesDialog = savedStateHandle.getStateFlow(
         scope = viewModelScope,
         initialValue = false,
         key = "showDiscardChangesDialog"
     )
-    private val storedValue = MutableStateFlow<CustomField?>(null)
-    private val isHtml = storedValue.map { it?.valueStrippedHtml != it?.valueAsString }
+    private val storedValue = navArgs.customField
+    private val isHtml = storedValue?.valueStrippedHtml != storedValue?.value
 
     val state = combine(
-        customFieldDraft.filterNotNull(),
-        storedValue,
-        isHtml,
+        customFieldDraft,
         showDiscardChangesDialog.mapToState()
-    ) { customField, storedValue, isHtml, discardChangesDialogState ->
+    ) { customField, discardChangesDialogState ->
         UiState(
             customField = customField,
             hasChanges = storedValue?.key.orEmpty() != customField.key ||
-                storedValue?.valueAsString.orEmpty() != customField.value,
+                storedValue?.value.orEmpty() != customField.value,
             isHtml = isHtml,
             discardChangesDialogState = discardChangesDialogState
         )
     }.asLiveData()
 
-    init {
-        initState()
-    }
-
     fun onKeyChanged(key: String) {
-        customFieldDraft.update { it?.copy(key = key) }
+        customFieldDraft.update { it.copy(key = key) }
     }
 
     fun onValueChanged(value: String) {
-        customFieldDraft.update { it?.copy(value = value) }
+        customFieldDraft.update { it.copy(value = value) }
     }
 
     fun onDoneClicked() {
         val value = requireNotNull(customFieldDraft.value)
         triggerEvent(MultiLiveEvent.Event.ExitWithResult(value))
-    }
-
-    private fun initState() {
-        if (navArgs.customFieldId == -1L && customFieldDraft.value == null) {
-            customFieldDraft.value = CustomFieldUiModel("", "")
-            return
-        }
-
-        launch {
-            val dbValue = requireNotNull(
-                repository.getCustomFieldById(
-                    parentItemId = navArgs.parentItemId,
-                    customFieldId = navArgs.customFieldId
-                )
-            ) {
-                "Custom field not found in database, this should not happen"
-            }
-
-            storedValue.value = dbValue
-            if (customFieldDraft.value == null) {
-                customFieldDraft.value = CustomFieldUiModel(dbValue)
-            }
-        }
     }
 
     fun onBackClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -24,7 +24,7 @@ class CustomFieldsEditorViewModel @Inject constructor(
     private val customFieldDraft = savedStateHandle.getStateFlow(
         scope = viewModelScope,
         initialValue = navArgs.customField ?: CustomFieldUiModel("", ""),
-        key = "customField"
+        key = "customFieldDraft"
     )
     private val showDiscardChangesDialog = savedStateHandle.getStateFlow(
         scope = viewModelScope,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
@@ -6,11 +6,13 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.customfields.CustomFieldContentType
 import com.woocommerce.android.ui.customfields.CustomFieldUiModel
+import com.woocommerce.android.ui.customfields.editor.CustomFieldsEditorFragment
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -37,6 +39,7 @@ class CustomFieldsFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         handleEvents()
+        handleResults()
     }
 
     private fun handleEvents() {
@@ -49,6 +52,12 @@ class CustomFieldsFragment : BaseFragment() {
                     findNavController().navigateUp()
                 }
             }
+        }
+    }
+
+    private fun handleResults() {
+        handleResult<CustomFieldUiModel>(CustomFieldsEditorFragment.RESULT_KEY) { result ->
+            viewModel.onCustomFieldUpdated(result)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
@@ -64,8 +64,7 @@ class CustomFieldsFragment : BaseFragment() {
     private fun openEditor(field: CustomFieldUiModel) {
         findNavController().navigate(
             CustomFieldsFragmentDirections.actionCustomFieldsFragmentToCustomFieldsEditorFragment(
-                customFieldId = field.id ?: -1,
-                parentItemId = viewModel.parentItemId,
+                customField = field
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
@@ -57,7 +57,11 @@ class CustomFieldsFragment : BaseFragment() {
 
     private fun handleResults() {
         handleResult<CustomFieldUiModel>(CustomFieldsEditorFragment.RESULT_KEY) { result ->
-            viewModel.onCustomFieldUpdated(result)
+            if (result.id == null) {
+                viewModel.onCustomFieldInserted(result)
+            } else {
+                viewModel.onCustomFieldUpdated(result)
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.customfields.CustomField
@@ -50,6 +51,7 @@ fun CustomFieldsScreen(viewModel: CustomFieldsViewModel) {
         CustomFieldsScreen(
             state = state,
             onPullToRefresh = viewModel::onPullToRefresh,
+            onSaveClicked = viewModel::onSaveClicked,
             onCustomFieldClicked = viewModel::onCustomFieldClicked,
             onCustomFieldValueClicked = viewModel::onCustomFieldValueClicked,
             onBackClick = viewModel::onBackClick
@@ -62,6 +64,7 @@ fun CustomFieldsScreen(viewModel: CustomFieldsViewModel) {
 private fun CustomFieldsScreen(
     state: CustomFieldsViewModel.UiState,
     onPullToRefresh: () -> Unit,
+    onSaveClicked: () -> Unit,
     onCustomFieldClicked: (CustomFieldUiModel) -> Unit,
     onCustomFieldValueClicked: (CustomFieldUiModel) -> Unit,
     onBackClick: () -> Unit
@@ -70,7 +73,15 @@ private fun CustomFieldsScreen(
         topBar = {
             Toolbar(
                 title = stringResource(id = R.string.custom_fields_list_title),
-                onNavigationButtonClick = onBackClick
+                onNavigationButtonClick = onBackClick,
+                actions = {
+                    if (state.hasChanges) {
+                        WCTextButton(
+                            text = stringResource(id = R.string.save),
+                            onClick = onSaveClicked
+                        )
+                    }
+                }
             )
         },
         backgroundColor = MaterialTheme.colors.surface
@@ -180,10 +191,10 @@ private fun CustomFieldsScreenPreview() {
                         )
                     ),
                     CustomFieldUiModel(CustomField(3, "key4", "https://url.com")),
-                ),
-                isLoading = false
+                )
             ),
             onPullToRefresh = {},
+            onSaveClicked = {},
             onCustomFieldClicked = {},
             onCustomFieldValueClicked = {},
             onBackClick = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
@@ -109,6 +110,13 @@ private fun CustomFieldsScreen(
                 refreshing = state.isRefreshing,
                 state = pullToRefreshState,
                 modifier = Modifier.align(Alignment.TopCenter)
+            )
+        }
+
+        if (state.isSaving) {
+            ProgressDialog(
+                title = stringResource(id = R.string.custom_fields_progress_dialog_title),
+                subtitle = stringResource(id = R.string.please_wait)
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -115,7 +115,7 @@ private fun CustomFieldsScreen(
 
         if (state.isSaving) {
             ProgressDialog(
-                title = stringResource(id = R.string.custom_fields_progress_dialog_title),
+                title = stringResource(id = R.string.custom_fields_list_progress_dialog_title),
                 subtitle = stringResource(id = R.string.please_wait)
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.DiscardChangesDialog
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCTextButton
@@ -117,6 +118,13 @@ private fun CustomFieldsScreen(
             ProgressDialog(
                 title = stringResource(id = R.string.custom_fields_list_progress_dialog_title),
                 subtitle = stringResource(id = R.string.please_wait)
+            )
+        }
+
+        state.discardChangesDialogState?.let {
+            DiscardChangesDialog(
+                discardButton = it.onDiscard,
+                dismissButton = it.onCancel
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -86,7 +86,7 @@ private fun CustomFieldsScreen(
         },
         backgroundColor = MaterialTheme.colors.surface
     ) { paddingValues ->
-        val pullToRefreshState = rememberPullRefreshState(state.isLoading, onPullToRefresh)
+        val pullToRefreshState = rememberPullRefreshState(state.isRefreshing, onPullToRefresh)
 
         Box(
             modifier = Modifier
@@ -106,7 +106,7 @@ private fun CustomFieldsScreen(
             }
 
             PullRefreshIndicator(
-                refreshing = state.isLoading,
+                refreshing = state.isRefreshing,
                 state = pullToRefreshState,
                 modifier = Modifier.align(Alignment.TopCenter)
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.customfields.list
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -71,6 +72,8 @@ private fun CustomFieldsScreen(
     onCustomFieldValueClicked: (CustomFieldUiModel) -> Unit,
     onBackClick: () -> Unit
 ) {
+    BackHandler { onBackClick() }
+
     Scaffold(
         topBar = {
             Toolbar(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
@@ -90,13 +90,15 @@ class CustomFieldsViewModel @Inject constructor(
             )
 
             repository.updateCustomFields(request)
-                .onSuccess {
-                    // Clear pending changes after successful save
-                    pendingChanges.value = PendingChanges()
-                }.onFailure {
-                    // TODO use a more specific error message
-                    triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.error_generic))
-                }
+                .fold(
+                    onSuccess = {
+                        pendingChanges.value = PendingChanges()
+                        triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.custom_fields_list_saving_succeeded))
+                    },
+                    onFailure = {
+                        triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.custom_fields_list_saving_failed))
+                    }
+                )
             isSaving.value = false
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
@@ -26,18 +26,18 @@ class CustomFieldsViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
     private val args: CustomFieldsFragmentArgs by savedStateHandle.navArgs()
 
-    private val isLoading = MutableStateFlow(false)
+    private val isRefreshing = MutableStateFlow(false)
     private val customFields = repository.observeDisplayableCustomFields(args.parentItemId)
     private val pendingChanges = savedStateHandle.getStateFlow(viewModelScope, PendingChanges())
 
     val state = combine(
         customFields,
         pendingChanges,
-        isLoading,
+        isRefreshing,
     ) { customFields, pendingChanges, isLoading ->
         UiState(
             customFields = customFields.map { CustomFieldUiModel(it) }.combineWithChanges(pendingChanges),
-            isLoading = isLoading,
+            isRefreshing = isLoading,
             hasChanges = pendingChanges.hasChanges
         )
     }.asLiveData()
@@ -48,11 +48,11 @@ class CustomFieldsViewModel @Inject constructor(
 
     fun onPullToRefresh() {
         launch {
-            isLoading.value = true
+            isRefreshing.value = true
             repository.refreshCustomFields(args.parentItemId, args.parentItemType).onFailure {
                 triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.custom_fields_list_loading_error))
             }
-            isLoading.value = false
+            isRefreshing.value = false
         }
     }
 
@@ -92,7 +92,7 @@ class CustomFieldsViewModel @Inject constructor(
 
     data class UiState(
         val customFields: List<CustomFieldUiModel>,
-        val isLoading: Boolean = false,
+        val isRefreshing: Boolean = false,
         val hasChanges: Boolean = false
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
@@ -30,8 +30,6 @@ class CustomFieldsViewModel @Inject constructor(
     private val customFields = repository.observeDisplayableCustomFields(args.parentItemId)
     private val pendingChanges = savedStateHandle.getStateFlow(viewModelScope, PendingChanges())
 
-    val parentItemId = args.parentItemId
-
     val state = combine(
         customFields,
         pendingChanges,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
@@ -27,6 +27,7 @@ class CustomFieldsViewModel @Inject constructor(
     private val args: CustomFieldsFragmentArgs by savedStateHandle.navArgs()
 
     private val isRefreshing = MutableStateFlow(false)
+    private val isSaving = MutableStateFlow(false)
     private val customFields = repository.observeDisplayableCustomFields(args.parentItemId)
     private val pendingChanges = savedStateHandle.getStateFlow(viewModelScope, PendingChanges())
 
@@ -34,10 +35,12 @@ class CustomFieldsViewModel @Inject constructor(
         customFields,
         pendingChanges,
         isRefreshing,
-    ) { customFields, pendingChanges, isLoading ->
+        isSaving
+    ) { customFields, pendingChanges, isLoading, isSaving ->
         UiState(
             customFields = customFields.map { CustomFieldUiModel(it) }.combineWithChanges(pendingChanges),
             isRefreshing = isLoading,
+            isSaving = isSaving,
             hasChanges = pendingChanges.hasChanges
         )
     }.asLiveData()
@@ -93,6 +96,7 @@ class CustomFieldsViewModel @Inject constructor(
     data class UiState(
         val customFields: List<CustomFieldUiModel>,
         val isRefreshing: Boolean = false,
+        val isSaving: Boolean = false,
         val hasChanges: Boolean = false
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
@@ -58,6 +58,10 @@ class CustomFieldsViewModel @Inject constructor(
         triggerEvent(CustomFieldValueClicked(field))
     }
 
+    fun onCustomFieldUpdated(result: CustomFieldUiModel) {
+        TODO("Not yet implemented")
+    }
+
     data class UiState(
         val customFields: List<CustomFieldUiModel>,
         val isLoading: Boolean

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
@@ -92,7 +92,7 @@ class CustomFieldsViewModel @Inject constructor(
 
     fun onCustomFieldUpdated(result: CustomFieldUiModel) {
         pendingChanges.update {
-            it.copy(editedFields = it.editedFields + result)
+            it.copy(editedFields = it.editedFields.filterNot { field -> field.id == result.id } + result)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
@@ -84,13 +84,15 @@ class CustomFieldsViewModel @Inject constructor(
         triggerEvent(CustomFieldValueClicked(field))
     }
 
+    fun onCustomFieldInserted(result: CustomFieldUiModel) {
+        pendingChanges.update {
+            it.copy(insertedFields = it.insertedFields + result)
+        }
+    }
+
     fun onCustomFieldUpdated(result: CustomFieldUiModel) {
         pendingChanges.update {
-            if (result.id == null) {
-                it.copy(insertedFields = it.insertedFields + result)
-            } else {
-                it.copy(editedFields = it.editedFields + result)
-            }
+            it.copy(editedFields = it.editedFields + result)
         }
     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_custom_fields.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_custom_fields.xml
@@ -28,11 +28,8 @@
         android:id="@+id/customFieldsEditorFragment"
         android:name="com.woocommerce.android.ui.customfields.editor.CustomFieldsEditorFragment">
         <argument
-            android:name="customFieldId"
-            app:argType="long"
-            android:defaultValue="-1L" />
-        <argument
-            android:name="parentItemId"
-            app:argType="long" />
+            android:name="customField"
+            app:argType="com.woocommerce.android.ui.customfields.CustomFieldUiModel"
+            app:nullable="true" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4271,7 +4271,9 @@
     -->
     <string name="custom_fields_list_title">Custom Fields</string>
     <string name="custom_fields_list_loading_error">Error while loading custom fields</string>
+    <string name="custom_fields_list_progress_dialog_title">Saving changes</string>
+    <string name="custom_fields_list_saving_succeeded">Changes saved</string>
+    <string name="custom_fields_list_saving_failed">Saving changes failed, please try again</string>
     <string name="custom_fields_editor_key_label">Key</string>
     <string name="custom_fields_editor_value_label">Value</string>
-    <string name="custom_fields_progress_dialog_title">Saving changes</string>
 </resources>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4273,4 +4273,5 @@
     <string name="custom_fields_list_loading_error">Error while loading custom fields</string>
     <string name="custom_fields_editor_key_label">Key</string>
     <string name="custom_fields_editor_value_label">Value</string>
+    <string name="custom_fields_progress_dialog_title">Saving changes</string>
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
@@ -163,4 +163,21 @@ class CustomFieldsEditorViewModelTest : BaseUnitTest() {
 
         assertThat(state.discardChangesDialogState).isNotNull
     }
+
+    @Test
+    fun `when done is clicked, then exit with result`() = testBlocking {
+        setup(editing = true)
+
+        val events = viewModel.event.runAndCaptureValues {
+            viewModel.onKeyChanged("new key")
+            viewModel.onValueChanged("new value")
+            viewModel.onDoneClicked()
+        }.last()
+
+        assertThat(events).isEqualTo(
+            MultiLiveEvent.Event.ExitWithResult(
+                CustomFieldUiModel(id = CUSTOM_FIELD_ID, key = "new key", value = "new value")
+            )
+        )
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
@@ -1,43 +1,55 @@
 package com.woocommerce.android.ui.customfields.editor
 
-import com.woocommerce.android.ui.customfields.CustomField
-import com.woocommerce.android.ui.customfields.CustomFieldsRepository
+import android.text.TextUtils
+import com.woocommerce.android.ui.customfields.CustomFieldUiModel
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.wordpress.android.util.HtmlUtils
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CustomFieldsEditorViewModelTest : BaseUnitTest() {
     companion object {
         private const val CUSTOM_FIELD_ID = 1L
-        private const val PARENT_ITEM_ID = 1L
-    }
-
-    private val repository: CustomFieldsRepository = mock {
-        onBlocking { getCustomFieldById(parentItemId = PARENT_ITEM_ID, customFieldId = CUSTOM_FIELD_ID) } doReturn
-            CustomField(
-                id = CUSTOM_FIELD_ID,
-                key = "key",
-                value = "value"
-            )
     }
 
     private lateinit var viewModel: CustomFieldsEditorViewModel
+    private lateinit var textUtilsStaticMock: MockedStatic<TextUtils>
+
+    @Before
+    fun prepare() {
+        /** [HtmlUtils.fastStripHtml] uses internally [TextUtils.isEmpty], so we need to mock it */
+        textUtilsStaticMock = mockStatic(TextUtils::class.java)
+        whenever(TextUtils.isEmpty(any())).thenAnswer { invocation ->
+            invocation.getArgument<String>(0).isEmpty()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        textUtilsStaticMock.close()
+    }
 
     suspend fun setup(editing: Boolean, prepareMocks: suspend () -> Unit = {}) {
         prepareMocks()
         viewModel = CustomFieldsEditorViewModel(
             savedStateHandle = CustomFieldsEditorFragmentArgs(
-                parentItemId = PARENT_ITEM_ID,
-                customFieldId = if (editing) CUSTOM_FIELD_ID else -1
-            ).toSavedStateHandle(),
-            repository = repository
+                customField = if (editing) CustomFieldUiModel(
+                    id = CUSTOM_FIELD_ID,
+                    key = "key",
+                    value = "value"
+                ) else null
+            ).toSavedStateHandle()
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
@@ -44,11 +44,15 @@ class CustomFieldsEditorViewModelTest : BaseUnitTest() {
         prepareMocks()
         viewModel = CustomFieldsEditorViewModel(
             savedStateHandle = CustomFieldsEditorFragmentArgs(
-                customField = if (editing) CustomFieldUiModel(
-                    id = CUSTOM_FIELD_ID,
-                    key = "key",
-                    value = "value"
-                ) else null
+                customField = if (editing) {
+                    CustomFieldUiModel(
+                        id = CUSTOM_FIELD_ID,
+                        key = "key",
+                        value = "value"
+                    )
+                } else {
+                    null
+                }
             ).toSavedStateHandle()
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
@@ -81,8 +81,8 @@ class CustomFieldsViewModelTest : BaseUnitTest() {
         }.drop(1)
 
         verify(repository).refreshCustomFields(PARENT_ITEM_ID, PARENT_ITEM_TYPE)
-        assertThat(states.first().isLoading).isTrue()
-        assertThat(states.last().isLoading).isFalse()
+        assertThat(states.first().isRefreshing).isTrue()
+        assertThat(states.last().isRefreshing).isFalse()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
@@ -208,6 +208,20 @@ class CustomFieldsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when updating a custom field twice, then make sure the last edit is the one kept`() = testBlocking {
+        val customField = CustomFieldUiModel(CUSTOM_FIELDS.first())
+        setup()
+
+        val state = viewModel.state.runAndCaptureValues {
+            viewModel.onCustomFieldUpdated(customField.copy(value = "new value"))
+            viewModel.onCustomFieldUpdated(customField.copy(value = "new value 2"))
+            advanceUntilIdle()
+        }.last()
+
+        assertThat(state.customFields.first().value).isEqualTo("new value 2")
+    }
+
+    @Test
     fun `when adding a custom field, then custom fields are refreshed`() = testBlocking {
         val customField = CustomFieldUiModel(
             key = "new key",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12459 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR includes the following changes:
- Adds logic to return results from the editor to the list screen.
- Show a save button on the list screen when there are pending changes.
- Update the `meta_data` array of the parent item when saving changes.

### Steps to reproduce
1. Open wp-admin and add some "Custom Fields" to one order.
2. Open the app.
3. Open the order.
4. Tap on "View custom fields"
5. Open some of the fields, and make some changes.
6. Notice the Save button is displayed.
7. Tap on Back.
8. Notice the discard changes dialog.
9. Tap on Cancel.
10. Tap on Save.
11. Confirm the saving worked fine.

### Testing information
- It would be great to test the happy and unhappy paths.
- Tested using the Android emulator running Android 13.

### Images/gif
https://github.com/user-attachments/assets/adf132c1-c33f-444e-a83a-a6fbd2b286cf


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->