### PR TITLE
[Order Tracking] Remove duplicated toolbar in carriers list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] Fixes navigation from product review detail screen when opened from notification [https://github.com/woocommerce/woocommerce-android/pull/12514]
 - [*] Added a blaze campaign reminder that appears after abandoning a campaign creation. [https://github.com/woocommerce/woocommerce-android/pull/12452]
 - [*] Fixes an issue that caused the an incorrect App Bar visibility in some rare cases [https://github.com/woocommerce/woocommerce-android/pull/12523]
+- [*] Fixes duplicated toolbar in the Order Tracking Carriers List [https://github.com/woocommerce/woocommerce-android/pull/12537]
 
 20.2
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/tracking/AddOrderTrackingProviderListFragment.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.OrderShipmentProvider
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.orders.tracking.AddOrderTrackingProviderListAdapter.OnProviderClickListener
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -33,6 +34,9 @@ class AddOrderTrackingProviderListFragment :
         const val TAG: String = "AddOrderTrackingProviderListFragment"
         const val SHIPMENT_TRACKING_PROVIDER_RESULT = "tracking-provider-result"
     }
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     @Inject lateinit var uiMessageResolver: UIMessageResolver
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12536 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we remove the duplicated toolbar in the order tracking carriers list.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
With [WC Shipment Tracking](https://woocommerce.com/products/shipment-tracking/) installed

1. Go to Orders
2. Go to an existing order details that contains products other than virtual
3. Tap on Add Tracking
4. Check that there's a selected carrier. If not, select one
5. Tap again on Carrier to open the carriers list
6. Tap on the back button.
7. Bug: the carrier is removed (it shouldn't)

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
See above

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested on device Samsung Galaxy S21 and tablet Galaxy A8

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

#### Before
<img src=https://github.com/user-attachments/assets/f2b34a6a-d08d-44b5-b538-29f1d1ddbc3c width="375">

#### After
<img src=https://github.com/user-attachments/assets/2797eae1-7e5f-4dff-b61f-8508a37b3755 width="375">

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->