### PR TITLE
Issue/12742 check objective is set from preview

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewScreen.kt
@@ -56,6 +56,7 @@ import com.woocommerce.android.ui.compose.component.ToolbarWithHelpButton
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.util.FeatureFlag
 
 @Composable
 fun BlazeCampaignCreationPreviewScreen(viewModel: BlazeCampaignCreationPreviewViewModel) {
@@ -318,8 +319,12 @@ fun CampaignDetails(
             text = stringResource(id = R.string.blaze_campaign_preview_details_section_title),
             style = MaterialTheme.typography.body2
         )
-        // Budget
-        CampaignPropertyGroupItem(items = listOf(campaignDetails.selectedObjective, campaignDetails.budget))
+        // Campaign Details
+        if (FeatureFlag.OBJECTIVE_SECTION.isEnabled()) {
+            CampaignPropertyGroupItem(items = listOf(campaignDetails.selectedObjective, campaignDetails.budget))
+        } else {
+            CampaignPropertyGroupItem(items = listOf(campaignDetails.budget))
+        }
         Spacer(modifier = Modifier.height(16.dp))
 
         // Ad Audience

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType.INTERES
 import com.woocommerce.android.ui.blaze.creation.targets.BlazeTargetType.LANGUAGE
 import com.woocommerce.android.ui.compose.DialogState
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -198,7 +199,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
                     positiveButtonOnClick = ::onEditAdClicked
                 )
 
-                isObjectiveMissing -> buildMissingRequiredDataDialog(
+                isObjectiveMissing && FeatureFlag.OBJECTIVE_SECTION.isEnabled() -> buildMissingRequiredDataDialog(
                     message = R.string.blaze_campaign_preview_missing_objective_dialog_text,
                     positiveButtonText = R.string.blaze_campaign_preview_missing_objective_dialog_positive_button,
                     positiveButtonOnClick = { triggerEvent(NavigateToObjectiveSelectionScreen) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -16,7 +16,8 @@ enum class FeatureFlag {
     SHOW_INBOX_CTA,
     ENDLESS_CAMPAIGNS_SUPPORT,
     CUSTOM_FIELDS,
-    REVAMP_WOO_SHIPPING;
+    REVAMP_WOO_SHIPPING,
+    OBJECTIVE_SECTION;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -28,7 +29,8 @@ enum class FeatureFlag {
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
             CUSTOM_FIELDS,
-            REVAMP_WOO_SHIPPING -> PackageUtils.isDebugBuild()
+            REVAMP_WOO_SHIPPING,
+            OBJECTIVE_SECTION -> PackageUtils.isDebugBuild()
 
             NEW_SHIPPING_SUPPORT,
             INBOX,

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3915,7 +3915,8 @@
     <string name="blaze_campaign_preview_missing_image_dialog_positive_button">Add Image</string>
     <string name="blaze_campaign_preview_missing_content_dialog_text">Please add a tagline and a description for your Blaze campaign</string>
     <string name="blaze_campaign_preview_missing_content_dialog_positive_button">Add</string>
-
+    <string name="blaze_campaign_preview_missing_objective_dialog_text">Please select an objective for the Blaze campaign</string>
+    <string name="blaze_campaign_preview_missing_objective_dialog_positive_button">Select objective</string>
     <!--
     Blaze campaign budget screen
     -->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModelTests.kt
@@ -169,6 +169,17 @@ class BlazeCampaignCreationPreviewViewModelTests : BaseUnitTest() {
     }
 
     @Test
+    fun `when screen is opened, then fetch objectives`() = testBlocking {
+        setup {
+            whenever(blazeRepository.fetchObjectives()).doReturn(Result.success(Unit))
+        }
+
+        advanceUntilIdle()
+
+        verify(blazeRepository).fetchObjectives()
+    }
+
+    @Test
     fun `when tapping on edit ad, then open edit ad screen`() = testBlocking {
         setup()
 
@@ -478,13 +489,43 @@ class BlazeCampaignCreationPreviewViewModelTests : BaseUnitTest() {
         }
 
     @Test
+    fun `given objective is missing, when tapping on confirm, then show a dialog`() = testBlocking {
+        setup {
+            whenever(blazeRepository.generateDefaultCampaignDetails(PRODUCT_ID)).doReturn(
+                defaultCampaignDetails.copy(
+                    campaignImage = BlazeCampaignImage.LocalImage("image"),
+                    tagLine = "tagline",
+                    description = "description",
+                    objectiveId = ""
+                )
+            )
+        }
+
+        val state = viewModel.viewState.runAndCaptureValues {
+            viewModel.onConfirmClicked()
+        }.last()
+
+        assertThat(state.dialogState).isNotNull
+        assertThat(state.dialogState!!.message).isEqualTo(
+            UiString.UiStringRes(R.string.blaze_campaign_preview_missing_objective_dialog_text)
+        )
+        assertThat(state.dialogState!!.positiveButton!!.text).isEqualTo(
+            UiString.UiStringRes(R.string.blaze_campaign_preview_missing_objective_dialog_positive_button)
+        )
+        assertThat(state.dialogState!!.negativeButton!!.text).isEqualTo(
+            UiString.UiStringRes(R.string.cancel)
+        )
+    }
+
+    @Test
     fun `given campaign requirements met, when tapping on confirm, then open payment summary`() = testBlocking {
         setup {
             whenever(blazeRepository.generateDefaultCampaignDetails(PRODUCT_ID)).doReturn(
                 defaultCampaignDetails.copy(
                     campaignImage = BlazeCampaignImage.LocalImage("image"),
                     tagLine = "tagline",
-                    description = "description"
+                    description = "description",
+                    objectiveId = "sales"
                 )
             )
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12742 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a couple things: 
- Check that the campaign objective is set before the user can move on in the creation flow
- Adds a feature flag for Objective section
- Unit tests for the new objective check. 

### Testing information
1. Trigger Blaze campaign creation flow
2. Without setting and objective tap on `Confirm details`
3. Notice a dialog is shown requesting to add an objective 
4. Tap on `Select objective` from the dialog
5. Notice how app navigates to objective screen (currently empty)

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/97631e04-a30e-4555-8703-537161dd9027

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->