### PR TITLE
Issue/12302 show toast undo from review notification

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 -----
 - [**] Stopped potential crash in the orders list screen when tapping "Filters" button [https://github.com/woocommerce/woocommerce-android/pull/12482]
 - [*] Fixes error when installing Jetpack plugin from the app [https://github.com/woocommerce/woocommerce-android/issues/12364]
+- [*] Fixes navigation from product review detail screen when opened from notification [https://github.com/woocommerce/woocommerce-android/pull/12514]
 
 20.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModel.kt
@@ -59,7 +59,7 @@ class ReviewDetailViewModel @Inject constructor(
             viewState.productReview?.let { review ->
                 reviewModerationHandler.postModerationRequest(review, newStatus)
                 // Close the detail view
-                triggerEvent(Exit)
+                closeDetailScreen()
             }
         } else {
             // Network is not connected
@@ -120,6 +120,7 @@ class ReviewDetailViewModel @Inject constructor(
                             )
                         }
                     }
+
                     RequestResult.ERROR -> triggerEvent(ShowSnackbar(R.string.wc_load_review_error))
                     RequestResult.API_ERROR -> Unit // Do nothing
                     RequestResult.RETRY -> Unit // Do nothing
@@ -132,12 +133,16 @@ class ReviewDetailViewModel @Inject constructor(
     }
 
     fun onBackPressed(): Boolean {
+        closeDetailScreen()
+        return false
+    }
+
+    private fun closeDetailScreen() {
         if (launchedFromNotification) {
             triggerEvent(NavigateBackFromNotification)
         } else {
             triggerEvent(Exit)
         }
-        return false
     }
 
     fun onReviewReplied(reviewReply: String) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModelTest.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -84,8 +83,8 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start(REVIEW_ID, false)
 
-        Assertions.assertThat(skeletonShown).containsExactly(true, false)
-        Assertions.assertThat(productReview).isEqualTo(review)
+        assertThat(skeletonShown).containsExactly(true, false)
+        assertThat(productReview).isEqualTo(review)
         verify(markReviewAsSeen, times(1)).invoke(REVIEW_ID, notification)
     }
 
@@ -111,9 +110,9 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
 
         viewModel.start(REVIEW_ID, false)
 
-        Assertions.assertThat(skeletonShown).containsExactly(true, false)
-        Assertions.assertThat(productReview).isEqualTo(review)
-        Assertions.assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.wc_load_review_error))
+        assertThat(skeletonShown).containsExactly(true, false)
+        assertThat(productReview).isEqualTo(review)
+        assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.wc_load_review_error))
         verify(markReviewAsSeen, times(1)).invoke(REVIEW_ID, notification)
     }
 
@@ -171,7 +170,7 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
 
             viewModel.moderateReview(SPAM)
             assertFalse(exitCalled)
-            Assertions.assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.offline_error))
+            assertThat(snackbar).isEqualTo(ShowSnackbar(R.string.offline_error))
         }
 
     @Test
@@ -181,7 +180,7 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
 
         viewModel.onBackPressed()
 
-        Assertions.assertThat(viewModel.event.value).isEqualTo(NavigateBackFromNotification)
+        assertThat(viewModel.event.value).isEqualTo(NavigateBackFromNotification)
     }
 
     @Test
@@ -191,7 +190,7 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
 
         viewModel.onBackPressed()
 
-        Assertions.assertThat(viewModel.event.value).isEqualTo(Exit)
+        assertThat(viewModel.event.value).isEqualTo(Exit)
     }
 
     @Test
@@ -246,4 +245,17 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
         verify(analyticsTracker).track(REVIEW_REPLY_SEND_FAILED)
         assertThat(events).last().isEqualTo(ShowSnackbar(R.string.review_reply_failure))
     }
+
+    @Test
+    fun `given review opened from notification, when review is moderated, trigger NavigateBackFromNotification`() =
+        testBlocking {
+            doReturn(true).whenever(networkStatus).isConnected()
+            doReturn(review).whenever(repository).getCachedProductReview(any())
+            doReturn(RequestResult.SUCCESS).whenever(repository).fetchProductReview(any())
+            viewModel.start(REVIEW_ID, launchedFromNotification = true)
+
+            viewModel.moderateReview(SPAM)
+
+            assertThat(viewModel.event.value).isEqualTo(NavigateBackFromNotification)
+        }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12302
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When opening a product review push notification, the notification detail screen is opened. If the user then "moderates" the notification by clicking on any of the available actions: "Trash, Spam, Approve, Reply", it should be taken back to the review list and a toast shown, with `undo` button. 


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Ensure push notifications are enabled on the app
2. On an Atomic site or Jetpack self hosted site, select a product and add a review.
3. Wait for the push notification to be received. 
4. Open the push notification and click on any of the 4 moderation actions. 
5. Check that the app navigates back to product review screen and a toast is shown with `undo` cta. 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/e5faec97-bc54-490a-88d6-7df65c5f81fa


- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->