### PR TITLE
[Crash] Revert "Lock shipping lines" PR

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,6 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 21.1
 -----
-- [*] Fixed shipping lines being editable at all states [https://github.com/woocommerce/woocommerce-android/pull/12890]
 - [*] Show web views on the payments hub screen in 3/4 of the screen [https://github.com/woocommerce/woocommerce-android/pull/12875]
 - [*] Receipts can be shared via a google's sms application now [https://github.com/woocommerce/woocommerce-android/pull/12874]
 - [*] Fixed a bug where picking date ranges (for Stats and Analytics) did not use the correct timezone [https://github.com/woocommerce/woocommerce-android/pull/12887]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -225,7 +225,6 @@ class OrderCreateEditFormFragment :
         initAdditionalInfoCollectionSection()
         initTaxRateSelectorSection()
         initTotalsSection()
-        initShippingLinesSection()
         adjustUIForScreenSize()
     }
 
@@ -410,6 +409,8 @@ class OrderCreateEditFormFragment :
             bindCustomAmountsSection(binding.customAmountsSection, it)
         }
 
+        bindShippingLinesSection(binding)
+
         bindCouponsLinesSection(binding)
 
         bindFeedbackSection(binding)
@@ -418,16 +419,14 @@ class OrderCreateEditFormFragment :
 
         viewModel.event.observe(viewLifecycleOwner) { handleViewModelEvents(it, binding) }
     }
