### PR TITLE
DO NOT MERGE: Dummy change to trigger Dangermattic

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemView.kt
@@ -52,6 +52,8 @@ class ProductItemView @JvmOverloads constructor(
         showProductStockStatusPrice(product, currencyFormatter, currencyCode)
     }
 
+    // Dummy change to trigger `view_changes_checker` Dangermattic rule. Do not merge.
+
     fun bind(
         orderCreationProduct: OrderCreationProduct,
         currencyFormatter: CurrencyFormatter,


### PR DESCRIPTION
This is a dummy PR for testing https://github.com/woocommerce/woocommerce-android/pull/12859

 - First targeting `trunk`, so that it uses the older version of Dangermattic that doesn't have the fix—expecting it to incorrectly detect the lack of image/video in the description
 - I'll then later update it to target https://github.com/woocommerce/woocommerce-android/pull/12859's head branch—so that it contains the Dangermattic fix that is expected to properly detect the image/video in the description and to not warn about the false negative anymore.

<details>
<summary>The below is dummy description extracted from PR https://github.com/woocommerce/woocommerce-ios/pull/14265 that contained videos that were not detected as such by the older Dangermattic version</summary>


### Typing invalid value

https://github.com/user-attachments/assets/8cdc7b5a-9a88-423d-bf7b-f2cf872824a6

### Scanning invalid value

https://github.com/user-attachments/assets/f3461fec-f96c-4376-9e00-f8faf65f3457


</details>
