### PR TITLE
[Product Filter] Remove redundant filter button

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductSelectorScreenTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/ProductSelectorScreenTest.kt
@@ -31,7 +31,8 @@ class ProductSelectorScreenTest {
                     selectedItemsCount = 0,
                     filterState = ProductSelectorViewModel.FilterState(emptyMap(), null),
                     searchState = ProductSelectorViewModel.SearchState.EMPTY,
-                    selectionMode = ProductSelectorViewModel.SelectionMode.MULTIPLE
+                    selectionMode = ProductSelectorViewModel.SelectionMode.MULTIPLE,
+                    productFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined
                 ),
                 onDoneButtonClick = {},
                 onClearButtonClick = {},
@@ -61,7 +62,8 @@ class ProductSelectorScreenTest {
                     selectedItemsCount = 0,
                     filterState = ProductSelectorViewModel.FilterState(emptyMap(), null),
                     searchState = ProductSelectorViewModel.SearchState.EMPTY,
-                    selectionMode = ProductSelectorViewModel.SelectionMode.MULTIPLE
+                    selectionMode = ProductSelectorViewModel.SelectionMode.MULTIPLE,
+                    productFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined
                 ),
                 onDoneButtonClick = {},
                 onClearButtonClick = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesFragment.kt
@@ -28,7 +28,7 @@ import com.woocommerce.android.ui.orders.filters.model.OrderFilterEvent.OnShowOr
 import com.woocommerce.android.ui.orders.filters.model.OrderFilterEvent.ShowFilterOptionsForCategory
 import com.woocommerce.android.ui.orders.list.OrderListFragment
 import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderList
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.ProductListFilter
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectionHandling.SIMPLE
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectionMode.SINGLE
@@ -176,7 +176,7 @@ class OrderFilterCategoriesFragment :
                         ctaButtonTextOverride = getString(R.string.done),
                         selectedItems = category.orderFilterOptions.firstOrNull { it.isSelected }
                             ?.let { arrayOf(SelectedItem.Product(it.key.toLong())) },
-                        productSelectorFlow = OrderList
+                        productSelectorFlow = ProductListFilter
                     )
             }
             else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesFragment.kt
@@ -28,7 +28,7 @@ import com.woocommerce.android.ui.orders.filters.model.OrderFilterEvent.OnShowOr
 import com.woocommerce.android.ui.orders.filters.model.OrderFilterEvent.ShowFilterOptionsForCategory
 import com.woocommerce.android.ui.orders.list.OrderListFragment
 import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.Undefined
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderList
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectionHandling.SIMPLE
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectionMode.SINGLE
@@ -176,7 +176,7 @@ class OrderFilterCategoriesFragment :
                         ctaButtonTextOverride = getString(R.string.done),
                         selectedItems = category.orderFilterOptions.firstOrNull { it.isSelected }
                             ?.let { arrayOf(SelectedItem.Product(it.key.toLong())) },
-                        productSelectorFlow = Undefined
+                        productSelectorFlow = OrderList
                     )
             }
             else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesFragment.kt
@@ -28,7 +28,7 @@ import com.woocommerce.android.ui.orders.filters.model.OrderFilterEvent.OnShowOr
 import com.woocommerce.android.ui.orders.filters.model.OrderFilterEvent.ShowFilterOptionsForCategory
 import com.woocommerce.android.ui.orders.list.OrderListFragment
 import com.woocommerce.android.ui.products.selector.ProductSelectorFragment
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.ProductListFilter
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderListFilter
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectedItem
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectionHandling.SIMPLE
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectionMode.SINGLE
@@ -176,7 +176,7 @@ class OrderFilterCategoriesFragment :
                         ctaButtonTextOverride = getString(R.string.done),
                         selectedItems = category.orderFilterOptions.firstOrNull { it.isSelected }
                             ?.let { arrayOf(SelectedItem.Product(it.key.toLong())) },
-                        productSelectorFlow = ProductListFilter
+                        productSelectorFlow = OrderListFilter
                     )
             }
             else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -366,7 +366,7 @@ private fun ProductList(
                     modifier = Modifier.align(Alignment.CenterStart)
                 )
             }
