### PR TITLE
Shipping rates pagination with tabs

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingRatesSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingRatesSection.kt
@@ -1,17 +1,25 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
+import androidx.compose.material.LeadingIconTab
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ScrollableTabRow
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
@@ -19,27 +27,38 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import kotlinx.coroutines.launch
+import kotlin.random.Random
 
 @Composable
 internal fun ShippingRatesCard(
+    shippingRates: Map<Carrier, List<ShippingRate>>,
     modifier: Modifier = Modifier
 ) {
     var selectedSortOption by remember { mutableStateOf(ShippingSortOption.CHEAPEST) }
     Column(modifier = modifier) {
         ShippingRatesHeader(
             selectedSortOption = selectedSortOption,
-            onSortOptionSelected = { selectedSortOption = it }
+            onSortOptionSelected = { selectedSortOption = it },
+            modifier = Modifier.padding(start = dimensionResource(R.dimen.major_100))
         )
+        ShippingRates(shippingRates)
     }
 }
 
@@ -124,6 +143,75 @@ private fun SortingDropdownMenu(
                     )
                 }
             }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ShippingRates(
+    shippingRates: Map<Carrier, List<ShippingRate>>,
+    modifier: Modifier = Modifier,
+    tabModifier: Modifier = Modifier
+) {
+    val pagerState = rememberPagerState { shippingRates.keys.size }
+    val scope = rememberCoroutineScope()
+    val carriers = shippingRates.keys.toList()
+
+    ScrollableTabRow(
+        selectedTabIndex = pagerState.currentPage,
+        edgePadding = dimensionResource(R.dimen.major_100),
+        backgroundColor = MaterialTheme.colors.surface,
+        contentColor = MaterialTheme.colors.primary,
+        modifier = tabModifier
+    ) {
+        shippingRates.keys.forEachIndexed { index, carrier ->
+            val textColor = if (index == pagerState.currentPage) {
+                MaterialTheme.colors.primary
+            } else {
+                colorResource(id = R.color.color_on_surface_medium)
+            }
+            LeadingIconTab(
+                text = {
+                    Text(
+                        text = carrier.name,
+                        color = textColor,
+                        style = MaterialTheme.typography.subtitle2
+                    )
+                },
+                icon = {
+                    carrier.logoRes?.let {
+                        Icon(
+                            painter = painterResource(id = it),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .sizeIn(maxWidth = 24.dp)
+                                .clip(RoundedCornerShape(5.dp)),
+                            tint = Color.Unspecified
+                        )
+                    }
+                },
+                selected = pagerState.currentPage == index,
+                onClick = {
+                    scope.launch {
+                        pagerState.animateScrollToPage(index)
+                    }
+                }
+            )
+        }
+    }
+
+    HorizontalPager(state = pagerState, modifier = modifier.fillMaxSize()) { page ->
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = carriers[page].name,
+                fontSize = 32.sp
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingRatesSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingRatesSection.kt
@@ -132,3 +132,67 @@ enum class ShippingSortOption(@StringRes val stringResource: Int) {
     CHEAPEST(R.string.shipping_label_shipping_rates_sort_option_cheapest),
     FASTEST(R.string.shipping_label_shipping_rates_sort_option_fastest)
 }
+
+data class Carrier(
+    val id: String,
+    val name: String,
+    val logoRes: Int? = null,
+)
+
+data class ShippingRate(
+    val rate: String,
+    val currency: String,
+    val deliveryDays: Int,
+    val insurance: String?,
+    val tracking: Boolean,
+    val freePickup: Boolean,
+    val signatureRequired: String?,
+    val adultSignatureRequired: String?,
+)
+
+fun generateShippingRates(): Map<Carrier, List<ShippingRate>> {
+    val carriers = listOf(
+        Carrier(
+            id = "dhl",
+            name = "DHL Express",
+            logoRes = R.drawable.dhl_logo
+        ),
+        Carrier(
+            id = "usps",
+            name = "USPS",
+            logoRes = R.drawable.usps_logo
+        ),
+        Carrier(
+            id = "ups",
+            name = "UPS",
+            logoRes = R.drawable.ups_logo
+        ),
+        Carrier(
+            id = "fedex",
+            name = "Fed Ex",
+            logoRes = R.drawable.fedex_logo
+        ),
+        Carrier(
+            id = "canadapost",
+            name = "Canada Post",
+            logoRes = null
+        )
+    )
+
+    return carriers.associateWith { generateRates(Random(0).nextInt(from = 3, until = 10)) }
+}
+
+fun generateRates(number: Int): List<ShippingRate> {
+    return List(number) {
+        ShippingRate(
+            rate = "${(it + 1) * 2}",
+            currency = "USD",
+            deliveryDays = it,
+            insurance = null,
+            tracking = false,
+            freePickup = false,
+            adultSignatureRequired = if (it % 2 == 0) null else "$3.00",
+            signatureRequired = "$2.00"
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingRatesSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingRatesSection.kt
@@ -62,6 +62,14 @@ internal fun ShippingRatesCard(
     }
 }
 
+@Preview
+@Composable
+private fun ShippingRatesCardPreview() {
+    WooThemeWithBackground {
+        ShippingRatesCard(shippingRates = generateShippingRates())
+    }
+}
+
 @Composable
 private fun ShippingRatesHeader(
     selectedSortOption: ShippingSortOption,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -99,7 +99,10 @@ fun WooShippingLabelCreationScreen(
                         .padding(start = 4.dp, end = 8.dp)
                 )
                 PackageCard(modifier = Modifier.padding(16.dp))
-                ShippingRatesCard(modifier = Modifier.padding(start = dimensionResource(id = R.dimen.major_100)))
+                ShippingRatesCard(
+                    shippingRates = generateShippingRates(),
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
         }
     }


### PR DESCRIPTION
Part of: #12285 

### Description
This PR includes the carrier pager to display the shipping rates in the Shipping Rates card. The changes in this PR only contain the pager interaction and the functions to generate mock data. The connection with real data will be tackled in a different PR.

### Testing information

1. Create an Order with the processing status on a store that can create shipping labels
2. Tap on Orders
3. Tap on the order created on step 1
4. Tap con create shipping labels
5. Tap on the different carriers and check that the carrier content change
6. Swipe the carrier content horizontally and check that the selected carrier change

### The tests that have been performed
1. Test that the UI interaction works as expected

### Images/gif

https://github.com/user-attachments/assets/bd2d0cb0-80af-4ce5-9368-03314b198d92



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
