### PR TITLE
[Custom Fields] Update buttons to be disabled instead of hidden when there are no changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorScreen.kt
@@ -103,12 +103,11 @@ private fun CustomFieldsEditorScreen(
                 title = "Custom Field",
                 onNavigationButtonClick = onBackButtonClick,
                 actions = {
-                    if (state.showDoneButton) {
-                        WCTextButton(
-                            onClick = onDoneClicked,
-                            text = stringResource(R.string.done)
-                        )
-                    }
+                    WCTextButton(
+                        onClick = onDoneClicked,
+                        text = stringResource(R.string.done),
+                        enabled = state.enableDoneButton
+                    )
                     WCOverflowMenu(
                         items = listOfNotNull(
                             R.string.custom_fields_editor_copy_key,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModel.kt
@@ -176,7 +176,7 @@ class CustomFieldsEditorViewModel @Inject constructor(
         val keyErrorMessage: UiString? = null,
         val isCreatingNewItem: Boolean = false,
     ) {
-        val showDoneButton
+        val enableDoneButton
             get() = customField.key.isNotEmpty() && hasChanges && keyErrorMessage == null
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsScreen.kt
@@ -122,12 +122,11 @@ private fun CustomFieldsScreen(
                 title = stringResource(id = R.string.custom_fields_list_title),
                 onNavigationButtonClick = onBackClick,
                 actions = {
-                    if (state.hasChanges) {
-                        WCTextButton(
-                            text = stringResource(id = R.string.save),
-                            onClick = onSaveClicked
-                        )
-                    }
+                    WCTextButton(
+                        text = stringResource(id = R.string.save),
+                        onClick = onSaveClicked,
+                        enabled = state.hasChanges
+                    )
                 }
             )
         },

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/editor/CustomFieldsEditorViewModelTest.kt
@@ -119,47 +119,47 @@ class CustomFieldsEditorViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given editing an existing field, when key is changed, then show done button`() = testBlocking {
+    fun `given editing an existing field, when key is changed, then enable done button`() = testBlocking {
         setup(editing = true)
 
         val state = viewModel.state.runAndCaptureValues {
             viewModel.onKeyChanged("new key")
         }.last()
 
-        assertThat(state.showDoneButton).isTrue()
+        assertThat(state.enableDoneButton).isTrue()
     }
 
     @Test
-    fun `given editing an existing field, when value is changed, then show done button`() = testBlocking {
+    fun `given editing an existing field, when value is changed, then enable done button`() = testBlocking {
         setup(editing = true)
 
         val state = viewModel.state.runAndCaptureValues {
             viewModel.onValueChanged("new value")
         }.last()
 
-        assertThat(state.showDoneButton).isTrue()
+        assertThat(state.enableDoneButton).isTrue()
     }
 
     @Test
-    fun `given creating a new field, when the key is not empty, then show done button`() = testBlocking {
+    fun `given creating a new field, when the key is not empty, then enable done button`() = testBlocking {
         setup(editing = false)
 
         val state = viewModel.state.runAndCaptureValues {
             viewModel.onKeyChanged("key")
         }.last()
 
-        assertThat(state.showDoneButton).isTrue()
+        assertThat(state.enableDoneButton).isTrue()
     }
 
     @Test
-    fun `when key is empty, then hide done button`() = testBlocking {
+    fun `when key is empty, then disable done button`() = testBlocking {
         setup(editing = false)
 
         val state = viewModel.state.runAndCaptureValues {
             viewModel.onKeyChanged("")
         }.last()
 
-        assertThat(state.showDoneButton).isFalse()
+        assertThat(state.enableDoneButton).isFalse()
     }
 
     @Test
@@ -249,7 +249,7 @@ class CustomFieldsEditorViewModelTest : BaseUnitTest() {
 
         assertThat(state.keyErrorMessage)
             .isEqualTo(UiString.UiStringRes(R.string.custom_fields_editor_key_error_duplicate))
-        assertThat(state.showDoneButton).isFalse()
+        assertThat(state.enableDoneButton).isFalse()
     }
 
     @Test
@@ -291,7 +291,7 @@ class CustomFieldsEditorViewModelTest : BaseUnitTest() {
 
         assertThat(state.keyErrorMessage)
             .isEqualTo(UiString.UiStringRes(R.string.custom_fields_editor_key_error_underscore))
-        assertThat(state.showDoneButton).isFalse()
+        assertThat(state.enableDoneButton).isFalse()
     }
 
     @Test


### PR DESCRIPTION
### Description
This PR updates the logic of the "Save" button in the list screen and the "Done" button in the editor screen to be disabled instead of hidden when there are no changes (or when we can't save).

The rationale for this is that it's better for user discoverability, and it's what we use for newer features (like Blaze), also it allows to align with iOS. More info here pe5sF9-357-p2#comment-4008

### Steps to reproduce
Follow steps from #12749 

### Testing information
I'm not sure there is much to test, code review should be enough here, but feel free to check the behavior of the Done and Save button too.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
| Before | After |
| --- | --- |
| ![Screenshot_20241002_171716](https://github.com/user-attachments/assets/913e5501-03b3-433f-9218-f2270fd41fac) | ![Screenshot_20241002_171631](https://github.com/user-attachments/assets/47fe84e7-7921-4733-a16b-1b1022f2a94c) |
| ![Screenshot_20241002_171710](https://github.com/user-attachments/assets/ae058656-24d8-435b-ae93-588ea9f41fab) | ![Screenshot_20241002_171644](https://github.com/user-attachments/assets/2be90df0-b1d0-4cff-b176-189864f60bc1) |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
