### PR TITLE
Fix failing ScreenshotTest in TR language

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/TestBase.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/helpers/TestBase.kt
@@ -53,7 +53,11 @@ internal class UnlocalizedDateHelper : HandlebarsHelper<Any?>() {
         val localeCode: String? = options.hash("locale", "en_US_POSIX")
         var date = Date()
         if (offset != null) {
-            date = DateOffset(offset).shift(date)
+            // Uppercase the unit using the invariant locale as a workaround for a bug in DateOffset
+            val fixedOffset = offset.split(" ").let { strings ->
+                "${strings[0]} ${strings[1].uppercase()}"
+            }
+            date = DateOffset(fixedOffset).shift(date)
         }
         var locale: Locale = Locale.getDefault()
         if (localeCode != null) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
`ScreenshotTest` was failing due to a bug in the Wiremock library. This PR applies @hichamboushaba suggestion (p1732272671780979/1732209135.456889-slack-CGPNUU63E) as a workaround to this library bug. 

Wiremock's `DateOffset` class was transforming "minutes" to "MİNUTES" when the device language was set to Turkish. Now, we'll convert "minutes" to "MINUTES" before sending it to the library to avoid the issue.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Set device language to Turkish.
2. Run `ScreenshotTest`.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Ran `ScreenshotTest`.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->