### PR TITLE
[Dashboard] Add corruption handlers to Data Stores using Protocol Buffer schemas.

### DIFF
--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/di/DataStoreModule.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/di/DataStoreModule.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStoreFile
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.wear.datastore.DataStoreQualifier
 import com.woocommerce.android.wear.datastore.DataStoreType.LOGIN
 import com.woocommerce.android.wear.datastore.DataStoreType.ORDERS
@@ -27,10 +28,14 @@ class DataStoreModule {
     @DataStoreQualifier(LOGIN)
     fun provideLoginDataStore(
         appContext: Context,
+        crashLogging: CrashLogging,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = { appContext.preferencesDataStoreFile(LOGIN.typeName) },
-        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+        corruptionHandler = ReplaceFileCorruptionHandler {
+            crashLogging.recordEvent("Corrupted data store: Wear ${LOGIN.typeName}")
+            emptyPreferences()
+        },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 
@@ -39,10 +44,14 @@ class DataStoreModule {
     @DataStoreQualifier(STATS)
     fun provideStatsDataStore(
         appContext: Context,
+        crashLogging: CrashLogging,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = { appContext.preferencesDataStoreFile(STATS.typeName) },
-        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+        corruptionHandler = ReplaceFileCorruptionHandler {
+            crashLogging.recordEvent("Corrupted data store: Wear ${STATS.typeName}")
+            emptyPreferences()
+        },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 
@@ -51,10 +60,14 @@ class DataStoreModule {
     @DataStoreQualifier(ORDERS)
     fun provideOrdersDataStore(
         appContext: Context,
+        crashLogging: CrashLogging,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = { appContext.preferencesDataStoreFile(ORDERS.typeName) },
-        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+        corruptionHandler = ReplaceFileCorruptionHandler {
+            crashLogging.recordEvent("Corrupted data store: Wear ${ORDERS.typeName}")
+            emptyPreferences()
+        },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/di/DataStoreModule.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/di/DataStoreModule.kt
@@ -2,8 +2,10 @@ package com.woocommerce.android.wear.di
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStoreFile
 import com.woocommerce.android.wear.datastore.DataStoreQualifier
 import com.woocommerce.android.wear.datastore.DataStoreType.LOGIN
@@ -28,6 +30,7 @@ class DataStoreModule {
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = { appContext.preferencesDataStoreFile(LOGIN.typeName) },
+        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 
@@ -39,6 +42,7 @@ class DataStoreModule {
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = { appContext.preferencesDataStoreFile(STATS.typeName) },
+        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 
@@ -50,6 +54,7 @@ class DataStoreModule {
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = { appContext.preferencesDataStoreFile(ORDERS.typeName) },
+        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 }

--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/di/DataStoreModule.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/di/DataStoreModule.kt
@@ -2,12 +2,9 @@ package com.woocommerce.android.wear.di
 
 import android.content.Context
 import androidx.datastore.core.DataStore
-import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStoreFile
-import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.wear.datastore.DataStoreQualifier
 import com.woocommerce.android.wear.datastore.DataStoreType.LOGIN
 import com.woocommerce.android.wear.datastore.DataStoreType.ORDERS
@@ -28,14 +25,9 @@ class DataStoreModule {
     @DataStoreQualifier(LOGIN)
     fun provideLoginDataStore(
         appContext: Context,
-        crashLogging: CrashLogging,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = { appContext.preferencesDataStoreFile(LOGIN.typeName) },
-        corruptionHandler = ReplaceFileCorruptionHandler {
-            crashLogging.recordEvent("Corrupted data store: Wear ${LOGIN.typeName}")
-            emptyPreferences()
-        },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 
@@ -44,14 +36,9 @@ class DataStoreModule {
     @DataStoreQualifier(STATS)
     fun provideStatsDataStore(
         appContext: Context,
-        crashLogging: CrashLogging,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = { appContext.preferencesDataStoreFile(STATS.typeName) },
-        corruptionHandler = ReplaceFileCorruptionHandler {
-            crashLogging.recordEvent("Corrupted data store: Wear ${STATS.typeName}")
-            emptyPreferences()
-        },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 
@@ -60,14 +47,9 @@ class DataStoreModule {
     @DataStoreQualifier(ORDERS)
     fun provideOrdersDataStore(
         appContext: Context,
-        crashLogging: CrashLogging,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = { appContext.preferencesDataStoreFile(ORDERS.typeName) },
-        corruptionHandler = ReplaceFileCorruptionHandler {
-            crashLogging.recordEvent("Corrupted data store: Wear ${ORDERS.typeName}")
-            emptyPreferences()
-        },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DashboardDataStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DashboardDataStoreModule.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.datastore
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.dataStoreFile
 import com.woocommerce.android.di.SiteComponent
 import com.woocommerce.android.di.SiteCoroutineScope
@@ -28,6 +29,9 @@ object DashboardDataStoreModule {
     ): DataStore<DashboardDataModel> = DataStoreFactory.create(
         produceFile = {
             appContext.dataStoreFile("dashboard_configuration_${site.id}")
+        },
+        corruptionHandler = ReplaceFileCorruptionHandler {
+            DashboardDataModel.getDefaultInstance()
         },
         scope = CoroutineScope(siteCoroutineScope.coroutineContext + Dispatchers.IO),
         serializer = DashboardSerializer

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DashboardDataStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DashboardDataStoreModule.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.dataStoreFile
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.di.SiteComponent
 import com.woocommerce.android.di.SiteCoroutineScope
 import com.woocommerce.android.di.SiteScope
@@ -24,6 +25,7 @@ object DashboardDataStoreModule {
     @SiteScope
     fun provideDashboardDataStore(
         appContext: Context,
+        crashLogging: CrashLogging,
         @SiteCoroutineScope siteCoroutineScope: CoroutineScope,
         site: SiteModel
     ): DataStore<DashboardDataModel> = DataStoreFactory.create(
@@ -31,6 +33,7 @@ object DashboardDataStoreModule {
             appContext.dataStoreFile("dashboard_configuration_${site.id}")
         },
         corruptionHandler = ReplaceFileCorruptionHandler {
+            crashLogging.recordEvent("Corrupted data store: Dashboard")
             DashboardDataModel.getDefaultInstance()
         },
         scope = CoroutineScope(siteCoroutineScope.coroutineContext + Dispatchers.IO),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DashboardDataStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DashboardDataStoreModule.kt
@@ -33,7 +33,7 @@ object DashboardDataStoreModule {
             appContext.dataStoreFile("dashboard_configuration_${site.id}")
         },
         corruptionHandler = ReplaceFileCorruptionHandler {
-            crashLogging.recordEvent("Corrupted data store: Dashboard")
+            crashLogging.recordEvent("Corrupted data store. DataStore Type: DASHBOARD")
             DashboardDataModel.getDefaultInstance()
         },
         scope = CoroutineScope(siteCoroutineScope.coroutineContext + Dispatchers.IO),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
-import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
@@ -8,9 +8,12 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStoreFile
+import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.woocommerce.android.datastore.DataStoreType.ANALYTICS_CONFIGURATION
 import com.woocommerce.android.datastore.DataStoreType.ANALYTICS_UI_CACHE
+import com.woocommerce.android.datastore.DataStoreType.COUPONS
 import com.woocommerce.android.datastore.DataStoreType.DASHBOARD_STATS
+import com.woocommerce.android.datastore.DataStoreType.LAST_UPDATE
 import com.woocommerce.android.datastore.DataStoreType.TOP_PERFORMER_PRODUCTS
 import com.woocommerce.android.datastore.DataStoreType.TRACKER
 import com.woocommerce.android.di.AppCoroutineScope
@@ -32,12 +35,16 @@ class DataStoreModule {
     @DataStoreQualifier(TRACKER)
     fun provideTrackerDataStore(
         appContext: Context,
+        crashLogging: CrashLogging,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = {
             appContext.preferencesDataStoreFile("tracker")
         },
-        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+        corruptionHandler = ReplaceFileCorruptionHandler {
+            crashLogging.recordEvent("Corrupted data store. DataStore Type: ${TRACKER.name}")
+            emptyPreferences()
+        },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 
@@ -46,12 +53,16 @@ class DataStoreModule {
     @DataStoreQualifier(ANALYTICS_UI_CACHE)
     fun provideAnalyticsDataStore(
         appContext: Context,
+        crashLogging: CrashLogging,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = {
             appContext.preferencesDataStoreFile("analytics")
         },
-        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+        corruptionHandler = ReplaceFileCorruptionHandler {
+            crashLogging.recordEvent("Corrupted data store. DataStore Type: ${ANALYTICS_UI_CACHE.name}")
+            emptyPreferences()
+        },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 
@@ -60,12 +71,16 @@ class DataStoreModule {
     @DataStoreQualifier(ANALYTICS_CONFIGURATION)
     fun provideAnalyticsConfigurationDataStore(
         appContext: Context,
+        crashLogging: CrashLogging,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
         produceFile = {
             appContext.preferencesDataStoreFile("analytics_configuration")
         },
-        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+        corruptionHandler = ReplaceFileCorruptionHandler {
+            crashLogging.recordEvent("Corrupted data store. DataStore Type: ${ANALYTICS_CONFIGURATION.name}")
+            emptyPreferences()
+        },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 
@@ -74,12 +89,14 @@ class DataStoreModule {
     @DataStoreQualifier(DASHBOARD_STATS)
     fun provideCustomDateRangeDataStore(
         appContext: Context,
+        crashLogging: CrashLogging,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<CustomDateRange> = DataStoreFactory.create(
         produceFile = {
             appContext.preferencesDataStoreFile("custom_date_range_configuration")
         },
         corruptionHandler = ReplaceFileCorruptionHandler {
+            crashLogging.recordEvent("Corrupted data store. DataStore Type: ${DASHBOARD_STATS.name}")
             CustomDateRange.getDefaultInstance()
         },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO),
@@ -91,12 +108,14 @@ class DataStoreModule {
     @DataStoreQualifier(TOP_PERFORMER_PRODUCTS)
     fun provideTopPerformersCustomDateRangeDataStore(
         appContext: Context,
+        crashLogging: CrashLogging,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<CustomDateRange> = DataStoreFactory.create(
         produceFile = {
             appContext.preferencesDataStoreFile("top_performers_custom_date_range_configuration")
         },
         corruptionHandler = ReplaceFileCorruptionHandler {
+            crashLogging.recordEvent("Corrupted data store. DataStore Type: ${TOP_PERFORMER_PRODUCTS.name}")
             CustomDateRange.getDefaultInstance()
         },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO),
@@ -105,15 +124,17 @@ class DataStoreModule {
 
     @Provides
     @Singleton
-    @DataStoreQualifier(DataStoreType.COUPONS)
+    @DataStoreQualifier(COUPONS)
     fun provideCouponsCustomDateRangeDataStore(
         appContext: Context,
+        crashLogging: CrashLogging,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ): DataStore<CustomDateRange> = DataStoreFactory.create(
         produceFile = {
             appContext.preferencesDataStoreFile("dashboard_coupons_custom_date_range_configuration")
         },
         corruptionHandler = ReplaceFileCorruptionHandler {
+            crashLogging.recordEvent("Corrupted data store. DataStore Type: ${COUPONS.name}")
             CustomDateRange.getDefaultInstance()
         },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO),
@@ -122,15 +143,19 @@ class DataStoreModule {
 
     @Provides
     @Singleton
-    @DataStoreQualifier(DataStoreType.LAST_UPDATE)
+    @DataStoreQualifier(LAST_UPDATE)
     fun provideLastUpdateDataStore(
         appContext: Context,
+        crashLogging: CrashLogging,
         @AppCoroutineScope appCoroutineScope: CoroutineScope
     ) = PreferenceDataStoreFactory.create(
         produceFile = {
             appContext.preferencesDataStoreFile("update")
         },
-        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+        corruptionHandler = ReplaceFileCorruptionHandler {
+            crashLogging.recordEvent("Corrupted data store. DataStore Type: ${LAST_UPDATE.name}")
+            emptyPreferences()
+        },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.datastore
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
@@ -101,6 +102,9 @@ class DataStoreModule {
     ): DataStore<CustomDateRange> = DataStoreFactory.create(
         produceFile = {
             appContext.preferencesDataStoreFile("dashboard_coupons_custom_date_range_configuration")
+        },
+        corruptionHandler = ReplaceFileCorruptionHandler {
+            CustomDateRange.getDefaultInstance()
         },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO),
         serializer = CustomDateRangeSerializer

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/datastore/DataStoreModule.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStoreFile
 import com.woocommerce.android.datastore.DataStoreType.ANALYTICS_CONFIGURATION
 import com.woocommerce.android.datastore.DataStoreType.ANALYTICS_UI_CACHE
@@ -36,6 +38,7 @@ class DataStoreModule {
         produceFile = {
             appContext.preferencesDataStoreFile("tracker")
         },
+        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 
@@ -49,6 +52,7 @@ class DataStoreModule {
         produceFile = {
             appContext.preferencesDataStoreFile("analytics")
         },
+        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 
@@ -62,6 +66,7 @@ class DataStoreModule {
         produceFile = {
             appContext.preferencesDataStoreFile("analytics_configuration")
         },
+        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 
@@ -74,6 +79,9 @@ class DataStoreModule {
     ): DataStore<CustomDateRange> = DataStoreFactory.create(
         produceFile = {
             appContext.preferencesDataStoreFile("custom_date_range_configuration")
+        },
+        corruptionHandler = ReplaceFileCorruptionHandler {
+            CustomDateRange.getDefaultInstance()
         },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO),
         serializer = CustomDateRangeSerializer
@@ -88,6 +96,9 @@ class DataStoreModule {
     ): DataStore<CustomDateRange> = DataStoreFactory.create(
         produceFile = {
             appContext.preferencesDataStoreFile("top_performers_custom_date_range_configuration")
+        },
+        corruptionHandler = ReplaceFileCorruptionHandler {
+            CustomDateRange.getDefaultInstance()
         },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO),
         serializer = CustomDateRangeSerializer
@@ -120,6 +131,7 @@ class DataStoreModule {
         produceFile = {
             appContext.preferencesDataStoreFile("update")
         },
+        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
         scope = CoroutineScope(appCoroutineScope.coroutineContext + Dispatchers.IO)
     )
 }


### PR DESCRIPTION
Note: [This change was originally implemented here, but we recreated it since we decided to branch it off a release branch. Adding it here for reference, since the original PR contains discussions. ](https://github.com/woocommerce/woocommerce-android/pull/13045#issuecomment-2515522573)

Summary
==========
This is a follow-up to https://github.com/woocommerce/woocommerce-android/pull/12891, where reverting the Data Store library upgrade didn't clear the corrupted files to some users. We verified that the corruption exception we're getting is very likely to be connected with a parsing failure of the Protocol Buffer schemas we have in the app, affecting two Data Stores: `Dashboard` and `CustomDateRange`. 

This PR adds a corruption handler to the DataStore creation, which simply restarts the DataStore with the default instance of each schema.

Additionally, this PR also updates all the Preferences DataStores used through the app to recover automatically and report the corruption event to Sentry. 

Steps to Reproduce
==========
Copy [this file](https://cloudup.com/c6YYEbOIyyj) to your device in `/data/data/com.woocommerce.android.dev/files/datastore`.
1. Open Dashboard
2. Edit the custom range for `Most active coupons` card
3. Tap on Save and verify the crash

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.