### PR TITLE
[Notifications] Fix for ConcurrentModificationException while handling notification

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 -----
 - [*] Fixes a bug that prevented users to rename the Product Variation Attributes to because of case insensitive checks [https://github.com/woocommerce/woocommerce-android/pull/12608]
 - [*] Users can directly pick product images when creating Blaze ads [https://github.com/woocommerce/woocommerce-android/pull/12610]
+- [*] Fix for ConcurrentModificationException while removing notification [https://github.com/woocommerce/woocommerce-android/pull/12646]
 
 20.4
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -52,10 +52,12 @@ class NotificationMessageHandler @Inject constructor(
         private val ACTIVE_NOTIFICATIONS_MAP = mutableMapOf<Int, Notification>()
     }
 
+    @Synchronized
     fun onPushNotificationDismissed(notificationId: Int) {
         removeNotificationByNotificationIdFromSystemsBar(notificationId)
     }
 
+    @Synchronized
     fun onLocalNotificationDismissed(notificationId: Int, notificationType: String) {
         removeNotificationByNotificationIdFromSystemsBar(notificationId)
         AnalyticsTracker.track(
@@ -221,6 +223,7 @@ class NotificationMessageHandler @Inject constructor(
         notificationBuilder.cancelAllNotifications()
     }
 
+    @Synchronized
     fun removeNotificationByRemoteIdFromSystemsBar(remoteNoteId: Long) {
         val keptNotifs = HashMap<Int, Notification>()
         ACTIVE_NOTIFICATIONS_MAP.asSequence()
@@ -254,6 +257,7 @@ class NotificationMessageHandler @Inject constructor(
         updateNotificationsState()
     }
 
+    @Synchronized
     fun removeNotificationsOfTypeFromSystemsBar(type: NotificationChannelType, remoteSiteId: Long) {
         val keptNotifs = HashMap<Int, Notification>()
         // Using a copy of the map to avoid concurrency problems

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -237,6 +237,7 @@ class NotificationMessageHandler @Inject constructor(
         updateNotificationsState()
     }
 
+    @Synchronized
     fun removeNotificationByNotificationIdFromSystemsBar(localPushId: Int) {
         val keptNotifs = HashMap<Int, Notification>()
         ACTIVE_NOTIFICATIONS_MAP.asSequence()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_REV
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.Base64Decoder
 import com.woocommerce.android.util.NotificationsParser
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLogWrapper
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.Dispatchers
@@ -31,6 +32,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.only
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -110,7 +112,7 @@ class NotificationMessageHandlerTest {
 
         notificationMessageHandler.onNewMessageReceived(emptyMap())
         verify(accountStore, atLeastOnce()).hasAccessToken()
-//        verify(wooLogWrapper, only()).e(eq(WooLog.T.NOTIFS), eq("User is not logged in!"))
+        verify(wooLogWrapper, only()).e(eq(WooLog.T.NOTIFS), eq("User is not logged in!"))
     }
 
     @Test
@@ -127,20 +129,20 @@ class NotificationMessageHandlerTest {
     fun `when the notification payload data is empty, then do not process the notification`() {
         notificationMessageHandler.onNewMessageReceived(emptyMap())
         verify(accountStore, atLeastOnce()).hasAccessToken()
-//        verify(wooLogWrapper, only()).e(
-//            eq(WooLog.T.NOTIFS),
-//            eq("Push notification received without a valid Bundle!")
-//        )
+        verify(wooLogWrapper, only()).e(
+            eq(WooLog.T.NOTIFS),
+            eq("Push notification received without a valid Bundle!")
+        )
     }
 
     @Test
     fun `when the user id does not match, then do not process the notification`() {
         notificationMessageHandler.onNewMessageReceived(mapOf("type" to "new_order", "user" to "67890"))
         verify(accountStore, atLeastOnce()).hasAccessToken()
-//        verify(wooLogWrapper, only()).e(
-//            eq(WooLog.T.NOTIFS),
-//            eq("WP.com userId found in the app doesn't match with the ID in the PN. Aborting.")
-//        )
+        verify(wooLogWrapper, only()).e(
+            eq(WooLog.T.NOTIFS),
+            eq("WP.com userId found in the app doesn't match with the ID in the PN. Aborting.")
+        )
     }
 
     @Test
@@ -152,7 +154,7 @@ class NotificationMessageHandlerTest {
             )
         )
 
-//        verify(wooLogWrapper, only()).e(eq(WooLog.T.NOTIFS), eq("Notification data is empty!"))
+        verify(wooLogWrapper, only()).e(eq(WooLog.T.NOTIFS), eq("Notification data is empty!"))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -464,7 +464,7 @@ class NotificationMessageHandlerTest {
     }
 
     @Test
-    fun `test remove notifications concurrently without throwing ConcurrentModificationException`() {
+    fun `remove notifications concurrently without throwing ConcurrentModificationException`() {
         notificationMessageHandler.removeAllNotificationsFromSystemsBar()
         val notificationsCount = 100
         repeat(notificationsCount) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12636 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR addresses a crash peaMlT-TT-p2 related to notifications. While I couldn't reproduce the crash directly, I was able to analyze the stacktrace, identify the root cause, and reproduce the issue through a unit test.

The crash occurred because `ACTIVE_NOTIFICATIONS_MAP` was being modified concurrently by multiple threads, leading to a `ConcurrentModificationException`.

For example - In `ReviewDetailViewModel`, while loading product reviews, the map is modified on a background thread when `markReviewAsSeen(remoteReviewId, it)` is called. Simultaneously, if a new notification arrives or the user dismisses an existing notification, we attempt to modify the same `ACTIVE_NOTIFICATIONS_MAP`, which could lead to a `ConcurrentModificationException`.

The issue is resolved by adding the `@Synchronized` annotation, ensuring that only one thread can modify `ACTIVE_NOTIFICATIONS_MAP` at a time. After applying this fix, the unit test passes successfully.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Remove the `@Synchronized` annotation from `removeNotificationByNotificationIdFromSystemsBar` method
2. Run `remove notifications concurrently without throwing ConcurrentModificationException` unit test
3. Ensure the test fails with `ConcurrentModificationException`



### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
I couldn't test this with real notifications, but the fact that the unit test passes after the fix provides enough confidence to assert that the `ConcurrentModificationException` crash has been resolved for this particular scenario.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->