### PR TITLE
Issue/12539 notification type api improvements

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/notifications/NotificationsScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/notifications/NotificationsScreen.kt
@@ -8,7 +8,7 @@ import com.woocommerce.android.e2e.screens.TabNavComponent
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.WooNotificationBuilder
-import com.woocommerce.android.notifications.WooNotificationType.NEW_ORDER
+import com.woocommerce.android.notifications.WooNotificationType.NewOrder
 
 /**
  * This is not a screen per-se, as it shows the notification drawer with a push notification.
@@ -32,7 +32,7 @@ class NotificationsScreen(private val wooNotificationBuilder: WooNotificationBui
                 icon = "https://s.wp.com/wp-content/mu-plugins/notes/images/update-payment-2x.png",
                 noteTitle = getTranslatedString(R.string.tests_notification_new_order_title),
                 noteMessage = getTranslatedString(R.string.tests_notification_new_order_message),
-                noteType = NEW_ORDER,
+                noteType = NewOrder,
                 channelType = NotificationChannelType.NEW_ORDER
             ),
             isGroupNotification = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Notification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Notification.kt
@@ -26,16 +26,13 @@ data class Notification(
     val data: String? = null
 ) : Parcelable {
     @IgnoredOnParcel
-    val isOrderNotification = noteType == WooNotificationType.NEW_ORDER
+    val isOrderNotification = noteType is WooNotificationType.NewOrder
 
     @IgnoredOnParcel
-    val isReviewNotification = noteType == WooNotificationType.PRODUCT_REVIEW
+    val isReviewNotification = noteType is WooNotificationType.ProductReview
 
     @IgnoredOnParcel
-    val isBlazeNotification = noteType == WooNotificationType.BLAZE_APPROVED_NOTE ||
-        noteType == WooNotificationType.BLAZE_REJECTED_NOTE ||
-        noteType == WooNotificationType.BLAZE_CANCELLED_NOTE ||
-        noteType == WooNotificationType.BLAZE_PERFORMED_NOTE
+    val isBlazeNotification = noteType is WooNotificationType.BlazeStatusUpdate
 
     /**
      * Notifications are grouped based on the notification type and the store the notification belongs to.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationType.kt
@@ -47,7 +47,6 @@ sealed interface WooNotificationType : Parcelable {
     }
 }
 
-
 fun NotificationModel.getWooType(): WooNotificationType {
     return when (this.type) {
         NotificationModel.Kind.STORE_ORDER -> WooNotificationType.NewOrder

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationType.kt
@@ -1,32 +1,49 @@
 package com.woocommerce.android.notifications
 
 import android.os.Parcelable
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 
 sealed interface WooNotificationType : Parcelable {
-    @Parcelize
-    data object NewOrder : WooNotificationType
+    val trackingValue: String
 
     @Parcelize
-    data object ProductReview : WooNotificationType
+    data object NewOrder : WooNotificationType {
+        @IgnoredOnParcel override val trackingValue: String = "NEW_ORDER"
+    }
 
     @Parcelize
-    data object LocalReminder : WooNotificationType
+    data object ProductReview : WooNotificationType {
+        @IgnoredOnParcel override val trackingValue: String = "PRODUCT_REVIEW"
+    }
+
+    @Parcelize
+    data object LocalReminder : WooNotificationType {
+        @IgnoredOnParcel override val trackingValue: String = "LOCAL_REMINDER"
+    }
 
     @Parcelize
     sealed interface BlazeStatusUpdate : WooNotificationType, Parcelable {
         @Parcelize
-        data object BlazeApprovedNote : BlazeStatusUpdate
+        data object BlazeApprovedNote : BlazeStatusUpdate {
+            @IgnoredOnParcel override val trackingValue: String = "blaze_approved_note"
+        }
 
         @Parcelize
-        data object BlazeRejectedNote : BlazeStatusUpdate
+        data object BlazeRejectedNote : BlazeStatusUpdate {
+            @IgnoredOnParcel override val trackingValue: String = "blaze_rejected_note"
+        }
 
         @Parcelize
-        data object BlazeCancelledNote : BlazeStatusUpdate
+        data object BlazeCancelledNote : BlazeStatusUpdate {
+            @IgnoredOnParcel override val trackingValue: String = "blaze_cancelled_note"
+        }
 
         @Parcelize
-        data object BlazePerformedNote : BlazeStatusUpdate
+        data object BlazePerformedNote : BlazeStatusUpdate {
+            @IgnoredOnParcel override val trackingValue: String = "blaze_performed_note"
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationType.kt
@@ -1,25 +1,44 @@
 package com.woocommerce.android.notifications
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 
-enum class WooNotificationType {
-    NEW_ORDER,
-    PRODUCT_REVIEW,
-    LOCAL_REMINDER,
-    BLAZE_APPROVED_NOTE,
-    BLAZE_REJECTED_NOTE,
-    BLAZE_CANCELLED_NOTE,
-    BLAZE_PERFORMED_NOTE,
+sealed interface WooNotificationType : Parcelable {
+    @Parcelize
+    data object NewOrder : WooNotificationType
+
+    @Parcelize
+    data object ProductReview : WooNotificationType
+
+    @Parcelize
+    data object LocalReminder : WooNotificationType
+
+    @Parcelize
+    sealed interface BlazeStatusUpdate : WooNotificationType, Parcelable {
+        @Parcelize
+        data object BlazeApprovedNote : BlazeStatusUpdate
+
+        @Parcelize
+        data object BlazeRejectedNote : BlazeStatusUpdate
+
+        @Parcelize
+        data object BlazeCancelledNote : BlazeStatusUpdate
+
+        @Parcelize
+        data object BlazePerformedNote : BlazeStatusUpdate
+    }
 }
+
 
 fun NotificationModel.getWooType(): WooNotificationType {
     return when (this.type) {
-        NotificationModel.Kind.STORE_ORDER -> WooNotificationType.NEW_ORDER
-        NotificationModel.Kind.COMMENT -> WooNotificationType.PRODUCT_REVIEW
-        NotificationModel.Kind.BLAZE_APPROVED_NOTE -> WooNotificationType.BLAZE_APPROVED_NOTE
-        NotificationModel.Kind.BLAZE_REJECTED_NOTE -> WooNotificationType.BLAZE_REJECTED_NOTE
-        NotificationModel.Kind.BLAZE_CANCELLED_NOTE -> WooNotificationType.BLAZE_CANCELLED_NOTE
-        NotificationModel.Kind.BLAZE_PERFORMED_NOTE -> WooNotificationType.BLAZE_PERFORMED_NOTE
-        else -> WooNotificationType.LOCAL_REMINDER
+        NotificationModel.Kind.STORE_ORDER -> WooNotificationType.NewOrder
+        NotificationModel.Kind.COMMENT -> WooNotificationType.ProductReview
+        NotificationModel.Kind.BLAZE_APPROVED_NOTE -> WooNotificationType.BlazeStatusUpdate.BlazeApprovedNote
+        NotificationModel.Kind.BLAZE_REJECTED_NOTE -> WooNotificationType.BlazeStatusUpdate.BlazeRejectedNote
+        NotificationModel.Kind.BLAZE_CANCELLED_NOTE -> WooNotificationType.BlazeStatusUpdate.BlazeCancelledNote
+        NotificationModel.Kind.BLAZE_PERFORMED_NOTE -> WooNotificationType.BlazeStatusUpdate.BlazePerformedNote
+        else -> WooNotificationType.LocalReminder
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
@@ -11,7 +11,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.notifications.NotificationChannelType.OTHER
 import com.woocommerce.android.notifications.WooNotificationBuilder
-import com.woocommerce.android.notifications.WooNotificationType.LOCAL_REMINDER
+import com.woocommerce.android.notifications.WooNotificationType.LocalReminder
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_DATA
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_DESC
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler.Companion.LOCAL_NOTIFICATION_ID
@@ -102,7 +102,7 @@ class LocalNotificationWorker @AssistedInject constructor(
         icon = null,
         noteTitle = title,
         noteMessage = description,
-        noteType = LOCAL_REMINDER,
+        noteType = LocalReminder,
         channelType = OTHER,
         data = data
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
@@ -18,7 +18,7 @@ class NotificationAnalyticsTracker @Inject constructor(
         val isFromSelectedSite = selectedSite.getIfExists()?.siteId == notification.remoteSiteId
         val properties = mutableMapOf<String, Any>()
         properties["notification_note_id"] = notification.remoteNoteId
-        properties["notification_type"] = notification.noteType.name
+        properties["notification_type"] = notification.noteType.trackingValue
         properties["push_notification_token"] = appPrefsWrapper.getFCMToken()
         properties["is_from_selected_site"] = isFromSelectedSite == true
         analyticsTrackerWrapper.track(stat, properties)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -13,7 +13,7 @@ import com.woocommerce.android.model.isOrderNotification
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.WooNotificationBuilder
-import com.woocommerce.android.notifications.WooNotificationType.NEW_ORDER
+import com.woocommerce.android.notifications.WooNotificationType.NewOrder
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.NotificationsParser
 import com.woocommerce.android.util.WooLog.T.NOTIFS
@@ -128,7 +128,7 @@ class NotificationMessageHandler @Inject constructor(
     }
 
     private fun handleWooNotification(notification: Notification) {
-        val randomNumber = if (notification.noteType == NEW_ORDER) Random.nextInt() else 0
+        val randomNumber = if (notification.noteType == NewOrder) Random.nextInt() else 0
         val localPushId = getLocalPushIdForNoteId(notification.remoteNoteId, randomNumber)
         ACTIVE_NOTIFICATIONS_MAP[getLocalPushId(localPushId, randomNumber)] = notification
         if (notificationBuilder.isNotificationsEnabled()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -15,13 +15,7 @@ import com.woocommerce.android.model.FeatureAnnouncement
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
-import com.woocommerce.android.notifications.WooNotificationType.BLAZE_APPROVED_NOTE
-import com.woocommerce.android.notifications.WooNotificationType.BLAZE_CANCELLED_NOTE
-import com.woocommerce.android.notifications.WooNotificationType.BLAZE_PERFORMED_NOTE
-import com.woocommerce.android.notifications.WooNotificationType.BLAZE_REJECTED_NOTE
-import com.woocommerce.android.notifications.WooNotificationType.LOCAL_REMINDER
-import com.woocommerce.android.notifications.WooNotificationType.NEW_ORDER
-import com.woocommerce.android.notifications.WooNotificationType.PRODUCT_REVIEW
+import com.woocommerce.android.notifications.WooNotificationType
 import com.woocommerce.android.notifications.local.LocalNotificationType
 import com.woocommerce.android.notifications.local.LocalNotificationType.BLAZE_ABANDONED_CAMPAIGN_REMINDER
 import com.woocommerce.android.notifications.local.LocalNotificationType.BLAZE_NO_CAMPAIGN_REMINDER
@@ -196,7 +190,7 @@ class MainActivityViewModel @Inject constructor(
         notificationHandler.markNotificationTapped(notification.remoteNoteId)
         notificationHandler.removeNotificationByNotificationIdFromSystemsBar(localPushId)
         when (notification.noteType) {
-            NEW_ORDER -> {
+            is WooNotificationType.NewOrder -> {
                 when {
                     siteStore.getSiteBySiteId(notification.remoteSiteId) != null -> triggerEvent(
                         ViewOrderDetail(
@@ -209,22 +203,19 @@ class MainActivityViewModel @Inject constructor(
                 }
             }
 
-            PRODUCT_REVIEW -> {
+            is WooNotificationType.ProductReview -> {
                 analyticsTrackerWrapper.track(REVIEW_OPEN)
                 triggerEvent(ViewReviewDetail(notification.uniqueId))
             }
 
-            BLAZE_APPROVED_NOTE,
-            BLAZE_REJECTED_NOTE,
-            BLAZE_CANCELLED_NOTE,
-            BLAZE_PERFORMED_NOTE -> triggerEvent(
+            is WooNotificationType.BlazeStatusUpdate -> triggerEvent(
                 ViewBlazeCampaignDetail(
                     campaignId = notification.uniqueId.toString(),
                     isOpenedFromPush = true
                 )
             )
 
-            LOCAL_REMINDER -> error("Local reminder notification should not be handled here")
+            is WooNotificationType.LocalReminder -> error("Local reminder notification should not be handled here")
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/NotificationTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/NotificationTest.kt
@@ -13,7 +13,7 @@ class NotificationTest {
         remoteSiteId = remoteSiteId,
         uniqueId = 0L,
         channelType = NotificationChannelType.NEW_ORDER,
-        noteType = WooNotificationType.NEW_ORDER
+        noteType = WooNotificationType.NewOrder
     )
 
     private val reviewNotification = NotificationTestUtils.generateTestNotification(
@@ -21,7 +21,7 @@ class NotificationTest {
         remoteSiteId = remoteSiteId,
         uniqueId = 0L,
         channelType = NotificationChannelType.REVIEW,
-        noteType = WooNotificationType.PRODUCT_REVIEW
+        noteType = WooNotificationType.ProductReview
     )
 
     private val otherNotification = NotificationTestUtils.generateTestNotification(
@@ -29,7 +29,7 @@ class NotificationTest {
         remoteSiteId = remoteSiteId,
         uniqueId = 0L,
         channelType = NotificationChannelType.OTHER,
-        noteType = WooNotificationType.LOCAL_REMINDER
+        noteType = WooNotificationType.LocalReminder
     )
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -104,7 +104,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         remoteSiteId = siteModel.siteId,
         uniqueId = TEST_BLAZE_CAMPAIGN_ID_1,
         channelType = NotificationChannelType.OTHER,
-        noteType = WooNotificationType.BlazeApprovedNote
+        noteType = WooNotificationType.BlazeStatusUpdate.BlazeApprovedNote
     )
 
     private val featureAnnouncementRepository: FeatureAnnouncementRepository = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -88,7 +88,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         remoteSiteId = siteModel.siteId,
         uniqueId = TEST_NEW_ORDER_ID_1,
         channelType = NotificationChannelType.NEW_ORDER,
-        noteType = WooNotificationType.NEW_ORDER
+        noteType = WooNotificationType.NewOrder
     )
 
     private val testReviewNotification = NotificationTestUtils.generateTestNotification(
@@ -96,7 +96,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         remoteSiteId = siteModel.siteId,
         uniqueId = TEST_NEW_REVIEW_ID_1,
         channelType = NotificationChannelType.REVIEW,
-        noteType = WooNotificationType.PRODUCT_REVIEW
+        noteType = WooNotificationType.ProductReview
     )
 
     private val testBlazeNotification = NotificationTestUtils.generateTestNotification(
@@ -104,7 +104,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         remoteSiteId = siteModel.siteId,
         uniqueId = TEST_BLAZE_CAMPAIGN_ID_1,
         channelType = NotificationChannelType.OTHER,
-        noteType = WooNotificationType.BLAZE_APPROVED_NOTE
+        noteType = WooNotificationType.BlazeApprovedNote
     )
 
     private val featureAnnouncementRepository: FeatureAnnouncementRepository = mock()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

API improvement of the current implementation fow: #12539
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Coming from this feedback: https://github.com/woocommerce/woocommerce-android/pull/12564#discussion_r1753628034 this changes aim to improve the API to handle `WooNotificationType`. The main change is converting `WooNotificationType` from `enum class` to `sealed interface`

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Passing the build checks should be enough. But in case you want to ensure everything works well feel free to smoke tests the push notifications. 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Smoke-tested push notifications

- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->