### PR TITLE
[Order Tracking] Avoid reseting the carrier value when coming back from another screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] Fixes navigation from product review detail screen when opened from notification [https://github.com/woocommerce/woocommerce-android/pull/12514]
 - [*] Added a blaze campaign reminder that appears after abandoning a campaign creation. [https://github.com/woocommerce/woocommerce-android/pull/12452]
 - [*] Fixes an issue that caused the an incorrect App Bar visibility in some rare cases [https://github.com/woocommerce/woocommerce-android/pull/12523]
+- [*] Fixes an issue on the Order Tracking screen that was causing the carrier being reset unintentionally [https://github.com/woocommerce/woocommerce-android/pull/12535]
 
 20.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderShipmentTrackingFragment.kt
@@ -7,7 +7,8 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.widget.doOnTextChanged
+import androidx.core.view.isVisible
+import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.AppPrefs
@@ -181,13 +182,15 @@ class AddOrderShipmentTrackingFragment :
             dateShippedPickerDialog?.show()
         }
 
-        binding.customProviderName.doOnTextChanged { text, _, _, _ ->
+        binding.customProviderName.doAfterTextChanged { text ->
+            if (!binding.customProviderNameLayout.isVisible) return@doAfterTextChanged
             viewModel.onCustomCarrierNameEntered(text.toString())
         }
-        binding.trackingNumber.doOnTextChanged { text, _, _, _ ->
+        binding.trackingNumber.doAfterTextChanged { text ->
             viewModel.onTrackingNumberEntered(text.toString())
         }
-        binding.customProviderUrl.doOnTextChanged { text, _, _, _ ->
+        binding.customProviderUrl.doAfterTextChanged { text ->
+            if (!binding.customProviderUrlLayout.isVisible) return@doAfterTextChanged
             viewModel.onTrackingLinkEntered(text.toString())
         }
     }

--- a/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
+++ b/WooCommerce/src/main/res/layout/fragment_add_shipment_tracking.xml
@@ -70,6 +70,7 @@
                     app:counterEnabled="true"
                     app:counterMaxLength="@integer/max_length_tracking_number"
                     app:errorEnabled="true"
+                    android:visibility="gone"
                     tools:visibility="visible">
 
                     <com.google.android.material.textfield.TextInputEditText
@@ -111,9 +112,11 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/order_shipment_tracking_custom_provider_url_label"
+                    android:visibility="gone"
                     app:counterEnabled="true"
                     app:counterMaxLength="@integer/max_length_tracking_number"
-                    app:errorEnabled="true">
+                    app:errorEnabled="true"
+                    tools:visibility="visible">
 
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/custom_provider_url"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12534 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR, we avoid resetting the carrier value when we return from another fragment by tapping the back button. The issue was that we were resetting the value because we didn't have any argument coming from that navigation. With these changes we only so that if the fields are visible, thus preventing the bug case. (Thanks @hichamboushaba for the fix!)

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
With [WC Shipment Tracking](https://woocommerce.com/products/shipment-tracking/) installed

1. Go to Orders
2. Go to an existing order details that contains products other than virtual
3. Tap on Add Tracking
4. Check that there's a selected carrier. If not, select one
5. Tap again on Carrier to open the carriers list
6. Tap on the back button.
7. Bug: the carrier is removed (it shouldn't)

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I verified that the above steps work as expected, also when selecting a custom carrier.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
#### Before

https://github.com/user-attachments/assets/e1a92d4e-89cd-438a-ba2d-bc56f29ae620

#### After


https://github.com/user-attachments/assets/b0557ec2-210a-4a6e-b017-a3abd291ede3


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->