### PR TITLE
[Login] Fix for the "Open Mail" button

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [**] Fixed navigation in tablet mode: after order is paid, the app should redirect to order details screen. [https://github.com/woocommerce/woocommerce-android/pull/12415]
 - [*] Show the back button on the Order Edit Screen for phones [https://github.com/woocommerce/woocommerce-android/pull/12421]
 - [**] Enables support to create Blaze Evergreen campaigns [https://github.com/woocommerce/woocommerce-android/issues/12176]
+- [*] Fixed a bug that caused the button "Open Mail" to not work during Magic Link login [https://github.com/woocommerce/woocommerce-android/pull/12486]
 
 20.1
 -----

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -23,6 +23,10 @@
     <queries>
         <package android:name="com.whatsapp" />
         <package android:name="org.telegram.messenger" />
+
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+        </intent>
     </queries>
 
     <application

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt
@@ -23,15 +23,13 @@ object ActivityUtils {
             return false
         }
 
-        val intent = Intent(Intent.ACTION_MAIN)
-        intent.addCategory(Intent.CATEGORY_APP_EMAIL)
+        val intent = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_EMAIL)
         val emailApps = context.packageManager.intentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
-        return !emailApps.isEmpty()
+        return emailApps.isNotEmpty()
     }
 
     fun openEmailClient(context: Context) {
-        val intent = Intent(Intent.ACTION_MAIN)
-        intent.addCategory(Intent.CATEGORY_APP_EMAIL)
+        val intent = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_EMAIL)
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         context.startActivity(intent)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12485 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds a fix to the "Open Mail" button by allowing the app to query installed email clients.

### Steps to reproduce
1. Using `release/20.2` branch
1. Open the app and sign out if needed.
1. Enter the address of a Jetpack website.
1. Enter the WordPress.com email and proceed.
1. Tap on "Log in with magic link"
1. Tap on "Open Mail"
1. Notice the error.

### Testing information
1. Switch to this branch.
2. Repeat 2 to 6 from above.
3. Confirm the button works now.

### The tests that have been performed
The above

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->