### PR TITLE
[Woo POS] Cannot reconnect to Reader after turning internet off and on

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
@@ -29,6 +29,7 @@ sealed class ChildToParentEvent {
         data object FullScreen : ProductsStatusChanged()
         data object WithCart : ProductsStatusChanged()
     }
+    data object NoInternet : ChildToParentEvent()
 }
 
 interface WooPosChildrenToParentEventReceiver {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -53,7 +53,11 @@ fun WooPosHomeScreen(
     val context = LocalContext.current
     LaunchedEffect(viewModel.toastEvent) {
         viewModel.toastEvent.collect { message ->
-            ToastUtils.showToast(context, message)
+            ToastUtils.showToast(
+                context,
+                context.getString(message.message),
+                ToastUtils.Duration.LONG
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -41,6 +42,7 @@ import com.woocommerce.android.ui.woopos.home.toolbar.WooPosFloatingToolbar
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreen
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreenPreview
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import org.wordpress.android.util.ToastUtils
 
 @Composable
 fun WooPosHomeScreen(
@@ -48,6 +50,12 @@ fun WooPosHomeScreen(
 ) {
     val viewModel: WooPosHomeViewModel = hiltViewModel()
     val state = viewModel.state.collectAsState().value
+    val context = LocalContext.current
+    LaunchedEffect(viewModel.toastEvent) {
+        viewModel.toastEvent.collect { message ->
+            ToastUtils.showToast(context, message)
+        }
+    }
 
     WooPosHomeScreen(
         state,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.home
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -29,8 +30,12 @@ class WooPosHomeViewModel @Inject constructor(
     )
     val state: StateFlow<WooPosHomeState> = _state
 
-    private val _toastEvent = MutableSharedFlow<Int>()
-    val toastEvent: SharedFlow<Int> = _toastEvent
+    private val _toastEvent = MutableSharedFlow<Toast>()
+    val toastEvent: SharedFlow<Toast> = _toastEvent
+
+    data class Toast(
+        @StringRes val message: Int,
+    )
 
     init {
         listenBottomEvents()
@@ -128,7 +133,7 @@ class WooPosHomeViewModel @Inject constructor(
 
                     ChildToParentEvent.NoInternet -> {
                         viewModelScope.launch {
-                            _toastEvent.emit(R.string.woopos_no_internet_message)
+                            _toastEvent.emit(Toast(R.string.woopos_no_internet_message))
                         }
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -128,7 +128,7 @@ class WooPosHomeViewModel @Inject constructor(
 
                     ChildToParentEvent.NoInternet -> {
                         viewModelScope.launch {
-                            _toastEvent.emit(R.string.orderlist_connectivity_tool_internet_check_suggestion)
+                            _toastEvent.emit(R.string.woopos_no_internet_message)
                         }
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -3,8 +3,11 @@ package com.woocommerce.android.ui.woopos.home
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -21,10 +24,13 @@ class WooPosHomeViewModel @Inject constructor(
         initialValue = WooPosHomeState(
             screenPositionState = WooPosHomeState.ScreenPositionState.Cart.Visible,
             productsInfoDialog = WooPosHomeState.ProductsInfoDialog(isVisible = false),
-            exitConfirmationDialog = WooPosHomeState.ExitConfirmationDialog(isVisible = false)
+            exitConfirmationDialog = WooPosHomeState.ExitConfirmationDialog(isVisible = false),
         )
     )
     val state: StateFlow<WooPosHomeState> = _state
+
+    private val _toastEvent = MutableSharedFlow<Int>()
+    val toastEvent: SharedFlow<Int> = _toastEvent
 
     init {
         listenBottomEvents()
@@ -118,6 +124,12 @@ class WooPosHomeViewModel @Inject constructor(
                         _state.value = _state.value.copy(
                             productsInfoDialog = WooPosHomeState.ProductsInfoDialog(isVisible = true)
                         )
+                    }
+
+                    ChildToParentEvent.NoInternet -> {
+                        viewModelScope.launch {
+                            _toastEvent.emit(R.string.orderlist_connectivity_tool_internet_check_suggestion)
+                        }
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/WooPosNetworkStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/WooPosNetworkStatus.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.woopos.util
+
+import android.content.Context
+import dagger.Reusable
+import org.wordpress.android.util.NetworkUtils
+import javax.inject.Inject
+
+@Reusable
+class WooPosNetworkStatus @Inject constructor(
+    private val context: Context
+) {
+    fun isConnected() = NetworkUtils.isNetworkAvailable(context)
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4252,7 +4252,7 @@
     <string name="woopos_floating_toolbar_menu_open_content_description">Toolbar with card reader status. Menu is open. Double tap to interact.</string>
     <string name="woopos_floating_toolbar_pop_up_menu_content_description">Open toolbar menu</string>
     <string name="woopos_floating_toolbar_pop_up_menu_open_content_description">Popup menu with options. Swipe to navigate through items.</string>
-    <string name="woopos_no_internet_message">It looks like you\'re not connected to the internet.\n\nEnsure your Wi-Fi is turned on. If you\'re using mobile data, make sure it\'s enabled in your device settings.</string>
+    <string name="woopos_no_internet_message">It looks like you\'re not connected to the internet. Ensure your Wi-Fi is turned on. If you\'re using mobile data, make sure it\'s enabled in your device settings.</string>
 
 
     <string name="customers_details_customer_section">Customer</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4251,6 +4251,7 @@
     <string name="woopos_floating_toolbar_menu_open_content_description">Toolbar with card reader status. Menu is open. Double tap to interact.</string>
     <string name="woopos_floating_toolbar_pop_up_menu_content_description">Open toolbar menu</string>
     <string name="woopos_floating_toolbar_pop_up_menu_open_content_description">Popup menu with options. Swipe to navigate through items.</string>
+    <string name="woopos_no_internet_message">It looks like you\'re not connected to the internet.\n\nEnsure your Wi-Fi is turned on. If you\'re using mobile data, make sure it\'s enabled in your device settings.</string>
 
 
     <string name="customers_details_customer_section">Customer</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModelTest.kt
@@ -134,30 +134,32 @@ class WooPosToolbarViewModelTest {
     }
 
     @Test
-    fun `given card reader status is Connected, when OnCardReaderStatusClicked, then disconnect from reader should be called`() = runTest {
-        // GIVEN
-        whenever(cardReaderFacade.readerStatus).thenReturn(flowOf(CardReaderStatus.Connected(mock())))
-        val viewModel = createViewModel()
+    fun `given card reader status is Connected, when OnCardReaderStatusClicked, then disconnect from reader should be called`() =
+        runTest {
+            // GIVEN
+            whenever(cardReaderFacade.readerStatus).thenReturn(flowOf(CardReaderStatus.Connected(mock())))
+            val viewModel = createViewModel()
 
-        // WHEN
-        viewModel.onUiEvent(WooPosToolbarUIEvent.OnCardReaderStatusClicked)
+            // WHEN
+            viewModel.onUiEvent(WooPosToolbarUIEvent.OnCardReaderStatusClicked)
 
-        // THEN
-        verify(cardReaderFacade).disconnectFromReader()
-    }
+            // THEN
+            verify(cardReaderFacade).disconnectFromReader()
+        }
 
     @Test
-    fun `given card reader status is NotConnected, when OnCardReaderStatusClicked, then connect to reader should be called`() = runTest {
-        // GIVEN
-        whenever(cardReaderFacade.readerStatus).thenReturn(flowOf(CardReaderStatus.NotConnected()))
-        val viewModel = createViewModel()
+    fun `given card reader status is NotConnected, when OnCardReaderStatusClicked, then connect to reader should be called`() =
+        runTest {
+            // GIVEN
+            whenever(cardReaderFacade.readerStatus).thenReturn(flowOf(CardReaderStatus.NotConnected()))
+            val viewModel = createViewModel()
 
-        // WHEN
-        viewModel.onUiEvent(WooPosToolbarUIEvent.OnCardReaderStatusClicked)
+            // WHEN
+            viewModel.onUiEvent(WooPosToolbarUIEvent.OnCardReaderStatusClicked)
 
-        // THEN
-        verify(cardReaderFacade).connectToReader()
-    }
+            // THEN
+            verify(cardReaderFacade).connectToReader()
+        }
 
     @Test
     fun `when get support clicked, then should open support form`() {
@@ -173,6 +175,17 @@ class WooPosToolbarViewModelTest {
         )
 
         verify(getSupportFacade).openSupportForm()
+    }
+
+    @Test
+    fun `given there is no internet, when trying to connect card reader, then trigger proper event`() = runTest {
+        whenever(networkStatus.isConnected()).thenReturn(false)
+        whenever(cardReaderFacade.readerStatus).thenReturn(flowOf(CardReaderStatus.NotConnected()))
+
+        val viewModel = createViewModel()
+        viewModel.onUiEvent(WooPosToolbarUIEvent.OnCardReaderStatusClicked)
+
+        verify(childrenToParentEventSender).sendToParent(ChildToParentEvent.NoInternet)
     }
 
     private fun createViewModel() = WooPosToolbarViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModelTest.kt
@@ -15,6 +15,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -107,6 +108,7 @@ class WooPosToolbarViewModelTest {
     fun `when ConnectToAReaderClicked passed, then connect to reader should be called`() = runTest {
         // GIVEN
         whenever(cardReaderFacade.readerStatus).thenReturn(flowOf(CardReaderStatus.NotConnected()))
+        whenever(networkStatus.isConnected()).thenReturn(true)
         val viewModel = createViewModel()
 
         // WHEN
@@ -152,6 +154,7 @@ class WooPosToolbarViewModelTest {
         runTest {
             // GIVEN
             whenever(cardReaderFacade.readerStatus).thenReturn(flowOf(CardReaderStatus.NotConnected()))
+            whenever(networkStatus.isConnected()).thenReturn(true)
             val viewModel = createViewModel()
 
             // WHEN
@@ -179,13 +182,30 @@ class WooPosToolbarViewModelTest {
 
     @Test
     fun `given there is no internet, when trying to connect card reader, then trigger proper event`() = runTest {
+        // GIVEN
         whenever(networkStatus.isConnected()).thenReturn(false)
         whenever(cardReaderFacade.readerStatus).thenReturn(flowOf(CardReaderStatus.NotConnected()))
 
+        // WHEN
         val viewModel = createViewModel()
         viewModel.onUiEvent(WooPosToolbarUIEvent.OnCardReaderStatusClicked)
 
+        // THEN
         verify(childrenToParentEventSender).sendToParent(ChildToParentEvent.NoInternet)
+    }
+
+    @Test
+    fun `given there is no internet, when trying to connect card reader, then connect card reader method is not called`() = runTest {
+        // GIVEN
+        whenever(networkStatus.isConnected()).thenReturn(false)
+        whenever(cardReaderFacade.readerStatus).thenReturn(flowOf(CardReaderStatus.NotConnected()))
+
+        // WHEN
+        val viewModel = createViewModel()
+        viewModel.onUiEvent(WooPosToolbarUIEvent.OnCardReaderStatusClicked)
+
+        // THEN
+        verify(cardReaderFacade, never()).connectToReader()
     }
 
     private fun createViewModel() = WooPosToolbarViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarViewModelTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.support.WooPosGetSupportFacade
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -27,6 +28,7 @@ class WooPosToolbarViewModelTest {
     }
     private val getSupportFacade: WooPosGetSupportFacade = mock()
     private val childrenToParentEventSender: WooPosChildrenToParentEventSender = mock()
+    private val networkStatus: WooPosNetworkStatus = mock()
 
     @Test
     fun `given card reader status is NotConnected, when initialized, then state should be NotConnected`() = runTest {
@@ -177,5 +179,6 @@ class WooPosToolbarViewModelTest {
         cardReaderFacade,
         childrenToParentEventSender,
         getSupportFacade,
+        networkStatus
     )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12497 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR addresses the issue of handling no internet connectivity when attempting to connect to the card reader.

**Previous Behavior:**
When attempting to connect the card reader without an internet connection, the app would not provide any feedback or response. This was due to the app first checking whether all onboarding conditions were met before initiating the card reader connection. In the case of no internet, the app would navigate to an onboarding screen that explains the need for an internet connection. However, since the onboarding screens were not integrated into the POS mode, the app became unresponsive.

**Updated Behavior:**
With this PR, we now check for internet connectivity before attempting to start the WooPosCardReaderActivity. If no internet connection is detected, the activity is not launched, and instead, a toast message is displayed asking the user to ensure a proper internet connection before proceeding.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Navigate to POS mode (More menu -> POS mode)
2. Click on connect to card reader button
3. While connecting, turn off the internet
4. Cancel the ongoing connection dialog
5. Try to connect to card reader again and notice the button won't respond anymore.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
I've tested this on tablet emulator by turning on and off internet.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
**Before**

https://github.com/user-attachments/assets/eda393e7-4189-47ed-aefd-7f0239b6c57e

**After**

https://github.com/user-attachments/assets/66604926-674f-499e-bbfd-2a508f1706cc



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->