### PR TITLE
Fix pagination load more

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -270,7 +270,7 @@ class OrderListViewModel @Inject constructor(
         )
         val listId = listDescriptor.uniqueIdentifier.value
         launch {
-            if (shouldUpdateOrdersList(listId)) {
+            if (shouldUpdateOrdersList(listDescriptor)) {
                 fetchOrdersAndOrderDependencies()
             } else {
                 // List is displayed from cache

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/ShouldUpdateOrdersList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/ShouldUpdateOrdersList.kt
@@ -13,7 +13,7 @@ class ShouldUpdateOrdersList @Inject constructor(
 ) {
     suspend operator fun invoke(listDescriptor: ListDescriptor): Boolean {
         val listId = listDescriptor.uniqueIdentifier.value
-        val shouldUpdateByState= listStore.getListState(listDescriptor) == ListState.NEEDS_REFRESH
+        val shouldUpdateByState = listStore.getListState(listDescriptor) == ListState.NEEDS_REFRESH
         val shouldUpdateByCache = lastUpdateDataStore.getLastUpdateKeyByOrdersListId(listId).let { key ->
             lastUpdateDataStore.shouldUpdateData(key).first()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/ShouldUpdateOrdersList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/ShouldUpdateOrdersList.kt
@@ -2,12 +2,21 @@ package com.woocommerce.android.ui.orders.list
 
 import com.woocommerce.android.background.LastUpdateDataStore
 import kotlinx.coroutines.flow.first
+import org.wordpress.android.fluxc.model.list.ListDescriptor
+import org.wordpress.android.fluxc.model.list.ListState
+import org.wordpress.android.fluxc.store.ListStore
 import javax.inject.Inject
 
-class ShouldUpdateOrdersList @Inject constructor(private val lastUpdateDataStore: LastUpdateDataStore) {
-    suspend operator fun invoke(listId: Int): Boolean {
-        return lastUpdateDataStore.getLastUpdateKeyByOrdersListId(listId).let { key ->
+class ShouldUpdateOrdersList @Inject constructor(
+    private val lastUpdateDataStore: LastUpdateDataStore,
+    private val listStore: ListStore
+) {
+    suspend operator fun invoke(listDescriptor: ListDescriptor): Boolean {
+        val listId = listDescriptor.uniqueIdentifier.value
+        val shouldUpdateByState= listStore.getListState(listDescriptor) == ListState.NEEDS_REFRESH
+        val shouldUpdateByCache = lastUpdateDataStore.getLastUpdateKeyByOrdersListId(listId).let { key ->
             lastUpdateDataStore.shouldUpdateData(key).first()
         }
+        return shouldUpdateByState || shouldUpdateByCache
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/list/ShouldUpdateOrdersListByStoreIdTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/list/ShouldUpdateOrdersListByStoreIdTest.kt
@@ -27,7 +27,7 @@ class ShouldUpdateOrdersListByStoreIdTest : BaseUnitTest() {
     fun `when should update return true and list state is not refresh, then the result is the expected`() = testBlocking {
         val listId = 1
         val key = "key-1"
-        val listDescriptor: WCOrderListDescriptor = mock{
+        val listDescriptor: WCOrderListDescriptor = mock {
             on { uniqueIdentifier }.doReturn(ListDescriptorUniqueIdentifier(listId))
         }
         whenever(lastUpdateDataStore.getLastUpdateKeyByOrdersListId(eq(listId))).doReturn(key)
@@ -43,7 +43,7 @@ class ShouldUpdateOrdersListByStoreIdTest : BaseUnitTest() {
     fun `when should update return true and list state is refresh, then the result is the expected`() = testBlocking {
         val listId = 1
         val key = "key-1"
-        val listDescriptor: WCOrderListDescriptor = mock{
+        val listDescriptor: WCOrderListDescriptor = mock {
             on { uniqueIdentifier }.doReturn(ListDescriptorUniqueIdentifier(listId))
         }
         whenever(lastUpdateDataStore.getLastUpdateKeyByOrdersListId(eq(listId))).doReturn(key)
@@ -59,7 +59,7 @@ class ShouldUpdateOrdersListByStoreIdTest : BaseUnitTest() {
     fun `when should update return false and list state is refresh, then the result is the expected`() = testBlocking {
         val listId = 1
         val key = "key-1"
-        val listDescriptor: WCOrderListDescriptor = mock{
+        val listDescriptor: WCOrderListDescriptor = mock {
             on { uniqueIdentifier }.doReturn(ListDescriptorUniqueIdentifier(listId))
         }
         whenever(lastUpdateDataStore.getLastUpdateKeyByOrdersListId(eq(listId))).doReturn(key)
@@ -75,7 +75,7 @@ class ShouldUpdateOrdersListByStoreIdTest : BaseUnitTest() {
     fun `when should update return false and list state is not refresh, then the result is the expected`() = testBlocking {
         val listId = 1
         val key = "key-1"
-        val listDescriptor: WCOrderListDescriptor = mock{
+        val listDescriptor: WCOrderListDescriptor = mock {
             on { uniqueIdentifier }.doReturn(ListDescriptorUniqueIdentifier(listId))
         }
         whenever(lastUpdateDataStore.getLastUpdateKeyByOrdersListId(eq(listId))).doReturn(key)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/list/ShouldUpdateOrdersListByStoreIdTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/list/ShouldUpdateOrdersListByStoreIdTest.kt
@@ -11,33 +11,78 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.WCOrderListDescriptor
+import org.wordpress.android.fluxc.model.list.ListDescriptorUniqueIdentifier
+import org.wordpress.android.fluxc.model.list.ListState
+import org.wordpress.android.fluxc.store.ListStore
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ShouldUpdateOrdersListByStoreIdTest : BaseUnitTest() {
     private val lastUpdateDataStore: LastUpdateDataStore = mock()
-    val sut = ShouldUpdateOrdersList(lastUpdateDataStore)
+    private val lisStore: ListStore = mock()
+    val sut = ShouldUpdateOrdersList(lastUpdateDataStore, lisStore)
 
     @Test
-    fun `when should update return true, then the result is the expected`() = testBlocking {
+    fun `when should update return true and list state is not refresh, then the result is the expected`() = testBlocking {
         val listId = 1
         val key = "key-1"
+        val listDescriptor: WCOrderListDescriptor = mock{
+            on { uniqueIdentifier }.doReturn(ListDescriptorUniqueIdentifier(listId))
+        }
         whenever(lastUpdateDataStore.getLastUpdateKeyByOrdersListId(eq(listId))).doReturn(key)
         whenever(lastUpdateDataStore.shouldUpdateData(eq(key), any())).doReturn(flowOf(true))
+        whenever(lisStore.getListState(eq(listDescriptor))).doReturn(ListState.CAN_LOAD_MORE)
 
-        val result = sut.invoke(listId)
+        val result = sut.invoke(listDescriptor)
 
         assertTrue(result)
     }
 
     @Test
-    fun `when should update return false, then the result is the expected`() = testBlocking {
+    fun `when should update return true and list state is refresh, then the result is the expected`() = testBlocking {
         val listId = 1
         val key = "key-1"
+        val listDescriptor: WCOrderListDescriptor = mock{
+            on { uniqueIdentifier }.doReturn(ListDescriptorUniqueIdentifier(listId))
+        }
+        whenever(lastUpdateDataStore.getLastUpdateKeyByOrdersListId(eq(listId))).doReturn(key)
+        whenever(lastUpdateDataStore.shouldUpdateData(eq(key), any())).doReturn(flowOf(true))
+        whenever(lisStore.getListState(eq(listDescriptor))).doReturn(ListState.NEEDS_REFRESH)
+
+        val result = sut.invoke(listDescriptor)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `when should update return false and list state is refresh, then the result is the expected`() = testBlocking {
+        val listId = 1
+        val key = "key-1"
+        val listDescriptor: WCOrderListDescriptor = mock{
+            on { uniqueIdentifier }.doReturn(ListDescriptorUniqueIdentifier(listId))
+        }
         whenever(lastUpdateDataStore.getLastUpdateKeyByOrdersListId(eq(listId))).doReturn(key)
         whenever(lastUpdateDataStore.shouldUpdateData(eq(key), any())).doReturn(flowOf(false))
+        whenever(lisStore.getListState(eq(listDescriptor))).doReturn(ListState.NEEDS_REFRESH)
 
-        val result = sut.invoke(listId)
+        val result = sut.invoke(listDescriptor)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `when should update return false and list state is not refresh, then the result is the expected`() = testBlocking {
+        val listId = 1
+        val key = "key-1"
+        val listDescriptor: WCOrderListDescriptor = mock{
+            on { uniqueIdentifier }.doReturn(ListDescriptorUniqueIdentifier(listId))
+        }
+        whenever(lastUpdateDataStore.getLastUpdateKeyByOrdersListId(eq(listId))).doReturn(key)
+        whenever(lastUpdateDataStore.shouldUpdateData(eq(key), any())).doReturn(flowOf(false))
+        whenever(lisStore.getListState(eq(listDescriptor))).doReturn(ListState.CAN_LOAD_MORE)
+
+        val result = sut.invoke(listDescriptor)
 
         assertFalse(result)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-3d8b46e8151493d563fd519c4406a5b83bc95255'
+    fluxCVersion = '3090-3d6d1df2e25d7ea902359f75488bd95541c23df3'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
Closes: #12491

### Description
This PR fixes the issue that prevented the load more behavior from triggering after reaching the end of the screen. The problem was that because of a timeout on the `getListState` function, the function returned a `need-to-refresh` state instead of the required to trigger the load more behavior `can-load-more`. 

This PR fixes this issue with two main changes:

1. It updates the FluxC version to use a new implementation that will not expire the final states `can-load-more` and `fetched`.
2. Update the `ShouldUpdateOrdersList` to consider the list status. With this change, we aim to prevent inconsistent states in case the app is closed before reaching one of the final states.

### Steps to reproduce
1. Open the app
2. Navigate to the orders screen
3. Pull-to-refresh the screen
4. Check that the last update timestamp is updated
5. Cose the app and wait 2 min (more than 1 min will work too)
6. Re-open the app 
7. Navigate to the orders screen
8. Scroll to the bottom of the screen
9. Check that the load more behavior is not triggered and only the first page is displayed

### Testing information
1. Open the app
2. Navigate to the orders screen
3. Pull-to-refresh the screen
4. Check that the last update timestamp is updated
5. Cose the app and wait 2 min (more than 1 min will work too)
6. Re-open the app 
7. Navigate to the orders screen
8. Scroll to the bottom of the screen
9. Check that the pagination is working as expected

### The tests that have been performed

1. Test that pagination works as expected when data is loaded from a cache older than 1 min.
2. Test that receiving an order notification updates the list
3. Test that creating a new order displays the new order in the list
4. Test that applying a status filter is working as expected
5. Test that completing an order in the list with the "processing" filter removes the order from the list.

### Images/gif

https://github.com/user-attachments/assets/8d2a4b44-97eb-467d-ab7a-9b1582dc0c1e

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->