### PR TITLE
Enable feature flag for blaze objective

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,13 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final APK before release (e.g. major library or targetSdk updates).
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
-20.9
------
-- Added objective selection in the blaze campaign creation flow [https://github.com/woocommerce/woocommerce-android/pull/12781]
-
 20.8
 -----
-
+- Added objective selection in the blaze campaign creation flow [https://github.com/woocommerce/woocommerce-android/pull/12781]
 
 20.7
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final APK before release (e.g. major library or targetSdk updates).
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
+20.9
+-----
+- Added objective selection in the blaze campaign creation flow [https://github.com/woocommerce/woocommerce-android/pull/12781]
+
 20.8
 -----
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 20.8
 -----
-- Added objective selection in the blaze campaign creation flow [https://github.com/woocommerce/woocommerce-android/pull/12781]
+- [*] Added objective selection in the blaze campaign creation flow [https://github.com/woocommerce/woocommerce-android/pull/12781]
 
 20.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -28,15 +28,15 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
-            REVAMP_WOO_SHIPPING,
-            OBJECTIVE_SECTION -> PackageUtils.isDebugBuild()
+            REVAMP_WOO_SHIPPING -> PackageUtils.isDebugBuild()
 
             NEW_SHIPPING_SUPPORT,
             INBOX,
             SHOW_INBOX_CTA,
             GOOGLE_ADS_M1,
             CUSTOM_FIELDS,
-            ENDLESS_CAMPAIGNS_SUPPORT -> true
+            ENDLESS_CAMPAIGNS_SUPPORT,
+            OBJECTIVE_SECTION -> true
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

This only enables the feature flag for the objective screen and updates release notes. The feature has been already tested in https://github.com/woocommerce/woocommerce-android/pull/12781 and https://github.com/woocommerce/woocommerce-android/pull/12795.

<img src="https://github.com/user-attachments/assets/f2dfb5e2-eea9-414f-9956-7b5d30c5dceb" width=300>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->