### PR TITLE
[Woo POS payments onboarding] Close SelectPaymentMethodFragment when we skip it in the WooPOS flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -213,7 +213,7 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
                     if (findNavController().currentDestination?.id == R.id.selectPaymentMethodFragment) {
                         findNavController().navigate(
                             SelectPaymentMethodFragmentDirections
-                                .actionSelectPaymentMethodFragmentToCardReaderPaymentFlow(
+                                .actionWooPosSelectPaymentMethodFragmentToCardReaderPaymentFlow(
                                     event.cardReaderFlowParam,
                                     event.cardReaderType
                                 )

--- a/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
@@ -22,6 +22,11 @@
             android:id="@+id/action_selectPaymentMethodFragment_to_cardReaderPaymentFlow"
             app:destination="@id/cardReaderStatusCheckerDialogFragment" />
         <action
+            android:id="@+id/action_wooPos_selectPaymentMethodFragment_to_cardReaderPaymentFlow"
+            app:destination="@id/cardReaderStatusCheckerDialogFragment"
+            app:popUpTo="@+id/selectPaymentMethodFragment"
+            app:popUpToInclusive="true" />
+        <action
             android:id="@+id/action_selectPaymentMethodFragment_to_cardReaderRefundFlow"
             app:destination="@id/cardReaderStatusCheckerDialogFragment"
             app:popUpTo="@+id/selectPaymentMethodFragment"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12951 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR fixes a bug when during pos payment flow if onboarding not finished and a user goes back then we still were showing SelectPaymentMethodFragment

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* Have a site with unfinished IPP onboarding
* More -> POS -> Add a product -> Collect payment
* Go back via the toolbar or system navigation
* Notice loading indicator

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/ac7913d8-34d0-4699-8f23-a2d07c05f67e


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->