### PR TITLE
[Tracks] Use invariant locale when converting stat names from the enum types

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
 import org.json.JSONObject
-import java.util.Locale
 import java.util.UUID
 
 class AnalyticsTracker private constructor(
@@ -91,7 +90,7 @@ class AnalyticsTracker private constructor(
             return
         }
 
-        val eventName = stat.name.lowercase(Locale.getDefault())
+        val eventName = stat.name.lowercase()
 
         val user = username ?: getAnonID() ?: generateNewAnonID()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12986 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
This PR fixes an issue where some Tracks events are ignored when using Turkish language, when an event uses an `i` character, the cause is that we were using the device `Locale` when lowercasing from the enum name, but we should be using the invariant locale here.

### Steps to reproduce
1. Switch your phone's language to Turkish.
2. Open the app.

### Testing information
Check logcat and confirm that no `EventNameException` is thrown.


### The tests that have been performed
^

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
