### PR TITLE
Bump CI toolkit to 3.7.1

### DIFF
--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -13,6 +13,6 @@ if [ $app_lint_exit_code -ne 0 ] || [ $wear_lint_exit_code -ne 0 ]; then
   lint_exit_code=1
 fi
 
-upload_sarif_to_github 'WooCommerce/build/reports/lint-results-jalapenoDebug.sarif' 'woocommerce' 'woocommerce-android'
+upload_sarif_to_github 'WooCommerce/build/reports/lint-results-jalapenoDebug.sarif'
 
 exit $lint_exit_code

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,6 +3,6 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.6.2"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.7.1"
 export TEST_COLLECTOR="test-collector#v1.10.1"
 


### PR DESCRIPTION
This tiny PR bumps ci toolkit to `3.7.1`. In this version, `upload_sarif_to_github` doesn't require to specify project's name or organization. 