### PR TITLE
Issue/12563 delete custom fields

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/OverflowMenu.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/OverflowMenu.kt
@@ -7,6 +7,8 @@ import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons.Outlined
 import androidx.compose.material.icons.outlined.MoreVert
@@ -30,7 +32,8 @@ fun <T> WCOverflowMenu(
     onSelected: (T) -> Unit,
     modifier: Modifier = Modifier,
     mapper: @Composable (T) -> String = { it.toString() },
-    tint: Color = Color.Black
+    itemColor: @Composable (T) -> Color = { LocalContentColor.current },
+    tint: Color = MaterialTheme.colors.primary
 ) {
     var showMenu by remember { mutableStateOf(false) }
     Box(modifier = modifier) {
@@ -57,7 +60,10 @@ fun <T> WCOverflowMenu(
                         onSelected(item)
                     }
                 ) {
-                    Text(mapper(item))
+                    Text(
+                        text = mapper(item),
+                        color = itemColor(item)
+                    )
                 }
                 if (index < items.size - 1) {
                     Spacer(modifier = Modifier.height(dimensionResource(id = dimen.minor_100)))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorFragment.kt
@@ -15,10 +15,6 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class CustomFieldsEditorFragment : BaseFragment() {
-    companion object {
-        const val RESULT_KEY = "custom_field_result"
-    }
-
     override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
 
     private val viewModel: CustomFieldsEditorViewModel by viewModels()
@@ -36,7 +32,7 @@ class CustomFieldsEditorFragment : BaseFragment() {
     private fun handleEvents() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                is MultiLiveEvent.Event.ExitWithResult<*> -> navigateBackWithResult(RESULT_KEY, event.data)
+                is MultiLiveEvent.Event.ExitWithResult<*> -> navigateBackWithResult(event.key!!, event.data)
                 MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
@@ -64,22 +64,24 @@ private fun CustomFieldsEditorScreen(
                             text = stringResource(R.string.done)
                         )
                     }
-                    WCOverflowMenu(
-                        items = listOf(R.string.delete),
-                        mapper = { stringResource(it) },
-                        itemColor = {
-                            when (it) {
-                                R.string.delete -> MaterialTheme.colors.error
-                                else -> LocalContentColor.current
+                    if (!state.isCreatingNewItem) {
+                        WCOverflowMenu(
+                            items = listOf(R.string.delete),
+                            mapper = { stringResource(it) },
+                            itemColor = {
+                                when (it) {
+                                    R.string.delete -> MaterialTheme.colors.error
+                                    else -> LocalContentColor.current
+                                }
+                            },
+                            onSelected = { resourceId ->
+                                when (resourceId) {
+                                    R.string.delete -> onDeleteClicked()
+                                    else -> error("Unhandled menu item")
+                                }
                             }
-                        },
-                        onSelected = { resourceId ->
-                            when (resourceId) {
-                                R.string.delete -> onDeleteClicked()
-                                else -> error("Unhandled menu item")
-                            }
-                        }
-                    )
+                        )
+                    }
                 }
             )
         },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
@@ -18,6 +19,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.DiscardChangesDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.WCOverflowMenu
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.component.aztec.OutlinedAztecEditor
 import com.woocommerce.android.ui.compose.component.getText
@@ -33,6 +35,7 @@ fun CustomFieldsEditorScreen(viewModel: CustomFieldsEditorViewModel) {
             onKeyChanged = viewModel::onKeyChanged,
             onValueChanged = viewModel::onValueChanged,
             onDoneClicked = viewModel::onDoneClicked,
+            onDeleteClicked = viewModel::onDeleteClicked,
             onBackButtonClick = viewModel::onBackClick,
         )
     }
@@ -44,6 +47,7 @@ private fun CustomFieldsEditorScreen(
     onKeyChanged: (String) -> Unit,
     onValueChanged: (String) -> Unit,
     onDoneClicked: () -> Unit,
+    onDeleteClicked: () -> Unit,
     onBackButtonClick: () -> Unit,
 ) {
     BackHandler { onBackButtonClick() }
@@ -60,6 +64,22 @@ private fun CustomFieldsEditorScreen(
                             text = stringResource(R.string.done)
                         )
                     }
+                    WCOverflowMenu(
+                        items = listOf(R.string.delete),
+                        mapper = { stringResource(it) },
+                        itemColor = {
+                            when (it) {
+                                R.string.delete -> MaterialTheme.colors.error
+                                else -> LocalContentColor.current
+                            }
+                        },
+                        onSelected = { resourceId ->
+                            when (resourceId) {
+                                R.string.delete -> onDeleteClicked()
+                                else -> error("Unhandled menu item")
+                            }
+                        }
+                    )
                 }
             )
         },
