### PR TITLE
[Wear App] Update wear stats loading strategy

### DIFF
--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/datasource/FetchStats.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/datasource/FetchStats.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.wear.ui.stats.datasource.FetchStats.StoreStatsReq
 import com.woocommerce.android.wear.ui.stats.datasource.FetchStats.StoreStatsRequest.Finished
 import com.woocommerce.android.wear.ui.stats.datasource.FetchStats.StoreStatsRequest.Waiting
 import com.woocommerce.android.wear.ui.stats.datasource.StoreStatsData.RevenueData
+import com.woocommerce.android.wear.ui.stats.datasource.StoreStatsData.StatRequest
 import com.woocommerce.commons.MessagePath
 import com.woocommerce.commons.WearAnalyticsEvent.WATCH_DATA_REQUESTED_FROM_PHONE
 import com.woocommerce.commons.WearAnalyticsEvent.WATCH_DATA_REQUESTED_FROM_STORE
@@ -28,8 +29,8 @@ class FetchStats @Inject constructor(
     private val connectionStatus: ConnectionStatus,
     private val analyticsTracker: AnalyticsTracker
 ) {
-    private val revenueStats = MutableStateFlow<RevenueData?>(null)
-    private val visitorStats = MutableStateFlow<Int?>(null)
+    private val revenueStats = MutableStateFlow<StatRequest<RevenueData>>(StatRequest.Waiting())
+    private val visitorStats = MutableStateFlow<StatRequest<Int>>(StatRequest.Waiting())
 
     suspend operator fun invoke(
         selectedSite: SiteModel
@@ -90,10 +91,10 @@ class FetchStats @Inject constructor(
                         orderCount = totals?.ordersCount ?: 0
                     )
 
-                    revenueStats.value = revenueData
+                    revenueStats.value = StatRequest.Finished(revenueData)
                 },
                 onFailure = {
-                    revenueStats.value = null
+                    revenueStats.value = StatRequest.Error()
                 }
             )
     }
@@ -102,10 +103,10 @@ class FetchStats @Inject constructor(
         statsRepository.fetchVisitorStats(selectedSite)
             .fold(
                 onSuccess = { visitors ->
-                    visitorStats.value = visitors ?: 0
+                    visitorStats.value = StatRequest.Finished(visitors ?: 0)
                 },
                 onFailure = {
-                    visitorStats.value = null
+                    visitorStats.value = StatRequest.Error()
                 }
             )
     }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/datasource/StatsRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/datasource/StatsRepository.kt
@@ -6,6 +6,10 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.google.android.gms.wearable.DataMap
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
 import com.woocommerce.android.wear.datastore.DataStoreQualifier
 import com.woocommerce.android.wear.datastore.DataStoreType
 import com.woocommerce.android.wear.extensions.formatToYYYYmmDDhhmmss
@@ -24,6 +28,7 @@ import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.store.WCStatsStore
 import org.wordpress.android.fluxc.store.WCStatsStore.FetchRevenueStatsPayload
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import java.lang.reflect.Type
 import java.util.Calendar
 import java.util.Locale
 import javax.inject.Inject
