### PR TITLE
[Product List] Fix product trashing failing to update product list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListFragment.kt
@@ -562,6 +562,7 @@ class ProductListFragment :
 
         // reload the product list without this product
         productListViewModel.reloadProductsFromDb(excludeProductId = remoteProductId)
+        enableProductsRefresh(false)
 
         val actionListener = View.OnClickListener {
             trashProductCancelled = true
@@ -569,6 +570,7 @@ class ProductListFragment :
 
         val callback = object : Snackbar.Callback() {
             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
+                enableProductsRefresh(true)
                 pendingTrashProductId = null
                 if (trashProductCancelled) {
                     productListViewModel.reloadProductsFromDb()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListFragment.kt
@@ -579,13 +579,12 @@ class ProductListFragment :
         }
 
         trashProductUndoSnack = uiMessageResolver.getUndoSnack(
-            R.string.product_trash_undo_snackbar_message,
+            stringResId = R.string.product_trash_undo_snackbar_message,
             actionListener = actionListener
-        )
-            .also {
-                it.addCallback(callback)
-                it.show()
-            }
+        ).apply {
+            addCallback(callback)
+            show()
+        }
     }
 
     override fun scrollToTop() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
@@ -593,6 +593,7 @@ class ProductListViewModel @Inject constructor(
             launch {
                 val successfullyTrashed = productRepository.trashProduct(remoteProductId)
                 if (successfullyTrashed) {
+                    loadProducts()
                     reloadProductsFromDb()
                 } else {
                     triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.product_trash_error))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
@@ -93,6 +93,12 @@ class ProductListViewModel @Inject constructor(
         get() = savedState[KEY_PRODUCT_SELECTED_ON_BIG_SCREEN]
         set(value) = savedState.set(KEY_PRODUCT_SELECTED_ON_BIG_SCREEN, value)
 
+    private val isLoading
+        get() = viewState.isLoading == true
+
+    private val isTrashing
+        get() = viewState.isTrashing == true
+
     init {
         EventBus.getDefault().register(this)
         if (_productList.value == null) {
@@ -119,8 +125,6 @@ class ProductListViewModel @Inject constructor(
     fun isSelecting() = viewState.productListState == ProductListViewState.ProductListState.Selecting
 
     fun isSkuSearch() = isSearching() && viewState.isSkuSearch
-
-    private fun isLoading() = viewState.isLoading == true
 
     fun getSearchQuery() = viewState.query
 
@@ -299,7 +303,7 @@ class ProductListViewModel @Inject constructor(
         scrollToTop: Boolean = false,
         isRefreshing: Boolean = false
     ) {
-        if (isLoading()) {
+        if (isLoading) {
             WooLog.d(WooLog.T.PRODUCTS, "already loading products")
             return
         }
@@ -339,6 +343,7 @@ class ProductListViewModel @Inject constructor(
         } else {
             // if a fetch is already active, wait for it to finish before we start another one
             waitForExistingLoad()
+            viewState = viewState.copy(isLoading = true)
 
             loadJob = launch {
                 val showSkeleton: Boolean
@@ -594,7 +599,6 @@ class ProductListViewModel @Inject constructor(
                 val successfullyTrashed = productRepository.trashProduct(remoteProductId)
                 if (successfullyTrashed) {
                     loadProducts()
-                    reloadProductsFromDb()
                 } else {
                     triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.product_trash_error))
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
@@ -591,7 +591,10 @@ class ProductListViewModel @Inject constructor(
     fun trashProduct(remoteProductId: Long) {
         if (checkConnection()) {
             launch {
-                if (!productRepository.trashProduct(remoteProductId)) {
+                val successfullyTrashed = productRepository.trashProduct(remoteProductId)
+                if (successfullyTrashed) {
+                    reloadProductsFromDb()
+                } else {
                     triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.product_trash_error))
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModel.kt
@@ -343,11 +343,10 @@ class ProductListViewModel @Inject constructor(
         } else {
             // if a fetch is already active, wait for it to finish before we start another one
             waitForExistingLoad()
-            viewState = viewState.copy(isLoading = true)
 
             loadJob = launch {
                 val showSkeleton: Boolean
-                if (loadMore) {
+                if (loadMore || isTrashing) {
                     showSkeleton = false
                 } else {
                     // if this is the initial load, first get the products from the db and show them immediately
@@ -595,10 +594,12 @@ class ProductListViewModel @Inject constructor(
 
     fun trashProduct(remoteProductId: Long) {
         if (checkConnection()) {
-            launch {
+            loadJob = launch {
+                viewState = viewState.copy(isTrashing = true)
                 val successfullyTrashed = productRepository.trashProduct(remoteProductId)
                 if (successfullyTrashed) {
-                    loadProducts()
+                    fetchProductList(loadMore = false, scrollToTop = false)
+                    viewState = viewState.copy(isTrashing = false)
                 } else {
                     triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.product_trash_error))
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListViewState.kt
@@ -11,6 +11,7 @@ data class ProductListViewState(
     val isLoadingMore: Boolean? = null,
     val canLoadMore: Boolean? = null,
     val isRefreshing: Boolean? = null,
+    val isTrashing: Boolean? = null,
     val query: String? = null,
     val isSkuSearch: Boolean = false,
     val filterCount: Int? = null,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.internal.verification.AtLeast
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -305,7 +306,7 @@ class ProductListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `trashProduct calls loadProducts and reloadProductsFromDb when trash succeeds`() = testBlocking {
+    fun `trashProduct trigger products refresh`() = testBlocking {
         val productId = 1L
         whenever(networkStatus.isConnected()).thenReturn(true)
         whenever(productRepository.trashProduct(productId)).thenReturn(true)
@@ -315,8 +316,7 @@ class ProductListViewModelTest : BaseUnitTest() {
         viewModel.trashProduct(productId)
 
         verify(productRepository).trashProduct(productId)
-        verify(viewModel).loadProducts()
-        verify(viewModel).reloadProductsFromDb()
+        verify(productRepository, times(2)).fetchProductList()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers.eq
 import org.mockito.internal.verification.AtLeast
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
@@ -305,6 +305,21 @@ class ProductListViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `trashProduct calls loadProducts and reloadProductsFromDb when trash succeeds`() = testBlocking {
+        val productId = 1L
+        whenever(networkStatus.isConnected()).thenReturn(true)
+        whenever(productRepository.trashProduct(productId)).thenReturn(true)
+
+        createViewModel()
+
+        viewModel.trashProduct(productId)
+
+        verify(productRepository).trashProduct(productId)
+        verify(viewModel).loadProducts()
+        verify(viewModel).reloadProductsFromDb()
+    }
+
+    @Test
     fun `Test Filters button tap`() {
         createViewModel()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
@@ -319,6 +319,24 @@ class ProductListViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `trashProduct updates the viewState as expected`() = testBlocking {
+        val productId = 1L
+        val isTrashingEvents: MutableList<Boolean?> = mutableListOf()
+        whenever(networkStatus.isConnected()).thenReturn(true)
+        whenever(productRepository.trashProduct(productId)).thenReturn(true)
+
+        createViewModel()
+
+        viewModel.viewStateLiveData.observeForever { old, new ->
+            if (old?.isTrashing == new.isTrashing) return@observeForever
+            isTrashingEvents.add(new.isTrashing)
+        }
+
+        viewModel.trashProduct(productId)
+        assertThat(isTrashingEvents).containsExactly(true, false)
+    }
+
+    @Test
     fun `Test Filters button tap`() {
         createViewModel()
 


### PR DESCRIPTION
Why
==========
Fix issue #12777 by introducing to the Product List awareness about when a product is being trashed.

The root cause of the issue is how the trashing action doesn't trigger an immediate event. It takes a few seconds to actually trigger the trashing to allow the user to `undo` the trashing from the Product List warning. 

Due to this problem, it's possible to swipe to refresh while the trashing is not confirmed, causing the product to be reloaded from the store API and reappear in the Product list.

How
==========
To solve this, two adjustments to the product list were necessary.

First, while the `undo` action is available to the user, the swipe to refresh is disabled. This shouldn't affect the user since it's disabled for a couple of seconds, and after the trashing is done, the Product List will be refreshed anyway.

This leads to the second adjustment: Once the trashing is confirmed, the Product List will be refreshed, and any subsequent swipe to refresh will be enqueued waiting for the Trashing request to finish. Loading the products from database will also be disabled, to avoid getting outdated data while the trashing request is not finished.

Screen Capture
==========
## Before
https://github.com/user-attachments/assets/8ef29003-0900-4baf-bf20-e3b6129d48c7

## After
https://github.com/user-attachments/assets/b294e87c-6977-4b8b-ba6d-a89a9637c650

How to Test
==========
1. Navigate to product details screen
2. From the overflow menu (3 dots in the toolbar), select the `Trash Product` option
3. The app returns to the Product List screen with a message saying that the product has been trashed
4. Verify the swipe to refresh is disabled for a few seconds and returns right after it
5. Swipe to refresh as soon as available and ensure the trashed product never returns to the list

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.