### PR TITLE
[Bug] Text hidden behind checkbox in the "change due calculator" screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 20.9
 -----
-
+- [*][Payments]Fixed UI glitch in change due calculation screen [https://github.com/woocommerce/woocommerce-android/pull/12808]
 
 20.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -178,10 +178,10 @@ fun RecordTransactionDetailsNote(
         modifier = modifier
             .fillMaxWidth()
             .clickable { onCheckedChange(!checked) },
-        horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
+            modifier = Modifier.weight(1f),
             text = stringResource(R.string.cash_payments_record_transaction_details),
             style = MaterialTheme.typography.body1
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/changeduecalculator/ChangeDueCalculatorScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.NullableCurrencyTextFieldValueMapper
@@ -217,6 +218,7 @@ fun MarkOrderAsCompleteButton(
 
 @Composable
 @PreviewLightDark
+@PreviewScreenSizes
 fun ChangeDueCalculatorScreenSuccessPreviewUnchecked() {
     ChangeDueCalculatorScreen(
         uiState = ChangeDueCalculatorViewModel.UiState(
@@ -240,6 +242,7 @@ fun ChangeDueCalculatorScreenSuccessPreviewUnchecked() {
 
 @Composable
 @PreviewLightDark
+@PreviewScreenSizes
 fun ChangeDueCalculatorScreenSuccessPreviewChecked() {
     ChangeDueCalculatorScreen(
         uiState = ChangeDueCalculatorViewModel.UiState(
@@ -263,6 +266,7 @@ fun ChangeDueCalculatorScreenSuccessPreviewChecked() {
 
 @Composable
 @PreviewLightDark
+@PreviewScreenSizes
 fun ChangeDueCalculatorScreenSuccessPreviewDisabled() {
     ChangeDueCalculatorScreen(
         uiState = ChangeDueCalculatorViewModel.UiState(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
### Fix for UI glitch in "Change due calculator" screen

Closes: #12662
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes UI issue in "Change due calculator" screen–the label was overlapping with the checkbox certain scenarios (locales/screen widhts):
<img width="263" alt="Screenshot 2024-10-22 at 13 39 11" src="https://github.com/user-attachments/assets/44afa3eb-e3a4-429d-95dd-1cfb29ba4fd8">
The bug was caused by the Row's `horizontalAlignment` setting.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
To reproduce the bug, modify the string length or adjust screen width and observe the checkbox overlapping the text as shown in the screenshot above.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on Google Pixel 7 Pro, Android 14 and in Compose previews of various screen sizes and orientations.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
1. Reproduced the original issue by adjusting the text of the label
2. Verified that updated horizontal alignment settings fix the issue on various screen sizes

### Images/gif
#### After
<!-- Include before and after images or gifs when appropriate. -->
<img width="569" alt="Screenshot 2024-10-22 at 13 23 41" src="https://github.com/user-attachments/assets/d86e690d-0bfa-4951-9fd8-76128a8533b3">
<img width="256" alt="Screenshot 2024-10-22 at 13 23 26" src="https://github.com/user-attachments/assets/b58ef764-7462-4b8f-b1b2-bfb04a2730c4">

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->