### PR TITLE
[Login] Pass the correct authorization URL to the application passwords tutorial

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -312,7 +312,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                     if (site.fullAuthorizationUrl.isNotNullOrEmpty()) {
                         triggerEvent(
                             ShowApplicationPasswordTutorialScreen(
-                                url = site.applicationPasswordsAuthorizeUrl,
+                                url = site.fullAuthorizationUrl!!,
                                 errorMessage = errorMessage
                             )
                         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -393,6 +393,8 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
         setup {
             whenever(wpApiSiteRepository.login(siteAddress, testUsername, testPassword))
                 .thenReturn(Result.failure(Exception()))
+            whenever(wpApiSiteRepository.fetchSite(siteAddress, testUsername, testPassword))
+                .thenReturn(Result.success(testSite.apply { applicationPasswordsAuthorizeUrl = urlAuthBase }))
         }
 
         val event = viewModel.event.runAndCaptureValues {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### Description
After working on fixing an issue with Application Passwords login in #12717, I made a mistake that will result in failure of Web authorization for all users 🤦, we pass the incomplete URL that doesn't have the required arguments.
This PR fixes this.

### Steps to reproduce
1. Install any Captcha plugin, an example setup is the following:
     - Install [Captcha For WordPress](https://wordpress.org/plugins/captcha-for-contact-form-7/)
     - Open the plugin settings (from the left navigation pane)
     - Enable Captcha for WordPress Login.
     - Choose "Arithmetic" captcha.
     - Save settings.
3. Open the app and attempt to sign in using correct site credentials.
4. Confirm you can finish the login successfully form the **WebView**.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->