### PR TITLE
Fix ignored OrdersUITest

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt
@@ -6,6 +6,7 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withParentIndex
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.woocommerce.android.R
 import com.woocommerce.android.e2e.helpers.util.NestedScrollViewExtension
@@ -43,7 +44,7 @@ class SingleOrderScreen : Screen(R.id.orderStatus_subtitle) {
     }
 
     fun assertOrderId(orderId: Int): SingleOrderScreen {
-        Espresso.onView(withId(R.id.toolbar))
+        Espresso.onView(Matchers.allOf(withId(R.id.toolbar), withParentIndex(0)))
             .check(ViewAssertions.matches(hasDescendant(withText("Order #$orderId"))))
             .check(ViewAssertions.matches(isDisplayed()))
         return this

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/tests/ui/OrdersUITest.kt
@@ -20,7 +20,6 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.json.JSONObject
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -55,7 +54,6 @@ class OrdersUITest : TestBase() {
 
     @Retry(numberOfTimes = 1)
     @Test
-    @Ignore
     fun e2eCreateOrderTest() {
         val note = "Just a placeholder text"
         val ordersJSONArray = MocksReader().readOrderToArray()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
`OrdersUITest` was [ignored during toolbar refactoring process](https://github.com/woocommerce/woocommerce-android/commit/b85d5625f592574fadb03273f2e5feb5ba9f510a). Some parts of the order-related tests were addressed in #12906. This PR resolves the remaining issues with `OrdersUITest.`

Before, `OrdersUITest` was failing with the following error:
```
 androidx.test.espresso.AmbiguousViewMatcherException: 'view.getId() is <2131364783/com.woocommerce.android.dev:id/toolbar>' matches 2 views in the hierarchy:
- [1] MaterialToolbar{id=2131364783, res-name=toolbar, visibility=VISIBLE, width=1069, height=154, has-focus=false, has-focusable=false, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=com.google.android.material.appbar.CollapsingToolbarLayout$LayoutParams@YYYYYY, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=-154.0, child-count=3}
- [2] MaterialToolbar{id=2131364783, res-name=toolbar, visibility=VISIBLE, width=1080, height=154, has-focus=false, has-focusable=false, has-window-focus=true, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params=android.widget.LinearLayout$LayoutParams@YYYYYY, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0, child-count=3}
```

This error was caused by duplicate toolbars on the screen. I'm not sure if this is optimal or not, but it falls outside the scope of this PR. To resolve the `AmbiguousViewMatcherException`, I used the first found toolbar to assert the toolbar title.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Test `OrdersUITest`.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
`OrdersUITest`

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->