### PR TITLE
Only filterable product types in product filter

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductType.kt
@@ -20,6 +20,9 @@ enum class ProductType(@StringRes val stringResource: Int = 0, val value: String
     fun isVariableProduct() = this == VARIABLE || this == VARIABLE_SUBSCRIPTION
 
     companion object {
+        val FILTERABLE_VALUES =
+            setOf(SIMPLE, GROUPED, EXTERNAL, VARIABLE, SUBSCRIPTION, VARIABLE_SUBSCRIPTION, BUNDLE, COMPOSITE)
+
         fun fromString(type: String): ProductType {
             return when (type.lowercase(Locale.US)) {
                 "grouped" -> GROUPED

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
@@ -185,7 +185,7 @@ class ProductFilterListViewModel @Inject constructor(
     }
 
     private fun getTypeFilterWithExploreOptions(): MutableList<FilterListOptionItemUiModel> {
-        return ProductType.values().filterNot { it == ProductType.OTHER }.map {
+        return ProductType.FILTERABLE_VALUES.map {
             when {
                 it == ProductType.BUNDLE && isPluginInstalled(it) == false -> {
                     FilterListOptionItemUiModel.ExploreOptionItemUiModel(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/filter/ProductFilterListViewModel.kt
@@ -220,7 +220,7 @@ class ProductFilterListViewModel @Inject constructor(
                 }
 
                 else -> {
-                    FilterListOptionItemUiModel.DefaultFilterListOptionItemUiModel(
+                    DefaultFilterListOptionItemUiModel(
                         resourceProvider.getString(it.stringResource),
                         filterOptionItemValue = it.value,
                         isSelected = productFilterOptions[TYPE] == it.value


### PR DESCRIPTION
Closes: #12526

### Description
We included some product types that are not allowed as filter options in the product filters screen ([documentation](https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-products)). When an invalid filter value was used, the app returned an error, making not obvious the cause of the failure. This PR fixes the issue by:
- Creating a FILTERABLE_VALUES set to include product types that can be used in the filter
- Using the new FILTERABLE_VALUES to fill the product types filter

With the changes included here, the filter by product type screen will include only valid filter options.

**Issue description:** 
> Filtering by Variation Product returns always an error. Furthermore, when trying again, it returns an empty list. On iOS there’s no such Variation Product filter value. We have to check if this is an issue on Core or the app.

### Steps to reproduce
1. Go to the Products tab
2. Tap on Filters
3. Tap on product type
4. Tap on Variation product
5. Apply the filter (press Show products button)
6. Check that the app displays a Error fetching product message

### Testing information
1. Go to the Products tab
2. Tap on Filters
3. Tap on product type
4. Check that filtering by all product's types is possible

### The tests that have been performed

1. Verified that the product filter worked for all product types listed
2. Verified that the explore option is working as expected for extensions not installed in the store
3. Verified that a variable product can be created using the app


### Images/gif

https://github.com/user-attachments/assets/1dd592c5-f058-46f2-ae38-7e8eea4b3050


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md --