### PR TITLE
[Woo POS] Checkout screen UI adjustments #1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosLazyColumn.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosLazyColumn.kt
@@ -32,9 +32,8 @@ fun WooPosLazyColumn(
     state: LazyListState = rememberLazyListState(),
     content: LazyListScope.() -> Unit
 ) {
-    Box {
+    Box(modifier = modifier) {
         LazyColumn(
-            modifier = modifier,
             contentPadding = contentPadding,
             verticalArrangement = verticalArrangement,
             horizontalAlignment = horizontalAlignment,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -2,10 +2,15 @@
 
 package com.woocommerce.android.ui.woopos.home.cart
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -233,7 +238,7 @@ private fun CartToolbar(
     val iconSize = 28.dp
     val iconTitlePadding = 16.dp.toAdaptivePadding()
     val titleOffset by animateDpAsState(
-        targetValue = if (toolbar.icon != null) iconSize + iconTitlePadding else 0.dp,
+        targetValue = if (toolbar.backIconVisible) iconSize + iconTitlePadding else 0.dp,
         animationSpec = tween(durationMillis = 300),
         label = "titleOffset"
     )
@@ -245,7 +250,11 @@ private fun CartToolbar(
     ) {
         val (backButton, title, spacer, itemsCount, clearAllButton) = createRefs()
 
-        toolbar.icon?.let {
+        AnimatedVisibility(
+            visible = toolbar.backIconVisible,
+            enter = fadeIn(animationSpec = tween(300)) + expandHorizontally(),
+            exit = fadeOut(animationSpec = tween(300)) + shrinkHorizontally()
+        ) {
             IconButton(
                 onClick = { onBackClicked() },
                 modifier = Modifier
@@ -256,7 +265,7 @@ private fun CartToolbar(
                     .padding(start = 8.dp.toAdaptivePadding())
             ) {
                 Icon(
-                    imageVector = ImageVector.vectorResource(it),
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_back_24dp),
                     contentDescription = stringResource(R.string.woopos_cart_back_content_description),
                     tint = MaterialTheme.colors.onBackground,
                     modifier = Modifier.size(iconSize)
@@ -446,7 +455,7 @@ fun WooPosCartScreenProductsPreview(modifier: Modifier = Modifier) {
             modifier = modifier,
             state = WooPosCartState(
                 toolbar = WooPosCartState.Toolbar(
-                    icon = null,
+                    backIconVisible = false,
                     itemsCount = "3 items",
                     isClearAllButtonVisible = true
                 ),
@@ -491,7 +500,7 @@ fun WooPosCartScreenCheckoutPreview(modifier: Modifier = Modifier) {
             modifier = modifier,
             state = WooPosCartState(
                 toolbar = WooPosCartState.Toolbar(
-                    icon = R.drawable.ic_back_24dp,
+                    backIconVisible = true,
                     itemsCount = "3 items",
                     isClearAllButtonVisible = true
                 ),
@@ -535,7 +544,7 @@ fun WooPosCartScreenEmptyPreview(modifier: Modifier = Modifier) {
             modifier = modifier,
             state = WooPosCartState(
                 toolbar = WooPosCartState.Toolbar(
-                    icon = null,
+                    backIconVisible = false,
                     itemsCount = null,
                     isClearAllButtonVisible = false
                 ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -83,6 +83,7 @@ fun WooPosCartScreen(modifier: Modifier = Modifier) {
 }
 
 @Composable
+@Suppress("DestructuringDeclarationWithTooManyEntries")
 private fun WooPosCartScreen(
     modifier: Modifier = Modifier,
     state: WooPosCartState,
@@ -94,7 +95,7 @@ private fun WooPosCartScreen(
             .background(MaterialTheme.colors.surface)
             .padding(top = 40.dp.toAdaptivePadding())
     ) {
-        val (toolbar, bodyEmpty, bodyList, checkoutButton, overlay) = createRefs()
+        val (toolbar, body, checkoutButton, overlay) = createRefs()
 
         CartToolbar(
             modifier = Modifier.constrainAs(toolbar) {
@@ -110,7 +111,7 @@ private fun WooPosCartScreen(
         when (state.body) {
             WooPosCartState.Body.Empty -> {
                 CartBodyEmpty(
-                    modifier = Modifier.constrainAs(bodyEmpty) {
+                    modifier = Modifier.constrainAs(body) {
                         top.linkTo(parent.top)
                         bottom.linkTo(parent.bottom)
                         start.linkTo(parent.start)
@@ -123,7 +124,7 @@ private fun WooPosCartScreen(
             is WooPosCartState.Body.WithItems -> {
                 val productsTopMargin = 20.dp.toAdaptivePadding()
                 CartBodyWithItems(
-                    modifier = Modifier.constrainAs(bodyList) {
+                    modifier = Modifier.constrainAs(body) {
                         top.linkTo(toolbar.bottom, margin = productsTopMargin)
                         bottom.linkTo(checkoutButton.top)
                         start.linkTo(parent.start)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -93,13 +93,23 @@ private fun WooPosCartScreen(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colors.surface)
-            .padding(top = 40.dp.toAdaptivePadding())
     ) {
-        val (toolbar, body, checkoutButton, overlay) = createRefs()
+        val (topMargin, toolbar, body, checkoutButton, overlay) = createRefs()
+
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(40.dp.toAdaptivePadding())
+                .constrainAs(topMargin) {
+                    top.linkTo(parent.top)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                }
+        )
 
         CartToolbar(
             modifier = Modifier.constrainAs(toolbar) {
-                top.linkTo(parent.top)
+                top.linkTo(topMargin.bottom)
                 start.linkTo(parent.start)
                 end.linkTo(parent.end)
             },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartState.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.cart
 
 import android.os.Parcelable
-import androidx.annotation.DrawableRes
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -43,7 +42,7 @@ data class WooPosCartState(
 
     @Parcelize
     data class Toolbar(
-        @DrawableRes val icon: Int? = null,
+        val backIconVisible: Boolean = false,
         val itemsCount: String? = null,
         val isClearAllButtonVisible: Boolean = false,
     ) : Parcelable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -162,7 +162,7 @@ class WooPosCartViewModel @Inject constructor(
         val newToolbar = when (newState.cartStatus) {
             EDITABLE -> {
                 WooPosCartState.Toolbar(
-                    icon = null,
+                    backIconVisible = false,
                     itemsCount = itemsCount,
                     isClearAllButtonVisible = newState.body is WooPosCartState.Body.WithItems
                 )
@@ -170,7 +170,7 @@ class WooPosCartViewModel @Inject constructor(
 
             CHECKOUT -> {
                 WooPosCartState.Toolbar(
-                    icon = R.drawable.ic_back_24dp,
+                    backIconVisible = true,
                     itemsCount = itemsCount,
                     isClearAllButtonVisible = false
                 )
@@ -178,7 +178,7 @@ class WooPosCartViewModel @Inject constructor(
 
             EMPTY -> {
                 WooPosCartState.Toolbar(
-                    icon = null,
+                    backIconVisible = false,
                     itemsCount = null,
                     isClearAllButtonVisible = false
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -153,7 +153,6 @@ private fun TotalsLoaded(
     }
 }
 
-
 @Composable
 private fun TotalsGrid(state: WooPosTotalsViewState.Totals) {
     Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -2,8 +2,10 @@ package com.woocommerce.android.ui.woopos.home.totals
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,7 +24,12 @@ import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -40,6 +47,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorS
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.toAdaptivePadding
 import com.woocommerce.android.ui.woopos.home.totals.payment.success.WooPosPaymentSuccessScreen
+import kotlinx.coroutines.delay
 
 @Composable
 fun WooPosTotalsScreen(modifier: Modifier = Modifier) {
@@ -97,11 +105,19 @@ private fun StateChangeAnimated(
     )
 }
 
+@OptIn(ExperimentalAnimationApi::class)
 @Composable
 private fun TotalsLoaded(
     state: WooPosTotalsViewState.Totals,
     onUIEvent: (WooPosTotalsUIEvent) -> Unit
 ) {
+    var isButtonVisible by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        delay(300)
+        isButtonVisible = true
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -124,12 +140,19 @@ private fun TotalsLoaded(
             Spacer(modifier = Modifier.weight(1f))
         }
 
-        WooPosButtonLarge(
-            text = stringResource(R.string.woopos_payment_collect_payment_label),
-            onClick = { onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked) },
-        )
+        AnimatedVisibility(visible = isButtonVisible) {
+            WooPosButtonLarge(
+                text = stringResource(R.string.woopos_payment_collect_payment_label),
+                onClick = { onUIEvent(WooPosTotalsUIEvent.CollectPaymentClicked) },
+                modifier = Modifier
+                    .animateEnterExit(
+                        enter = slideInVertically { it },
+                    )
+            )
+        }
     }
 }
+
 
 @Composable
 private fun TotalsGrid(state: WooPosTotalsViewState.Totals) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -132,7 +132,7 @@ class WooPosCartViewModelTest {
 
             // THEN
             val toolbar = states.last().toolbar
-            assertThat(toolbar.icon).isNull()
+            assertThat(toolbar.backIconVisible).isFalse()
             assertThat(toolbar.itemsCount).isNull()
             assertThat(toolbar.isClearAllButtonVisible).isFalse()
         }
@@ -161,7 +161,7 @@ class WooPosCartViewModelTest {
 
             // THEN
             val toolbar = states.last().toolbar
-            assertThat(toolbar.icon).isNull()
+            assertThat(toolbar.backIconVisible).isFalse()
             assertThat(toolbar.itemsCount).isEqualTo("Item in cart: 1")
             assertThat(toolbar.isClearAllButtonVisible).isTrue()
         }
@@ -192,7 +192,7 @@ class WooPosCartViewModelTest {
 
             // THEN
             val toolbar = states.last().toolbar
-            assertThat(toolbar.icon).isEqualTo(R.drawable.ic_back_24dp)
+            assertThat(toolbar.backIconVisible).isTrue()
             assertThat(toolbar.itemsCount).isEqualTo("Item in cart: 1")
             assertThat(toolbar.isClearAllButtonVisible).isFalse()
         }
@@ -362,7 +362,7 @@ class WooPosCartViewModelTest {
 
             // THEN
             val toolbar = states.last().toolbar
-            assertThat(toolbar.icon).isNull()
+            assertThat(toolbar.backIconVisible).isFalse()
             assertThat(toolbar.itemsCount).isNull()
             assertThat(toolbar.isClearAllButtonVisible).isFalse()
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12516 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
* Animation of the appearance/disappearance of the checkout button
* Animation of the appearance of the back button on the cart screen when we move to checkout
* Animation of the appearance "collect payment" button


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Go via the flow noticing the new animations mentioned in the description. Try dark mode too

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The one in the testing information

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/1f52b157-984f-4898-b5d0-7c14ecd35308



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->