### PR TITLE
Fix bug where the App Bar and Bottom Nav don't get updated when navigation is interrupted

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] Fixes error when installing Jetpack plugin from the app [https://github.com/woocommerce/woocommerce-android/issues/12364]
 - [*] Fixes toolbar shown twice on Package details screen while adding shipping label [https://github.com/woocommerce/woocommerce-android/pull/12489]
 - [*] Fixes navigation from product review detail screen when opened from notification [https://github.com/woocommerce/woocommerce-android/pull/12514]
+- [*] Fixes an issue that caused the an incorrect App Bar visibility in some rare cases [https://github.com/woocommerce/woocommerce-android/pull/12523]
 
 20.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -208,6 +208,10 @@ class MainActivity :
 
     private val fragmentLifecycleObserver: FragmentLifecycleCallbacks = object : FragmentLifecycleCallbacks() {
         override fun onFragmentViewCreated(fm: FragmentManager, f: Fragment, v: View, savedInstanceState: Bundle?) {
+            updateAppBarAndBottomNav(f)
+        }
+
+        private fun updateAppBarAndBottomNav(f: Fragment) {
             if (f is DialogFragment) return
 
             when (val appBarStatus = (f as? BaseFragment)?.activityAppBarStatus ?: AppBarStatus.Visible()) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12521 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes an issue that caused the App Bar and Bottom Nav view to not get updated if the navigation was interrupted and cancelled, this happens in the following scenario:

1. User navigates from Fragment A to Fragment B
2. Quickly, the user goes back to Fragment A
3. The app won't update the App Bar and Bottom Nav according to Fragment A rules, but it will keep Fragment B rules.

The code has a comment that explains in technical terms why this happens.

### Steps to reproduce
1. Open the My Store tab.
2. Tap on any other tab, then quickly return to the My Store tab.​

### Testing information
Confirm the App Bar is visible after going to the My Store tab.

### Images/gif

https://github.com/user-attachments/assets/2925c59e-4dad-4cfc-bcc7-671289e4263f


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->