### PR TITLE
Fix date range picker issues with TimeZone

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [*] Show web views on the payments hub screen in 3/4 of the screen [https://github.com/woocommerce/woocommerce-android/pull/12875]
 - [*] Receipts can be shared via a google's sms application now [https://github.com/woocommerce/woocommerce-android/pull/12874]
+- [*] Fixed a bug where picking date ranges (for Stats and Analytics) did not use the correct timezone [https://github.com/woocommerce/woocommerce-android/pull/12887]
 
 21.0
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -16,6 +16,9 @@ import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.ui.analytics.hub.AnalyticsHubFragment
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import kotlin.math.abs
 
 /**
@@ -198,19 +201,38 @@ fun Fragment.showDateRangePicker(
     toMillis: Long = System.currentTimeMillis(),
     onCustomRangeSelected: (Long, Long) -> Unit
 ) {
-    val datePicker =
-        MaterialDatePicker.Builder.dateRangePicker()
-            .setTitleText(getString(R.string.orderfilters_date_range_picker_title))
-            .setSelection(androidx.core.util.Pair(fromMillis, toMillis))
-            .setCalendarConstraints(
-                CalendarConstraints.Builder()
-                    .setEnd(MaterialDatePicker.todayInUtcMilliseconds())
-                    .setValidator(DateValidatorPointBackward.now())
-                    .build()
+    fun shiftTime(time: Long, originalZoneId: ZoneId, targetZoneId: ZoneId): Long {
+        // The timestamps returned by the MaterialDatePicker are in UTC timezone, if we use them directly
+        // we will get a shift in the selected range.
+        // To avoid this, we get the local date using UTC timestamps and then convert it to the selected timezone
+        // See: https://github.com/material-components/material-components-android/issues/882
+        val originalDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(time), originalZoneId).toLocalDateTime()
+        val targetDateTime = ZonedDateTime.of(originalDateTime, targetZoneId)
+        return targetDateTime.toInstant().toEpochMilli()
+    }
+
+    val deviceZoneId = ZoneId.systemDefault()
+    val datePicker = MaterialDatePicker.Builder.dateRangePicker()
+        .setTitleText(getString(R.string.orderfilters_date_range_picker_title))
+        .setSelection(
+            androidx.core.util.Pair(
+                shiftTime(fromMillis, deviceZoneId, ZoneId.of("UTC")),
+                shiftTime(toMillis, deviceZoneId, ZoneId.of("UTC"))
             )
-            .build()
+        )
+        .setCalendarConstraints(
+            CalendarConstraints.Builder()
+                .setEnd(MaterialDatePicker.todayInUtcMilliseconds())
+                .setValidator(DateValidatorPointBackward.now())
+                .build()
+        )
+        .build()
+
     datePicker.show(parentFragmentManager, AnalyticsHubFragment.DATE_PICKER_FRAGMENT_TAG)
     datePicker.addOnPositiveButtonClickListener {
-        onCustomRangeSelected(it?.first ?: 0L, it.second ?: 0L)
+        val start = shiftTime(it.first ?: 0, ZoneId.of("UTC"), deviceZoneId)
+        val end = shiftTime(it.second ?: 0, ZoneId.of("UTC"), deviceZoneId)
+
+        onCustomRangeSelected(start, end)
     }
 }


### PR DESCRIPTION
Closes: #12885 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes an issue with the `MaterialDatePicker`, as stated in the ticket above, the component is buggy, it uses UTC internally, so when we get the result from it (as epoch time), it ends up shifted depending on the device timezone.

The fix is to shift the time to UTC before passing it to the date picker, then shift it back to the device timezone when we get the picked date.

### Steps to reproduce
1. Set you phone to a US timezone (for example NewYork)
2. Open the app and make sure the performance card is added.
3. Select a custom range.
4. Confirm the dates shown in the card matches the picked dates in the picker.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->