### PR TITLE
Fix unresponsive email icon from customer details screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/customer/CustomerDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/customer/CustomerDetailsFragment.kt
@@ -11,6 +11,7 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -37,6 +38,8 @@ class CustomerDetailsFragment : BaseFragment() {
                 is MultiLiveEvent.Event.Exit -> {
                     findNavController().navigateUp()
                 }
+
+                is SendEmailEvent -> ActivityUtils.sendEmail(requireContext(), event.emailAddress)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/customer/CustomerDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/customer/CustomerDetailsScreen.kt
@@ -68,6 +68,7 @@ fun CustomerDetailsScreen(viewModel: CustomerDetailsViewModel) {
             CustomerDetailsScreen(
                 state = currentState,
                 onRefresh = viewModel::refresh,
+                onEmailTapped = viewModel::onEmailTapped,
                 modifier = Modifier.padding(padding)
             )
         }
@@ -79,6 +80,7 @@ fun CustomerDetailsScreen(viewModel: CustomerDetailsViewModel) {
 fun CustomerDetailsScreen(
     state: CustomerViewState,
     onRefresh: () -> Unit,
+    onEmailTapped: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val pullRefreshState = rememberPullRefreshState(state.isRefreshingData, { onRefresh() })
@@ -86,7 +88,8 @@ fun CustomerDetailsScreen(
         Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
             CustomerSection(
                 customer = state.customerWithAnalytics,
-                isLoadingAnalytics = state.isLoadingAnalytics
+                isLoadingAnalytics = state.isLoadingAnalytics,
+                onEmailTapped = onEmailTapped
             )
             OrdersSection(
                 customer = state.customerWithAnalytics,
@@ -118,12 +121,16 @@ fun CustomerDetailsScreen(
 @Composable
 fun CustomerSection(
     customer: CustomerWithAnalytics,
-    isLoadingAnalytics: Boolean
+    isLoadingAnalytics: Boolean,
+    onEmailTapped: () -> Unit,
 ) {
     SectionTitle(stringResource(id = R.string.customers_details_customer_section))
     SectionValue(title = customer.getFullName(), value = null)
     Divider()
-    SectionValue(title = customer.email) {
+    SectionValue(
+        title = customer.email,
+        action = onEmailTapped
+    ) {
         Icon(
             imageVector = Icons.Filled.Email,
             contentDescription = "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/customer/CustomerDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/customer/CustomerDetailsViewModel.kt
@@ -59,6 +59,10 @@ class CustomerDetailsViewModel @Inject constructor(
     fun onNavigateBack() {
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
+
+    fun onEmailTapped() {
+        triggerEvent(SendEmailEvent(viewState.value?.customerWithAnalytics?.email ?: ""))
+    }
 }
 
 @Parcelize
@@ -67,3 +71,5 @@ data class CustomerViewState(
     val isLoadingAnalytics: Boolean,
     val isRefreshingData: Boolean
 ) : Parcelable
+
+data class SendEmailEvent(val emailAddress: String) : MultiLiveEvent.Event()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12954
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
Fix unresponsive email icon from customer details screen

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
From `trunk`
1. Navigate to more menu
2. Click on customers item
3. Open a customer detail item
4. Click on the email icon
5. Verify nothing happens

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Repeat the above steps. This time tapping on the email icon will open the email app ready to compose a new email with the customer's address. If not email client app installed, the app will show a toast stating "No e-mail app was found"

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/3b6a1c35-eed2-4103-9d12-2177c3f25c2f


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->