### PR TITLE
[Products] Extract subscriptions outside of the Product DB table - Part 2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetails.kt
@@ -50,3 +50,46 @@ fun SubscriptionDetails.toMetadataJson(): JsonArray {
     }
     return jsonArray
 }
+
+fun SubscriptionDetails.toMetaData() = listOf(
+    WCMetaData(
+        id = 0,
+        key = SubscriptionMetadataKeys.SUBSCRIPTION_PRICE,
+        value = price?.toString().orEmpty()
+    ),
+    WCMetaData(
+        id = 0,
+        key = SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD,
+        value = period.value
+    ),
+    WCMetaData(
+        id = 0,
+        key = SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD_INTERVAL,
+        value = periodInterval.toString()
+    ),
+    WCMetaData(
+        id = 0,
+        key = SubscriptionMetadataKeys.SUBSCRIPTION_LENGTH,
+        value = length?.toString().orEmpty()
+    ),
+    WCMetaData(
+        id = 0,
+        key = SubscriptionMetadataKeys.SUBSCRIPTION_SIGN_UP_FEE,
+        value = signUpFee?.toString().orEmpty()
+    ),
+    WCMetaData(
+        id = 0,
+        key = SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_PERIOD,
+        value = (trialPeriod ?: SubscriptionPeriod.Day).value
+    ),
+    WCMetaData(
+        id = 0,
+        key = SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH,
+        value = (trialLength ?: 0).toString()
+    ),
+    WCMetaData(
+        id = 0,
+        key = SubscriptionMetadataKeys.SUBSCRIPTION_ONE_TIME_SHIPPING,
+        value = if (oneTimeShipping) "yes" else "no"
+    )
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/SubscriptionDetails.kt
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.WCProductModel.SubscriptionMetadataKeys
 import org.wordpress.android.fluxc.model.metadata.WCMetaData
+import org.wordpress.android.fluxc.model.metadata.WCMetaDataValue
 import java.math.BigDecimal
 
 @Parcelize
@@ -51,45 +52,14 @@ fun SubscriptionDetails.toMetadataJson(): JsonArray {
     return jsonArray
 }
 
-fun SubscriptionDetails.toMetaData() = listOf(
-    WCMetaData(
-        id = 0,
-        key = SubscriptionMetadataKeys.SUBSCRIPTION_PRICE,
-        value = price?.toString().orEmpty()
-    ),
-    WCMetaData(
-        id = 0,
-        key = SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD,
-        value = period.value
-    ),
-    WCMetaData(
-        id = 0,
-        key = SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD_INTERVAL,
-        value = periodInterval.toString()
-    ),
-    WCMetaData(
-        id = 0,
-        key = SubscriptionMetadataKeys.SUBSCRIPTION_LENGTH,
-        value = length?.toString().orEmpty()
-    ),
-    WCMetaData(
-        id = 0,
-        key = SubscriptionMetadataKeys.SUBSCRIPTION_SIGN_UP_FEE,
-        value = signUpFee?.toString().orEmpty()
-    ),
-    WCMetaData(
-        id = 0,
-        key = SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_PERIOD,
-        value = (trialPeriod ?: SubscriptionPeriod.Day).value
-    ),
-    WCMetaData(
-        id = 0,
-        key = SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH,
-        value = (trialLength ?: 0).toString()
-    ),
-    WCMetaData(
-        id = 0,
-        key = SubscriptionMetadataKeys.SUBSCRIPTION_ONE_TIME_SHIPPING,
-        value = if (oneTimeShipping) "yes" else "no"
-    )
+fun SubscriptionDetails.toMetaData() = mapOf(
+    SubscriptionMetadataKeys.SUBSCRIPTION_PRICE to WCMetaDataValue(price?.toString().orEmpty()),
+    SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD to WCMetaDataValue(period.value),
+    SubscriptionMetadataKeys.SUBSCRIPTION_PERIOD_INTERVAL to WCMetaDataValue(periodInterval),
+    SubscriptionMetadataKeys.SUBSCRIPTION_LENGTH to WCMetaDataValue(length?.toString().orEmpty()),
+    SubscriptionMetadataKeys.SUBSCRIPTION_SIGN_UP_FEE to WCMetaDataValue(signUpFee?.toString().orEmpty()),
+    SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_PERIOD to
+        WCMetaDataValue((trialPeriod ?: SubscriptionPeriod.Day).value),
+    SubscriptionMetadataKeys.SUBSCRIPTION_TRIAL_LENGTH to WCMetaDataValue(trialLength?.toString().orEmpty()),
+    SubscriptionMetadataKeys.SUBSCRIPTION_ONE_TIME_SHIPPING to WCMetaDataValue(if (oneTimeShipping) "yes" else "no"),
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -376,7 +376,7 @@ class ProductDetailViewModel @Inject constructor(
      * Validates if the view model was started for the **add** flow AND there is an already valid product to modify.
      */
     val isProductUnderCreation: Boolean
-        get() = isAddNewProductFlow and isProductStoredAtSite.not()
+        get() = isAddNewProductFlow && isProductStoredAtSite.not()
 
     /**
      * Returns boolean value of [navArgs.isTrashEnabled] to determine if the detail fragment should enable
@@ -1019,8 +1019,8 @@ class ProductDetailViewModel @Inject constructor(
     fun saveAsDraftIfNewVariableProduct() = launch {
         viewState.productAggregateDraft
             ?.takeIf {
-                isProductStoredAtSite.not() and
-                    it.product.productType.isVariableProduct() and
+                isProductStoredAtSite.not() &&
+                    it.product.productType.isVariableProduct() &&
                     (it.product.status == DRAFT)
             }
             ?.takeIf { addProduct(it).first }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/media/ProductImagesUploadWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/media/ProductImagesUploadWorkerTest.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.media.ProductImagesUploadWorker.Event.ProductUpda
 import com.woocommerce.android.media.ProductImagesUploadWorker.Event.ProductUpdateEvent.ProductUpdateSucceeded
 import com.woocommerce.android.media.ProductImagesUploadWorker.Event.ProductUploadsCompleted
 import com.woocommerce.android.media.ProductImagesUploadWorker.Work
+import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.details.ProductDetailRepository
@@ -222,7 +223,7 @@ class ProductImagesUploadWorkerTest : BaseUnitTest() {
     fun `when update product succeeds, then send an event`() = testBlocking {
         val product = ProductTestUtils.generateProduct(REMOTE_PRODUCT_ID)
         whenever(productDetailRepository.fetchAndGetProduct(REMOTE_PRODUCT_ID)).thenReturn(product)
-        whenever(productDetailRepository.updateProduct(any())).thenReturn(Pair(true, null))
+        whenever(productDetailRepository.updateProduct(any<Product>())).thenReturn(Pair(true, null))
 
         val eventsList = mutableListOf<Event>()
         val job = launch {
@@ -239,7 +240,7 @@ class ProductImagesUploadWorkerTest : BaseUnitTest() {
     fun `when update product fails, then retry three times`() = testBlocking {
         val product = ProductTestUtils.generateProduct(REMOTE_PRODUCT_ID)
         whenever(productDetailRepository.fetchAndGetProduct(REMOTE_PRODUCT_ID)).thenReturn(product)
-        whenever(productDetailRepository.updateProduct(any())).thenReturn(Pair(false, null))
+        whenever(productDetailRepository.updateProduct(any<Product>())).thenReturn(Pair(false, null))
 
         worker.enqueueWork(Work.UpdateProduct(REMOTE_PRODUCT_ID, listOf(UPLOADED_MEDIA)))
 
@@ -252,7 +253,7 @@ class ProductImagesUploadWorkerTest : BaseUnitTest() {
     fun `when update product fails, then send an event`() = testBlocking {
         val product = ProductTestUtils.generateProduct(REMOTE_PRODUCT_ID)
         whenever(productDetailRepository.fetchAndGetProduct(REMOTE_PRODUCT_ID)).thenReturn(product)
-        whenever(productDetailRepository.updateProduct(any())).thenReturn(Pair(false, null))
+        whenever(productDetailRepository.updateProduct(any<Product>())).thenReturn(Pair(false, null))
 
         val eventsList = mutableListOf<Event>()
         val job = launch {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -487,7 +487,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `Displays progress dialog when product is edited`() = testBlocking {
         doReturn(productAggregate).whenever(productRepository).getProductAggregate(any())
-        doReturn(Pair(false, null)).whenever(productRepository).updateProduct(any())
+        doReturn(Pair(false, null)).whenever(productRepository).updateProduct(any<ProductAggregate>())
 
         val isProgressDialogShown = ArrayList<Boolean>()
         viewModel.productDetailViewStateData.observeForever { old, new ->
@@ -520,7 +520,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
         viewModel.onSaveButtonClicked()
 
-        verify(productRepository, times(0)).updateProduct(any())
+        verify(productRepository, times(0)).updateProduct(any<ProductAggregate>())
         Assertions.assertThat(snackbar).isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.offline_error))
         Assertions.assertThat(productData?.isProgressDialogShown).isFalse()
     }
@@ -528,7 +528,8 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `Display error message on generic update product error`() = testBlocking {
         doReturn(productAggregate).whenever(productRepository).getProductAggregate(any())
-        doReturn(Pair(false, WCProductStore.ProductError())).whenever(productRepository).updateProduct(any())
+        doReturn(Pair(false, WCProductStore.ProductError())).whenever(productRepository)
+            .updateProduct(any<ProductAggregate>())
 
         var snackbar: MultiLiveEvent.Event.ShowSnackbar? = null
         viewModel.event.observeForever {
@@ -542,7 +543,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
         viewModel.onSaveButtonClicked()
 
-        verify(productRepository, times(1)).updateProduct(any())
+        verify(productRepository, times(1)).updateProduct(any<ProductAggregate>())
         Assertions.assertThat(snackbar)
             .isEqualTo(MultiLiveEvent.Event.ShowSnackbar(R.string.product_detail_update_product_error))
         Assertions.assertThat(productData?.isProgressDialogShown).isFalse()
@@ -561,7 +562,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                 )
             )
         )
-            .whenever(productRepository).updateProduct(any())
+            .whenever(productRepository).updateProduct(any<ProductAggregate>())
 
         var showUpdateProductError: ProductDetailViewModel.ShowUpdateProductError? = null
         viewModel.event.observeForever {
@@ -575,7 +576,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
         viewModel.onSaveButtonClicked()
 
-        verify(productRepository, times(1)).updateProduct(any())
+        verify(productRepository, times(1)).updateProduct(any<ProductAggregate>())
         Assertions.assertThat(showUpdateProductError)
             .isEqualTo(ProductDetailViewModel.ShowUpdateProductError(displayErrorMessage))
         Assertions.assertThat(productData?.isProgressDialogShown).isFalse()
@@ -584,7 +585,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     @Test
     fun `Display success message on update product success`() = testBlocking {
         doReturn(productAggregate).whenever(productRepository).getProductAggregate(any())
-        doReturn(Pair(true, null)).whenever(productRepository).updateProduct(any())
+        doReturn(Pair(true, null)).whenever(productRepository).updateProduct(any<ProductAggregate>())
 
         var successSnackbarShown = false
         viewModel.event.observeForever {
@@ -603,7 +604,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
 
         viewModel.onSaveButtonClicked()
 
-        verify(productRepository, times(1)).updateProduct(any())
+        verify(productRepository, times(1)).updateProduct(any<ProductAggregate>())
         verify(productRepository, times(2)).getProductAggregate(PRODUCT_REMOTE_ID)
 
         Assertions.assertThat(successSnackbarShown).isTrue()
@@ -1130,7 +1131,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(productRepository.getProductAggregate(any())).thenReturn(productAggregate)
-            whenever(productRepository.updateProduct(any())).thenReturn(Pair(true, null))
+            whenever(productRepository.updateProduct(any<ProductAggregate>())).thenReturn(Pair(true, null))
             viewModel.start()
 
             // WHEN
@@ -1216,7 +1217,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             whenever(determineProductPasswordApi.invoke()).thenReturn(ProductPasswordApi.WPCOM)
             whenever(productRepository.getProductAggregate(any())).thenReturn(productAggregate)
             whenever(productRepository.fetchProductPassword(any())).thenReturn(password)
-            whenever(productRepository.updateProduct(any())).thenReturn(Pair(true, null))
+            whenever(productRepository.updateProduct(any<ProductAggregate>())).thenReturn(Pair(true, null))
 
             // WHEN
             viewModel.start()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel_AddFlowTest.kt
@@ -224,7 +224,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     fun `Display success message on add product success`() = testBlocking {
         // given
         doReturn(ProductAggregate(product)).whenever(productRepository).getProductAggregate(any())
-        doReturn(Pair(true, 1L)).whenever(productRepository).addProduct(any())
+        doReturn(Pair(true, 1L)).whenever(productRepository).addProduct(any<ProductAggregate>())
 
         var successSnackbarShown = false
         viewModel.event.observeForever {
@@ -256,7 +256,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     @Test
     fun `Display error message on add product failed`() = testBlocking {
         // given
-        doReturn(Pair(false, 0L)).whenever(productRepository).addProduct(any())
+        doReturn(Pair(false, 0L)).whenever(productRepository).addProduct(any<ProductAggregate>())
 
         var successSnackbarShown = false
         viewModel.event.observeForever {
@@ -310,7 +310,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         testBlocking {
             // given
             doReturn(ProductAggregate(product)).whenever(productRepository).getProductAggregate(any())
-            doReturn(Pair(true, 1L)).whenever(productRepository).addProduct(any())
+            doReturn(Pair(true, 1L)).whenever(productRepository).addProduct(any<ProductAggregate>())
 
             var successSnackbarShown = false
             viewModel.event.observeForever {
@@ -399,7 +399,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
     @Test
     fun `when a new product is saved, then assign the new id to ongoing image uploads`() = testBlocking {
-        doReturn(Pair(true, PRODUCT_REMOTE_ID)).whenever(productRepository).addProduct(any())
+        doReturn(Pair(true, PRODUCT_REMOTE_ID)).whenever(productRepository).addProduct(any<ProductAggregate>())
         doReturn(product).whenever(productRepository).getProductAggregate(any())
         savedState = ProductDetailFragmentArgs(
             mode = ProductDetailFragment.Mode.AddNewProduct
@@ -454,7 +454,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
     @Test
     fun `given a product is under creation, when clicking on save product, then assign uploads to the new id`() =
         testBlocking {
-            doReturn(Pair(true, PRODUCT_REMOTE_ID)).whenever(productRepository).addProduct(any())
+            doReturn(Pair(true, PRODUCT_REMOTE_ID)).whenever(productRepository).addProduct(any<ProductAggregate>())
             doReturn(product).whenever(productRepository).getProductAggregate(any())
             viewModel.productDetailViewStateData.observeForever { _, _ -> }
 
@@ -494,7 +494,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
 
     @Test
     fun `given product status is draft, when save is clicked, then save product with correct status`() = testBlocking {
-        whenever(productRepository.addProduct(any())).thenAnswer { it.arguments.first() as Product }
+        whenever(productRepository.addProduct(any<ProductAggregate>())).thenAnswer { it.arguments.first() as Product }
         var viewState: ProductDetailViewModel.ProductDetailViewState? = null
         viewModel.productDetailViewStateData.observeForever { _, new -> viewState = new }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel_AddFlowTest.kt
@@ -339,10 +339,10 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
             Assertions.assertThat(productData?.productDraft).isEqualTo(product)
 
             // when
-            doReturn(Pair(true, null)).whenever(productRepository).updateProduct(any())
+            doReturn(Pair(true, null)).whenever(productRepository).updateProduct(any<ProductAggregate>())
 
             viewModel.onPublishButtonClicked()
-            verify(productRepository, times(1)).updateProduct(any())
+            verify(productRepository, times(1)).updateProduct(any<ProductAggregate>())
 
             viewModel.event.observeForever {
                 if (it is ShowSnackbar && it.message == R.string.product_detail_save_product_success) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/inventory/ScanToUpdateInventoryViewModelTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
@@ -214,7 +215,7 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
                     GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
                 )
             )
-            whenever(productRepo.updateProduct(any())).thenReturn(Pair(true, null))
+            whenever(productRepo.updateProduct(any<Product>())).thenReturn(Pair(true, null))
             whenever(
                 resourceProvider.getString(
                     R.string.scan_to_update_inventory_success_snackbar,
@@ -248,7 +249,7 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
                     GoogleBarcodeFormatMapper.BarcodeFormat.FormatEAN8
                 )
             )
-            whenever(productRepo.updateProduct(any())).thenReturn(Pair(true, null))
+            whenever(productRepo.updateProduct(any<Product>())).thenReturn(Pair(true, null))
             whenever(
                 resourceProvider.getString(
                     R.string.scan_to_update_inventory_success_snackbar,
@@ -280,7 +281,7 @@ class ScanToUpdateInventoryViewModelTest : BaseUnitTest() {
 
             whenever(fetchProductBySKU(any(), any())).thenReturn(Result.success(product))
             whenever(productRepo.getProduct(productId)).thenReturn(product)
-            whenever(productRepo.updateProduct(any())).thenReturn(Pair(true, null))
+            whenever(productRepo.updateProduct(any<Product>())).thenReturn(Pair(true, null))
             whenever(
                 resourceProvider.getString(
                     eq(R.string.scan_to_update_inventory_success_snackbar),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12752
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR builds on top of what was added in #12766, it adds the saving logic, it updates both `addProduct` and `updateProduct` functions to handle passing the changed subscription details too.

### Steps to reproduce
1. Open the app.
2. Navigate to the Products tab.
3. For some scenarios: open an existing subscription product
4. For other scenarios: create a new subscription product

### Testing information
- Confirm that saving changes of an existing product works as expected.
- Confirm that creating a new subscription product works.
- Confirm that duplicating a subscription product duplicates all subscription details.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->