### PR TITLE
Fix issue with JSON parsing in Product AI creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ai/AIRepository.kt
@@ -77,7 +77,11 @@ class AIRepository @Inject constructor(
             feature = PRODUCT_CREATION_FEATURE,
             format = ResponseFormat.JSON,
             maxTokens = 4000 // Specify a higher limit for max_tokens to avoid truncated responses, see pe5sF9-2UY-p2
-        )
+        ).map {
+            // OpenAI sometimes returns the JSON response wrapped in a code block Markdown syntax, we remove it
+            // see: https://community.openai.com/t/why-do-some-responses-message-content-start-with-json/573289
+            it.removePrefix("```json").removeSuffix("```")
+        }
     }
 
     suspend fun generateOrderThankYouNote(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12768
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This fixes the JSON parsing when OpenAI decides to wrap the response in a Markdown code block.

### Steps to reproduce
1. Use an atomic website.
2. Open the app.
3. Start product creation.
4. Select the AI mode.

### Testing information
- Confirm the creation works without issues now.

### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->