### PR TITLE
Lock shipping lines when the screen is not idle or the order editable

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,12 +3,11 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 21.2
 -----
-
+- [*] Fixed shipping lines being editable at all states [https://github.com/woocommerce/woocommerce-android/pull/12890]
 
 21.1
 -----
 - [*] Disable Edit option for orders whose currency does not match with store currency [https://github.com/woocommerce/woocommerce-android/pull/12880]
-- [*] Fixed shipping lines being editable at all states [https://github.com/woocommerce/woocommerce-android/pull/12890]
 - [*] Show web views on the payments hub screen in 3/4 of the screen [https://github.com/woocommerce/woocommerce-android/pull/12875]
 - [*] Receipts can be shared via a google's sms application now [https://github.com/woocommerce/woocommerce-android/pull/12874]
 - [*] Fixed a bug where picking date ranges (for Stats and Analytics) did not use the correct timezone [https://github.com/woocommerce/woocommerce-android/pull/12887]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -423,10 +423,11 @@ class OrderCreateEditFormFragment :
         binding.shippingLines.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-                viewModel.shippingLineList.observeAsState().value?.let { shippingLines ->
+                viewModel.shippingLineSection.observeAsState().value?.let { shippingLineSection ->
                     WooThemeWithBackground {
                         ShippingLineFormSection(
-                            shippingLineDetails = shippingLines,
+                            shippingLineDetails = shippingLineSection.shippingLines,
+                            isEnabled = shippingLineSection.isEnabled,
                             formatCurrency = { amount -> currencyFormatter.formatCurrency(amount) },
                             modifier = Modifier.padding(bottom = 1.dp),
                             onAddClicked = { viewModel.onAddOrEditShippingClicked() },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.asFlow
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
@@ -172,7 +171,6 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
@@ -469,20 +467,20 @@ class OrderCreateEditViewModel @Inject constructor(
         }
     }
 
+    private var _isFirstShippingLineChange = true
+
     private fun shouldDisplayShippingFeedback() {
         launch {
-            shippingLineList
-                .asFlow()
-                .drop(1)
-                .take(1)
-                .takeIf { shouldDisplayShippingLinesFeedback() }
-                ?.collect {
+            if (_isFirstShippingLineChange && shouldDisplayShippingLinesFeedback()) {
+                launch {
                     delay(DELAY_BEFORE_SHOWING_SHIPPING_FEEDBACK)
                     viewState = viewState.copy(
                         showShippingFeedback = true,
                         isTotalsExpanded = false
                     )
+                    _isFirstShippingLineChange = false
                 }
+            }
         }
     }
 
@@ -1611,6 +1609,7 @@ class OrderCreateEditViewModel @Inject constructor(
 
             draft.copy(shippingLines = shipping)
         }
+        shouldDisplayShippingFeedback()
     }
 
     fun onRemoveShipping(itemId: Long) {
@@ -1633,6 +1632,7 @@ class OrderCreateEditViewModel @Inject constructor(
                 }
             )
         }
+        shouldDisplayShippingFeedback()
     }
 
     fun onFeeEdited(feeValue: BigDecimal) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
@@ -116,10 +117,10 @@ import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavi
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget.TaxRateSelector
 import com.woocommerce.android.ui.orders.creation.product.discount.CurrencySymbolFinder
 import com.woocommerce.android.ui.orders.creation.shipping.GetShippingMethodsWithOtherValue
-import com.woocommerce.android.ui.orders.creation.shipping.ShippingLineDetails
-import com.woocommerce.android.ui.orders.creation.shipping.ShippingMethodsRepository
+import com.woocommerce.android.ui.orders.creation.shipping.ShippingLineSection
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingUpdateResult
 import com.woocommerce.android.ui.orders.creation.shipping.getMethodIdOrDefault
+import com.woocommerce.android.ui.orders.creation.shipping.toShippingLineDetails
 import com.woocommerce.android.ui.orders.creation.taxes.GetAddressFromTaxRate
 import com.woocommerce.android.ui.orders.creation.taxes.GetTaxRatesInfoDialogViewState
 import com.woocommerce.android.ui.orders.creation.taxes.TaxBasedOnSetting
@@ -174,7 +175,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
-import kotlinx.coroutines.flow.withIndex
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.IgnoredOnParcel
@@ -380,30 +380,19 @@ class OrderCreateEditViewModel @Inject constructor(
     private val giftCardWasEnabledAtLeastOnce: MutableStateFlow<Boolean> =
         savedState.getStateFlow(viewModelScope, false)
 
-    val shippingLineList =
-        combine(
-            _orderDraft.filter { it.shippingLines.isNotEmpty() }
-                .map { it.shippingLines.filter { line -> line.methodId != null } },
-            getShippingMethodsWithOtherValue().withIndex()
-        ) { shippingLines, shippingMethods ->
-            val shippingMethodsMap = shippingMethods.value.associateBy { it.id }
-
-            shippingLines.map { shippingLine ->
-                val method = shippingLine.methodId?.let {
-                    if (it == " ") {
-                        shippingMethodsMap[ShippingMethodsRepository.NA_ID]
-                    } else {
-                        shippingMethodsMap[it]
-                    }
-                }
-                ShippingLineDetails(
-                    id = shippingLine.itemId,
-                    name = shippingLine.methodTitle,
-                    shippingMethod = method,
-                    amount = shippingLine.total
+    val shippingLineSection = viewStateData.liveData
+        .combineWith(
+            orderDraft.map { it.shippingLines },
+            getShippingMethodsWithOtherValue().asLiveData()
+        ) { viewState, shippingLines, shippingMethods ->
+            if (viewState == null || shippingLines == null || shippingMethods == null) return@combineWith null
+            shippingLines.toShippingLineDetails(shippingMethods)?.let { shippingLineDetails ->
+                ShippingLineSection(
+                    shippingLines = shippingLineDetails,
+                    isEnabled = viewState.isIdle && viewState.isEditable
                 )
             }
-        }.asLiveData()
+        }.distinctUntilChanged()
 
     private val _couponLinesLiveData = MediatorLiveData(CouponSection(emptyList(), true))
     val couponLinesLiveData = _couponLinesLiveData.distinctUntilChanged()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingLineDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingLineDetails.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.creation.shipping
 
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.ShippingMethod
 import java.math.BigDecimal
 
@@ -9,3 +10,29 @@ data class ShippingLineDetails(
     val amount: BigDecimal,
     val name: String
 )
+
+fun List<Order.ShippingLine>.toShippingLineDetails(
+    shippingMethods: List<ShippingMethod>,
+): List<ShippingLineDetails>? {
+    if (this.isEmpty()) {
+        return null
+    }
+    val filteredShippingLines = this.filter { line -> line.methodId != null }
+    val shippingMethodsMap = shippingMethods.associateBy { it.id }
+    return filteredShippingLines.map { shippingLine ->
+        val method = shippingLine.methodId?.let {
+            if (it == " ") {
+                shippingMethodsMap[ShippingMethodsRepository.NA_ID]
+            } else {
+                shippingMethodsMap[it]
+            }
+        }
+
+        ShippingLineDetails(
+            id = shippingLine.itemId,
+            name = shippingLine.methodTitle,
+            shippingMethod = method,
+            amount = shippingLine.total
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingLineFormSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingLineFormSection.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.creation.shipping
 
-import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -10,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.Icon
@@ -22,11 +22,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -35,13 +37,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.woocommerce.android.R
-import com.woocommerce.android.model.ShippingMethod
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import java.math.BigDecimal
 
 @Composable
 fun ShippingLineFormSection(
     shippingLineDetails: List<ShippingLineDetails>,
+    isEnabled: Boolean,
     onAddClicked: () -> Unit,
     onEditClicked: (id: Long) -> Unit,
     formatCurrency: (amount: BigDecimal) -> String,
@@ -58,23 +60,37 @@ fun ShippingLineFormSection(
                             .weight(2f, true)
                             .align(Alignment.CenterVertically)
                     )
-                    Icon(
-                        imageVector = Icons.Default.Add,
-                        contentDescription = stringResource(id = R.string.order_creation_add_shipping),
-                        modifier = Modifier
-                            .align(Alignment.CenterVertically)
-                            .clickable(
-                                interactionSource = remember { MutableInteractionSource() },
-                                indication = null
-                            ) { onAddClicked() },
-                        tint = MaterialTheme.colors.primary
-                    )
+                    if (isEnabled) {
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = stringResource(id = R.string.order_creation_add_shipping),
+                            modifier = Modifier
+                                .clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null
+                                ) {
+                                    onAddClicked()
+                                }
+                                .align(Alignment.CenterVertically),
+                            tint = MaterialTheme.colors.primary
+                        )
+                    } else {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_lock),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .align(Alignment.CenterVertically)
+                                .size(dimensionResource(id = R.dimen.image_minor_40)),
+                            tint = MaterialTheme.colors.primary
+                        )
+                    }
                 }
 
                 shippingLineDetails.forEachIndexed { i, shippingDetails ->
                     val itemModifier = if (i == 0) Modifier else Modifier.padding(top = 8.dp)
                     ShippingLineEditCard(
                         shippingLine = shippingDetails,
+                        isEnabled = isEnabled,
                         onEdit = onEditClicked,
                         formatCurrency = formatCurrency,
                         modifier = itemModifier
@@ -88,20 +104,28 @@ fun ShippingLineFormSection(
 @Composable
 fun ShippingLineEditCard(
     shippingLine: ShippingLineDetails,
+    isEnabled: Boolean,
     formatCurrency: (amount: BigDecimal) -> String,
     onEdit: (id: Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val rowModifier = if (isEnabled) {
+        modifier
+            .clip(RoundedCornerShape(dimensionResource(id = R.dimen.corner_radius_large)))
+            .clickable { onEdit(shippingLine.id) }
+    } else {
+        modifier
+    }
+
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
+        modifier = rowModifier
             .fillMaxWidth()
             .border(
                 brush = SolidColor(MaterialTheme.colors.onSurface.copy(alpha = 0.12f)),
                 width = 1.dp,
                 shape = RoundedCornerShape(dimensionResource(id = R.dimen.corner_radius_large))
             )
-            .clickable { onEdit(shippingLine.id) }
             .padding(dimensionResource(id = R.dimen.major_100))
 
     ) {
@@ -143,26 +167,36 @@ fun ShippingLineEditCard(
             color = colorResource(id = R.color.color_on_surface),
             modifier = Modifier.align(Alignment.CenterVertically)
         )
-        Icon(
-            imageVector = Icons.Outlined.Edit,
-            contentDescription = null,
-            modifier = Modifier
-                .align(Alignment.CenterVertically)
-                .padding(start = 16.dp)
-        )
+        if (isEnabled) {
+            Icon(
+                imageVector = Icons.Outlined.Edit,
+                contentDescription = null,
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+                    .padding(start = 16.dp)
+            )
+        }
     }
 }
 
 @Preview
-@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
-fun ShippingLineDetailsPreview() {
-    WooThemeWithBackground {
+fun ShippingLineFormSectionLockedPreview() {
+    val shippingDetails = List(3) { i ->
         ShippingLineDetails(
-            id = 1L,
-            name = "UPS Shipping",
-            shippingMethod = ShippingMethod(id = "ups", title = "UPS"),
-            amount = BigDecimal.TEN,
+            id = i * 1L,
+            shippingMethod = null,
+            amount = BigDecimal.TEN * i.toBigDecimal(),
+            name = "Shipping $i"
+        )
+    }
+    WooThemeWithBackground {
+        ShippingLineFormSection(
+            shippingLineDetails = shippingDetails,
+            formatCurrency = { it.toString() },
+            isEnabled = false,
+            onAddClicked = { },
+            onEditClicked = { }
         )
     }
 }
@@ -182,6 +216,7 @@ fun ShippingLineFormSectionPreview() {
         ShippingLineFormSection(
             shippingLineDetails = shippingDetails,
             formatCurrency = { it.toString() },
+            isEnabled = true,
             onAddClicked = { },
             onEditClicked = { }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingLineSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingLineSection.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.ui.orders.creation.shipping
+
+data class ShippingLineSection(
+    val shippingLines: List<ShippingLineDetails>,
+    val isEnabled: Boolean
+)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/ShippingLineDetailsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/ShippingLineDetailsTest.kt
@@ -1,0 +1,67 @@
+package com.woocommerce.android.model
+
+import com.woocommerce.android.ui.orders.creation.shipping.toShippingLineDetails
+import junit.framework.TestCase.assertEquals
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ShippingLineDetailsTest {
+    private val defaultShippingMethods = List(3) { i ->
+        ShippingMethod(
+            id = "method$i",
+            title = "methodTitle$i"
+        )
+    }
+
+    private val defaultShippingLines = List(3) { i ->
+        Order.ShippingLine(
+            itemId = i.toLong(),
+            methodId = "method$i",
+            methodTitle = "shippingLineTitle$i",
+            totalTax = BigDecimal.TEN * i.toBigDecimal(),
+            total = BigDecimal.ZERO
+        )
+    }
+
+
+    @Test
+    fun `toShippingLineDetails should return null for empty list`() {
+        val shippingLines = emptyList<Order.ShippingLine>()
+        val result = shippingLines.toShippingLineDetails(defaultShippingMethods)
+        assertNull(result)
+    }
+
+    @Test
+    fun `toShippingLineDetails should use method title from the shipping method field`() {
+        val result = defaultShippingLines.toShippingLineDetails(defaultShippingMethods)
+        assertNotNull(result)
+        result.forEachIndexed { index, shippingLineDetails ->
+            // Use the method title from Order.ShippingLine as name
+            assertEquals(shippingLineDetails.name, "shippingLineTitle$index")
+            // Use the method title from ShippingMethod as the method title
+            assertEquals(shippingLineDetails.shippingMethod!!.title, "methodTitle$index")
+        }
+    }
+
+    @Test
+    fun `toShippingLineDetails should skip shipping lines with null methodId`() {
+        val shippingLines = defaultShippingLines.toMutableList()
+        shippingLines.add(
+            // Because this shipping line methodId is null it should be discarded
+            Order.ShippingLine(
+                itemId = 33L,
+                methodId = null,
+                methodTitle = "shippingLineDiscarded",
+                totalTax = BigDecimal.TEN,
+                total = BigDecimal.ZERO
+            )
+        )
+        val result = shippingLines.toShippingLineDetails(defaultShippingMethods)
+        assertNotNull(result)
+        assertNotEquals(result.size, shippingLines.size)
+        assertEquals(result.size, defaultShippingLines.size)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/ShippingLineDetailsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/ShippingLineDetailsTest.kt
@@ -26,7 +26,6 @@ class ShippingLineDetailsTest {
         )
     }
 
-
     @Test
     fun `toShippingLineDetails should return null for empty list`() {
         val shippingLines = emptyList<Order.ShippingLine>()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.ShippingMethod
+import com.woocommerce.android.model.WooPlugin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.barcodescanner.BarcodeScanningTracker
 import com.woocommerce.android.ui.feedback.FeedbackRepository
@@ -31,7 +32,7 @@ import com.woocommerce.android.ui.orders.creation.configuration.ProductRules
 import com.woocommerce.android.ui.orders.creation.navigation.OrderCreateEditNavigationTarget
 import com.woocommerce.android.ui.orders.creation.product.discount.CurrencySymbolFinder
 import com.woocommerce.android.ui.orders.creation.shipping.GetShippingMethodsWithOtherValue
-import com.woocommerce.android.ui.orders.creation.shipping.ShippingLineDetails
+import com.woocommerce.android.ui.orders.creation.shipping.ShippingLineSection
 import com.woocommerce.android.ui.orders.creation.shipping.ShippingUpdateResult
 import com.woocommerce.android.ui.orders.creation.taxes.GetAddressFromTaxRate
 import com.woocommerce.android.ui.orders.creation.taxes.GetTaxRatesInfoDialogViewState
@@ -131,6 +132,12 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                     any<Order>()
                 )
             } doReturn MutableLiveData(emptyOrder)
+            on {
+                getLiveData(
+                    key = eq("plugins_information"),
+                    initialValue = any<HashMap<String, WooPlugin>>(),
+                )
+            } doReturn MutableLiveData(HashMap())
         }
         createUpdateOrderUseCase = mock {
             onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(Order.getEmptyOrder(Date(), Date())))
@@ -191,8 +198,24 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         prefs = mock()
         mapFeeLineToCustomAmountUiModel = mock()
         totalsHelper = mock()
-        getShippingMethodsWithOtherValue = mock()
-        feedbackRepository = mock()
+        getShippingMethodsWithOtherValue = mock {
+            onBlocking { invoke() } doReturn flowOf(
+                listOf(
+                    ShippingMethod(
+                        id = "other",
+                        title = "Other"
+                    )
+                )
+            )
+        }
+        feedbackRepository = mock {
+            onBlocking {
+                getFeatureFeedbackSetting(eq(FeatureFeedbackSettings.Feature.ORDER_SHIPPING_LINES))
+            } doReturn FeatureFeedbackSettings(
+                feature = FeatureFeedbackSettings.Feature.ORDER_SHIPPING_LINES,
+                feedbackState = FeatureFeedbackSettings.FeedbackState.UNANSWERED
+            )
+        }
         fetchProductBySKU = mock()
     }
 
@@ -1884,14 +1907,14 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         whenever(getShippingMethodsWithOtherValue.invoke()).doReturn(getShippingMethodsResult)
         createSut()
 
-        var shippingDetails: List<ShippingLineDetails>? = null
-        sut.shippingLineList.observeForever {
-            shippingDetails = it
+        var shippingSection: ShippingLineSection? = null
+        sut.shippingLineSection.observeForever {
+            shippingSection = it
         }
 
-        assertThat(shippingDetails).isNotNull
-        assertThat(shippingDetails!!.size).isEqualTo(shippingLines.size)
-        val shippingMethod = shippingDetails!!.firstOrNull { it.shippingMethod?.id == shippingMethodId }
+        assertThat(shippingSection).isNotNull
+        assertThat(shippingSection!!.shippingLines.size).isEqualTo(shippingLines.size)
+        val shippingMethod = shippingSection!!.shippingLines.firstOrNull { it.shippingMethod?.id == shippingMethodId }
         assertThat(shippingMethod).isNotNull
         assertThat(shippingMethod!!.shippingMethod!!.title).isEqualTo(shippingMethodTitle)
     }
@@ -1921,14 +1944,14 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         whenever(getShippingMethodsWithOtherValue.invoke()).doReturn(getShippingMethodsResult)
         createSut()
 
-        var shippingDetails: List<ShippingLineDetails>? = null
-        sut.shippingLineList.observeForever {
-            shippingDetails = it
+        var shippingSection: ShippingLineSection? = null
+        sut.shippingLineSection.observeForever {
+            shippingSection = it
         }
 
-        assertThat(shippingDetails).isNotNull
-        assertThat(shippingDetails!!.size).isEqualTo(shippingLines.size)
-        val shippingMethod = shippingDetails!!.firstOrNull { it.shippingMethod?.id == shippingMethodId }
+        assertThat(shippingSection).isNotNull
+        assertThat(shippingSection!!.shippingLines.size).isEqualTo(shippingLines.size)
+        val shippingMethod = shippingSection!!.shippingLines.firstOrNull { it.shippingMethod?.id == shippingMethodId }
         assertThat(shippingMethod).isNull()
     }
 


### PR DESCRIPTION
Closes: #12869 

### Description
This PR fixes the issue of the shipping lines being editable at all times. It does that by introducing the `ShippingLineSection` class that includes the isEnabled state. Relying on the isEnabled state value, the shipping lines section now locks(disabled) the interaction with the shipping lines controls if the isEnabled property is false,

### Testing information

1. Go to Order List
2. Click on Create Order
3. Add a product
4. Notice Add shipping button is disabled when the order is refreshed
5. Add a shipping line
6. Notice the added shipping line is disabled when the order is refreshed
7. Add a product
8. Notice Add shipping button is disabled when the order is refreshed

### The tests that have been performed
1. Testing that the shipping lines section is disabled when the order is refreshing or is not editable.

### Images/gif

https://github.com/user-attachments/assets/5c87bad7-0993-44e5-a9cf-4539bd198466

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