-            if (state.searchState.searchQuery.isEmpty()) {
+            if (state.shouldDisplayFilterButton) {
                 WCTextButton(
                     onClick = onFilterButtonClick,
                     text = StringUtils.getQuantityString(
@@ -375,7 +375,8 @@ private fun ProductList(
                         zero = string.product_selector_filter_button_title_zero
                     ),
                     allCaps = false,
-                    modifier = Modifier.align(Alignment.CenterEnd)
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorScreen.kt
@@ -64,6 +64,7 @@ import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.Lis
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.APPENDING
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.IDLE
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.LOADING
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.Undefined
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectionMode
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ViewState
 import com.woocommerce.android.ui.products.selector.SelectionState.PARTIALLY_SELECTED
@@ -600,7 +601,8 @@ fun PopularProductsListPreview() {
             searchState = ProductSelectorViewModel.SearchState(),
             popularProducts = products,
             recentProducts = emptyList(),
-            selectionMode = SelectionMode.MULTIPLE
+            selectionMode = SelectionMode.MULTIPLE,
+            productFlow = Undefined
         ),
         onDoneButtonClick = {},
         onClearButtonClick = {},
@@ -670,7 +672,8 @@ fun RecentProductsListPreview() {
             searchState = ProductSelectorViewModel.SearchState(),
             popularProducts = emptyList(),
             recentProducts = products,
-            selectionMode = SelectionMode.MULTIPLE
+            selectionMode = SelectionMode.MULTIPLE,
+            productFlow = Undefined
         ),
         onDoneButtonClick = {},
         onClearButtonClick = {},
@@ -748,7 +751,8 @@ fun ProductListPreview() {
             searchState = ProductSelectorViewModel.SearchState(),
             popularProducts = products,
             recentProducts = products,
-            selectionMode = SelectionMode.MULTIPLE
+            selectionMode = SelectionMode.MULTIPLE,
+            productFlow = Undefined
         ),
         onDoneButtonClick = {},
         onClearButtonClick = {},
@@ -772,7 +776,8 @@ fun ProductListEmptyPreview() {
             searchState = ProductSelectorViewModel.SearchState(),
             popularProducts = emptyList(),
             recentProducts = emptyList(),
-            selectionMode = SelectionMode.MULTIPLE
+            selectionMode = SelectionMode.MULTIPLE,
+            productFlow = Undefined
         ),
         onClearFiltersButtonClick = {}
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorTracker.kt
@@ -21,7 +21,9 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                     mapOf(AnalyticsTracker.KEY_SOURCE to sourceProperty)
                 )
             }
-            else -> {}
+            ProductSelectorFlow.CouponEdition -> {}
+            ProductSelectorFlow.OrderList -> {}
+            ProductSelectorFlow.Undefined -> {}
         }
     }
 
@@ -32,7 +34,9 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                     AnalyticsEvent.ORDER_CREATION_PRODUCT_SELECTOR_ITEM_SELECTED,
                 )
             }
-            else -> {}
+            ProductSelectorFlow.CouponEdition -> {}
+            ProductSelectorFlow.OrderList -> {}
+            ProductSelectorFlow.Undefined -> {}
         }
     }
 
@@ -43,7 +47,9 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                     AnalyticsEvent.ORDER_CREATION_PRODUCT_SELECTOR_ITEM_UNSELECTED,
                 )
             }
-            else -> {}
+            ProductSelectorFlow.CouponEdition -> {}
+            ProductSelectorFlow.OrderList -> {}
+            ProductSelectorFlow.Undefined -> {}
         }
     }
 
@@ -64,7 +70,9 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                     )
                 )
             }
-            else -> {}
+            ProductSelectorFlow.CouponEdition -> {}
+            ProductSelectorFlow.OrderList -> {}
+            ProductSelectorFlow.Undefined -> {}
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorTracker.kt
@@ -21,8 +21,7 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                     mapOf(AnalyticsTracker.KEY_SOURCE to sourceProperty)
                 )
             }
-            ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorFlow.Undefined -> {}
+            else -> {}
         }
     }
 
@@ -33,8 +32,7 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                     AnalyticsEvent.ORDER_CREATION_PRODUCT_SELECTOR_ITEM_SELECTED,
                 )
             }
