### PR TITLE
[Shipping Label Revamp] Introduce saved package selection

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/FetchSavedPackagesFromStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/FetchSavedPackagesFromStore.kt
@@ -1,8 +1,9 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages
 
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageData
+import javax.inject.Inject
 
-class FetchSavedPackagesFromStore {
+class FetchSavedPackagesFromStore @Inject constructor() {
     operator fun invoke(): List<PackageData> {
         return emptyList()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/FetchSavedPackagesFromStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/FetchSavedPackagesFromStore.kt
@@ -1,10 +1,41 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages
 
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageData
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType
 import javax.inject.Inject
 
 class FetchSavedPackagesFromStore @Inject constructor() {
     operator fun invoke(): List<PackageData> {
-        return emptyList()
+        // This is a mocked response.
+        // When fully implemented, this will be sorted from the Shipping plugin API.
+        return listOf(
+            PackageData(
+                type = PackageType.ENVELOPE,
+                name = "Small Flat Rate Box",
+                description = "USPS Priority Mail Flat Rate Boxes",
+                length = "10",
+                width = "10",
+                height = "10",
+                isSelected = true
+            ),
+            PackageData(
+                type = PackageType.BOX,
+                name = "Small Flat Rate Box",
+                description = "Custom package",
+                length = "20",
+                width = "20",
+                height = "20",
+                isSelected = false
+            ),
+            PackageData(
+                type = PackageType.BOX,
+                name = "Small Flat Rate Box",
+                description = "DHL Express",
+                length = "30",
+                width = "30",
+                height = "30",
+                isSelected = false
+            )
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/FetchSavedPackagesFromStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/FetchSavedPackagesFromStore.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels.packages
+
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageData
+
+class FetchSavedPackagesFromStore {
+    operator fun invoke(): List<PackageData> {
+        return emptyList()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Tab
@@ -23,6 +21,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageData
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PageTab
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PageType.CARRIER
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PageType.CUSTOM
@@ -83,7 +83,6 @@ fun WooShippingLabelPackageCreationScreen(
                     .background(MaterialTheme.colors.surface)
                     .padding(paddingValues)
                     .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
             ) { currentPageIndex ->
                 when (tabs[currentPageIndex].type) {
                     CUSTOM -> createCustomPackageScreen()
@@ -120,8 +119,42 @@ fun WooShippingLabelsPackageCreationScreenPreview() {
                     onSavePackageChanged = { }
                 )
             },
-            createCarrierPackageScreen = { },
-            createSavedPackageScreen = { }
+            createSavedPackageScreen = {
+                WooShippingSavedPackageScreen(
+                    savedPackages = listOf(
+                        PackageData(
+                            type = PackageType.ENVELOPE,
+                            name = "Small Flat Rate Box",
+                            description = "USPS Priority Mail Flat Rate Boxes",
+                            length = "10",
+                            width = "10",
+                            height = "10",
+                            isSelected = true
+                        ),
+                        PackageData(
+                            type = PackageType.BOX,
+                            name = "Small Flat Rate Box",
+                            description = "Custom package",
+                            length = "20",
+                            width = "20",
+                            height = "20",
+                            isSelected = false
+                        ),
+                        PackageData(
+                            type = PackageType.BOX,
+                            name = "Small Flat Rate Box",
+                            description = "DHL Express",
+                            length = "30",
+                            width = "30",
+                            height = "30",
+                            isSelected = false
+                        )
+                    ),
+                    isAddPackageEnabled = true,
+                    onAddPackageClick = { }
+                )
+            },
+            createCarrierPackageScreen = { }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
@@ -66,9 +66,13 @@ fun WooShippingLabelPackageCreationScreen(
 
     Scaffold(
         topBar = {
-            TabRow(selectedTabIndex = tabIndex) {
+            TabRow(
+                selectedTabIndex = tabIndex,
+                backgroundColor = MaterialTheme.colors.surface,
+            ) {
                 tabs.forEachIndexed { index, pageTab ->
                     Tab(
+                        selectedContentColor = MaterialTheme.colors.onSurface,
                         text = { Text(text = pageTab.title) },
                         selected = tabIndex == index,
                         onClick = { tabIndex = index }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
@@ -151,7 +151,8 @@ fun WooShippingLabelsPackageCreationScreenPreview() {
                         )
                     ),
                     isAddPackageEnabled = true,
-                    onAddPackageClick = { }
+                    onAddPackageClick = { },
+                    onSavedPackageSelected = { _, _ -> }
                 )
             },
             createCarrierPackageScreen = { }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationScreen.kt
@@ -40,7 +40,7 @@ fun WooShippingLabelPackageCreationScreen(
         tabs = viewState.value?.pageTabs.orEmpty(),
         createCustomPackageScreen = { WooShippingCustomPackageCreationScreen(viewModel) },
         createCarrierPackageScreen = { WooShippingCarrierPackageScreen() },
-        createSavedPackageScreen = { WooShippingSavedPackageScreen() }
+        createSavedPackageScreen = { WooShippingSavedPackageScreen(viewModel) }
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -98,6 +98,15 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     ) : Parcelable
 
     @Parcelize
+    data class PackageData(
+        val type: PackageType,
+        val name: String,
+        val length: String,
+        val width: String,
+        val height: String
+    ) : Parcelable
+
+    @Parcelize
     data class CustomPackageCreationData(
         val type: PackageType,
         val length: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -42,6 +42,16 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
             )
         )
 
+    fun onSavedPackageSelected(packageData: PackageData) {
+        _viewState.update { viewState ->
+            viewState.savedPackages
+                .filter { it != packageData }
+                .map { it.copy(isSelected = false) }
+                .let { it + packageData.copy(isSelected = true) }
+                .let { viewState.copy(savedPackages = it) }
+        }
+    }
+
     fun onAddPackageClick() {
         triggerEvent(PackageSelected(_viewState.value.customPackageCreationData))
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -52,9 +52,10 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     fun onSavedPackageSelected(packageData: PackageData, isSelected: Boolean) {
         _viewState.update { viewState ->
             viewState.savedPackageSelection.packages
-                .filter { it != packageData }
                 .map { it.copy(isSelected = false) }
-                .let { SavedPackageSelection(it + packageData.copy(isSelected = isSelected)) }
+                .toMutableList()
+                .apply { set(indexOf(packageData), packageData.copy(isSelected = isSelected)) }
+                .let { SavedPackageSelection(it) }
                 .let { viewState.copy(savedPackageSelection = it) }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -129,10 +129,11 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
         val length: String,
         val width: String,
         val height: String,
-        val isSelected: Boolean
+        val isSelected: Boolean,
+        val dimensionUnit: String = "cm"
     ) : Parcelable {
         val dimensionsForDisplay: String
-            get() = "$length x $width x $height cm"
+            get() = "$length x $width x $height $dimensionUnit"
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -17,7 +17,8 @@ import javax.inject.Inject
 @HiltViewModel
 class WooShippingLabelPackageCreationViewModel @Inject constructor(
     savedState: SavedStateHandle,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val fetchSavedPackages: FetchSavedPackagesFromStore
 ) : ScopedViewModel(savedState) {
 
     private val _viewState = savedState.getStateFlow(
@@ -41,6 +42,12 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
                 title = resourceProvider.getString(R.string.woo_shipping_labels_package_creation_tab_saved)
             )
         )
+
+    init {
+        _viewState.update { viewState ->
+            viewState.copy(savedPackages = fetchSavedPackages())
+        }
+    }
 
     fun onSavedPackageSelected(packageData: PackageData) {
         _viewState.update { viewState ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -59,9 +59,11 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
         }
     }
 
-    fun onAddPackageClick() {
+    fun onAddCustomPackageClick() {
         triggerEvent(PackageSelected(_viewState.value.customPackageCreationData))
     }
+
+
 
     fun onPackageTypeSpinnerClick() {
         triggerEvent(ShowPackageTypeDialog(_viewState.value.customPackageCreationData.type))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -102,10 +102,14 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     data class PackageData(
         val type: PackageType,
         val name: String,
+        val description: String,
         val length: String,
         val width: String,
         val height: String
-    ) : Parcelable
+    ) : Parcelable {
+        val dimensionsForDisplay: String
+            get() = "$length x $width x $height cm"
+    }
 
     @Parcelize
     data class CustomPackageCreationData(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -45,25 +45,28 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
 
     init {
         _viewState.update { viewState ->
-            viewState.copy(savedPackages = fetchSavedPackages())
+            viewState.copy(savedPackageSelection = SavedPackageSelection(fetchSavedPackages()))
         }
     }
 
     fun onSavedPackageSelected(packageData: PackageData) {
         _viewState.update { viewState ->
-            viewState.savedPackages
+            viewState.savedPackageSelection.packages
                 .filter { it != packageData }
                 .map { it.copy(isSelected = false) }
-                .let { it + packageData.copy(isSelected = true) }
-                .let { viewState.copy(savedPackages = it) }
+                .let { SavedPackageSelection(it + packageData.copy(isSelected = true)) }
+                .let { viewState.copy(savedPackageSelection = it) }
         }
     }
 
-    fun onAddCustomPackageClick() {
-        triggerEvent(PackageSelected(_viewState.value.customPackageCreationData))
+    fun onAddSavedPackageClick() {
+        _viewState.value.savedPackageSelection.packages.find { it.isSelected }
+            ?.let { triggerEvent(SavedPackageSelected(it)) }
     }
 
-
+    fun onAddCustomPackageClick() {
+        triggerEvent(CustomPackageCreated(_viewState.value.customPackageCreationData))
+    }
 
     fun onPackageTypeSpinnerClick() {
         triggerEvent(ShowPackageTypeDialog(_viewState.value.customPackageCreationData.type))
@@ -108,7 +111,7 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     data class ViewState(
         val pageTabs: List<PageTab> = emptyList(),
         val customPackageCreationData: CustomPackageCreationData = CustomPackageCreationData.EMPTY,
-        val savedPackages: List<PackageData> = emptyList()
+        val savedPackageSelection: SavedPackageSelection = SavedPackageSelection(emptyList())
     ) : Parcelable
 
     @Parcelize
@@ -129,6 +132,14 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     ) : Parcelable {
         val dimensionsForDisplay: String
             get() = "$length x $width x $height cm"
+    }
+
+    @Parcelize
+    data class SavedPackageSelection(
+        val packages: List<PackageData>
+    ): Parcelable {
+        val hasSelection: Boolean
+            get() = packages.find { it.isSelected } != null
     }
 
     @Parcelize
@@ -164,6 +175,7 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
         ENVELOPE(R.string.woo_shipping_labels_package_creation_envelope_type)
     }
 
-    data class PackageSelected(val packageData: CustomPackageCreationData) : MultiLiveEvent.Event()
+    data class SavedPackageSelected(val packageData: PackageData) : MultiLiveEvent.Event()
+    data class CustomPackageCreated(val packageData: CustomPackageCreationData) : MultiLiveEvent.Event()
     data class ShowPackageTypeDialog(val currentSelection: PackageType) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -49,12 +49,12 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
         }
     }
 
-    fun onSavedPackageSelected(packageData: PackageData) {
+    fun onSavedPackageSelected(packageData: PackageData, isSelected: Boolean) {
         _viewState.update { viewState ->
             viewState.savedPackageSelection.packages
                 .filter { it != packageData }
                 .map { it.copy(isSelected = false) }
-                .let { SavedPackageSelection(it + packageData.copy(isSelected = true)) }
+                .let { SavedPackageSelection(it + packageData.copy(isSelected = isSelected)) }
                 .let { viewState.copy(savedPackageSelection = it) }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -22,7 +22,7 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
 
     private val _viewState = savedState.getStateFlow(
         scope = viewModelScope,
-        initialValue = ViewState(pageTabs, CustomPackageCreationData.EMPTY)
+        initialValue = ViewState(pageTabs)
     )
     val viewState = _viewState.asLiveData()
 
@@ -88,7 +88,8 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     @Parcelize
     data class ViewState(
         val pageTabs: List<PageTab> = emptyList(),
-        val customPackageCreationData: CustomPackageCreationData
+        val customPackageCreationData: CustomPackageCreationData = CustomPackageCreationData.EMPTY,
+        val savedPackages: List<PackageData> = emptyList()
     ) : Parcelable
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -105,7 +105,8 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
         val description: String,
         val length: String,
         val width: String,
-        val height: String
+        val height: String,
+        val isSelected: Boolean
     ) : Parcelable {
         val dimensionsForDisplay: String
             get() = "$length x $width x $height cm"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModel.kt
@@ -137,7 +137,7 @@ class WooShippingLabelPackageCreationViewModel @Inject constructor(
     @Parcelize
     data class SavedPackageSelection(
         val packages: List<PackageData>
-    ): Parcelable {
+    ) : Parcelable {
         val hasSelection: Boolean
             get() = packages.find { it.isSelected } != null
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingCustomPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingCustomPackageScreen.kt
@@ -6,7 +6,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
 import androidx.compose.material.Text
@@ -65,6 +67,7 @@ fun WooShippingCustomPackageCreationScreen(
         modifier = modifier
             .fillMaxSize()
             .padding(16.dp)
+            .verticalScroll(rememberScrollState())
     ) {
         Column(
             modifier = modifier.weight(1f),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingCustomPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingCustomPackageScreen.kt
@@ -37,7 +37,7 @@ fun WooShippingCustomPackageCreationScreen(viewModel: WooShippingLabelPackageCre
         packageLength = viewState?.customPackageCreationData?.length.orEmpty(),
         packageWidth = viewState?.customPackageCreationData?.width.orEmpty(),
         isAddPackageEnabled = viewState?.customPackageCreationData?.isValid ?: false,
-        onAddPackageClick = viewModel::onAddPackageClick,
+        onAddPackageClick = viewModel::onAddCustomPackageClick,
         onPackageTypeClick = viewModel::onPackageTypeSpinnerClick,
         onLengthChange = viewModel::onLengthChange,
         onWidthChange = viewModel::onWidthChange,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -13,6 +15,7 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
@@ -26,22 +29,36 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingL
 fun WooShippingSavedPackageScreen(viewModel: WooShippingLabelPackageCreationViewModel) {
     val viewState = viewModel.viewState.observeAsState()
     WooShippingSavedPackageScreen(
-        savedPackages = viewState.value?.savedPackages.orEmpty()
+        savedPackages = viewState.value?.savedPackageSelection?.packages.orEmpty(),
+        isAddPackageEnabled = viewState.value?.savedPackageSelection?.hasSelection ?: false,
+        onAddPackageClick = viewModel::onAddSavedPackageClick
+
     )
 }
 
 @Composable
 fun WooShippingSavedPackageScreen(
     modifier: Modifier = Modifier,
-    savedPackages: List<PackageData>
+    savedPackages: List<PackageData>,
+    isAddPackageEnabled: Boolean,
+    onAddPackageClick: () -> Unit
 ) {
     Column(
         modifier = modifier
             .fillMaxSize()
             .padding(16.dp)
     ) {
-        savedPackages.forEach { packageData ->
-            WooShippingSavedPackageItem(modifier, packageData)
+        Column(modifier = modifier.weight(1f)) {
+            savedPackages.forEach { packageData ->
+                WooShippingSavedPackageItem(modifier, packageData)
+            }
+        }
+        Button(
+            modifier = modifier.fillMaxWidth(),
+            enabled = isAddPackageEnabled,
+            onClick = onAddPackageClick
+        ) {
+            Text(stringResource(id = R.string.woo_shipping_labels_package_creation_add_package))
         }
     }
 }
@@ -116,7 +133,9 @@ fun WooShippingSavedPackageScreenPreview() {
                     height = "30",
                     isSelected = false
                 )
-            )
+            ),
+            isAddPackageEnabled = true,
+            onAddPackageClick = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -88,8 +88,8 @@ fun WooShippingSavedPackageItem(
 ) {
     Column(
         modifier = modifier
-            .padding(top = 8.dp)
-            .clickable { onPackageSelected(packageData, packageData.isSelected.not()) },
+            .clickable { onPackageSelected(packageData, packageData.isSelected.not()) }
+            .padding(top = 8.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         Row(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -46,19 +46,26 @@ fun WooShippingSavedPackageScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(16.dp)
     ) {
-        Column(modifier = modifier.weight(1f)) {
+        Column(modifier = modifier
+            .weight(1f)
+            .padding(16.dp)
+        ) {
             savedPackages.forEach { packageData ->
                 WooShippingSavedPackageItem(modifier, packageData)
             }
         }
-        Button(
-            modifier = modifier.fillMaxWidth(),
-            enabled = isAddPackageEnabled,
-            onClick = onAddPackageClick
-        ) {
-            Text(stringResource(id = R.string.woo_shipping_labels_package_creation_add_package))
+        Column {
+            Divider()
+            Button(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                enabled = isAddPackageEnabled,
+                onClick = onAddPackageClick
+            ) {
+                Text(stringResource(id = R.string.woo_shipping_labels_package_creation_add_package))
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -6,9 +6,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageData
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType
 
 @Composable
 fun WooShippingSavedPackageScreen(viewModel: WooShippingLabelPackageCreationViewModel) {
@@ -39,4 +41,34 @@ fun WooShippingSavedPackageItem(packageData: PackageData) {
     Column {
 
     }
+}
+
+@Preview
+@Composable
+fun WooShippingSavedPackageScreenPreview() {
+    WooShippingSavedPackageScreen(
+        savedPackages = listOf(
+            PackageData(
+                type = PackageType.ENVELOPE,
+                name = "Package 1",
+                length = "10",
+                width = "10",
+                height = "10"
+            ),
+            PackageData(
+                type = PackageType.BOX,
+                name = "Package 2",
+                length = "20",
+                width = "20",
+                height = "20"
+            ),
+            PackageData(
+                type = PackageType.BOX,
+                name = "Package 3",
+                length = "30",
+                width = "30",
+                height = "30"
+            )
+        )
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -52,10 +52,11 @@ fun WooShippingSavedPackageScreen(
         modifier = modifier
             .fillMaxSize()
     ) {
-        Column(modifier = modifier
-            .weight(1f)
-            .padding(16.dp)
-            .verticalScroll(rememberScrollState())
+        Column(
+            modifier = modifier
+                .weight(1f)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
         ) {
             savedPackages.forEach { packageData ->
                 WooShippingSavedPackageItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -4,11 +4,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Checkbox
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -47,17 +47,15 @@ fun WooShippingSavedPackageItem(
     packageData: PackageData
 ) {
     Column {
-        Row {
+        Row (verticalAlignment = Alignment.CenterVertically) {
             SelectionCheck(
                 isSelected = true,
                 onSelectionChange = {}
             )
             Column {
+                Text(text = packageData.description)
                 Text(text = packageData.name)
-                Text(text = "Type: ${packageData.type}")
-                Text(text = "Length: ${packageData.length}")
-                Text(text = "Width: ${packageData.width}")
-                Text(text = "Height: ${packageData.height}")
+                Text(text = packageData.dimensionsForDisplay)
             }
         }
         Divider()
@@ -72,21 +70,24 @@ fun WooShippingSavedPackageScreenPreview() {
             savedPackages = listOf(
                 PackageData(
                     type = PackageType.ENVELOPE,
-                    name = "Package 1",
+                    name = "Small Flat Rate Box",
+                    description = "USPS Priority Mail Flat Rate Boxes",
                     length = "10",
                     width = "10",
                     height = "10"
                 ),
                 PackageData(
                     type = PackageType.BOX,
-                    name = "Package 2",
+                    name = "Small Flat Rate Box",
+                    description = "Custom package",
                     length = "20",
                     width = "20",
                     height = "20"
                 ),
                 PackageData(
                     type = PackageType.BOX,
-                    name = "Package 3",
+                    name = "Small Flat Rate Box",
+                    description = "DHL Express",
                     length = "30",
                     width = "30",
                     height = "30"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.forms
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -33,7 +34,8 @@ fun WooShippingSavedPackageScreen(viewModel: WooShippingLabelPackageCreationView
     WooShippingSavedPackageScreen(
         savedPackages = viewState.value?.savedPackageSelection?.packages.orEmpty(),
         isAddPackageEnabled = viewState.value?.savedPackageSelection?.hasSelection ?: false,
-        onAddPackageClick = viewModel::onAddSavedPackageClick
+        onAddPackageClick = viewModel::onAddSavedPackageClick,
+        onSavedPackageSelected = viewModel::onSavedPackageSelected
 
     )
 }
@@ -43,7 +45,8 @@ fun WooShippingSavedPackageScreen(
     modifier: Modifier = Modifier,
     savedPackages: List<PackageData>,
     isAddPackageEnabled: Boolean,
-    onAddPackageClick: () -> Unit
+    onAddPackageClick: () -> Unit,
+    onSavedPackageSelected: (PackageData, Boolean) -> Unit
 ) {
     Column(
         modifier = modifier
@@ -55,7 +58,11 @@ fun WooShippingSavedPackageScreen(
             .verticalScroll(rememberScrollState())
         ) {
             savedPackages.forEach { packageData ->
-                WooShippingSavedPackageItem(modifier, packageData)
+                WooShippingSavedPackageItem(
+                    modifier,
+                    packageData,
+                    onSavedPackageSelected
+                )
             }
         }
         Column {
@@ -76,10 +83,13 @@ fun WooShippingSavedPackageScreen(
 @Composable
 fun WooShippingSavedPackageItem(
     modifier: Modifier,
-    packageData: PackageData
+    packageData: PackageData,
+    onPackageSelected: (PackageData, Boolean) -> Unit
 ) {
     Column(
-        modifier = modifier.padding(top = 8.dp),
+        modifier = modifier
+            .padding(top = 8.dp)
+            .clickable { onPackageSelected(packageData, packageData.isSelected.not()) },
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         Row(
@@ -88,7 +98,7 @@ fun WooShippingSavedPackageItem(
         ) {
             SelectionCheck(
                 isSelected = packageData.isSelected,
-                onSelectionChange = {}
+                onSelectionChange = { onPackageSelected(packageData, it) }
             )
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text(
@@ -145,7 +155,8 @@ fun WooShippingSavedPackageScreenPreview() {
                 )
             ),
             isAddPackageEnabled = true,
-            onAddPackageClick = {}
+            onAddPackageClick = {},
+            onSavedPackageSelected = { _, _ -> }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -1,9 +1,30 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.forms
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
 
 @Composable
-fun WooShippingSavedPackageScreen() {
-    Text("Saved Package Form")
+fun WooShippingSavedPackageScreen(viewModel: WooShippingLabelPackageCreationViewModel) {
+    val viewState = viewModel.viewState.observeAsState()
+    WooShippingSavedPackageScreen()
+}
+
+@Composable
+fun WooShippingSavedPackageScreen(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -12,8 +12,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.SelectionCheck
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
@@ -39,16 +41,20 @@ fun WooShippingSavedPackageScreen(
             .padding(16.dp)
     ) {
         savedPackages.forEach { packageData ->
-            WooShippingSavedPackageItem(packageData)
+            WooShippingSavedPackageItem(modifier, packageData)
         }
     }
 }
 
 @Composable
 fun WooShippingSavedPackageItem(
+    modifier: Modifier,
     packageData: PackageData
 ) {
-    Column {
+    Column (
+        modifier = modifier.padding(top = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
         Row (
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically
@@ -57,10 +63,11 @@ fun WooShippingSavedPackageItem(
                 isSelected = true,
                 onSelectionChange = {}
             )
-            Column {
+            Column (verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text(
                     text = packageData.description,
-                    style = MaterialTheme.typography.caption
+                    style = MaterialTheme.typography.caption,
+                    color = colorResource(id = R.color.color_on_surface_disabled)
                 )
                 Text(
                     text = packageData.name,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -8,22 +8,35 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageData
 
 @Composable
 fun WooShippingSavedPackageScreen(viewModel: WooShippingLabelPackageCreationViewModel) {
     val viewState = viewModel.viewState.observeAsState()
-    WooShippingSavedPackageScreen()
+    WooShippingSavedPackageScreen(
+        savedPackages = viewState.value?.savedPackages.orEmpty()
+    )
 }
 
 @Composable
 fun WooShippingSavedPackageScreen(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    savedPackages: List<PackageData>
 ) {
     Column(
         modifier = modifier
             .fillMaxSize()
             .padding(16.dp)
     ) {
+        savedPackages.forEach { packageData ->
+            WooShippingSavedPackageItem(packageData)
+        }
+    }
+}
+
+@Composable
+fun WooShippingSavedPackageItem(packageData: PackageData) {
+    Column {
 
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -3,11 +3,14 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.packages.forms
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType
@@ -39,36 +42,43 @@ fun WooShippingSavedPackageScreen(
 @Composable
 fun WooShippingSavedPackageItem(packageData: PackageData) {
     Column {
-
+        Text(text = packageData.name)
+        Text(text = "Type: ${packageData.type}")
+        Text(text = "Length: ${packageData.length}")
+        Text(text = "Width: ${packageData.width}")
+        Text(text = "Height: ${packageData.height}")
+        Divider()
     }
 }
 
 @Preview
 @Composable
 fun WooShippingSavedPackageScreenPreview() {
-    WooShippingSavedPackageScreen(
-        savedPackages = listOf(
-            PackageData(
-                type = PackageType.ENVELOPE,
-                name = "Package 1",
-                length = "10",
-                width = "10",
-                height = "10"
-            ),
-            PackageData(
-                type = PackageType.BOX,
-                name = "Package 2",
-                length = "20",
-                width = "20",
-                height = "20"
-            ),
-            PackageData(
-                type = PackageType.BOX,
-                name = "Package 3",
-                length = "30",
-                width = "30",
-                height = "30"
+    WooThemeWithBackground {
+        WooShippingSavedPackageScreen(
+            savedPackages = listOf(
+                PackageData(
+                    type = PackageType.ENVELOPE,
+                    name = "Package 1",
+                    length = "10",
+                    width = "10",
+                    height = "10"
+                ),
+                PackageData(
+                    type = PackageType.BOX,
+                    name = "Package 2",
+                    length = "20",
+                    width = "20",
+                    height = "20"
+                ),
+                PackageData(
+                    type = PackageType.BOX,
+                    name = "Package 3",
+                    length = "30",
+                    width = "30",
+                    height = "30"
+                )
             )
         )
-    )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -60,7 +60,7 @@ fun WooShippingSavedPackageItem(
             verticalAlignment = Alignment.CenterVertically
         ) {
             SelectionCheck(
-                isSelected = true,
+                isSelected = packageData.isSelected,
                 onSelectionChange = {}
             )
             Column (verticalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -95,7 +95,8 @@ fun WooShippingSavedPackageScreenPreview() {
                     description = "USPS Priority Mail Flat Rate Boxes",
                     length = "10",
                     width = "10",
-                    height = "10"
+                    height = "10",
+                    isSelected = true
                 ),
                 PackageData(
                     type = PackageType.BOX,
@@ -103,7 +104,8 @@ fun WooShippingSavedPackageScreenPreview() {
                     description = "Custom package",
                     length = "20",
                     width = "20",
-                    height = "20"
+                    height = "20",
+                    isSelected = false
                 ),
                 PackageData(
                     type = PackageType.BOX,
@@ -111,7 +113,8 @@ fun WooShippingSavedPackageScreenPreview() {
                     description = "DHL Express",
                     length = "30",
                     width = "30",
-                    height = "30"
+                    height = "30",
+                    isSelected = false
                 )
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.packages.forms
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.forms
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
@@ -47,15 +49,27 @@ fun WooShippingSavedPackageItem(
     packageData: PackageData
 ) {
     Column {
-        Row (verticalAlignment = Alignment.CenterVertically) {
+        Row (
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
             SelectionCheck(
                 isSelected = true,
                 onSelectionChange = {}
             )
             Column {
-                Text(text = packageData.description)
-                Text(text = packageData.name)
-                Text(text = packageData.dimensionsForDisplay)
+                Text(
+                    text = packageData.description,
+                    style = MaterialTheme.typography.caption
+                )
+                Text(
+                    text = packageData.name,
+                    style = MaterialTheme.typography.body1
+                )
+                Text(
+                    text = packageData.dimensionsForDisplay,
+                    style = MaterialTheme.typography.body2
+                )
             }
         }
         Divider()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -1,8 +1,10 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.forms
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Checkbox
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -10,6 +12,7 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.ui.compose.component.SelectionCheck
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageData
@@ -40,13 +43,23 @@ fun WooShippingSavedPackageScreen(
 }
 
 @Composable
-fun WooShippingSavedPackageItem(packageData: PackageData) {
+fun WooShippingSavedPackageItem(
+    packageData: PackageData
+) {
     Column {
-        Text(text = packageData.name)
-        Text(text = "Type: ${packageData.type}")
-        Text(text = "Length: ${packageData.length}")
-        Text(text = "Width: ${packageData.width}")
-        Text(text = "Height: ${packageData.height}")
+        Row {
+            SelectionCheck(
+                isSelected = true,
+                onSelectionChange = {}
+            )
+            Column {
+                Text(text = packageData.name)
+                Text(text = "Type: ${packageData.type}")
+                Text(text = "Length: ${packageData.length}")
+                Text(text = "Width: ${packageData.width}")
+                Text(text = "Height: ${packageData.height}")
+            }
+        }
         Divider()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
@@ -50,6 +52,7 @@ fun WooShippingSavedPackageScreen(
         Column(modifier = modifier
             .weight(1f)
             .padding(16.dp)
+            .verticalScroll(rememberScrollState())
         ) {
             savedPackages.forEach { packageData ->
                 WooShippingSavedPackageItem(modifier, packageData)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/forms/WooShippingSavedPackageScreen.kt
@@ -68,11 +68,11 @@ fun WooShippingSavedPackageItem(
     modifier: Modifier,
     packageData: PackageData
 ) {
-    Column (
+    Column(
         modifier = modifier.padding(top = 8.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Row (
+        Row(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -80,7 +80,7 @@ fun WooShippingSavedPackageItem(
                 isSelected = packageData.isSelected,
                 onSelectionChange = {}
             )
-            Column (verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text(
                     text = packageData.description,
                     style = MaterialTheme.typography.caption,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -61,7 +60,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         sut.onSavePackageChanged(true)
         sut.onPackageTypeSelected(PackageType.ENVELOPE)
 
-        sut.onAddPackageClick()
+        sut.onAddCustomPackageClick()
 
         assertThat(lastEvent).isEqualTo(PackageSelected(customPackageData))
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.CustomPackageCreationData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageData
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageSelected
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.CustomPackageCreated
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ShowPackageTypeDialog
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ViewState
@@ -62,7 +62,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
 
         sut.onAddCustomPackageClick()
 
-        assertThat(lastEvent).isEqualTo(PackageSelected(customPackageData))
+        assertThat(lastEvent).isEqualTo(CustomPackageCreated(customPackageData))
     }
 
     @Test
@@ -131,8 +131,6 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
     @Test
     fun `onSavedPackageSelected selects only one package at a time`() = testBlocking {
         var lastViewState: ViewState? = null
-        sut.viewState.observeForever { lastViewState = it }
-
         val package1 = PackageData(
             type = PackageType.BOX,
             name = "Package 1",
@@ -153,10 +151,11 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         )
         whenever(fetchSavedPackages()).thenReturn(listOf(package1, package2))
 
+        sut = WooShippingLabelPackageCreationViewModel(SavedStateHandle(), resourceProvider, fetchSavedPackages)
+        sut.viewState.observeForever { lastViewState = it }
         sut.onSavedPackageSelected(package1)
 
-        val selectedPackages = lastViewState?.savedPackages?.filter { it.isSelected }
-
+        val selectedPackages = lastViewState?.savedPackageSelection?.packages?.filter { it.isSelected }
         assertThat(selectedPackages).isNotNull
         assertThat(selectedPackages).size().isEqualTo(1)
         assertThat(selectedPackages?.first()).isEqualTo(package1.copy(isSelected = true))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.packages
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.CustomPackageCreationData
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageSelected
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ShowPackageTypeDialog
@@ -14,6 +15,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -21,8 +23,8 @@ import org.mockito.kotlin.whenever
 class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
 
     private lateinit var sut: WooShippingLabelPackageCreationViewModel
-    private val savedStateHandle: SavedStateHandle = SavedStateHandle()
     private val resourceProvider: ResourceProvider = mock()
+    private val fetchSavedPackages: FetchSavedPackagesFromStore = mock()
 
     @Before
     fun setUp() {
@@ -35,7 +37,9 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         whenever(
             resourceProvider.getString(R.string.woo_shipping_labels_package_creation_tab_saved)
         ).thenReturn("Saved")
-        sut = WooShippingLabelPackageCreationViewModel(savedStateHandle, resourceProvider)
+
+        whenever(fetchSavedPackages()).thenReturn(emptyList())
+        sut = WooShippingLabelPackageCreationViewModel(SavedStateHandle(), resourceProvider, fetchSavedPackages)
     }
 
     @Test
@@ -123,5 +127,39 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
         sut.onSavePackageChanged(newSaveAsTemplate)
 
         assertThat(lastViewState?.customPackageCreationData?.saveAsTemplate).isEqualTo(newSaveAsTemplate)
+    }
+
+    @Test
+    fun `onSavedPackageSelected selects only one package at a time`() = testBlocking {
+        var lastViewState: ViewState? = null
+        sut.viewState.observeForever { lastViewState = it }
+
+        val package1 = PackageData(
+            type = PackageType.BOX,
+            name = "Package 1",
+            description = "Description 1",
+            length = "10",
+            width = "10",
+            height = "10",
+            isSelected = false
+        )
+        val package2 = PackageData(
+            type = PackageType.ENVELOPE,
+            name = "Package 2",
+            description = "Description 2",
+            length = "20",
+            width = "20",
+            height = "20",
+            isSelected = false
+        )
+        whenever(fetchSavedPackages()).thenReturn(listOf(package1, package2))
+
+        sut.onSavedPackageSelected(package1)
+
+        val selectedPackages = lastViewState?.savedPackages?.filter { it.isSelected }
+
+        assertThat(selectedPackages).isNotNull
+        assertThat(selectedPackages).size().isEqualTo(1)
+        assertThat(selectedPackages?.first()).isEqualTo(package1.copy(isSelected = true))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -2,9 +2,9 @@ package com.woocommerce.android.ui.orders.wooshippinglabels.packages
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.CustomPackageCreated
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.CustomPackageCreationData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageData
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.CustomPackageCreated
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.PackageType
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ShowPackageTypeDialog
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingLabelPackageCreationViewModel.ViewState

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/WooShippingLabelPackageCreationViewModelTest.kt
@@ -153,7 +153,7 @@ class WooShippingLabelPackageCreationViewModelTest : BaseUnitTest() {
 
         sut = WooShippingLabelPackageCreationViewModel(SavedStateHandle(), resourceProvider, fetchSavedPackages)
         sut.viewState.observeForever { lastViewState = it }
-        sut.onSavedPackageSelected(package1)
+        sut.onSavedPackageSelected(package1, true)
 
         val selectedPackages = lastViewState?.savedPackageSelection?.packages?.filter { it.isSelected }
         assertThat(selectedPackages).isNotNull


### PR DESCRIPTION
Summary
==========
Fix issue #12746 by introducing the Saved Packages UI to the Package management flow and fixing some issues from the main screen UI.

Screen Capture
==========
https://github.com/user-attachments/assets/de37d419-ccfd-4c5f-bf45-808b284b793d

1. This is a purely UI implementation, so the code is not operational or testable as it is. It's hidden under a feature flag to avoid being reachable to our users.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.
