### PR TITLE
[Blaze i4] Add switch to the objective screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -127,7 +127,8 @@ object AppPrefs {
         TIMES_AI_PRODUCT_CREATION_SURVEY_DISPLAYED,
         AI_PRODUCT_CREATION_SURVEY_DISMISSED,
         CUSTOM_FIELDS_TOP_BANNER_DISMISSED,
-        BLAZE_CAMPAIGN_SELECTED_OBJECTIVE
+        BLAZE_CAMPAIGN_SELECTED_OBJECTIVE,
+        BLAZE_CAMPAIGN_STORE_OBJECTIVE_ENABLED
     }
 
     /**
@@ -276,6 +277,10 @@ object AppPrefs {
     var blazeCampaignSelectedObjective: String
         get() = getString(DeletablePrefKey.BLAZE_CAMPAIGN_SELECTED_OBJECTIVE, "")
         set(value) = setString(DeletablePrefKey.BLAZE_CAMPAIGN_SELECTED_OBJECTIVE, value)
+
+    var blazeCampaignStoreObjectiveEnabled: Boolean
+        get() = getBoolean(DeletablePrefKey.BLAZE_CAMPAIGN_STORE_OBJECTIVE_ENABLED, true)
+        set(value) = setBoolean(DeletablePrefKey.BLAZE_CAMPAIGN_STORE_OBJECTIVE_ENABLED, value)
 
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -128,7 +128,7 @@ object AppPrefs {
         AI_PRODUCT_CREATION_SURVEY_DISMISSED,
         CUSTOM_FIELDS_TOP_BANNER_DISMISSED,
         BLAZE_CAMPAIGN_SELECTED_OBJECTIVE,
-        BLAZE_CAMPAIGN_STORE_OBJECTIVE_ENABLED
+        BLAZE_CAMPAIGN_OBJECTIVE_SWITCH_CHECKED
     }
 
     /**
@@ -278,9 +278,9 @@ object AppPrefs {
         get() = getString(DeletablePrefKey.BLAZE_CAMPAIGN_SELECTED_OBJECTIVE, "")
         set(value) = setString(DeletablePrefKey.BLAZE_CAMPAIGN_SELECTED_OBJECTIVE, value)
 
-    var blazeCampaignStoreObjectiveEnabled: Boolean
-        get() = getBoolean(DeletablePrefKey.BLAZE_CAMPAIGN_STORE_OBJECTIVE_ENABLED, true)
-        set(value) = setBoolean(DeletablePrefKey.BLAZE_CAMPAIGN_STORE_OBJECTIVE_ENABLED, value)
+    var blazeCampaignObjectiveSwitchChecked: Boolean
+        get() = getBoolean(DeletablePrefKey.BLAZE_CAMPAIGN_OBJECTIVE_SWITCH_CHECKED, true)
+        set(value) = setBoolean(DeletablePrefKey.BLAZE_CAMPAIGN_OBJECTIVE_SWITCH_CHECKED, value)
 
     fun getProductSortingChoice(currentSiteId: Int) = getString(getProductSortingKey(currentSiteId)).orNullIfEmpty()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -38,7 +38,7 @@ class AppPrefsWrapper @Inject constructor() {
 
     var blazeCampaignSelectedObjective by AppPrefs::blazeCampaignSelectedObjective
 
-    var blazeCampaignStoreObjectiveEnabled by AppPrefs::blazeCampaignStoreObjectiveEnabled
+    var blazeCampaignObjectiveSwitchChecked by AppPrefs::blazeCampaignObjectiveSwitchChecked
 
     fun getAppInstallationDate() = AppPrefs.installationDate
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -38,6 +38,8 @@ class AppPrefsWrapper @Inject constructor() {
 
     var blazeCampaignSelectedObjective by AppPrefs::blazeCampaignSelectedObjective
 
+    var blazeCampaignStoreObjectiveEnabled by AppPrefs::blazeCampaignStoreObjectiveEnabled
+
     fun getAppInstallationDate() = AppPrefs.installationDate
 
     fun getReceiptUrl(localSiteId: Int, remoteSiteId: Long, selfHostedSiteId: Long, orderId: Long) =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -1031,6 +1031,7 @@ enum class AnalyticsEvent(override val siteless: Boolean = false) : IAnalyticsEv
     BLAZE_CREATION_EDIT_LOCATION_SAVE_TAPPED,
     BLAZE_CREATION_EDIT_DESTINATION_SAVE_TAPPED,
     BLAZE_CAMPAIGN_CREATION_FEEDBACK,
+    BLAZE_CAMPAIGN_OBJECTIVE_SAVED,
 
     // Hazmat Shipping Declaration
     CONTAINS_HAZMAT_CHECKED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -618,6 +618,7 @@ class AnalyticsTracker private constructor(
         const val KEY_BLAZE_IS_AI_CONTENT = "is_ai_suggested_ad_content"
         const val KEY_BLAZE_ERROR = "blaze_creation_error"
         const val KEY_BLAZE_CAMPAIGN_TYPE = "campaign_type"
+        const val KEY_BLAZE_OBJECTIVE = "objective"
 
         const val PRODUCT_TYPES = "product_types"
         const val HAS_ADDONS = "has_addons"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -379,10 +379,10 @@ class BlazeRepository @Inject constructor(
         }
     }
 
-    fun isStoreObjectiveEnabled() = appPrefsWrapper.blazeCampaignStoreObjectiveEnabled
+    fun isCampaignObjectiveSwitchChecked() = appPrefsWrapper.blazeCampaignObjectiveSwitchChecked
 
-    fun setStoreObjectiveEnabled(enabled: Boolean) {
-        appPrefsWrapper.blazeCampaignStoreObjectiveEnabled = enabled
+    fun setCampaignObjectiveSwitchChecked(enabled: Boolean) {
+        appPrefsWrapper.blazeCampaignObjectiveSwitchChecked = enabled
     }
 
     fun storeSelectedObjective(objectiveId: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -379,6 +379,16 @@ class BlazeRepository @Inject constructor(
         }
     }
 
+    fun isStoreObjectiveEnabled() = appPrefsWrapper.blazeCampaignStoreObjectiveEnabled
+
+    fun setStoreObjectiveEnabled(enabled: Boolean) {
+        appPrefsWrapper.blazeCampaignStoreObjectiveEnabled = enabled
+    }
+
+    fun storeSelectedObjective(objectiveId: String) {
+        appPrefsWrapper.blazeCampaignSelectedObjective = objectiveId
+    }
+
     @Parcelize
     data class CampaignDetails(
         val productId: Long,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
@@ -34,7 +35,9 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.blaze.creation.objective.BlazeCampaignObjectiveViewModel.ObjectiveItem
 import com.woocommerce.android.ui.blaze.creation.objective.BlazeCampaignObjectiveViewModel.ObjectiveViewState
 import com.woocommerce.android.ui.compose.annotatedStringRes
+import com.woocommerce.android.ui.compose.component.BottomSheetSwitchColors
 import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCSwitch
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 
@@ -45,7 +48,8 @@ fun BlazeCampaignObjectiveScreen(viewModel: BlazeCampaignObjectiveViewModel) {
             state = state,
             onBackPressed = viewModel::onBackPressed,
             onSaveTapped = viewModel::onSaveTapped,
-            onObjectiveTapped = viewModel::onItemToggled
+            onObjectiveTapped = viewModel::onItemToggled,
+            onStoreObjectiveSwitchChanged = viewModel::onStoreObjectiveSwitchChanged
         )
     }
 }
@@ -56,6 +60,7 @@ private fun ObjectiveScreen(
     onBackPressed: () -> Unit,
     onSaveTapped: () -> Unit,
     onObjectiveTapped: (ObjectiveItem) -> Unit,
+    onStoreObjectiveSwitchChanged: (Boolean) -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -81,7 +86,9 @@ private fun ObjectiveScreen(
                 .fillMaxSize()
         ) {
             LazyColumn(
-                modifier = Modifier.padding(vertical = 4.dp)
+                modifier = Modifier
+                    .padding(vertical = 4.dp)
+                    .weight(1f)
             ) {
                 items(state.items) {
                     ObjectiveListItem(
@@ -99,6 +106,16 @@ private fun ObjectiveScreen(
                     )
                 }
             }
+            Divider()
+            WCSwitch(
+                text = stringResource(id = R.string.blaze_campaign_objective_save_selection_switch_label),
+                checked = state.isStoreSelectionButtonToggled,
+                onCheckedChange = { onStoreObjectiveSwitchChanged(it) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                colors = BottomSheetSwitchColors()
+            )
         }
     }
 }
@@ -216,5 +233,6 @@ fun PreviewObjectiveScreen() {
         onBackPressed = { },
         onSaveTapped = { },
         onObjectiveTapped = { },
+        onStoreObjectiveSwitchChanged = { }
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
@@ -4,6 +4,9 @@ import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CAMPAIGN_OBJECTIVE_SAVED
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.blaze.BlazeRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -23,6 +26,7 @@ import javax.inject.Inject
 class BlazeCampaignObjectiveViewModel @Inject constructor(
     private val blazeRepository: BlazeRepository,
     savedStateHandle: SavedStateHandle,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val navArgs: BlazeCampaignObjectiveFragmentArgs by savedStateHandle.navArgs()
 
@@ -74,6 +78,9 @@ class BlazeCampaignObjectiveViewModel @Inject constructor(
         }
         selectedId.value?.let {
             triggerEvent(ExitWithResult(ObjectiveResult(it)))
+            analyticsTrackerWrapper.track(
+                stat = BLAZE_CAMPAIGN_OBJECTIVE_SAVED,
+                properties = mapOf(AnalyticsTracker.KEY_BLAZE_OBJECTIVE to it)
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
@@ -61,9 +61,21 @@ class BlazeCampaignObjectiveViewModel @Inject constructor(
         triggerEvent(Exit)
     }
 
+    fun onStoreObjectiveSwitchChanged(checked: Boolean) {
+        storeObjectiveSwitchState.update { checked }
+    }
+
     fun onSaveTapped() {
-        selectedId.value?.let { triggerEvent(ExitWithResult(ObjectiveResult(it))) }
-        // TODO analyticsTrackerWrapper.track(BLAZE_...)
+        viewState.value?.isStoreSelectionButtonToggled?.let {
+            blazeRepository.setStoreObjectiveEnabled(it)
+            if (it) {
+                blazeRepository.storeSelectedObjective(selectedId.value.orEmpty())
+            }
+        }
+        selectedId.value?.let {
+            triggerEvent(ExitWithResult(ObjectiveResult(it)))
+            )
+        }
     }
 
     data class ObjectiveViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/objective/BlazeCampaignObjectiveViewModel.kt
@@ -38,7 +38,7 @@ class BlazeCampaignObjectiveViewModel @Inject constructor(
     )
     private val storeObjectiveSwitchState = savedState.getStateFlow(
         scope = this,
-        initialValue = blazeRepository.isStoreObjectiveEnabled(),
+        initialValue = blazeRepository.isCampaignObjectiveSwitchChecked(),
         key = "storeObjectiveSwitchState"
     )
 
@@ -71,7 +71,7 @@ class BlazeCampaignObjectiveViewModel @Inject constructor(
 
     fun onSaveTapped() {
         viewState.value?.isStoreSelectionButtonToggled?.let {
-            blazeRepository.setStoreObjectiveEnabled(it)
+            blazeRepository.setCampaignObjectiveSwitchChecked(it)
             if (it) {
                 blazeRepository.storeSelectedObjective(selectedId.value.orEmpty())
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -182,7 +182,8 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
                         AnalyticsTracker.VALUE_EVERGREEN_CAMPAIGN
 
                     else -> AnalyticsTracker.VALUE_START_END_CAMPAIGN
-                }
+                },
+                AnalyticsTracker.KEY_BLAZE_OBJECTIVE to campaignDetails.value?.objectiveId,
             )
         )
         campaignDetails.value?.let {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3917,6 +3917,14 @@
     <string name="blaze_campaign_preview_missing_content_dialog_positive_button">Add</string>
     <string name="blaze_campaign_preview_missing_objective_dialog_text">Please select an objective for the Blaze campaign</string>
     <string name="blaze_campaign_preview_missing_objective_dialog_positive_button">Select objective</string>
+
+    <!--
+    Blaze campaign objective screen
+    -->
+    <string name="blaze_campaign_objective_select_objective_label">Select objective %s</string>
+    <string name="blaze_campaign_objective_good_for"><![CDATA[<b>Good for:</b> %s]]></string>
+    <string name="blaze_campaign_objective_save_selection_switch_label">Save my selection for future campaigns</string>
+
     <!--
     Blaze campaign budget screen
     -->
@@ -3992,8 +4000,6 @@
     <string name="blaze_campaign_creation_location_search_message">Start typing country, state or city to see available options</string>
     <string name="blaze_campaign_creation_location_search_no_results_message">No location found.\nPlease try again.</string>
     <string name="blaze_campaign_creation_location_search_failed_message">Searching failed.\nPlease try again</string>
-    <string name="blaze_campaign_objective_select_objective_label">Select objective %s</string>
-    <string name="blaze_campaign_objective_good_for"><![CDATA[<b>Good for:</b> %s]]></string>
 
     <!--
     Blaze edit ad destination


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a switch to the bottom of the blaze objective screen. The switch will store the selected objective and in the next campaign creation, the it will be selected automatically.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Log into a Blaze-eligible site.
2. Trigger Blaze campaign creation flow.
3. Tap "Campaign objective" on the preview screen.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
#### Case 1
1. Verify the switch is disabled.
2. Disable switch.
3. Tap back button.
4. Reopen objective screen.
5. The switch button should be enabled.

#### Case 2
1. Select an objective
2. Enable the switch.
3. Tap SAVE.
3. Kill the app.
4. Retrigger the blaze flow and open objective screen.
5. Verify the same objective is selected.

Case 3 - Analytics
1. Tap the objective row, select an option from the list, and tap Save. Confirm that blaze_campaign_objective_saved is tracked with the ID of the selected objective.
2. Tap Confirm Details on the Preview screen. Confirm that blaze_creation_confirm_details_tapped is tracked with the ID of the selected objective.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested cases above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
||split screen|
|-|-|
|<img src="https://github.com/user-attachments/assets/5b7fcb66-dfb3-46b5-9705-0cd99a711168" width=300>|<img src="https://github.com/user-attachments/assets/1fd72af8-b6a8-4197-9048-9b4892fabb7b" width=300>|



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->