### PR TITLE
[Woo POS]  Softer and bigger shadows for the products cards

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosCard.kt
@@ -48,6 +48,7 @@ fun WooPosCard(
     contentColor: Color = contentColorFor(backgroundColor),
     border: BorderStroke? = null,
     elevation: Dp = 1.dp,
+    shadowType: ShadowType = ShadowType.Normal,
     content: @Composable () -> Unit
 ) {
     val absoluteElevation = LocalAbsoluteElevation.current + elevation
@@ -65,7 +66,8 @@ fun WooPosCard(
                         absoluteElevation = absoluteElevation
                     ),
                     border = border,
-                    elevation = elevation
+                    elevation = elevation,
+                    shadowType = shadowType
                 )
                 .semantics(mergeDescendants = false) {
                     isTraversalGroup = true
@@ -83,16 +85,17 @@ private fun Modifier.surface(
     shape: Shape,
     backgroundColor: Color,
     border: BorderStroke?,
-    elevation: Dp
+    elevation: Dp,
+    shadowType: ShadowType
 ): Modifier {
     return this
         .drawShadow(
             color = Color.Black,
             borderRadius = shape.toCornerRadius(LocalDensity.current),
-            shadowRadius = elevation,
-            alpha = 0.24f,
+            shadowRadius = elevation * shadowType.shadowRadiusCoefficient,
+            alpha = shadowType.alpha,
             offsetX = 0.dp,
-            offsetY = elevation * 0.5f
+            offsetY = elevation * shadowType.offsetYCoefficient
         )
         .then(if (border != null) Modifier.border(border, shape) else Modifier)
         .background(color = backgroundColor, shape = shape)
@@ -120,6 +123,24 @@ fun Shape.toCornerRadius(density: Density): Dp {
         }
     } else {
         0.dp
+    }
+}
+
+sealed class ShadowType {
+    abstract val alpha : Float
+    abstract val shadowRadiusCoefficient: Float
+    abstract val offsetYCoefficient: Float
+
+    data object Soft : ShadowType() {
+        override val alpha = 0.1f
+        override val shadowRadiusCoefficient = 1.4F
+        override val offsetYCoefficient = 0.7f
+    }
+
+    data object Normal : ShadowType() {
+        override val alpha = 0.24f
+        override val shadowRadiusCoefficient = 1F
+        override val offsetYCoefficient = 0.5f
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosCard.kt
@@ -126,6 +126,7 @@ fun Shape.toCornerRadius(density: Density): Dp {
     }
 }
 
+@Suppress("MagicNumber")
 sealed class ShadowType {
     abstract val alpha : Float
     abstract val shadowRadiusCoefficient: Float

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosCard.kt
@@ -128,7 +128,7 @@ fun Shape.toCornerRadius(density: Density): Dp {
 
 @Suppress("MagicNumber")
 sealed class ShadowType {
-    abstract val alpha : Float
+    abstract val alpha: Float
     abstract val shadowRadiusCoefficient: Float
     abstract val offsetYCoefficient: Float
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -62,6 +62,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.ShadowType
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosCard
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosTheme
@@ -405,8 +406,9 @@ private fun ProductItem(
         hasAnimationStarted = true
     }
 
+    val cardElevation = 6.dp
     val elevation by animateDpAsState(
-        targetValue = if (hasAnimationStarted) 4.dp else 0.dp,
+        targetValue = if (hasAnimationStarted) cardElevation else 0.dp,
         animationSpec = tween(durationMillis = 150, delayMillis = 250),
         label = "elevation"
     )
@@ -418,7 +420,7 @@ private fun ProductItem(
     )
 
     LaunchedEffect(elevation) {
-        if (elevation == 4.dp) {
+        if (elevation == cardElevation) {
             onUIEvent(WooPosCartUIEvent.OnCartItemAppearanceAnimationPlayed(item))
         }
     }
@@ -435,6 +437,7 @@ private fun ProductItem(
                 .height(64.dp)
                 .semantics { contentDescription = itemContentDescription },
             elevation = elevation,
+            shadowType = ShadowType.Soft,
             shape = RoundedCornerShape(8.dp),
         ) {
             Row(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsScreen.kt
@@ -61,6 +61,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.ShadowType
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosCard
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosTheme
@@ -299,6 +300,8 @@ private fun ProductLoadingItem() {
     WooPosCard(
         shape = RoundedCornerShape(8.dp),
         backgroundColor = MaterialTheme.colors.surface,
+        elevation = 6.dp,
+        shadowType = ShadowType.Soft,
     ) {
         Row(
             modifier = Modifier
@@ -351,6 +354,8 @@ private fun ProductItem(
             .semantics { contentDescription = itemContentDescription },
         shape = RoundedCornerShape(8.dp),
         backgroundColor = MaterialTheme.colors.surface,
+        elevation = 6.dp,
+        shadowType = ShadowType.Soft,
     ) {
         Row(
             modifier = Modifier


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12693
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As per request from Joe (check the issue for more details)

pdfdoF-5iv-p2#comment-6514

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Open the POS
* Add a product to a card
* Notice the shadows

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
* Open the POS
* Add a product to a card
* Notice  shadows are softer

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
^

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="1029" alt="image" src="https://github.com/user-attachments/assets/f8a9691c-c687-4d78-b566-cb689fac06ac">


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->