### PR TITLE
Remove duplicated toolbar from subscription free trial screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/ProductSubscriptionFreeTrialFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/subscriptions/ProductSubscriptionFreeTrialFragment.kt
@@ -45,6 +45,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WcExposedDropDown
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity.Companion.BackPressListener
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -57,6 +58,9 @@ class ProductSubscriptionFreeTrialFragment : BaseFragment(), BackPressListener {
     companion object {
         const val KEY_SUBSCRIPTION_FREE_TRIAL_RESULT = "key_subscription_free_trial_result"
     }
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
 
     private val resourceProvider: ResourceProvider by lazy { ResourceProvider(requireContext()) }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12679 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
`ProductSubscriptionFreeTrialFragment` was displaying 2 different toolbars. This PR fixes that and removes the extra Toolbar shown. 

### Steps to reproduce
1. Log into a site with subscriptions enabled
2. Open a subscription product or a variation subscription product. 
3. Tap on `Subscription free trial` section
4. Check that two toolbars are displayed. 

### Testing information
1. Log into a site with subscriptions enabled
2. Open a subscription product or a variation subscription product. 
3. Tap on `Subscription free trial` section
4. Check that a single toolbar with the title `Subscription free trial` is shown. 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/da194569-0b63-4f18-806a-98993f19408c

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->