### PR TITLE
[Custom Fields] Empty state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
@@ -57,6 +57,7 @@ class CustomFieldsFragment : BaseFragment() {
                     action = { event.action.onClick(null) }
                 )
 
+                is MultiLiveEvent.Event.OpenUrl -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 is MultiLiveEvent.Event.Exit -> {
                     findNavController().navigateUp()
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -87,6 +87,7 @@ fun CustomFieldsScreen(
             onCustomFieldClicked = viewModel::onCustomFieldClicked,
             onCustomFieldValueClicked = viewModel::onCustomFieldValueClicked,
             onAddCustomFieldClicked = viewModel::onAddCustomFieldClicked,
+            onLearnMoreClicked = viewModel::onLearnMoreClicked,
             onBackClick = viewModel::onBackClick,
             snackbarHostState = snackbarHostState
         )
@@ -109,6 +110,7 @@ private fun CustomFieldsScreen(
     onCustomFieldClicked: (CustomFieldUiModel) -> Unit,
     onCustomFieldValueClicked: (CustomFieldUiModel) -> Unit,
     onAddCustomFieldClicked: () -> Unit,
+    onLearnMoreClicked: () -> Unit,
     onBackClick: () -> Unit,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
 ) {
@@ -173,7 +175,7 @@ private fun CustomFieldsScreen(
                     )
                 } else {
                     CustomFieldsEmptyView(
-                        onLearnMoreTapped = {},
+                        onLearnMoreClicked = onLearnMoreClicked,
                         modifier = Modifier.fillMaxSize()
                     )
                 }
@@ -226,7 +228,7 @@ private fun CustomFieldsList(
 
 @Composable
 private fun CustomFieldsEmptyView(
-    onLearnMoreTapped: () -> Unit,
+    onLearnMoreClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -254,7 +256,7 @@ private fun CustomFieldsEmptyView(
             style = MaterialTheme.typography.body1
         )
 
-        WCColoredButton(onClick = onLearnMoreTapped) {
+        WCColoredButton(onClick = onLearnMoreClicked) {
             Text(text = stringResource(id = R.string.learn_more))
         }
 
@@ -416,6 +418,7 @@ private fun CustomFieldsScreenPreview() {
             onCustomFieldClicked = {},
             onCustomFieldValueClicked = {},
             onAddCustomFieldClicked = {},
+            onLearnMoreClicked = {},
             onBackClick = {}
         )
     }
@@ -452,6 +455,7 @@ private fun CustomFieldsEmptyViewPreview() {
             onCustomFieldClicked = {},
             onCustomFieldValueClicked = {},
             onAddCustomFieldClicked = {},
+            onLearnMoreClicked = {},
             onBackClick = {}
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.customfields.list
 
 import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.Interaction
@@ -18,7 +19,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.ClickableText
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FloatingActionButton
@@ -43,14 +46,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.UrlAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.woocommerce.android.R
@@ -58,6 +62,7 @@ import com.woocommerce.android.ui.compose.component.DiscardChangesDialog
 import com.woocommerce.android.ui.compose.component.ExpandableTopBanner
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -159,16 +164,18 @@ private fun CustomFieldsScreen(
                     .padding(paddingValues)
                     .pullRefresh(state = pullToRefreshState)
             ) {
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(state.customFields) { customField ->
-                        CustomFieldItem(
-                            customField = customField,
-                            onClicked = onCustomFieldClicked,
-                            onValueClicked = onCustomFieldValueClicked,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                        Divider()
-                    }
+                if (state.customFields.isNotEmpty()) {
+                    CustomFieldsList(
+                        customFields = state.customFields,
+                        onCustomFieldClicked = onCustomFieldClicked,
+                        onCustomFieldValueClicked = onCustomFieldValueClicked,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                } else {
+                    CustomFieldsEmptyView(
+                        onLearnMoreTapped = {},
+                        modifier = Modifier.fillMaxSize()
+                    )
                 }
 
                 PullRefreshIndicator(
@@ -192,6 +199,66 @@ private fun CustomFieldsScreen(
                 dismissButton = it.onCancel
             )
         }
+    }
+}
+
+@Composable
+private fun CustomFieldsList(
+    customFields: List<CustomFieldUiModel>,
+    onCustomFieldClicked: (CustomFieldUiModel) -> Unit,
+    onCustomFieldValueClicked: (CustomFieldUiModel) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(customFields) { customField ->
+            CustomFieldItem(
+                customField = customField,
+                onClicked = onCustomFieldClicked,
+                onValueClicked = onCustomFieldValueClicked
+            )
+            Divider()
+        }
+    }
+}
+
+@Composable
+private fun CustomFieldsEmptyView(
+    onLearnMoreTapped: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(32.dp),
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.weight(1f))
+
+        Text(
+            text = stringResource(id = R.string.custom_fields_empty_view_title),
+            style = MaterialTheme.typography.h6,
+            textAlign = TextAlign.Center
+        )
+        Image(
+            painter = painterResource(id = R.drawable.img_empty_tax),
+            contentDescription = null,
+        )
+        Text(
+            text = stringResource(id = R.string.custom_fields_empty_view_message),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.body1
+        )
+
+        WCColoredButton(onClick = onLearnMoreTapped) {
+            Text(text = stringResource(id = R.string.learn_more))
+        }
+
+        Spacer(Modifier.weight(1f))
     }
 }
 
@@ -324,7 +391,6 @@ private fun JsonCustomFieldViewer(
 }
 
 @LightDarkThemePreviews
-@Preview
 @Composable
 private fun CustomFieldsScreenPreview() {
     WooThemeWithBackground {
@@ -356,7 +422,6 @@ private fun CustomFieldsScreenPreview() {
 }
 
 @LightDarkThemePreviews
-@Preview
 @Composable
 private fun JsonCustomFieldViewerPreview() {
     WooThemeWithBackground {
@@ -369,6 +434,25 @@ private fun JsonCustomFieldViewerPreview() {
                 )
             ),
             onDismiss = {}
+        )
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun CustomFieldsEmptyViewPreview() {
+    WooThemeWithBackground {
+        CustomFieldsScreen(
+            state = CustomFieldsViewModel.UiState(
+                customFields = emptyList(),
+                topBannerState = CustomFieldsViewModel.TopBannerState { }
+            ),
+            onPullToRefresh = {},
+            onSaveClicked = {},
+            onCustomFieldClicked = {},
+            onCustomFieldValueClicked = {},
+            onAddCustomFieldClicked = {},
+            onBackClick = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.customfields.list
 
 import android.os.Parcelable
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
@@ -25,6 +26,7 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import org.wordpress.android.fluxc.model.metadata.MetaDataParentItemType
 import org.wordpress.android.fluxc.model.metadata.UpdateMetadataRequest
 import javax.inject.Inject
 
@@ -35,6 +37,15 @@ class CustomFieldsViewModel @Inject constructor(
     private val appPrefs: AppPrefsWrapper,
     private val resourceProvider: ResourceProvider
 ) : ScopedViewModel(savedStateHandle) {
+    companion object {
+        @VisibleForTesting
+        const val PRODUCTS_HELP_DOCUMENT = "https://woocommerce.com/document/custom-product-fields/"
+
+        @VisibleForTesting
+        const val ORDERS_HELP_DOCUMENT =
+            "https://woocommerce.com/document/managing-orders/view-edit-or-add-an-order/#custom-fields"
+    }
+
     private val args: CustomFieldsFragmentArgs by savedStateHandle.navArgs()
     val parentItemId: Long = args.parentItemId
 
@@ -181,6 +192,14 @@ class CustomFieldsViewModel @Inject constructor(
                 }
             )
         )
+    }
+
+    fun onLearnMoreClicked() {
+        val url = when (args.parentItemType) {
+            MetaDataParentItemType.PRODUCT -> PRODUCTS_HELP_DOCUMENT
+            MetaDataParentItemType.ORDER -> ORDERS_HELP_DOCUMENT
+        }
+        triggerEvent(MultiLiveEvent.Event.OpenUrl(url))
     }
 
     fun onSaveClicked() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
@@ -97,7 +97,7 @@ class CustomFieldsViewModel @Inject constructor(
                     onCancel = { showDiscardChangesDialog.value = false }
                 )
             },
-            topBannerState = bannerDismissed.takeIf { !it }?.let {
+            topBannerState = (!bannerDismissed && pendingChanges.hasChanges).takeIf { it }?.let {
                 TopBannerState {
                     appPrefs.isCustomFieldsTopBannerDismissed = true
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/viewmodel/MultiLiveEvent.kt
@@ -202,5 +202,7 @@ open class MultiLiveEvent<T : Event> : MutableLiveData<T>() {
                 )
             }
         }
+
+        data class OpenUrl(val url: String) : Event()
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4301,6 +4301,8 @@
     <string name="custom_fields_list_top_banner_title">View and edit Custom Fields</string>
     <string name="custom_fields_list_top_banner_message">When saving changes to custom fields, they will take effect immediately.</string>
     <string name="custom_fields_add_button">Add custom fields</string>
+    <string name="custom_fields_empty_view_message">Custom fields are optional metadata to display extra information or customize your store’s shopping experience.</string>
+    <string name="custom_fields_empty_view_title">No custom fields found</string>
     <string name="custom_fields_editor_key_label">Key</string>
     <string name="custom_fields_editor_value_label">Value</string>
     <string name="custom_fields_editor_key_error_duplicate">This key is already used for another custom field.\nThe app currently does not support creating duplicate keys. Please use wp-admin to duplicate a key if needed.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
@@ -411,7 +411,7 @@ class CustomFieldsViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given custom fields top banner is not dismissed, when screen is opened, then banner is shown`() = testBlocking {
+    fun `given custom fields top banner is not dismissed, when there are pending changes, then banner is shown`() = testBlocking {
         appPrefs.isCustomFieldsTopBannerDismissed = false
         setup()
         // Trigger a change to make sure the banner is shown

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
@@ -411,20 +411,23 @@ class CustomFieldsViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given custom fields top banner is not dismissed, when screen is opened, then banner is shown`() =
-        testBlocking {
-            appPrefs.isCustomFieldsTopBannerDismissed = false
-            setup()
+    fun `given custom fields top banner is not dismissed, when screen is opened, then banner is shown`() = testBlocking {
+        appPrefs.isCustomFieldsTopBannerDismissed = false
+        setup()
+        // Trigger a change to make sure the banner is shown
+        viewModel.onCustomFieldInserted(CustomFieldUiModel(key = "key", value = "value"))
 
-            val state = viewModel.state.getOrAwaitValue()
+        val state = viewModel.state.getOrAwaitValue()
 
-            assertThat(state.topBannerState).isNotNull
-        }
+        assertThat(state.topBannerState).isNotNull
+    }
 
     @Test
     fun `given custom fields top banner is shown, when banner is dismissed, then banner is not shown`() = testBlocking {
         appPrefs.isCustomFieldsTopBannerDismissed = false
         setup()
+        // Trigger a change to make sure the banner is shown
+        viewModel.onCustomFieldInserted(CustomFieldUiModel(key = "key", value = "value"))
 
         val initialState = viewModel.state.getOrAwaitValue()
         val state = viewModel.state.runAndCaptureValues {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
@@ -65,10 +65,13 @@ class CustomFieldsViewModelTest : BaseUnitTest() {
     }
     private lateinit var viewModel: CustomFieldsViewModel
 
-    suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
+    suspend fun setup(
+        parentItemType: MetaDataParentItemType = PARENT_ITEM_TYPE,
+        prepareMocks: suspend () -> Unit = {}
+    ) {
         prepareMocks()
         viewModel = CustomFieldsViewModel(
-            savedStateHandle = CustomFieldsFragmentArgs(PARENT_ITEM_ID, PARENT_ITEM_TYPE).toSavedStateHandle(),
+            savedStateHandle = CustomFieldsFragmentArgs(PARENT_ITEM_ID, parentItemType).toSavedStateHandle(),
             repository = repository,
             appPrefs = appPrefs,
             resourceProvider = resourceProvider
@@ -468,5 +471,27 @@ class CustomFieldsViewModelTest : BaseUnitTest() {
         }.last()
 
         assertThat(overlayedField).isNull()
+    }
+
+    @Test
+    fun `given product custom fields, when learn more button is tapped, then open correct URL`() = testBlocking {
+        setup(parentItemType = MetaDataParentItemType.PRODUCT)
+
+        val event = viewModel.event.runAndCaptureValues {
+            viewModel.onLearnMoreClicked()
+        }.last()
+
+        assertThat(event).isEqualTo(MultiLiveEvent.Event.OpenUrl(CustomFieldsViewModel.PRODUCTS_HELP_DOCUMENT))
+    }
+
+    @Test
+    fun `given order custom fields, when learn more button is tapped, then open correct URL`() = testBlocking {
+        setup(parentItemType = MetaDataParentItemType.ORDER)
+
+        val event = viewModel.event.runAndCaptureValues {
+            viewModel.onLearnMoreClicked()
+        }.last()
+
+        assertThat(event).isEqualTo(MultiLiveEvent.Event.OpenUrl(CustomFieldsViewModel.ORDERS_HELP_DOCUMENT))
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12732
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR adds an empty state to the custom fields screen.

It also updates the logic of the top banner to be shown only when there are pending changes, this was discussed here p1727697084758769/1727685068.374159-slack-C03L1NF1EA3

### Steps to reproduce
##### Orders
1. Open an order in the app.
2. Tap on "Edit Fields" button.
3. If there are some existing fields, then delete them.

##### Products
1. Open a product in the app.
2. Tap on "Add more details", then select custom fields.

### Testing information
- Check the UI of the empty view.
- Test the Learn more button.
- Confirm the empty view is hidden when adding some custom fields.
- Confirm the top banner is shown when there are some changes to save.

### The tests that have been performed
The above.

### Images/gif
<img src=https://github.com/user-attachments/assets/0aeb4fc1-5e2f-4e5a-87d7-d07beae2f72c width=360 />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->