### PR TITLE
Integrate security lint checks

### DIFF
--- a/WooCommerce-Wear/build.gradle
+++ b/WooCommerce-Wear/build.gradle
@@ -215,6 +215,7 @@ dependencies {
         // See https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/919
         exclude group: 'com.squareup.okhttp3'
     }
+    lintChecks "com.android.security.lint:lint:$securityLintVersion"
 }
 
 def checkGradlePropertiesFile() {

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -469,6 +469,8 @@ dependencies {
     implementation "com.google.guava:guava:$guavaVersion"
 
     implementation "com.google.protobuf:protobuf-javalite:$protobufVersion"
+
+    lintChecks "com.android.security.lint:lint:$securityLintVersion"
 }
 
 protobuf {

--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,7 @@ ext {
     protobufVersion = '3.25.3'
     gravatarVersion = '0.2.0'
     wearHorologistVersion = '0.6.10'
+    securityLintVersion = '1.0.1'
 
     // Apache
     commonsText = '1.10.0'


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR integrates additional Android Lint checks, focused on security: https://github.com/google/android-security-lints?tab=readme-ov-file

## Testing Instructions

Compare:
- security checks on trunk: https://github.com/woocommerce/woocommerce-android/security/code-scanning?query=tag%3ASecurity+is%3Aopen+tool%3A%22Android+Lint%22+branch%3Atrunk+
- security checks on this branch: https://github.com/woocommerce/woocommerce-android/security/code-scanning?query=tag%3ASecurity+is%3Aopen+tool%3A%22Android+Lint%22+pr%3A12645

This report from this branch should have more security Lint issues.
