### PR TITLE
Fix NoSuchElementException on the site picker screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -140,7 +140,10 @@ class SitePickerViewModel @Inject constructor(
     }
 
     private suspend fun fetchSitesFromApi(showSkeleton: Boolean) {
-        sitePickerViewState = sitePickerViewState.copy(isSkeletonViewVisible = showSkeleton)
+        sitePickerViewState = sitePickerViewState.copy(
+            isSkeletonViewVisible = showSkeleton,
+            isPrimaryBtnVisible = false
+        )
 
         val startTime = System.currentTimeMillis()
         val result = repository.fetchWooCommerceSites()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10553 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In low memory conditions, the "Continue" button may stay visible even if the screen is in the loading state. This PR fixes this case and aims to prevent the [Sentry crash](https://a8c.sentry.io/issues/4641555369/?referrer=github_integration) that is thrown after the continue button is tapped. 

I couldn't reproduce the crash but there's a possibility this fixes the Sentry issue.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
To reproduce the visible Continue button case, use the `trunk` branch.
1. Enable "Don't keep activities" from the device's "Developer settings".
2. Go to Menu and tap the first button to open the Site Picker screen.
3. After sites are loaded, open the device's Home screen.
4. Open the Woo app again.
 
[bug.webm](https://github.com/user-attachments/assets/50b03138-e283-4496-b59c-4ad7ccf89b4a)

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Repeat the "Steps to reproduce" and verify that the "Continue button" is not visible when loading. Please also test when "Don't keep activities" is disabled.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Explained in "Testing information".

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|before|after|
|-|-|
|<img src="https://github.com/user-attachments/assets/a7adb359-0bb8-4720-bb90-ed42a1372060" width=300>|<img src="https://github.com/user-attachments/assets/6f4d4dca-6f68-49ac-b72c-27c474d8ddba" width=300>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->