### PR TITLE
Missing impressions icon

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/budget/BlazeCampaignBudgetScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/budget/BlazeCampaignBudgetScreen.kt
@@ -253,12 +253,10 @@ private fun CampaignImpressionsRow(
     onBudgetChangeFinished: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.Start
-    ) {
+    Column(modifier = modifier) {
         Row(
             modifier = Modifier
+                .fillMaxWidth()
                 .clickable { onImpressionsInfoTapped() }
                 .padding(top = 8.dp, bottom = 8.dp, end = 8.dp),
             verticalAlignment = Alignment.CenterVertically,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/budget/BlazeCampaignBudgetScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/budget/BlazeCampaignBudgetScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
@@ -42,9 +44,13 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.woocommerce.android.R
 import com.woocommerce.android.R.color
 import com.woocommerce.android.R.dimen
@@ -247,19 +253,41 @@ private fun CampaignImpressionsRow(
     onBudgetChangeFinished: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier = modifier) {
-        Row(modifier = Modifier.fillMaxWidth()) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.Start
+    ) {
+        Row(
+            modifier = Modifier
+                .clickable { onImpressionsInfoTapped() }
+                .padding(top = 8.dp, bottom = 8.dp, end = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            val id = "inlineIcon"
+            val text = buildAnnotatedString {
+                append(stringResource(id = R.string.blaze_campaign_budget_reach_forecast))
+                appendInlineContent(id = id, alternateText = "[Icon]")
+            }
+            val inlineContent = mapOf(
+                id to InlineTextContent(
+                    Placeholder(
+                        width = 24.sp,
+                        height = 20.sp,
+                        placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter
+                    )
+                ) {
+                    Icon(
+                        modifier = Modifier.padding(start = 4.dp),
+                        painter = painterResource(id = drawable.ic_info_outline_20dp),
+                        contentDescription = ""
+                    )
+                }
+            )
             Text(
-                text = stringResource(id = R.string.blaze_campaign_budget_reach_forecast),
+                text = text,
+                inlineContent = inlineContent,
                 style = MaterialTheme.typography.body1,
                 color = colorResource(id = color.color_on_surface_medium)
-            )
-            Icon(
-                modifier = Modifier
-                    .padding(start = 4.dp)
-                    .clickable { onImpressionsInfoTapped() },
-                painter = painterResource(id = drawable.ic_info_outline_20dp),
-                contentDescription = null
             )
         }
         if (state.forecast.isLoading) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12562
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Fixes an issue where the ℹ️ icon next to the impression label inside the Blaze budget screen, would go missing if the text was too long. 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
From `trunk`
1. Set Woo app language to Spanish
2. Trigger Blaze campaign creation flow and navigate to the budget screen.
3. Check the ℹ️ icon is missing next to the impressions label. 

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Repeat the steps above from this branch and verify that the ℹ️ icon is displayed correctly when the text is one line (English) and when the text is 2 lines (Spanish for example)

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested Blaze campaign creation flow. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

Expected UI: 

![Screenshot 2024-09-19 at 13 35 45](https://github.com/user-attachments/assets/1c5cd589-edd5-489e-8d7d-35f7e4a08aa3)
![Screenshot 2024-09-19 at 13 35 21](https://github.com/user-attachments/assets/6a31d24f-4193-4de2-8d01-5c6534d9ebe3)


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->