### PR TITLE
Fix crash on site picker for accounts without woo sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -337,7 +337,10 @@ class SitePickerViewModel @Inject constructor(
                 loadAndDisplaySites()
             }
         )
-        sitePickerViewState = sitePickerViewState.copy(isSkeletonViewVisible = false, isPrimaryBtnVisible = true)
+        sitePickerViewState = sitePickerViewState.copy(
+            isSkeletonViewVisible = false,
+            isPrimaryBtnVisible = sites.value!!.any { it is WooSiteUiModel }
+        )
     }
 
     private fun loadWooNotFoundView(site: SiteModel) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -377,6 +377,31 @@ class SitePickerViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given the site address does not match the user account and there is no woo site, continue button is hidden`() =
+        testBlocking {
+            givenThatUserLoggedInFromEnteringSiteAddress(null)
+            whenever(repository.fetchSiteInfo(any())).thenReturn(
+                Result.success(
+                    ConnectSiteInfoPayload(
+                        url = SitePickerTestUtils.loginSiteAddress,
+                        isWordPress = true,
+                        isWPCom = false
+                    )
+                )
+            )
+            val nonWooSite = SiteModel().apply {
+                id = 1
+                siteId = 1
+                hasWooCommerce = false
+            }
+            val siteList = listOf(nonWooSite)
+            whenSitesAreFetched(sitesFromApi = siteList, sitesFromDb = siteList)
+            whenViewModelIsCreated()
+
+            assertThat(viewModel.sitePickerViewState.isPrimaryBtnVisible).isEqualTo(false)
+        }
+
+    @Test
     fun `given that the site address entered during login does not have Woo, no woo error screen is displayed`() =
         testBlocking {
             givenThatUserLoggedInFromEnteringSiteAddress(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10553 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes a crash that occurs when using the wrong account that does not have any Woo sites. When the mismatch screen is displayed, the primary button on the site picker screen was always visible. This PR checks existing woo sites to set the visibility of the primary button. 

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Open the login flow and enter a Woo site address.
2. Enter your WP account that does not have any Woo sites.
3. When the jetpack connection error screen is displayed, navigate back.
4. On the site picker screen tap the "Continue" button.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
- [ ] Login with an account that has Woo site (but wrong site)
- [ ] Login with an account without any Woo sites.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
I tested the mismatch account screen with accounts that have Woo sites and accounts without any Woo sites.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|before|after|
|-|-|
|<img src="https://github.com/user-attachments/assets/35609c3b-096a-45ff-bfbd-523e1a5f7c35" width=300>|<img src="https://github.com/user-attachments/assets/162a2209-8b20-4f08-9642-b67a1eaf7d3e" width=300> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
