### PR TITLE
Issue/11114 avoid tracking signup as error

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComEmailViewModel.kt
@@ -131,23 +131,20 @@ class JetpackActivationWPComEmailViewModel @Inject constructor(
                         triggerEvent(ShowSnackbar(R.string.error_generic))
                     }
                 }
-
-                trackLoginFlowAuthOptionError(failure, isSignup)
+                if (!isSignup) {
+                    trackLoginFlowAuthOptionError(failure)
+                }
             }
         )
         isLoadingDialogShown.value = false
     }
 
-    private fun trackLoginFlowAuthOptionError(
-        failure: AuthOptionsError?,
-        isSignup: Boolean
-    ) {
+    private fun trackLoginFlowAuthOptionError(failure: AuthOptionsError?) {
         analyticsTrackerWrapper.track(
             JETPACK_SETUP_LOGIN_FLOW,
             mapOf(
                 AnalyticsTracker.KEY_STEP to AnalyticsTracker.VALUE_JETPACK_SETUP_STEP_EMAIL_ADDRESS,
                 AnalyticsTracker.KEY_FAILURE to (failure?.type?.name ?: "Unknown error"),
-                AnalyticsTracker.KEY_IS_SIGN_UP to isSignup
             )
         )
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3431,7 +3431,7 @@
     <string name="login_magic_link_auto_sent">We just sent you a magic link to your e-mail address. Please tap the link in the email to log in.</string>
     <string name="login_magic_link_button">Log in with magic link</string>
 
-    <string name="username_not_registered_wpcom">Hmm, we can\'t find a WordPress.com account connected to this username. You can enter an email to create a new account.</string>
+    <string name="username_not_registered_wpcom">We can\'t find a WordPress.com account connected to this username. You can enter an email to create a new account.</string>
     <string name="login_magic_links_label">We\'ll email you a link that\'ll log you in instantly, no password needed.</string>
     <string name="login_get_link_by_email">Get a login link by email</string>
     <string name="signup_magic_link_message">We’ve emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com.</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11114 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Small change on how we track failures during login step in Jetpack installation flow. 
Full discussion here: p1732113936622179/1731431785.549369-slack-C03L1NF1EA3
TLDR: We won't track `signup` case as `woocommerceandroid_jetpack_setup_login_flow, Properties: {"step":"email_address","failure":"UNKNOWN_USER", ...` event anymore. 

Additionally this PR adds a small update on `username_not_registered_wpcom` removing the `Hmm` part and just leaving it as: `We can\'t find a WordPress.com account connected to this username. You can enter an email to create a new account.`

![Screenshot 2024-11-21 at 13 24 34](https://github.com/user-attachments/assets/0a19f3d3-1198-4c37-990e-af8d810eb01d)

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
1. Log into a self hosted site that is not Jetpack connected
2. Click on Jetpack banner and enter an invalid `username`
3. Check that the error message is shown as expected and check that `woocommerceandroid_jetpack_setup_login_flow, Properties: {"step":"email_address","failure":"UNKNOWN_USER"` is tracked in the Logcat
4. Erase the invalid username and enter a unknown WP.com email
5. Check that no event for `failure` is tracked. 

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->