### PR TITLE
[Login] Cleanup the LoginSiteCredentialsViewModel

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
@@ -36,7 +35,6 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCPasswordField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.component.getText
-import com.woocommerce.android.ui.compose.component.web.WCWebView
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
@@ -50,8 +48,7 @@ fun LoginSiteCredentialsScreen(viewModel: LoginSiteCredentialsViewModel) {
             onResetPasswordClick = viewModel::onResetPasswordClick,
             onBackClick = viewModel::onBackClick,
             onHelpButtonClick = viewModel::onHelpButtonClick,
-            onErrorDialogDismissed = viewModel::onErrorDialogDismissed,
-            onWebAuthorizationUrlLoaded = viewModel::onWebAuthorizationUrlLoaded
+            onErrorDialogDismissed = viewModel::onErrorDialogDismissed
         )
     }
 }
@@ -66,7 +63,6 @@ fun LoginSiteCredentialsScreen(
     onBackClick: () -> Unit,
     onHelpButtonClick: () -> Unit,
     onErrorDialogDismissed: () -> Unit,
-    onWebAuthorizationUrlLoaded: (String) -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -74,204 +70,128 @@ fun LoginSiteCredentialsScreen(
                 title = stringResource(id = R.string.log_in),
                 onNavigationButtonClick = onBackClick,
                 onHelpButtonClick = onHelpButtonClick,
-                navigationIcon = if (viewState is LoginSiteCredentialsViewModel.ViewState.WebAuthorizationViewState) {
-                    Icons.Filled.Clear
-                } else {
-                    Icons.AutoMirrored.Filled.ArrowBack
-                }
+                navigationIcon = Icons.AutoMirrored.Filled.ArrowBack
             )
         }
     ) { paddingValues ->
-        when (viewState) {
-            is LoginSiteCredentialsViewModel.ViewState.NativeLoginViewState -> NativeLoginForm(
-                viewState = viewState,
-                onUsernameChanged = onUsernameChanged,
-                onPasswordChanged = onPasswordChanged,
-                onContinueClick = onContinueClick,
-                onResetPasswordClick = onResetPasswordClick,
-                onErrorDialogDismissed = onErrorDialogDismissed,
-                onHelpButtonClick = onHelpButtonClick,
-                modifier = Modifier.padding(paddingValues)
-            )
-
-            is LoginSiteCredentialsViewModel.ViewState.WebAuthorizationViewState -> WebAuthorizationScreen(
-                viewState = viewState,
-                onPageFinished = onWebAuthorizationUrlLoaded,
-                onErrorDialogDismissed = {
-                    onErrorDialogDismissed()
-                    onBackClick()
-                },
-                modifier = Modifier.padding(paddingValues)
-            )
-        }
-    }
-}
-
-@Composable
-private fun NativeLoginForm(
-    viewState: LoginSiteCredentialsViewModel.ViewState.NativeLoginViewState,
-    onUsernameChanged: (String) -> Unit,
-    onPasswordChanged: (String) -> Unit,
-    onContinueClick: () -> Unit,
-    onResetPasswordClick: () -> Unit,
-    onErrorDialogDismissed: () -> Unit,
-    onHelpButtonClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier
-            .background(MaterialTheme.colors.surface)
-            .fillMaxSize(),
-    ) {
         Column(
             modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
-                .padding(dimensionResource(id = R.dimen.major_100)),
+                .padding(paddingValues)
+                .background(MaterialTheme.colors.surface)
+                .fillMaxSize(),
         ) {
-            Text(
-                text = stringResource(id = R.string.enter_credentials_for_site, viewState.siteUrl),
-                style = MaterialTheme.typography.body2
-            )
-            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
-            WCOutlinedTextField(
-                value = viewState.username,
-                onValueChange = onUsernameChanged,
-                label = stringResource(id = R.string.username),
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
-            )
-            WCPasswordField(
-                value = viewState.password,
-                onValueChange = onPasswordChanged,
-                label = stringResource(id = R.string.password),
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                keyboardActions = KeyboardActions(
-                    onDone = { onContinueClick() }
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(dimensionResource(id = R.dimen.major_100)),
+            ) {
+                Text(
+                    text = stringResource(id = R.string.enter_credentials_for_site, viewState.siteUrl),
+                    style = MaterialTheme.typography.body2
                 )
-            )
-            WCTextButton(onClick = onResetPasswordClick) {
-                Text(text = stringResource(id = R.string.reset_your_password))
-            }
-        }
-
-        WCColoredButton(
-            onClick = onContinueClick,
-            enabled = viewState.isValid,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = dimensionResource(id = R.dimen.major_100))
-        ) {
-            Text(
-                text = stringResource(id = R.string.continue_button)
-            )
-        }
-        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
-    }
-
-    if (viewState.errorDialogMessage != null) {
-        AlertDialog(
-            text = {
-                Text(text = viewState.errorDialogMessage.getText())
-            },
-            onDismissRequest = onErrorDialogDismissed,
-            buttons = {
-                Column(
-                    horizontalAlignment = Alignment.End,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = dimensionResource(id = R.dimen.major_100))
-                ) {
-                    WCTextButton(
-                        onClick = {
-                            onErrorDialogDismissed()
-                            onHelpButtonClick()
-                        }
-                    ) {
-                        Text(text = stringResource(id = R.string.login_site_address_more_help))
-                    }
-                    WCTextButton(
-                        onClick = onErrorDialogDismissed
-                    ) {
-                        Text(
-                            text = stringResource(id = R.string.cancel),
-                            textAlign = TextAlign.End
-                        )
-                    }
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                WCOutlinedTextField(
+                    value = viewState.username,
+                    onValueChange = onUsernameChanged,
+                    label = stringResource(id = R.string.username),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
+                )
+                WCPasswordField(
+                    value = viewState.password,
+                    onValueChange = onPasswordChanged,
+                    label = stringResource(id = R.string.password),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(
+                        onDone = { onContinueClick() }
+                    )
+                )
+                WCTextButton(onClick = onResetPasswordClick) {
+                    Text(text = stringResource(id = R.string.reset_your_password))
                 }
             }
-        )
-    }
 
