### PR TITLE
An attempt to fix a crash in the Dashboard Performance card

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
@@ -649,8 +649,7 @@ class DashboardStatsView @JvmOverloads constructor(
     }
 
     private fun generateLineDataSet(revenueStats: Map<String, Double>): LineDataSet {
-        chartRevenueStats = revenueStats
-        val entries = chartRevenueStats.values.mapIndexed { index, value ->
+        val entries = revenueStats.values.mapIndexed { index, value ->
             Entry((index + 1).toFloat(), value.toFloat())
         }
         return LineDataSet(entries, "")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt
@@ -552,6 +552,7 @@ class DashboardStatsView @JvmOverloads constructor(
         fadeInLabelValue(ordersValue, orders)
 
         if (chartRevenueStats.isEmpty() || revenueStatsModel?.totalSales == 0.toDouble()) {
+            binding.chart.clear()
             isRequestingStats = false
             return
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12548 
<!-- Id number of the GitHub issue this PR addresses. -->

Please don't merge yet, I'll add a release notes entry later.

### Description
This PR is an attempt to fix a crash in the performance card. I'm not 100% certain this is the situation that the users face, but it's the only way I found where I was able to reproduce the crash.
And this is what happens according to my theory:
1. The user has a cached revenue stats that contain some data.
2. When the app is launched, the app will start by showing the cached data, then start fetching fresh data.
3. If the updated data is empty, and given these [lines](https://github.com/woocommerce/woocommerce-android/blob/618cb953618911475fcc277dc68212620ca42b72/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsView.kt#L554-L557), we'll keep displaying the cached data.
4. If the user taps on a line, then we'll get the crash.

Using the cached data followed up with a fetch is a new behavior that we [added](https://github.com/woocommerce/woocommerce-android/commit/711ebb724718822f5024117e871c0f5e71b022a9) recently (precisely as part of 19.6), and I think this could explain why the crash started happening just now.

@JorgeMucientes given your experience with the stats, I'm assigning you this for review 🙏 

### Steps to reproduce the crash
1. Use `trunk`
2. Apply the patch from below to simulate an empty revenue result after a non-empty one.
3. Open the app, and make sure the performance card is shown.
4. Switch to a tab that has some sales.
5. Tap on one of the entries.
6. Notice the crash.

### Confirm the fix
1. Use this branch
2. Repeat 2-5 from above.
3. Confirm the performance card is correctly showing "No revenue this period" and that you can't tap a line.

<details>
<summary> 

### Patch

 </summary>

```Patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt	(revision 328f85127b189b99eaae501c8457aaeeeb4a515f)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsCard.kt	(date 1726221143819)
@@ -36,6 +36,8 @@
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.util.Date
 
 @Composable
@@ -209,6 +211,16 @@
                 statsView.showErrorView(false)
                 statsView.showSkeleton(false)
                 statsView.updateView(revenueStatsState.revenueStats)
+                launch {
+                    delay(100)
+                    statsView.updateView(
+                        revenueStatsState.revenueStats?.copy(
+                            intervalList = emptyList(),
+                            totalSales = 0.0,
+                            totalOrdersCount = 0
+                        )
+                    )
+                }
             }
 
             DashboardStatsViewModel.RevenueStatsViewState.GenericError -> {
```
</details>


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->