### PR TITLE
[Notifications] Replace mutable map with Thread safe map for storing all active notifications

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 20.6
 -----
-
+- [*][Internal] Replace mutable map with Thread safe map for storing all active notifications [https://github.com/woocommerce/woocommerce-android/pull/12655]
 
 20.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.generated.NotificationActionBuilder
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationPayload
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.random.Random
@@ -49,7 +50,7 @@ class NotificationMessageHandler @Inject constructor(
         @VisibleForTesting
         const val MAX_INBOX_ITEMS = 5
 
-        private val activeNotificationsMap = mutableMapOf<Int, Notification>()
+        private val activeNotificationsMap = ConcurrentHashMap<Int, Notification>()
     }
 
     @Synchronized

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -256,8 +256,7 @@ class NotificationMessageHandler @Inject constructor(
 
     fun removeNotificationsOfTypeFromSystemsBar(type: NotificationChannelType, remoteSiteId: Long) {
         val keptNotifs = HashMap<Int, Notification>()
-        // Using a copy of the map to avoid concurrency problems
-        activeNotificationsMap.toMap().asSequence().forEach { row ->
+        activeNotificationsMap.asSequence().forEach { row ->
             if (row.value.channelType == type && row.value.remoteSiteId == remoteSiteId) {
                 notificationBuilder.cancelNotification(row.key)
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -53,12 +53,10 @@ class NotificationMessageHandler @Inject constructor(
         private val activeNotificationsMap = ConcurrentHashMap<Int, Notification>()
     }
 
-    @Synchronized
     fun onPushNotificationDismissed(notificationId: Int) {
         removeNotificationByNotificationIdFromSystemsBar(notificationId)
     }
 
-    @Synchronized
     fun onLocalNotificationDismissed(notificationId: Int, notificationType: String) {
         removeNotificationByNotificationIdFromSystemsBar(notificationId)
         AnalyticsTracker.track(
@@ -224,7 +222,6 @@ class NotificationMessageHandler @Inject constructor(
         notificationBuilder.cancelAllNotifications()
     }
 
-    @Synchronized
     fun removeNotificationByRemoteIdFromSystemsBar(remoteNoteId: Long) {
         val keptNotifs = HashMap<Int, Notification>()
         activeNotificationsMap.asSequence()
@@ -241,7 +238,6 @@ class NotificationMessageHandler @Inject constructor(
         updateNotificationsState()
     }
 
-    @Synchronized
     fun removeNotificationByNotificationIdFromSystemsBar(localPushId: Int) {
         val keptNotifs = HashMap<Int, Notification>()
         activeNotificationsMap.asSequence()
@@ -258,7 +254,6 @@ class NotificationMessageHandler @Inject constructor(
         updateNotificationsState()
     }
 
-    @Synchronized
     fun removeNotificationsOfTypeFromSystemsBar(type: NotificationChannelType, remoteSiteId: Long) {
         val keptNotifs = HashMap<Int, Notification>()
         // Using a copy of the map to avoid concurrency problems

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -113,7 +113,7 @@ class NotificationMessageHandlerTest {
 
         notificationMessageHandler.onNewMessageReceived(emptyMap())
         verify(accountStore, atLeastOnce()).hasAccessToken()
-//        verify(wooLogWrapper, only()).e(eq(WooLog.T.NOTIFS), eq("User is not logged in!"))
+        verify(wooLogWrapper, only()).e(eq(WooLog.T.NOTIFS), eq("User is not logged in!"))
     }
 
     @Test
@@ -130,20 +130,20 @@ class NotificationMessageHandlerTest {
     fun `when the notification payload data is empty, then do not process the notification`() {
         notificationMessageHandler.onNewMessageReceived(emptyMap())
         verify(accountStore, atLeastOnce()).hasAccessToken()
-//        verify(wooLogWrapper, only()).e(
-//            eq(WooLog.T.NOTIFS),
-//            eq("Push notification received without a valid Bundle!")
-//        )
+        verify(wooLogWrapper, only()).e(
+            eq(WooLog.T.NOTIFS),
+            eq("Push notification received without a valid Bundle!")
+        )
     }
 
     @Test
     fun `when the user id does not match, then do not process the notification`() {
         notificationMessageHandler.onNewMessageReceived(mapOf("type" to "new_order", "user" to "67890"))
         verify(accountStore, atLeastOnce()).hasAccessToken()
-//        verify(wooLogWrapper, only()).e(
-//            eq(WooLog.T.NOTIFS),
-//            eq("WP.com userId found in the app doesn't match with the ID in the PN. Aborting.")
-//        )
+        verify(wooLogWrapper, only()).e(
+            eq(WooLog.T.NOTIFS),
+            eq("WP.com userId found in the app doesn't match with the ID in the PN. Aborting.")
+        )
     }
 
     @Test
@@ -155,7 +155,7 @@ class NotificationMessageHandlerTest {
             )
         )
 
-//        verify(wooLogWrapper, only()).e(eq(WooLog.T.NOTIFS), eq("Notification data is empty!"))
+        verify(wooLogWrapper, only()).e(eq(WooLog.T.NOTIFS), eq("Notification data is empty!"))
     }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12654 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
While fixing `ConcurrencyModificationException` https://github.com/woocommerce/woocommerce-android/pull/12646, we came to conclusion that replacing `mutableMap` with Thread safe map would benefit in the long run.

This PR:
1. Renames `ACTIVE_NOTIFICATIONS_MAP` to `activeNotificationsMap`
2. Replace `mutableMap` with `ConcurrentHashMap`
3. Remove `@Synchronized` annotation from public methods in `NotificationMessageHandler`
4. Remove unnecessary copy of a map
5. Update test to handle all notification related public methods to verify it doesn't throw `ConcurrentModificationException`

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
I've tested this by ensuring unit test pass after making this change and fails if we revert this change. Please ensure the notifications flow isn't broken by this change.

1. Make `activeNotificationsMap` mutableMap from `ConcurrentHashMap`
2. Run `handle notifications concurrently without throwing ConcurrentModificationException` unit test
3. Ensure the test fails
4. Now, revert back `activeNotificationsMap` to `ConcurrentHashMap`
5. Ensure the test passes now.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->