### PR TITLE
[Custom Fields] Fix typo in tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModel.kt
@@ -240,7 +240,7 @@ class CustomFieldsViewModel @Inject constructor(
                 stat = AnalyticsEvent.SAVE_CUSTOM_FIELD_TAPPED,
                 properties = mapOf(
                     "edited_fields_count" to currentPendingChanges.editedFields.size,
-                    "added_field_count" to currentPendingChanges.insertedFields.size,
+                    "added_fields_count" to currentPendingChanges.insertedFields.size,
                     "deleted_fields_count" to currentPendingChanges.deletedFieldIds.size
                 )
             )


### PR DESCRIPTION
### Description
While comparing the tracking logic between Android and iOS, I noticed a typo in our implementation (https://github.com/woocommerce/woocommerce-ios/pull/14273#discussion_r1824545874), this PR updates fixes the typo.

### Steps to reproduce
Code review and green CI are enough.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->