### PR TITLE
Add feature flag for non-simple product types project

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/featureflags/IsNonSimpleProductTypesEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/featureflags/IsNonSimpleProductTypesEnabled.kt
@@ -1,0 +1,10 @@
+package com.woocommerce.android.ui.woopos.featureflags
+
+import com.woocommerce.android.util.FeatureFlag
+import javax.inject.Inject
+
+class IsNonSimpleProductTypesEnabled @Inject constructor() {
+    operator fun invoke(): Boolean {
+        return FeatureFlag.POS_NON_SIMPLE_PRODUCT_TYPES.isEnabled()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -17,7 +17,8 @@ enum class FeatureFlag {
     ENDLESS_CAMPAIGNS_SUPPORT,
     CUSTOM_FIELDS,
     REVAMP_WOO_SHIPPING,
-    OBJECTIVE_SECTION;
+    OBJECTIVE_SECTION,
+    POS_NON_SIMPLE_PRODUCT_TYPES;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -28,7 +29,8 @@ enum class FeatureFlag {
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
-            REVAMP_WOO_SHIPPING -> PackageUtils.isDebugBuild()
+            REVAMP_WOO_SHIPPING,
+            POS_NON_SIMPLE_PRODUCT_TYPES -> PackageUtils.isDebugBuild()
 
             NEW_SHIPPING_SUPPORT,
             INBOX,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsDataSourceTest.kt
@@ -505,4 +505,24 @@ class WooPosProductsDataSourceTest {
             )
         )
     }
+
+    @Test
+    fun `given non-simple product types feature enabled, when loadSimpleProducts called, then do not add filter to display only simple products`() = runTest {
+        // GIVEN
+        whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
+        whenever(handler.productsFlow).thenReturn(flowOf(sampleProducts))
+        whenever(isNonSimpleProductTypesEnabled.invoke()).thenReturn(true)
+        val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
+
+        // WHEN
+        sut.loadSimpleProducts(forceRefreshProducts = true).first()
+
+        // THEN
+        verify(handler).loadFromCacheAndFetch(
+            searchType = ProductListHandler.SearchType.DEFAULT,
+            filters = mapOf(
+                WCProductStore.ProductFilterOption.STATUS to ProductStatus.PUBLISH.value
+            )
+        )
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/products/WooPosProductsDataSourceTest.kt
@@ -1,7 +1,10 @@
 package com.woocommerce.android.ui.woopos.home.products
 
+import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductTestUtils
+import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.selector.ProductListHandler
+import com.woocommerce.android.ui.woopos.featureflags.IsNonSimpleProductTypesEnabled
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -12,7 +15,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.store.WCProductStore
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -65,13 +70,14 @@ class WooPosProductsDataSourceTest {
     )
 
     private val handler: ProductListHandler = mock()
+    private val isNonSimpleProductTypesEnabled: IsNonSimpleProductTypesEnabled = mock()
 
     @Test
     fun `given force refresh, when loadSimpleProducts called, then should clear cache`() = runTest {
         // GIVEN
         whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
         whenever(handler.productsFlow).thenReturn(flowOf(sampleProducts))
-        val sut = WooPosProductsDataSource(handler)
+        val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
 
         // Pre-populate the cache
         sut.loadSimpleProducts(forceRefreshProducts = false).first()
@@ -96,7 +102,7 @@ class WooPosProductsDataSourceTest {
         whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
         whenever(handler.productsFlow).thenReturn(flowOf(sampleProducts))
         whenever(handler.loadFromCacheAndFetch(any(), any(), any())).thenReturn(Result.success(Unit))
-        val sut = WooPosProductsDataSource(handler)
+        val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
 
         // WHEN
         sut.loadSimpleProducts(forceRefreshProducts = false).first()
@@ -115,7 +121,7 @@ class WooPosProductsDataSourceTest {
             whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
             whenever(handler.productsFlow).thenReturn(flowOf(sampleProducts))
             whenever(handler.loadFromCacheAndFetch(any(), any(), any())).thenReturn(Result.success(Unit))
-            val sut = WooPosProductsDataSource(handler)
+            val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
 
             // WHEN
             sut.loadSimpleProducts(forceRefreshProducts = false).first()
@@ -139,7 +145,7 @@ class WooPosProductsDataSourceTest {
             val exception = Exception("Remote load failed")
             whenever(handler.loadFromCacheAndFetch(any(), any(), any())).thenReturn(Result.success(Unit))
 
-            val sut = WooPosProductsDataSource(handler)
+            val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
 
             // Prepopulate the cache by calling loadSimpleProducts once
             sut.loadSimpleProducts(forceRefreshProducts = false).first()
@@ -168,7 +174,7 @@ class WooPosProductsDataSourceTest {
                 flowOf(sampleProducts + additionalProducts)
             )
             whenever(handler.loadMore()).thenReturn(Result.success(Unit))
-            val sut = WooPosProductsDataSource(handler)
+            val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
 
             sut.loadSimpleProducts(forceRefreshProducts = false).first()
 
@@ -193,7 +199,7 @@ class WooPosProductsDataSourceTest {
             whenever(handler.productsFlow).thenReturn(flowOf(sampleProducts))
             val exception = Exception("Load more failed")
             whenever(handler.loadMore()).thenReturn(Result.failure(exception))
-            val sut = WooPosProductsDataSource(handler)
+            val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
 
             sut.loadSimpleProducts(forceRefreshProducts = false).first()
 
@@ -219,7 +225,7 @@ class WooPosProductsDataSourceTest {
             val exception = Exception("Remote load failed")
             whenever(handler.loadFromCacheAndFetch(any(), any(), any())).thenReturn(Result.failure(exception))
 
-            val sut = WooPosProductsDataSource(handler)
+            val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
 
             // WHEN
             val flow = sut.loadSimpleProducts(forceRefreshProducts = false).toList()
@@ -240,7 +246,7 @@ class WooPosProductsDataSourceTest {
             whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
             whenever(handler.productsFlow).thenReturn(flowOf(emptyList()))
             whenever(handler.loadFromCacheAndFetch(any(), any(), any())).thenReturn(Result.success(Unit))
-            val sut = WooPosProductsDataSource(handler)
+            val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
 
             // WHEN
             val flow = sut.loadSimpleProducts(forceRefreshProducts = false).toList()
@@ -280,7 +286,7 @@ class WooPosProductsDataSourceTest {
                 )
             )
             whenever(handler.loadFromCacheAndFetch(any(), any(), any())).thenReturn(Result.success(Unit))
-            val sut = WooPosProductsDataSource(handler)
+            val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
 
             // WHEN
             val flow = sut.loadSimpleProducts(forceRefreshProducts = false).toList()
@@ -317,7 +323,7 @@ class WooPosProductsDataSourceTest {
                 )
             )
             whenever(handler.loadFromCacheAndFetch(any(), any(), any())).thenReturn(Result.success(Unit))
-            val sut = WooPosProductsDataSource(handler)
+            val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
 
             // WHEN
             val flow = sut.loadSimpleProducts(forceRefreshProducts = true).toList()
@@ -355,7 +361,7 @@ class WooPosProductsDataSourceTest {
                 )
             )
             whenever(handler.loadFromCacheAndFetch(any(), any(), any())).thenReturn(Result.success(Unit))
-            val sut = WooPosProductsDataSource(handler)
+            val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
 
             // WHEN
             val flow = sut.loadSimpleProducts(forceRefreshProducts = false).toList()
@@ -394,7 +400,7 @@ class WooPosProductsDataSourceTest {
                 )
             )
             whenever(handler.loadFromCacheAndFetch(any(), any(), any())).thenReturn(Result.success(Unit))
-            val sut = WooPosProductsDataSource(handler)
+            val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
 
             // WHEN
             val flow = sut.loadSimpleProducts(forceRefreshProducts = true).toList()
@@ -431,7 +437,7 @@ class WooPosProductsDataSourceTest {
                 )
             )
             whenever(handler.loadFromCacheAndFetch(any(), any(), any())).thenReturn(Result.success(Unit))
-            val sut = WooPosProductsDataSource(handler)
+            val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
 
             // WHEN
             val flow = sut.loadSimpleProducts(forceRefreshProducts = false).toList()
@@ -469,7 +475,7 @@ class WooPosProductsDataSourceTest {
                 )
             )
             whenever(handler.loadFromCacheAndFetch(any(), any(), any())).thenReturn(Result.success(Unit))
-            val sut = WooPosProductsDataSource(handler)
+            val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
 
             // WHEN
             val flow = sut.loadSimpleProducts(forceRefreshProducts = true).toList()
@@ -478,4 +484,25 @@ class WooPosProductsDataSourceTest {
             val remoteResult = flow[1] as WooPosProductsDataSource.ProductsResult.Remote
             assertThat(remoteResult.productsResult.getOrNull()?.any { it.remoteId == 1L }).isFalse()
         }
+
+    @Test
+    fun `given non-simple product types feature disabled, when loadSimpleProducts called, then add filter to display only simple products`() = runTest {
+        // GIVEN
+        whenever(handler.canLoadMore).thenReturn(AtomicBoolean(true))
+        whenever(handler.productsFlow).thenReturn(flowOf(sampleProducts))
+        whenever(isNonSimpleProductTypesEnabled.invoke()).thenReturn(false)
+        val sut = WooPosProductsDataSource(handler, isNonSimpleProductTypesEnabled)
+
+        // WHEN
+        sut.loadSimpleProducts(forceRefreshProducts = true).first()
+
+        // THEN
+        verify(handler).loadFromCacheAndFetch(
+            searchType = ProductListHandler.SearchType.DEFAULT,
+            filters = mapOf(
+                WCProductStore.ProductFilterOption.TYPE to ProductType.SIMPLE.value,
+                WCProductStore.ProductFilterOption.STATUS to ProductStatus.PUBLISH.value
+            )
+        )
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12807 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a feature flag so that we could remove the "Simple" products filter for the products api and start showing all different product types for POS. This would help us in development of supporting Variable products for POS.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Unit tests have been added to ensure this change doesn't break anything.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
1. Unit tests for testing that both enabling and disabling the feature flag works as expected.
2. Create a release build and ensure you don't see Variable products on POS. In other words, you should only see Simple products only on POS.
3. Create a Debug build and ensure you see all products on POS.


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->