### PR TITLE
Clean old feature flags from Kiwi 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.mystore.data.DashboardWidgetDataModel
-import com.woocommerce.android.util.FeatureFlag
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -46,7 +45,6 @@ data class DashboardWidget(
         INBOX(
             titleResource = R.string.inbox_screen_title,
             trackingIdentifier = "inbox",
-            isSupported = FeatureFlag.INBOX.isEnabled()
         ),
         REVIEWS(
             titleResource = R.string.my_store_widget_reviews_title,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/IsGoogleForWooEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/google/IsGoogleForWooEnabled.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.google
 
 import com.woocommerce.android.extensions.isVersionAtLeast
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.FeatureFlag
 import org.json.JSONArray
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
@@ -24,7 +23,7 @@ class IsGoogleForWooEnabled @Inject constructor(
         if (!result.isError) {
             result.model?.let { ssr ->
                 if (isGoogleForWooPluginEligible(JSONArray(ssr.activePlugins))) {
-                    return FeatureFlag.GOOGLE_ADS_M1.isEnabled() && googleRepository.isGoogleAdsAccountConnected()
+                    return googleRepository.isGoogleAdsAccountConnected()
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/inbox/InboxUtils.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.ui.inbox.domain.InboxNote.NoteType.SURVEY
 import com.woocommerce.android.ui.inbox.domain.InboxNote.Status.ACTIONED
 import com.woocommerce.android.ui.inbox.domain.InboxNoteAction
 import com.woocommerce.android.util.DateUtils
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.ResourceProvider
 import org.wordpress.android.util.DateTimeUtils
 import java.util.Date
@@ -63,9 +62,7 @@ fun InboxNote.mapInboxActionsToUi(
     }
 
     val noteActionsUi = mutableListOf<InboxNoteActionUi>()
-    if (FeatureFlag.SHOW_INBOX_CTA.isEnabled()) {
-        noteActionsUi.addAll(actions.map { it.toInboxActionUi(id, onAction) })
-    }
+    noteActionsUi.addAll(actions.map { it.toInboxActionUi(id, onAction) })
 
     addDismissActionIfMissing(noteActionsUi, onDismiss)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepository.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.moremenu.domain
 import com.woocommerce.android.extensions.isFreeTrial
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -19,7 +18,7 @@ class MoreMenuRepository @Inject constructor(
 
     suspend fun isInboxEnabled(): Boolean =
         withContext(Dispatchers.IO) {
-            if (!selectedSite.exists() || !FeatureFlag.INBOX.isEnabled()) return@withContext false
+            if (!selectedSite.exists()) return@withContext false
 
             val currentWooCoreVersion = getWooVersion() ?: return@withContext false
             currentWooCoreVersion.semverCompareTo(INBOX_MINIMUM_SUPPORTED_VERSION) >= 0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -7,7 +7,6 @@ import android.content.Context
  */
 enum class FeatureFlag {
     DB_DOWNGRADE,
-    INBOX,
     WC_SHIPPING_BANNER,
     BETTER_CUSTOMER_SEARCH_M2,
     ORDER_CREATION_AUTO_TAX_RATE,
@@ -35,7 +34,6 @@ enum class FeatureFlag {
             PRODUCT_GLOBAL_UNIQUE_IDENTIFIER_SUPPORT -> PackageUtils.isDebugBuild()
 
             NEW_SHIPPING_SUPPORT,
-            INBOX,
             SHOW_INBOX_CTA,
             GOOGLE_ADS_M1,
             CUSTOM_FIELDS,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -11,7 +11,6 @@ enum class FeatureFlag {
     BETTER_CUSTOMER_SEARCH_M2,
     ORDER_CREATION_AUTO_TAX_RATE,
     NEW_SHIPPING_SUPPORT,
-    GOOGLE_ADS_M1,
     ENDLESS_CAMPAIGNS_SUPPORT,
     CUSTOM_FIELDS,
     REVAMP_WOO_SHIPPING,
@@ -33,7 +32,6 @@ enum class FeatureFlag {
             PRODUCT_GLOBAL_UNIQUE_IDENTIFIER_SUPPORT -> PackageUtils.isDebugBuild()
 
             NEW_SHIPPING_SUPPORT,
-            GOOGLE_ADS_M1,
             CUSTOM_FIELDS,
             ENDLESS_CAMPAIGNS_SUPPORT,
             OBJECTIVE_SECTION -> true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -12,7 +12,6 @@ enum class FeatureFlag {
     ORDER_CREATION_AUTO_TAX_RATE,
     NEW_SHIPPING_SUPPORT,
     GOOGLE_ADS_M1,
-    SHOW_INBOX_CTA,
     ENDLESS_CAMPAIGNS_SUPPORT,
     CUSTOM_FIELDS,
     REVAMP_WOO_SHIPPING,
@@ -34,7 +33,6 @@ enum class FeatureFlag {
             PRODUCT_GLOBAL_UNIQUE_IDENTIFIER_SUPPORT -> PackageUtils.isDebugBuild()
 
             NEW_SHIPPING_SUPPORT,
-            SHOW_INBOX_CTA,
             GOOGLE_ADS_M1,
             CUSTOM_FIELDS,
             ENDLESS_CAMPAIGNS_SUPPORT,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR just removes 3 old feature flags that we don't need anymore as the feature has been enabled for a while now. 
```
     INBOX,
     SHOW_INBOX_CTA,
     GOOGLE_ADS_M1,
```

### Testing information
For either a debug or production build:
1. Check `Inbox` feature is still enabled
2. Check Google Ads feature is still enabled/shown.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->