### PR TITLE
[Product Details] Fix failure when trashing a new duplicated product

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -986,9 +986,9 @@ class MainActivity :
         restart()
     }
 
-    override fun showProductDetail(remoteProductId: Long, enableTrash: Boolean, popUpToProducts: Boolean) {
-        val action = when (popUpToProducts) {
-            true -> NavGraphMainDirections.actionGlobalProductDetailFragmentPopUpToProducts(
+    override fun showProductDetail(remoteProductId: Long, enableTrash: Boolean, popUpToProductList: Boolean) {
+        val action = when (popUpToProductList) {
+            true -> NavGraphMainDirections.actionGlobalProductDetailFragmentPopUpToProductList(
                 mode = ProductDetailFragment.Mode.ShowProduct(remoteProductId),
                 isTrashEnabled = enableTrash
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -986,7 +986,7 @@ class MainActivity :
         restart()
     }
 
-    override fun showProductDetail(remoteProductId: Long, enableTrash: Boolean) {
+    override fun showProductDetail(remoteProductId: Long, enableTrash: Boolean, popUpToProducts: Boolean) {
         val action = NavGraphMainDirections.actionGlobalProductDetailFragment(
             mode = ProductDetailFragment.Mode.ShowProduct(remoteProductId),
             isTrashEnabled = enableTrash

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -987,10 +987,16 @@ class MainActivity :
     }
 
     override fun showProductDetail(remoteProductId: Long, enableTrash: Boolean, popUpToProducts: Boolean) {
-        val action = NavGraphMainDirections.actionGlobalProductDetailFragment(
-            mode = ProductDetailFragment.Mode.ShowProduct(remoteProductId),
-            isTrashEnabled = enableTrash
-        )
+        val action = when (popUpToProducts) {
+            true -> NavGraphMainDirections.actionGlobalProductDetailFragmentPopUpToProducts(
+                mode = ProductDetailFragment.Mode.ShowProduct(remoteProductId),
+                isTrashEnabled = enableTrash
+            )
+            else -> NavGraphMainDirections.actionGlobalProductDetailFragment(
+                mode = ProductDetailFragment.Mode.ShowProduct(remoteProductId),
+                isTrashEnabled = enableTrash
+            )
+        }
         navController.navigateSafely(action)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -7,7 +7,7 @@ interface MainNavigationRouter {
     fun isAtNavigationRoot(): Boolean
     fun isChildFragmentShowing(): Boolean
 
-    fun showProductDetail(remoteProductId: Long, enableTrash: Boolean = false, popUpToProducts: Boolean = false)
+    fun showProductDetail(remoteProductId: Long, enableTrash: Boolean = false, popUpToProductList: Boolean = false)
     fun showProductDetailWithSharedTransition(
         remoteProductId: Long,
         sharedView: View,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -7,7 +7,7 @@ interface MainNavigationRouter {
     fun isAtNavigationRoot(): Boolean
     fun isChildFragmentShowing(): Boolean
 
-    fun showProductDetail(remoteProductId: Long, enableTrash: Boolean = false)
+    fun showProductDetail(remoteProductId: Long, enableTrash: Boolean = false, popUpToProducts: Boolean = false)
     fun showProductDetailWithSharedTransition(
         remoteProductId: Long,
         sharedView: View,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
@@ -465,7 +465,11 @@ class ProductDetailFragment :
 
     private fun openProductDetails(productRemoteId: Long) {
         hideProgressDialog()
-        (activity as? MainNavigationRouter)?.showProductDetail(productRemoteId, enableTrash = true)
+        (activity as? MainNavigationRouter)?.showProductDetail(
+            remoteProductId = productRemoteId,
+            enableTrash = true,
+            popUpToProducts = true
+        )
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailFragment.kt
@@ -468,7 +468,7 @@ class ProductDetailFragment :
         (activity as? MainNavigationRouter)?.showProductDetail(
             remoteProductId = productRemoteId,
             enableTrash = true,
-            popUpToProducts = true
+            popUpToProductList = true
         )
     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -394,8 +394,28 @@
 
     <action
         android:id="@+id/action_global_productDetailFragment"
-        app:popUpTo="@id/products"
         app:destination="@id/nav_graph_products">
+        <argument
+            android:name="mode"
+            app:argType="com.woocommerce.android.ui.products.details.ProductDetailFragment$Mode" />
+        <argument
+            android:name="isTrashEnabled"
+            android:defaultValue="false"
+            app:argType="boolean" />
+        <argument
+            android:name="images"
+            android:defaultValue="@null"
+            app:argType="string[]"
+            app:nullable="true" />
+        <argument
+            android:name="source"
+            android:defaultValue="PRODUCT_TAB"
+            app:argType="com.woocommerce.android.ui.products.AddProductSource" />
+    </action>
+    <action
+        android:id="@+id/action_global_productDetailFragment_popUpTo_products"
+        app:destination="@id/nav_graph_products"
+        app:popUpTo="@id/products">
         <argument
             android:name="mode"
             app:argType="com.woocommerce.android.ui.products.details.ProductDetailFragment$Mode" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -413,7 +413,7 @@
             app:argType="com.woocommerce.android.ui.products.AddProductSource" />
     </action>
     <action
-        android:id="@+id/action_global_productDetailFragment_popUpTo_products"
+        android:id="@+id/action_global_productDetailFragment_popUpTo_product_list"
         app:destination="@id/nav_graph_products"
         app:popUpTo="@id/products">
         <argument

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -394,6 +394,7 @@
 
     <action
         android:id="@+id/action_global_productDetailFragment"
+        app:popUpTo="@id/products"
         app:destination="@id/nav_graph_products">
         <argument
             android:name="mode"


### PR DESCRIPTION
Summary
==========
Fix issue #12766 by making sure that when the Product Details call itself again, the back stack always targets the products list. 

Currently, the Product Details screen has a single scenario where it calls itself: during a product duplication. However, this creates an issue with trashing. 

The app delegates the trashing operation of a product to the Product list screen. When a product is trashed, the Product Details screen is dismissed, and the Product List screen is notified to trash that product. But when it's about a duplicated product, the trashing operation wasn't returning to the Product list screen, but to the original Product Details screen, which doesn't know how to trash a product.

To fix this, a specific handling was introduced: when the Product Details call itself, it will keep targeting the Product List as the screen to pop up from the back stack.



Screen Capture
==========
https://github.com/user-attachments/assets/65e2c988-8229-4e74-b922-98d5957172a4

How to Test
==========
Since this is primarily a navigation logic change, adding unit tests to it is impossible. So, I'm keeping here the flow difference between the original and adjusted flows.

### Original flow

Start point: Product List Screen
   -> Selecting a Product in the list navigates to
   -> Product Details Screen (Original product)
   -> Duplication event navigates to 
   -> Product Details Screen (Duplicated Product)
   -> Trashing the Duplicated navigates to
   -> Product Details Screen (Original product)

### Adjusted flow


Start point: Product List Screen
   -> Selecting a Product in the list navigates to
   -> Product Details Screen (Original product)
   -> Duplication event navigates to 
   -> Product Details Screen (Duplicated Product)
   -> Trashing the Duplicated navigates to
   -> Product List Screen

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.