### PR TITLE
Google for WooCommerce: Add Google Ads into "shown by default" cards list if available.

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
@@ -58,7 +58,8 @@ class DashboardDataStore @Inject constructor(
             this == DashboardWidget.Type.STATS ||
                 this == DashboardWidget.Type.POPULAR_PRODUCTS ||
                 this == DashboardWidget.Type.ONBOARDING ||
-                this == DashboardWidget.Type.BLAZE
+                this == DashboardWidget.Type.BLAZE ||
+                this == DashboardWidget.Type.GOOGLE_ADS
 
         return DashboardWidget.Type.supportedWidgets.map {
             DashboardWidgetDataModel.newBuilder()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11790
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR makes it so that if a merchant logs in to a site in the app, and the site is eligible for the Google for WooCommerce feature, then the **Google Ads Campaign** card will be displayed by default. iOS already has this behavior and this feature was one of the planned parts in i1, but I missed to add it before.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Start from a logged out state,
2. Login to a site that is eligible for Google for WooCommerce (has Google for WooCommerce plugin installed above version 2.7.7 and has its setup process completed),
3. When My Store loads for the first time, ensure that **Google Ads Campaign card** is shown.
4. Switch to a site that doesn't have Google for WooCommerce,
3. When My Store loads for the first time, ensure that **Google Ads Campaign card** is not shown.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested the steps above this on emulator with API 34, for both cases (eligible and not eligible)

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->