### PR TITLE
Fix product filter `NoSuchElementException` crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListAdapter.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FilterListItemBinding
 import com.woocommerce.android.ui.products.filter.ProductFilterListAdapter.ProductFilterViewHolder
 import com.woocommerce.android.ui.products.filter.ProductFilterListViewModel.FilterListItemUiModel
-import com.woocommerce.android.ui.products.filter.ProductFilterListViewModel.FilterListOptionItemUiModel
 
 class ProductFilterListAdapter(
     private val clickListener: OnProductFilterClickListener,
@@ -58,12 +57,7 @@ class ProductFilterListAdapter(
         RecyclerView.ViewHolder(viewBinding.root) {
         fun bind(filterItem: FilterListItemUiModel, defaultFilterOption: String) {
             viewBinding.filterItemName.text = filterItem.filterItemName
-            viewBinding.filterItemSelection.text =
-                filterItem.filterOptionListItems
-                    .filterIsInstance<FilterListOptionItemUiModel.DefaultFilterListOptionItemUiModel>()
-                    .firstOrNull { it.isSelected }
-                    ?.filterOptionItemName
-                    ?: defaultFilterOption
+            viewBinding.filterItemSelection.text = filterItem.firstSelectedOption ?: defaultFilterOption
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListAdapter.kt
@@ -13,7 +13,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 
 class ProductFilterListAdapter(
     private val clickListener: OnProductFilterClickListener,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: (resourceId: Int) -> String
 ) : RecyclerView.Adapter<ProductFilterViewHolder>() {
     var filterList = listOf<FilterListItemUiModel>()
         set(value) {
@@ -44,7 +44,7 @@ class ProductFilterListAdapter(
     override fun onBindViewHolder(holder: ProductFilterViewHolder, position: Int) {
         holder.bind(
             filterItem = filterList[position],
-            defaultFilterOption = resourceProvider.getString(R.string.product_filter_default)
+            defaultFilterOption = resourceProvider(R.string.product_filter_default)
         )
         holder.itemView.setOnClickListener {
             clickListener.onProductFilterClick(position)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListAdapter.kt
@@ -56,7 +56,9 @@ class ProductFilterListAdapter(
             viewBinding.filterItemSelection.text =
                 filter.filterOptionListItems
                     .filterIsInstance<FilterListOptionItemUiModel.DefaultFilterListOptionItemUiModel>()
-                    .first { it.isSelected }.filterOptionItemName
+                    .firstOrNull { it.isSelected }
+                    ?.filterOptionItemName
+                    .orEmpty()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListAdapter.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.databinding.FilterListItemBinding
 import com.woocommerce.android.ui.products.filter.ProductFilterListAdapter.ProductFilterViewHolder
 import com.woocommerce.android.ui.products.filter.ProductFilterListViewModel.FilterListItemUiModel
 import com.woocommerce.android.ui.products.filter.ProductFilterListViewModel.FilterListOptionItemUiModel
-import com.woocommerce.android.viewmodel.ResourceProvider
 
 class ProductFilterListAdapter(
     private val clickListener: OnProductFilterClickListener,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListAdapter.kt
@@ -4,13 +4,16 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FilterListItemBinding
 import com.woocommerce.android.ui.products.filter.ProductFilterListAdapter.ProductFilterViewHolder
 import com.woocommerce.android.ui.products.filter.ProductFilterListViewModel.FilterListItemUiModel
 import com.woocommerce.android.ui.products.filter.ProductFilterListViewModel.FilterListOptionItemUiModel
+import com.woocommerce.android.viewmodel.ResourceProvider
 
 class ProductFilterListAdapter(
-    private val clickListener: OnProductFilterClickListener
+    private val clickListener: OnProductFilterClickListener,
+    private val resourceProvider: ResourceProvider
 ) : RecyclerView.Adapter<ProductFilterViewHolder>() {
     var filterList = listOf<FilterListItemUiModel>()
         set(value) {
@@ -39,7 +42,10 @@ class ProductFilterListAdapter(
     }
 
     override fun onBindViewHolder(holder: ProductFilterViewHolder, position: Int) {
-        holder.bind(filterList[position])
+        holder.bind(
+            filterItem = filterList[position],
+            defaultFilterOption = resourceProvider.getString(R.string.product_filter_default)
+        )
         holder.itemView.setOnClickListener {
             clickListener.onProductFilterClick(position)
         }
@@ -51,14 +57,14 @@ class ProductFilterListAdapter(
 
     class ProductFilterViewHolder(val viewBinding: FilterListItemBinding) :
         RecyclerView.ViewHolder(viewBinding.root) {
-        fun bind(filter: FilterListItemUiModel) {
-            viewBinding.filterItemName.text = filter.filterItemName
+        fun bind(filterItem: FilterListItemUiModel, defaultFilterOption: String) {
+            viewBinding.filterItemName.text = filterItem.filterItemName
             viewBinding.filterItemSelection.text =
-                filter.filterOptionListItems
+                filterItem.filterOptionListItems
                     .filterIsInstance<FilterListOptionItemUiModel.DefaultFilterListOptionItemUiModel>()
                     .firstOrNull { it.isSelected }
                     ?.filterOptionItemName
-                    .orEmpty()
+                    ?: defaultFilterOption
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListFragment.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.products.list.ProductListFragment
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -53,7 +54,10 @@ class ProductFilterListFragment :
         requireActivity().addMenuProvider(this, viewLifecycleOwner)
         setupObservers(viewModel)
 
-        productFilterListAdapter = ProductFilterListAdapter(this)
+        productFilterListAdapter = ProductFilterListAdapter(
+            clickListener = this,
+            resourceProvider = ResourceProvider(requireContext())
+        )
         with(binding.filterList) {
             addItemDecoration(
                 DividerItemDecoration(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListFragment.kt
@@ -21,7 +21,6 @@ import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.ui.products.list.ProductListFragment
 import com.woocommerce.android.viewmodel.MultiLiveEvent
-import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.fixedHiltNavGraphViewModels
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListFragment.kt
@@ -56,7 +56,7 @@ class ProductFilterListFragment :
 
         productFilterListAdapter = ProductFilterListAdapter(
             clickListener = this,
-            resourceProvider = ResourceProvider(requireContext())
+            resourceProvider = { requireContext().getString(it) }
         )
         with(binding.filterList) {
             addItemDecoration(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
+import com.woocommerce.android.ui.products.filter.ProductFilterListViewModel.FilterListOptionItemUiModel.DefaultFilterListOptionItemUiModel
 import com.woocommerce.android.viewmodel.LiveDataDelegate
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -517,7 +518,13 @@ class ProductFilterListViewModel @Inject constructor(
         val filterItemKey: ProductFilterOption,
         val filterItemName: String,
         var filterOptionListItems: List<FilterListOptionItemUiModel>
-    ) : Parcelable
+    ) : Parcelable {
+        val firstSelectedOption: String?
+            get() = filterOptionListItems
+                .filterIsInstance<DefaultFilterListOptionItemUiModel>()
+                .firstOrNull { it.isSelected }
+                ?.filterOptionItemName
+    }
 
     @Parcelize
     sealed class FilterListOptionItemUiModel : Parcelable {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/FilterListItemUiModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/FilterListItemUiModelTest.kt
@@ -1,0 +1,90 @@
+package com.woocommerce.android.ui.products.filter
+
+import com.woocommerce.android.ui.products.filter.ProductFilterListViewModel.FilterListItemUiModel
+import com.woocommerce.android.ui.products.filter.ProductFilterListViewModel.FilterListOptionItemUiModel.DefaultFilterListOptionItemUiModel
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FilterListItemUiModelTest : BaseUnitTest() {
+
+    @Test
+    fun `firstSelectedOption returns null when no options are selected`() {
+        val filterListItemUiModel = FilterListItemUiModel(
+            filterItemKey = ProductFilterOption.STATUS,
+            filterItemName = "Status",
+            filterOptionListItems = listOf(
+                DefaultFilterListOptionItemUiModel(
+                    filterOptionItemName = "Option 1",
+                    filterOptionItemValue = "option_1",
+                    isSelected = false
+                ),
+                DefaultFilterListOptionItemUiModel(
+                    filterOptionItemName = "Option 2",
+                    filterOptionItemValue = "option_2",
+                    isSelected = false
+                )
+            )
+        )
+
+        assertThat(filterListItemUiModel.firstSelectedOption).isNull()
+    }
+
+    @Test
+    fun `firstSelectedOption returns the name of the first selected option`() {
+        val filterListItemUiModel = FilterListItemUiModel(
+            filterItemKey = ProductFilterOption.STATUS,
+            filterItemName = "Status",
+            filterOptionListItems = listOf(
+                DefaultFilterListOptionItemUiModel(
+                    filterOptionItemName = "Option 1",
+                    filterOptionItemValue = "option_1",
+                    isSelected = true
+                ),
+                DefaultFilterListOptionItemUiModel(
+                    filterOptionItemName = "Option 2",
+                    filterOptionItemValue = "option_2",
+                    isSelected = false
+                )
+            )
+        )
+
+        assertThat(filterListItemUiModel.firstSelectedOption).isEqualTo("Option 1")
+    }
+
+    @Test
+    fun `firstSelectedOption returns the name of the first selected option when multiple options are selected`() {
+        val filterListItemUiModel = FilterListItemUiModel(
+            filterItemKey = ProductFilterOption.STATUS,
+            filterItemName = "Status",
+            filterOptionListItems = listOf(
+                DefaultFilterListOptionItemUiModel(
+                    filterOptionItemName = "Option 1",
+                    filterOptionItemValue = "option_1",
+                    isSelected = true
+                ),
+                DefaultFilterListOptionItemUiModel(
+                    filterOptionItemName = "Option 2",
+                    filterOptionItemValue = "option_2",
+                    isSelected = true
+                )
+            )
+        )
+
+        assertThat(filterListItemUiModel.firstSelectedOption).isEqualTo("Option 1")
+    }
+
+    @Test
+    fun `firstSelectedOption returns null when filterOptionListItems is empty`() {
+        val filterListItemUiModel = FilterListItemUiModel(
+            filterItemKey = ProductFilterOption.STATUS,
+            filterItemName = "Status",
+            filterOptionListItems = emptyList()
+        )
+
+        assertThat(filterListItemUiModel.firstSelectedOption).isNull()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/FilterListItemUiModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/filter/FilterListItemUiModelTest.kt
@@ -3,10 +3,10 @@ package com.woocommerce.android.ui.products.filter
 import com.woocommerce.android.ui.products.filter.ProductFilterListViewModel.FilterListItemUiModel
 import com.woocommerce.android.ui.products.filter.ProductFilterListViewModel.FilterListOptionItemUiModel.DefaultFilterListOptionItemUiModel
 import com.woocommerce.android.viewmodel.BaseUnitTest
-import kotlin.test.Test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
+import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FilterListItemUiModelTest : BaseUnitTest() {


### PR DESCRIPTION
Summary
==========
Fix issue #11956 by creating a fallback for the Products Filter when it encounters an inconsistent state of no filter option selected. Now, the fallback is always the `Any` option, correctly reflecting the presented state.

Test instructions
==========
I couldn't reproduce the issue directly, but [Sentry report](https://a8c.sentry.io/issues/5312429982/?project=1459556) points out that the problem originated from always expecting a Product Filter selection when it's possible to have none with the `Any` selection. 

With that said, I recommend only verifying if the Product Filters are working as expected in both Product List and Order Creation Product selection list.

Also, to mitigate the lack of bug reproduction, I've isolated the code causing issue out of the List adapter to the Filter Option model, and added proper unit test coverage to the expected scenarios.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
