### PR TITLE
Issue/12146 enable Blaze for Blaze for WooCoomerce plugin

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 -----
 - [*] Fixes a bug that prevented users to rename the Product Variation Attributes to because of case insensitive checks [https://github.com/woocommerce/woocommerce-android/pull/12608]
 - [*] Users can directly pick product images when creating Blaze ads [https://github.com/woocommerce/woocommerce-android/pull/12610]
+- [*] Enables Blaze feature for sites with Blaze for WooCommerce plugin installed and active [https://github.com/woocommerce/woocommerce-android/pull/12640]
 
 20.4
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -1,17 +1,34 @@
 package com.woocommerce.android.ui.blaze
 
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.tools.SiteConnectionType.Jetpack
+import com.woocommerce.android.tools.SiteConnectionType.JetpackConnectionPackage
 import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.util.RemoteFeatureFlag.WOO_BLAZE
 import javax.inject.Inject
 
 class IsBlazeEnabled @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled,
+    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled
 ) {
+    companion object {
+        private const val BLAZE_FOR_WOOCOMMERCE_PLUGIN_SLUG = "blaze-ads"
+    }
+
     suspend operator fun invoke(): Boolean = selectedSite.getIfExists()?.isAdmin ?: false &&
-        selectedSite.connectionType == SiteConnectionType.Jetpack &&
+        hasAValidJetpackConnectionForBlaze() &&
         selectedSite.getIfExists()?.canBlaze ?: false &&
         isRemoteFeatureFlagEnabled(WOO_BLAZE)
+
+    /**
+     * In order for Blaze to work, the site requires the Jetpack Sync module to be enabled. This means not all
+     * Jetpack connection will work. For now, Blaze will only be enabled for sites with Jetpack plugin installed and
+     * active, or for sites with Blaze for WooCommerce plugin installed and connected (Jetpack CP with sync module)
+     */
+    private fun hasAValidJetpackConnectionForBlaze() =
+        selectedSite.connectionType == Jetpack ||
+            (selectedSite.connectionType == JetpackConnectionPackage && isBlazeForWooCommercePluginInstalled())
+
+    private fun isBlazeForWooCommercePluginInstalled(): Boolean =
+        selectedSite.get().activeJetpackConnectionPlugins.any { it.toString() == BLAZE_FOR_WOOCOMMERCE_PLUGIN_SLUG }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.blaze
 
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType.Jetpack
-import com.woocommerce.android.tools.SiteConnectionType.JetpackConnectionPackage
 import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.util.RemoteFeatureFlag.WOO_BLAZE
 import javax.inject.Inject
@@ -23,12 +22,11 @@ class IsBlazeEnabled @Inject constructor(
     /**
      * In order for Blaze to work, the site requires the Jetpack Sync module to be enabled. This means not all
      * Jetpack connection will work. For now, Blaze will only be enabled for sites with Jetpack plugin installed and
-     * active, or for sites with Blaze for WooCommerce plugin installed and connected (Jetpack CP with sync module)
+     * active, or for sites with Blaze for WooCommerce plugin installed and connected.
      */
     private fun hasAValidJetpackConnectionForBlaze() =
-        selectedSite.connectionType == Jetpack ||
-            (selectedSite.connectionType == JetpackConnectionPackage && isBlazeForWooCommercePluginInstalled())
+        selectedSite.connectionType == Jetpack || isBlazeForWooCommercePluginActive()
 
-    private fun isBlazeForWooCommercePluginInstalled(): Boolean =
-        selectedSite.get().activeJetpackConnectionPlugins.any { it.toString() == BLAZE_FOR_WOOCOMMERCE_PLUGIN_SLUG }
+    private fun isBlazeForWooCommercePluginActive(): Boolean =
+        selectedSite.get().activeJetpackConnectionPlugins?.contains(BLAZE_FOR_WOOCOMMERCE_PLUGIN_SLUG) == true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '3097-0d25ae0e6b61912c048702f780340d37291d4eda'
+    fluxCVersion = 'trunk-11af0e4fa36c4b057856be7bef88d86f62801f42'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = 'trunk-11af0e4fa36c4b057856be7bef88d86f62801f42'
+    fluxCVersion = 'trunk-b96c0d2e70b1a2975ef8dce322f37a9ee4a60891'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ tasks.register("installGitHooks", Copy) {
 }
 
 ext {
-    fluxCVersion = '2.96.0'
+    fluxCVersion = '3097-0d25ae0e6b61912c048702f780340d37291d4eda'
     glideVersion = '4.16.0'
     coilVersion = '2.1.0'
     constraintLayoutVersion = '1.2.0'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Requires FluxC changes to be merged first: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3097

Closes: #12146
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Enables Blaze feature when [Blaze for WooCommerce](https://woocommerce.com/products/blaze-ads/) plugin is installed on the site. 

I initially added code to fetch installed plugins for the site and see if Blaze ads was present. I later found out there's a much more convenient way to check if Blaze ads is installed and Jetpack CP connection active for it. All without requiring to fire any extra request, which is important considering `IsBlazeEnabled` use case is checked frequently. 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
1. Create a [jurassic ninja](https://jurassic.ninja/) site with WooCommerce but no Jetpack plugin. 
2. Install and activate [Blaze for WooCommerce](https://woocommerce.com/products/blaze-ads/) plugin.
3. From `wp-admin` navigate to marketing > Blaze for WooCommerce and click `Connect now`
4. Wait like a min or so, for the Jetpack sync to happen. (In my tests never took longer than 2 mins to sync the required data to display the site as `jetpack_connection:true`)
5. Log into the site where you've just installed Blaze for WooCommerce. If you were already logged in, kill the app and restart it to trigger `me/sites` request. 
6. Add at least one product. 
8. Notice how Blaze feature is enabled.
9. Create a Blaze campaign using some image selected from WordPress media library.
10. Verify campaign is created successfully 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested Blaze campaign creation flow, for self hosted site with [Blaze for WooCommerce](https://woocommerce.com/products/blaze-ads/)

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->