### PR TITLE
Connecting shipping lines

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/ShipmentDetails.kt
@@ -52,6 +52,8 @@ import kotlinx.coroutines.launch
 @Composable
 fun ShipmentDetails(
     scaffoldState: BottomSheetScaffoldState,
+    shippableItems: ShippableItemsUI,
+    shippingLines: List<ShippingLineSummaryUI>,
     markOrderComplete: Boolean,
     onMarkOrderCompleteChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
@@ -98,18 +100,26 @@ fun ShipmentDetails(
         }
     }
     if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-        ShipmentDetailsLandscape(modifier = modifier)
+        ShipmentDetailsLandscape(
+            shippableItems = shippableItems,
+            shippingLines = shippingLines,
+            modifier = modifier
+        )
     } else {
         ShipmentDetailsPortrait(
-            modifier = modifier,
+            shippableItems = shippableItems,
+            shippingLines = shippingLines,
             markOrderComplete = markOrderComplete,
-            onMarkOrderCompleteChange = onMarkOrderCompleteChange
+            onMarkOrderCompleteChange = onMarkOrderCompleteChange,
+            modifier = modifier
         )
     }
 }
 
 @Composable
 private fun ShipmentDetailsPortrait(
+    shippableItems: ShippableItemsUI,
+    shippingLines: List<ShippingLineSummaryUI>,
     markOrderComplete: Boolean,
     onMarkOrderCompleteChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
@@ -126,9 +136,9 @@ private fun ShipmentDetailsPortrait(
             OrderDetailsSection(
                 shipFrom = getShipFrom(),
                 shipTo = getShipTo(),
-                totalItems = 5,
-                totalItemsCost = "$120.99",
-                shippingLines = getShippingLines(3)
+                totalItems = shippableItems.shippableItems.size,
+                totalItemsCost = shippableItems.formattedTotalPrice,
+                shippingLines = shippingLines
             )
             Divider(modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.major_100)))
             ShipmentCostSection(
@@ -147,6 +157,8 @@ private fun ShipmentDetailsPortrait(
 
 @Composable
 private fun ShipmentDetailsLandscape(
+    shippableItems: ShippableItemsUI,
+    shippingLines: List<ShippingLineSummaryUI>,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
@@ -169,9 +181,9 @@ private fun ShipmentDetailsLandscape(
                     .fillMaxWidth()
             ) {
                 OrderDetailsSectionLandscape(
-                    totalItems = 5,
-                    totalItemsCost = "$120.99",
-                    shippingLines = getShippingLines(3),
+                    totalItems = shippableItems.shippableItems.size,
+                    totalItemsCost = shippableItems.formattedTotalPrice,
+                    shippingLines = shippingLines,
                     modifier = Modifier.weight(1f)
                 )
                 VerticalDivider(modifier = Modifier.padding(top = dimensionResource(R.dimen.major_100)))
@@ -214,7 +226,7 @@ private fun OrderDetailsSection(
     shipTo: Address,
     totalItems: Int,
     totalItemsCost: String,
-    shippingLines: List<ShippingLineSummary>,
+    shippingLines: List<ShippingLineSummaryUI>,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier.fillMaxWidth()) {
@@ -241,7 +253,7 @@ private fun OrderDetailsSection(
 private fun OrderDetailsSectionLandscape(
     totalItems: Int,
     totalItemsCost: String,
-    shippingLines: List<ShippingLineSummary>,
+    shippingLines: List<ShippingLineSummaryUI>,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier.fillMaxWidth()) {
@@ -266,7 +278,14 @@ private fun OrderDetailsSectionLandscape(
 fun ShipmentDetailsLandscapePreview() {
     WooThemeWithBackground {
         Surface {
-            ShipmentDetailsLandscape()
+            ShipmentDetailsLandscape(
+                shippableItems = ShippableItemsUI(
+                    shippableItems = generateItems(6),
+                    formattedTotalWeight = "8.5kg",
+                    formattedTotalPrice = "$92.78"
+                ),
+                shippingLines = getShippingLines()
+            )
         }
     }
 }
@@ -275,7 +294,7 @@ fun ShipmentDetailsLandscapePreview() {
 private fun TotalCard(
     totalItems: Int,
     totalItemsCost: String,
-    shippingLines: List<ShippingLineSummary>,
+    shippingLines: List<ShippingLineSummaryUI>,
     modifier: Modifier = Modifier
 ) {
     Column(modifier) {
@@ -314,7 +333,7 @@ private fun ItemsCostPreview() {
 
 @Composable
 private fun ShippingLines(
-    shippingLines: List<ShippingLineSummary>,
+    shippingLines: List<ShippingLineSummaryUI>,
     modifier: Modifier = Modifier
 ) {
     Column(modifier) {
@@ -445,8 +464,8 @@ private fun ShipmentCostSectionPreview() {
     }
 }
 
-private fun getShippingLines(number: Int = 3) = List(number) { i ->
-    ShippingLineSummary(
+fun getShippingLines(number: Int = 3) = List(number) { i ->
+    ShippingLineSummaryUI(
         title = "Shipping $i",
         amount = "$12.99"
     )
@@ -454,7 +473,7 @@ private fun getShippingLines(number: Int = 3) = List(number) { i ->
 
 fun Address.toShippingFromString() = this.getEnvelopeAddress().replace("\n", " ")
 
-data class ShippingLineSummary(
+data class ShippingLineSummaryUI(
     val title: String,
     val amount: String
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationScreen.kt
@@ -60,7 +60,8 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
             WooShippingLabelCreationScreen(
                 onSelectPackageClick = viewModel::onSelectPackageClicked,
                 onPurchaseShippingLabel = viewModel::onPurchaseShippingLabel,
-                shippableItems = viewState.shippableItems
+                shippableItems = viewState.shippableItems,
+                shippingLines = viewState.shippingLines
             )
         }
     }
@@ -70,6 +71,7 @@ fun WooShippingLabelCreationScreen(viewModel: WooShippingLabelCreationViewModel)
 @Composable
 fun WooShippingLabelCreationScreen(
     shippableItems: ShippableItemsUI,
+    shippingLines: List<ShippingLineSummaryUI>,
     modifier: Modifier = Modifier,
     onSelectPackageClick: () -> Unit,
     onPurchaseShippingLabel: () -> Unit
@@ -80,7 +82,8 @@ fun WooShippingLabelCreationScreen(
             shippableItems = shippableItems,
             modifier = modifier,
             onSelectPackageClick = onSelectPackageClick,
-            scaffoldState = scaffoldState
+            scaffoldState = scaffoldState,
+            shippingLines = shippingLines
         )
         val isDarkTheme = isSystemInDarkTheme()
         val isCollapsed = scaffoldState.bottomSheetState.isCollapsed
@@ -115,6 +118,7 @@ fun WooShippingLabelCreationScreen(
 @Composable
 private fun LabelCreationScreenWithBottomSheet(
     shippableItems: ShippableItemsUI,
+    shippingLines: List<ShippingLineSummaryUI>,
     modifier: Modifier = Modifier,
     onSelectPackageClick: () -> Unit,
     scaffoldState: BottomSheetScaffoldState
@@ -123,10 +127,12 @@ private fun LabelCreationScreenWithBottomSheet(
         sheetContent = {
             val markOrderComplete = remember { mutableStateOf(false) }
             ShipmentDetails(
-                modifier = Modifier.padding(bottom = 74.dp),
+                shippableItems = shippableItems,
+                shippingLines = shippingLines,
                 scaffoldState = scaffoldState,
                 markOrderComplete = markOrderComplete.value,
-                onMarkOrderCompleteChange = { markOrderComplete.value = it }
+                onMarkOrderCompleteChange = { markOrderComplete.value = it },
+                modifier = Modifier.padding(bottom = 74.dp),
             )
         },
         sheetPeekHeight = 132.dp,
@@ -204,6 +210,7 @@ private fun WooShippingLabelCreationScreenPreview() {
                 formattedTotalWeight = "8.5kg",
                 formattedTotalPrice = "$92.78"
             ),
+            shippingLines = getShippingLines(),
             modifier = Modifier.fillMaxSize(),
             onSelectPackageClick = {},
             onPurchaseShippingLabel = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.orders.wooshippinglabels
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.extensions.sumByFloat
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.models.StoreOptionsModel
@@ -12,7 +13,6 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -37,22 +37,22 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     init {
         launch {
             orderDetailRepository.getOrderById(navArgs.orderId)?.let { order ->
-                shippableItems.value = getShippableItems(order)
-            }
-        }
+                val items = getShippableItems(order)
+                shippableItems.value = items
 
-        launch {
-            shippableItems.filter { it.isNotEmpty() }.collect { items ->
-                val shippableItems = items.map { item -> item.toUIModel(currencyFormatter, storeOptions) }
+                val shippableItemsUI = items.map { item -> item.toUIModel(currencyFormatter, storeOptions) }
                 val formattedTotalPrice = getTotalPrice(items)
                 val formattedTotalWeight = getTotalWeight(items)
 
+                val shippingLineSummary = getShippingLinesSummary(order)
+
                 viewState.value = WooShippingViewState.DataState(
                     shippableItems = ShippableItemsUI(
-                        shippableItems = shippableItems,
+                        shippableItems = shippableItemsUI,
                         formattedTotalWeight = formattedTotalWeight,
                         formattedTotalPrice = formattedTotalPrice
-                    )
+                    ),
+                    shippingLines = shippingLineSummary
                 )
             }
         }
@@ -71,6 +71,15 @@ class WooShippingLabelCreationViewModel @Inject constructor(
         return "${totalWeight.formatToString()} ${storeOptions.weightUnit}"
     }
 
+    private fun getShippingLinesSummary(order: Order): List<ShippingLineSummaryUI> {
+        return order.shippingLines.map {
+            ShippingLineSummaryUI(
+                title = it.methodTitle,
+                amount = currencyFormatter.formatCurrency(it.total, order.currency)
+            )
+        }
+    }
+
     fun onSelectPackageClicked() {
         triggerEvent(StartPackageSelection)
     }
@@ -85,7 +94,8 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     sealed class WooShippingViewState {
         data object Loading : WooShippingViewState()
         data class DataState(
-            val shippableItems: ShippableItemsUI
+            val shippableItems: ShippableItemsUI,
+            val shippingLines: List<ShippingLineSummaryUI>
         ) : WooShippingViewState()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -1,0 +1,102 @@
+package com.woocommerce.android.ui.orders.wooshippinglabels
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.ui.orders.wooshippinglabels.WooShippingLabelCreationViewModel.WooShippingViewState
+import com.woocommerce.android.ui.orders.wooshippinglabels.models.ShippableItemModel
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
+    private val orderId = 1L
+    private val defaultShippableItems = List(3) {
+        ShippableItemModel(
+            itemId = it.toLong(),
+            productId = it.toLong(),
+            title = "Product $it",
+            price = BigDecimal(it),
+            quantity = it.toFloat(),
+            weight = it.toFloat(),
+            currency = "USD",
+            imageUrl = "https://example.com/image.jpg",
+            width = it.toFloat(),
+            height = it.toFloat(),
+            length = it.toFloat()
+        )
+    }
+    private val defaultShippingLines = List(3) {
+        Order.ShippingLine(
+            methodTitle = "Shipping Line $it",
+            total = BigDecimal(it),
+            methodId = it.toString(),
+            itemId = it.toLong(),
+            totalTax = BigDecimal.ZERO,
+        )
+    }
+    private val orderDetailRepository: OrderDetailRepository = mock()
+    private val getShippableItems: GetShippableItems = mock()
+    private val currencyFormatter: CurrencyFormatter = mock {
+        on { formatCurrency(any<BigDecimal>(), any(), any()) } doAnswer {
+            val amount = it.getArgument(0) as BigDecimal
+            "$ ${amount.toPlainString()}"
+        }
+    }
+    private val savedState: SavedStateHandle =
+        WooShippingLabelCreationFragmentArgs(orderId = orderId).toSavedStateHandle()
+
+    private lateinit var sut: WooShippingLabelCreationViewModel
+
+    fun createViewModel() {
+        sut = WooShippingLabelCreationViewModel(
+            orderDetailRepository = orderDetailRepository,
+            getShippableItems = getShippableItems,
+            currencyFormatter = currencyFormatter,
+            savedState = savedState
+        )
+    }
+
+    @Test
+    fun `when the order NO contains shipping lines, then NO shipping lines summary is displayed`() = testBlocking {
+        val order = OrderTestUtils.generateTestOrder(orderId = orderId).copy(
+            shippingLines = emptyList()
+        )
+        whenever(orderDetailRepository.getOrderById(any())) doReturn order
+        whenever(getShippableItems(any())) doReturn defaultShippableItems
+
+        createViewModel()
+
+        val currentViewState = sut.viewState.value
+        assert(currentViewState is WooShippingViewState.DataState)
+        val dataState = currentViewState as WooShippingViewState.DataState
+        assert(dataState.shippingLines.isEmpty())
+    }
+
+    @Test
+    fun `when the order contains shipping lines, then shipping lines summary is displayed`() = testBlocking {
+        val order = OrderTestUtils.generateTestOrder(orderId = orderId).copy(
+            shippingLines = defaultShippingLines
+        )
+        whenever(orderDetailRepository.getOrderById(any())) doReturn order
+        whenever(getShippableItems(any())) doReturn defaultShippableItems
+
+        createViewModel()
+
+        val currentViewState = sut.viewState.value
+        assert(currentViewState is WooShippingViewState.DataState)
+        val dataState = currentViewState as WooShippingViewState.DataState
+        assert(dataState.shippingLines.isNotEmpty())
+        assertEquals(dataState.shippingLines.size, defaultShippingLines.size)
+    }
+}


### PR DESCRIPTION
Part of: https://github.com/woocommerce/woocommerce-android/issues/12998

### Description
This PR connects the shipping lines section inside the shipment details bottom sheet with real data (order's shipping lines).
To achieve this, I'm mapping the shipping lines from the order into ShippingLineSumary and exposing them to the view state.

### Testing information

TC1

1. Create an Order with the processing status on a store that can create shipping labels
2. Tap on Orders
3. Tap on the order created in step 1
4. Add some shipping lines
5. Tap on create shipping labels
6. Expand the shipment details section
7. Check that the shipping lines & items sections in the shipment details bottom sheet are accurate

TC2

1. Create an Order with the processing status on a store that can create shipping labels
2. Tap on Orders
3. Tap on the order created in step 1
4. Tap on create shipping labels
5. Expand the shipment details section
6. Check that the shipping lines & items sections in the shipment details bottom sheet are accurate (no shipping lines)

### The tests that have been performed
Checking the UI works as expected

### Images/gif

https://github.com/user-attachments/assets/8dcdf3f9-2f84-48da-9641-b6839e11c536

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->