### PR TITLE
[Custom Fields] Enable Feature

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [**] Fixed bug with coupons disappearing from the order creation screen unexpectedly [https://github.com/woocommerce/woocommerce-android/pull/12724]
 - [Internal] Fixes crash [https://github.com/woocommerce/woocommerce-android/issues/12715]
 - [*] Fixed incorrect instructions on "What is Tap to Pay" screen in the Payments section [https://github.com/woocommerce/woocommerce-android/pull/12709]
+- [***] Merchants can now view and edit custom fields of their products and orders from the app [https://github.com/woocommerce/woocommerce-android/issues/12207]
 
 20.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -27,13 +27,13 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
-            CUSTOM_FIELDS,
             REVAMP_WOO_SHIPPING -> PackageUtils.isDebugBuild()
 
             NEW_SHIPPING_SUPPORT,
             INBOX,
             SHOW_INBOX_CTA,
             GOOGLE_ADS_M1,
+            CUSTOM_FIELDS,
             ENDLESS_CAMPAIGNS_SUPPORT -> true
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12748 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR enables the feature flag.

### Steps to reproduce
##### Orders
1. Open an order in the app.
2. Tap on "Edit Fields" button.
3. If there are some existing fields, then delete them.

##### Products
1. Open a product in the app.
2. If the product has already custom fields, tap on the "Custom Fields" row.
3. If not, tap on "Add more details" and select "Custom Fields"

### Testing information
Smoke test the feature, all the changes should have been tested in previous PRs.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->