### PR TITLE
[Product Variation Attributes] Do not use ignore case when renaming attributes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 20.5
 -----
+- [*] Fixes a bug that prevented users to rename the Product Variation Attributes to because of case insensitive checks [https://github.com/woocommerce/woocommerce-android/pull/12608]
 
 
 20.4

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -1664,7 +1664,7 @@ class ProductDetailViewModel @Inject constructor(
     fun renameAttributeInDraft(attributeId: Long, oldAttributeName: String, newAttributeName: String): Boolean {
         // first make sure an attribute with the new name doesn't already exist in the draft
         productDraftAttributes.forEach {
-            if (it.name.equals(newAttributeName, ignoreCase = true)) {
+            if (it.name.equals(newAttributeName)) {
                 triggerEvent(ShowSnackbar(R.string.product_attribute_name_already_exists))
                 return false
             }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.media.MediaFilesRepository
 import com.woocommerce.android.media.ProductImagesServiceWrapper
+import com.woocommerce.android.model.ProductAttribute
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.SelectedSite
@@ -740,6 +741,37 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         val draftTerms = draftAttribute.terms
         Assertions.assertThat(draftTerms[0]).isEqualTo(secondTerm)
         Assertions.assertThat(draftTerms[1]).isEqualTo(firstTerm)
+    }
+
+    @Test
+    fun `Re-name attribute terms is saved correctly`() = testBlocking {
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        val attributeName = "name"
+        val newName = attributeName.replaceFirstChar { it.uppercase() }
+
+        val attributes = ArrayList<ProductAttribute>()
+        attributes.add(
+            ProductAttribute(
+                id = 1,
+                name = attributeName,
+                isVariation = true,
+                isVisible = true,
+                terms = ArrayList<String>().also {
+                    it.add("one")
+                }
+            )
+        )
+
+        val storedProduct = product.copy(
+            attributes = attributes
+        )
+        doReturn(storedProduct).whenever(productRepository).getProductAsync(any())
+
+        viewModel.start()
+        viewModel.renameAttributeInDraft(1, attributeName, newName)
+
+        val draftAttribute = viewModel.productDraftAttributes[0]
+        Assertions.assertThat(draftAttribute.name).isEqualTo(newName)
     }
 
     /**


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12561 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix the issue that was preventing users from renaming their variation attributes from a different case (upper to lower or vice-versa)

Note: there are other cases where we ignore the case for attributes: when adding a new attribute, or when deleting them. I preferred to leave them like that as we could have unexpected cases if we modified. For renaming it's ok though, as this case is isolated enough.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Attempt to rename a product attribute by just changing any number of characters from lower case to upper case.
2. Then navigate back
3. See a toast stating that the product attribute
4. The product attribute won't be renamed and you'll have to remove it and add it again with the correct letter case. See screen recording for extra details.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
See steps to reproduce

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I ensured with the steps to reproduce that it's working properly. I also verified it in wc-admin

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

#### Before
https://github.com/user-attachments/assets/8067bc19-3f1b-4a21-b259-2a1153807b43

#### After


https://github.com/user-attachments/assets/b3bf7d91-810f-49a1-a8a9-dd07a4ccb927


- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->