@@ -117,6 +137,7 @@ private fun CustomFieldsEditorScreenPreview() {
             onKeyChanged = {},
             onValueChanged = {},
             onDoneClicked = {},
+            onDeleteClicked = {},
             onBackButtonClick = {}
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -62,7 +62,8 @@ class CustomFieldsEditorViewModel @Inject constructor(
                 storedValue?.value.orEmpty() != customField.value,
             isHtml = isHtml,
             discardChangesDialogState = discardChangesDialogState,
-            keyErrorMessage = keyErrorMessage
+            keyErrorMessage = keyErrorMessage,
+            isCreatingNewItem = storedValue == null
         )
     }.asLiveData()
 
@@ -133,6 +134,7 @@ class CustomFieldsEditorViewModel @Inject constructor(
         val isHtml: Boolean = false,
         val discardChangesDialogState: DiscardChangesDialogState? = null,
         val keyErrorMessage: UiString? = null,
+        val isCreatingNewItem: Boolean = false
     ) {
         val showDoneButton
             get() = customField.key.isNotEmpty() && hasChanges && keyErrorMessage == null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -25,6 +25,11 @@ class CustomFieldsEditorViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val repository: CustomFieldsRepository
 ) : ScopedViewModel(savedStateHandle) {
+    companion object {
+        const val CUSTOM_FIELD_UPDATED_RESULT_KEY = "custom_field_updated"
+        const val CUSTOM_FIELD_DELETED_RESULT_KEY = "custom_field_deleted"
+    }
+
     private val navArgs by savedStateHandle.navArgs<CustomFieldsEditorFragmentArgs>()
 
     private val customFieldDraft = savedStateHandle.getStateFlow(
@@ -84,13 +89,23 @@ class CustomFieldsEditorViewModel @Inject constructor(
                 if (existingFields.any { it.key == value.key }) {
                     keyErrorMessage.value = UiString.UiStringRes(R.string.custom_fields_editor_key_error_duplicate)
                 } else {
-                    triggerEvent(MultiLiveEvent.Event.ExitWithResult(value))
+                    triggerEvent(
+                        MultiLiveEvent.Event.ExitWithResult(data = value, key = CUSTOM_FIELD_UPDATED_RESULT_KEY)
+                    )
                 }
             }
         } else {
             // When editing, we don't need to check for duplicate keys
-            triggerEvent(MultiLiveEvent.Event.ExitWithResult(value))
+            triggerEvent(
+                MultiLiveEvent.Event.ExitWithResult(data = value, key = CUSTOM_FIELD_UPDATED_RESULT_KEY)
+            )
         }
+    }
+
+    fun onDeleteClicked() {
+        triggerEvent(
+            MultiLiveEvent.Event.ExitWithResult(data = navArgs.customField, key = CUSTOM_FIELD_DELETED_RESULT_KEY)
+        )
     }
 
     fun onBackClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
@@ -12,7 +12,7 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.customfields.CustomFieldContentType
 import com.woocommerce.android.ui.customfields.CustomFieldUiModel