-    if (viewState.loadingMessage != null) {
-        ProgressDialog(title = "", subtitle = stringResource(id = viewState.loadingMessage))
-    }
-}
-
-@Composable
-private fun WebAuthorizationScreen(
-    viewState: LoginSiteCredentialsViewModel.ViewState.WebAuthorizationViewState,
-    onPageFinished: (String) -> Unit,
-    onErrorDialogDismissed: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    when {
-        viewState.loadingMessage != null -> {
-            ProgressDialog(title = "", subtitle = stringResource(id = viewState.loadingMessage))
+            WCColoredButton(
+                onClick = onContinueClick,
+                enabled = viewState.isValid,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+            ) {
+                Text(
+                    text = stringResource(id = R.string.continue_button)
+                )
+            }
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         }
 
-        viewState.errorDialogMessage != null -> {
+        if (viewState.errorDialogMessage != null) {
             AlertDialog(
                 text = {
                     Text(text = viewState.errorDialogMessage.getText())
                 },
                 onDismissRequest = onErrorDialogDismissed,
-                confirmButton = {
-                    WCTextButton(
-                        onClick = onErrorDialogDismissed
+                buttons = {
+                    Column(
+                        horizontalAlignment = Alignment.End,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = dimensionResource(id = R.dimen.major_100))
                     ) {
-                        Text(text = stringResource(id = android.R.string.ok))
+                        WCTextButton(
+                            onClick = {
+                                onErrorDialogDismissed()
+                                onHelpButtonClick()
+                            }
+                        ) {
+                            Text(text = stringResource(id = R.string.login_site_address_more_help))
+                        }
+                        WCTextButton(
+                            onClick = onErrorDialogDismissed
+                        ) {
+                            Text(
+                                text = stringResource(id = R.string.cancel),
+                                textAlign = TextAlign.End
+                            )
+                        }
                     }
                 }
             )
         }
 
-        viewState.authorizationUrl != null -> {
-            WCWebView(
-                url = viewState.authorizationUrl,
-                userAgent = viewState.userAgent,
-                onPageFinished = onPageFinished,
-                modifier = modifier
-            )
+        if (viewState.loadingMessage != null) {
+            ProgressDialog(title = "", subtitle = stringResource(id = viewState.loadingMessage))
         }
     }
 }
 
 @Preview
 @Composable
-private fun NativeLoginFormPreview() {
+private fun LoginSiteCredentialsScreenPreview() {
     WooThemeWithBackground {
-        NativeLoginForm(
-            viewState = LoginSiteCredentialsViewModel.ViewState.NativeLoginViewState(
+        LoginSiteCredentialsScreen(
+            viewState = LoginSiteCredentialsViewModel.ViewState(
                 siteUrl = "https://wordpress.com"
             ),
             onUsernameChanged = {},
             onPasswordChanged = {},
             onContinueClick = {},
             onResetPasswordClick = {},
-            onErrorDialogDismissed = {},
-            onHelpButtonClick = {}
+            onBackClick = {},
+            onHelpButtonClick = {},
+            onErrorDialogDismissed = {}
         )
     }
 }
 
 @Preview
 @Composable
-private fun NativeLoginFormWithErrorDialogPreview() {
+private fun LoginSiteCredentialsScreenWithErrorPreview() {
     WooThemeWithBackground {
-        NativeLoginForm(
-            viewState = LoginSiteCredentialsViewModel.ViewState.NativeLoginViewState(
+        LoginSiteCredentialsScreen(
+            viewState = LoginSiteCredentialsViewModel.ViewState(
                 siteUrl = "https://wordpress.com",
                 errorDialogMessage = UiString.UiStringRes(R.string.login_site_credentials_fetching_site_failed)
             ),
@@ -279,8 +199,9 @@ private fun NativeLoginFormWithErrorDialogPreview() {
             onPasswordChanged = {},
             onContinueClick = {},
             onResetPasswordClick = {},
-            onErrorDialogDismissed = {},
-            onHelpButtonClick = {}
+            onBackClick = {},
+            onHelpButtonClick = {},
+            onErrorDialogDismissed = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -189,6 +189,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     }
 
     fun retryApplicationPasswordsCheck() = launch {
+        fetchedSiteId.value = -1
         login()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.module.ApplicationPasswordsClientId
-import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.INVALID_CREDENTIALS
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
 import org.wordpress.android.login.LoginAnalyticsListener
@@ -55,7 +54,6 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     applicationPasswordsNotifier: ApplicationPasswordsNotifier,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val appPrefs: AppPrefsWrapper,
-    private val userAgent: UserAgent,
     private val resourceProvider: ResourceProvider,
     @ApplicationPasswordsClientId private val applicationPasswordsClientId: String
 ) : ScopedViewModel(savedStateHandle) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -312,7 +312,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                     if (site.fullAuthorizationUrl.isNotNullOrEmpty()) {
                         triggerEvent(
                             ShowApplicationPasswordTutorialScreen(
-                                url = site.applicationPasswordsAuthorizeUrl,
+                                url = site.fullAuthorizationUrl!!,
                                 errorMessage = errorMessage
                             )
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -191,7 +191,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     }
 
     fun retryApplicationPasswordsCheck() = launch {
-        fetchUserInfo()
+        login()
     }
 
     private suspend fun login() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -30,10 +30,7 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -75,7 +72,6 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
     private val siteAddress: String = savedStateHandle[SITE_ADDRESS_KEY]!!
 
-    private val state = savedStateHandle.getStateFlow(viewModelScope, State.NativeLogin)
     private val errorDialogMessage = savedStateHandle.getNullableStateFlow(
         scope = viewModelScope,
         initialValue = null,
@@ -90,17 +86,20 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         get() = this?.applicationPasswordsAuthorizeUrl
             ?.let { url -> "$url?app_name=$applicationPasswordsClientId&success_url=$REDIRECTION_URL" }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    val viewState = state.flatMapLatest {
-        // Reset loading and error state when the state changes
-        loadingMessage.value = 0
-        errorDialogMessage.value = null
-
-        when (it) {
-            State.NativeLogin -> prepareNativeLoginViewState()
-            State.WebAuthorization -> prepareWebAuthorizationViewState()
-            State.RetryWebAuthorization -> prepareWebAuthorizationViewState()
-        }
+    val viewState = combine(
+        flowOf(siteAddress.removeSchemeAndSuffix()),
+        savedStateHandle.getStateFlow(USERNAME_KEY, ""),
+        savedStateHandle.getStateFlow(PASSWORD_KEY, ""),
+        loadingMessage.map { message -> message.takeIf { it != 0 } },
+        errorDialogMessage
+    ) { siteAddress, username, password, loadingMessage, errorDialog ->
+        ViewState(
+            siteUrl = siteAddress,
+            username = username,
+            password = password,
+            loadingMessage = loadingMessage,
+            errorDialogMessage = errorDialog
+        )
     }.asLiveData()
 
     init {
@@ -150,28 +149,13 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     }
 
     fun onBackClick() {
-        if (state.value == State.WebAuthorization) {
-            fetchedSiteId.value = -1
-            state.value = State.NativeLogin
-        } else {
-            triggerEvent(Exit)
-        }
+        triggerEvent(Exit)
     }
 
     fun onHelpButtonClick() {
         viewState.value?.let {
-            triggerEvent(ShowHelpScreen(siteAddress, (it as? ViewState.NativeLoginViewState)?.username.orEmpty()))
+            triggerEvent(ShowHelpScreen(siteAddress, it.username))
         }
-    }
-
-    /**
-     * This is currently a unreachable event due to the current usage of the application passwords feature
-     * available in the [ShowApplicationPasswordTutorialScreen] event, but it's kept here for future reference
-     * in case we need to start the Authorization from here back again.
-     */
-    fun onStartWebAuthorizationClick() {
-        state.value = State.WebAuthorization
-        analyticsTracker.track(AnalyticsEvent.APPLICATION_PASSWORDS_AUTHORIZATION_WEB_VIEW_SHOWN)
     }
 
     fun onWebAuthorizationUrlLoaded(url: String) {
@@ -185,7 +169,6 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                 val isSuccess = params[SUCCESS_PARAMETER]?.toBoolean() ?: true
                 if (!isSuccess) {
                     fetchedSiteId.value = -1
-                    state.value = State.NativeLogin
 
                     analyticsTracker.track(AnalyticsEvent.APPLICATION_PASSWORDS_AUTHORIZATION_REJECTED)
                     triggerEvent(ShowSnackbar(R.string.login_site_credentials_web_authorization_connection_rejected))
@@ -208,53 +191,11 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     }
 
     fun retryApplicationPasswordsCheck() = launch {
-        if (state.value == State.NativeLogin) {
-            // When using native login, retry fetching user info
-            fetchUserInfo()
-        } else {
-            // When using web authorization, retry fetching the site
-            fetchSite()
-            state.value = State.RetryWebAuthorization
-        }
-    }
-
-    private fun prepareNativeLoginViewState(): Flow<ViewState.NativeLoginViewState> = combine(
-        flowOf(siteAddress.removeSchemeAndSuffix()),
-        savedStateHandle.getStateFlow(USERNAME_KEY, ""),
-        savedStateHandle.getStateFlow(PASSWORD_KEY, ""),
-        loadingMessage.map { message -> message.takeIf { it != 0 } },
-        errorDialogMessage
-    ) { siteAddress, username, password, loadingMessage, errorDialog ->
-        ViewState.NativeLoginViewState(
-            siteUrl = siteAddress,
-            username = username,
-            password = password,
-            loadingMessage = loadingMessage,
-            errorDialogMessage = errorDialog
-        )
-    }
-
-    private fun prepareWebAuthorizationViewState(): Flow<ViewState.WebAuthorizationViewState> {
-        if (fetchedSiteId.value == -1) {
-            launch { fetchSite() }
-        }
-
-        return combine(
-            loadingMessage.map { message -> message.takeIf { it != 0 } },
-            errorDialogMessage,
-            fetchedSiteId.map { if (it == -1) null else wpApiSiteRepository.getSiteByLocalId(it) }
-        ) { loadingMessage, errorDialogMessage, site ->
-            ViewState.WebAuthorizationViewState(
-                authorizationUrl = site?.fullAuthorizationUrl,
-                userAgent = userAgent,
-                loadingMessage = loadingMessage,
-                errorDialogMessage = errorDialogMessage
-            )
-        }
+        fetchUserInfo()
     }
 
     private suspend fun login() {
-        val state = requireNotNull(this@LoginSiteCredentialsViewModel.viewState.value as ViewState.NativeLoginViewState)
+        val state = requireNotNull(this@LoginSiteCredentialsViewModel.viewState.value)
         loadingMessage.value = R.string.logging_in
         wpApiSiteRepository.login(
             url = siteAddress,
@@ -333,27 +274,16 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
     private suspend fun fetchSite() {
         val viewState = viewState.value
-        loadingMessage.value = if (state.value == State.WebAuthorization) {
-            R.string.login_site_credentials_fetching_site
-        } else {
-            R.string.logging_in
-        }
+        loadingMessage.value = R.string.logging_in
         wpApiSiteRepository.fetchSite(
             url = siteAddress,
-            username = (viewState as? ViewState.NativeLoginViewState)?.username,
-            password = (viewState as? ViewState.NativeLoginViewState)?.password
+            username = viewState?.username,
+            password = viewState?.password
         ).fold(
             onSuccess = { site ->
                 if (site.hasWooCommerce) {
                     fetchedSiteId.value = site.id
-                    // In case of the native login, then continue with the login flow
-                    // Otherwise, the web authorization flow will handle the login
-                    if (state.value == State.NativeLogin) {
-                        fetchUserInfo()
-                    } else if (site.applicationPasswordsAuthorizeUrl.isNullOrEmpty()) {
-                        analyticsTracker.track(AnalyticsEvent.APPLICATION_PASSWORDS_AUTHORIZATION_URL_NOT_AVAILABLE)
-                        triggerEvent(ShowApplicationPasswordsUnavailableScreen(siteAddress, site.isJetpackConnected))
-                    }
+                    fetchUserInfo()
                 } else {
                     triggerEvent(ShowNonWooErrorScreen(siteAddress))
                 }
@@ -450,27 +380,14 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         is UiStringText -> text
     }
 
-    private enum class State {
-        NativeLogin, WebAuthorization, RetryWebAuthorization
-    }
-
-    sealed interface ViewState {
-        data class NativeLoginViewState(
-            val siteUrl: String,
-            val username: String = "",
-            val password: String = "",
-            @StringRes val loadingMessage: Int? = null,
-            val errorDialogMessage: UiString? = null
-        ) : ViewState {
-            val isValid = username.isNotBlank() && password.isNotBlank()
-        }
-
-        data class WebAuthorizationViewState(
-            val authorizationUrl: String?,
-            val userAgent: UserAgent,
-            @StringRes val loadingMessage: Int? = null,
-            val errorDialogMessage: UiString? = null
-        ) : ViewState
+    data class ViewState(
+        val siteUrl: String,
+        val username: String = "",
+        val password: String = "",
+        @StringRes val loadingMessage: Int? = null,
+        val errorDialogMessage: UiString? = null
+    ) {
+        val isValid = username.isNotBlank() && password.isNotBlank()
     }
 
     @VisibleForTesting

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/applicationpassword/ApplicationPasswordTutorialScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.login.sitecredentials.applicationpassword
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -38,6 +39,8 @@ import org.wordpress.android.fluxc.network.UserAgent
 
 @Composable
 fun ApplicationPasswordTutorialScreen(viewModel: ApplicationPasswordTutorialViewModel) {
+    BackHandler { viewModel.onNavigationButtonClicked() }
+
     val viewState = viewModel.viewState.observeAsState()
     ApplicationPasswordTutorialScreen(
         authorizationStarted = viewState.value?.authorizationStarted ?: false,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -37,7 +37,6 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
-import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.login.LoginAnalyticsListener
@@ -74,7 +73,6 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
     private val loginAnalyticsListener: LoginAnalyticsListener = mock()
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
     private val appPrefs: AppPrefsWrapper = mock()
-    private val userAgent: UserAgent = mock()
     private val resourceProvider: ResourceProvider = mock {
         on { getString(any()) } doAnswer { it.arguments[0].toString() }
     }
@@ -97,7 +95,6 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             applicationPasswordsNotifier = applicationPasswordsNotifier,
             analyticsTracker = analyticsTracker,
             appPrefs = appPrefs,
-            userAgent = userAgent,
             applicationPasswordsClientId = clientId,
             resourceProvider = resourceProvider
         )
@@ -112,7 +109,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
         }.last()
 
         assertThat(state).isEqualTo(
-            LoginSiteCredentialsViewModel.ViewState.NativeLoginViewState(
+            LoginSiteCredentialsViewModel.ViewState(
                 siteUrl = siteAddressWithoutSchemeAndSuffix,
                 username = "",
                 password = ""
@@ -126,7 +123,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
 
         val state = viewModel.viewState.runAndCaptureValues {
             viewModel.onUsernameChanged(testUsername)
-        }.last() as LoginSiteCredentialsViewModel.ViewState.NativeLoginViewState
+        }.last()
 
         assertThat(state.username).isEqualTo(testUsername)
     }
@@ -137,7 +134,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
 
         val state = viewModel.viewState.runAndCaptureValues {
             viewModel.onUsernameChanged(testPassword)
-        }.last() as LoginSiteCredentialsViewModel.ViewState.NativeLoginViewState
+        }.last()
 
         assertThat(state.username).isEqualTo(testPassword)
     }
@@ -148,7 +145,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
 
         val state = viewModel.viewState.runAndCaptureValues {
             viewModel.onUsernameChanged("")
-        }.last() as LoginSiteCredentialsViewModel.ViewState.NativeLoginViewState
+        }.last()
 
         assertThat(state.isValid).isFalse()
     }
@@ -159,7 +156,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
 
         val state = viewModel.viewState.runAndCaptureValues {
             viewModel.onPasswordChanged("")
-        }.last() as LoginSiteCredentialsViewModel.ViewState.NativeLoginViewState
+        }.last()
 
         assertThat(state.isValid).isFalse()
     }
@@ -224,7 +221,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             viewModel.onUsernameChanged(testUsername)
             viewModel.onPasswordChanged(testPassword)
             viewModel.onContinueClick()
-        }.last() as LoginSiteCredentialsViewModel.ViewState.NativeLoginViewState
+        }.last()
 
         assertThat(state.errorDialogMessage).isEqualTo(expectedError.errorMessage)
         verify(analyticsTracker).track(
@@ -295,7 +292,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given application pwd disabled and wp-login-php accessible, when submitting native login, then show error screen`() = testBlocking {
+    fun `given application pwd disabled and wp-login-php accessible, when submitting login, then show error screen`() = testBlocking {
         setup {
             whenever(wpApiSiteRepository.checkIfUserIsEligible(testSite)).thenReturn(Result.failure(Exception()))
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -121,26 +121,6 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given shown login error dialog, when user chooses wp-admin login, then show login webview`() = testBlocking {
-        setup {
-            whenever(wpApiSiteRepository.getSiteByLocalId(testSite.id)).thenReturn(
-                testSite.apply { applicationPasswordsAuthorizeUrl = urlAuthBase }
-            )
-        }
-
-        val state = viewModel.viewState.runAndCaptureValues {
-            viewModel.onStartWebAuthorizationClick()
-        }.last()
-
-        assertThat(state).isEqualTo(
-            LoginSiteCredentialsViewModel.ViewState.WebAuthorizationViewState(
-                authorizationUrl = urlAuthFull,
-                userAgent = userAgent
-            )
-        )
-    }
-
-    @Test
     fun `when changing username, then update state`() = testBlocking {
         setup()
 
@@ -324,19 +304,6 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             viewModel.onUsernameChanged(testUsername)
             viewModel.onPasswordChanged(testPassword)
             viewModel.onContinueClick()
-            applicationPasswordsUnavailableEvents.tryEmit(mock())
-        }
-
-        assertThat(viewModel.event.value)
-            .isEqualTo(ShowApplicationPasswordsUnavailableScreen(siteAddress, isJetpackConnected))
-    }
-
-    @Test
-    fun `given application pwd disabled and wp-login-php inaccessible, when choosing webview login, then show error`() = testBlocking {
-        setup()
-
-        viewModel.viewState.observeForTesting {
-            viewModel.onStartWebAuthorizationClick()
             applicationPasswordsUnavailableEvents.tryEmit(mock())
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -393,6 +393,8 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
         setup {
             whenever(wpApiSiteRepository.login(siteAddress, testUsername, testPassword))
                 .thenReturn(Result.failure(Exception()))
+            whenever(wpApiSiteRepository.fetchSite(siteAddress, testUsername, testPassword))
+                .thenReturn(Result.success(testSite.apply { applicationPasswordsAuthorizeUrl = urlAuthBase }))
         }
 
         val event = viewModel.event.runAndCaptureValues {


### PR DESCRIPTION
### Description
While working on fixing the identified Application Passwords issue in #12717, I noticed that much of the logic of `LoginSiteCredentialsViewModel` is not used anymore since the introduction of the Application Passwords tutorial screen.

This PR removes the unused logic, to make the maintenance easier in the future.

### Steps to reproduce
1.  Use a self-hosted website (non-atomic).
2. If the site has Jetpack, then use the button "Sign in using site credentials" in the email screen.
3. If the site doesn't have Jetpack, then the app will directly take you to the site credentials screen.

### Testing information
Generally the changes shouldn't have an impact, as we removed just dead-code, but if you have time, these are ideas to what to test:
- Test happy path (sign in using native UI)
- Test sign in using the WebView (when an error other than wrong credentials occur, for example `Captcha`, check https://github.com/woocommerce/woocommerce-android/pull/12758 for how to set it up)
- Test the case where Application Passwords are disabled.

### The tests that have been performed
I tested the above scenarios.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->