### PR TITLE
Fix crash for mismatched account case

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -339,7 +339,7 @@ class SitePickerViewModel @Inject constructor(
         )
         sitePickerViewState = sitePickerViewState.copy(
             isSkeletonViewVisible = false,
-            isPrimaryBtnVisible = sites.value!!.any { it is WooSiteUiModel }
+            isPrimaryBtnVisible = sites.value?.any { it is WooSiteUiModel } ?: false
         )
     }
 


### PR DESCRIPTION
(cherry picked from commit 8219ffa0b7d5a58daf2d81bc9ed201d6f7a39561)

<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes a crash on the site picker screen when the sites data is null. I couldn't reproduce the crash. But when the sites.value is null for any reason, it makes sense to hide the primary button on the site picker screen.
This case may occur rarely and temporarily when the screen is initializing.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
"To reproduce the issue, you need a WordPress.com account with 0 sites. Not even a blog. Which is tricky to get through the normal flow because WP.com will create 1 blog for you as soon as you create a new account. However, if you delete that blog (and wait a few hours until the deletion is completed) you'll end up with a WP.com account with 0 sites. Using that account o log into any Jetpack connected site will result in the account mismatch screen and the app crashing. - https://github.com/woocommerce/woocommerce-android/pull/12889#issuecomment-2462908860"

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested normal mismatch account case.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Tested normal mismatch account case again for this PR.
<img src="https://github.com/user-attachments/assets/1c25ccef-266f-4862-a331-a293882dc00d" width=300> <img src="https://github.com/user-attachments/assets/38464755-7261-499d-9e28-2ad90a7b18e1" width=300>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->