### PR TITLE
[Woo POS] Fix for the payment flow crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -60,6 +60,8 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
                     if (viewModel.isPos) {
                         // If the user is in POS, we should navigate back skipping everything
                         requireActivity().finish()
+                    } else {
+                        findNavController().popBackStack()
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat.getColor
@@ -51,6 +52,18 @@ class CardReaderOnboardingFragment : BaseFragment(R.layout.fragment_card_reader_
         val binding = FragmentCardReaderOnboardingBinding.bind(view)
         setupToolbar(binding)
         initObservers(binding)
+
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    if (viewModel.isPos) {
+                        // If the user is in POS, we should navigate back skipping everything
+                        requireActivity().finish()
+                    }
+                }
+            }
+        )
     }
 
     private fun setupToolbar(binding: FragmentCardReaderOnboardingBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -89,6 +89,14 @@ class CardReaderOnboardingViewModel @Inject constructor(
 
     private var lastShownOnboardingState: CardReaderOnboardingState? = null
 
+    val isPos: Boolean
+        get() {
+            val cardReaderFlowParam = arguments.cardReaderOnboardingParam.cardReaderFlowParam
+            return cardReaderFlowParam is CardReaderFlowParam.WooPosConnection ||
+                (cardReaderFlowParam is CardReaderFlowParam.PaymentOrRefund.Payment &&
+                    cardReaderFlowParam.paymentType == CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.WOO_POS)
+        }
+
     init {
         when (val onboardingParam = arguments.cardReaderOnboardingParam) {
             is Check -> refreshState(onboardingParam.pluginType)
@@ -143,7 +151,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
     @Suppress("LongMethod", "ComplexMethod")
     private fun showOnboardingState(state: CardReaderOnboardingState) {
         lastShownOnboardingState = state
-        if (arguments.cardReaderOnboardingParam.cardReaderFlowParam is CardReaderFlowParam.WooPosConnection) {
+        if (isPos) {
             paymentsFlowTracker.trackOnboardingShownInPosFlow(state)
         }
 
@@ -453,7 +461,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
     }
 
     fun clearViewModel() {
-        if (arguments.cardReaderOnboardingParam.cardReaderFlowParam is CardReaderFlowParam.WooPosConnection) {
+        if (isPos) {
             lastShownOnboardingState?.let {
                 paymentsFlowTracker.trackOnboardingDismissedInPosFlow(it)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -89,7 +89,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
 
     private var lastShownOnboardingState: CardReaderOnboardingState? = null
 
-    val isPos: Boolean
+    private val isPos: Boolean
         get() {
             val cardReaderFlowParam = arguments.cardReaderOnboardingParam.cardReaderFlowParam
             return cardReaderFlowParam is CardReaderFlowParam.WooPosConnection ||

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -93,8 +93,8 @@ class CardReaderOnboardingViewModel @Inject constructor(
         get() {
             val cardReaderFlowParam = arguments.cardReaderOnboardingParam.cardReaderFlowParam
             return cardReaderFlowParam is CardReaderFlowParam.WooPosConnection ||
-                (cardReaderFlowParam is CardReaderFlowParam.PaymentOrRefund.Payment &&
-                    cardReaderFlowParam.paymentType == CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.WOO_POS)
+                cardReaderFlowParam is CardReaderFlowParam.PaymentOrRefund.Payment &&
+                cardReaderFlowParam.paymentType == CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.WOO_POS
         }
 
     init {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModel.kt
@@ -89,7 +89,7 @@ class CardReaderOnboardingViewModel @Inject constructor(
 
     private var lastShownOnboardingState: CardReaderOnboardingState? = null
 
-    private val isPos: Boolean
+    val isPos: Boolean
         get() {
             val cardReaderFlowParam = arguments.cardReaderOnboardingParam.cardReaderFlowParam
             return cardReaderFlowParam is CardReaderFlowParam.WooPosConnection ||

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -211,9 +211,12 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
 
                 is SkipScreenInPosAndNavigateToCardReaderPaymentFlow -> {
                     if (findNavController().currentDestination?.id == R.id.selectPaymentMethodFragment) {
+                        // as we open the dialog, we want to make the UI was still invisible behind it
+                        // but we need to keep it in back stack as IPP logic works with returning notice back
+                        binding.snackRoot.isVisible = false
                         findNavController().navigate(
                             SelectPaymentMethodFragmentDirections
-                                .actionWooPosSelectPaymentMethodFragmentToCardReaderPaymentFlow(
+                                .actionSelectPaymentMethodFragmentToCardReaderPaymentFlow(
                                     event.cardReaderFlowParam,
                                     event.cardReaderType
                                 )

--- a/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
@@ -22,11 +22,6 @@
             android:id="@+id/action_selectPaymentMethodFragment_to_cardReaderPaymentFlow"
             app:destination="@id/cardReaderStatusCheckerDialogFragment" />
         <action
-            android:id="@+id/action_wooPos_selectPaymentMethodFragment_to_cardReaderPaymentFlow"
-            app:destination="@id/cardReaderStatusCheckerDialogFragment"
-            app:popUpTo="@+id/selectPaymentMethodFragment"
-            app:popUpToInclusive="true" />
-        <action
             android:id="@+id/action_selectPaymentMethodFragment_to_cardReaderRefundFlow"
             app:destination="@id/cardReaderStatusCheckerDialogFragment"
             app:popUpTo="@+id/selectPaymentMethodFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingViewModelTest.kt
@@ -2043,6 +2043,68 @@ class CardReaderOnboardingViewModelTest : BaseUnitTest() {
             assertThat(viewModel.viewStateData.value).isInstanceOf(NoConnectionErrorState::class.java)
         }
 
+    @Test
+    fun `given WooPosConnection param, when checking isPos, then it returns true`() {
+        val viewModel = createVM(
+            CardReaderOnboardingFragmentArgs(
+                cardReaderOnboardingParam = CardReaderOnboardingParams.Check(
+                    cardReaderFlowParam = CardReaderFlowParam.WooPosConnection
+                ),
+                cardReaderType = CardReaderType.EXTERNAL
+            ).toSavedStateHandle()
+        )
+
+        assertTrue(viewModel.isPos)
+    }
+
+    @Test
+    fun `given PaymentOrRefund param with WooPos payment type, when checking isPos, then it returns true`() {
+        val viewModel = createVM(
+            CardReaderOnboardingFragmentArgs(
+                cardReaderOnboardingParam = CardReaderOnboardingParams.Check(
+                    cardReaderFlowParam = CardReaderFlowParam.PaymentOrRefund.Payment(
+                        1L,
+                        CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType.WOO_POS
+                    )
+                ),
+                cardReaderType = CardReaderType.EXTERNAL
+            ).toSavedStateHandle()
+        )
+
+        assertTrue(viewModel.isPos)
+    }
+
+    @Test
+    fun `given PaymentOrRefund param with non-WooPos payment type, when checking isPos, then it returns false`() {
+        val viewModel = createVM(
+            CardReaderOnboardingFragmentArgs(
+                cardReaderOnboardingParam = CardReaderOnboardingParams.Check(
+                    cardReaderFlowParam = CardReaderFlowParam.PaymentOrRefund.Payment(
+                        1L,
+                        ORDER
+                    )
+                ),
+                cardReaderType = CardReaderType.EXTERNAL
+            ).toSavedStateHandle()
+        )
+
+        assertFalse(viewModel.isPos)
+    }
+
+    @Test
+    fun `given CardReadersHub param, when checking isPos, then it returns false`() {
+        val viewModel = createVM(
+            CardReaderOnboardingFragmentArgs(
+                cardReaderOnboardingParam = CardReaderOnboardingParams.Check(
+                    cardReaderFlowParam = CardReaderFlowParam.CardReadersHub()
+                ),
+                cardReaderType = CardReaderType.EXTERNAL
+            ).toSavedStateHandle()
+        )
+
+        assertFalse(viewModel.isPos)
+    }
+
     // Tracking Begin
     @Test
     fun `given cod disabled screen, when skip button clicked, then track event`() =


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes:#12974
Closes:#12975
### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The PR: 
* Fixes the crash during payment flow in the POS
* Fixes the tracking of the onboarding events during POS during payments flow. Before it was tracked only on the connection flow
  * `woocommerceandroid_pos_payments_onboarding_shown` 
  *  `woocommerceandroid_pos_payments_onboarding_dismissed`

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
* More -> POS
* Add an item
* Collect payment
* Notice a crash

@AnirudhBhat @samiuelson could you please review the PR as this is quite dangerous


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Pay attention to POS flows:
* Payments flow
* Onboarding screen, including going back from onboarding 
* Notice that the mentioned events are tracked both on the connection and payments flows now

###Retest IPP too!

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
Check the video


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/13966c4b-a309-4544-84dc-bcdf3fe3b9b3



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->