@@ -36,6 +41,11 @@ class StatsRepository @Inject constructor(
     private val locale: Locale
 ) {
     private val gson by lazy { Gson() }
+    private val statsGson by lazy {
+        GsonBuilder()
+            .registerTypeAdapter(StoreStatsData::class.java, StoreStatsDataDeserializer())
+            .create()
+    }
 
     suspend fun fetchRevenueStats(
         selectedSite: SiteModel
@@ -117,10 +127,27 @@ class StatsRepository @Inject constructor(
         selectedSite: SiteModel
     ) = statsDataStore.data
         .mapNotNull { it[stringPreferencesKey(generateStatsKey(selectedSite.siteId))] }
-        .map { gson.fromJson(it, StoreStatsData::class.java) }
+        .map { statsGson.fromJson(it, StoreStatsData::class.java) }
 
     private fun generateStatsKey(siteId: Long): String {
         return "$STATS_KEY_PREFIX:$siteId"
+    }
+
+    class StoreStatsDataDeserializer : JsonDeserializer<StoreStatsData> {
+        override fun deserialize(
+            json: JsonElement?,
+            typeOfT: Type?,
+            context: JsonDeserializationContext?
+        ): StoreStatsData {
+            val revenueDataJson = json?.asJsonObject?.get("revenueData")?.asJsonObject
+            val revenueData = RevenueData(
+                totalRevenue = revenueDataJson?.get("totalRevenue")?.asString ?: "",
+                orderCount = revenueDataJson?.get("orderCount")?.asInt ?: 0
+            )
+            val visitorData = json?.asJsonObject?.get("visitorData")?.asInt ?: 0
+
+            return StoreStatsData(revenueData, visitorData)
+        }
     }
 
     companion object {

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/datasource/StoreStatsData.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/datasource/StoreStatsData.kt
@@ -37,7 +37,7 @@ class StoreStatsData(
         }
 
     val isComplete
-        get() = revenueRequest.isComplete && visitorRequest.isComplete
+        get() = revenueRequest is StatRequest.Finished && visitorRequest.isComplete
 
     data class RevenueData(
         val totalRevenue: String,

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/datasource/StoreStatsData.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/datasource/StoreStatsData.kt
@@ -2,10 +2,30 @@ package com.woocommerce.android.wear.ui.stats.datasource
 
 import com.woocommerce.android.wear.extensions.convertedFrom
 
-data class StoreStatsData(
-    private val revenueData: RevenueData?,
-    private val visitorData: Int?
+class StoreStatsData(
+    private val revenueRequest: StatRequest<RevenueData>,
+    private val visitorRequest: StatRequest<Int>
 ) {
+    private val revenueData: RevenueData?
+    private val visitorData: Int?
+
+    constructor(
+        revenueData: RevenueData,
+        visitorData: Int
+    ) : this(StatRequest.Finished(revenueData), StatRequest.Finished(visitorData))
+
+    init {
+        revenueData = when (revenueRequest) {
+            is StatRequest.Finished -> revenueRequest.data
+            else -> null
+        }
+
+        visitorData = when (visitorRequest) {
+            is StatRequest.Finished -> visitorRequest.data
+            else -> null
+        }
+    }
+
     val revenue get() = revenueData?.totalRevenue.orEmpty()
     val ordersCount get() = revenueData?.orderCount ?: 0
     val visitorsCount get() = visitorData ?: 0
@@ -17,11 +37,18 @@ data class StoreStatsData(
         }
 
     val isComplete
-        get() = revenueData != null &&
-            visitorData != null
+        get() = revenueRequest.isComplete && visitorRequest.isComplete
 
     data class RevenueData(
         val totalRevenue: String,
         val orderCount: Int
     )
+
+    sealed class StatRequest<T> {
+        class Error<T> : StatRequest<T>()
+        class Waiting<T> : StatRequest<T>()
+        class Finished<T>(val data: T) : StatRequest<T>()
+
+        val isComplete get() = this is Finished || this is Error
+    }
 }

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/wear/ui/stats/datasource/FetchStatsTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/wear/ui/stats/datasource/FetchStatsTest.kt
@@ -61,11 +61,7 @@ class FetchStatsTest : BaseUnitTest() {
             .filter { it !is Waiting }
             .first()
 
-        assertThat(event).isInstanceOf(Finished::class.java)
-        val eventData = (event as Finished).data
-        assertThat(eventData.revenue).isEmpty()
-        assertThat(eventData.ordersCount).isEqualTo(0)
-        assertThat(eventData.visitorsCount).isEqualTo(0)
+        assertThat(event).isEqualTo(StoreStatsRequest.Error)
     }
 
     @Test

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/wear/ui/stats/datasource/FetchStatsTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/wear/ui/stats/datasource/FetchStatsTest.kt
@@ -43,24 +43,15 @@ class FetchStatsTest : BaseUnitTest() {
             .invoke(selectedSite)
             .first()
 
-        assertThat(event).isEqualTo(Finished(expectedData))
+        assertThat(event).isInstanceOf(Finished::class.java)
+        val eventData = (event as Finished).data
+        assertThat(eventData.revenue).isEqualTo(expectedData.revenue)
+        assertThat(eventData.ordersCount).isEqualTo(expectedData.ordersCount)
+        assertThat(eventData.visitorsCount).isEqualTo(expectedData.visitorsCount)
     }
 
     @Test
-    fun `returns Waiting when no stats and not timeout`() = testBlocking {
-        whenever(statsRepository.fetchRevenueStats(selectedSite)).thenReturn(Result.failure(Throwable()))
-        whenever(statsRepository.fetchVisitorStats(selectedSite)).thenReturn(Result.failure(Throwable()))
-        whenever(connectionStatus.isStoreConnected()).thenReturn(true)
-
-        val event = createSut()
-            .invoke(selectedSite)
-            .first()
-
-        assertThat(event).isEqualTo(Waiting)
-    }
-
-    @Test
-    fun `returns Error when no stats and timeout`() = testBlocking {
+    fun `Recovers when no stats and timeout`() = testBlocking {
         whenever(statsRepository.fetchRevenueStats(selectedSite)).thenReturn(Result.failure(Throwable()))
         whenever(statsRepository.fetchVisitorStats(selectedSite)).thenReturn(Result.failure(Throwable()))
         whenever(connectionStatus.isStoreConnected()).thenReturn(true)
@@ -70,7 +61,11 @@ class FetchStatsTest : BaseUnitTest() {
             .filter { it !is Waiting }
             .first()
 
-        assertThat(event).isEqualTo(StoreStatsRequest.Error)
+        assertThat(event).isInstanceOf(Finished::class.java)
+        val eventData = (event as Finished).data
+        assertThat(eventData.revenue).isEmpty()
+        assertThat(eventData.ordersCount).isEqualTo(0)
+        assertThat(eventData.visitorsCount).isEqualTo(0)
     }
 
     @Test

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/wear/ui/stats/datasource/StoreStatsDataTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/wear/ui/stats/datasource/StoreStatsDataTest.kt
@@ -1,0 +1,49 @@
+package com.woocommerce.android.wear.ui.stats.datasource
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class StoreStatsDataTest {
+
+    @Test
+    fun `StoreStatsData with finished requests should return correct values`() {
+        val revenueData = StoreStatsData.RevenueData(totalRevenue = "1000", orderCount = 10)
+        val visitorData = 100
+
+        val storeStatsData = StoreStatsData(revenueData, visitorData)
+
+        assertEquals("1000", storeStatsData.revenue)
+        assertEquals(10, storeStatsData.ordersCount)
+        assertEquals(100, storeStatsData.visitorsCount)
+        assertEquals("10%", storeStatsData.conversionRate)
+        assertTrue(storeStatsData.isComplete)
+    }
+
+    @Test
+    fun `StoreStatsData with waiting requests should return default values`() {
+        val revenueRequest = StoreStatsData.StatRequest.Waiting<StoreStatsData.RevenueData>()
+        val visitorRequest = StoreStatsData.StatRequest.Waiting<Int>()
+
+        val storeStatsData = StoreStatsData(revenueRequest, visitorRequest)
+
+        assertEquals("", storeStatsData.revenue)
+        assertEquals(0, storeStatsData.ordersCount)
+        assertEquals(0, storeStatsData.visitorsCount)
+        assertEquals("0%", storeStatsData.conversionRate)
+        assertFalse(storeStatsData.isComplete)
+    }
+
+    @Test
+    fun `StoreStatsData with error requests should return default values`() {
+        val revenueRequest = StoreStatsData.StatRequest.Error<StoreStatsData.RevenueData>()
+        val visitorRequest = StoreStatsData.StatRequest.Error<Int>()
+
+        val storeStatsData = StoreStatsData(revenueRequest, visitorRequest)
+
+        assertEquals("", storeStatsData.revenue)
+        assertEquals(0, storeStatsData.ordersCount)
+        assertEquals(0, storeStatsData.visitorsCount)
+        assertEquals("0%", storeStatsData.conversionRate)
+        assertTrue(storeStatsData.isComplete)
+    }
+}

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/wear/ui/stats/datasource/StoreStatsDataTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/wear/ui/stats/datasource/StoreStatsDataTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.wear.ui.stats.datasource
 
+import com.woocommerce.android.wear.ui.stats.datasource.StoreStatsData.StatRequest.*
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -21,8 +22,8 @@ class StoreStatsDataTest {
 
     @Test
     fun `StoreStatsData with waiting requests should return default values`() {
-        val revenueRequest = StoreStatsData.StatRequest.Waiting<StoreStatsData.RevenueData>()
-        val visitorRequest = StoreStatsData.StatRequest.Waiting<Int>()
+        val revenueRequest = Waiting<StoreStatsData.RevenueData>()
+        val visitorRequest = Waiting<Int>()
 
         val storeStatsData = StoreStatsData(revenueRequest, visitorRequest)
 
@@ -35,8 +36,8 @@ class StoreStatsDataTest {
 
     @Test
     fun `StoreStatsData with error requests should return default values`() {
-        val revenueRequest = StoreStatsData.StatRequest.Error<StoreStatsData.RevenueData>()
-        val visitorRequest = StoreStatsData.StatRequest.Error<Int>()
+        val revenueRequest = Error<StoreStatsData.RevenueData>()
+        val visitorRequest = Error<Int>()
 
         val storeStatsData = StoreStatsData(revenueRequest, visitorRequest)
 
@@ -44,6 +45,36 @@ class StoreStatsDataTest {
         assertEquals(0, storeStatsData.ordersCount)
         assertEquals(0, storeStatsData.visitorsCount)
         assertEquals("0%", storeStatsData.conversionRate)
+        assertFalse(storeStatsData.isComplete)
+    }
+
+    @Test
+    fun `StoreStatsData with mixed finished and waiting requests should return incomplete`() {
+        val revenueData = StoreStatsData.RevenueData(totalRevenue = "1000", orderCount = 10)
+        val visitorRequest = Waiting<Int>()
+
+        val storeStatsData = StoreStatsData(Finished(revenueData), visitorRequest)
+
+        assertFalse(storeStatsData.isComplete)
+    }
+
+    @Test
+    fun `StoreStatsData with mixed finished and error requests should return complete`() {
+        val revenueData = StoreStatsData.RevenueData(totalRevenue = "1000", orderCount = 10)
+        val visitorRequest = Error<Int>()
+
+        val storeStatsData = StoreStatsData(Finished(revenueData), visitorRequest)
+
         assertTrue(storeStatsData.isComplete)
+    }
+
+    @Test
+    fun `StoreStatsData with mixed waiting and error requests should return complete`() {
+        val revenueRequest = Waiting<StoreStatsData.RevenueData>()
+        val visitorRequest = Error<Int>()
+
+        val storeStatsData = StoreStatsData(revenueRequest, visitorRequest)
+
+        assertFalse(storeStatsData.isComplete)
     }
 }

--- a/WooCommerce-Wear/src/test/java/com/woocommerce/android/wear/ui/stats/datasource/StoreStatsDataTest.kt
+++ b/WooCommerce-Wear/src/test/java/com/woocommerce/android/wear/ui/stats/datasource/StoreStatsDataTest.kt
@@ -1,7 +1,8 @@
 package com.woocommerce.android.wear.ui.stats.datasource
 
-import com.woocommerce.android.wear.ui.stats.datasource.StoreStatsData.StatRequest.*
-import org.junit.Assert.*
+import com.woocommerce.android.wear.ui.stats.datasource.StoreStatsData.StatRequest
+import com.woocommerce.android.wear.ui.stats.datasource.StoreStatsData.StatRequest.Waiting
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class StoreStatsDataTest {
@@ -13,11 +14,11 @@ class StoreStatsDataTest {
 
         val storeStatsData = StoreStatsData(revenueData, visitorData)
 
-        assertEquals("1000", storeStatsData.revenue)
-        assertEquals(10, storeStatsData.ordersCount)
-        assertEquals(100, storeStatsData.visitorsCount)
-        assertEquals("10%", storeStatsData.conversionRate)
-        assertTrue(storeStatsData.isComplete)
+        assertThat(storeStatsData.revenue).isEqualTo("1000")
+        assertThat(storeStatsData.ordersCount).isEqualTo(10)
+        assertThat(storeStatsData.visitorsCount).isEqualTo(100)
+        assertThat(storeStatsData.conversionRate).isEqualTo("10%")
+        assertThat(storeStatsData.isComplete).isTrue
     }
 
     @Test
@@ -27,25 +28,25 @@ class StoreStatsDataTest {
 
         val storeStatsData = StoreStatsData(revenueRequest, visitorRequest)
 
-        assertEquals("", storeStatsData.revenue)
-        assertEquals(0, storeStatsData.ordersCount)
-        assertEquals(0, storeStatsData.visitorsCount)
-        assertEquals("0%", storeStatsData.conversionRate)
-        assertFalse(storeStatsData.isComplete)
+        assertThat(storeStatsData.revenue).isEqualTo("")
+        assertThat(storeStatsData.ordersCount).isEqualTo(0)
+        assertThat(storeStatsData.visitorsCount).isEqualTo(0)
+        assertThat(storeStatsData.conversionRate).isEqualTo("0%")
+        assertThat(storeStatsData.isComplete).isFalse
     }
 
     @Test
     fun `StoreStatsData with error requests should return default values`() {
-        val revenueRequest = Error<StoreStatsData.RevenueData>()
-        val visitorRequest = Error<Int>()
+        val revenueRequest = StatRequest.Error<StoreStatsData.RevenueData>()
+        val visitorRequest = StatRequest.Error<Int>()
 
         val storeStatsData = StoreStatsData(revenueRequest, visitorRequest)
 
-        assertEquals("", storeStatsData.revenue)
-        assertEquals(0, storeStatsData.ordersCount)
-        assertEquals(0, storeStatsData.visitorsCount)
-        assertEquals("0%", storeStatsData.conversionRate)
-        assertFalse(storeStatsData.isComplete)
+        assertThat(storeStatsData.revenue).isEqualTo("")
+        assertThat(storeStatsData.ordersCount).isEqualTo(0)
+        assertThat(storeStatsData.visitorsCount).isEqualTo(0)
+        assertThat(storeStatsData.conversionRate).isEqualTo("0%")
+        assertThat(storeStatsData.isComplete).isFalse
     }
 
     @Test
@@ -53,28 +54,28 @@ class StoreStatsDataTest {
         val revenueData = StoreStatsData.RevenueData(totalRevenue = "1000", orderCount = 10)
         val visitorRequest = Waiting<Int>()
 
-        val storeStatsData = StoreStatsData(Finished(revenueData), visitorRequest)
+        val storeStatsData = StoreStatsData(StatRequest.Finished(revenueData), visitorRequest)
 
-        assertFalse(storeStatsData.isComplete)
+        assertThat(storeStatsData.isComplete).isFalse
     }
 
     @Test
     fun `StoreStatsData with mixed finished and error requests should return complete`() {
         val revenueData = StoreStatsData.RevenueData(totalRevenue = "1000", orderCount = 10)
-        val visitorRequest = Error<Int>()
+        val visitorRequest = StatRequest.Error<Int>()
 
-        val storeStatsData = StoreStatsData(Finished(revenueData), visitorRequest)
+        val storeStatsData = StoreStatsData(StatRequest.Finished(revenueData), visitorRequest)
 
-        assertTrue(storeStatsData.isComplete)
+        assertThat(storeStatsData.isComplete).isTrue
     }
 
     @Test
     fun `StoreStatsData with mixed waiting and error requests should return complete`() {
         val revenueRequest = Waiting<StoreStatsData.RevenueData>()
-        val visitorRequest = Error<Int>()
+        val visitorRequest = StatRequest.Error<Int>()
 
         val storeStatsData = StoreStatsData(revenueRequest, visitorRequest)
 
-        assertFalse(storeStatsData.isComplete)
+        assertThat(storeStatsData.isComplete).isFalse
     }
 }


### PR DESCRIPTION
Summary
==========
This is an adjustment to the Wear app targeting a more resilient approach to the Stats screen, where missing data will still allow the other stats to be displayed. This corner case can only be observed in test stores with no real activity, but it's blocking our release strategy.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.
