### PR TITLE
Add unit test for sitepicker loading state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.sitepicker
 
 import android.os.Parcelable
 import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
@@ -78,7 +79,9 @@ class SitePickerViewModel @Inject constructor(
      */
     @Suppress("OPT_IN_USAGE")
     val sitePickerViewStateData = LiveDataDelegate(savedState, SitePickerViewState())
-    private var sitePickerViewState by sitePickerViewStateData
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    var sitePickerViewState by sitePickerViewStateData
 
     private val _sites = MutableLiveData<List<SitesListItem>>()
     val sites: LiveData<List<SitesListItem>> = _sites


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “ a See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a unit test for the issue fixed in https://github.com/woocommerce/woocommerce-android/pull/12603.
- In low memory case `SitePickerViewModel` could be initialized but with its previous view state. This might cause `isPrimaryBtnVisible=true` after initialization. To mock this behavior, I set it to `true` manually after initialization. 
- I needed to handle coroutines manually and I used `StandardTestDispatcher()` for this test.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Run `given initiated, when isPrimaryBtnVisible and loading state, then primary button view is not displayed` test.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
`given initiated, when isPrimaryBtnVisible and loading state, then primary button view is not displayed`

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->