### PR TITLE
[Custom Fields] Some fixes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -83,7 +83,7 @@ class CustomFieldsEditorViewModel @Inject constructor(
 
     fun onDoneClicked() {
         val value = requireNotNull(customFieldDraft.value)
-        if (storedValue == null) {
+        if (value.id == null) {
             // Check for duplicate keys before inserting the new custom field
             // For more context: pe5sF9-33t-p2#comment-3880
             launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -99,7 +99,6 @@ class CustomFieldsEditorViewModel @Inject constructor(
 
             val event = if (storedValue == null) {
                 MultiLiveEvent.Event.ExitWithResult(data = value, key = CUSTOM_FIELD_CREATED_RESULT_KEY)
-
             } else {
                 MultiLiveEvent.Event.ExitWithResult(
                     data = CustomFieldUpdateResult(oldKey = storedValue.key, updatedField = value),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.customfields.editor
 
+import android.os.Parcelable
 import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
@@ -19,6 +20,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
@@ -99,7 +101,10 @@ class CustomFieldsEditorViewModel @Inject constructor(
                 MultiLiveEvent.Event.ExitWithResult(data = value, key = CUSTOM_FIELD_CREATED_RESULT_KEY)
 
             } else {
-                MultiLiveEvent.Event.ExitWithResult(data = value, key = CUSTOM_FIELD_UPDATED_RESULT_KEY)
+                MultiLiveEvent.Event.ExitWithResult(
+                    data = CustomFieldUpdateResult(oldKey = storedValue.key, updatedField = value),
+                    key = CUSTOM_FIELD_UPDATED_RESULT_KEY
+                )
             }
             triggerEvent(event)
         }
@@ -159,4 +164,10 @@ class CustomFieldsEditorViewModel @Inject constructor(
         @StringRes val labelResource: Int,
         val content: String
     ) : MultiLiveEvent.Event()
+
+    @Parcelize
+    data class CustomFieldUpdateResult(
+        val oldKey: String,
+        val updatedField: CustomFieldUiModel
+    ) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
@@ -64,12 +64,11 @@ class CustomFieldsFragment : BaseFragment() {
     }
 
     private fun handleResults() {
+        handleResult<CustomFieldUiModel>(CustomFieldsEditorViewModel.CUSTOM_FIELD_CREATED_RESULT_KEY) { result ->
+            viewModel.onCustomFieldInserted(result)
+        }
         handleResult<CustomFieldUiModel>(CustomFieldsEditorViewModel.CUSTOM_FIELD_UPDATED_RESULT_KEY) { result ->
-            if (result.id == null) {
-                viewModel.onCustomFieldInserted(result)
-            } else {
-                viewModel.onCustomFieldUpdated(result)
-            }
+            viewModel.onCustomFieldUpdated(result)
         }
         handleResult<CustomFieldUiModel>(CustomFieldsEditorViewModel.CUSTOM_FIELD_DELETED_RESULT_KEY) { result ->
             viewModel.onCustomFieldDeleted(result)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.customfields.CustomFieldContentType
 import com.woocommerce.android.ui.customfields.CustomFieldUiModel
 import com.woocommerce.android.ui.customfields.editor.CustomFieldsEditorViewModel
+import com.woocommerce.android.ui.customfields.editor.CustomFieldsEditorViewModel.CustomFieldUpdateResult
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -67,8 +68,8 @@ class CustomFieldsFragment : BaseFragment() {
         handleResult<CustomFieldUiModel>(CustomFieldsEditorViewModel.CUSTOM_FIELD_CREATED_RESULT_KEY) { result ->
             viewModel.onCustomFieldInserted(result)
         }
-        handleResult<CustomFieldUiModel>(CustomFieldsEditorViewModel.CUSTOM_FIELD_UPDATED_RESULT_KEY) { result ->
-            viewModel.onCustomFieldUpdated(result)
+        handleResult<CustomFieldUpdateResult>(CustomFieldsEditorViewModel.CUSTOM_FIELD_UPDATED_RESULT_KEY) { result ->
+            viewModel.onCustomFieldUpdated(result.oldKey, result.updatedField)
         }
         handleResult<CustomFieldUiModel>(CustomFieldsEditorViewModel.CUSTOM_FIELD_DELETED_RESULT_KEY) { result ->
             viewModel.onCustomFieldDeleted(result)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -183,7 +183,6 @@ private fun CustomFieldItem(
             )
             Spacer(modifier = Modifier.height(4.dp))
 
-
             if (customField.contentType != CustomFieldContentType.TEXT) {
                 val text = buildAnnotatedString {
                     withStyle(SpanStyle(color = MaterialTheme.colors.primary)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.UrlAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
@@ -182,29 +183,38 @@ private fun CustomFieldItem(
             )
             Spacer(modifier = Modifier.height(4.dp))
 
-            val text = buildAnnotatedString {
-                if (customField.contentType != CustomFieldContentType.TEXT) {
-                    pushUrlAnnotation(UrlAnnotation(customField.value))
-                    pushStyle(SpanStyle(color = MaterialTheme.colors.primary))
-                }
-                append(customField.valueStrippedHtml)
-            }
-            ClickableText(
-                text = text,
-                style = MaterialTheme.typography.body2.copy(
-                    color = MaterialTheme.colors.onSurface
-                ),
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                onClick = { offset ->
-                    text.getUrlAnnotations(
-                        start = offset,
-                        end = offset
-                    ).firstOrNull()?.let { _ ->
-                        onValueClicked(customField)
+
+            if (customField.contentType != CustomFieldContentType.TEXT) {
+                val text = buildAnnotatedString {
+                    withStyle(SpanStyle(color = MaterialTheme.colors.primary)) {
+                        pushUrlAnnotation(UrlAnnotation(customField.value))
+                        append(customField.value)
                     }
                 }
-            )
+                ClickableText(
+                    text = text,
+                    style = MaterialTheme.typography.body2.copy(
+                        color = MaterialTheme.colors.onSurface
+                    ),
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    onClick = { offset ->
+                        text.getUrlAnnotations(
+                            start = offset,
+                            end = offset
+                        ).firstOrNull()?.let { _ ->
+                            onValueClicked(customField)
+                        }
+                    }
+                )
+            } else {
+                Text(
+                    text = customField.value,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.body2
+                )
+            }
         }
 
         Icon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
@@ -97,9 +97,14 @@ class CustomFieldsViewModel @Inject constructor(
         }
     }
 
-    fun onCustomFieldUpdated(result: CustomFieldUiModel) {
+    fun onCustomFieldUpdated(oldValueKey: String, result: CustomFieldUiModel) {
         pendingChanges.update {
-            it.copy(editedFields = it.editedFields.filterNot { field -> field.id == result.id } + result)
+            if (result.id == null) {
+                // We are updating a field that was just added and hasn't been saved yet
+                it.copy(insertedFields = it.insertedFields.filterNot { field -> field.key == oldValueKey } + result)
+            } else {
+                it.copy(editedFields = it.editedFields.filterNot { field -> field.id == result.id } + result)
+            }
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
@@ -171,7 +171,7 @@ class CustomFieldsEditorViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when done is clicked, then exit with result`() = testBlocking {
+    fun `given editing an existing field, when done is clicked, then exit with result`() = testBlocking {
         setup(editing = true)
 
         val events = viewModel.event.runAndCaptureValues {
@@ -182,8 +182,31 @@ class CustomFieldsEditorViewModelTest : BaseUnitTest() {
 
         assertThat(events).isEqualTo(
             MultiLiveEvent.Event.ExitWithResult(
-                data = CustomFieldUiModel(id = CUSTOM_FIELD_ID, key = "new key", value = "new value"),
+                data = CustomFieldsEditorViewModel.CustomFieldUpdateResult(
+                    CUSTOM_FIELD.key,
+                    CustomFieldUiModel(id = CUSTOM_FIELD_ID, key = "new key", value = "new value")
+                ),
                 key = CustomFieldsEditorViewModel.CUSTOM_FIELD_UPDATED_RESULT_KEY
+            )
+        )
+    }
+
+    @Test
+    fun `given creating a new field, when done is clicked, then exit with result`() = testBlocking {
+        setup(editing = false) {
+            whenever(repository.getDisplayableCustomFields(PARENT_ITEM_ID)).thenReturn(emptyList())
+        }
+
+        val events = viewModel.event.runAndCaptureValues {
+            viewModel.onKeyChanged("key")
+            viewModel.onValueChanged("value")
+            viewModel.onDoneClicked()
+        }.last()
+
+        assertThat(events).isEqualTo(
+            MultiLiveEvent.Event.ExitWithResult(
+                data = CustomFieldUiModel(key = "key", value = "value"),
+                key = CustomFieldsEditorViewModel.CUSTOM_FIELD_CREATED_RESULT_KEY
             )
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
@@ -217,7 +217,7 @@ class CustomFieldsViewModelTest : BaseUnitTest() {
         setup()
 
         val state = viewModel.state.runAndCaptureValues {
-            viewModel.onCustomFieldUpdated(customField)
+            viewModel.onCustomFieldUpdated(CUSTOM_FIELDS.first().key, customField)
             advanceUntilIdle()
         }.last()
 
@@ -230,8 +230,8 @@ class CustomFieldsViewModelTest : BaseUnitTest() {
         setup()
 
         val state = viewModel.state.runAndCaptureValues {
-            viewModel.onCustomFieldUpdated(customField.copy(value = "new value"))
-            viewModel.onCustomFieldUpdated(customField.copy(value = "new value 2"))
+            viewModel.onCustomFieldUpdated(CUSTOM_FIELDS.first().key, customField.copy(value = "new value"))
+            viewModel.onCustomFieldUpdated(CUSTOM_FIELDS.first().key, customField.copy(value = "new value 2"))
             advanceUntilIdle()
         }.last()
 
@@ -254,6 +254,25 @@ class CustomFieldsViewModelTest : BaseUnitTest() {
         assertThat(state.customFields).hasSize(CUSTOM_FIELDS.size + 1)
         assertThat(state.customFields.last().key).isEqualTo(customField.key)
         assertThat(state.customFields.last().value).isEqualTo(customField.value)
+    }
+
+    @Test
+    fun `when adding a custom field then updating it, then confirm the field is not duplicated`() = testBlocking {
+        val customField = CustomFieldUiModel(
+            key = "new key",
+            value = "new value"
+        )
+        setup()
+
+        val state = viewModel.state.runAndCaptureValues {
+            viewModel.onCustomFieldInserted(customField)
+            viewModel.onCustomFieldUpdated(customField.key, customField.copy(value = "new value 2"))
+            advanceUntilIdle()
+        }.last()
+
+        assertThat(state.customFields).hasSize(CUSTOM_FIELDS.size + 1)
+        assertThat(state.customFields.last().key).isEqualTo(customField.key)
+        assertThat(state.customFields.last().value).isEqualTo("new value 2")
     }
 
     @Test
@@ -325,7 +344,7 @@ class CustomFieldsViewModelTest : BaseUnitTest() {
 
         setup()
 
-        viewModel.onCustomFieldUpdated(updatedField)
+        viewModel.onCustomFieldUpdated(CUSTOM_FIELDS.first().key, updatedField)
         viewModel.onCustomFieldInserted(insertedField)
         viewModel.onSaveClicked()
 


### PR DESCRIPTION
### Description
This PR fixes some issues with the Custom Fields feature:
1. The custom field content wasn't capturing click events (this was raised [here](https://github.com/woocommerce/woocommerce-android/pull/12478#issuecomment-2329605607) and [here](https://github.com/woocommerce/woocommerce-android/pull/12484#issuecomment-2341217747)), this was fixed in 
948e8ee
2. The condition I was using to decide when to check for duplicate fields wasn't reliable, when editing a new non-saved field, we were ignoring the check, this was fixed in ad94ecd
3. We had a corner case that when editing a new non-saved field, we would add a new entry instead of updating the existing one, this was fixed in 205a684 and 
0c8557f

### Steps to reproduce
1. Make sure an order has at least one custom field.
2. Opent the order in the app.
3. Tap on View Custom Fields.

### Testing information
TC1:
- Make sure tapping on the custom field's content opens the editor.

TC2:
1. Add a new field.
2. Tap on Done.
3. Tap on the new field to edit it again.
4. Update the key to match the content of an existing one.
5. Tap on Done.
6. Confirm an error is shown.

TC3:
1. Add a new field.
2. Tap on Done.
3. Tap on the new field to edit again.
4. Make some changes.
5. Tap on Done.
6. Confirm the field was updated correctly. 

### The tests that have been performed
The above.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->