### PR TITLE
[Wear] Use black as a background for the Spalsh Screen

### DIFF
--- a/WooCommerce-Wear/src/main/res/values/colors_base.xml
+++ b/WooCommerce-Wear/src/main/res/values/colors_base.xml
@@ -110,7 +110,7 @@
     <color name="divider_color">@color/woo_black_90_alpha_012</color>
     <color name="color_ripple_overlay">@color/woo_black_90_alpha_012</color>
     <color name="image_border_color">@color/woo_black_90_alpha_012</color>
-    <color name="splash_background">@color/woo_purple_60</color>
+    <color name="splash_background">@color/woo_black</color>
     <color name="color_toolbar">@color/woo_white</color>
     <color name="bottom_sheet_background">@color/color_surface</color>
 </resources>


### PR DESCRIPTION
### Description
The Black color as background is required by Google Play policy, so we are updating it to get the app to be compliant.

### Steps to reproduce
1. Launch the wear app on a WearOS device.

### Testing information
Confirm the splash screen has a black background now (on Wasabi and Vanilla builds, I kept the color for the Jalapeno variant as green)

### Images/gif
| Before | After |
| --- | --- |
| <img width="180" alt="Screenshot 2024-09-13 at 18 07 42" src="https://github.com/user-attachments/assets/81f75196-a9ca-4887-b173-db539d4bf8ab"> | <img width="180" alt="Screenshot 2024-09-13 at 18 08 07" src="https://github.com/user-attachments/assets/cc58e0d3-f4c5-45ea-9b25-81a7d57860a9"> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->