### PR TITLE
Remove all code related to Blaze remote feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/IsBlazeEnabled.kt
@@ -2,22 +2,18 @@ package com.woocommerce.android.ui.blaze
 
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType.Jetpack
-import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
-import com.woocommerce.android.util.RemoteFeatureFlag.WOO_BLAZE
 import javax.inject.Inject
 
 class IsBlazeEnabled @Inject constructor(
-    private val selectedSite: SelectedSite,
-    private val isRemoteFeatureFlagEnabled: IsRemoteFeatureFlagEnabled
+    private val selectedSite: SelectedSite
 ) {
     companion object {
         private const val BLAZE_FOR_WOOCOMMERCE_PLUGIN_SLUG = "blaze-ads"
     }
 
-    suspend operator fun invoke(): Boolean = selectedSite.getIfExists()?.isAdmin ?: false &&
+    operator fun invoke(): Boolean = selectedSite.getIfExists()?.isAdmin ?: false &&
         hasAValidJetpackConnectionForBlaze() &&
-        selectedSite.getIfExists()?.canBlaze ?: false &&
-        isRemoteFeatureFlagEnabled(WOO_BLAZE)
+        selectedSite.getIfExists()?.canBlaze ?: false
 
     /**
      * In order for Blaze to work, the site requires the Jetpack Sync module to be enabled. This means not all

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/IsRemoteFeatureFlagEnabled.kt
@@ -4,7 +4,6 @@ import com.woocommerce.android.config.WPComRemoteFeatureFlagRepository
 import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES
 import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES
 import com.woocommerce.android.util.RemoteFeatureFlag.LOCAL_NOTIFICATION_STORE_CREATION_READY
-import com.woocommerce.android.util.RemoteFeatureFlag.WOO_BLAZE
 import com.woocommerce.android.util.RemoteFeatureFlag.WOO_POS
 import javax.inject.Inject
 
@@ -16,8 +15,7 @@ class IsRemoteFeatureFlagEnabled @Inject constructor(
             LOCAL_NOTIFICATION_STORE_CREATION_READY,
             LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES,
             LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES,
-            WOO_POS,
-            WOO_BLAZE ->
+            WOO_POS ->
                 PackageUtils.isDebugBuild() ||
                     wpComRemoteFeatureFlagRepository.isRemoteFeatureFlagEnabled(featureFlag.remoteKey)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/RemoteFeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/RemoteFeatureFlag.kt
@@ -4,6 +4,5 @@ enum class RemoteFeatureFlag(val remoteKey: String) {
     LOCAL_NOTIFICATION_STORE_CREATION_READY("woo_notification_store_creation_ready"),
     LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES("woo_notification_1d_before_free_trial_expires"),
     LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES("woo_notification_1d_after_free_trial_expires"),
-    WOO_BLAZE("woo_blaze"),
     WOO_POS("woo_pos"),
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12668
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Remove all code related to Blaze remote feature flag. This remote feature flag is no longer in use. 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Test that Blaze is enabled (Blaze CTAs are visible) for the following type of sites should be enough: 
- Atomic Sites 
- Self-hosted site with Jetpack connection active
- Self-hosted site with Blaze for WooCommerce 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested Blaze CTAs are visible in the above scenarios. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->