### PR TITLE
[Woo POS] UI issues fix with the cart screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosLazyColumn.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosLazyColumn.kt
@@ -65,12 +65,12 @@ fun WooPosLazyColumn(
         }
 
         if (showTopShadow.value) {
-            Shadow(modifier)
+            Shadow()
         }
 
         if (showBottomShadow.value && withBottomShadow) {
             Shadow(
-                modifier
+                Modifier
                     .align(Alignment.BottomCenter)
                     .graphicsLayer(rotationZ = 180f)
             )
@@ -79,7 +79,7 @@ fun WooPosLazyColumn(
 }
 
 @Composable
-private fun Shadow(modifier: Modifier) {
+private fun Shadow(modifier: Modifier = Modifier) {
     WooPosCard(
         shape = MaterialTheme.shapes.large,
         backgroundColor = Color.Black.copy(alpha = 0.1f),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -147,8 +147,8 @@ private fun WooPosCartScreen(
 
         AnimatedVisibility(
             visible = state.isCheckoutButtonVisible,
-            enter = fadeIn(animationSpec = tween(1000)),
-            exit = fadeOut(animationSpec = tween(1000)),
+            enter = fadeIn(animationSpec = tween(300)),
+            exit = fadeOut(animationSpec = tween(300)),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp.toAdaptivePadding())
@@ -298,8 +298,8 @@ private fun CartToolbar(
 
         AnimatedVisibility(
             visible = toolbar.backIconVisible,
-            enter = fadeIn(animationSpec = tween(1000)) + expandHorizontally(),
-            exit = fadeOut(animationSpec = tween(1000)) + shrinkHorizontally()
+            enter = fadeIn(animationSpec = tween(300)) + expandHorizontally(),
+            exit = fadeOut(animationSpec = tween(300)) + shrinkHorizontally()
         ) {
             IconButton(
                 onClick = { onBackClicked() },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosBanner.kt
@@ -64,110 +64,105 @@ fun WooPosBanner(
             modifier = Modifier
                 .fillMaxWidth()
         ) {
-            Box(
+            ConstraintLayout(
                 modifier = Modifier
-                    .fillMaxWidth()
                     .padding(32.dp.toAdaptivePadding())
+                    .fillMaxWidth()
             ) {
-                ConstraintLayout(
+                val (icon, header, description, close) = createRefs()
+
+                Box(
                     modifier = Modifier
-                        .fillMaxWidth()
-                ) {
-                    val (icon, header, description, close) = createRefs()
-
-                    Box(
-                        modifier = Modifier
-                            .size(48.dp)
-                            .constrainAs(icon) {
-                                top.linkTo(parent.top)
-                                start.linkTo(parent.start)
-                                bottom.linkTo(parent.bottom)
-                            }
-                    ) {
-                        Icon(
-                            painterResource(id = bannerIcon),
-                            contentDescription = stringResource(
-                                id = R.string.woopos_banner_simple_products_info_content_description
-                            ),
-                            tint = MaterialTheme.colors.primary,
-                            modifier = Modifier.align(Alignment.Center)
-                        )
-                    }
-
-                    Text(
-                        text = title,
-                        style = MaterialTheme.typography.h5,
-                        color = MaterialTheme.colors.onBackground.copy(alpha = 0.87f),
-                        fontWeight = FontWeight.SemiBold,
-                        modifier = Modifier
-                            .padding(
-                                start = 32.dp.toAdaptivePadding(),
-                                bottom = 8.dp.toAdaptivePadding()
-                            )
-                            .constrainAs(header) {
-                                top.linkTo(parent.top)
-                                start.linkTo(icon.end)
-                                end.linkTo(close.start)
-                                width = Dimension.fillToConstraints
-                            }
-                    )
-
-                    val annotatedText = buildAnnotatedString {
-                        append(message)
-                        withStyle(style = SpanStyle(color = MaterialTheme.colors.primary)) {
-                            append(" ")
-                            append(stringResource(id = R.string.woopos_banner_simple_products_only_message_learn_more))
+                        .size(48.dp)
+                        .constrainAs(icon) {
+                            top.linkTo(parent.top)
+                            start.linkTo(parent.start)
+                            bottom.linkTo(parent.bottom)
                         }
-                    }
+                ) {
+                    Icon(
+                        painterResource(id = bannerIcon),
+                        contentDescription = stringResource(
+                            id = R.string.woopos_banner_simple_products_info_content_description
+                        ),
+                        tint = MaterialTheme.colors.primary,
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
 
-                    Box(
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.h5,
+                    color = MaterialTheme.colors.onBackground.copy(alpha = 0.87f),
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier
+                        .padding(
+                            start = 32.dp.toAdaptivePadding(),
+                            bottom = 8.dp.toAdaptivePadding()
+                        )
+                        .constrainAs(header) {
+                            top.linkTo(parent.top)
+                            start.linkTo(icon.end)
+                            end.linkTo(close.start)
+                            width = Dimension.fillToConstraints
+                        }
+                )
+
+                val annotatedText = buildAnnotatedString {
+                    append(message)
+                    withStyle(style = SpanStyle(color = MaterialTheme.colors.primary)) {
+                        append(" ")
+                        append(stringResource(id = R.string.woopos_banner_simple_products_only_message_learn_more))
+                    }
+                }
+
+                Box(
+                    modifier = Modifier
+                        .constrainAs(description) {
+                            top.linkTo(header.bottom)
+                            start.linkTo(header.start)
+                            end.linkTo(close.start)
+                            width = Dimension.fillToConstraints
+                        }
+                        .padding(
+                            start = 24.dp.toAdaptivePadding(),
+                            end = 18.dp.toAdaptivePadding()
+                        )
+                ) {
+                    Text(
                         modifier = Modifier
-                            .constrainAs(description) {
-                                top.linkTo(header.bottom)
-                                start.linkTo(header.start)
-                                end.linkTo(close.start)
-                                width = Dimension.fillToConstraints
+                            .clickable {
+                                onLearnMore()
                             }
                             .padding(
-                                start = 24.dp.toAdaptivePadding(),
-                                end = 18.dp.toAdaptivePadding()
-                            )
-                    ) {
-                        Text(
-                            modifier = Modifier
-                                .clickable {
-                                    onLearnMore()
-                                }
-                                .padding(
-                                    start = 8.dp.toAdaptivePadding(),
-                                    top = 8.dp.toAdaptivePadding(),
-                                    bottom = 8.dp.toAdaptivePadding(),
-                                ),
-                            text = annotatedText,
-                            style = MaterialTheme.typography.body1,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colors.onBackground.copy(alpha = 0.87f)
-                        )
-                    }
-
-                    IconButton(
-                        modifier = Modifier
-                            .constrainAs(close) {
-                                top.linkTo(header.top)
-                                bottom.linkTo(header.bottom)
-                                end.linkTo(parent.end)
-                            },
-                        onClick = { onClose() }
-                    ) {
-                        Icon(
-                            modifier = Modifier.size(32.dp),
-                            imageVector = Icons.Default.Close,
-                            tint = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
-                            contentDescription = stringResource(
-                                id = R.string.woopos_banner_simple_products_close_content_description
+                                start = 8.dp.toAdaptivePadding(),
+                                top = 8.dp.toAdaptivePadding(),
+                                bottom = 8.dp.toAdaptivePadding(),
                             ),
-                        )
-                    }
+                        text = annotatedText,
+                        style = MaterialTheme.typography.body1,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colors.onBackground.copy(alpha = 0.87f)
+                    )
+                }
+
+                IconButton(
+                    modifier = Modifier
+                        .constrainAs(close) {
+                            top.linkTo(header.top)
+                            bottom.linkTo(header.bottom)
+                            end.linkTo(parent.end)
+                        },
+                    onClick = { onClose() }
+                ) {
+                    Icon(
+                        modifier = Modifier.size(32.dp),
+                        imageVector = Icons.Default.Close,
+                        tint = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
+                        contentDescription = stringResource(
+                            id = R.string.woopos_banner_simple_products_close_content_description
+                        ),
+                    )
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosBanner.kt
@@ -66,7 +66,7 @@ fun WooPosBanner(
         ) {
             ConstraintLayout(
                 modifier = Modifier
-                    .padding(32.dp.toAdaptivePadding())
+                    .padding(24.dp.toAdaptivePadding())
                     .fillMaxWidth()
             ) {
                 val (icon, header, description, close) = createRefs()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12618
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR:
* Fixes the broken top shadow and missing bottom shadow for the cart products list
* The fade-out animation is too long -> get it back to 300
* The animation of the back arrow is too long -> get it back to 300
* Changed outer padding from 32 to 24 on the products banner to match the design
* ~~And the cart not aligned with the products again~~ was fixed on the trunk already

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Open the POS, notice the changes from the description. Try dark mode too

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Only what in the testing information

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/83017b19-42fa-4a96-b2fc-619117c5f52b



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->