### PR TITLE
Fix of the theoretical race condition in case of multiple calls to JITM cache

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*] Fixes toolbar shown twice on Package details screen while adding shipping label [https://github.com/woocommerce/woocommerce-android/pull/12489]
 - [*] Fixes navigation from product review detail screen when opened from notification [https://github.com/woocommerce/woocommerce-android/pull/12514]
 - [*] Added a blaze campaign reminder that appears after abandoning a campaign creation. [https://github.com/woocommerce/woocommerce-android/pull/12452]
+- [**] [Internal] Fix a crash during JITM cache initialisation
 
 20.2
 -----

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmStoreInMemoryCacheTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmStoreInMemoryCacheTest.kt
@@ -219,7 +219,7 @@ class JitmStoreInMemoryCacheTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given concurrent calls to getMessagesForPath, when init is not complete, then IllegalStateException is thrown`() =
+    fun `given concurrent calls to getMessagesForPath, when init is not complete, then Exceptions are not thrown`() =
         testBlocking {
             // GIVEN
             val messagePath = "path:screen:1"
@@ -247,7 +247,7 @@ class JitmStoreInMemoryCacheTest : BaseUnitTest() {
             val jobsGetMessages = List(50) {
                 async(Dispatchers.Default) {
                     try {
-                        cache.init()
+                        cache.getMessagesForPath(messagePath)
                     } catch (e: Exception) {
                         exceptions.add(e)
                     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmStoreInMemoryCacheTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jitm/JitmStoreInMemoryCacheTest.kt
@@ -234,18 +234,28 @@ class JitmStoreInMemoryCacheTest : BaseUnitTest() {
             val exceptions = mutableListOf<Throwable>()
 
             // WHEN
-            cache.init()
-            val jobs = List(100) {
+            val jobsInit = List(50) {
                 async(Dispatchers.Default) {
                     try {
-                        cache.getMessagesForPath(messagePath)
+                        cache.init()
                     } catch (e: Exception) {
                         exceptions.add(e)
                     }
                 }
             }
 
-            jobs.forEach { it.await() }
+            val jobsGetMessages = List(50) {
+                async(Dispatchers.Default) {
+                    try {
+                        cache.init()
+                    } catch (e: Exception) {
+                        exceptions.add(e)
+                    }
+                }
+            }
+
+            jobsInit.forEach { it.await() }
+            jobsGetMessages.forEach { it.await() }
 
             // THEN
             assertThat(exceptions).isEmpty()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12529
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
My theory is that this started to happen as JITM was placed on the Store screen, so in some cases, we may get both `init` and `getMessagesForPath` roughly in parallel, which causes continuation to be resumed twice

I could not reproduce this even with a test, but I could reproduce a deadlock with this test. 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
I could not reproduce this

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Maybe try to reproduce this with another unit test?

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Only unit test and I simulated JITM to be shown

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->