### PR TITLE
[Crash] Fix crash when edit of an order clicked

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -7,9 +7,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.asFlow
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
@@ -116,11 +116,10 @@ import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavi
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.TaxRateSelector
 import com.woocommerce.android.ui.orders.creation.product.discount.CurrencySymbolFinder
 import com.woocommerce.android.ui.orders.creation.shipping.GetShippingMethodsWithOtherValue
-import com.woocommerce.android.ui.orders.creation.shipping.ShippingLineDetails
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingLineSection
-import com.woocommerce.android.ui.orders.creation.shipping.ShippingMethodsRepository
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingUpdateResult
 import com.woocommerce.android.ui.orders.creation.shipping.getMethodIdOrDefault
+import com.woocommerce.android.ui.orders.creation.shipping.toShippingLineDetails
 import com.woocommerce.android.ui.orders.creation.taxes.GetAddressFromTaxRate
 import com.woocommerce.android.ui.orders.creation.taxes.GetTaxRatesInfoDialogViewState
 import com.woocommerce.android.ui.orders.creation.taxes.TaxBasedOnSetting
@@ -172,10 +171,8 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
-import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.IgnoredOnParcel
@@ -183,7 +180,6 @@ import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.store.WooCommerceStore.WooPlugin.WOO_GIFT_CARDS
 import org.wordpress.android.fluxc.utils.putIfNotNull
-import org.wordpress.android.mediapicker.util.map
 import java.math.BigDecimal
 import java.util.Date
 import javax.inject.Inject
