### PR TITLE
[Woo POS] Change colors for the payment success screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
@@ -45,7 +45,6 @@ private object WooPosColors {
 
     // DarkCustomColors
     val darkCustomColorsError = Color(0xFFBE4400)
-    val darkCustomColorsPaymentSuccessBackground = Color(0xFF005139)
     val darkCustomColorsPaymentSuccessIconBackground = Color(0xFF00AD64)
     val darkCustomloadingSkeleton = Color(0xFF616161)
     val darkCustomColorsSuccess = Color(0xFF06B166)
@@ -53,7 +52,6 @@ private object WooPosColors {
 
     // LightCustomColors
     val lightCustomColorsError = Color(0xFFF16618)
-    val lightCustomColorsPaymentSuccessBackground = Color(0xFF98F179)
     val lightCustomColorsSuccess = Color(0xFF03D479)
     val lightCustomColorsLoadingSkeleton = Color(0xFFE1E1E1)
     val lightCustomColorsBorder = Color(0xFFC6C6C8)
@@ -190,7 +188,7 @@ private val DarkCustomColors = CustomColors(
     border = WooPosColors.oldGrayMedium,
     success = WooPosColors.darkCustomColorsSuccess,
     error = WooPosColors.darkCustomColorsError,
-    paymentSuccessBackground = WooPosColors.darkCustomColorsPaymentSuccessBackground,
+    paymentSuccessBackground = WooPosColors.darkCustomColorsHomeBackground,
     paymentSuccessText = WooPosColors.oldGrayLight,
     paymentSuccessIcon = Color.White,
     paymentSuccessIconBackground = WooPosColors.darkCustomColorsPaymentSuccessIconBackground,
@@ -202,7 +200,7 @@ private val LightCustomColors = CustomColors(
     border = WooPosColors.lightCustomColorsBorder,
     success = WooPosColors.lightCustomColorsSuccess,
     error = WooPosColors.lightCustomColorsError,
-    paymentSuccessBackground = WooPosColors.lightCustomColorsPaymentSuccessBackground,
+    paymentSuccessBackground = WooPosColors.White,
     paymentSuccessText = WooPosColors.Purple90,
     paymentSuccessIcon = WooPosColors.lightCustomColorsSuccess,
     paymentSuccessIconBackground = Color.White,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
@@ -45,7 +45,6 @@ private object WooPosColors {
 
     // DarkCustomColors
     val darkCustomColorsError = Color(0xFFBE4400)
-    val darkCustomColorsPaymentSuccessIconBackground = Color(0xFF00AD64)
     val darkCustomloadingSkeleton = Color(0xFF616161)
     val darkCustomColorsSuccess = Color(0xFF06B166)
     val darkCustomColorsHomeBackground = Color(0xFF1E1E1E)
@@ -190,8 +189,8 @@ private val DarkCustomColors = CustomColors(
     error = WooPosColors.darkCustomColorsError,
     paymentSuccessBackground = WooPosColors.darkCustomColorsHomeBackground,
     paymentSuccessText = WooPosColors.oldGrayLight,
-    paymentSuccessIcon = Color.White,
-    paymentSuccessIconBackground = WooPosColors.darkCustomColorsPaymentSuccessIconBackground,
+    paymentSuccessIcon = Color.Black,
+    paymentSuccessIconBackground = Color(0xFF08FB87),
     homeBackground = WooPosColors.darkCustomColorsHomeBackground
 )
 
@@ -202,8 +201,8 @@ private val LightCustomColors = CustomColors(
     error = WooPosColors.lightCustomColorsError,
     paymentSuccessBackground = WooPosColors.White,
     paymentSuccessText = WooPosColors.Purple90,
-    paymentSuccessIcon = WooPosColors.lightCustomColorsSuccess,
-    paymentSuccessIconBackground = Color.White,
+    paymentSuccessIcon = Color.White,
+    paymentSuccessIconBackground = Color(0xFF08FB87),
     homeBackground = WooPosColors.Gray0
 )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
@@ -21,7 +21,6 @@ data class CustomColors(
     val paymentSuccessBackground: Color,
     val paymentSuccessText: Color,
     val paymentSuccessIcon: Color,
-    val paymentSuccessIconBackground: Color,
     val dialogSubtitleHighlightBackground: Color = Color(0x14747480),
     val homeBackground: Color,
 )
@@ -38,6 +37,8 @@ private object WooPosColors {
     val secondary = Color(0xFF0A9400)
     val surface = Color(0xFF2E2E2E)
 
+    val greenNotFromPalette = Color(0xFF08FB87)
+
     // LightColorPalette
     val lightColorPaletteSecondary = Color(0xFF004B3E)
     val lightColorPaletteSecondaryVariant = Color(0xFF50575E)
@@ -46,12 +47,10 @@ private object WooPosColors {
     // DarkCustomColors
     val darkCustomColorsError = Color(0xFFBE4400)
     val darkCustomloadingSkeleton = Color(0xFF616161)
-    val darkCustomColorsSuccess = Color(0xFF06B166)
     val darkCustomColorsHomeBackground = Color(0xFF1E1E1E)
 
     // LightCustomColors
     val lightCustomColorsError = Color(0xFFF16618)
-    val lightCustomColorsSuccess = Color(0xFF03D479)
     val lightCustomColorsLoadingSkeleton = Color(0xFFE1E1E1)
     val lightCustomColorsBorder = Color(0xFFC6C6C8)
 
@@ -185,24 +184,22 @@ private val LightColorPalette = lightColors(
 private val DarkCustomColors = CustomColors(
     loadingSkeleton = WooPosColors.darkCustomloadingSkeleton,
     border = WooPosColors.oldGrayMedium,
-    success = WooPosColors.darkCustomColorsSuccess,
+    success = WooPosColors.greenNotFromPalette,
     error = WooPosColors.darkCustomColorsError,
     paymentSuccessBackground = WooPosColors.darkCustomColorsHomeBackground,
     paymentSuccessText = WooPosColors.oldGrayLight,
     paymentSuccessIcon = Color.Black,
-    paymentSuccessIconBackground = Color(0xFF08FB87),
     homeBackground = WooPosColors.darkCustomColorsHomeBackground
 )
 
 private val LightCustomColors = CustomColors(
     loadingSkeleton = WooPosColors.lightCustomColorsLoadingSkeleton,
     border = WooPosColors.lightCustomColorsBorder,
-    success = WooPosColors.lightCustomColorsSuccess,
+    success = WooPosColors.greenNotFromPalette,
     error = WooPosColors.lightCustomColorsError,
     paymentSuccessBackground = WooPosColors.White,
     paymentSuccessText = WooPosColors.Purple90,
     paymentSuccessIcon = Color.White,
-    paymentSuccessIconBackground = Color(0xFF08FB87),
     homeBackground = WooPosColors.Gray0
 )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/WooPosTheme.kt
@@ -188,7 +188,7 @@ private val DarkCustomColors = CustomColors(
     error = WooPosColors.darkCustomColorsError,
     paymentSuccessBackground = WooPosColors.darkCustomColorsHomeBackground,
     paymentSuccessText = WooPosColors.oldGrayLight,
-    paymentSuccessIcon = Color.Black,
+    paymentSuccessIcon = WooPosColors.darkCustomColorsHomeBackground,
     homeBackground = WooPosColors.darkCustomColorsHomeBackground
 )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
@@ -177,7 +177,7 @@ private fun CheckMarkIcon(
         modifier = modifier
             .size(size)
             .shadow(8.dp, CircleShape)
-            .background(WooPosTheme.colors.paymentSuccessIconBackground, CircleShape)
+            .background(WooPosTheme.colors.success, CircleShape)
     ) {
         Icon(
             imageVector = Icons.Default.Check,

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3761,7 +3761,7 @@
     <string name="more_menu_button_settings_description">Update your preferences</string>
 
     <string name="more_menu_button_woo_pos">Point of Sale Mode</string>
-    <string name="more_menu_button_woo_pos_description">Use the app as a cash register</string>
+    <string name="more_menu_button_woo_pos_description">Accept payments at your physical store</string>
 
     <string name="more_menu_customers_title">Customers</string>
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12718
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

TfaZ4LUkEwEGrxfnEFzvJj-fi-5193_39710

* Payment success background color: FFFFFF/1E1E1E
* Green on the card reader connected and checkbox background: 08FB87 (both light and dark)
* Tick on the payment success screen color: FFFFFF/1E1E1E
* Text on the entry point: `Accept payments at your physical store`

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Go to the payments success screen and validate the changes with Figma. Both dark and light mode



### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
^

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

<img width="888" alt="image" src="https://github.com/user-attachments/assets/4a860638-69b6-4a13-bafa-2eea75d6afbc">
<img width="883" alt="image" src="https://github.com/user-attachments/assets/457654ff-1750-4508-ba0d-f705f0d15b88">
<img width="881" alt="image" src="https://github.com/user-attachments/assets/3f00d9e0-9b0b-4ac1-b119-f69b3775e77f">


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->