### PR TITLE
[Woo POS - payments onboarding] Workaround for the visual glitch when SelectPaymentMethodFragment was visible

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 21.3
 -----
+- [Internal][POS] Fixed a visual glitch during payment flow [https://github.com/woocommerce/woocommerce-android/pull/12991]
 
 
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -211,6 +211,8 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
 
                 is SkipScreenInPosAndNavigateToCardReaderPaymentFlow -> {
                     if (findNavController().currentDestination?.id == R.id.selectPaymentMethodFragment) {
+                        // as we open the dialog, even if it's pop-uped from the back stack, the UI was still visible
+                        binding.snackRoot.isVisible = false
                         findNavController().navigate(
                             SelectPaymentMethodFragmentDirections
                                 .actionWooPosSelectPaymentMethodFragmentToCardReaderPaymentFlow(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12975 
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR makes UI of SelectPaymentMethodFragment invisible after navigation to the next step as during onboarding project the WooPOSCardReader activity is not invisible anymore and as we open the dialog, even if it's pop-uped from the back stack, the UI was still visible

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* More -> POS
* Add an item
* Start collecting payments
* Notice that there is visible fragment on the background of the reader connection dialog

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The one in the steps to repro

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/c2f1d505-0d54-438e-9b3f-81f2dac6d8e5

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->