### PR TITLE
Change the domain used for prototypes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,7 +15,7 @@ WEAR_APP = 'WooCommerce-Wear'
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 VERSIONS_CATALOG_FILE = File.join(PROJECT_ROOT_FOLDER, 'gradle/libs.versions.toml')
 BUILD_PRODUCTS_PATH = File.join(PROJECT_ROOT_FOLDER, 'artifacts')
-PROTOTYPE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
+PROTOTYPE_BUILD_DOMAIN = 'https://cdn.a8c-ci.services'
 # The `android_download_translations` action joins the `RES_DIR_PATH` with `PROJECT_ROOT_FOLDER`, so we don't want to
 # add `PROJECT_ROOT_FOLDER` to the beginning of this path
 RES_DIR_PATH = File.join('WooCommerce', 'src', 'main', 'res')


### PR DESCRIPTION
This PR swaps out the CloudFront domain to remove the safety warning shown in Chrome.

## Testing

1. Click the Direct Download link for the prototype builds from @wpmobilebot while using Chrome.
2. Expect: The domain for the prototype build to be `cdn.a8c-ci.services` and not `d2twmm2nzpx3bg.cloudfront.net`.
3. Expect: To not get a "Dangerous site" error like the one below after opening the link.

![image](https://github.com/user-attachments/assets/40f65dcb-1ad5-4332-a325-23a012321b12)