### PR TITLE
Ensures budget label doesn't get cut off in smaller screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NumberExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NumberExt.kt
@@ -1,6 +1,12 @@
 package com.woocommerce.android.extensions
 
+import android.icu.number.Notation
+import android.icu.number.NumberFormatter
+import android.icu.text.CompactDecimalFormat
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import java.text.DecimalFormat
+import java.util.Locale
 import kotlin.math.roundToInt
 
 fun Float.formatToString(): String {
@@ -38,14 +44,18 @@ infix fun <T> Comparable<T>?.lesserThan(other: T) =
         ?: false
 
 /**
- * The number is shortened to the nearest thousand or million. For example, 1,500 is shortened to 1.5k.
+ * Shortens a number to the nearest thousand and appends a 'K' to the end. For example, 1000 will be shortened to 1K.
  */
-fun Long.shortenToNearestThousand(): String = when {
-    this >= ONE_MILLION -> "${(this / ONE_MILLION)}m"
-    this >= ONE_THOUSAND -> "${(this / ONE_THOUSAND)}k"
-    else -> this.toString()
-}
+fun compactNumberCompat(number: Long, locale: Locale = Locale.getDefault()): String =
+    if (VERSION.SDK_INT >= VERSION_CODES.R) {
+        NumberFormatter.with()
+            .notation(Notation.compactShort())
+            .locale(locale)
+            .format(number)
+            .toString()
+    } else {
+        CompactDecimalFormat.getInstance(locale, CompactDecimalFormat.CompactStyle.SHORT)
+            .format(number.toDouble())
+    }
 
 const val PERCENTAGE_BASE = 100.0
-const val ONE_THOUSAND = 1000
-const val ONE_MILLION = 1000000

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NumberExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NumberExt.kt
@@ -37,4 +37,15 @@ infix fun <T> Comparable<T>?.lesserThan(other: T) =
     this?.let { it < other }
         ?: false
 
+/**
+ * The number is shortened to the nearest thousand or million. For example, 1,500 is shortened to 1.5k.
+ */
+fun Long.shortenToNearestThousand(): String = when {
+    this >= ONE_MILLION -> "${(this / ONE_MILLION)}m"
+    this >= ONE_THOUSAND -> "${(this / ONE_THOUSAND)}k"
+    else -> this.toString()
+}
+
 const val PERCENTAGE_BASE = 100.0
+const val ONE_THOUSAND = 1000
+const val ONE_MILLION = 1000000

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NumberExtensionsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NumberExtensionsWrapper.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.extensions
+
+import java.util.Locale
+import javax.inject.Inject
+
+class NumberExtensionsWrapper @Inject constructor() {
+    fun compactNumberCompat(
+        number: Long,
+        locale: Locale = Locale.getDefault()
+    ): String = compactNumberCompat(number, locale)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiMapper.kt
@@ -1,23 +1,25 @@
 package com.woocommerce.android.ui.blaze
 
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.compactNumberCompat
+import com.woocommerce.android.extensions.NumberExtensionsWrapper
 import com.woocommerce.android.util.CurrencyFormatter
 import org.wordpress.android.fluxc.model.blaze.BlazeCampaignModel
 
-fun BlazeCampaignModel.toUiState(currencyFormatter: CurrencyFormatter) =
-    BlazeCampaignUi(
-        product = BlazeProductUi(
-            name = title,
-            imgUrl = imageUrl.orEmpty(),
-        ),
-        status = CampaignStatusUi.fromString(uiStatus),
-        isEndlessCampaign = isEndlessCampaign,
-        impressions = compactNumberCompat(impressions),
-        clicks = compactNumberCompat(clicks),
-        formattedBudget = getBudgetValue(this, currencyFormatter),
-        budgetLabel = getBudgetTitle(this)
-    )
+fun BlazeCampaignModel.toUiState(
+    currencyFormatter: CurrencyFormatter,
+    numberExtensionsWrapper: NumberExtensionsWrapper
+) = BlazeCampaignUi(
+    product = BlazeProductUi(
+        name = title,
+        imgUrl = imageUrl.orEmpty(),
+    ),
+    status = CampaignStatusUi.fromString(uiStatus),
+    isEndlessCampaign = isEndlessCampaign,
+    impressions = numberExtensionsWrapper.compactNumberCompat(impressions),
+    clicks = numberExtensionsWrapper.compactNumberCompat(clicks),
+    formattedBudget = getBudgetValue(this, currencyFormatter),
+    budgetLabel = getBudgetTitle(this)
+)
 
 private fun getBudgetTitle(campaign: BlazeCampaignModel) =
     when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiMapper.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.blaze
 
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.shortenToNearestThousand
 import com.woocommerce.android.util.CurrencyFormatter
 import org.wordpress.android.fluxc.model.blaze.BlazeCampaignModel
 
@@ -12,8 +13,8 @@ fun BlazeCampaignModel.toUiState(currencyFormatter: CurrencyFormatter) =
         ),
         status = CampaignStatusUi.fromString(uiStatus),
         isEndlessCampaign = isEndlessCampaign,
-        impressions = impressions,
-        clicks = clicks,
+        impressions = impressions.shortenToNearestThousand(),
+        clicks = clicks.shortenToNearestThousand(),
         formattedBudget = getBudgetValue(this, currencyFormatter),
         budgetLabel = getBudgetTitle(this)
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiMapper.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.blaze
 
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.shortenToNearestThousand
+import com.woocommerce.android.extensions.compactNumberCompat
 import com.woocommerce.android.util.CurrencyFormatter
 import org.wordpress.android.fluxc.model.blaze.BlazeCampaignModel
 
@@ -13,8 +13,8 @@ fun BlazeCampaignModel.toUiState(currencyFormatter: CurrencyFormatter) =
         ),
         status = CampaignStatusUi.fromString(uiStatus),
         isEndlessCampaign = isEndlessCampaign,
