### PR TITLE
[WOO POS] UI tests for Exit pos dialog

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosExitPosDialogTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosExitPosDialogTest.kt
@@ -6,7 +6,6 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -68,7 +67,7 @@ class WooPosExitPosDialogTest : TestBase() {
     }
 
     @Test
-    fun testExitPOSDialogIsDisplayedWhenExitButtonClicked() = runTest {
+    fun testExitPOSConfirmationDialogIsDisplayedWhenExitButtonClicked() = runTest {
         composeTestRule.waitUntil(5000) {
             try {
                 composeTestRule.onNodeWithTag("product_list")
@@ -104,7 +103,7 @@ class WooPosExitPosDialogTest : TestBase() {
     }
 
     @Test
-    fun testExitPOSDialogIsDisplayedWithProperLabels() = runTest {
+    fun testExitPOSConfirmationDialogIsDisplayedWithProperLabels() = runTest {
         composeTestRule.waitUntil(5000) {
             try {
                 composeTestRule.onNodeWithTag("product_list")
@@ -152,7 +151,7 @@ class WooPosExitPosDialogTest : TestBase() {
     }
 
     @Test
-    fun testExitPOSDialogIsDismissedWhenCloseButtonClicked() = runTest {
+    fun testExitPOSConfirmationDialogIsDismissedWhenCloseButtonClicked() = runTest {
         composeTestRule.waitUntil(5000) {
             try {
                 composeTestRule.onNodeWithTag("product_list")
@@ -192,7 +191,7 @@ class WooPosExitPosDialogTest : TestBase() {
     }
 
     @Test
-    fun testExitPOSDialogIsDismissedWhenExitButtonClicked() = runTest {
+    fun testExitPOSConfirmationDialogIsDismissedWhenExitButtonClicked() = runTest {
         composeTestRule.waitUntil(5000) {
             try {
                 composeTestRule.onNodeWithTag("product_list")

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosExitPosDialogTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosExitPosDialogTest.kt
@@ -1,0 +1,102 @@
+@file:Suppress("DEPRECATION")
+
+package com.woocommerce.android
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import com.woocommerce.android.e2e.helpers.InitializationRule
+import com.woocommerce.android.e2e.helpers.TestBase
+import com.woocommerce.android.e2e.rules.RetryTestRule
+import com.woocommerce.android.e2e.screens.TabNavComponent
+import com.woocommerce.android.e2e.screens.login.WelcomeScreen
+import com.woocommerce.android.ui.login.LoginActivity
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class WooPosExitPosDialogTest : TestBase() {
+    @get:Rule(order = 1)
+    val rule = HiltAndroidRule(this)
+
+    @get:Rule(order = 2)
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @get:Rule(order = 3)
+    val initRule = InitializationRule()
+
+    @get:Rule(order = 4)
+    var activityRule = ActivityTestRule(LoginActivity::class.java)
+
+    @get:Rule(order = 5)
+    var retryTestRule = RetryTestRule()
+
+    @Inject
+    lateinit var dataStore: DataStore<Preferences>
+
+    @Before
+    fun setUp() = runTest {
+        rule.inject()
+        dataStore.edit { it.clear() }
+        WelcomeScreen
+            .skipCarouselIfNeeded()
+            .selectLogin()
+            .proceedWith(BuildConfig.SCREENSHOTS_URL)
+            .proceedWith(BuildConfig.SCREENSHOTS_USERNAME)
+            .proceedWith(BuildConfig.SCREENSHOTS_PASSWORD)
+
+        TabNavComponent()
+            .gotoMoreMenuScreen()
+            .openPOSScreen(composeTestRule)
+    }
+
+    @Test
+    fun testExitPOSDialogIsDisplayedWhenExitButtonClicked() = runTest {
+        composeTestRule.waitUntil(5000) {
+            try {
+                composeTestRule.onNodeWithTag("product_list")
+                    .assertExists()
+                    .assertIsDisplayed()
+                true
+            } catch (e: AssertionError) {
+                false
+            }
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag(
+                "woo_pos_menu_button"
+            ).performClick()
+            true
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag(
+                "woo_pos_popup_menu_${R.string.woopos_exit_confirmation_title}",
+                useUnmergedTree = true
+            ).performClick()
+            true
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag("woo_pos_exit_confirmation_dialog")
+                .assertExists()
+                .assertIsDisplayed()
+            true
+        }
+    }
+}

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosExitPosDialogTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosExitPosDialogTest.kt
@@ -230,4 +230,44 @@ class WooPosExitPosDialogTest : TestBase() {
             true
         }
     }
+
+    @Test
+    fun testWoPosHomeScreenIsDismissedWhenExitButtonClicked() = runTest {
+        composeTestRule.waitUntil(5000) {
+            try {
+                composeTestRule.onNodeWithTag("product_list")
+                    .assertExists()
+                    .assertIsDisplayed()
+                true
+            } catch (e: AssertionError) {
+                false
+            }
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag(
+                "woo_pos_menu_button"
+            ).performClick()
+            true
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag(
+                "woo_pos_popup_menu_${R.string.woopos_exit_confirmation_title}",
+                useUnmergedTree = true
+            ).performClick()
+            true
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag("woo_pos_exit_confirmation_dialog_exit").performClick()
+            true
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag("woo_pos_home_screen")
+                .assertIsNotDisplayed()
+            true
+        }
+    }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosExitPosDialogTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosExitPosDialogTest.kt
@@ -190,4 +190,44 @@ class WooPosExitPosDialogTest : TestBase() {
             true
         }
     }
+
+    @Test
+    fun testExitPOSDialogIsDismissedWhenExitButtonClicked() = runTest {
+        composeTestRule.waitUntil(5000) {
+            try {
+                composeTestRule.onNodeWithTag("product_list")
+                    .assertExists()
+                    .assertIsDisplayed()
+                true
+            } catch (e: AssertionError) {
+                false
+            }
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag(
+                "woo_pos_menu_button"
+            ).performClick()
+            true
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag(
+                "woo_pos_popup_menu_${R.string.woopos_exit_confirmation_title}",
+                useUnmergedTree = true
+            ).performClick()
+            true
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag("woo_pos_exit_confirmation_dialog_exit").performClick()
+            true
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag("woo_pos_exit_confirmation_dialog")
+                .assertIsNotDisplayed()
+            true
+        }
+    }
 }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosExitPosDialogTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosExitPosDialogTest.kt
@@ -4,7 +4,9 @@ package com.woocommerce.android
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -145,6 +147,46 @@ class WooPosExitPosDialogTest : TestBase() {
             composeTestRule.onNodeWithText(
                 composeTestRule.activity.getString(R.string.woopos_exit_dialog_confirmation_confirm_button)
             ).assertIsDisplayed()
+            true
+        }
+    }
+
+    @Test
+    fun testExitPOSDialogIsDismissedWhenCloseButtonClicked() = runTest {
+        composeTestRule.waitUntil(5000) {
+            try {
+                composeTestRule.onNodeWithTag("product_list")
+                    .assertExists()
+                    .assertIsDisplayed()
+                true
+            } catch (e: AssertionError) {
+                false
+            }
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag(
+                "woo_pos_menu_button"
+            ).performClick()
+            true
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag(
+                "woo_pos_popup_menu_${R.string.woopos_exit_confirmation_title}",
+                useUnmergedTree = true
+            ).performClick()
+            true
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag("woo_pos_exit_confirmation_dialog_close").performClick()
+            true
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag("woo_pos_exit_confirmation_dialog")
+                .assertIsNotDisplayed()
             true
         }
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosExitPosDialogTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosExitPosDialogTest.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
@@ -96,6 +97,54 @@ class WooPosExitPosDialogTest : TestBase() {
             composeTestRule.onNodeWithTag("woo_pos_exit_confirmation_dialog")
                 .assertExists()
                 .assertIsDisplayed()
+            true
+        }
+    }
+
+    @Test
+    fun testExitPOSDialogIsDisplayedWithProperLabels() = runTest {
+        composeTestRule.waitUntil(5000) {
+            try {
+                composeTestRule.onNodeWithTag("product_list")
+                    .assertExists()
+                    .assertIsDisplayed()
+                true
+            } catch (e: AssertionError) {
+                false
+            }
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag(
+                "woo_pos_menu_button"
+            ).performClick()
+            true
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithTag(
+                "woo_pos_popup_menu_${R.string.woopos_exit_confirmation_title}",
+                useUnmergedTree = true
+            ).performClick()
+            true
+        }
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithText(
+                composeTestRule.activity.getString(R.string.woopos_exit_dialog_confirmation_title)
+            ).assertIsDisplayed()
+            true
+        }
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithText(
+                composeTestRule.activity.getString(R.string.woopos_exit_dialog_confirmation_message)
+            ).assertIsDisplayed()
+            true
+        }
+        composeTestRule.waitUntil(5000) {
+            composeTestRule.onNodeWithText(
+                composeTestRule.activity.getString(R.string.woopos_exit_dialog_confirmation_confirm_button)
+            ).assertIsDisplayed()
             true
         }
     }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosExitPosDialogTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosExitPosDialogTest.kt
@@ -75,6 +75,7 @@ class WooPosExitPosDialogTest : TestBase() {
                     .assertIsDisplayed()
                 true
             } catch (e: AssertionError) {
+                e.printStackTrace()
                 false
             }
         }
@@ -111,6 +112,7 @@ class WooPosExitPosDialogTest : TestBase() {
                     .assertIsDisplayed()
                 true
             } catch (e: AssertionError) {
+                e.printStackTrace()
                 false
             }
         }
@@ -159,6 +161,7 @@ class WooPosExitPosDialogTest : TestBase() {
                     .assertIsDisplayed()
                 true
             } catch (e: AssertionError) {
+                e.printStackTrace()
                 false
             }
         }
@@ -199,6 +202,7 @@ class WooPosExitPosDialogTest : TestBase() {
                     .assertIsDisplayed()
                 true
             } catch (e: AssertionError) {
+                e.printStackTrace()
                 false
             }
         }
@@ -239,6 +243,7 @@ class WooPosExitPosDialogTest : TestBase() {
                     .assertIsDisplayed()
                 true
             } catch (e: AssertionError) {
+                e.printStackTrace()
                 false
             }
         }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosHomeProductInfoDialogTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosHomeProductInfoDialogTest.kt
@@ -76,6 +76,7 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
                     .assertIsDisplayed()
                 true
             } catch (e: AssertionError) {
+                e.printStackTrace()
                 false
             }
         }
@@ -94,8 +95,7 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
     }
 
     @Test
-    fun testProductInfoDialogIsDisplayedOnIconClick()  = runTest {
-
+    fun testProductInfoDialogIsDisplayedOnIconClick() = runTest {
         composeTestRule.waitUntil(5000) {
             try {
                 composeTestRule.onNodeWithTag("product_list")
@@ -103,6 +103,7 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
                     .assertIsDisplayed()
                 true
             } catch (e: AssertionError) {
+                e.printStackTrace()
                 false
             }
         }
@@ -134,6 +135,7 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
                     .assertIsDisplayed()
                 true
             } catch (e: AssertionError) {
+                e.printStackTrace()
                 false
             }
         }
@@ -171,8 +173,7 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
     }
 
     @Test
-    fun testProductInfoDialogIsDismissedWhenCloseClick()  = runTest {
-
+    fun testProductInfoDialogIsDismissedWhenCloseClick() = runTest {
         composeTestRule.waitUntil(5000) {
             try {
                 composeTestRule.onNodeWithTag("product_list")
@@ -180,6 +181,7 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
                     .assertIsDisplayed()
                 true
             } catch (e: AssertionError) {
+                e.printStackTrace()
                 false
             }
         }
@@ -207,8 +209,7 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
     }
 
     @Test
-    fun testProductInfoDialogIsDismissedWhenPrimaryButtonClicked()  = runTest {
-
+    fun testProductInfoDialogIsDismissedWhenPrimaryButtonClicked() = runTest {
         composeTestRule.waitUntil(5000) {
             try {
                 composeTestRule.onNodeWithTag("product_list")
@@ -216,6 +217,7 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
                     .assertIsDisplayed()
                 true
             } catch (e: AssertionError) {
+                e.printStackTrace()
                 false
             }
         }
@@ -226,7 +228,7 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
         composeTestRule.waitUntil(5000) {
             composeTestRule.onNodeWithContentDescription(
                 composeTestRule.activity.getString(R.string.woopos_banner_simple_products_info_content_description)
-                )
+            )
                 .assertExists()
             true
         }
@@ -249,8 +251,7 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
     }
 
     @Test
-    fun testProductInfoDialogIsDismissedWhenOutsideDialogClicked()  = runTest {
-
+    fun testProductInfoDialogIsDismissedWhenOutsideDialogClicked() = runTest {
         composeTestRule.waitUntil(5000) {
             try {
                 composeTestRule.onNodeWithTag("product_list")
@@ -258,6 +259,7 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
                     .assertIsDisplayed()
                 true
             } catch (e: AssertionError) {
+                e.printStackTrace()
                 false
             }
         }

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosHomeProductInfoDialogTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosHomeProductInfoDialogTest.kt
@@ -139,13 +139,13 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
                 false
             }
         }
-        composeTestRule.onNodeWithContentDescription(
-            composeTestRule.activity.getString(R.string.woopos_banner_simple_products_close_content_description)
+        composeTestRule.onNodeWithTag(
+            "woo_pos_simple_products_dialog_info_close_icon"
         ).performClick()
 
         composeTestRule.waitUntil(5000) {
-            composeTestRule.onNodeWithContentDescription(
-                composeTestRule.activity.getString(R.string.woopos_banner_simple_products_info_content_description)
+            composeTestRule.onNodeWithTag(
+                "woo_pos_simple_products_banner_icon"
             ).performClick()
             true
         }
@@ -196,8 +196,8 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
             true
         }
 
-        composeTestRule.onNodeWithContentDescription(
-            composeTestRule.activity.getString(R.string.woopos_banner_simple_products_close_content_description)
+        composeTestRule.onNodeWithTag(
+            "woo_pos_simple_products_dialog_info_close_icon"
         ).performClick()
 
         composeTestRule.waitUntil(5000) {
@@ -237,10 +237,8 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
             composeTestRule.activity.getString(R.string.woopos_banner_simple_products_info_content_description)
         ).performClick()
 
-        composeTestRule.onNodeWithContentDescription(
-            composeTestRule.activity.getString(
-                R.string.woopos_banner_simple_products_dialog_primary_button_content_description
-            )
+        composeTestRule.onNodeWithTag(
+            "woo_pos_simple_product_info_dialog_primary_button"
         ).performClick()
 
         composeTestRule.waitUntil(5000) {

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosHomeProductInfoDialogTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooPosHomeProductInfoDialogTest.kt
@@ -249,41 +249,4 @@ class WooPosHomeProductInfoDialogTest : TestBase() {
             true
         }
     }
-
-    @Test
-    fun testProductInfoDialogIsDismissedWhenOutsideDialogClicked() = runTest {
-        composeTestRule.waitUntil(5000) {
-            try {
-                composeTestRule.onNodeWithTag("product_list")
-                    .assertExists()
-                    .assertIsDisplayed()
-                true
-            } catch (e: AssertionError) {
-                e.printStackTrace()
-                false
-            }
-        }
-        composeTestRule.onNodeWithContentDescription(
-            composeTestRule.activity.getString(R.string.woopos_banner_simple_products_close_content_description)
-        ).performClick()
-
-        composeTestRule.waitUntil(5000) {
-            composeTestRule.onNodeWithContentDescription(
-                composeTestRule.activity.getString(R.string.woopos_banner_simple_products_info_content_description)
-            ).performClick()
-            true
-        }
-
-        composeTestRule.waitUntil(5000) {
-            composeTestRule.onNodeWithTag("woo_pos_product_info_dialog_background")
-                .performClick()
-            true
-        }
-
-        composeTestRule.waitUntil(5000) {
-            composeTestRule.onNodeWithTag("woo_pos_product_info_dialog")
-                .assertIsNotDisplayed()
-            true
-        }
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosExitConfirmationDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosExitConfirmationDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -45,7 +46,9 @@ fun WooPosExitConfirmationDialog(
         onDismissRequest = onDismissRequest,
     ) {
         Box(
-            modifier = modifier.padding(40.dp.toAdaptivePadding())
+            modifier = modifier
+                .padding(40.dp.toAdaptivePadding())
+                .testTag("woo_pos_exit_confirmation_dialog")
         ) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Spacer(modifier = modifier.height(48.dp.toAdaptivePadding()))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosExitConfirmationDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosExitConfirmationDialog.kt
@@ -79,6 +79,7 @@ fun WooPosExitConfirmationDialog(
                 onClick = { onDismissRequest() },
                 modifier = modifier
                     .align(Alignment.TopEnd)
+                    .testTag("woo_pos_exit_confirmation_dialog_close")
             ) {
                 Icon(
                     Icons.Default.Close,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosExitConfirmationDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosExitConfirmationDialog.kt
@@ -67,7 +67,8 @@ fun WooPosExitConfirmationDialog(
                 Spacer(modifier = modifier.height(56.dp.toAdaptivePadding()))
                 WooPosButton(
                     modifier = modifier
-                        .fillMaxWidth(),
+                        .fillMaxWidth()
+                        .testTag("woo_pos_exit_confirmation_dialog_exit"),
                     onClick = {
                         onExit()
                     },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeProductInfoDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeProductInfoDialog.kt
@@ -95,6 +95,7 @@ fun WooPosProductInfoDialog(
                             end.linkTo(parent.end)
                         }
                         .focusable(enabled = false)
+                        .testTag("woo_pos_simple_products_dialog_info_close_icon")
                 ) {
                     Icon(
                         modifier = Modifier
@@ -154,7 +155,8 @@ fun WooPosProductInfoDialog(
                             .fillMaxWidth()
                             .semantics {
                                 contentDescription = primaryButtonContentDescription
-                            },
+                            }
+                            .testTag("woo_pos_simple_product_info_dialog_primary_button"),
                         border = BorderStroke(2.dp, MaterialTheme.colors.primary),
                         shape = RoundedCornerShape(8.dp),
                     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -127,6 +128,7 @@ private fun WooPosHomeScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colors.background)
+            .testTag("woo_pos_home_screen")
     ) {
         Row(
             modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsScreen.kt
@@ -193,7 +193,9 @@ private fun ProductsToolbar(
             is WooPosProductsViewState.Content -> {
                 if (productViewState.bannerState.isBannerHiddenByUser) {
                     IconButton(
-                        modifier = Modifier.size(40.dp),
+                        modifier = Modifier
+                            .size(40.dp)
+                            .testTag("woo_pos_simple_products_banner_icon"),
                         onClick = {
                             onToolbarInfoIconClicked()
                         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbar.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.contentDescription
@@ -202,7 +203,9 @@ private fun MenuButtonWithPopUpMenu(
         shape = RoundedCornerShape(8.dp),
     ) {
         TextButton(
-            modifier = Modifier.semantics { contentDescription = menuContentDescription },
+            modifier = Modifier
+                .semantics { contentDescription = menuContentDescription }
+                .testTag("woo_pos_menu_button"),
             onClick = onClick,
             contentPadding = PaddingValues(0.dp),
             colors = ButtonDefaults.textButtonColors(
@@ -262,10 +265,12 @@ private fun PopUpMenuItem(
             modifier = Modifier.size(24.dp)
         )
         Spacer(modifier = Modifier.width(16.dp.toAdaptivePadding()))
+        println("popupmenuid: woo_pos_popup_menu_${menuItem.title}")
         Text(
             modifier = Modifier
                 .padding(vertical = 8.dp.toAdaptivePadding())
-                .weight(1f),
+                .weight(1f)
+                .testTag("woo_pos_popup_menu_${menuItem.title}"),
             text = stringResource(id = menuItem.title),
             color = MaterialTheme.colors.onSurface,
             style = MaterialTheme.typography.body1,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12689 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds UI tests for Exit POS dialog

<img width="696" alt="Screenshot 2024-09-27 at 8 33 51 AM" src="https://github.com/user-attachments/assets/e7d7d6b4-0cf8-4f40-9b25-5fbbdae6e29c">


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Ensure the CI is happy - specifically, UI test pipeline is green.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
1. Add UI test to verify Exit POS dialog is displayed on exit POS click
2. Add UI test to verify Exit POS dialog is displayed with proper labels
3. Add UI test to verify Exit POS dialog is dismissed on close icon click
4. Add UI test to verify Exit POS dialog is dismissed on Exit button click
5. Add UI test to verify Exit POS Home screen is dismissed on Exit button click

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->