### PR TITLE
Selecting shipping service header

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingRatesSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingRatesSection.kt
@@ -1,0 +1,120 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+
+@Composable
+internal fun ShippingRatesCard(
+    modifier: Modifier = Modifier
+) {
+    var selectedSortOption by remember { mutableStateOf(ShippingSortOption.CHEAPEST) }
+    Column(modifier = modifier) {
+        ShippingRatesHeader(
+            selectedSortOption = selectedSortOption,
+            onSortOptionSelected = { selectedSortOption = it }
+        )
+    }
+}
+
+@Composable
+private fun ShippingRatesHeader(
+    selectedSortOption: ShippingSortOption,
+    onSortOptionSelected: (ShippingSortOption) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = stringResource(R.string.shipping_label_shipping_service_title),
+            color = MaterialTheme.colors.onSurface,
+            style = MaterialTheme.typography.subtitle1,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.weight(1f)
+        )
+
+        SortingDropdownMenu(
+            selectedSortOption = selectedSortOption,
+            onSortOptionSelected = onSortOptionSelected,
+            modifier = Modifier.padding(dimensionResource(R.dimen.major_100))
+        )
+    }
+}
+
+@Composable
+private fun SortingDropdownMenu(
+    selectedSortOption: ShippingSortOption,
+    onSortOptionSelected: (ShippingSortOption) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val options = ShippingSortOption.entries
+
+    Box {
+        Row(
+            modifier = Modifier
+                .clickable { expanded = true }
+                .then(modifier),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(selectedSortOption.stringResource),
+                style = MaterialTheme.typography.subtitle1,
+                color = MaterialTheme.colors.primary
+            )
+            Icon(
+                imageVector = Icons.Filled.ArrowDropDown,
+                contentDescription = stringResource(
+                    R.string.sorted_by,
+                    stringResource(selectedSortOption.stringResource)
+                ),
+                tint = MaterialTheme.colors.primary
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.sizeIn(minWidth = 150.dp)
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(onClick = {
+                    onSortOptionSelected(option)
+                    expanded = false
+                }) {
+                    Text(
+                        text = stringResource(option.stringResource),
+                        style = MaterialTheme.typography.subtitle1
+                    )
+                }
+            }
+        }
+    }
+}
+
+enum class ShippingSortOption(@StringRes val stringResource: Int) {
+    CHEAPEST(R.string.shipping_label_shipping_rates_sort_option_cheapest),
+    FASTEST(R.string.shipping_label_shipping_rates_sort_option_fastest)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingRatesSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingRatesSection.kt
@@ -25,8 +25,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 internal fun ShippingRatesCard(
@@ -60,6 +62,18 @@ private fun ShippingRatesHeader(
             selectedSortOption = selectedSortOption,
             onSortOptionSelected = onSortOptionSelected,
             modifier = Modifier.padding(dimensionResource(R.dimen.major_100))
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ShippingRatesHeaderPreview() {
+    WooThemeWithBackground {
+        ShippingRatesHeader(
+            selectedSortOption = ShippingSortOption.CHEAPEST,
+            onSortOptionSelected = {},
+            modifier = Modifier.padding(start = 16.dp)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -99,6 +99,7 @@ fun WooShippingLabelCreationScreen(
                         .padding(start = 4.dp, end = 8.dp)
                 )
                 PackageCard(modifier = Modifier.padding(16.dp))
+                ShippingRatesCard(modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_100)))
             }
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -162,6 +162,7 @@
     <string name="last_update_with_frequency">Last update %s (Updates every 30 minutes)</string>
     <string name="receipt_fetching_error">Sorry, we couldn\'t load a receipt for this order</string>
     <string name="store_name_default">Store name</string>
+    <string name="sorted_by">Sorted by 1%s</string>
 
     <!--
         Date/Time Labels
@@ -1267,6 +1268,10 @@
     <string name="shipping_label_shipment_details_mark_order_complete">Mark this order as complete and notify the customer</string>
     <string name="shipping_label_shipment_details_purchase_label">Purchase Label · %1$s </string>
     <string name="shipping_label_shipment_details_purchase_label_disabled">Purchase Label</string>
+    <string name="shipping_label_shipping_rates_sort_option_cheapest">Cheapest</string>
+    <string name="shipping_label_shipping_rates_sort_option_fastest">Fastest</string>
+    <string name="shipping_label_shipping_service_title">Shipping service</string>
+
     <!--
     Shipping label package creation labels
     -->


### PR DESCRIPTION

Part of: #12285

### Description
This PR starts the Shipping rates card work and introduces the shipping rates card header. The header contains the sorting rate selection and the title. For the sorting rate selection, I used the `DropdownMenu` from Jetpack Compose. For the sorting options, I created the `ShippingSortOption` enum.

### Testing information

1. Create an Order with the processing status on a store that can create shipping labels
2. Tap on Orders
3. Tap on the order created on step 1
4. Tap con create shipping labels
5. Check that Shipment details card is displayed at the bottom of the screen
6. Tap on/Drag up Shipment details
7. Check that the bottom sheets expand and the shipping rates header is visible

### The tests that have been performed
1. Test that the UI interaction works as expected

### Images/gif

https://github.com/user-attachments/assets/12680720-d24c-4c29-abf1-8b08edbdbe40


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
