### PR TITLE
Fix ScreenshotTest for different locales

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/moremenu/MoreMenuScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/moremenu/MoreMenuScreen.kt
@@ -31,7 +31,7 @@ class MoreMenuScreen : Screen(R.id.more_menu_compose_view) {
 
         while (currentAttempt < maxAttempts) {
             try {
-                composeTestRule.onNodeWithContentDescription(getTranslatedString(R.string.settings))
+                composeTestRule.onNodeWithContentDescription(getTranslatedString(R.string.more_menu_button_settings))
                     .assertIsDisplayed()
                     .assertHasClickAction()
                 break // Exit loop if node is displayed and clickable
@@ -47,7 +47,7 @@ class MoreMenuScreen : Screen(R.id.more_menu_compose_view) {
         }
 
         composeTestRule.onNodeWithContentDescription(
-            getTranslatedString(R.string.settings)
+            getTranslatedString(R.string.more_menu_button_settings)
         ).assertHasClickAction().performClick()
 
         return SettingsScreen()

--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/orders/SingleOrderScreen.kt
@@ -14,7 +14,7 @@ import com.woocommerce.android.e2e.helpers.util.ProductData
 import com.woocommerce.android.e2e.helpers.util.Screen
 import org.hamcrest.Matchers
 
-class SingleOrderScreen : Screen(R.id.orderStatus_subtitle) {
+class SingleOrderScreen : Screen(R.id.orderDetail_container) {
     fun goBackToOrdersScreen(): OrderListScreen {
         if (isElementDisplayed(R.id.orderDetail_container)) {
             pressBack()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: woocommerce/woomobile-private#393
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
`ScreenshotTest` was failing when the language is set to Arabic or French. This PR fixes these failures.

> [!IMPORTANT]  
> Do not merge now, we'll merge this as a beta fix for 21.2.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Set the device language to Arabic (ar).
2. Run `ScreenshotTest`.
3. Set the device language to French (fr-FR).
4. Run `ScreenshotTest`.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
`ScreenshotTest`

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->