### PR TITLE
Make UserAgent a singleton

### DIFF
--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/di/AppConfigModule.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/di/AppConfigModule.kt
@@ -25,6 +25,7 @@ class AppConfigModule {
     fun provideAppSecrets() = AppSecrets(BuildConfig.OAUTH_APP_ID, BuildConfig.OAUTH_APP_SECRET)
 
     @Provides
+    @Singleton
     fun provideUserAgent(appContext: Context) = UserAgent(appContext, USER_AGENT_APPNAME)
 
     @Provides

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/AppConfigModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/AppConfigModule.kt
@@ -25,6 +25,7 @@ class AppConfigModule {
     fun provideAppSecrets() = AppSecrets(BuildConfig.OAUTH_APP_ID, BuildConfig.OAUTH_APP_SECRET)
 
     @Provides
+    @Singleton
     fun provideUserAgent(appContext: Context) = UserAgent(appContext, USER_AGENT_APPNAME)
 
     @Provides


### PR DESCRIPTION
### Description
While helping the investigation of peaMlT-Tk-p2, I noticed an issue with our DI configuration, the `UserAgent` class is not singleton, and given it has a background initialization for a relatively heavy operation, instantiating multiple times is problematic:
- It's not great for the app performance.
- It increases the chance of using the [default](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/07f08124c02b03d5d380cdaf7066ec4ccf9457f4/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt#L26) user agent, as we will be using a fresh instance instead of the cached one.

### Testing information
This shouldn't have any impact, testing some screens like products and orders to confirm network operations are not impacted would be enough.

### The tests that have been performed
I added a log entry to the `provideUserAgent` function to check how many times it's executed, and confirmed that the `Singleton` annotation works as expected.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->