### PR TITLE
Fix/12594 crash on date formatting

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -58,9 +58,10 @@ fun Date.formatToDDMMMYYYY(locale: Locale = Locale.getDefault()): String = Simpl
     locale
 ).format(this)
 
-fun Date.formatToMMMddYYYY(locale: Locale = Locale.getDefault()): String = SimpleDateFormat
-    .getDateInstance(SimpleDateFormat.MEDIUM, locale)
-    .format(this)
+fun Date.formatToMMMddYYYY(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
+    "MMM d, yyyy",
+    locale
+).format(this)
 
 fun Date.formatToMMMddYYYYhhmm(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
     "MMM d, yyyy hh:mm a",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/DateExt.kt
@@ -63,6 +63,13 @@ fun Date.formatToMMMddYYYY(locale: Locale = Locale.getDefault()): String = Simpl
     locale
 ).format(this)
 
+/**
+ * Formats the date to a string in the format "MMM d, yyyy" considering the current locale.
+ */
+fun Date.formatToLocalizedMedium(locale: Locale = Locale.getDefault()): String = SimpleDateFormat
+    .getDateInstance(SimpleDateFormat.MEDIUM, locale)
+    .format(this)
+
 fun Date.formatToMMMddYYYYhhmm(locale: Locale = Locale.getDefault()): String = SimpleDateFormat(
     "MMM d, yyyy hh:mm a",
     locale

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/budget/BlazeCampaignBudgetScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/budget/BlazeCampaignBudgetScreen.kt
@@ -49,7 +49,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.drawable
-import com.woocommerce.android.extensions.formatToMMMddYYYY
+import com.woocommerce.android.extensions.formatToLocalizedMedium
 import com.woocommerce.android.ui.blaze.BlazeRepository.Companion.CAMPAIGN_MAXIMUM_DAILY_SPEND
 import com.woocommerce.android.ui.blaze.BlazeRepository.Companion.CAMPAIGN_MINIMUM_DAILY_SPEND
 import com.woocommerce.android.ui.blaze.creation.budget.BlazeCampaignBudgetViewModel.BudgetUiState
@@ -504,7 +504,7 @@ private fun EditDurationBottomSheet(
                         .clip(RoundedCornerShape(4.dp))
                         .background(colorResource(id = color.divider_color))
                         .padding(8.dp),
-                    text = selectedStartDate.formatToMMMddYYYY(),
+                    text = selectedStartDate.formatToLocalizedMedium(),
                     style = MaterialTheme.typography.body1,
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/budget/BlazeCampaignBudgetViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/budget/BlazeCampaignBudgetViewModel.kt
@@ -8,8 +8,8 @@ import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CREATION_EDIT_BUDG
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CREATION_EDIT_BUDGET_SET_DURATION_APPLIED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.formatToLocalizedMedium
 import com.woocommerce.android.extensions.formatToMMMdd
-import com.woocommerce.android.extensions.formatToMMMddYYYY
 import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.ui.blaze.BlazeRepository.Budget
 import com.woocommerce.android.ui.blaze.BlazeRepository.Companion.CAMPAIGN_MAX_DURATION
@@ -225,12 +225,12 @@ class BlazeCampaignBudgetViewModel @Inject constructor(
 
     private fun getFormattedStartDate(startDateMillis: Long, isEndlessCampaign: Boolean) =
         when {
-            isEndlessCampaign -> Date(startDateMillis).formatToMMMddYYYY()
+            isEndlessCampaign -> Date(startDateMillis).formatToLocalizedMedium()
             else -> Date(startDateMillis).formatToMMMdd()
         }
 
     private fun getFormattedEndDate(startDateMillis: Long, duration: Int) =
-        Date(startDateMillis + duration.days.inWholeMilliseconds).formatToMMMddYYYY()
+        Date(startDateMillis + duration.days.inWholeMilliseconds).formatToLocalizedMedium()
 
     private fun formatBudget(rawValue: Float) =
         currencyFormatter.formatCurrencyRounded(rawValue.toDouble(), navArgs.budget.currencyCode)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -9,8 +9,8 @@ import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CREATION_EDIT_AD_T
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CREATION_FORM_DISPLAYED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.extensions.formatToLocalizedMedium
 import com.woocommerce.android.extensions.formatToMMMdd
-import com.woocommerce.android.extensions.formatToMMMddYYYY
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.ui.blaze.BlazeRepository.AiSuggestionForAd
@@ -326,7 +326,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
             isEndlessCampaign -> resourceProvider.getString(
                 R.string.blaze_campaign_preview_days_duration_endless,
                 totalBudgetWithCurrency,
-                startDate.formatToMMMddYYYY()
+                startDate.formatToLocalizedMedium()
             )
 
             else ->


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12594
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
I applied this [change](https://github.com/woocommerce/woocommerce-android/commit/9c470750d43741ff037e7469cd62f5e4357b4ae9) to improve date formatting localization, but it resulted in some crashes in places where we don't want to localize dates. 
This PR revert the [change](https://github.com/woocommerce/woocommerce-android/commit/9c470750d43741ff037e7469cd62f5e4357b4ae9) and adds a new function that formats dates in a localized style. To keep the changes as safe as possible, this new function is only being used for displaying dates in Blaze feature. 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. From `trunk` launch the app. 
2. Change app language to something different than English. 
3. Open product detail > price > schedule sale > Select start date. 
4. The app Will crash


https://github.com/user-attachments/assets/104724f8-cab4-467b-a46a-4d317b1b5766


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Repeat the same steps above and check the app doesn't crash. 
Also verify that dates are displayed correctly for Blaze feature

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested editing product sales doesn't crash the app (when app language set to Spanish)
Smoke tested Blaze campaign creation and verified dates are displayed correctly. 

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->12594