### PR TITLE
Optimize the logic of "no blaze campaign" local notification

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -119,6 +119,7 @@ object AppPrefs {
         STORE_CREATION_PROFILER_ANSWERS,
         AI_CONTENT_GENERATION_TONE,
         AI_PRODUCT_CREATION_IS_FIRST_ATTEMPT,
+        BLAZE_FIRST_TIME_WITHOUT_CAMPAIGN,
         BLAZE_CAMPAIGN_CREATED,
         BLAZE_CELEBRATION_SCREEN_SHOWN,
         BLAZE_NO_CAMPAIGN_REMINDER_SHOWN,
@@ -1046,6 +1047,16 @@ object AppPrefs {
             key = DeletablePrefKey.BLAZE_ABANDONED_CAMPAIGN_REMINDER_SHOWN,
             value = value
         )
+
+    var blazeFirstTimeWithoutCampaign: Long
+        get() = getLong(DeletablePrefKey.BLAZE_FIRST_TIME_WITHOUT_CAMPAIGN, 0L)
+        set(value) = setLong(DeletablePrefKey.BLAZE_FIRST_TIME_WITHOUT_CAMPAIGN, value)
+
+    fun removeBlazeFirstTimeWithoutCampaign() {
+        remove(DeletablePrefKey.BLAZE_FIRST_TIME_WITHOUT_CAMPAIGN)
+    }
+
+    fun existsBlazeFirstTimeWithoutCampaign() = exists(DeletablePrefKey.BLAZE_FIRST_TIME_WITHOUT_CAMPAIGN)
 
     fun setBlazeCampaignCreated(siteId: Long) {
         setBoolean(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -24,6 +24,8 @@ class AppPrefsWrapper @Inject constructor() {
 
     var isBlazeCelebrationScreenShown by AppPrefs::isBlazeCelebrationScreenShown
 
+    var blazeFirstTimeWithoutCampaign by AppPrefs::blazeFirstTimeWithoutCampaign
+
     var isBlazeNoCampaignReminderShown by AppPrefs::isBlazeNoCampaignReminderShown
 
     var isBlazeAbandonedCampaignReminderShown by AppPrefs::isBlazeAbandonedCampaignReminderShown
@@ -375,6 +377,12 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun getNotificationChannelTypeSuffix(channel: NotificationChannelType): Int? =
         AppPrefs.getNotificationChannelTypeSuffix(channel)
+
+    fun removeBlazeFirstTimeWithoutCampaign() {
+        AppPrefs.removeBlazeFirstTimeWithoutCampaign()
+    }
+
+    fun existsBlazeFirstTimeWithoutCampaign() = AppPrefs.existsBlazeFirstTimeWithoutCampaign()
 
     fun setBlazeCampaignCreated(siteId: Long) {
         AppPrefs.setBlazeCampaignCreated(siteId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationScheduler.kt
@@ -8,6 +8,7 @@ import androidx.work.WorkManager
 import androidx.work.workDataOf
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -47,6 +48,11 @@ class LocalNotificationScheduler @Inject constructor(
                 AnalyticsTracker.KEY_BLOG_ID to notification.siteId,
             )
         )
+        WooLog.d(
+            tag = WooLog.T.NOTIFICATIONS,
+            message = "Local notification scheduled: " +
+                "type=${notification.type}, delay=${notification.delay}${notification.delayUnit}"
+        )
     }
 
     private fun buildPreconditionCheckWorkRequest(notification: LocalNotification): OneTimeWorkRequest {
@@ -79,5 +85,9 @@ class LocalNotificationScheduler @Inject constructor(
 
     fun cancelScheduledNotification(type: LocalNotificationType) {
         workManager.cancelAllWorkByTag(type.value)
+        WooLog.d(
+            tag = WooLog.T.NOTIFICATIONS,
+            message = "Local notification canceled: $type"
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/local/LocalNotificationWorker.kt
@@ -75,6 +75,7 @@ class LocalNotificationWorker @AssistedInject constructor(
         when (LocalNotificationType.fromString(type)) {
             LocalNotificationType.BLAZE_NO_CAMPAIGN_REMINDER -> {
                 appsPrefsWrapper.isBlazeAbandonedCampaignReminderShown = true
+                appsPrefsWrapper.removeBlazeFirstTimeWithoutCampaign()
             }
 
             LocalNotificationType.BLAZE_ABANDONED_CAMPAIGN_REMINDER -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/notification/BlazeCampaignsObserver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/notification/BlazeCampaignsObserver.kt
@@ -4,7 +4,9 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.extensions.daysLater
 import com.woocommerce.android.notifications.local.LocalNotification.BlazeNoCampaignReminderNotification
 import com.woocommerce.android.notifications.local.LocalNotificationScheduler
+import com.woocommerce.android.notifications.local.LocalNotificationType
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.blaze.CampaignStatusUi
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -13,6 +15,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.blaze.BlazeCampaignModel
 import org.wordpress.android.fluxc.store.blaze.BlazeCampaignsStore
 import java.util.Calendar
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 /**
@@ -36,29 +39,57 @@ class BlazeCampaignsObserver @Inject constructor(
     private suspend fun observeBlazeCampaigns(site: SiteModel) {
         blazeCampaignsStore.observeBlazeCampaigns(site)
             .filter { it.isNotEmpty() }
-            .collectLatest { scheduleNotification(it) }
+            .collectLatest { processCampaigns(it) }
     }
 
-    private fun scheduleNotification(campaigns: List<BlazeCampaignModel>) {
+    private fun processCampaigns(campaigns: List<BlazeCampaignModel>) {
         if (campaigns.isEmpty()) {
             // There are no campaigns. Skip scheduling the notification.
             return
+        } else if (hasActiveEndlessCampaigns(campaigns)) {
+            appPrefsWrapper.removeBlazeFirstTimeWithoutCampaign()
+            localNotificationScheduler.cancelScheduledNotification(LocalNotificationType.BLAZE_NO_CAMPAIGN_REMINDER)
+        } else if (campaigns.any { CampaignStatusUi.isActive(it.uiStatus) }) {
+            // There are active limited campaigns.
+            val latestEndTime = getLatestEndTimeOfActiveLimitedCampaigns(campaigns)
+            scheduleNotification(latestEndTime)
+        } else if (!appPrefsWrapper.existsBlazeFirstTimeWithoutCampaign() ||
+            appPrefsWrapper.blazeFirstTimeWithoutCampaign > Calendar.getInstance().time.time
+        ) {
+            scheduleNotification(Calendar.getInstance().time.time)
         }
-
-        val delayForNotification = calculateDelayForNotification(campaigns)
-
-        localNotificationScheduler.scheduleNotification(
-            BlazeNoCampaignReminderNotification(selectedSite.get().siteId, delayForNotification)
-        )
     }
 
-    private fun calculateDelayForNotification(campaigns: List<BlazeCampaignModel>): Long {
-        val latestEndTime = campaigns.maxOf { it.startTime.daysLater(it.durationInDays) }
-        val notificationTime = latestEndTime.daysLater(DAYS_DURATION_NO_CAMPAIGN_REMINDER_NOTIFICATION)
-        return notificationTime.time - Calendar.getInstance().time.time
+    private fun hasActiveEndlessCampaigns(campaigns: List<BlazeCampaignModel>) = campaigns.any {
+        it.isEndlessCampaign && CampaignStatusUi.isActive(it.uiStatus)
+    }
+
+    private fun getLatestEndTimeOfActiveLimitedCampaigns(campaigns: List<BlazeCampaignModel>): Long {
+        val activeLimitedCampaigns = campaigns.filter {
+            !it.isEndlessCampaign && CampaignStatusUi.isActive(it.uiStatus)
+        }
+        return activeLimitedCampaigns.maxOf { it.startTime.daysLater(it.durationInDays) }.time
+    }
+
+    private fun scheduleNotification(firstTimeWithoutCampaign: Long) {
+        if (appPrefsWrapper.blazeFirstTimeWithoutCampaign == firstTimeWithoutCampaign) {
+            // There is already a scheduled notification for firstTimeWithoutCampaign.
+            return
+        }
+        appPrefsWrapper.blazeFirstTimeWithoutCampaign = firstTimeWithoutCampaign
+
+        val notificationTime = firstTimeWithoutCampaign +
+            TimeUnit.DAYS.toMillis(DAYS_DURATION_NO_CAMPAIGN_REMINDER_NOTIFICATION)
+
+        val notification = BlazeNoCampaignReminderNotification(
+            siteId = selectedSite.get().siteId,
+            delay = notificationTime - Calendar.getInstance().time.time
+        )
+
+        localNotificationScheduler.scheduleNotification(notification)
     }
 
     companion object {
-        const val DAYS_DURATION_NO_CAMPAIGN_REMINDER_NOTIFICATION = 30
+        private const val DAYS_DURATION_NO_CAMPAIGN_REMINDER_NOTIFICATION = 30L
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12574

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The current logic is not optimal as it schedules the same notification multiple times and does not effectively handle evergreen notifications. This PR updates the logic based on the flowchart below:

![flowchart](https://github.com/user-attachments/assets/8bdc9feb-37af-4d13-be3b-b3fd21781802)

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Each time a new campaign list is fetched, the logic for scheduling the reminder is triggered. I won’t provide specific testing instructions. Please test it on your own and check `Local notification canceled: blaze_no_campaign_reminder` and `Local notification scheduled: type=blaze_no_campaign_reminder, delay=2592000000MILLISECONDS` logs to verify the scheduled notifications. You don’t need to test the actual notification, as it’s outside the scope of this PR.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Please test by adding endless and limited campaigns, and removing them.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I tested each step in the flowchart by checking logs.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->