### PR TITLE
Enforce default dollar currency when displaying budget value for Blaze

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiMapper.kt
@@ -31,7 +31,8 @@ private fun getBudgetValue(campaign: BlazeCampaignModel, currencyFormatter: Curr
             campaign.isEndlessCampaign -> getWeeklyBudget(campaign)
             CampaignStatusUi.isActive(campaign.uiStatus) -> (campaign.totalBudget - campaign.spentBudget)
             else -> campaign.totalBudget
-        }
+        },
+        BlazeRepository.BLAZE_DEFAULT_CURRENCY_CODE
     )
 
 private fun getWeeklyBudget(campaign: BlazeCampaignModel): Double =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModelTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.captureValues
@@ -45,7 +46,8 @@ class BlazeCampaignListViewModelTest : BaseUnitTest() {
     @Before
     fun setup() = testBlocking {
         whenever(selectedSite.get()).thenReturn(siteModel)
-        whenever(currencyFormatter.formatCurrencyRounded(TOTAL_BUDGET)).thenReturn(TOTAL_BUDGET.toString())
+        whenever(currencyFormatter.formatCurrencyRounded(TOTAL_BUDGET, BlazeRepository.BLAZE_DEFAULT_CURRENCY_CODE))
+            .thenReturn(TOTAL_BUDGET.toString())
         whenever(blazeCampaignsStore.observeBlazeCampaigns(selectedSite.get())).thenReturn(campaignsEntityFlow)
         whenever(blazeCampaignsStore.fetchBlazeCampaigns(any(), any(), any(), any(), eq(null)))
             .thenReturn(BlazeCampaignsResult(EMPTY_BLAZE_CAMPAIGN_MODEL))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12504 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Blaze only support dollar currency for now. So, any 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->


1. From the web, change you site's currency to something other than USD.
2. Create a Blaze campaign on the app.
3. Check that the currency for anything related to Blaze is always set to USD. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

![Screenshot 2024-09-03 at 21 13 07](https://github.com/user-attachments/assets/49761a74-f37c-41df-8c23-2028fc7836cc)

- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->