### PR TITLE
[Custom Fields] Support for copying key and value

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorFragment.kt
@@ -6,12 +6,15 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.copyToClipboard
 import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.util.ToastUtils
 
 @AndroidEntryPoint
 class CustomFieldsEditorFragment : BaseFragment() {
@@ -32,9 +35,15 @@ class CustomFieldsEditorFragment : BaseFragment() {
     private fun handleEvents() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
+                is CustomFieldsEditorViewModel.CopyContentToClipboard -> copyToClipboard(event)
                 is MultiLiveEvent.Event.ExitWithResult<*> -> navigateBackWithResult(event.key!!, event.data)
                 MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
         }
+    }
+
+    private fun copyToClipboard(event: CustomFieldsEditorViewModel.CopyContentToClipboard) {
+        requireContext().copyToClipboard(getString(event.labelResource), event.content)
+        ToastUtils.showToast(requireContext(), R.string.copied_to_clipboard)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
@@ -36,6 +36,8 @@ fun CustomFieldsEditorScreen(viewModel: CustomFieldsEditorViewModel) {
             onValueChanged = viewModel::onValueChanged,
             onDoneClicked = viewModel::onDoneClicked,
             onDeleteClicked = viewModel::onDeleteClicked,
+            onCopyKeyClicked = viewModel::onCopyKeyClicked,
+            onCopyValueClicked = viewModel::onCopyValueClicked,
             onBackButtonClick = viewModel::onBackClick,
         )
     }
@@ -48,6 +50,8 @@ private fun CustomFieldsEditorScreen(
     onValueChanged: (String) -> Unit,
     onDoneClicked: () -> Unit,
     onDeleteClicked: () -> Unit,
+    onCopyKeyClicked: () -> Unit,
+    onCopyValueClicked: () -> Unit,
     onBackButtonClick: () -> Unit,
 ) {
     BackHandler { onBackButtonClick() }
@@ -64,24 +68,28 @@ private fun CustomFieldsEditorScreen(
                             text = stringResource(R.string.done)
                         )
                     }
-                    if (!state.isCreatingNewItem) {
-                        WCOverflowMenu(
-                            items = listOf(R.string.delete),
-                            mapper = { stringResource(it) },
-                            itemColor = {
-                                when (it) {
-                                    R.string.delete -> MaterialTheme.colors.error
-                                    else -> LocalContentColor.current
-                                }
-                            },
-                            onSelected = { resourceId ->
-                                when (resourceId) {
-                                    R.string.delete -> onDeleteClicked()
-                                    else -> error("Unhandled menu item")
-                                }
+                    WCOverflowMenu(
+                        items = listOfNotNull(
+                            R.string.custom_fields_editor_copy_key,
+                            R.string.custom_fields_editor_copy_value,
+                            if (!state.isCreatingNewItem) R.string.delete else null,
+                        ),
+                        mapper = { stringResource(it) },
+                        itemColor = {
+                            when (it) {
+                                R.string.delete -> MaterialTheme.colors.error
+                                else -> LocalContentColor.current
                             }
-                        )
-                    }
+                        },
+                        onSelected = { resourceId ->
+                            when (resourceId) {
+                                R.string.delete -> onDeleteClicked()
+                                R.string.custom_fields_editor_copy_key -> onCopyKeyClicked()
+                                R.string.custom_fields_editor_copy_value -> onCopyValueClicked()
+                                else -> error("Unhandled menu item")
+                            }
+                        }
+                    )
                 }
             )
         },
@@ -140,6 +148,8 @@ private fun CustomFieldsEditorScreenPreview() {
             onValueChanged = {},
             onDoneClicked = {},
             onDeleteClicked = {},
+            onCopyKeyClicked = {},
+            onCopyValueClicked = {},
             onBackButtonClick = {}
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.customfields.editor
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
@@ -110,11 +111,11 @@ class CustomFieldsEditorViewModel @Inject constructor(
     }
 
     fun onCopyKeyClicked() {
-        TODO()
+        triggerEvent(CopyContentToClipboard(R.string.custom_fields_editor_key_label, customFieldDraft.value.key))
     }
 
     fun onCopyValueClicked() {
-        TODO()
+        triggerEvent(CopyContentToClipboard(R.string.custom_fields_editor_value_label, customFieldDraft.value.value))
     }
 
     fun onBackClick() {
@@ -152,4 +153,9 @@ class CustomFieldsEditorViewModel @Inject constructor(
         val onDiscard: () -> Unit,
         val onCancel: () -> Unit
     )
+
+    data class CopyContentToClipboard(
+        @StringRes val labelResource: Int,
+        val content: String
+    ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -109,6 +109,14 @@ class CustomFieldsEditorViewModel @Inject constructor(
         )
     }
 
+    fun onCopyKeyClicked() {
+        TODO()
+    }
+
+    fun onCopyValueClicked() {
+        TODO()
+    }
+
     fun onBackClick() {
         if (state.value?.hasChanges == true) {
             showDiscardChangesDialog.value = true

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4296,4 +4296,6 @@
     <string name="custom_fields_editor_value_label">Value</string>
     <string name="custom_fields_editor_key_error_duplicate">This key is already used for another custom field.\nThe app currently does not support creating duplicate keys. Please use wp-admin to duplicate a key if needed.</string>
     <string name="custom_fields_editor_key_error_underscore">Invalid key: please remove the \"_\" character from the beginning.</string>
+    <string name="custom_fields_editor_copy_key">Copy Key</string>
+    <string name="custom_fields_editor_copy_value">Copy Value</string>
 </resources>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
@@ -246,4 +246,36 @@ class CustomFieldsEditorViewModelTest : BaseUnitTest() {
             .isEqualTo(UiString.UiStringRes(R.string.custom_fields_editor_key_error_underscore))
         assertThat(state.showDoneButton).isFalse()
     }
+
+    @Test
+    fun `when tapping copy key, then copy key to clipboard`() = testBlocking {
+        setup(editing = true)
+
+        val event = viewModel.event.runAndCaptureValues {
+            viewModel.onCopyKeyClicked()
+        }.last()
+
+        assertThat(event).isEqualTo(
+            CustomFieldsEditorViewModel.CopyContentToClipboard(
+                R.string.custom_fields_editor_key_label,
+                CUSTOM_FIELD.key
+            )
+        )
+    }
+
+    @Test
+    fun `when tapping copy value, then copy value to clipboard`() = testBlocking {
+        setup(editing = true)
+
+        val event = viewModel.event.runAndCaptureValues {
+            viewModel.onCopyValueClicked()
+        }.last()
+
+        assertThat(event).isEqualTo(
+            CustomFieldsEditorViewModel.CopyContentToClipboard(
+                R.string.custom_fields_editor_value_label,
+                CUSTOM_FIELD.valueAsString
+            )
+        )
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12578 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds two menu entries to the overflow menu to allow copying either the key or the value of the custom field.

### Steps to reproduce
1. Make sure an order has at least one custom field.
2. Open the order in the app.
3. Tap on "View custom fields"
4. Add or edit a new custom field.
5. Tap on the overflow menu.

### Testing information
Test copying the key and the value

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->