### PR TITLE
[Woo POS] 32dp instead of 24 to determine if gesture navigation enabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -70,8 +70,8 @@ private fun Modifier.gesturesOrButtonsNavigationPadding(): Modifier {
     }
 }
 
-// That seems to be different on different devices, but 24dp is a common upper value
-private const val GESTURE_NAVIGATION_BAR_HEIGHT_DP = 24
+// That seems to be different on different devices, but 32dp is a common upper value
+private const val GESTURE_NAVIGATION_BAR_HEIGHT_DP = 32
 private fun WindowInsetsCompat.isGestureNavigation(context: Context): Boolean {
     val bottomInset = getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Pixel tablet uses 32dp as bottom panel height in gesture navigation, so in order to determine this case, I increase that from 24dp

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Use Pixel tablet and notice that bottom padding is not 0 but the height of the gesture navigation bar

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I used a pixel tablet emulator to reproduce the problem and the resolution

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="911" alt="image" src="https://github.com/user-attachments/assets/29997f26-f13f-40e7-b150-39d959d13c79">

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->