### PR TITLE
Fix crash on order details when tapping customer info buttons

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 21.2
 -----
-
+- [*] Fixed a crash that occurred when tapping on the customer shipping address in the order details screen [https://github.com/woocommerce/woocommerce-android/pull/12920]
 
 21.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
@@ -240,11 +240,7 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
             )
 
             binding.customerInfoCustomerNoteSection.setOnClickListener {
-                val action =
-                    OrderDetailFragmentDirections.actionOrderDetailFragmentToEditCustomerOrderNoteFragment(
-                        order.id
-                    )
-                findNavController().navigateSafely(action)
+                navigateToCustomerNote(order)
             }
         }
     }
@@ -290,13 +286,26 @@ class OrderDetailCustomerInfoView @JvmOverloads constructor(
         }
     }
 
+    private fun navigateToCustomerNote(order: Order) {
+        if (!isAttachedToWindow) return
+
+        val action = OrderDetailFragmentDirections.actionOrderDetailFragmentToEditCustomerOrderNoteFragment(
+            order.id
+        )
+        findNavController().navigateSafely(action)
+    }
+
     private fun navigateToShippingAddressEditingView(address: Address) {
+        if (!isAttachedToWindow) return
+
         OrderDetailFragmentDirections
             .actionOrderDetailFragmentToShippingAddressEditingFragment(storedAddress = address)
             .let { findNavController().navigateSafely(it) }
     }
 
     private fun navigateToBillingAddressEditingView(address: Address) {
+        if (!isAttachedToWindow) return
+
         OrderDetailFragmentDirections
             .actionOrderDetailFragmentToBillingAddressEditingFragment(storedAddress = address)
             .let { findNavController().navigateSafely(it) }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12913 
Closes: #12919 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes a crash that can occur in order details screen when tapping on of the buttons of the `OrderDetailCustomerInfoView`, the crash occurs if the user tries to tap on the buttons after the view was detached from the window, this can happen during transition animations, and happens more frequently on tablets given how the navigation works with the dual pane mode.

For technical side, this crash happens because when the fragment view is destroyed, the `NavHostFragment` will [detach](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:navigation/navigation-fragment/src/main/java/androidx/navigation/fragment/NavHostFragment.kt;l=302?q=NavHostFra) the `navController`, so if a button click listener was to be invoked after this, the `findNavController` will throw the exception.

### Steps to reproduce
Please repeat the following on both `trunk` and this branch to confirm the fix.

1. Use a physical device.
2. Open the order list on dual pane mode (Either on a tablet, or alternatively on a phone by opening the order list when the phone is on landscape)
3. Use two fingers to tap instantly on both:
   - The shipping section of order details.
   - The row of another order.
4. Repeat 3 few times, and the app should crash occasionally on `trunk`, and shouldn't crash on this branch.

Alternatively, if the above wasn't enough to reproduce it, please apply the following patch to simulate it, the patch will trigger manually the click after the view is destroyed, which should cause the crash on `trunk` and would confirm the fix of this branch.

<details>
<summary>Patch</summary>

```patch
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt	(revision 564631291444e615d443e2bd4f6e00d8252602d8)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailCustomerInfoView.kt	(date 1731511463945)
@@ -40,7 +40,7 @@
         private const val TELEGRAM_PACKAGE_NAME = "org.telegram.messenger"
     }
 
-    private val binding = OrderDetailCustomerInfoBinding.inflate(LayoutInflater.from(ctx), this)
+    val binding = OrderDetailCustomerInfoBinding.inflate(LayoutInflater.from(ctx), this)
     private var isCustomerInfoViewExpanded = false
 
     override fun onSaveInstanceState(): Parcelable {
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt	(revision 564631291444e615d443e2bd4f6e00d8252602d8)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt	(date 1731508415600)
@@ -311,7 +311,9 @@
 
     override fun onDestroyView() {
         super.onDestroyView()
+        val customerInfoBinding = binding.orderDetailCustomerInfo.binding
         _binding = null
+        customerInfoBinding.customerInfoShippingAddressSection.callOnClick()
     }
 
     fun onPrepareMenu(menu: Menu) {
```
</details>


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->