### PR TITLE
[Tooling] Update `Dangerfile` to run Rubocop with `bundle exec`

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -3,8 +3,7 @@
 github.dismiss_out_of_range_messages
 
 # `files: []` forces rubocop to scan all files, not just the ones modified in the PR
-# `skip_bundle_exec` prevents RuboCop from running using `bundle exec`, which we don't want on the linter agent
-rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inline_comment: true, include_cop_names: true, skip_bundle_exec: true)
+rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inline_comment: true, include_cop_names: true)
 
 manifest_pr_checker.check_gemfile_lock_updated
 


### PR DESCRIPTION
As the title says.

This is a change related to an update in the Linter CI Agent to make sure Rubocop is run with `bundle exec`.

### Testing

CI should be 🟢 