### PR TITLE
Product details: Do not show "one time shipping" label on Simple Product

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,8 +4,10 @@
 21.3
 -----
 - [*] "One time shipping" label in Product Subscriptions now matches its availability state correctly. [https://github.com/woocommerce/woocommerce-android/pull/13021]
+- [*] "One time shipping" label should not be shown in Simple product after conversion from Subscriptions product. [https://github.com/woocommerce/woocommerce-android/pull/13032]
 - [Internal] Refactored IPP Payment flow to allow customizing payment collection UI in POS [https://github.com/woocommerce/woocommerce-android/pull/13014]
 - [*] Blaze Campaign Intro screen now offers creating a new product if the site has no products yet [https://github.com/woocommerce/woocommerce-android/pull/13001]
+
 
 -----
 21.2

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilder.kt
@@ -483,8 +483,8 @@ class ProductDetailCardBuilder(
                     viewModel.getShippingClassByRemoteShippingClassId(currentProduct.shippingClassId)
                 )
 
-                // Only add "One time shipping" info if product is subscription type
-                if (currentProduct.productType == SUBSCRIPTION) {
+                // Only add "One time shipping" info if product is Subscription types
+                if (currentProduct.productType == SUBSCRIPTION || currentProduct.productType == VARIABLE_SUBSCRIPTION) {
                     put(
                         resources.getString(string.subscription_one_time_shipping),
                         buildOneTimeShippingDescription(subscription)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilder.kt
@@ -471,21 +471,26 @@ class ProductDetailCardBuilder(
 
     @Suppress("LongMethod")
     private fun ProductAggregate.shipping(): ProductProperty? {
-        return if (!this.product.isVirtual && hasShipping) {
+        val currentProduct = this.product
+        return if (!currentProduct.isVirtual && hasShipping) {
             val weightWithUnits = product.getWeightWithUnits(parameters.weightUnit)
             val sizeWithUnits = product.getSizeWithUnits(parameters.dimensionUnit)
-            val shippingGroup = mapOf(
-                Pair(resources.getString(string.product_weight), weightWithUnits),
-                Pair(resources.getString(string.product_dimensions), sizeWithUnits),
-                Pair(
+            val shippingGroup = buildMap {
+                put(resources.getString(string.product_weight), weightWithUnits)
+                put(resources.getString(string.product_dimensions), sizeWithUnits)
+                put(
                     resources.getString(string.product_shipping_class),
-                    viewModel.getShippingClassByRemoteShippingClassId(this.product.shippingClassId)
-                ),
-                Pair(
-                    resources.getString(string.subscription_one_time_shipping),
-                    buildOneTimeShippingDescription(subscription)
+                    viewModel.getShippingClassByRemoteShippingClassId(currentProduct.shippingClassId)
                 )
-            )
+
+                // Only add "One time shipping" info if product is subscription type
+                if (currentProduct.productType == SUBSCRIPTION) {
+                    put(
+                        resources.getString(string.subscription_one_time_shipping),
+                        buildOneTimeShippingDescription(subscription)
+                    )
+                }
+            }
 
             PropertyGroup(
                 string.product_shipping,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilderTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.model.ProductAggregate
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
 import com.woocommerce.android.ui.customfields.CustomFieldsRepository
+import com.woocommerce.android.ui.products.ProductHelper
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.addons.AddonRepository
@@ -35,6 +36,10 @@ class ProductDetailCardBuilderTest : BaseUnitTest() {
     }
     private val customFieldsRepository: CustomFieldsRepository = mock {
         onBlocking { hasDisplayableCustomFields(any()) } doReturn false
+    }
+
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(any()) } doAnswer { it.getArgument<Any?>(0).toString() }
     }
 
     @Before
@@ -193,5 +198,74 @@ class ProductDetailCardBuilderTest : BaseUnitTest() {
                 it.title == R.string.product_custom_fields
         }
         Assertions.assertThat(customFieldsCard).isNull()
+    }
+
+    @Test
+    fun `given subscription product with one time shipping enabled, when building cards, then shipping includes one-time shipping`() = testBlocking {
+        productStub = ProductTestUtils.generateProduct()
+            .copy(
+                isVirtual = false,
+                type = ProductType.SUBSCRIPTION.value,
+                weight = 1.5f,
+                length = 10f,
+                width = 20f,
+                height = 30f,
+                shippingClassId = 123
+            )
+
+        val subscriptionDetails = ProductHelper.getDefaultSubscriptionDetails().copy(
+            oneTimeShipping = true
+        )
+
+        val cards = sut.buildPropertyCards(
+            ProductAggregate(
+                product = productStub,
+                subscription = subscriptionDetails
+            ),
+            ""
+        )
+
+        val shippingGroup = cards.first { it.type == ProductPropertyCard.Type.SECONDARY }
+            .properties
+            .find {
+                it is ProductProperty.PropertyGroup &&
+                    it.title == R.string.product_shipping
+            } as ProductProperty.PropertyGroup
+
+        val propertyKeys = shippingGroup.properties.toList().map { it.first }
+        Assertions.assertThat(propertyKeys).hasSize(4) // Weight, Dimensions, Shipping class, One-time shipping
+        Assertions.assertThat(propertyKeys).contains(
+            resourceProvider.getString(R.string.subscription_one_time_shipping)
+        )
+    }
+
+    @Test
+    fun `given simple non-virtual product, when building cards, then shipping excludes one-time shipping`() = testBlocking {
+        productStub = ProductTestUtils.generateProduct()
+            .copy(
+                isVirtual = false,
+                type = ProductType.SIMPLE.value,
+                weight = 1.5f,
+                length = 10f,
+                width = 20f,
+                height = 30f,
+                shippingClassId = 123
+            )
+
+        val cards = sut.buildPropertyCards(ProductAggregate(productStub), "")
+
+        val shippingGroup = cards.first { it.type == ProductPropertyCard.Type.SECONDARY }
+            .properties
+            .find {
+                it is ProductProperty.PropertyGroup &&
+                    it.title == R.string.product_shipping
+            } as ProductProperty.PropertyGroup
+
+        val propertyKeys = shippingGroup.properties.toList().map { it.first }
+
+        Assertions.assertThat(propertyKeys).hasSize(3) // Weight, Dimensions, Shipping class
+        Assertions.assertThat(propertyKeys).doesNotContain(
+            resourceProvider.getString(R.string.subscription_one_time_shipping)
+        )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilderTest.kt
@@ -240,6 +240,45 @@ class ProductDetailCardBuilderTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given variable subscription product with one time shipping enabled, when building cards, then shipping includes one-time shipping`() = testBlocking {
+        productStub = ProductTestUtils.generateProduct()
+            .copy(
+                isVirtual = false,
+                type = ProductType.VARIABLE_SUBSCRIPTION.value,
+                weight = 1.5f,
+                length = 10f,
+                width = 20f,
+                height = 30f,
+                shippingClassId = 123
+            )
+
+        val subscriptionDetails = ProductHelper.getDefaultSubscriptionDetails().copy(
+            oneTimeShipping = true
+        )
+
+        val cards = sut.buildPropertyCards(
+            ProductAggregate(
+                product = productStub,
+                subscription = subscriptionDetails
+            ),
+            ""
+        )
+
+        val shippingGroup = cards.first { it.type == ProductPropertyCard.Type.SECONDARY }
+            .properties
+            .find {
+                it is ProductProperty.PropertyGroup &&
+                    it.title == R.string.product_shipping
+            } as ProductProperty.PropertyGroup
+
+        val propertyKeys = shippingGroup.properties.toList().map { it.first }
+        Assertions.assertThat(propertyKeys).hasSize(4) // Weight, Dimensions, Shipping class, One-time shipping
+        Assertions.assertThat(propertyKeys).contains(
+            resourceProvider.getString(R.string.subscription_one_time_shipping)
+        )
+    }
+
+    @Test
     fun `given simple non-virtual product, when building cards, then shipping excludes one-time shipping`() = testBlocking {
         productStub = ProductTestUtils.generateProduct()
             .copy(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -208,8 +208,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
                             resources.getString(R.string.product_dimensions),
                             productWithParameters.productDraft?.getSizeWithUnits(siteParams.dimensionUnit) ?: ""
                         ),
-                        Pair(resources.getString(R.string.product_shipping_class), ""),
-                        Pair(resources.getString(R.string.subscription_one_time_shipping), "")
+                        Pair(resources.getString(R.string.product_shipping_class), "")
                     ),
                     R.drawable.ic_gridicons_shipping,
                     true


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13027
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When a subscription product that has "One time shipping" enabled get converted into simple product, "One time shipping" label is still shown. This is incorrect because "one time shipping" is only supported in subscription product, not simple.

This PR adds the fix by checking product type and not showing the label if it's simple.

That issue is not tackled here yet.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Create a Simple Subscription product,
2. Go to Add More Details > Shipping,
3. Enter a weight value, and enable "One time shipping", then press back,
4. Confirm that "Shipping" card is shown with "One time shipping: Enabled" text shown,
5. Publish the product,
6. Once published, tap "Product Type" card and switch to "Simple Physical Product", confirm the change,
7. Check the "Shipping" card and ensure it now only says "Weight" and doesn't mention "One time shipping".

### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Tested in API 35 with Simulator.

I also discovered a separate issue when working on this:

[Given product details with "one time shipping" enabled but no other shipping values entered, when switching to simple product, Shipping card disappears](https://github.com/woocommerce/woocommerce-android/issues/13033)

This issue is not tackled in this PR.

### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->
The listed steps above.


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/8897e15d-5c6c-4dfb-8b4c-5cb676146454



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->