-        impressions = impressions.shortenToNearestThousand(),
-        clicks = clicks.shortenToNearestThousand(),
+        impressions = compactNumberCompat(impressions),
+        clicks = compactNumberCompat(clicks),
         formattedBudget = getBudgetValue(this, currencyFormatter),
         budgetLabel = getBudgetTitle(this)
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiModels.kt
@@ -13,8 +13,8 @@ data class BlazeCampaignUi(
     val product: BlazeProductUi,
     val status: CampaignStatusUi?,
     val isEndlessCampaign: Boolean,
-    val impressions: Long,
-    val clicks: Long,
+    val impressions: String,
+    val clicks: String,
     val formattedBudget: String,
     @StringRes val budgetLabel: Int
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignItem.kt
@@ -76,9 +76,9 @@ fun BlazeCampaignItem(
                     CampaignStat(
                         statName = stringResource(R.string.blaze_campaign_status_ctr_label),
                         statValue = stringResource(
-                            id = R.string.blaze_campaign_status_ctr_valur,
+                            id = R.string.blaze_campaign_status_ctr_value_shortened,
+                            campaign.impressions,
                             campaign.clicks,
-                            campaign.impressions
                         )
                     )
                     val orientation = LocalConfiguration.current.orientation

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignItem.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.blaze.campaigs
 
+import android.content.res.Configuration
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -15,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
@@ -79,8 +81,14 @@ fun BlazeCampaignItem(
                             campaign.impressions
                         )
                     )
-                    Spacer(modifier = Modifier.width(42.dp))
+                    val orientation = LocalConfiguration.current.orientation
+                    if (orientation == Configuration.ORIENTATION_PORTRAIT) {
+                        Spacer(modifier = Modifier.weight(1f))
+                    } else {
+                        Spacer(modifier = Modifier.width(16.dp))
+                    }
                     CampaignStat(
+                        modifier = Modifier.padding(start = 16.dp),
                         statName = stringResource(campaign.budgetLabel),
                         statValue = campaign.formattedBudget
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListScreen.kt
@@ -232,8 +232,8 @@ fun BlazeCampaignListScreenPreview() {
                         ),
                         status = Active,
                         isEndlessCampaign = false,
-                        impressions = 100,
-                        clicks = 10,
+                        impressions = "6k",
+                        clicks = "10",
                         formattedBudget = "$100",
                         budgetLabel = R.string.blaze_campaign_status_budget_total
                     ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModel.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CAMPAIGN_DETAIL_SELECTED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.NumberExtensionsWrapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.BlazeCampaignUi
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper
@@ -36,7 +37,8 @@ class BlazeCampaignListViewModel @Inject constructor(
     private val blazeUrlsHelper: BlazeUrlsHelper,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val currencyFormatter: CurrencyFormatter
+    private val currencyFormatter: CurrencyFormatter,
+    private val numberExtensionsWrapper: NumberExtensionsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         private const val LOADING_TRANSITION_DELAY = 200L
@@ -63,7 +65,7 @@ class BlazeCampaignListViewModel @Inject constructor(
         BlazeCampaignListState(
             campaigns = campaigns.map {
                 ClickableCampaign(
-                    campaignUi = it.toUiState(currencyFormatter),
+                    campaignUi = it.toUiState(currencyFormatter, numberExtensionsWrapper),
                     onCampaignClicked = { onCampaignClicked(it.campaignId) }
                 )
             },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeCard.kt
@@ -348,8 +348,8 @@ fun MyStoreBlazeViewCampaignPreview() {
                 product = product,
                 status = CampaignStatusUi.Active,
                 isEndlessCampaign = false,
-                impressions = 100,
-                clicks = 10,
+                impressions = "32435",
+                clicks = "43",
                 formattedBudget = "$100",
                 budgetLabel = R.string.blaze_campaign_status_budget_total
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/blaze/DashboardBlazeViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CAMPAIGN_LIST_ENTR
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_ENTRY_POINT_DISPLAYED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.NumberExtensionsWrapper
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.ui.blaze.BlazeCampaignUi
@@ -56,7 +57,8 @@ class DashboardBlazeViewModel @AssistedInject constructor(
     private val productListRepository: ProductListRepository,
     private val blazeUrlsHelper: BlazeUrlsHelper,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val currencyFormatter: CurrencyFormatter
+    private val currencyFormatter: CurrencyFormatter,
+    private val numberExtensionsWrapper: NumberExtensionsWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val _refreshTrigger = MutableSharedFlow<RefreshEvent>(extraBufferCapacity = 1)
     private val refreshTrigger = merge(_refreshTrigger, (parentViewModel.refreshTrigger))
@@ -142,7 +144,7 @@ class DashboardBlazeViewModel @AssistedInject constructor(
 
     private fun showUiForCampaign(campaign: BlazeCampaignModel): DashboardBlazeCampaignState {
         return Campaign(
-            campaign = campaign.toUiState(currencyFormatter),
+            campaign = campaign.toUiState(currencyFormatter, numberExtensionsWrapper),
             onCampaignClicked = {
                 parentViewModel.trackCardInteracted(DashboardWidget.Type.BLAZE.trackingIdentifier)
                 analyticsTrackerWrapper.track(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3859,6 +3859,7 @@
     <string name="blaze_campaign_status_suspended">Suspended</string>
     <string name="blaze_campaign_status_ctr_label">Click-throughs</string>
     <string name="blaze_campaign_status_ctr_valur">%1$d ➔ %2$d</string>
+    <string name="blaze_campaign_status_ctr_value_shortened">%1$s ➔ %2$s</string>
     <string name="blaze_campaign_status_budget_total">Total</string>
     <string name="blaze_campaign_status_budget_remaining">Remaining</string>
     <string name="blaze_campaign_status_budget_weekly">Weekly</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3858,7 +3858,6 @@
     <string name="blaze_campaign_status_canceled">Canceled</string>
     <string name="blaze_campaign_status_suspended">Suspended</string>
     <string name="blaze_campaign_status_ctr_label">Click-throughs</string>
-    <string name="blaze_campaign_status_ctr_valur">%1$d ➔ %2$d</string>
     <string name="blaze_campaign_status_ctr_value_shortened">%1$s ➔ %2$s</string>
     <string name="blaze_campaign_status_budget_total">Total</string>
     <string name="blaze_campaign_status_budget_remaining">Remaining</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/campaigs/BlazeCampaignListViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.blaze.campaigs
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.NumberExtensionsWrapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper
 import com.woocommerce.android.util.CurrencyFormatter
@@ -39,12 +40,14 @@ class BlazeCampaignListViewModelTest : BaseUnitTest() {
     private val siteModel: SiteModel = mock()
     private val campaignsEntityFlow = flow { emit(listOf(BLAZE_CAMPAIGN_MODEL)) }
     private val currencyFormatter: CurrencyFormatter = mock()
+    private val numberExtensionsWrapper: NumberExtensionsWrapper = mock()
 
     private lateinit var viewModel: BlazeCampaignListViewModel
 
     @Before
     fun setup() = testBlocking {
         whenever(selectedSite.get()).thenReturn(siteModel)
+        whenever(numberExtensionsWrapper.compactNumberCompat(any(), any())).thenReturn("0")
         whenever(currencyFormatter.formatCurrencyRounded(TOTAL_BUDGET)).thenReturn(TOTAL_BUDGET.toString())
         whenever(blazeCampaignsStore.observeBlazeCampaigns(selectedSite.get())).thenReturn(campaignsEntityFlow)
         whenever(blazeCampaignsStore.fetchBlazeCampaigns(any(), any(), any(), any(), eq(null)))
@@ -149,7 +152,8 @@ class BlazeCampaignListViewModelTest : BaseUnitTest() {
             blazeUrlsHelper = blazeUrlsHelper,
             appPrefsWrapper = appPrefsWrapper,
             analyticsTrackerWrapper = analyticsTrackerWrapper,
-            currencyFormatter = currencyFormatter
+            currencyFormatter = currencyFormatter,
+            numberExtensionsWrapper = numberExtensionsWrapper
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12520
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fix UI glitch when displaying Blaze budget in small screens. It also improves how the Blaze stats are displayed in larger screens or tablets. 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
1. Use a device with a small screen, an emulator should work. For example: `720x1280 - 4.6 inch` screen. 
2. Log into the app to a site with Blaze campaigns
3. Check the Blaze campaign stats are displayed without any cuts of like this: 

<img src="https://github.com/user-attachments/assets/3b89cd79-5b23-4830-a4a7-9b9692ccf1d9" width=300>

Additionally these changes shorten the figures displayed for impressions and clicks to avoid potential issues if this numbers are really big. Testing this will require to hardcode the `impressions` and `clicks` values. You can apply this patch for it: 

```diff
Subject: [PATCH] Shortens impressions and clicks numbers to avoid issues with spacing
---
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiMapper.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiMapper.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiMapper.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiMapper.kt	(revision ddf8cfd4c8d4f8898ce5d5724d2c9c9ff4ec01f0)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeUiMapper.kt	(date 1725466236462)
@@ -13,8 +13,8 @@
         ),
         status = CampaignStatusUi.fromString(uiStatus),
         isEndlessCampaign = isEndlessCampaign,
-        impressions = impressions.shortenToNearestThousand(),
-        clicks = clicks.shortenToNearestThousand(),
+        impressions = 5421134221L.shortenToNearestThousand(),
+        clicks = 35432L.shortenToNearestThousand(),
         formattedBudget = getBudgetValue(this, currencyFormatter),
         budgetLabel = getBudgetTitle(this)
     )

```

![Screenshot 2024-09-04 at 18 08 10](https://github.com/user-attachments/assets/4109db2e-31a5-4ef7-ac15-39d9738ec4d2)


### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested different label and value lengths as well as tested portrait and landscape orientations in different screen sizes: 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/14603348-b419-4410-9f26-dab579ad792d

https://github.com/user-attachments/assets/66d8d278-1e9b-4122-86ec-c4d83a65eb08

- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->