-            ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorFlow.Undefined -> {}
+            else -> {}
         }
     }
 
@@ -45,8 +43,7 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                     AnalyticsEvent.ORDER_CREATION_PRODUCT_SELECTOR_ITEM_UNSELECTED,
                 )
             }
-            ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorFlow.Undefined -> {}
+            else -> {}
         }
     }
 
@@ -67,8 +64,7 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                     )
                 )
             }
-            ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorFlow.Undefined -> {}
+            else -> {}
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorTracker.kt
@@ -22,7 +22,7 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                 )
             }
             ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorFlow.OrderList -> {}
+            ProductSelectorFlow.ProductListFilter -> {}
             ProductSelectorFlow.Undefined -> {}
         }
     }
@@ -35,7 +35,7 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                 )
             }
             ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorFlow.OrderList -> {}
+            ProductSelectorFlow.ProductListFilter -> {}
             ProductSelectorFlow.Undefined -> {}
         }
     }
@@ -48,7 +48,7 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                 )
             }
             ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorFlow.OrderList -> {}
+            ProductSelectorFlow.ProductListFilter -> {}
             ProductSelectorFlow.Undefined -> {}
         }
     }
@@ -71,7 +71,7 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                 )
             }
             ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorFlow.OrderList -> {}
+            ProductSelectorFlow.ProductListFilter -> {}
             ProductSelectorFlow.Undefined -> {}
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorTracker.kt
@@ -22,7 +22,7 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                 )
             }
             ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorFlow.ProductListFilter -> {}
+            ProductSelectorFlow.OrderListFilter -> {}
             ProductSelectorFlow.Undefined -> {}
         }
     }
@@ -35,7 +35,7 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                 )
             }
             ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorFlow.ProductListFilter -> {}
+            ProductSelectorFlow.OrderListFilter -> {}
             ProductSelectorFlow.Undefined -> {}
         }
     }
@@ -48,7 +48,7 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                 )
             }
             ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorFlow.ProductListFilter -> {}
+            ProductSelectorFlow.OrderListFilter -> {}
             ProductSelectorFlow.Undefined -> {}
         }
     }
@@ -71,7 +71,7 @@ class ProductSelectorTracker @Inject constructor(private val tracker: AnalyticsT
                 )
             }
             ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorFlow.ProductListFilter -> {}
+            ProductSelectorFlow.OrderListFilter -> {}
             ProductSelectorFlow.Undefined -> {}
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -150,15 +150,8 @@ class ProductSelectorViewModel @Inject constructor(
         )
     }.asLiveData()
 
