### PR TITLE
Return user to email screen after entering wrong email

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 21.3
 -----
 - [*] Blaze Campaign Intro screen now offers creating a new product if the site has no products yet [https://github.com/woocommerce/woocommerce-android/pull/13001]
+- [*] When entering a wrong WordPress.com account for login, retrying will bring the step back to the email input screen [https://github.com/woocommerce/woocommerce-android/pull/13024]
 
 -----
 21.2

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/LoginNoWPcomAccountFoundDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/error/LoginNoWPcomAccountFoundDialogFragment.kt
@@ -38,7 +38,9 @@ class LoginNoWPcomAccountFoundDialogFragment : LoginBaseErrorDialogFragment() {
             title = R.string.login_try_another_account,
             onClick = {
                 unifiedLoginTracker.trackClick(Click.TRY_ANOTHER_ACCOUNT)
-                loginListener.startOver()
+
+                // Return merchant to the WPCom account login screen
+                dismiss()
             }
         )
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12483
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR deals with the following login flow:

User enters a WPCom/Jetpack-connected site > User sees the WPCom email login screen > User entered incorrect email.

On the third step above, the app shows the "No WPCom account found" dialog, which has a CTA to try with a different account. When the button is tapped, it returns the user to the very start of the step, asking them to enter their site address again.

This PR implements the suggestion in #12483 to let merchants return to the email input screen, instead of starting over by entering site address again. This makes sense because at the point where merchants arrive at the WPCom email screen, it means the site is already discovered as a WPCom/JP-connected site, and so do not need to go through discovery process again.

Finally, when the email input screen is shown, the previously entered email is preserved. I think this is a good thing, because then merchants will be able to see the wrong email and be able to fix it (e.g: in case they entered a typo).

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Have a WordPress.com/JP-connected test site,
2. Start from login, enter the site address,
3. On the next screen where it asks for a WordPress.com account email, enter a random, incorrect email,
4. Ensure the "No WPCom email" dialog is shown,
5. Tap the **Log in with another account** button,
6. Ensure the dialog is dismissed and the WordPress.com account email screen is shown again.

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested on a Pixel emulator with API 35.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

I tested the steps above, as also shown in the recording below.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/b7dd0b0f-0296-456b-971d-7d875b895efb


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->