-import com.woocommerce.android.ui.customfields.editor.CustomFieldsEditorFragment
+import com.woocommerce.android.ui.customfields.editor.CustomFieldsEditorViewModel
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -56,12 +56,15 @@ class CustomFieldsFragment : BaseFragment() {
     }
 
     private fun handleResults() {
-        handleResult<CustomFieldUiModel>(CustomFieldsEditorFragment.RESULT_KEY) { result ->
+        handleResult<CustomFieldUiModel>(CustomFieldsEditorViewModel.CUSTOM_FIELD_UPDATED_RESULT_KEY) { result ->
             if (result.id == null) {
                 viewModel.onCustomFieldInserted(result)
             } else {
                 viewModel.onCustomFieldUpdated(result)
             }
+        }
+        handleResult<CustomFieldUiModel>(CustomFieldsEditorViewModel.CUSTOM_FIELD_DELETED_RESULT_KEY) { result ->
+            viewModel.onCustomFieldDeleted(result)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
@@ -48,6 +48,11 @@ class CustomFieldsFragment : BaseFragment() {
                 is CustomFieldsViewModel.OpenCustomFieldEditor -> openEditor(event.field)
                 is CustomFieldsViewModel.CustomFieldValueClicked -> handleValueClick(event.field)
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                is MultiLiveEvent.Event.ShowActionSnackbar -> uiMessageResolver.showActionSnack(
+                    message = event.message,
+                    actionText = event.actionText,
+                    action = event.action
+                )
                 is MultiLiveEvent.Event.Exit -> {
                     findNavController().navigateUp()
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
@@ -29,6 +31,7 @@ import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -52,7 +55,10 @@ import com.woocommerce.android.ui.customfields.CustomFieldContentType
 import com.woocommerce.android.ui.customfields.CustomFieldUiModel
 
 @Composable
-fun CustomFieldsScreen(viewModel: CustomFieldsViewModel) {
+fun CustomFieldsScreen(
+    viewModel: CustomFieldsViewModel,
+    snackbarHostState: SnackbarHostState
+) {
     viewModel.state.observeAsState().value?.let { state ->
         CustomFieldsScreen(
             state = state,
@@ -61,7 +67,8 @@ fun CustomFieldsScreen(viewModel: CustomFieldsViewModel) {
             onCustomFieldClicked = viewModel::onCustomFieldClicked,
             onCustomFieldValueClicked = viewModel::onCustomFieldValueClicked,
             onAddCustomFieldClicked = viewModel::onAddCustomFieldClicked,
-            onBackClick = viewModel::onBackClick
+            onBackClick = viewModel::onBackClick,
+            snackbarHostState = snackbarHostState
         )
     }
 }
@@ -75,7 +82,8 @@ private fun CustomFieldsScreen(
     onCustomFieldClicked: (CustomFieldUiModel) -> Unit,
     onCustomFieldValueClicked: (CustomFieldUiModel) -> Unit,
     onAddCustomFieldClicked: () -> Unit,
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
 ) {
     BackHandler { onBackClick() }
 
@@ -106,6 +114,7 @@ private fun CustomFieldsScreen(
                 )
             }
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         backgroundColor = MaterialTheme.colors.surface
     ) { paddingValues ->
         val pullToRefreshState = rememberPullRefreshState(state.isRefreshing, onPullToRefresh)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.customfields.CustomFieldUiModel
 import com.woocommerce.android.ui.customfields.CustomFieldsRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import com.woocommerce.android.viewmodel.navArgs
@@ -23,7 +24,8 @@ import javax.inject.Inject
 @HiltViewModel
 class CustomFieldsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val repository: CustomFieldsRepository
+    private val repository: CustomFieldsRepository,
+    private val resourceProvider: ResourceProvider
 ) : ScopedViewModel(savedStateHandle) {
     private val args: CustomFieldsFragmentArgs by savedStateHandle.navArgs()
     val parentItemId: Long = args.parentItemId
@@ -110,6 +112,22 @@ class CustomFieldsViewModel @Inject constructor(
                 it.copy(deletedFieldIds = it.deletedFieldIds + field.id)
             }
         }
+
+        triggerEvent(
+            MultiLiveEvent.Event.ShowActionSnackbar(
+                message = resourceProvider.getString(R.string.custom_fields_list_field_deleted),
+                actionText = resourceProvider.getString(R.string.undo),
+                action = {
+                    pendingChanges.update {
+                        if (field.id == null) {
+                            it.copy(insertedFields = it.insertedFields + field)
+                        } else {
+                            it.copy(deletedFieldIds = it.deletedFieldIds - field.id)
+                        }
+                    }
+                }
+            )
+        )
     }
 
     fun onSaveClicked() {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4290,6 +4290,7 @@
     <string name="custom_fields_list_progress_dialog_title">Saving changes</string>
     <string name="custom_fields_list_saving_succeeded">Changes saved</string>
     <string name="custom_fields_list_saving_failed">Saving changes failed, please try again</string>
+    <string name="custom_fields_list_field_deleted">Custom Field deleted</string>
     <string name="custom_fields_add_button">Add custom fields</string>
     <string name="custom_fields_editor_key_label">Key</string>
     <string name="custom_fields_editor_value_label">Value</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
@@ -182,7 +182,8 @@ class CustomFieldsEditorViewModelTest : BaseUnitTest() {
 
         assertThat(events).isEqualTo(
             MultiLiveEvent.Event.ExitWithResult(
-                CustomFieldUiModel(id = CUSTOM_FIELD_ID, key = "new key", value = "new value")
+                data = CustomFieldUiModel(id = CUSTOM_FIELD_ID, key = "new key", value = "new value"),
+                key = CustomFieldsEditorViewModel.CUSTOM_FIELD_UPDATED_RESULT_KEY
             )
         )
     }
@@ -215,6 +216,22 @@ class CustomFieldsEditorViewModelTest : BaseUnitTest() {
         }.last()
 
         assertThat(state.keyErrorMessage).isNull()
+    }
+
+    @Test
+    fun `given editing an existing field, when delete is clicked, then return result`() = testBlocking {
+        setup(editing = true)
+
+        val event = viewModel.event.runAndCaptureValues {
+            viewModel.onDeleteClicked()
+        }.last()
+
+        assertThat(event).isEqualTo(
+            MultiLiveEvent.Event.ExitWithResult(
+                data = CustomFieldUiModel(CUSTOM_FIELD),
+                key = CustomFieldsEditorViewModel.CUSTOM_FIELD_DELETED_RESULT_KEY
+            )
+        )
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '3091-2a183925babb0d9f5813500881f275789ab7ca88'
+    fluxCVersion = 'trunk-c35b83606f0d4f661d6cf17bf916553e9f3820b4'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.95.0'
+    fluxCVersion = '3091-2a183925babb0d9f5813500881f275789ab7ca88'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12563 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds support for deleting custom fields.

### Steps to reproduce
1. Open wp-admin, and add at least one custom field to an order.
2. Open the order in the app.
3. Tap on "View custom fields"
4. Open an existing custom field.
5. Tap on the overflow menu button.
6. Tap on Delete button.

### Testing information
1. Test the delete flow for an existing field.
2. Test the delete flow for a new non-saved field.
3. Test the undo SnackBar.
4. Test saving changes after deleting some items.

### The tests that have been performed
Same as above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->