### PR TITLE
[Blaze i4] Objective screen UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material.Text
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
@@ -22,7 +21,7 @@ class BlazeCampaignObjectiveFragment : BaseFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {
-            Text(text = "Select Campaign Objective")
+            BlazeCampaignObjectiveScreen(viewModel)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveFragment.kt
@@ -6,10 +6,12 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateBackWithResult
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -33,7 +35,12 @@ class BlazeCampaignObjectiveFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
+                is ExitWithResult<*> -> navigateBackWithResult(BLAZE_OBJECTIVE_SELECTION_RESULT, event.data)
             }
         }
+    }
+
+    companion object {
+        const val BLAZE_OBJECTIVE_SELECTION_RESULT = "blaze_objective_selection_result"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveScreen.kt
@@ -85,9 +85,9 @@ private fun ObjectiveScreen(
             ) {
                 items(state.items) {
                     ObjectiveListItem(
-                        it.title,
-                        it.description,
-                        it.suitableForDescription,
+                        title = it.title,
+                        description = it.description,
+                        suitableForDescription = it.suitableForDescription,
                         isSelected = it.id == state.selectedItemId,
                         onItemClick = { onObjectiveTapped(it) },
                         modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveScreen.kt
@@ -88,10 +88,6 @@ private fun ObjectiveScreen(
                         it.title,
                         it.description,
                         it.suitableForDescription,
-                        onClickLabel = stringResource(
-                            id = R.string.blaze_campaign_objective_select_objective_label,
-                            it.title
-                        ),
                         isSelected = it.id == state.selectedItemId,
                         onItemClick = { onObjectiveTapped(it) },
                         modifier = Modifier
@@ -113,7 +109,6 @@ fun ObjectiveListItem(
     description: String,
     suitableForDescription: String,
     isSelected: Boolean,
-    onClickLabel: String?,
     onItemClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -124,7 +119,7 @@ fun ObjectiveListItem(
         .clickable(
             role = Role.Button,
             onClick = { onItemClick() },
-            onClickLabel = onClickLabel
+            onClickLabel = stringResource(id = R.string.blaze_campaign_objective_select_objective_label, title)
         )
         .border(
             width = if (isSelected) 2.dp else 0.5.dp,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveScreen.kt
@@ -93,9 +93,14 @@ private fun ObjectiveScreen(
                             it.title
                         ),
                         isSelected = it.id == state.selectedItemId,
-                    ) {
-                        onObjectiveTapped(it)
-                    }
+                        onItemClick = { onObjectiveTapped(it) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(
+                                horizontal = dimensionResource(id = R.dimen.major_100),
+                                vertical = dimensionResource(id = R.dimen.minor_50)
+                            )
+                    )
                 }
             }
         }
@@ -110,16 +115,12 @@ fun ObjectiveListItem(
     isSelected: Boolean,
     onClickLabel: String?,
     onItemClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val roundedShape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
     val borderSize = if (isSelected) R.dimen.minor_25 else R.dimen.minor_10
     val borderColor = if (isSelected) R.color.woo_purple_60 else R.color.woo_gray_5
-    val modifier = Modifier
-        .fillMaxWidth()
-        .padding(
-            horizontal = dimensionResource(id = R.dimen.major_100),
-            vertical = dimensionResource(id = R.dimen.minor_50)
-        )
+    val updatedModifier = modifier
         .clip(roundedShape)
         .clickable(
             role = Role.Button,
@@ -134,9 +135,9 @@ fun ObjectiveListItem(
 
     Row(
         modifier = if (isSelected) {
-            modifier.then(Modifier.background(colorResource(id = R.color.blaze_campaign_objective_item_background)))
+            updatedModifier.background(colorResource(id = R.color.blaze_campaign_objective_item_background))
         } else {
-            modifier
+            updatedModifier
         }.padding(dimensionResource(id = R.dimen.major_100)),
         horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100))
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveScreen.kt
@@ -25,11 +25,11 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.blaze.creation.objective.BlazeCampaignObjectiveViewModel.ObjectiveItem
 import com.woocommerce.android.ui.blaze.creation.objective.BlazeCampaignObjectiveViewModel.ObjectiveViewState
@@ -81,7 +81,7 @@ private fun ObjectiveScreen(
                 .fillMaxSize()
         ) {
             LazyColumn(
-                modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.minor_50))
+                modifier = Modifier.padding(vertical = 4.dp)
             ) {
                 items(state.items) {
                     ObjectiveListItem(
@@ -97,8 +97,8 @@ private fun ObjectiveScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(
-                                horizontal = dimensionResource(id = R.dimen.major_100),
-                                vertical = dimensionResource(id = R.dimen.minor_50)
+                                horizontal = 16.dp,
+                                vertical = 4.dp
                             )
                     )
                 }
@@ -117,8 +117,7 @@ fun ObjectiveListItem(
     onItemClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val roundedShape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
-    val borderSize = if (isSelected) R.dimen.minor_25 else R.dimen.minor_10
+    val roundedShape = RoundedCornerShape(8.dp)
     val borderColor = if (isSelected) R.color.woo_purple_60 else R.color.woo_gray_5
     val updatedModifier = modifier
         .clip(roundedShape)
@@ -128,7 +127,7 @@ fun ObjectiveListItem(
             onClickLabel = onClickLabel
         )
         .border(
-            width = dimensionResource(id = borderSize),
+            width = if (isSelected) 2.dp else 0.5.dp,
             color = colorResource(id = borderColor),
             shape = roundedShape
         )
@@ -138,8 +137,8 @@ fun ObjectiveListItem(
             updatedModifier.background(colorResource(id = R.color.blaze_campaign_objective_item_background))
         } else {
             updatedModifier
-        }.padding(dimensionResource(id = R.dimen.major_100)),
-        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100))
+        }.padding(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         val selectionDrawable = if (isSelected) {
             R.drawable.ic_rounded_chcekbox_checked
@@ -158,7 +157,7 @@ fun ObjectiveListItem(
 
         Column(
             modifier = Modifier.animateContentSize(),
-            verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100))
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Text(
                 text = title,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveScreen.kt
@@ -1,0 +1,225 @@
+package com.woocommerce.android.ui.blaze.creation.objective
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.blaze.creation.objective.BlazeCampaignObjectiveViewModel.ObjectiveItem
+import com.woocommerce.android.ui.blaze.creation.objective.BlazeCampaignObjectiveViewModel.ObjectiveViewState
+import com.woocommerce.android.ui.compose.annotatedStringRes
+import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+
+@Composable
+fun BlazeCampaignObjectiveScreen(viewModel: BlazeCampaignObjectiveViewModel) {
+    viewModel.viewState.observeAsState().value?.let { state ->
+        ObjectiveScreen(
+            state = state,
+            onBackPressed = viewModel::onBackPressed,
+            onSaveTapped = viewModel::onSaveTapped,
+            onObjectiveTapped = viewModel::onItemToggled
+        )
+    }
+}
+
+@Composable
+private fun ObjectiveScreen(
+    state: ObjectiveViewState,
+    onBackPressed: () -> Unit,
+    onSaveTapped: () -> Unit,
+    onObjectiveTapped: (ObjectiveItem) -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            Toolbar(
+                title = stringResource(id = R.string.blaze_campaign_preview_details_objective),
+                onNavigationButtonClick = onBackPressed,
+                navigationIcon = Icons.AutoMirrored.Filled.ArrowBack,
+                actions = {
+                    WCTextButton(
+                        onClick = onSaveTapped,
+                        enabled = state.isSaveButtonEnabled,
+                        text = stringResource(R.string.save)
+                    )
+                }
+            )
+        },
+        modifier = Modifier.background(MaterialTheme.colors.surface)
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .background(MaterialTheme.colors.surface)
+                .padding(paddingValues)
+                .fillMaxSize()
+        ) {
+            LazyColumn(
+                modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.minor_50))
+            ) {
+                items(state.items) {
+                    ObjectiveListItem(
+                        it.title,
+                        it.description,
+                        it.suitableForDescription,
+                        onClickLabel = stringResource(
+                            id = R.string.blaze_campaign_objective_select_objective_label,
+                            it.title
+                        ),
+                        isSelected = it.id == state.selectedItemId,
+                    ) {
+                        onObjectiveTapped(it)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ObjectiveListItem(
+    title: String,
+    description: String,
+    suitableForDescription: String,
+    isSelected: Boolean,
+    onClickLabel: String?,
+    onItemClick: () -> Unit,
+) {
+    val roundedShape = RoundedCornerShape(dimensionResource(id = R.dimen.minor_100))
+    val borderSize = if (isSelected) R.dimen.minor_25 else R.dimen.minor_10
+    val borderColor = if (isSelected) R.color.woo_purple_60 else R.color.woo_gray_5
+    val modifier = Modifier
+        .fillMaxWidth()
+        .padding(
+            horizontal = dimensionResource(id = R.dimen.major_100),
+            vertical = dimensionResource(id = R.dimen.minor_50)
+        )
+        .clip(roundedShape)
+        .clickable(
+            role = Role.Button,
+            onClick = { onItemClick() },
+            onClickLabel = onClickLabel
+        )
+        .border(
+            width = dimensionResource(id = borderSize),
+            color = colorResource(id = borderColor),
+            shape = roundedShape
+        )
+
+    Row(
+        modifier = if (isSelected) {
+            modifier.then(Modifier.background(colorResource(id = R.color.blaze_campaign_objective_item_background)))
+        } else {
+            modifier
+        }.padding(dimensionResource(id = R.dimen.major_100)),
+        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100))
+    ) {
+        val selectionDrawable = if (isSelected) {
+            R.drawable.ic_rounded_chcekbox_checked
+        } else {
+            R.drawable.ic_rounded_chcekbox_unchecked
+        }
+        Crossfade(
+            targetState = selectionDrawable,
+            label = "itemSelection"
+        ) { icon ->
+            Image(
+                painter = painterResource(id = icon),
+                contentDescription = null
+            )
+        }
+
+        Column(
+            modifier = Modifier.animateContentSize(),
+            verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.minor_100))
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.subtitle1,
+                fontWeight = FontWeight.W600,
+                color = MaterialTheme.colors.onSurface,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.subtitle1,
+                color = MaterialTheme.colors.onSurface,
+            )
+            if (isSelected) {
+                Text(
+                    text = annotatedStringRes(
+                        stringResId = R.string.blaze_campaign_objective_good_for,
+                        suitableForDescription
+                    ),
+                    style = MaterialTheme.typography.subtitle1,
+                    color = MaterialTheme.colors.onSurface,
+                )
+            }
+        }
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+fun PreviewObjectiveScreen() {
+    ObjectiveScreen(
+        state = ObjectiveViewState(
+            items = listOf(
+                ObjectiveItem(
+                    id = "traffic",
+                    title = "Traffic",
+                    description = "Aims to drive more visitors and increase page views.",
+                    suitableForDescription = "E-commerce sites, content-driven websites, startups."
+                ),
+                ObjectiveItem(
+                    id = "sales",
+                    title = "Sales",
+                    description = "Converts potential customers into buyers by encouraging purchase.",
+                    suitableForDescription = "E-commerce, retailers, subscription services."
+                ),
+                ObjectiveItem(
+                    id = "awareness",
+                    title = "Awareness",
+                    description = "Focuses on increasing brand recognition and visibility.",
+                    suitableForDescription = "New businesses, brands launching new products."
+                ),
+                ObjectiveItem(
+                    id = "engagement",
+                    title = "Engagement",
+                    description = "Encourages your audience to interact and connect with your brand.",
+                    suitableForDescription = "Influencers and community builders looking for followers of the same" +
+                        "interest."
+                ),
+            ),
+            selectedItemId = null
+        ),
+        onBackPressed = { },
+        onSaveTapped = { },
+        onObjectiveTapped = { },
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveScreen.kt
@@ -118,7 +118,7 @@ fun ObjectiveListItem(
         .clip(roundedShape)
         .clickable(
             role = Role.Button,
-            onClick = { onItemClick() },
+            onClick = onItemClick,
             onClickLabel = stringResource(id = R.string.blaze_campaign_objective_select_objective_label, title)
         )
         .border(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
@@ -27,7 +27,7 @@ class BlazeCampaignObjectiveViewModel @Inject constructor(
 
     private val selectedId = savedStateHandle.getNullableStateFlow(
         scope = viewModelScope,
-        initialValue = navArgs.selectedId,
+        initialValue = navArgs.selectedObjectiveId,
         clazz = String::class.java
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.navArgs
@@ -14,6 +15,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
@@ -49,6 +51,9 @@ class BlazeCampaignObjectiveViewModel @Inject constructor(
     }
 
     fun onSaveTapped() {
+        selectedId.value?.let { triggerEvent(ExitWithResult(ObjectiveResult(it))) }
+        TODO("Track")
+        // analyticsTrackerWrapper.track(BLAZE_...)
     }
 
     data class ObjectiveViewState(
@@ -66,4 +71,7 @@ class BlazeCampaignObjectiveViewModel @Inject constructor(
         val description: String,
         val suitableForDescription: String,
     )
+
+    @Parcelize
+    data class ObjectiveResult(val objectiveId: String) : Parcelable
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
@@ -61,7 +61,7 @@ class BlazeCampaignObjectiveViewModel @Inject constructor(
         val isStoreSelectionButtonToggled: Boolean = false,
     ) {
         val isSaveButtonEnabled: Boolean
-            get() = selectedItemId != null
+            get() = !selectedItemId.isNullOrEmpty()
     }
 
     data class ObjectiveItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
@@ -52,8 +52,7 @@ class BlazeCampaignObjectiveViewModel @Inject constructor(
 
     fun onSaveTapped() {
         selectedId.value?.let { triggerEvent(ExitWithResult(ObjectiveResult(it))) }
-        TODO("Track")
-        // analyticsTrackerWrapper.track(BLAZE_...)
+        // TODO analyticsTrackerWrapper.track(BLAZE_...)
     }
 
     data class ObjectiveViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
@@ -13,4 +13,20 @@ class BlazeCampaignObjectiveViewModel @Inject constructor(
     fun onDismissClick() {
         triggerEvent(Exit)
     }
+
+    data class ObjectiveViewState(
+        val items: List<ObjectiveItem>,
+        val selectedItemId: String? = null,
+        val isStoreSelectionButtonToggled: Boolean = false,
+    ) {
+        val isSaveButtonEnabled: Boolean
+            get() = selectedItemId != null
+    }
+
+    data class ObjectiveItem(
+        val id: String,
+        val title: String,
+        val description: String,
+        val suitableForDescription: String,
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
@@ -1,17 +1,54 @@
 package com.woocommerce.android.ui.blaze.creation.objective
 
+import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getNullableStateFlow
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
 class BlazeCampaignObjectiveViewModel @Inject constructor(
+    blazeRepository: BlazeRepository,
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
-    fun onDismissClick() {
+    private val navArgs: BlazeCampaignObjectiveFragmentArgs by savedStateHandle.navArgs()
+
+    private val selectedId = savedStateHandle.getNullableStateFlow(
+        scope = viewModelScope,
+        initialValue = navArgs.selectedId,
+        clazz = String::class.java
+    )
+
+    private val items: Flow<List<ObjectiveItem>> =
+        blazeRepository.observeObjectives().map { objectives ->
+            objectives.map { objective ->
+                ObjectiveItem(objective.id, objective.title, objective.description, objective.suitableForDescription)
+            }
+        }
+
+    val viewState = combine(items, selectedId) { items, selectedId ->
+        ObjectiveViewState(items = items, selectedItemId = selectedId)
+    }.asLiveData()
+
+    fun onItemToggled(item: ObjectiveItem) {
+        selectedId.update { item.id }
+    }
+
+    fun onBackPressed() {
         triggerEvent(Exit)
+    }
+
+    fun onSaveTapped() {
     }
 
     data class ObjectiveViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
@@ -16,6 +16,8 @@ import com.woocommerce.android.ui.blaze.creation.ad.BlazeCampaignCreationEditAdF
 import com.woocommerce.android.ui.blaze.creation.ad.BlazeCampaignCreationEditAdViewModel.EditAdResult
 import com.woocommerce.android.ui.blaze.creation.budget.BlazeCampaignBudgetFragment
 import com.woocommerce.android.ui.blaze.creation.destination.BlazeCampaignCreationAdDestinationFragment
+import com.woocommerce.android.ui.blaze.creation.objective.BlazeCampaignObjectiveFragment
+import com.woocommerce.android.ui.blaze.creation.objective.BlazeCampaignObjectiveViewModel.ObjectiveResult
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.NavigateToAdDestinationScreen
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.NavigateToBudgetScreen
 import com.woocommerce.android.ui.blaze.creation.preview.BlazeCampaignCreationPreviewViewModel.NavigateToEditAdScreen
@@ -78,6 +80,11 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
                         )
                 )
 
+                is NavigateToObjectiveSelectionScreen -> findNavController().navigateSafely(
+                    BlazeCampaignCreationPreviewFragmentDirections
+                        .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignObjectiveFragment(event.selectedId)
+                )
+
                 is NavigateToTargetSelectionScreen -> findNavController().navigateSafely(
                     BlazeCampaignCreationPreviewFragmentDirections
                         .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignTargetSelectionFragment(
@@ -106,11 +113,6 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
                         .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignPaymentSummaryFragment(
                             event.campaignDetails
                         )
-                )
-
-                is NavigateToObjectiveSelectionScreen -> findNavController().navigateSafely(
-                    BlazeCampaignCreationPreviewFragmentDirections
-                        .actionBlazeCampaignCreationPreviewFragmentToBlazeCampaignObjectiveFragment()
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewFragment.kt
@@ -120,6 +120,9 @@ class BlazeCampaignCreationPreviewFragment : BaseFragment() {
         handleResult<EditAdResult>(BlazeCampaignCreationEditAdFragment.EDIT_AD_RESULT) {
             viewModel.onAdUpdated(it.tagline, it.description, it.campaignImage)
         }
+        handleResult<ObjectiveResult>(BlazeCampaignObjectiveFragment.BLAZE_OBJECTIVE_SELECTION_RESULT) {
+            viewModel.onObjectiveUpdated(it.objectiveId)
+        }
         handleResult<Budget>(BlazeCampaignBudgetFragment.EDIT_BUDGET_AND_DURATION_RESULT) {
             viewModel.onBudgetAndDurationUpdated(it)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -206,7 +206,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
                 isObjectiveMissing && FeatureFlag.OBJECTIVE_SECTION.isEnabled() -> buildMissingRequiredDataDialog(
                     message = R.string.blaze_campaign_preview_missing_objective_dialog_text,
                     positiveButtonText = R.string.blaze_campaign_preview_missing_objective_dialog_positive_button,
-                    positiveButtonOnClick = { triggerEvent(NavigateToObjectiveSelectionScreen) }
+                    positiveButtonOnClick = { triggerEvent(NavigateToObjectiveSelectionScreen(selectedId = null)) }
                 )
 
                 else -> triggerEvent(NavigateToPaymentSummary(it))
@@ -287,7 +287,7 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         return CampaignDetailItemUi(
             displayTitle = resourceProvider.getString(R.string.blaze_campaign_preview_details_objective),
             displayValue = selectedObjectiveDisplayValue,
-            onItemSelected = { triggerEvent(NavigateToObjectiveSelectionScreen) }
+            onItemSelected = { triggerEvent(NavigateToObjectiveSelectionScreen(campaignDetails.value?.objectiveId)) }
         )
     }
 
@@ -445,9 +445,9 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         val aiSuggestions: List<BlazeRepository.AiSuggestionForAd>
     ) : MultiLiveEvent.Event()
 
+    data class NavigateToObjectiveSelectionScreen(val selectedId: String? = null) : MultiLiveEvent.Event()
+
     data class NavigateToPaymentSummary(
         val campaignDetails: CampaignDetails
     ) : MultiLiveEvent.Event()
-
-    data object NavigateToObjectiveSelectionScreen : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -125,6 +125,10 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
         }
     }
 
+    fun onObjectiveUpdated(objectiveId: String) {
+        campaignDetails.update { it?.copy(objectiveId = objectiveId) }
+    }
+
     fun onBudgetAndDurationUpdated(updatedBudget: BlazeRepository.Budget) {
         campaignDetails.update { it?.copy(budget = updatedBudget) }
     }

--- a/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
@@ -110,7 +110,7 @@
         android:name="com.woocommerce.android.ui.blaze.creation.objective.BlazeCampaignObjectiveFragment"
         android:label="BlazeCampaignObjectiveFragment">
         <argument
-            android:name="selectedId"
+            android:name="selectedObjectiveId"
             app:argType="string"
             app:nullable="true" />
     </fragment>

--- a/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_blaze_campaign_creation.xml
@@ -106,6 +106,15 @@
             app:destination="@id/productImagePickerFragment" />
     </fragment>
     <fragment
+        android:id="@+id/blazeCampaignObjectiveFragment"
+        android:name="com.woocommerce.android.ui.blaze.creation.objective.BlazeCampaignObjectiveFragment"
+        android:label="BlazeCampaignObjectiveFragment">
+        <argument
+            android:name="selectedId"
+            app:argType="string"
+            app:nullable="true" />
+    </fragment>
+    <fragment
         android:id="@+id/blazeCampaignBudgetFragment"
         android:name="com.woocommerce.android.ui.blaze.creation.budget.BlazeCampaignBudgetFragment"
         android:label="BlazeCampaignBudgetFragment">
@@ -197,8 +206,4 @@
             android:name="productId"
             app:argType="long" />
     </fragment>
-    <fragment
-        android:id="@+id/blazeCampaignObjectiveFragment"
-        android:name="com.woocommerce.android.ui.blaze.creation.objective.BlazeCampaignObjectiveFragment"
-        android:label="BlazeCampaignObjectiveFragment" />
 </navigation>

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -231,5 +231,6 @@
     -->
     <color name="blaze_campaign_bottom_sheet_highlight_background">@color/woo_black_90_alpha_038</color>
     <color name="blaze_campaign_preview_header_background">@color/woo_white_alpha_012</color>
+    <color name="blaze_campaign_objective_item_background">@color/woo_purple_90</color>
 
 </resources>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -301,6 +301,7 @@
     <color name="blaze_campaign_bottom_sheet_highlight_background">@color/woo_gray_6</color>
     <color name="blaze_campaign_preview_header_background">@color/woo_gray_0</color>
     <color name="blaze_campaign_preview_shop_now_button">@color/woo_gray_0</color>
+    <color name="blaze_campaign_objective_item_background">@color/woo_purple_0</color>
 
     <!--
     Deposit summary

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3992,6 +3992,8 @@
     <string name="blaze_campaign_creation_location_search_message">Start typing country, state or city to see available options</string>
     <string name="blaze_campaign_creation_location_search_no_results_message">No location found.\nPlease try again.</string>
     <string name="blaze_campaign_creation_location_search_failed_message">Searching failed.\nPlease try again</string>
+    <string name="blaze_campaign_objective_select_objective_label">Select objective %s</string>
+    <string name="blaze_campaign_objective_good_for"><![CDATA[<b>Good for:</b> %s]]></string>
 
     <!--
     Blaze edit ad destination


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12661
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the objective screen where users can choose the campaign objective. The feature is still behind a feature flag.

> [!NOTE] 
> We could add unit tests for `BlazeCampaignObjectiveViewModel` but I haven't done it intentionally. The logic inside `BlazeCampaignObjectiveViewModel` is quite simple and tests would be just copying the same logic to the view model and verifying. Please let me know if you think we should add some tests.

> [!TIP]  
> Since this is my first large Compose PR, I welcome nitpicking comments regarding code style.


### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log into a Blaze-eligible site.
2. Trigger Blaze campaign creation flow.
3. Tap "Campaign objective" on the preview screen.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- [x] Save button should be disabled if an objective is not selected.
- [x] After creating a campaign, you should see the selected objective on the campaign detail screen.
- [x] "Good for" description should be visible only if the item is selected.
- [ ] If talkback is enabled and you long tap on an objective item, the Talkback should say `...Double tap to select objective Traffic`.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested also on a tablet. Tested Talkback, dark theme. I could create a campaign with an objective successfully. 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
[Screen_recording_20241015_031443.webm](https://github.com/user-attachments/assets/a39fa80f-3042-4929-8d08-40b3b684bf31)

|dark|tablet|
|-|-|
|<img src="https://github.com/user-attachments/assets/8ebb8339-471e-4c30-83f9-53011440d584" width=300>|<img src="https://github.com/user-attachments/assets/cf5ab585-ac96-47ce-bafe-fa51675a5c83" width=450>|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->