### PR TITLE
Wrong package calculation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 20.4
 -----
 - [**] Users can now scan their tracking number when adding it to the order [https://github.com/woocommerce/woocommerce-android/pull/12533]
+- [*] Fixed an issue where shipping labels were incorrectly calculating the weight for packages containing multiple quantities of the same product [https://github.com/woocommerce/woocommerce-android/pull/12602]
 
 20.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModel.kt
@@ -102,7 +102,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         loadProductsWeightsIfNeeded(order)
 
         val items = order.getShippableItems().map { it.toShippingItem() }
-        val totalWeight = items.sumByFloat { it.weight * it.quantity } + (lastUsedPackage?.boxWeight ?: 0f)
+        val totalWeight = getPackageTotalWeight(items, lastUsedPackage?.boxWeight ?: 0f)
         return listOf(
             ShippingLabelPackage(
                 position = 1,
@@ -111,6 +111,10 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
                 items = items
             )
         )
+    }
+
+    private fun getPackageTotalWeight(items: List<ShippingLabelPackage.Item>, packageWeight: Float): Float {
+        return items.sumByFloat { it.weight * it.quantity } + packageWeight
     }
 
     private suspend fun loadProductsWeightsIfNeeded(order: Order) {
@@ -179,7 +183,7 @@ class EditShippingLabelPackagesViewModel @Inject constructor(
         val packages = viewState.packagesUiModels.toMutableList()
         val updatedPackage = with(packages[position].data) {
             val weight = if (!viewState.packagesWithEditedWeight.contains(packageId)) {
-                items.sumByFloat { it.weight } + selectedPackage.boxWeight
+                getPackageTotalWeight(items, selectedPackage.boxWeight)
             } else {
                 weight
             }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/shippinglabels/creation/EditShippingLabelPackagesViewModelTest.kt
@@ -406,4 +406,26 @@ class EditShippingLabelPackagesViewModelTest : BaseUnitTest() {
             )
         )
     }
+
+    @Test
+    fun `when the package selected changes, then the weight is updated`() = testBlocking {
+        val item1 = defaultItem.copy(quantity = 2, weight = 2f)
+        val item2 = defaultItem.copy(quantity = 1, weight = 5f)
+        val items = listOf(item1, item2)
+        val currentShippingPackages = arrayOf(
+            CreateShippingLabelTestUtils.generateShippingLabelPackage(
+                items = items,
+                weight = 10f
+            )
+        )
+        val selectedPackage = CreateShippingLabelTestUtils.generatePackage()
+        val expectedWeight = 5f + (2f * 2f) + selectedPackage.boxWeight
+
+        setup(currentShippingPackages)
+
+        viewModel.onPackageSelected(0, selectedPackage)
+
+        val packages = viewModel.viewStateData.liveData.value!!.packages
+        assertThat(packages.first().weight).isEqualTo(expectedWeight)
+    }
 }


### PR DESCRIPTION
Closes: #12596 

### Description
The current implementation of `onPackageSelected` incorrectly calculated the total weight of a new package by only considering the weight of the items and not the quantity. This led to inaccurate weight calculations, impacting shipping rates.

**To address this issue, I have:**

- Extracted package weight calculation logic: The package weight calculation has been encapsulated into a dedicated function, getPackageTotalWeight. This promotes code reusability and maintainability.
- Improved calculation accuracy: The getPackageTotalWeight function now correctly calculates the total weight by considering the weight of each item, the quantity of each item, and the weight of the shipping box itself.

##### Issue description
> In the existing (legacy) shipping labels flow: If I have multiples of the same product in one package, the shipping weight is calculated incorrectly. Only the weight for one of each product is included in the calculation, so my package weight is lower than it should be. This means the shipping rate is incorrect (too low) and the shipping carrier will have to make an adjustment.

### Steps to reproduce

1. Enable the WooCommerce Shipping & Tax extension and set it up on your store.
2. Make sure you have at least one product with the weight defined in the product's shipping settings.
3. Create an order and add the product to it with a quantity of 2 or more.
4. In order details, tap "Create shipping label" to start the shipping label flow.
5. Confirm the shipping addresses.
6. In the package selection screen, notice that the package weight is correct.
7. Select a package and notice that the package weight is incorrect — it is now the sum of the package weight and a single product.

### Testing information
1. Enable the WooCommerce Shipping & Tax extension and set it up on your store.
2. Make sure you have at least one product with the weight defined in the product's shipping settings.
3. Create an order and add the product to it with a quantity of 2 or more.
4. In order details, tap "Create shipping label" to start the shipping label flow.
5. Confirm the shipping addresses.
6. In the package selection screen, notice that the package weight is correct.
7. Select a package and notice that the package weight is updated and the expected (items weight considering quantity + box weight).

### The tests that have been performed
- Checked that package selection correctly updated the package weight 
- Checked that opening the package selection screen correctly updated the package weight 

### Images/gif
| Before package selection  | After package selection |
| ------------- | ------------- |
| <img width="300" src="https://github.com/user-attachments/assets/adec9685-310a-490e-8218-7673a4f8919b" /> | <img width="300" src="https://github.com/user-attachments/assets/59d98de1-605e-43e0-918d-90323a7b4edc" />  |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->