@@ -214,11 +210,11 @@ class OrderCreateEditViewModel @Inject constructor(
     private val totalsHelper: OrderCreateEditTotalsHelper,
     private val feedbackRepository: FeedbackRepository,
     private val fetchProductBySKU: FetchProductBySKU,
+    getShippingMethodsWithOtherValue: GetShippingMethodsWithOtherValue,
     dateUtils: DateUtils,
     autoSyncOrder: AutoSyncOrder,
     autoSyncPriceModifier: AutoSyncPriceModifier,
     parameterRepository: ParameterRepository,
-    getShippingMethodsWithOtherValue: GetShippingMethodsWithOtherValue
 ) : ScopedViewModel(savedState) {
     companion object {
         val EMPTY_BIG_DECIMAL = -Double.MAX_VALUE.toBigDecimal()
@@ -382,8 +378,19 @@ class OrderCreateEditViewModel @Inject constructor(
     private val giftCardWasEnabledAtLeastOnce: MutableStateFlow<Boolean> =
         savedState.getStateFlow(viewModelScope, false)
 
-    private val _shippingLineSection = MutableLiveData<ShippingLineSection>()
-    val shippingLineSection: LiveData<ShippingLineSection> = _shippingLineSection
+    val shippingLineSection = viewStateData.liveData
+        .combineWith(
+            orderDraft.map { it.shippingLines },
+            getShippingMethodsWithOtherValue().asLiveData()
+        ) { viewState, shippingLines, shippingMethods ->
+            if (viewState == null || shippingLines == null || shippingMethods == null) return@combineWith null
+            shippingLines.toShippingLineDetails(shippingMethods)?.let { shippingLineDetails ->
+                ShippingLineSection(
+                    shippingLines = shippingLineDetails,
+                    isEnabled = viewState.isIdle && viewState.isEditable
+                )
+            }
+        }.distinctUntilChanged()
 
     private val _couponLinesLiveData = MediatorLiveData(CouponSection(emptyList(), true))
     val couponLinesLiveData = _couponLinesLiveData.distinctUntilChanged()
@@ -402,38 +409,6 @@ class OrderCreateEditViewModel @Inject constructor(
             _couponLinesLiveData.value = _couponLinesLiveData.value
                 ?.copy(isEnabled = newViewState.isIdle && viewState.isEditable)
         }
-
-        viewStateData.liveData.map { it.isIdle && it.isEditable }
-            .combineWith(
-                _orderDraft.filter { it.shippingLines.isNotEmpty() }
-                    .map { it.shippingLines.filter { line -> line.methodId != null } }.asLiveData(),
-                getShippingMethodsWithOtherValue().withIndex().asLiveData()
-            ) { isIdle, shippingLines, shippingMethods ->
-                if (isIdle == null || shippingLines == null || shippingMethods == null) return@combineWith null
-
-                val shippingMethodsMap = shippingMethods.value.associateBy { it.id }
-                val shippingLineDetails = shippingLines.map { shippingLine ->
-                    val method = shippingLine.methodId?.let {
-                        if (it == " ") {
-                            shippingMethodsMap[ShippingMethodsRepository.NA_ID]
-                        } else {
-                            shippingMethodsMap[it]
-                        }
-                    }
-
-                    ShippingLineDetails(
-                        id = shippingLine.itemId,
-                        name = shippingLine.methodTitle,
-                        shippingMethod = method,
-                        amount = shippingLine.total
-                    )
-                }
-
-                _shippingLineSection.value = ShippingLineSection(
-                    shippingLines = shippingLineDetails,
-                    isEnabled = isIdle
-                )
-            }
 
         when (mode) {
             is Mode.Creation -> {
@@ -492,20 +467,18 @@ class OrderCreateEditViewModel @Inject constructor(
         }
     }
 
+    private var _isFirstShippingLineChange = true
+
     private fun shouldDisplayShippingFeedback() {
-        launch {
-            shippingLineSection
-                .asFlow()
-                .drop(1)
-                .take(1)
-                .takeIf { shouldDisplayShippingLinesFeedback() }
-                ?.collect {
-                    delay(DELAY_BEFORE_SHOWING_SHIPPING_FEEDBACK)
-                    viewState = viewState.copy(
-                        showShippingFeedback = true,
-                        isTotalsExpanded = false
-                    )
-                }
+        if (_isFirstShippingLineChange && shouldDisplayShippingLinesFeedback()) {
+            launch {
+                delay(DELAY_BEFORE_SHOWING_SHIPPING_FEEDBACK)
+                viewState = viewState.copy(
+                    showShippingFeedback = true,
+                    isTotalsExpanded = false
+                )
+                _isFirstShippingLineChange = false
+            }
         }
     }
 
@@ -1635,6 +1608,7 @@ class OrderCreateEditViewModel @Inject constructor(
 
             draft.copy(shippingLines = shipping)
         }
+        shouldDisplayShippingFeedback()
     }
 
     fun onRemoveShipping(itemId: Long) {
@@ -1657,6 +1631,7 @@ class OrderCreateEditViewModel @Inject constructor(
                 }
             )
         }
+        shouldDisplayShippingFeedback()
     }
 
     fun onFeeEdited(feeValue: BigDecimal) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.distinctUntilChanged
-import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
@@ -184,6 +183,7 @@ import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.store.WooCommerceStore.WooPlugin.WOO_GIFT_CARDS
 import org.wordpress.android.fluxc.utils.putIfNotNull
+import org.wordpress.android.mediapicker.util.map
 import java.math.BigDecimal
 import java.util.Date
 import javax.inject.Inject
@@ -382,36 +382,8 @@ class OrderCreateEditViewModel @Inject constructor(
     private val giftCardWasEnabledAtLeastOnce: MutableStateFlow<Boolean> =
         savedState.getStateFlow(viewModelScope, false)
 
-    val shippingLineSection =
-        viewStateData.liveData.map { it.isIdle && it.isEditable }.combineWith(
-            _orderDraft.filter { it.shippingLines.isNotEmpty() }
-                .map { it.shippingLines.filter { line -> line.methodId != null } }.asLiveData(),
-            getShippingMethodsWithOtherValue().withIndex().asLiveData()
-        ) { isIdle, shippingLines, shippingMethods ->
-            if (isIdle == null || shippingLines == null || shippingMethods == null) return@combineWith null
-
-            val shippingMethodsMap = shippingMethods.value.associateBy { it.id }
-
-            val shippingLineDetails = shippingLines.map { shippingLine ->
-                val method = shippingLine.methodId?.let {
-                    if (it == " ") {
-                        shippingMethodsMap[ShippingMethodsRepository.NA_ID]
-                    } else {
-                        shippingMethodsMap[it]
-                    }
-                }
-                ShippingLineDetails(
-                    id = shippingLine.itemId,
-                    name = shippingLine.methodTitle,
-                    shippingMethod = method,
-                    amount = shippingLine.total
-                )
-            }
-            ShippingLineSection(
-                shippingLines = shippingLineDetails,
-                isEnabled = isIdle
-            )
-        }
+    private val _shippingLineSection = MutableLiveData<ShippingLineSection>()
+    val shippingLineSection: LiveData<ShippingLineSection> = _shippingLineSection
 
     private val _couponLinesLiveData = MediatorLiveData(CouponSection(emptyList(), true))
     val couponLinesLiveData = _couponLinesLiveData.distinctUntilChanged()
@@ -430,6 +402,38 @@ class OrderCreateEditViewModel @Inject constructor(
             _couponLinesLiveData.value = _couponLinesLiveData.value
                 ?.copy(isEnabled = newViewState.isIdle && viewState.isEditable)
         }
+
+        viewStateData.liveData.map { it.isIdle && it.isEditable }
+            .combineWith(
+                _orderDraft.filter { it.shippingLines.isNotEmpty() }
+                    .map { it.shippingLines.filter { line -> line.methodId != null } }.asLiveData(),
+                getShippingMethodsWithOtherValue().withIndex().asLiveData()
+            ) { isIdle, shippingLines, shippingMethods ->
+                if (isIdle == null || shippingLines == null || shippingMethods == null) return@combineWith null
+
+                val shippingMethodsMap = shippingMethods.value.associateBy { it.id }
+                val shippingLineDetails = shippingLines.map { shippingLine ->
+                    val method = shippingLine.methodId?.let {
+                        if (it == " ") {
+                            shippingMethodsMap[ShippingMethodsRepository.NA_ID]
+                        } else {
+                            shippingMethodsMap[it]
+                        }
+                    }
+
+                    ShippingLineDetails(
+                        id = shippingLine.itemId,
+                        name = shippingLine.methodTitle,
+                        shippingMethod = method,
+                        amount = shippingLine.total
+                    )
+                }
+
+                _shippingLineSection.value = ShippingLineSection(
+                    shippingLines = shippingLineDetails,
+                    isEnabled = isIdle
+                )
+            }
 
         when (mode) {
             is Mode.Creation -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingLineDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingLineDetails.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.creation.shipping
 
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.ShippingMethod
 import java.math.BigDecimal
 
@@ -9,3 +10,29 @@ data class ShippingLineDetails(
     val amount: BigDecimal,
     val name: String
 )
+
+fun List<Order.ShippingLine>.toShippingLineDetails(
+    shippingMethods: List<ShippingMethod>,
+): List<ShippingLineDetails>? {
+    if (this.isEmpty()) {
+        return null
+    }
+    val filteredShippingLines = this.filter { line -> line.methodId != null }
+    val shippingMethodsMap = shippingMethods.associateBy { it.id }
+    return filteredShippingLines.map { shippingLine ->
+        val method = shippingLine.methodId?.let {
+            if (it == " ") {
+                shippingMethodsMap[ShippingMethodsRepository.NA_ID]
+            } else {
+                shippingMethodsMap[it]
+            }
+        }
+
+        ShippingLineDetails(
+            id = shippingLine.itemId,
+            name = shippingLine.methodTitle,
+            shippingMethod = method,
+            amount = shippingLine.total
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.ShippingMethod
+import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.barcodescanner.BarcodeScanningTracker
 import com.woocommerce.android.ui.feedback.FeedbackRepository
@@ -131,6 +132,12 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                     any<Order>()
                 )
             } doReturn MutableLiveData(emptyOrder)
+            on {
+                getLiveData(
+                    key = eq("plugins_information"),
+                    initialValue = any<HashMap<String, WooPlugin>>(),
+                )
+            } doReturn MutableLiveData(HashMap())
         }
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(Order.getEmptyOrder(Date(), Date())))
@@ -191,8 +198,24 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         prefs = mock()
         mapFeeLineToCustomAmountUiModel = mock()
         totalsHelper = mock()
-        getShippingMethodsWithOtherValue = mock()
-        feedbackRepository = mock()
+        getShippingMethodsWithOtherValue = mock {
+            onBlocking { invoke() } doReturn flowOf(
+                listOf(
+                    ShippingMethod(
+                        id = "other",
+                        title = "Other"
+                    )
+                )
+            )
+        }
+        feedbackRepository = mock {
+            onBlocking {
+                getFeatureFeedbackSetting(eq(FeatureFeedbackSettings.Feature.ORDER_SHIPPING_LINES))
+            } doReturn FeatureFeedbackSettings(
+                feature = FeatureFeedbackSettings.Feature.ORDER_SHIPPING_LINES,
+                feedbackState = FeatureFeedbackSettings.FeedbackState.UNANSWERED
+            )
+        }
         fetchProductBySKU = mock()
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->


### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
[The PR](https://github.com/woocommerce/woocommerce-android/pull/12890/files) caused a breakage of edit functionality of an order:

```
Process: com.woocommerce.android.dev, PID: 15852
java.lang.IllegalStateException: Multiple observers registered but only one is supported.
at com.woocommerce.android.viewmodel.LiveDataDelegate.observe(LiveDataDelegate.kt:53)
at com.woocommerce.android.ui.orders.creation.OrderCreateEditFormFragment.observeViewStateChanges(OrderCreateEditFormFragment.kt:486)
at com.woocommerce.android.ui.orders.creation.OrderCreateEditFormFragment.setupObserversWith(OrderCreateEditFormFragment.kt:417)
at com.woocommerce.android.ui.orders.creation.OrderCreateEditFormFragment.onViewCreated(OrderCreateEditFormFragment.kt:164)
at androidx.fragment.app.Fragment.performViewCreated(Fragment.java:3152)
at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:608)
at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:286)
at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2164)
at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:2065)
at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:2002)
at androidx.fragment.app.FragmentManager$5.run(FragmentManager.java:702)
at android.os.Handler.handleCallback(Handler.java:938)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loopOnce(Looper.java:201)
at android.os.Looper.loop(Looper.java:288)
at android.app.ActivityThread.main(ActivityThread.java:7839)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```

This fixes the crash

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Orders -> Order -> Edit -> notice crash

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
* Make sure that this doesn't bring regression to the changes from the mentioned PR
* Make sure that the crash is gone

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->