### PR TITLE
Track errors when failing to load suggestions in Blaze campaign creation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -1032,6 +1032,7 @@ enum class AnalyticsEvent(override val siteless: Boolean = false) : IAnalyticsEv
     BLAZE_CREATION_EDIT_DESTINATION_SAVE_TAPPED,
     BLAZE_CAMPAIGN_CREATION_FEEDBACK,
     BLAZE_CAMPAIGN_OBJECTIVE_SAVED,
+    BLAZE_SUGGESTIONS_LOADING_FAILED,
 
     // Hazmat Shipping Declaration
     CONTAINS_HAZMAT_CHECKED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/BlazeRepository.kt
@@ -157,7 +157,7 @@ class BlazeRepository @Inject constructor(
         return when {
             result.isError -> {
                 WooLog.w(WooLog.T.BLAZE, "Failed to fetch ad suggestions: ${result.error}")
-                Result.failure(OnChangedException(result.error))
+                Result.failure(OnChangedException(result.error, result.error.message))
             }
 
             else -> Result.success(result.model?.mapToUiModel() ?: emptyList())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CREATION_CONFIRM_DETAILS_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CREATION_EDIT_AD_TAPPED
 import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_CREATION_FORM_DISPLAYED
@@ -254,16 +255,27 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
             blazeRepository.fetchDevices()
             blazeRepository.fetchInterests()
 
-            blazeRepository.fetchAdSuggestions(productId = navArgs.productId).getOrNull().let { suggestions ->
-                aiSuggestions = suggestions.orEmpty()
-                adDetailsState.value = AdDetailsUiState.LOADED
-                campaignDetails.update {
-                    it?.copy(
-                        tagLine = suggestions?.firstOrNull()?.tagLine.orEmpty(),
-                        description = suggestions?.firstOrNull()?.description.orEmpty(),
-                    )
-                }
-            }
+            blazeRepository.fetchAdSuggestions(productId = navArgs.productId)
+                .fold(
+                    onSuccess = { suggestions ->
+                        aiSuggestions = suggestions
+                        adDetailsState.value = AdDetailsUiState.LOADED
+                        campaignDetails.update {
+                            it?.copy(
+                                tagLine = suggestions.firstOrNull()?.tagLine.orEmpty(),
+                                description = suggestions.firstOrNull()?.description.orEmpty(),
+                            )
+                        }
+                    },
+                    onFailure = { error ->
+                        analyticsTrackerWrapper.track(
+                            stat = AnalyticsEvent.BLAZE_SUGGESTIONS_LOADING_FAILED,
+                            properties = mapOf(
+                                AnalyticsTracker.KEY_ERROR to error.message
+                            )
+                        )
+                    }
+                )
             blazeRepository.fetchObjectives()
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModel.kt
@@ -259,7 +259,6 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
                 .fold(
                     onSuccess = { suggestions ->
                         aiSuggestions = suggestions
-                        adDetailsState.value = AdDetailsUiState.LOADED
                         campaignDetails.update {
                             it?.copy(
                                 tagLine = suggestions.firstOrNull()?.tagLine.orEmpty(),
@@ -275,7 +274,9 @@ class BlazeCampaignCreationPreviewViewModel @Inject constructor(
                             )
                         )
                     }
-                )
+                ).also {
+                    adDetailsState.value = AdDetailsUiState.LOADED
+                }
             blazeRepository.fetchObjectives()
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModelTests.kt
@@ -81,6 +81,7 @@ class BlazeCampaignCreationPreviewViewModelTests : BaseUnitTest() {
         on { observeInterests() } doReturn flowOf(interests)
         on { observeLanguages() } doReturn flowOf(languages)
         on { observeObjectives() } doReturn flowOf(objectives)
+        onBlocking { fetchAdSuggestions(any()) } doReturn Result.success(emptyList())
     }
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
     private lateinit var viewModel: BlazeCampaignCreationPreviewViewModel


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12878
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds tracking to errors when fetching suggestion for a Blaze ad. 

### Steps to reproduce
To reproduce the error where fetching suggestions fail to load, you have to create a scenario where Jetpack sync issues happen. I followed the next steps to create a Jetpack Sync issues: 
1. Create jurassic ninja site with WooCommerce and Jetapack
2. Connect Jetpack
3. dd a few products (I used smooth generator) 
4. Disconnect Jetpack from your account. Jetpack > My Jetpack > scroll down and click `Manage` > Disconnect Jetpack
5. Add some more products to your site (remember which are the new products you are adding in this step) 
6. Connect Jetpack again to the same account you connected it before
7. Attempt to create a Blaze campaign for one of the products you added in step 5
8. Loading the suggestions will fail with the following error: 
```json
{"message":"Unexpected Server Error","errorMessage":"Request failed with status code 404","stack":["AxiosError: Request failed with status code 404","    at settle (\/app\/dsp\/node_modules\/axios\/lib\/core\/settle.js:19:12)","    at BrotliDecompress.handleStreamEnd (\/app\/dsp\/node_modules\/axios\/lib\/adapters\/http.js:585:11)","    at BrotliDecompress.emit (node:events:529:35)","    at endReadableNT (node:internal\/streams\/readable:1400:12)","    at processTicksAndRejections (node:internal\/process\/task_queues:82:21)"]}
```

If you can't reproduce this error or don't want to follow these steps ping me and I'll invite you to `https://traditional-sable-finfoot.jurassic.ninja/` which is already experiencing the Jetpack sync issue.

### Testing information
1. Follow the steps above
2. Attempt to create a Blaze campaign for a product that is not synced (step 5 products)
3. When suggestions fail to load check logcat to verify the following event is tracked: 
```
🔵 Tracked: blaze_suggestions_loading_failed, Properties: {"error":"Unexpected Server Error",
```

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above

https://github.com/user-attachments/assets/8e1c0324-475c-44e5-9d61-ad31d1663563

This is an internal tracking change no need to add anything to release notes. 

- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
