### PR TITLE
[Shipping Labels Revamp] Fix Shipping Label package serialization

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageMapper.kt
@@ -4,13 +4,13 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.C
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.datasource.CarrierType.USPS
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CarrierPackageGroupDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CarrierPredefinedPackagesDTO
+import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.CustomPackageDTO
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.PackageResponse
-import com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking.PredefinedPackageDTO
 import javax.inject.Inject
 
 class WooShippingLabelPackageMapper @Inject constructor() {
     operator fun invoke(response: PackageResponse): StorePackagesDAO {
-        val savedPackagesResponse = response.packages?.saved?.predefined ?: emptyList()
+        val savedPackagesResponse = response.packages?.saved?.custom ?: emptyList()
 
         return StorePackagesDAO(
             savedPackages = mapSavedPackages(savedPackagesResponse),
@@ -18,7 +18,7 @@ class WooShippingLabelPackageMapper @Inject constructor() {
         )
     }
 
-    private fun mapSavedPackages(savedResponse: List<PredefinedPackageDTO>): List<PackageDAO> {
+    private fun mapSavedPackages(savedResponse: List<CustomPackageDTO>): List<PackageDAO> {
         return savedResponse.map {
             PackageDAO(
                 id = it.id.orEmpty(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/WooShippingLabelPackageMapper.kt
@@ -59,7 +59,7 @@ class WooShippingLabelPackageMapper @Inject constructor() {
             PackageDAO(
                 id = it.id.orEmpty(),
                 name = it.name.orEmpty(),
-                dimensions = it.dimensions.orEmpty(),
+                dimensions = it.outerDimensions.orEmpty(),
                 isLetter = it.isLetter ?: false
             )
         } ?: emptyList()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/CarrierPackageDTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/CarrierPackageDTOs.kt
@@ -1,19 +1,33 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking
 
+import com.google.gson.annotations.SerializedName
+
 class CarrierPredefinedPackagesDTO {
     val usps: USPSPackageDTO? = null
+
+    @SerializedName("dhlexpress")
     val dhlExpress: DHLPackageDTO? = null
 }
 
 class USPSPackageDTO {
+    @SerializedName("pri_flat_boxes")
     val flatBoxes: CarrierPackageGroupDTO? = null
+
+    @SerializedName("pri_boxes")
     val boxes: CarrierPackageGroupDTO? = null
+
+    @SerializedName("pri_express_boxes")
     val expressBoxes: CarrierPackageGroupDTO? = null
+
+    @SerializedName("pri_envelopes")
     val envelopes: CarrierPackageGroupDTO? = null
+
+    @SerializedName("pri_express_envelopes")
     val expressEnvelopes: CarrierPackageGroupDTO? = null
 }
 
 class DHLPackageDTO {
+    @SerializedName("domestic_and_international")
     val domesticAndInternationalPackages: CarrierPackageGroupDTO? = null
 }
 
@@ -23,15 +37,31 @@ class CarrierPackageGroupDTO {
 }
 
 class PredefinedPackageDTO {
-    val innerDimensions: String? = null
-    val outerDimensions: String? = null
-    val boxWeight: Double? = null
-    val isFlatRate: Boolean? = null
     val id: String? = null
     val name: String? = null
     val dimensions: String? = null
+
+    @SerializedName("inner_dimensions")
+    val innerDimensions: String? = null
+
+    @SerializedName("outer_dimensions")
+    val outerDimensions: String? = null
+
+    @SerializedName("box_weight")
+    val boxWeight: Double? = null
+
+    @SerializedName("is_flat_rate")
+    val isFlatRate: Boolean? = null
+
+    @SerializedName("max_weight")
     val maxWeight: Double? = null
+
+    @SerializedName("is_letter")
     val isLetter: Boolean? = null
+
+    @SerializedName("group_id")
     val groupId: String? = null
+
+    @SerializedName("can_ship_international")
     val canShipInternational: Boolean? = null
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/CarrierPackageDTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/CarrierPackageDTOs.kt
@@ -39,7 +39,6 @@ class CarrierPackageGroupDTO {
 class PredefinedPackageDTO {
     val id: String? = null
     val name: String? = null
-    val dimensions: String? = null
 
     @SerializedName("inner_dimensions")
     val innerDimensions: String? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/PackageResponseDTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/PackageResponseDTOs.kt
@@ -1,14 +1,23 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking
 
+import com.google.gson.annotations.SerializedName
+
 class PackageResponse {
     val storeOptions: PackageStoreOptionsDTO? = null
     val packages: PackagesInfoDTO? = null
 }
 
 class PackageStoreOptionsDTO {
+    @SerializedName("currency_symbol")
     val currencySymbol: String? = null
+
+    @SerializedName("dimension_unit")
     val dimensionUnit: String? = null
+
+    @SerializedName("weight_unit")
     val weightUnit: String? = null
+
+    @SerializedName("origin_country")
     val originCountry: String? = null
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/StorePackageDTOs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/StorePackageDTOs.kt
@@ -1,8 +1,9 @@
 package com.woocommerce.android.ui.orders.wooshippinglabels.packages.networking
 
+import com.google.gson.annotations.SerializedName
+
 class SavedPackageInfoDTO {
     val custom: List<CustomPackageDTO>? = null
-    val predefined: List<PredefinedPackageDTO>? = null
 }
 
 class CustomPackageDTO {
@@ -12,8 +13,14 @@ class CustomPackageDTO {
     val length: Double? = null
     val width: Double? = null
     val height: Double? = null
-    val boxWeight: Double? = null
-    val isLetter: Boolean? = null
-    val isUserDefined: Boolean? = null
     val type: String? = null
+
+    @SerializedName("box_weight")
+    val boxWeight: Double? = null
+
+    @SerializedName("is_letter")
+    val isLetter: Boolean? = null
+
+    @SerializedName("is_user_defined")
+    val isUserDefined: Boolean? = null
 }


### PR DESCRIPTION
Summary
==========
Finish issue #12284 by adding JSON parsing and mapping resilient to the different responses the Package API might return.

Screen Capture
==========
https://github.com/user-attachments/assets/de2949f8-7c63-45f2-94d7-af9165db2178

How to Test
==========
1. Go to the Shipping Labels new feature through an eligible Order
2. Hit the `Select Package` button
3. Verify that both `Saved` and `Carrier` Package options are loading data

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.
