### PR TITLE
Remove site condition from abandoned Blaze campaign reminder

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -1047,15 +1047,15 @@ object AppPrefs {
             value = value
         )
 
-    fun setBlazeCampaignCreated(siteId: Long) {
+    fun setBlazeCampaignCreated() {
         setBoolean(
-            key = PrefKeyString("$BLAZE_CAMPAIGN_CREATED:$siteId"),
+            key = PrefKeyString("$BLAZE_CAMPAIGN_CREATED"),
             value = true
         )
     }
 
-    fun getBlazeCampaignCreated(siteId: Long) = getBoolean(
-        key = PrefKeyString("$BLAZE_CAMPAIGN_CREATED:$siteId"),
+    fun getBlazeCampaignCreated() = getBoolean(
+        key = PrefKeyString("$BLAZE_CAMPAIGN_CREATED"),
         default = false
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -376,9 +376,9 @@ class AppPrefsWrapper @Inject constructor() {
     fun getNotificationChannelTypeSuffix(channel: NotificationChannelType): Int? =
         AppPrefs.getNotificationChannelTypeSuffix(channel)
 
-    fun setBlazeCampaignCreated(siteId: Long) {
-        AppPrefs.setBlazeCampaignCreated(siteId)
+    fun setBlazeCampaignCreated() {
+        AppPrefs.setBlazeCampaignCreated()
     }
 
-    fun getBlazeCampaignCreated(siteId: Long) = AppPrefs.getBlazeCampaignCreated(siteId)
+    fun getBlazeCampaignCreated() = AppPrefs.getBlazeCampaignCreated()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/notification/AbandonedCampaignReminder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/notification/AbandonedCampaignReminder.kt
@@ -18,15 +18,13 @@ class AbandonedCampaignReminder @Inject constructor(
         get() = BlazeAbandonedCampaignReminderNotification(selectedSite.get().siteId)
 
     fun scheduleReminderIfNeeded() {
-        if (!appPrefsWrapper.getBlazeCampaignCreated(selectedSite.get().siteId) &&
-            !appPrefsWrapper.isBlazeAbandonedCampaignReminderShown
-        ) {
+        if (!appPrefsWrapper.getBlazeCampaignCreated() && !appPrefsWrapper.isBlazeAbandonedCampaignReminderShown) {
             localNotificationScheduler.scheduleNotification(notification)
         }
     }
 
     fun setBlazeCampaignCreated() {
-        appPrefsWrapper.setBlazeCampaignCreated(selectedSite.get().siteId)
+        appPrefsWrapper.setBlazeCampaignCreated()
         localNotificationScheduler.cancelScheduledNotification(notification.type)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a missing part of 4d55dbc9aed19ed168c8749872aedd263f912477. We forgot to remove site info from abandoned campaigns and it's handled here.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Use this patch to change 24h case with 1 minute: [_Trigger_blaze_reminder_notification_for_testing.patch](https://github.com/user-attachments/files/16806983/_Trigger_blaze_reminder_notification_for_testing.patch)
2. Clean install.
3. Select a site that is eligible for Blaze.
4. Tap the "Create campaign" button on the dashboard to start the campaign creation screen.
5. Navigate back.
6. Wait a minute.
7. Before tapping the notification, change your site.
8. Tap the notificaiton.
9. Verify that the campaign creation screen is launched, but for the previously selected site (not the current site.)

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
"Steps to reproduce" section

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->