-
-    private fun FragmentOrderCreateEditFormBinding.initShippingLinesSection() {
-        shippingLines.apply {
+    private fun bindShippingLinesSection(binding: FragmentOrderCreateEditFormBinding) {
+        binding.shippingLines.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                viewModel.shippingLineSection.observeAsState().value?.let { shippingLineSection ->
+                viewModel.shippingLineList.observeAsState().value?.let { shippingLines ->
                     WooThemeWithBackground {
                         ShippingLineFormSection(
-                            shippingLineDetails = shippingLineSection.shippingLines,
-                            isEnabled = shippingLineSection.isEnabled,
+                            shippingLineDetails = shippingLines,
                             formatCurrency = { amount -> currencyFormatter.formatCurrency(amount) },
                             modifier = Modifier.padding(bottom = 1.dp),
                             onAddClicked = { viewModel.onAddOrEditShippingClicked() },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.distinctUntilChanged
-import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
@@ -118,7 +117,6 @@ import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavi
 import com.woocommerce.android.ui.orders.creation.product.discount.CurrencySymbolFinder
 import com.woocommerce.android.ui.orders.creation.shipping.GetShippingMethodsWithOtherValue
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingLineDetails
-import com.woocommerce.android.ui.orders.creation.shipping.ShippingLineSection
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingMethodsRepository
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingUpdateResult
 import com.woocommerce.android.ui.orders.creation.shipping.getMethodIdOrDefault
@@ -382,17 +380,15 @@ class OrderCreateEditViewModel @Inject constructor(
     private val giftCardWasEnabledAtLeastOnce: MutableStateFlow<Boolean> =
         savedState.getStateFlow(viewModelScope, false)
 
-    val shippingLineSection =
-        viewStateData.liveData.map { it.isIdle && it.isEditable }.combineWith(
+    val shippingLineList =
+        combine(
             _orderDraft.filter { it.shippingLines.isNotEmpty() }
-                .map { it.shippingLines.filter { line -> line.methodId != null } }.asLiveData(),
-            getShippingMethodsWithOtherValue().withIndex().asLiveData()
-        ) { isIdle, shippingLines, shippingMethods ->
-            if (isIdle == null || shippingLines == null || shippingMethods == null) return@combineWith null
-
+                .map { it.shippingLines.filter { line -> line.methodId != null } },
+            getShippingMethodsWithOtherValue().withIndex()
+        ) { shippingLines, shippingMethods ->
             val shippingMethodsMap = shippingMethods.value.associateBy { it.id }
 
-            val shippingLineDetails = shippingLines.map { shippingLine ->
+            shippingLines.map { shippingLine ->
                 val method = shippingLine.methodId?.let {
                     if (it == " ") {
                         shippingMethodsMap[ShippingMethodsRepository.NA_ID]
@@ -407,11 +403,7 @@ class OrderCreateEditViewModel @Inject constructor(
                     amount = shippingLine.total
                 )
             }
-            ShippingLineSection(
-                shippingLines = shippingLineDetails,
-                isEnabled = isIdle
-            )
-        }
+        }.asLiveData()
 
     private val _couponLinesLiveData = MediatorLiveData(CouponSection(emptyList(), true))
     val couponLinesLiveData = _couponLinesLiveData.distinctUntilChanged()
@@ -490,7 +482,7 @@ class OrderCreateEditViewModel @Inject constructor(
 
     private fun shouldDisplayShippingFeedback() {
         launch {
-            shippingLineSection
+            shippingLineList
                 .asFlow()
                 .drop(1)
                 .take(1)
@@ -1318,7 +1310,6 @@ class OrderCreateEditViewModel @Inject constructor(
             triggerEvent(ShippingLinesFeedback)
         }
     }
-
     fun onCloseShippingFeedback() {
         launch {
             feedbackRepository.saveFeatureFeedback(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingLineFormSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingLineFormSection.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.creation.shipping
 
+import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -9,7 +10,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.Icon
@@ -22,13 +22,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -37,13 +35,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.woocommerce.android.R
+import com.woocommerce.android.model.ShippingMethod
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import java.math.BigDecimal
 
 @Composable
 fun ShippingLineFormSection(
     shippingLineDetails: List<ShippingLineDetails>,
-    isEnabled: Boolean,
     onAddClicked: () -> Unit,
     onEditClicked: (id: Long) -> Unit,
     formatCurrency: (amount: BigDecimal) -> String,
@@ -60,37 +58,23 @@ fun ShippingLineFormSection(
                             .weight(2f, true)
                             .align(Alignment.CenterVertically)
                     )
-                    if (isEnabled) {
-                        Icon(
-                            imageVector = Icons.Default.Add,
-                            contentDescription = stringResource(id = R.string.order_creation_add_shipping),
-                            modifier = Modifier
-                                .clickable(
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    indication = null
-                                ) {
-                                    onAddClicked()
-                                }
-                                .align(Alignment.CenterVertically),
-                            tint = MaterialTheme.colors.primary
-                        )
-                    } else {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_lock),
-                            contentDescription = null,
-                            modifier = Modifier
-                                .align(Alignment.CenterVertically)
-                                .size(dimensionResource(id = R.dimen.image_minor_40)),
-                            tint = MaterialTheme.colors.primary
-                        )
-                    }
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = stringResource(id = R.string.order_creation_add_shipping),
+                        modifier = Modifier
+                            .align(Alignment.CenterVertically)
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) { onAddClicked() },
+                        tint = MaterialTheme.colors.primary
+                    )
                 }
 
                 shippingLineDetails.forEachIndexed { i, shippingDetails ->
                     val itemModifier = if (i == 0) Modifier else Modifier.padding(top = 8.dp)
                     ShippingLineEditCard(
                         shippingLine = shippingDetails,
-                        isEnabled = isEnabled,
                         onEdit = onEditClicked,
                         formatCurrency = formatCurrency,
                         modifier = itemModifier
@@ -104,28 +88,20 @@ fun ShippingLineFormSection(
 @Composable
 fun ShippingLineEditCard(
     shippingLine: ShippingLineDetails,
-    isEnabled: Boolean,
     formatCurrency: (amount: BigDecimal) -> String,
     onEdit: (id: Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val rowModifier = if (isEnabled) {
-        modifier
-            .clip(RoundedCornerShape(dimensionResource(id = R.dimen.corner_radius_large)))
-            .clickable { onEdit(shippingLine.id) }
-    } else {
-        modifier
-    }
-
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = rowModifier
+        modifier = modifier
             .fillMaxWidth()
             .border(
                 brush = SolidColor(MaterialTheme.colors.onSurface.copy(alpha = 0.12f)),
                 width = 1.dp,
                 shape = RoundedCornerShape(dimensionResource(id = R.dimen.corner_radius_large))
             )
+            .clickable { onEdit(shippingLine.id) }
             .padding(dimensionResource(id = R.dimen.major_100))
 
     ) {
@@ -167,36 +143,26 @@ fun ShippingLineEditCard(
             color = colorResource(id = R.color.color_on_surface),
             modifier = Modifier.align(Alignment.CenterVertically)
         )
-        if (isEnabled) {
-            Icon(
-                imageVector = Icons.Outlined.Edit,
-                contentDescription = null,
-                modifier = Modifier
-                    .align(Alignment.CenterVertically)
-                    .padding(start = 16.dp)
-            )
-        }
+        Icon(
+            imageVector = Icons.Outlined.Edit,
+            contentDescription = null,
+            modifier = Modifier
+                .align(Alignment.CenterVertically)
+                .padding(start = 16.dp)
+        )
     }
 }
 
 @Preview
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
-fun ShippingLineFormSectionLockedPreview() {
-    val shippingDetails = List(3) { i ->
-        ShippingLineDetails(
-            id = i * 1L,
-            shippingMethod = null,
-            amount = BigDecimal.TEN * i.toBigDecimal(),
-            name = "Shipping $i"
-        )
-    }
+fun ShippingLineDetailsPreview() {
     WooThemeWithBackground {
-        ShippingLineFormSection(
-            shippingLineDetails = shippingDetails,
-            formatCurrency = { it.toString() },
-            isEnabled = false,
-            onAddClicked = { },
-            onEditClicked = { }
+        ShippingLineDetails(
+            id = 1L,
+            name = "UPS Shipping",
+            shippingMethod = ShippingMethod(id = "ups", title = "UPS"),
+            amount = BigDecimal.TEN,
         )
     }
 }
@@ -216,7 +182,6 @@ fun ShippingLineFormSectionPreview() {
         ShippingLineFormSection(
             shippingLineDetails = shippingDetails,
             formatCurrency = { it.toString() },
-            isEnabled = true,
             onAddClicked = { },
             onEditClicked = { }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingLineSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingLineSection.kt
@@ -1,6 +1,0 @@
-package com.woocommerce.android.ui.orders.creation.shipping
-
-data class ShippingLineSection(
-    val shippingLines: List<ShippingLineDetails>,
-    val isEnabled: Boolean
-)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -31,7 +31,7 @@ import com.woocommerce.android.ui.orders.creation.configuration.ProductRules
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget
 import com.woocommerce.android.ui.orders.creation.product.discount.CurrencySymbolFinder
 import com.woocommerce.android.ui.orders.creation.shipping.GetShippingMethodsWithOtherValue
-import com.woocommerce.android.ui.orders.creation.shipping.ShippingLineSection
+import com.woocommerce.android.ui.orders.creation.shipping.ShippingLineDetails
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingUpdateResult
 import com.woocommerce.android.ui.orders.creation.taxes.GetAddressFromTaxRate
 import com.woocommerce.android.ui.orders.creation.taxes.GetTaxRatesInfoDialogViewState
@@ -1884,15 +1884,14 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         whenever(getShippingMethodsWithOtherValue.invoke()).doReturn(getShippingMethodsResult)
         createSut()
 
-        var shippingLineSection: ShippingLineSection? = null
-        sut.shippingLineSection.observeForever {
-            shippingLineSection = it
+        var shippingDetails: List<ShippingLineDetails>? = null
+        sut.shippingLineList.observeForever {
+            shippingDetails = it
         }
 
-        assertThat(shippingLineSection).isNotNull
-        assertThat(shippingLineSection!!.shippingLines.size).isEqualTo(shippingLines.size)
-        val shippingMethod = shippingLineSection!!.shippingLines
-            .firstOrNull { it.shippingMethod?.id == shippingMethodId }
+        assertThat(shippingDetails).isNotNull
+        assertThat(shippingDetails!!.size).isEqualTo(shippingLines.size)
+        val shippingMethod = shippingDetails!!.firstOrNull { it.shippingMethod?.id == shippingMethodId }
         assertThat(shippingMethod).isNotNull
         assertThat(shippingMethod!!.shippingMethod!!.title).isEqualTo(shippingMethodTitle)
     }
@@ -1922,14 +1921,14 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         whenever(getShippingMethodsWithOtherValue.invoke()).doReturn(getShippingMethodsResult)
         createSut()
 
-        var shippingDetails: ShippingLineSection? = null
-        sut.shippingLineSection.observeForever {
+        var shippingDetails: List<ShippingLineDetails>? = null
+        sut.shippingLineList.observeForever {
             shippingDetails = it
         }
 
         assertThat(shippingDetails).isNotNull
-        assertThat(shippingDetails!!.shippingLines.size).isEqualTo(shippingLines.size)
-        val shippingMethod = shippingDetails!!.shippingLines.firstOrNull { it.shippingMethod?.id == shippingMethodId }
+        assertThat(shippingDetails!!.size).isEqualTo(shippingLines.size)
+        val shippingMethod = shippingDetails!!.firstOrNull { it.shippingMethod?.id == shippingMethodId }
         assertThat(shippingMethod).isNull()
     }
 


### PR DESCRIPTION
Reverts woocommerce/woocommerce-android#12890

The PR causes a crash when a user attempts to edit an order

```
FATAL EXCEPTION: main
                                                                                                    Process: com.woocommerce.android.dev, PID: 16548
                                                                                                    java.lang.IllegalStateException: Multiple observers registered but only one is supported.
                                                                                                    	at com.woocommerce.android.viewmodel.LiveDataDelegate.observe(LiveDataDelegate.kt:53)
                                                                                                    	at com.woocommerce.android.ui.orders.creation.OrderCreateEditFormFragment.observeViewStateChanges(OrderCreateEditFormFragment.kt:484)
                                                                                                    	at com.woocommerce.android.ui.orders.creation.OrderCreateEditFormFragment.setupObserversWith(OrderCreateEditFormFragment.kt:416)
                                                                                                    	at com.woocommerce.android.ui.orders.creation.OrderCreateEditFormFragment.onViewCreated(OrderCreateEditFormFragment.kt:164)
                                                                                                    	at androidx.fragment.app.Fragment.performViewCreated(Fragment.java:3152)
                                                                                                    	at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:608)
                                                                                                    	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:286)
                                                                                                    	at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2164)
                                                                                                    	at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:2065)
                                                                                                    	at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:2002)
                                                                                                    	at androidx.fragment.app.FragmentManager$5.run(FragmentManager.java:702)
                                                                                                    	at android.os.Handler.handleCallback(Handler.java:938)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:99)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:201)
                                                                                                    	at android.os.Looper.loop(Looper.java:288)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:7839)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```