### PR TITLE
[Tooling] Update Dangermattic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'danger-dangermattic', '~> 1.1'
+gem 'danger-dangermattic', '~> 1.2'
 gem 'fastlane', '~> 2.216'
 gem 'nokogiri'
 gem 'rubocop', '~> 1.65'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
       octokit (>= 4.0)
       pstore (~> 0.1)
       terminal-table (>= 1, < 4)
-    danger-dangermattic (1.1.2)
+    danger-dangermattic (1.2.0)
       danger (~> 9.4)
       danger-plugin-api (~> 1.0)
       danger-rubocop (~> 0.13)
@@ -90,7 +90,7 @@ GEM
     dotenv (2.8.1)
     drb (2.2.1)
     emoji_regex (3.2.3)
-    excon (0.112.0)
+    excon (0.111.0)
     faraday (1.10.4)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -232,7 +232,7 @@ GEM
     java-properties (0.3.0)
     jmespath (1.6.2)
     json (2.7.5)
-    jwt (2.9.3)
+    jwt (2.8.2)
       base64
     kramdown (2.4.0)
       rexml
@@ -261,7 +261,7 @@ GEM
     optparse (0.5.0)
     os (1.1.4)
     parallel (1.26.3)
-    parser (3.3.5.0)
+    parser (3.3.5.1)
       ast (~> 2.4.1)
       racc
     plist (3.7.1)
@@ -313,7 +313,6 @@ GEM
     simctl (1.6.10)
       CFPropertyList
       naturally
-    sysrandom (1.0.5)
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -343,7 +342,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  danger-dangermattic (~> 1.1)
+  danger-dangermattic (~> 1.2)
   fastlane (~> 2.216)
   fastlane-plugin-wpmreleasetoolkit (~> 12.3)
   nokogiri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     ast (2.4.2)
     atomos (0.1.3)
     aws-eventstream (1.3.0)
-    aws-partitions (1.999.0)
+    aws-partitions (1.1001.0)
     aws-sdk-core (3.211.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -72,7 +72,7 @@ GEM
       octokit (>= 4.0)
       pstore (~> 0.1)
       terminal-table (>= 1, < 4)
-    danger-dangermattic (1.2.0)
+    danger-dangermattic (1.2.1)
       danger (~> 9.4)
       danger-plugin-api (~> 1.0)
       danger-rubocop (~> 0.13)
@@ -90,7 +90,7 @@ GEM
     dotenv (2.8.1)
     drb (2.2.1)
     emoji_regex (3.2.3)
-    excon (0.111.0)
+    excon (0.112.0)
     faraday (1.10.4)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -231,8 +231,8 @@ GEM
       concurrent-ruby (~> 1.0)
     java-properties (0.3.0)
     jmespath (1.6.2)
-    json (2.7.5)
-    jwt (2.8.2)
+    json (2.7.6)
+    jwt (2.9.3)
       base64
     kramdown (2.4.0)
       rexml
@@ -242,7 +242,6 @@ GEM
     logger (1.6.1)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.7)
     minitest (5.25.1)
     multi_json (1.15.0)
     multipart-post (2.4.1)
@@ -250,8 +249,17 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     nkf (0.2.0)
-    nokogiri (1.16.7)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.16.7-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.7-arm-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.7-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     octokit (6.1.1)
       faraday (>= 1, < 3)
@@ -261,7 +269,7 @@ GEM
     optparse (0.5.0)
     os (1.1.4)
     parallel (1.26.3)
-    parser (3.3.5.1)
+    parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
     plist (3.7.1)
@@ -295,7 +303,7 @@ GEM
       rubocop-ast (>= 1.32.2, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.33.0)
+    rubocop-ast (1.34.0)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
@@ -313,6 +321,7 @@ GEM
     simctl (1.6.10)
       CFPropertyList
       naturally
+    sysrandom (1.0.5)
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -339,7 +348,13 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
+  aarch64-linux
+  arm-linux
+  arm64-darwin
   ruby
+  x86-linux
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   danger-dangermattic (~> 1.2)
@@ -350,4 +365,4 @@ DEPENDENCIES
   rubocop (~> 1.65)
 
 BUNDLED WITH
-   2.4.19
+   2.5.20


### PR DESCRIPTION
This PR updates Dangermattic; the main goal is to update to get a fix to the View Check validation, which reports a warning whenever there are changes to View files and the PR doesn't have screenshots / videos attached. There was a bug where it would wrongly report a warning even with a video/image already in the description. ([example](https://github.com/woocommerce/woocommerce-ios/pull/14265#issuecomment-2447562919))