### PR TITLE
Issue/12597 custom fields banner

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -128,6 +128,7 @@ object AppPrefs {
         CHA_CHING_SOUND_ISSUE_DIALOG_DISMISSED,
         TIMES_AI_PRODUCT_CREATION_SURVEY_DISPLAYED,
         AI_PRODUCT_CREATION_SURVEY_DISMISSED,
+        CUSTOM_FIELDS_TOP_BANNER_DISMISSED,
     }
 
     /**
@@ -268,6 +269,10 @@ object AppPrefs {
     var chaChingSoundIssueDialogDismissed: Boolean
         get() = getBoolean(DeletablePrefKey.CHA_CHING_SOUND_ISSUE_DIALOG_DISMISSED, false)
         set(value) = setBoolean(DeletablePrefKey.CHA_CHING_SOUND_ISSUE_DIALOG_DISMISSED, value)
+
+    var isCustomFieldsTopBannerDismissed: Boolean
+        get() = getBoolean(DeletablePrefKey.CUSTOM_FIELDS_TOP_BANNER_DISMISSED, false)
+        set(value) = setBoolean(DeletablePrefKey.CUSTOM_FIELDS_TOP_BANNER_DISMISSED, value)
 
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -38,6 +38,8 @@ class AppPrefsWrapper @Inject constructor() {
 
     var isAiProductCreationSurveyDismissed by AppPrefs::isAiProductCreationSurveyDismissed
 
+    var isCustomFieldsTopBannerDismissed by AppPrefs::isCustomFieldsTopBannerDismissed
+
     fun getAppInstallationDate() = AppPrefs.installationDate
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/ExpandableTopBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/ExpandableTopBanner.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Card
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
@@ -72,6 +74,7 @@ fun ExpandableTopBanner(
                 Text(
                     text = message,
                     style = MaterialTheme.typography.body2,
+                    color = LocalContentColor.current.copy(alpha = ContentAlpha.medium),
                     modifier = Modifier.padding(start = 48.dp, end = 16.dp)
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/ExpandableTopBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/ExpandableTopBanner.kt
@@ -1,0 +1,121 @@
+package com.woocommerce.android.ui.compose.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Card
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Campaign
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun ExpandableTopBanner(
+    title: String,
+    message: String,
+    buttons: @Composable RowScope.() -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        shape = RectangleShape,
+        modifier = modifier
+    ) {
+        var isExpanded by rememberSaveable { mutableStateOf(false) }
+
+        Column {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .clickable { isExpanded = !isExpanded }
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Campaign,
+                    contentDescription = null,
+                    tint = MaterialTheme.colors.primary
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.subtitle1,
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Icon(
+                    imageVector = if (isExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                    contentDescription = null,
+                    tint = MaterialTheme.colors.primary
+                )
+            }
+
+            AnimatedVisibility(visible = isExpanded) {
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.body2,
+                    modifier = Modifier.padding(start = 48.dp, end = 16.dp)
+                )
+            }
+
+            Row(
+                modifier = Modifier
+                    .align(Alignment.End)
+                    .padding(horizontal = 16.dp)
+            ) {
+                buttons()
+            }
+        }
+    }
+}
+
+@Composable
+fun ExpandableTopBanner(
+    title: String,
+    message: String,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ExpandableTopBanner(
+        title = title,
+        message = message,
+        buttons = {
+            WCTextButton(
+                onClick = onDismiss,
+            ) {
+                Text(stringResource(id = R.string.dismiss))
+            }
+        },
+        modifier = modifier
+    )
+}
+
+@Composable
+@LightDarkThemePreviews
+private fun ExpandableTopBannerPreview() {
+    WooThemeWithBackground {
+        ExpandableTopBanner(
+            title = "Title",
+            message = "Message",
+            onDismiss = {},
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/ExpandableTopBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/ExpandableTopBanner.kt
@@ -37,13 +37,14 @@ fun ExpandableTopBanner(
     title: String,
     message: String,
     buttons: @Composable RowScope.() -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    expandedByDefault: Boolean = false,
 ) {
     Card(
         shape = RectangleShape,
         modifier = modifier
     ) {
-        var isExpanded by rememberSaveable { mutableStateOf(false) }
+        var isExpanded by rememberSaveable { mutableStateOf(expandedByDefault) }
 
         Column {
             Row(
@@ -95,7 +96,8 @@ fun ExpandableTopBanner(
     title: String,
     message: String,
     onDismiss: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    expandedByDefault: Boolean = false,
 ) {
     ExpandableTopBanner(
         title = title,
@@ -107,7 +109,8 @@ fun ExpandableTopBanner(
                 Text(stringResource(id = R.string.dismiss))
             }
         },
-        modifier = modifier
+        modifier = modifier,
+        expandedByDefault = expandedByDefault,
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.DiscardChangesDialog
+import com.woocommerce.android.ui.compose.component.ExpandableTopBanner
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCTextButton
@@ -120,28 +121,41 @@ private fun CustomFieldsScreen(
     ) { paddingValues ->
         val pullToRefreshState = rememberPullRefreshState(state.isRefreshing, onPullToRefresh)
 
-        Box(
+        Column(
             modifier = Modifier
                 .padding(paddingValues)
-                .pullRefresh(state = pullToRefreshState)
         ) {
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
-                items(state.customFields) { customField ->
-                    CustomFieldItem(
-                        customField = customField,
-                        onClicked = onCustomFieldClicked,
-                        onValueClicked = onCustomFieldValueClicked,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    Divider()
-                }
+            if (state.topBannerState != null) {
+                ExpandableTopBanner(
+                    title = stringResource(id = R.string.custom_fields_list_top_banner_title),
+                    message = stringResource(id = R.string.custom_fields_list_top_banner_message),
+                    onDismiss = state.topBannerState.onDismiss,
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
+            Box(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .pullRefresh(state = pullToRefreshState)
+            ) {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(state.customFields) { customField ->
+                        CustomFieldItem(
+                            customField = customField,
+                            onClicked = onCustomFieldClicked,
+                            onValueClicked = onCustomFieldValueClicked,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        Divider()
+                    }
+                }
 
-            PullRefreshIndicator(
-                refreshing = state.isRefreshing,
-                state = pullToRefreshState,
-                modifier = Modifier.align(Alignment.TopCenter)
-            )
+                PullRefreshIndicator(
+                    refreshing = state.isRefreshing,
+                    state = pullToRefreshState,
+                    modifier = Modifier.align(Alignment.TopCenter)
+                )
+            }
         }
 
         if (state.isSaving) {
@@ -245,7 +259,8 @@ private fun CustomFieldsScreenPreview() {
                         )
                     ),
                     CustomFieldUiModel(CustomField(3, "key4", "https://url.com")),
-                )
+                ),
+                topBannerState = CustomFieldsViewModel.TopBannerState { }
             ),
             onPullToRefresh = {},
             onSaveClicked = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.customfields.list
 
+import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -35,6 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.SpanStyle
@@ -130,6 +132,7 @@ private fun CustomFieldsScreen(
                     title = stringResource(id = R.string.custom_fields_list_top_banner_title),
                     message = stringResource(id = R.string.custom_fields_list_top_banner_message),
                     onDismiss = state.topBannerState.onDismiss,
+                    expandedByDefault = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT,
                     modifier = Modifier.fillMaxWidth()
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
@@ -173,12 +173,17 @@ class CustomFieldsViewModel @Inject constructor(
         val isRefreshing: Boolean = false,
         val isSaving: Boolean = false,
         val hasChanges: Boolean = false,
-        val discardChangesDialogState: DiscardChangesDialogState? = null
+        val discardChangesDialogState: DiscardChangesDialogState? = null,
+        val topBannerState: TopBannerState? = null
     )
 
     data class DiscardChangesDialogState(
         val onDiscard: () -> Unit,
         val onCancel: () -> Unit
+    )
+
+    data class TopBannerState(
+        val onDismiss: () -> Unit
     )
 
     @Parcelize

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4296,6 +4296,8 @@
     <string name="custom_fields_list_saving_succeeded">Changes saved</string>
     <string name="custom_fields_list_saving_failed">Saving changes failed, please try again</string>
     <string name="custom_fields_list_field_deleted">Custom Field deleted</string>
+    <string name="custom_fields_list_top_banner_title">View and edit Custom Fields</string>
+    <string name="custom_fields_list_top_banner_message">When saving changes to custom fields, they will take effect immediately.</string>
     <string name="custom_fields_add_button">Add custom fields</string>
     <string name="custom_fields_editor_key_label">Key</string>
     <string name="custom_fields_editor_value_label">Value</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12597 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds a banner to the custom fields list screen to show a message that would help explaining how the saving works for them, in contrast to how it works in the other parts of the Product Details.
For more information on why we need this and how we reached this decision please check this discussion p1725968896022239/1725948493.332539-slack-C03L1NF1EA3 

### Steps to reproduce
1. Ensure an order has at least one custom field.
2. Open the order in the app.
3. Tap on View Custom Fields.

### Testing information
1. Confirm the top banner is shown.
2. Confirm it can be dismissed.

### The tests that have been performed
The above.

### Images/gif
<img width=300 src=https://github.com/user-attachments/assets/2b36758b-da96-4bd6-80a7-8f328f0de164/>

---------
- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->