### PR TITLE
Fix Stackoverflow crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NumberExtensionsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/NumberExtensionsWrapper.kt
@@ -2,10 +2,11 @@ package com.woocommerce.android.extensions
 
 import java.util.Locale
 import javax.inject.Inject
+import com.woocommerce.android.extensions.compactNumberCompat as compactNumberCompatExt
 
 class NumberExtensionsWrapper @Inject constructor() {
     fun compactNumberCompat(
         number: Long,
         locale: Locale = Locale.getDefault()
-    ): String = compactNumberCompat(number, locale)
+    ): String = compactNumberCompatExt(number, locale)
 }


### PR DESCRIPTION
### Description
This PR fixes a [crash](https://a8c.sentry.io/issues/5806300004/?project=1459556) that I faced when testing the beta during the code freeze flow, the crash occurs due to an infinite recursion, this was caused by this [commit](https://github.com/woocommerce/woocommerce-android/pull/12524/commits/e466d9984203be431953a7772d497f5caa39a055).

### Steps to reproduce
1. Open the app.
2. Add the Blaze card to the Dashboard.
3. Assuming you have some Blaze campaigns.
4. Confirm the app doesn't crash.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->