### PR TITLE
[WOO POS] UI changes on the cart screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/adapter/MultipleCardReadersFoundViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/adapter/MultipleCardReadersFoundViewHolder.kt
@@ -41,7 +41,10 @@ sealed class MultipleCardReadersFoundViewHolder(
         var binding: CardReaderConnectScanningItemBinding = CardReaderConnectScanningItemBinding.bind(itemView)
 
         init {
-            WooAnimUtils.rotate(binding.cardReaderConnectProgressIndicator)
+            WooAnimUtils.rotate(
+                binding.cardReaderConnectProgressIndicator,
+                rotationDirection = WooAnimUtils.RotationDirection.ANTICLOCKWISE
+            )
         }
 
         override fun onBind(uiState: ListItemViewState) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -147,8 +147,8 @@ private fun WooPosCartScreen(
 
         AnimatedVisibility(
             visible = state.isCheckoutButtonVisible,
-            enter = fadeIn(),
-            exit = fadeOut(),
+            enter = fadeIn(animationSpec = tween(1000)),
+            exit = fadeOut(animationSpec = tween(1000)),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp.toAdaptivePadding())
@@ -298,8 +298,8 @@ private fun CartToolbar(
 
         AnimatedVisibility(
             visible = toolbar.backIconVisible,
-            enter = fadeIn(animationSpec = tween(300)) + expandHorizontally(),
-            exit = fadeOut(animationSpec = tween(300)) + shrinkHorizontally()
+            enter = fadeIn(animationSpec = tween(1000)) + expandHorizontally(),
+            exit = fadeOut(animationSpec = tween(1000)) + shrinkHorizontally()
         ) {
             IconButton(
                 onClick = { onBackClicked() },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooAnimUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WooAnimUtils.kt
@@ -165,17 +165,40 @@ object WooAnimUtils {
         view.isVisible = isVisible
     }
 
-    fun rotate(view: View, duration: Duration = EXTRA_LONG) {
-        val rotationAnimation: Animation = RotateAnimation(
-            DEGREES_0,
-            DEGREES_360,
-            Animation.RELATIVE_TO_SELF,
-            PIVOT_CENTER,
-            Animation.RELATIVE_TO_SELF,
-            PIVOT_CENTER
-        )
+    fun rotate(
+        view: View,
+        rotationDirection: RotationDirection = RotationDirection.CLOCKWISE,
+        duration: Duration = EXTRA_LONG
+    ) {
+        val rotationAnimation = when (rotationDirection) {
+            RotationDirection.CLOCKWISE -> {
+                RotateAnimation(
+                    DEGREES_0,
+                    DEGREES_360,
+                    Animation.RELATIVE_TO_SELF,
+                    PIVOT_CENTER,
+                    Animation.RELATIVE_TO_SELF,
+                    PIVOT_CENTER
+                )
+            }
+            RotationDirection.ANTICLOCKWISE -> {
+                RotateAnimation(
+                    DEGREES_360,
+                    DEGREES_0,
+                    Animation.RELATIVE_TO_SELF,
+                    PIVOT_CENTER,
+                    Animation.RELATIVE_TO_SELF,
+                    PIVOT_CENTER
+                )
+            }
+        }
         rotationAnimation.repeatCount = REPEAT_COUNT_LOOP
         rotationAnimation.duration = duration.toMillis(view.context)
         view.startAnimation(rotationAnimation)
+    }
+
+    enum class RotationDirection {
+        CLOCKWISE,
+        ANTICLOCKWISE,
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12593 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR does UI changes on the cart screen as per the design suggestion. Additionally, this PR also fixes the icon rotation direction while scanning for readers during IPP transaction.

**Changes:**
1. Increase delay for back arrow icon in the cart screen
2. Increase delay for cart checkout button in the cart screen
3. Fix the icon rotation direction while scanning for readers during IPP transaction

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested in both light and dark mode in tablet emulator.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/f3bca7c7-33fb-49ec-9375-02d2855a1d42



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->