### PR TITLE
[Product Variations] Fix variations not updating in product details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -38,6 +38,7 @@ import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.ProductFile
 import com.woocommerce.android.model.ProductGlobalAttribute
 import com.woocommerce.android.model.ProductTag
+import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.model.RequestResult
 import com.woocommerce.android.model.SubscriptionPeriod
 import com.woocommerce.android.model.addTags
@@ -2584,6 +2585,10 @@ class ProductDetailViewModel @Inject constructor(
         } else {
             null
         }
+    }
+
+    fun onProductVariationsCountChanged(numVariation: Int) {
+        updateProductDraft(numVariation = numVariation)
     }
 
     private fun observeProductCategorySearchQuery() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -38,7 +38,6 @@ import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.ProductFile
 import com.woocommerce.android.model.ProductGlobalAttribute
 import com.woocommerce.android.model.ProductTag
-import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.model.RequestResult
 import com.woocommerce.android.model.SubscriptionPeriod
 import com.woocommerce.android.model.addTags

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -2586,10 +2586,6 @@ class ProductDetailViewModel @Inject constructor(
         }
     }
 
-    fun onProductVariationsCountChanged(numVariation: Int) {
-        updateProductDraft(numVariation = numVariation)
-    }
-
     private fun observeProductCategorySearchQuery() {
         viewModelScope.launch {
             productCategorySearchQuery

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
@@ -340,10 +340,9 @@ class VariationListViewModel @Inject constructor(
                     tracker.track(AnalyticsEvent.PRODUCT_VARIATION_GENERATION_SUCCESS)
                     refreshVariations(remoteProductId)
 
-                    productRepository.fetchAndGetProduct(remoteProductId)
-                        ?.let { viewState = viewState.copy(parentProduct = it, progressDialogState = Hidden) }
-
-                    viewState = viewState.copy(progressDialogState = Hidden)
+                    viewState = productRepository.fetchAndGetProduct(remoteProductId)
+                        ?.let { viewState.copy(parentProduct = it, progressDialogState = Hidden) }
+                        ?: viewState.copy(progressDialogState = Hidden)
                 }
                 else -> {
                     tracker.track(AnalyticsEvent.PRODUCT_VARIATION_GENERATION_FAILURE)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListViewModel.kt
@@ -339,6 +339,10 @@ class VariationListViewModel @Inject constructor(
                 RequestResult.SUCCESS -> {
                     tracker.track(AnalyticsEvent.PRODUCT_VARIATION_GENERATION_SUCCESS)
                     refreshVariations(remoteProductId)
+
+                    productRepository.fetchAndGetProduct(remoteProductId)
+                        ?.let { viewState = viewState.copy(parentProduct = it, progressDialogState = Hidden) }
+
                     viewState = viewState.copy(progressDialogState = Hidden)
                 }
                 else -> {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/VariationListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/VariationListViewModelTest.kt
@@ -377,6 +377,28 @@ class VariationListViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `When generated variations succeeds, then parent product is updated`() = testBlocking {
+        // Given a valid variation candidates list
+        val variationCandidates = List(5) { id ->
+            listOf(VariantOption(id.toLong(), "Number", id.toString()))
+        }
+        val expectedUpdatedProduct = product.copy(name = "Updated Product")
+
+        productRepository.stub {
+            onBlocking { fetchAndGetProduct(productRemoteId) } doReturn expectedUpdatedProduct
+        }
+        createViewModel()
+        viewModel.start()
+
+        // When AddAllVariations succeed
+        viewModel.onGenerateVariationsConfirmed(variationCandidates)
+
+        // Then parent product is updated
+        verify(productRepository).fetchAndGetProduct(productRemoteId)
+        assertThat(viewModel.viewStateLiveData.liveData.value?.parentProduct).isEqualTo(expectedUpdatedProduct)
+    }
+
+    @Test
     fun `When user requested variation generation but there are no candidates, show error`() = testBlocking {
         // given
         whenever(generateVariationCandidates(product)).thenReturn(emptyList())


### PR DESCRIPTION
Summary
==========
Fix issue #12507 by updating the Variation generation logic to update the main Product model, which was missing from the `Generate All Variations` option.

Screen Capture
==========
https://github.com/user-attachments/assets/77f7d86c-1a8b-4961-85c0-aee3c6010b4c

How to Test
==========
1. Create a brand new Variable Product configured with Attributes to enable Variation creation
2. Enter the Product Details section and select `Add variations`
3. Click in the `Generate Variations` option
4. After the creation is done, hit back and verify that the `Add variation` button is gone, and where it was previously, is a `Variations` label with the number of variations associated with that product.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.
