### PR TITLE
Introduce AVIF displaying support

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 21.0
 -----
 - [*] Fixed text formatting in the "Collect Payment has moved" rationale bottom sheet [https://github.com/woocommerce/woocommerce-android/pull/12815]
-- [*] Added support for loading Product images using the AVIF format.
+- [*] Added support for loading Product images using the AVIF format [https://github.com/woocommerce/woocommerce-android/pull/12835]
 
 20.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [*] Fixed text formatting in the "Collect Payment has moved" rationale bottom sheet [https://github.com/woocommerce/woocommerce-android/pull/12815]
 - [*] We added support for loading Products containing AVIF images.
+- [*] Added support for loading Product images using the AVIF format.
 
 20.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,6 @@
 21.0
 -----
 - [*] Fixed text formatting in the "Collect Payment has moved" rationale bottom sheet [https://github.com/woocommerce/woocommerce-android/pull/12815]
-- [*] We added support for loading Products containing AVIF images.
 - [*] Added support for loading Product images using the AVIF format.
 
 20.9

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 21.0
 -----
 - [*] Fixed text formatting in the "Collect Payment has moved" rationale bottom sheet [https://github.com/woocommerce/woocommerce-android/pull/12815]
+- [*] We added support for loading Products containing AVIF images.
 
 20.9
 -----

--- a/WooCommerce/build.gradle
+++ b/WooCommerce/build.gradle
@@ -322,6 +322,7 @@ dependencies {
     implementation(libs.bumptech.glide.main)
     ksp(libs.bumptech.glide.compiler)
     implementation(libs.bumptech.glide.volley.integration)
+    implementation(libs.bumptech.glide.avif.integration)
     implementation(libs.google.play.app.update)
     implementation(libs.google.play.review)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,7 +90,7 @@ wordpress-fluxc = '2.99.1'
 wordpress-login = '1.19.0'
 wordpress-libaddressinput = '0.0.2'
 wordpress-mediapicker = '0.3.1'
-wordpress-utils = '154-67cff9cc68be6b058c59e6180120750a088cb36a'
+wordpress-utils = '3.15.0'
 zendesk = '5.0.8'
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -167,6 +167,7 @@ automattic-tracks-crashlogging = { group = "com.automattic.tracks", name = "cras
 bumptech-glide-main = { group = "com.github.bumptech.glide", name = "glide", version.ref = "bumptech-glide" }
 bumptech-glide-compiler = { group = "com.github.bumptech.glide", name = "compiler", version.ref = "bumptech-glide" }
 bumptech-glide-volley-integration = { group = "com.github.bumptech.glide", name = "volley-integration", version.ref = "bumptech-glide" }
+bumptech-glide-avif-integration = { group = "com.github.bumptech.glide", name = "avif-integration", version.ref = "bumptech-glide" }
 cashapp-turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "cashapp-turbine" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 coil-svg = { group = "io.coil-kt", name = "coil-svg", version.ref = "coil" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,7 +90,7 @@ wordpress-fluxc = '2.99.1'
 wordpress-login = '1.19.0'
 wordpress-libaddressinput = '0.0.2'
 wordpress-mediapicker = '0.3.1'
-wordpress-utils = '154-5f4ee59477f0e3141a31c8906e8494bf4534a8ec'
+wordpress-utils = '154-67cff9cc68be6b058c59e6180120750a088cb36a'
 zendesk = '5.0.8'
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,7 +90,7 @@ wordpress-fluxc = '2.99.1'
 wordpress-login = '1.19.0'
 wordpress-libaddressinput = '0.0.2'
 wordpress-mediapicker = '0.3.1'
-wordpress-utils = '3.5.0'
+wordpress-utils = '154-5f4ee59477f0e3141a31c8906e8494bf4534a8ec'
 zendesk = '5.0.8'
 
 [libraries]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
Summary
==========
Depends on https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/154

Fix issue #12810 by introducing an update from the PhotonUtils in the `WordPress-Utils-Android` and adding the AVIF integration to the Glide dependency. 

There's no code to cover with unit tests in the PR changelog.

How to Test
==========
To test this, you will need at least one product configured with an image in the AVIF format. I highly recommend using [this one](https://raw.githubusercontent.com/link-u/avif-sample-images/refs/heads/master/fox.profile0.8bpc.yuv420.avif) from [an open source AVIF samples repository](https://github.com/link-u/avif-sample-images?tab=readme-ov-file).

Please bear in mind that the AVIF format supports multiple different metadata and configurations, and the Android OS doesn't support them all, some AVIF images will load, while others may not.

The testing should ensure that sections like Orders, Product Details, Product List, Product Gallery, and related sections successfully display the image in the AVIF format.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.