-    private fun mapProductsToUiModel(
-        it: Product,
-        selectedIds: List<SelectedItem>
-    ) = when (navArgs.selectionHandling) {
-        NORMAL -> it.toUiModel(selectedIds)
-        SIMPLE -> it.toSimpleUiModel(selectedIds)
-    }
-
-    val selectionMode = navArgs.selectionMode
+    val selectionMode: SelectionMode = navArgs.selectionMode
+    val selectionHandling: SelectionHandling = navArgs.selectionHandling
 
     init {
         if (navArgs.selectionMode == SelectionMode.SINGLE && (navArgs.selectedItems?.size ?: 0) > 1) {
@@ -171,6 +164,14 @@ class ProductSelectorViewModel @Inject constructor(
             loadRecentProducts()
             fetchProducts(searchType = searchState.value.searchType)
         }
+    }
+
+    private fun mapProductsToUiModel(
+        it: Product,
+        selectedIds: List<SelectedItem>
+    ) = when (selectionHandling) {
+        NORMAL -> it.toUiModel(selectedIds)
+        SIMPLE -> it.toSimpleUiModel(selectedIds)
     }
 
     private fun getPopularProductsToDisplay(
@@ -392,7 +393,7 @@ class ProductSelectorViewModel @Inject constructor(
             isVariable() && numVariations > 0
 
         if (item.hasVariations()) {
-            val variationSelectorScreenMode = when (navArgs.selectionMode) {
+            val variationSelectorScreenMode = when (selectionMode) {
                 SelectionMode.SINGLE, SelectionMode.MULTIPLE -> VariationSelectorViewModel.ScreenMode.FULLSCREEN
                 SelectionMode.LIVE -> VariationSelectorViewModel.ScreenMode.DIALOG
             }
@@ -402,7 +403,7 @@ class ProductSelectorViewModel @Inject constructor(
                     selectedVariationIds = item.selectedVariationIds,
                     productSelectorFlow = productSelectorFlow,
                     productSourceForTracking = productSource,
-                    selectionMode = navArgs.selectionMode,
+                    selectionMode = selectionMode,
                     screenMode = variationSelectorScreenMode
                 )
             )
@@ -419,7 +420,7 @@ class ProductSelectorViewModel @Inject constructor(
     }
 
     private fun handleConfigurableItemTap(item: ListItem.ConfigurableListItem) {
-        if (selectedItems.value.containsItemWith(item.id) && navArgs.selectionMode == SelectionMode.MULTIPLE) {
+        if (selectedItems.value.containsItemWith(item.id) && selectionMode == SelectionMode.MULTIPLE) {
             tracker.trackItemUnselected(productSelectorFlow)
             selectedItemsSource.remove(item.id)
             _selectedItems.update { items -> items.filter { it.id != item.id } }
@@ -432,7 +433,7 @@ class ProductSelectorViewModel @Inject constructor(
     }
 
     private fun updateItemSelection(item: SelectedItem, productSource: ProductSourceForTracking) {
-        when (navArgs.selectionMode) {
+        when (selectionMode) {
             SelectionMode.SINGLE -> {
                 tracker.trackItemSelected(productSelectorFlow)
                 selectedItemsSource[item.id] = productSource
@@ -627,7 +628,7 @@ class ProductSelectorViewModel @Inject constructor(
         tracker.trackItemSelected(productSelectorFlow)
         _selectedItems.update { items ->
             val newItem = SelectedItem.ConfigurableProduct(productId, productConfiguration)
-            when (navArgs.selectionMode) {
+            when (selectionMode) {
                 SelectionMode.SINGLE -> listOf(newItem)
                 SelectionMode.MULTIPLE, SelectionMode.LIVE -> items + newItem
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -24,7 +24,7 @@ import com.woocommerce.android.ui.products.selector.ProductListHandler.SearchTyp
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.APPENDING
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.IDLE
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.LOADING
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderList
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.ProductListFilter
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectionHandling.NORMAL
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectionHandling.SIMPLE
 import com.woocommerce.android.ui.products.selector.SelectionState.PARTIALLY_SELECTED
@@ -154,7 +154,7 @@ class ProductSelectorViewModel @Inject constructor(
 
     private val selectionHandling: SelectionHandling = navArgs.selectionHandling
     val selectionMode: SelectionMode = navArgs.selectionMode
-    val shouldDisplayFilterButton: Boolean = navArgs.productSelectorFlow != OrderList
+    val shouldDisplayFilterButton: Boolean = navArgs.productSelectorFlow != ProductListFilter
 
     init {
         if (navArgs.selectionMode == SelectionMode.SINGLE && (navArgs.selectedItems?.size ?: 0) > 1) {
@@ -676,7 +676,7 @@ class ProductSelectorViewModel @Inject constructor(
         val selectionEnabled: Boolean = true
     ) {
         val isDoneButtonEnabled: Boolean = selectionMode == SelectionMode.MULTIPLE || selectedItemsCount > 0
-        val shouldDisplayFilterButton = searchState.searchQuery.isEmpty() && productFlow != OrderList
+        val shouldDisplayFilterButton = searchState.searchQuery.isEmpty() && productFlow != ProductListFilter
     }
 
     @Parcelize
@@ -793,7 +793,7 @@ class ProductSelectorViewModel @Inject constructor(
     }
 
     enum class ProductSelectorFlow {
-        OrderCreation, OrderEditing, CouponEdition, OrderList, Undefined
+        OrderCreation, OrderEditing, CouponEdition, ProductListFilter, Undefined
     }
 
     enum class SelectionMode {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -24,7 +24,7 @@ import com.woocommerce.android.ui.products.selector.ProductListHandler.SearchTyp
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.APPENDING
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.IDLE
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.LOADING
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.ProductListFilter
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderListFilter
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectionHandling.NORMAL
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectionHandling.SIMPLE
 import com.woocommerce.android.ui.products.selector.SelectionState.PARTIALLY_SELECTED
@@ -154,7 +154,7 @@ class ProductSelectorViewModel @Inject constructor(
 
     private val selectionHandling: SelectionHandling = navArgs.selectionHandling
     val selectionMode: SelectionMode = navArgs.selectionMode
-    val shouldDisplayFilterButton: Boolean = navArgs.productSelectorFlow != ProductListFilter
+    val shouldDisplayFilterButton: Boolean = navArgs.productSelectorFlow != OrderListFilter
 
     init {
         if (navArgs.selectionMode == SelectionMode.SINGLE && (navArgs.selectedItems?.size ?: 0) > 1) {
@@ -676,7 +676,7 @@ class ProductSelectorViewModel @Inject constructor(
         val selectionEnabled: Boolean = true
     ) {
         val isDoneButtonEnabled: Boolean = selectionMode == SelectionMode.MULTIPLE || selectedItemsCount > 0
-        val shouldDisplayFilterButton = searchState.searchQuery.isEmpty() && productFlow != ProductListFilter
+        val shouldDisplayFilterButton = searchState.searchQuery.isEmpty() && productFlow != OrderListFilter
     }
 
     @Parcelize
@@ -793,7 +793,7 @@ class ProductSelectorViewModel @Inject constructor(
     }
 
     enum class ProductSelectorFlow {
-        OrderCreation, OrderEditing, CouponEdition, ProductListFilter, Undefined
+        OrderCreation, OrderEditing, CouponEdition, OrderListFilter, Undefined
     }
 
     enum class SelectionMode {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.ui.products.selector.ProductListHandler.SearchTyp
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.APPENDING
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.IDLE
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.LoadingState.LOADING
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderList
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectionHandling.NORMAL
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.SelectionHandling.SIMPLE
 import com.woocommerce.android.ui.products.selector.SelectionState.PARTIALLY_SELECTED
@@ -144,14 +145,16 @@ class ProductSelectorViewModel @Inject constructor(
             filterState = filterState,
             searchState = searchState,
             selectionMode = navArgs.selectionMode,
+            productFlow = navArgs.productSelectorFlow,
             screenTitleOverride = navArgs.screenTitleOverride,
             ctaButtonTextOverride = navArgs.ctaButtonTextOverride,
             selectionEnabled = enabled,
         )
     }.asLiveData()
 
+    private val selectionHandling: SelectionHandling = navArgs.selectionHandling
     val selectionMode: SelectionMode = navArgs.selectionMode
-    val selectionHandling: SelectionHandling = navArgs.selectionHandling
+    val shouldDisplayFilterButton: Boolean = navArgs.productSelectorFlow != OrderList
 
     init {
         if (navArgs.selectionMode == SelectionMode.SINGLE && (navArgs.selectedItems?.size ?: 0) > 1) {
@@ -667,11 +670,13 @@ class ProductSelectorViewModel @Inject constructor(
         val filterState: FilterState,
         val searchState: SearchState,
         val selectionMode: SelectionMode,
+        val productFlow: ProductSelectorFlow,
         val screenTitleOverride: String? = null,
         val ctaButtonTextOverride: String? = null,
-        val selectionEnabled: Boolean = true,
+        val selectionEnabled: Boolean = true
     ) {
         val isDoneButtonEnabled: Boolean = selectionMode == SelectionMode.MULTIPLE || selectedItemsCount > 0
+        val shouldDisplayFilterButton = searchState.searchQuery.isEmpty() && productFlow != OrderList
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModel.kt
@@ -787,7 +787,7 @@ class ProductSelectorViewModel @Inject constructor(
     }
 
     enum class ProductSelectorFlow {
-        OrderCreation, OrderEditing, CouponEdition, Undefined
+        OrderCreation, OrderEditing, CouponEdition, OrderList, Undefined
     }
 
     enum class SelectionMode {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorViewModel.kt
@@ -156,7 +156,6 @@ class VariationSelectorViewModel @Inject constructor(
             CouponEdition -> {}
             OrderList -> {}
             Undefined -> {}
-
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorViewModel.kt
@@ -17,7 +17,7 @@ import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.Pro
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.CouponEdition
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderCreation
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderEditing
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderList
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.ProductListFilter
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.Undefined
 import com.woocommerce.android.ui.products.selector.ProductSourceForTracking
 import com.woocommerce.android.ui.products.selector.SelectionState
@@ -154,7 +154,7 @@ class VariationSelectorViewModel @Inject constructor(
                 )
             }
             CouponEdition -> {}
-            OrderList -> {}
+            ProductListFilter -> {}
             Undefined -> {}
         }
     }
@@ -176,7 +176,7 @@ class VariationSelectorViewModel @Inject constructor(
                 tracker.trackItemSelected(productSelectorFlow)
             }
             CouponEdition -> {}
-            OrderList -> {}
+            ProductListFilter -> {}
             Undefined -> {}
         }
     }
@@ -188,7 +188,7 @@ class VariationSelectorViewModel @Inject constructor(
                 tracker.trackItemUnselected(productSelectorFlow)
             }
             CouponEdition -> {}
-            OrderList -> {}
+            ProductListFilter -> {}
             Undefined -> {}
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorViewModel.kt
@@ -17,7 +17,7 @@ import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.Pro
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.CouponEdition
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderCreation
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderEditing
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.ProductListFilter
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderListFilter
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.Undefined
 import com.woocommerce.android.ui.products.selector.ProductSourceForTracking
 import com.woocommerce.android.ui.products.selector.SelectionState
@@ -154,7 +154,7 @@ class VariationSelectorViewModel @Inject constructor(
                 )
             }
             CouponEdition -> {}
-            ProductListFilter -> {}
+            OrderListFilter -> {}
             Undefined -> {}
         }
     }
@@ -176,7 +176,7 @@ class VariationSelectorViewModel @Inject constructor(
                 tracker.trackItemSelected(productSelectorFlow)
             }
             CouponEdition -> {}
-            ProductListFilter -> {}
+            OrderListFilter -> {}
             Undefined -> {}
         }
     }
@@ -188,7 +188,7 @@ class VariationSelectorViewModel @Inject constructor(
                 tracker.trackItemUnselected(productSelectorFlow)
             }
             CouponEdition -> {}
-            ProductListFilter -> {}
+            OrderListFilter -> {}
             Undefined -> {}
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorViewModel.kt
@@ -149,7 +149,9 @@ class VariationSelectorViewModel @Inject constructor(
                 )
             }
             ProductSelectorViewModel.ProductSelectorFlow.CouponEdition -> {}
+            ProductSelectorViewModel.ProductSelectorFlow.OrderList -> {}
             ProductSelectorViewModel.ProductSelectorFlow.Undefined -> {}
+
         }
     }
 
@@ -170,6 +172,7 @@ class VariationSelectorViewModel @Inject constructor(
                 tracker.trackItemSelected(productSelectorFlow)
             }
             ProductSelectorViewModel.ProductSelectorFlow.CouponEdition -> {}
+            ProductSelectorViewModel.ProductSelectorFlow.OrderList -> {}
             ProductSelectorViewModel.ProductSelectorFlow.Undefined -> {}
         }
     }
@@ -181,6 +184,7 @@ class VariationSelectorViewModel @Inject constructor(
                 tracker.trackItemUnselected(productSelectorFlow)
             }
             ProductSelectorViewModel.ProductSelectorFlow.CouponEdition -> {}
+            ProductSelectorViewModel.ProductSelectorFlow.OrderList -> {}
             ProductSelectorViewModel.ProductSelectorFlow.Undefined -> {}
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/selector/VariationSelectorViewModel.kt
@@ -13,7 +13,12 @@ import com.woocommerce.android.ui.products.ProductStockStatus.Custom
 import com.woocommerce.android.ui.products.ProductStockStatus.InStock
 import com.woocommerce.android.ui.products.ProductStockStatus.NotAvailable
 import com.woocommerce.android.ui.products.selector.ProductSelectorTracker
-import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.CouponEdition
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderCreation
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderEditing
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderList
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.Undefined
 import com.woocommerce.android.ui.products.selector.ProductSourceForTracking
 import com.woocommerce.android.ui.products.selector.SelectionState
 import com.woocommerce.android.ui.products.selector.SelectionState.SELECTED
@@ -64,7 +69,7 @@ class VariationSelectorViewModel @Inject constructor(
     }
 
     private val navArgs: VariationSelectorFragmentArgs by savedState.navArgs()
-    private val productSelectorFlow = navArgs.productSelectorFlow
+    private val productSelectorFlow: ProductSelectorFlow = navArgs.productSelectorFlow
 
     private val loadingState = MutableStateFlow(IDLE)
     private val selectedVariationIds = savedState.getStateFlow(viewModelScope, navArgs.variationIds.toSet())
@@ -140,17 +145,17 @@ class VariationSelectorViewModel @Inject constructor(
     }
 
     private fun trackClearSelectionButtonClicked() {
-        when (navArgs.productSelectorFlow) {
-            ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
-            ProductSelectorViewModel.ProductSelectorFlow.OrderEditing -> {
+        when (productSelectorFlow) {
+            OrderCreation,
+            OrderEditing -> {
                 tracker.trackClearSelectionButtonClicked(
                     productSelectorFlow,
                     ProductSelectorTracker.ProductSelectorSource.VariationSelector
                 )
             }
-            ProductSelectorViewModel.ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorViewModel.ProductSelectorFlow.OrderList -> {}
-            ProductSelectorViewModel.ProductSelectorFlow.Undefined -> {}
+            CouponEdition -> {}
+            OrderList -> {}
+            Undefined -> {}
 
         }
     }
@@ -166,26 +171,26 @@ class VariationSelectorViewModel @Inject constructor(
     }
 
     private fun trackVariationSelected() {
-        when (navArgs.productSelectorFlow) {
-            ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
-            ProductSelectorViewModel.ProductSelectorFlow.OrderEditing -> {
+        when (productSelectorFlow) {
+            OrderCreation,
+            OrderEditing -> {
                 tracker.trackItemSelected(productSelectorFlow)
             }
-            ProductSelectorViewModel.ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorViewModel.ProductSelectorFlow.OrderList -> {}
-            ProductSelectorViewModel.ProductSelectorFlow.Undefined -> {}
+            CouponEdition -> {}
+            OrderList -> {}
+            Undefined -> {}
         }
     }
 
     private fun trackVariationUnselected() {
-        when (navArgs.productSelectorFlow) {
-            ProductSelectorViewModel.ProductSelectorFlow.OrderCreation,
-            ProductSelectorViewModel.ProductSelectorFlow.OrderEditing -> {
+        when (productSelectorFlow) {
+            OrderCreation,
+            OrderEditing -> {
                 tracker.trackItemUnselected(productSelectorFlow)
             }
-            ProductSelectorViewModel.ProductSelectorFlow.CouponEdition -> {}
-            ProductSelectorViewModel.ProductSelectorFlow.OrderList -> {}
-            ProductSelectorViewModel.ProductSelectorFlow.Undefined -> {}
+            CouponEdition -> {}
+            OrderList -> {}
+            Undefined -> {}
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -1479,6 +1479,28 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
         }
     }
 
+    @Test
+    fun `shouldDisplayFilterButton is true when productFlow is Undefined`() = testBlocking {
+        val navArgs = ProductSelectorFragmentArgs(
+            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
+        ).toSavedStateHandle()
+
+        val sut = createViewModel(navArgs)
+        val viewState = sut.viewState.captureValues().last()
+        assertThat(viewState.shouldDisplayFilterButton).isTrue
+    }
+
+    @Test
+    fun `shouldDisplayFilterButton is false when productFlow is ProductListFilter`() = testBlocking {
+        val navArgs = ProductSelectorFragmentArgs(
+            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.ProductListFilter,
+        ).toSavedStateHandle()
+
+        val sut = createViewModel(navArgs)
+        val viewState = sut.viewState.captureValues().last()
+        assertThat(viewState.shouldDisplayFilterButton).isFalse
+    }
+
     private fun generateProductListItem(
         id: Long,
     ) = ProductListItem(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductSelectorViewModelTest.kt
@@ -20,6 +20,8 @@ import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.ProductTestUtils.generateProduct
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ListItem.ProductListItem
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.OrderListFilter
+import com.woocommerce.android.ui.products.selector.ProductSelectorViewModel.ProductSelectorFlow.Undefined
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorRepository
 import com.woocommerce.android.ui.products.variations.selector.VariationSelectorViewModel
 import com.woocommerce.android.util.CurrencyFormatter
@@ -106,7 +108,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
     fun `given variable product, when view model created, should generate correct item subtitle`() {
         val navArgs = ProductSelectorFragmentArgs(
             selectedItems = emptyArray(),
-            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
+            productSelectorFlow = Undefined,
         ).toSavedStateHandle()
 
         whenever(currencyFormatter.formatCurrency(VARIABLE_PRODUCT.price!!, "USD"))
@@ -128,7 +130,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
     fun `given variable subscription product, when view model created, should generate correct item subtitle`() {
         val navArgs = ProductSelectorFragmentArgs(
             selectedItems = emptyArray(),
-            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
+            productSelectorFlow = Undefined,
         ).toSavedStateHandle()
 
         whenever(currencyFormatter.formatCurrency(VARIABLE_SUBSCRIPTION_PRODUCT.price!!, "USD"))
@@ -150,7 +152,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
     fun `given non-variable product, when view model created, should generate correct item subtitle`() {
         val navArgs = ProductSelectorFragmentArgs(
             selectedItems = emptyArray(),
-            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
+            productSelectorFlow = Undefined,
         ).toSavedStateHandle()
 
         whenever(currencyFormatter.formatCurrency(VALID_PRODUCT.price!!, "USD")).thenReturn("$${VALID_PRODUCT.price}")
@@ -171,7 +173,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
     fun `given no restrictions, when view model created, should show all products`() {
         val navArgs = ProductSelectorFragmentArgs(
             selectedItems = emptyArray(),
-            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
+            productSelectorFlow = Undefined,
         ).toSavedStateHandle()
 
         val sut = createViewModel(navArgs)
@@ -1482,7 +1484,7 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
     @Test
     fun `shouldDisplayFilterButton is true when productFlow is Undefined`() = testBlocking {
         val navArgs = ProductSelectorFragmentArgs(
-            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.Undefined,
+            productSelectorFlow = Undefined,
         ).toSavedStateHandle()
 
         val sut = createViewModel(navArgs)
@@ -1491,9 +1493,9 @@ internal class ProductSelectorViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `shouldDisplayFilterButton is false when productFlow is ProductListFilter`() = testBlocking {
+    fun `shouldDisplayFilterButton is false when productFlow is OrderListFilter`() = testBlocking {
         val navArgs = ProductSelectorFragmentArgs(
-            productSelectorFlow = ProductSelectorViewModel.ProductSelectorFlow.ProductListFilter,
+            productSelectorFlow = OrderListFilter,
         ).toSavedStateHandle()
 
         val sut = createViewModel(navArgs)


### PR DESCRIPTION
Summary
==========
Fix issue #12623 by making sure that the Product selection screen never displays the `filter` button when the selector is already being opened from a Filtering flow.

The Product selection screen is used in multiple areas of the app, like Order Editing and Creation, and due to it's nature, it also features a filter button to enhance the search. But the main Product Filter inside the Product list screen can also call the Product Selector screen, causing a weird scenario where we display a filter button inside an already filtering flow.

To mitigate this issue, the Product selection screen is aware if it was called from a filtering flow or not, and hide the filter button when it's not needed.

Screen Capture
==========
https://github.com/user-attachments/assets/7189dbc4-1e99-4a5d-93a5-e2155ddef555

How to Test
==========
### Scenario 1
1. Open the app and go to the Orders list
2. Select the `Filters` option and go to the `Products` sub-option
3. Once in the Product Selector screen, make sure the `filter` button is not visible anywhere there

### Scenario 2
1. Open the app and go to the Order Creation
2. Select the `Add Product` option
3. Once in the Product Selector screen, make sure the `filter` button is visible and works as expected

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
