### PR TITLE
Product details: Keep Shipping card with One Time Shipping available when changing from Subscription to Non-Subscription Type Product

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [*] "One time shipping" label in Product Subscriptions now matches its availability state correctly. [https://github.com/woocommerce/woocommerce-android/pull/13021]
 - [*] "One time shipping" label should not be shown in Simple product after conversion from Subscriptions product. [https://github.com/woocommerce/woocommerce-android/pull/13032]
+- [*] Fixed bug related to missing Shipping card in Product details when converting from Subscriptions to Simple product. [https://github.com/woocommerce/woocommerce-android/pull/13035]
 - [Internal] Refactored IPP Payment flow to allow customizing payment collection UI in POS [https://github.com/woocommerce/woocommerce-android/pull/13014]
 - [*] Blaze Campaign Intro screen now offers creating a new product if the site has no products yet [https://github.com/woocommerce/woocommerce-android/pull/13001]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 -----
 - [*] "One time shipping" label in Product Subscriptions now matches its availability state correctly. [https://github.com/woocommerce/woocommerce-android/pull/13021]
 - [*] "One time shipping" label should not be shown in Simple product after conversion from Subscriptions product. [https://github.com/woocommerce/woocommerce-android/pull/13032]
-- [*] Fixed bug related to missing Shipping card in Product details when converting from Subscriptions to Simple product. [https://github.com/woocommerce/woocommerce-android/pull/13035]
+- [*] Fixed a bug related to incorrect Shipping settings in Product details when converting from Subscriptions to Simple product. [https://github.com/woocommerce/woocommerce-android/pull/13035]
 - [Internal] Refactored IPP Payment flow to allow customizing payment collection UI in POS [https://github.com/woocommerce/woocommerce-android/pull/13014]
 - [*] Blaze Campaign Intro screen now offers creating a new product if the site has no products yet [https://github.com/woocommerce/woocommerce-android/pull/13001]
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -2740,7 +2740,7 @@ class ProductDetailViewModel @Inject constructor(
             }
         )
 
-        fun copy(subscriptionDraft: SubscriptionDetails) = copy(
+        fun copy(subscriptionDraft: SubscriptionDetails?) = copy(
             productAggregateDraft = productAggregateDraft?.copy(subscription = subscriptionDraft)
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -2740,7 +2740,7 @@ class ProductDetailViewModel @Inject constructor(
             }
         )
 
-        fun copy(subscriptionDraft: SubscriptionDetails?) = copy(
+        fun copy(subscriptionDraft: SubscriptionDetails) = copy(
             productAggregateDraft = productAggregateDraft?.copy(subscription = subscriptionDraft)
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -1226,6 +1226,13 @@ class ProductDetailViewModel @Inject constructor(
         productType: ProductType,
         isVirtual: Boolean
     ) {
+        // Reset subscription data that might have existed to null when changing type to non-subscription product type.
+        // This avoids any Product Details card conflicts after conversion (e.g: displaying Subscription-related info
+        // in a non-subscription product)
+        if (productType != ProductType.SUBSCRIPTION) {
+            viewState = viewState.copy(subscriptionDraft = null)
+        }
+
         updateProductDraft(type = productType.value, isVirtual = isVirtual)
 
         viewState.productAggregateDraft?.let { productAggregateDraft ->
@@ -2731,7 +2738,7 @@ class ProductDetailViewModel @Inject constructor(
             }
         )
 
-        fun copy(subscriptionDraft: SubscriptionDetails) = copy(
+        fun copy(subscriptionDraft: SubscriptionDetails?) = copy(
             productAggregateDraft = productAggregateDraft?.copy(subscription = subscriptionDraft)
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -1226,23 +1226,25 @@ class ProductDetailViewModel @Inject constructor(
         productType: ProductType,
         isVirtual: Boolean
     ) {
-        // Reset subscription data that might have existed to null when changing type to non-subscription product type.
-        // This avoids any Product Details card conflicts after conversion (e.g: displaying Subscription-related info
-        // in a non-subscription product)
-        if (productType != ProductType.SUBSCRIPTION) {
-            viewState = viewState.copy(subscriptionDraft = null)
-        }
-
         updateProductDraft(type = productType.value, isVirtual = isVirtual)
 
         viewState.productAggregateDraft?.let { productAggregateDraft ->
-            if (productType == ProductType.SUBSCRIPTION && productAggregateDraft.subscription == null) {
-                viewState = viewState.copy(
-                    subscriptionDraft = ProductHelper.getDefaultSubscriptionDetails().copy(
-                        price = productAggregateDraft.product.regularPrice
-                    )
-                )
-            }
+            viewState = viewState.copy(
+                subscriptionDraft = when {
+                    // If converting to subscription product, set the default subscription details
+                    productType == ProductType.SUBSCRIPTION && productAggregateDraft.subscription == null ->
+                        ProductHelper.getDefaultSubscriptionDetails().copy(
+                            price = productAggregateDraft.product.regularPrice
+                        )
+
+                    // If converting to non-subscription products, reset subscription data that might have existed
+                    // (e.g: if the original product is of subscription type).
+                    // This avoids any Product Details card conflicts that can happen after conversion.
+                    productType !in setOf(ProductType.SUBSCRIPTION, ProductType.VARIABLE_SUBSCRIPTION) -> null
+
+                    else -> viewState.subscriptionDraft
+                }
+            )
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -199,16 +199,4 @@ object ProductTestUtils {
             return this
         }
     }
-
-    fun generateProductSubscriptionDetails() = SubscriptionDetails(
-        price = BigDecimal.TEN,
-        period = SubscriptionPeriod.Month,
-        periodInterval = 1,
-        length = null,
-        signUpFee = null,
-        trialPeriod = null,
-        trialLength = null,
-        oneTimeShipping = true,
-        paymentsSyncDate = null
-    )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -5,10 +5,13 @@ import com.woocommerce.android.model.ProductAttribute
 import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.model.ProductVariation
+import com.woocommerce.android.model.SubscriptionDetails
+import com.woocommerce.android.model.SubscriptionPeriod
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.ui.products.ProductStatus.DRAFT
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
+import java.math.BigDecimal
 import java.sql.Date
 import java.time.Instant
 
@@ -196,4 +199,17 @@ object ProductTestUtils {
             return this
         }
     }
+
+    fun generateProductSubscriptionDetails() = SubscriptionDetails(
+        price = BigDecimal.TEN,
+        period = SubscriptionPeriod.Month,
+        periodInterval = 1,
+        length = null,
+        signUpFee = null,
+        trialPeriod = null,
+        trialLength = null,
+        oneTimeShipping = true,
+        paymentsSyncDate = null
+    )
+
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -211,5 +211,4 @@ object ProductTestUtils {
         oneTimeShipping = true,
         paymentsSyncDate = null
     )
-
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ProductTestUtils.kt
@@ -5,13 +5,10 @@ import com.woocommerce.android.model.ProductAttribute
 import com.woocommerce.android.model.ProductCategory
 import com.woocommerce.android.model.ProductTag
 import com.woocommerce.android.model.ProductVariation
-import com.woocommerce.android.model.SubscriptionDetails
-import com.woocommerce.android.model.SubscriptionPeriod
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.ui.products.ProductStatus.DRAFT
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
-import java.math.BigDecimal
 import java.sql.Date
 import java.time.Instant
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -978,7 +978,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         doReturn(
             productAggregate.copy(product = productAggregate.product.copy(regularPrice = BigDecimal(99)))
         ).whenever(productRepository).getProductAggregate(any())
-        viewModel.productDetailViewStateData.observeForever { _, _ -> }
         viewModel.start()
 
         viewModel.updateProductDraft(sku = "E9999999")
@@ -991,7 +990,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         doReturn(
             productAggregate.copy(product = productAggregate.product.copy(salePrice = BigDecimal(99)))
         ).whenever(productRepository).getProductAggregate(any())
-        viewModel.productDetailViewStateData.observeForever { _, _ -> }
         viewModel.start()
 
         viewModel.updateProductDraft(sku = "E9999999")
@@ -1004,7 +1002,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         doReturn(
             productAggregate.copy(product = productAggregate.product.copy(regularPrice = BigDecimal(99)))
         ).whenever(productRepository).getProductAggregate(any())
-        viewModel.productDetailViewStateData.observeForever { _, _ -> }
         viewModel.start()
 
         viewModel.updateProductDraft(regularPrice = BigDecimal(0))
@@ -1017,7 +1014,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         doReturn(
             productAggregate.copy(product = productAggregate.product.copy(regularPrice = BigDecimal(99)))
         ).whenever(productRepository).getProductAggregate(any())
-        viewModel.productDetailViewStateData.observeForever { _, _ -> }
         viewModel.start()
 
         viewModel.updateProductDraft(salePrice = BigDecimal(0))
@@ -1030,7 +1026,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         doReturn(
             productAggregate.copy(product = productAggregate.product.copy(regularPrice = BigDecimal(99)))
         ).whenever(productRepository).getProductAggregate(any())
-        viewModel.productDetailViewStateData.observeForever { _, _ -> }
         viewModel.start()
 
         viewModel.updateProductDraft(regularPrice = null)
@@ -1043,7 +1038,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         doReturn(
             productAggregate.copy(product = productAggregate.product.copy(regularPrice = BigDecimal(99)))
         ).whenever(productRepository).getProductAggregate(any())
-        viewModel.productDetailViewStateData.observeForever { _, _ -> }
         viewModel.start()
 
         viewModel.updateProductDraft(salePrice = null)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -1254,7 +1254,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             subscription = ProductTestUtils.generateProductSubscriptionDetails()
         )
         doReturn(subscriptionProduct).whenever(productRepository).getProductAggregate(any())
-        viewModel.productDetailViewStateData.observeForever { _, _ -> }
         viewModel.start()
 
         // Verify initial state has subscription data
@@ -1278,7 +1277,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             subscription = null
         )
         doReturn(simpleProduct).whenever(productRepository).getProductAggregate(any())
-        viewModel.productDetailViewStateData.observeForever { _, _ -> }
         viewModel.start()
 
         // Verify initial state has no subscription data
@@ -1307,7 +1305,6 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             subscription = ProductTestUtils.generateProductSubscriptionDetails()
         )
         doReturn(subscriptionProduct).whenever(productRepository).getProductAggregate(any())
-        viewModel.productDetailViewStateData.observeForever { _, _ -> }
         viewModel.start()
 
         val originalSubscription = viewModel.getProduct().subscriptionDraft

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductTestUtils
+import com.woocommerce.android.ui.products.ProductType
 import com.woocommerce.android.ui.products.addons.AddonRepository
 import com.woocommerce.android.ui.products.categories.ProductCategoriesRepository
 import com.woocommerce.android.ui.products.models.ProductProperty
@@ -1242,6 +1243,81 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             Assertions.assertThat(viewState.draftPassword).isNull()
             verify(productRepository, never()).fetchProductPassword(any())
         }
+
+    @Test
+    fun `When converting from subscription to simple product, subscription data is cleared`() = testBlocking {
+        // GIVEN
+        val subscriptionProduct = productAggregate.copy(
+            product = productAggregate.product.copy(
+                type = ProductType.SUBSCRIPTION.value
+            ),
+            subscription = ProductTestUtils.generateProductSubscriptionDetails()
+        )
+        doReturn(subscriptionProduct).whenever(productRepository).getProductAggregate(any())
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        viewModel.start()
+
+        // Verify initial state has subscription data
+        Assertions.assertThat(viewModel.getProduct().subscriptionDraft).isNotNull()
+
+        // WHEN
+        viewModel.onProductTypeChanged(ProductType.SIMPLE, false)
+
+        // THEN
+        Assertions.assertThat(viewModel.getProduct().subscriptionDraft).isNull()
+    }
+
+    @Test
+    fun `When converting from simple to subscription product, default subscription data is added`() = testBlocking {
+        // GIVEN
+        val simpleProduct = productAggregate.copy(
+            product = productAggregate.product.copy(
+                type = ProductType.SIMPLE.value,
+                regularPrice = BigDecimal("10.00")
+            ),
+            subscription = null
+        )
+        doReturn(simpleProduct).whenever(productRepository).getProductAggregate(any())
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        viewModel.start()
+
+        // Verify initial state has no subscription data
+        Assertions.assertThat(viewModel.getProduct().subscriptionDraft).isNull()
+
+        // WHEN
+        viewModel.onProductTypeChanged(ProductType.SUBSCRIPTION, false)
+
+        // THEN
+        viewModel.getProduct().subscriptionDraft?.let {
+            Assertions.assertThat(it.price).isEqualTo(simpleProduct.product.regularPrice)
+            Assertions.assertThat(it.period)
+                .isEqualTo(ProductTestUtils.generateProductSubscriptionDetails().period)
+            Assertions.assertThat(it.periodInterval)
+                .isEqualTo(ProductTestUtils.generateProductSubscriptionDetails().periodInterval)
+        } ?: Assertions.fail("Subscription draft should not be null")
+    }
+
+    @Test
+    fun `When converting from simple subscription to variable subscription product, subscription data is preserved`() = testBlocking {
+        // GIVEN
+        val subscriptionProduct = productAggregate.copy(
+            product = productAggregate.product.copy(
+                type = ProductType.SUBSCRIPTION.value
+            ),
+            subscription = ProductTestUtils.generateProductSubscriptionDetails()
+        )
+        doReturn(subscriptionProduct).whenever(productRepository).getProductAggregate(any())
+        viewModel.productDetailViewStateData.observeForever { _, _ -> }
+        viewModel.start()
+
+        val originalSubscription = viewModel.getProduct().subscriptionDraft
+
+        // WHEN
+        viewModel.onProductTypeChanged(ProductType.VARIABLE_SUBSCRIPTION, false)
+
+        // THEN
+        Assertions.assertThat(viewModel.getProduct().subscriptionDraft).isEqualTo(originalSubscription)
+    }
 
     private val productsDraft
         get() = viewModel.productDetailViewStateData.liveData.value?.productDraft

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.blaze.IsBlazeEnabled
 import com.woocommerce.android.ui.customfields.CustomFieldsRepository
 import com.woocommerce.android.ui.media.MediaFileUploadHandler
 import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.ui.products.ProductHelper
 import com.woocommerce.android.ui.products.ProductStatus
 import com.woocommerce.android.ui.products.ProductTestUtils
 import com.woocommerce.android.ui.products.ProductType
@@ -1245,7 +1246,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             product = productAggregate.product.copy(
                 type = ProductType.SUBSCRIPTION.value
             ),
-            subscription = ProductTestUtils.generateProductSubscriptionDetails()
+            subscription = ProductHelper.getDefaultSubscriptionDetails()
         )
         doReturn(subscriptionProduct).whenever(productRepository).getProductAggregate(any())
         viewModel.start()
@@ -1283,9 +1284,9 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         viewModel.getProduct().subscriptionDraft?.let {
             Assertions.assertThat(it.price).isEqualTo(simpleProduct.product.regularPrice)
             Assertions.assertThat(it.period)
-                .isEqualTo(ProductTestUtils.generateProductSubscriptionDetails().period)
+                .isEqualTo(ProductHelper.getDefaultSubscriptionDetails().period)
             Assertions.assertThat(it.periodInterval)
-                .isEqualTo(ProductTestUtils.generateProductSubscriptionDetails().periodInterval)
+                .isEqualTo(ProductHelper.getDefaultSubscriptionDetails().periodInterval)
         } ?: Assertions.fail("Subscription draft should not be null")
     }
 
@@ -1296,7 +1297,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             product = productAggregate.product.copy(
                 type = ProductType.SUBSCRIPTION.value
             ),
-            subscription = ProductTestUtils.generateProductSubscriptionDetails()
+            subscription = ProductHelper.getDefaultSubscriptionDetails()
         )
         doReturn(subscriptionProduct).whenever(productRepository).getProductAggregate(any())
         viewModel.start()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13033 

<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR handles the edge case bug outlined in #13033: when converting from Simple Subscription or Variable Subscription to Simple Physical product, and the subscription product has "One time shipping" enabled but no other shipping values, then the Shipping card would disappear after the conversion, making it impossible to set Shipping.

**Why does this happen?**
The issue happens inside `ProductDetailViewModel.onProductTypeChanged()`. When it is called, `updateProductDraft()` does not take into account the existing `subscriptionDraft` that the product has from when it was originally a subscription product. When a Product becomes a simply physical but its `subscriptionDraft` value still exists, it causes issue with how cards are displayed.

With the issue in #13033 specifically, because `subscriptionDraft` still exists, this returns true:

https://github.com/woocommerce/woocommerce-android/blob/509b9c9c3c7efc59ab8004838ac8e7a025ed0b7b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/ProductAggregate.kt#L22-L23

which then makes the app try to show the Shipping card on 

https://github.com/woocommerce/woocommerce-android/blob/509b9c9c3c7efc59ab8004838ac8e7a025ed0b7b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilder.kt#L473-L474

However because there are no other values aside from One time shipping, and One time shipping display is gated behind Subscription product type check, nothing is shown for this card as there's nothing to show. 

And again due to the `hasShipping` check, it becomes unavailable in "Add more details", too:

https://github.com/woocommerce/woocommerce-android/blob/509b9c9c3c7efc59ab8004838ac8e7a025ed0b7b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailBottomSheetBuilder.kt#L109-L110


**Solution:**
The fix in this PR is to reset the data inside `subscriptionDraft` whenever converting to a non simple/variable subscription product. That way `hasShipping` will properly return false and the checks above will behave correctly.

### Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Create a Simple Subscription product,
2. Go to Add More Details > Shipping,
3. Enable "One time shipping" but don't fill in another values, then press back,
4. Publish the product,
5. Once published, tap "Product Type" card and switch to "Simple Physical Product", confirm the change,
6. Confirm that "Shipping" is not listed there. But, if you tap "Add More Details", you should see the "Shipping" option there.

Also to test: 
- Try the above also but from Variable Subscription product to simple physical product. The result should be the same.
- Try converting from Simple Subscription to Variable Subscription. The Shipping card should not be removed and the "One time shipping" label and setting should be preserved.
- Try the above also but with some values inside Shipping (weight, length, etc) in addition to "One time shipping". The Shipping card should still exist and showing the right values (minus "One time shipping") after converting to Simple physical product.


### Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested this in an emulator with API 35. 



### The tests that have been performed
<!-- To give the reviewer an idea of what could be missed in terms of testing -->

All the tests listed above.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->