### PR TITLE
Fix dark mode issues

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingRatesSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShippingRatesSection.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels
 
 import android.content.Context
+import android.content.res.Configuration
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.animation.animateColorAsState
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Colors
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
@@ -49,6 +51,7 @@ import androidx.compose.ui.text.capitalize
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
@@ -57,6 +60,9 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.util.StringUtils
 import kotlinx.coroutines.launch
 import kotlin.random.Random
+
+@Suppress("MagicNumber")
+val Colors.selectedRateBackgroundColor: Color get() = if (isLight) Color(0xFFF2EDFF) else Color(0x22F2EDFF)
 
 @Composable
 internal fun ShippingRatesCard(
@@ -86,7 +92,8 @@ internal fun ShippingRatesCard(
     }
 }
 
-@Preview
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES, device = Devices.PIXEL)
+@Preview(name = "light", uiMode = Configuration.UI_MODE_NIGHT_NO, device = Devices.PIXEL)
 @Composable
 private fun ShippingRatesCardPreview() {
     val rates = generateShippingRates()
@@ -300,7 +307,7 @@ private fun ShippingRateItem(
     }
 
     val backgroundColor = if (isSelected) {
-        animateColorAsState(targetValue = Color(0xFFF2EDFF), label = "colorAnimation")
+        animateColorAsState(targetValue = MaterialTheme.colors.selectedRateBackgroundColor, label = "colorAnimation")
     } else {
         animateColorAsState(targetValue = MaterialTheme.colors.surface, label = "colorAnimation")
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -66,7 +67,14 @@ fun WooShippingLabelCreationScreen(
             onSelectPackageClick = onSelectPackageClick,
             scaffoldState = scaffoldState
         )
-        val elevation = if (scaffoldState.bottomSheetState.isCollapsed) { 0.dp } else { 4.dp }
+        val isDarkTheme = isSystemInDarkTheme()
+        val isCollapsed = scaffoldState.bottomSheetState.isCollapsed
+        val elevation = when {
+            isDarkTheme && isCollapsed -> { 7.dp }
+            !isDarkTheme && isCollapsed -> { 0.dp }
+            isDarkTheme && !isCollapsed -> { 16.dp }
+            else -> { 8.dp }
+        }
         Box(
             modifier = Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
Part of: #12281

### Description
This PR fixes two small issues in dark mode. 

The first one is the purchase button elevation. In dark mode, the bottom section elevation differs from the bottom sheet, making the UI look weird. In this PR, I fix that by using different elevations depending on whether the device is in dark mode or expanded. 

The second issue was the selected rate background in dark mode.

### Testing information

1. Create an Order with the processing status on a store that can create shipping labels
2. Tap on Orders
3. Tap on the order created on step 1
4. Tap on create shipping labels
5. Check that the shipment details section works as expected
6. Tap on a shipping rate
7. Check that the selected background is the expected
8. Turn on dark mode
9. Check the UI is readable and that the shipment section and the purchase button have the same elevation

### The tests that have been performed
- Testing the UI works as expected

### Images/gif
| Before  | After |
| ------------- | ------------- |
| <img width="300" src="https://github.com/user-attachments/assets/0d18fc94-4081-4529-9ce6-2584eed3f5ad" />  | <img width="300" src="https://github.com/user-attachments/assets/eb9340da-d838-4994-a2d7-c6e86aea02f3" />  |
| <img width="300" src="https://github.com/user-attachments/assets/b5af5648-7548-48ab-a98e-94ad5bf97397" />  | <img width="300" src="https://github.com/user-attachments/assets/0edd61f3-3507-4749-a5b2-e0ded681979f" />  |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->