### PR TITLE
[Hack Week] ApiFaker: Adding, deleting and deleting endpoints

### DIFF
--- a/WooCommerce/src/debug/kotlin/com/woocommerce/android/WooCommerceDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com/woocommerce/android/WooCommerceDebug.kt
@@ -12,13 +12,18 @@ import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
 import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin
 import com.facebook.soloader.SoLoader
+import com.woocommerce.android.apifaker.ApiFakerUiHelper
 import com.woocommerce.android.util.SystemVersionUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
 class WooCommerceDebug : WooCommerce() {
+    @Inject
+    lateinit var apiFakerUiHelper: ApiFakerUiHelper
+
     override fun onCreate() {
         if (FlipperUtils.shouldEnableFlipper(this)) {
             SoLoader.init(this, false)
@@ -33,6 +38,7 @@ class WooCommerceDebug : WooCommerce() {
         enableWebContentDebugging()
         super.onCreate()
         enableStrictMode()
+        apiFakerUiHelper.attachToApplication(this)
     }
 
     /**

--- a/libs/apifaker/build.gradle
+++ b/libs/apifaker/build.gradle
@@ -51,6 +51,7 @@ android {
 
 dependencies {
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.appcompat)
     implementation(libs.androidx.navigation.compose)
 
     implementation(platform(libs.androidx.compose.bom))

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerInterceptor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerInterceptor.kt
@@ -22,7 +22,7 @@ internal class ApiFakerInterceptor @Inject constructor(private val endpointProce
         }
 
         return if (fakeResponse != null) {
-            Log.d(LOG_TAG, "Fake request: ${chain.request().url}:\n$fakeResponse")
+            Log.d(LOG_TAG, "Matched request: ${chain.request().url}:\nSending Mocked Response: $fakeResponse")
             Response.Builder()
                 .request(request)
                 .protocol(Protocol.HTTP_1_1)

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerInterceptor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerInterceptor.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.apifaker
 
 import android.util.Log
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Interceptor.Chain
 import okhttp3.MediaType.Companion.toMediaType
@@ -9,9 +11,16 @@ import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import javax.inject.Inject
 
-internal class ApiFakerInterceptor @Inject constructor(private val endpointProcessor: EndpointProcessor) : Interceptor {
+internal class ApiFakerInterceptor @Inject constructor(
+    private val apiFakerConfig: ApiFakerConfig,
+    private val endpointProcessor: EndpointProcessor
+) : Interceptor {
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
     override fun intercept(chain: Chain): Response {
+        if (!apiFakerConfig.enabled.value) {
+            return chain.proceed(chain.request())
+        }
+
         Log.d(LOG_TAG, "Intercepting request: ${chain.request().url}")
         val request = chain.request()
         val fakeResponse = try {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerInterceptor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerInterceptor.kt
@@ -7,6 +7,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.internal.EMPTY_RESPONSE
 import javax.inject.Inject
 
 private const val ARTIFICIAL_DELAY_MS = 500L
@@ -39,7 +40,10 @@ internal class ApiFakerInterceptor @Inject constructor(
                 .message("Fake Response")
                 .code(fakeResponse.statusCode)
                 // TODO check if it's safe to always use JSON as the content type
-                .body(fakeResponse.body?.toResponseBody("application/json".toMediaType()))
+                .body(
+                    fakeResponse.body?.toResponseBody("application/json".toMediaType())
+                        ?: EMPTY_RESPONSE
+                )
                 .addHeader("content-type", "application/json")
                 .build()
         } else {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerInterceptor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerInterceptor.kt
@@ -1,8 +1,6 @@
 package com.woocommerce.android.apifaker
 
 import android.util.Log
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Interceptor.Chain
 import okhttp3.MediaType.Companion.toMediaType
@@ -10,6 +8,8 @@ import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import javax.inject.Inject
+
+private const val ARTIFICIAL_DELAY_MS = 500L
 
 internal class ApiFakerInterceptor @Inject constructor(
     private val apiFakerConfig: ApiFakerConfig,
@@ -32,6 +32,7 @@ internal class ApiFakerInterceptor @Inject constructor(
 
         return if (fakeResponse != null) {
             Log.d(LOG_TAG, "Matched request: ${chain.request().url}:\nSending Mocked Response: $fakeResponse")
+            Thread.sleep(ARTIFICIAL_DELAY_MS)
             Response.Builder()
                 .request(request)
                 .protocol(Protocol.HTTP_1_1)

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerUiHelper.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerUiHelper.kt
@@ -1,0 +1,108 @@
+package com.woocommerce.android.apifaker
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.app.Application
+import android.app.Application.ActivityLifecycleCallbacks
+import android.graphics.Color
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewGroup.MarginLayoutParams
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.core.view.doOnLayout
+import androidx.core.view.updateLayoutParams
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+import java.lang.ref.WeakReference
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ApiFakerUiHelper @Inject constructor() : ActivityLifecycleCallbacks {
+    @Inject
+    internal lateinit var apiFakerConfig: ApiFakerConfig
+
+    private val apiFakerHintId = View.generateViewId()
+
+    fun attachToApplication(application: Application) {
+        application.registerActivityLifecycleCallbacks(this)
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        (activity as LifecycleOwner).lifecycleScope.launch {
+            updateApiFakerHint(WeakReference(activity))
+        }
+    }
+
+    override fun onActivityStarted(activity: Activity) {}
+
+    override fun onActivityResumed(activity: Activity) {}
+
+    override fun onActivityPaused(activity: Activity) {}
+
+    override fun onActivityStopped(activity: Activity) {}
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+
+    override fun onActivityDestroyed(activity: Activity) {}
+
+    private suspend fun updateApiFakerHint(
+        activityReference: WeakReference<Activity>
+    ) {
+        apiFakerConfig.enabled.collect { enabled ->
+            activityReference.get()?.let { activity ->
+                if (enabled) {
+                    activity.window.decorView.post {
+                        activity.window.decorView.showApiFakerHint()
+                    }
+                } else {
+                    activity.window.decorView.post {
+                        activity.window.decorView.hideApiFakerHint()
+                    }
+                }
+            }
+        }
+    }
+
+    @SuppressLint("SetTextI18n")
+    private fun View.showApiFakerHint() {
+        // This works only for activities that has the content view as a direct child of the FrameLayout, which is true
+        // for all AppCompat activities, so it should work for all the cases we need.
+        val contentLayout = findViewById<View>(android.R.id.content) as? FrameLayout ?: return
+        val activityLayout = contentLayout.getChildAt(0)
+
+        val apiFakerHint = FrameLayout(context).apply {
+            id = apiFakerHintId
+            setBackgroundColor(Color.RED)
+            addView(
+                TextView(context).apply {
+                    text = "ApiFaker Enabled"
+                    textAlignment = View.TEXT_ALIGNMENT_CENTER
+                }
+            )
+        }
+        contentLayout.addView(
+            apiFakerHint,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT
+            ).apply {
+                gravity = android.view.Gravity.BOTTOM
+            }
+        )
+
+        apiFakerHint.doOnLayout { view ->
+            activityLayout.updateLayoutParams<MarginLayoutParams> { bottomMargin = view.measuredHeight }
+        }
+    }
+
+    private fun View.hideApiFakerHint() {
+        val contentLayout = findViewById<ViewGroup>(android.R.id.content)
+        contentLayout.findViewById<View>(apiFakerHintId)?.let { apiFakerHint ->
+            contentLayout.removeView(apiFakerHint)
+        }
+    }
+}

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerUiHelper.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerUiHelper.kt
@@ -38,17 +38,17 @@ class ApiFakerUiHelper @Inject constructor() : ActivityLifecycleCallbacks {
         }
     }
 
-    override fun onActivityStarted(activity: Activity) {}
+    override fun onActivityStarted(activity: Activity) = Unit
 
-    override fun onActivityResumed(activity: Activity) {}
+    override fun onActivityResumed(activity: Activity) = Unit
 
-    override fun onActivityPaused(activity: Activity) {}
+    override fun onActivityPaused(activity: Activity) = Unit
 
-    override fun onActivityStopped(activity: Activity) {}
+    override fun onActivityStopped(activity: Activity) = Unit
 
-    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
 
-    override fun onActivityDestroyed(activity: Activity) {}
+    override fun onActivityDestroyed(activity: Activity) = Unit
 
     private suspend fun updateApiFakerHint(
         activityReference: WeakReference<ComponentActivity>

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerUiHelper.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerUiHelper.kt
@@ -82,6 +82,7 @@ class ApiFakerUiHelper @Inject constructor() : ActivityLifecycleCallbacks {
                 TextView(context).apply {
                     text = "ApiFaker Enabled"
                     textAlignment = View.TEXT_ALIGNMENT_CENTER
+                    setTextColor(Color.WHITE)
                 }
             )
             setOnClickListener {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
@@ -36,7 +36,7 @@ internal class EndpointProcessor @Inject constructor(
 
     private fun Request.extractDataFromWPComEndpoint(): EndpointData {
         val originalBody = readBody()
-        return if (url.encodedPath.trimEnd('/').matches(Regex(JETPACK_TUNNEL_REGEX))) {
+        return if (url.isJetpackTunnelRequest) {
             val (path, method, body) = if (method == "GET") {
                 Triple(
                     url.queryParameter("path")!!.substringBefore("&"),
@@ -89,11 +89,22 @@ internal class EndpointProcessor @Inject constructor(
         )
     }
 
-    private fun HttpUrl.checkQueryParameters(queryParameters: List<QueryParameter>): Boolean {
-        if (queryParameters.isEmpty()) return true
+    private fun HttpUrl.checkQueryParameters(mockedQueryParameters: List<QueryParameter>): Boolean {
+        if (mockedQueryParameters.isEmpty()) return true
 
-        return queryParameters.all { queryParameter ->
-            queryParameter(queryParameter.name) == queryParameter.value
+        val requestQueryParameters = if (isJetpackTunnelRequest) {
+            queryParameter("query")?.let {
+                val json = jsonObjectProvider.parseString(it)
+                json.keys().asSequence().map { key ->
+                    key to json.getString(key)
+                }.toMap()
+            } ?: emptyMap()
+        } else {
+            queryParameterNames.associateWith { queryParameter(it) }
+        }
+
+        return mockedQueryParameters.all { queryParameter ->
+            requestQueryParameters[queryParameter.name] == queryParameter.value
         }
     }
 
@@ -110,8 +121,7 @@ internal class EndpointProcessor @Inject constructor(
     }
 
     private fun String.wrapBodyIfNecessary(url: HttpUrl): String {
-        return if (url.host == WPCOM_HOST &&
-            url.encodedPath.trimEnd('/').matches(Regex(JETPACK_TUNNEL_REGEX)) &&
+        return if (url.isJetpackTunnelRequest &&
             !startsWith("{\"data\":")
         ) {
             "{\"data\": $this}"
@@ -122,6 +132,9 @@ internal class EndpointProcessor @Inject constructor(
 
     private val Request.httpMethod
         get() = HttpMethod.valueOf(this.method.uppercase())
+
+    private val HttpUrl.isJetpackTunnelRequest
+        get() = host == WPCOM_HOST && encodedPath.trimEnd('/').matches(Regex(JETPACK_TUNNEL_REGEX))
 
     private data class EndpointData(
         val apiType: ApiType,

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.apifaker
 
+import android.util.Log
 import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.ApiType
 import com.woocommerce.android.apifaker.models.HttpMethod
@@ -27,6 +28,15 @@ internal class EndpointProcessor @Inject constructor(
 
         return with(endpointData) {
             endpointDao.queryEndpoint(apiType, endpointData.httpMethod, path.trimEnd('/'), body.orEmpty())
+        }.also {
+            if (it.size > 1) {
+                Log.w(
+                    LOG_TAG,
+                    "More than one endpoint matched the request: $request, " +
+                        "the endpoints matched are\n$it\n" +
+                        "The first one will be used."
+                )
+            }
         }.firstOrNull {
             request.url.checkQueryParameters(it.request.queryParameters)
         }?.response?.let {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.apifaker
 import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.ApiType
 import com.woocommerce.android.apifaker.models.HttpMethod
+import com.woocommerce.android.apifaker.models.QueryParameter
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.util.JSONObjectProvider
 import okhttp3.HttpUrl
@@ -18,7 +19,6 @@ internal class EndpointProcessor @Inject constructor(
     private val jsonObjectProvider: JSONObjectProvider
 ) {
     fun fakeRequestIfNeeded(request: Request): Response? {
-        // TODO match against method and query parameters too
         val endpointData = when {
             request.url.host == WPCOM_HOST -> request.extractDataFromWPComEndpoint()
             request.url.encodedPath.startsWith("/wp-json") -> request.extractDataFromWPApiEndpoint()
@@ -27,6 +27,8 @@ internal class EndpointProcessor @Inject constructor(
 
         return with(endpointData) {
             endpointDao.queryEndpoint(apiType, endpointData.httpMethod, path.trimEnd('/'), body.orEmpty())
+        }.firstOrNull {
+            request.url.checkQueryParameters(it.request.queryParameters)
         }?.response?.let {
             it.copy(body = it.body?.wrapBodyIfNecessary(request.url))
         }
@@ -85,6 +87,14 @@ internal class EndpointProcessor @Inject constructor(
             path = url.encodedPath,
             body = readBody()
         )
+    }
+
+    private fun HttpUrl.checkQueryParameters(queryParameters: List<QueryParameter>): Boolean {
+        if (queryParameters.isEmpty()) return true
+
+        return queryParameters.all { queryParameter ->
+            queryParameter(queryParameter.name) == queryParameter.value
+        }
     }
 
     private fun Request.readBody(): String {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
@@ -27,7 +27,7 @@ internal class EndpointProcessor @Inject constructor(
         }
 
         return with(endpointData) {
-            endpointDao.queryEndpoint(apiType, endpointData.httpMethod, path.trimEnd('/'), body.orEmpty())
+            endpointDao.queryEndpoint(apiType, httpMethod, path.trimEnd('/'), body.orEmpty())
         }.also {
             if (it.size > 1) {
                 Log.w(

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
@@ -28,6 +28,8 @@ internal class EndpointProcessor @Inject constructor(
 
         return with(endpointData) {
             endpointDao.queryEndpoint(apiType, httpMethod, path.trimEnd('/'), body.orEmpty())
+        }.filter {
+            request.url.checkQueryParameters(it.request.queryParameters)
         }.also {
             if (it.size > 1) {
                 Log.w(
@@ -37,9 +39,7 @@ internal class EndpointProcessor @Inject constructor(
                         "The first one will be used."
                 )
             }
-        }.firstOrNull {
-            request.url.checkQueryParameters(it.request.queryParameters)
-        }?.response?.let {
+        }.firstOrNull()?.response?.let {
             it.copy(body = it.body?.wrapBodyIfNecessary(request.url))
         }
     }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/ApiFakerDatabase.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/ApiFakerDatabase.kt
@@ -13,7 +13,7 @@ import com.woocommerce.android.apifaker.models.Response
         Request::class,
         Response::class
     ],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 @TypeConverters(

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/ApiFakerDatabase.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/ApiFakerDatabase.kt
@@ -16,7 +16,10 @@ import com.woocommerce.android.apifaker.models.Response
     version = 1,
     exportSchema = false
 )
-@TypeConverters(EndpointTypeConverter::class)
+@TypeConverters(
+    EndpointTypeConverter::class,
+    QueryParameterConverter::class
+)
 internal abstract class ApiFakerDatabase : RoomDatabase() {
     companion object {
         fun buildDb(applicationContext: Context) = Room

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/EndpointDao.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/EndpointDao.kt
@@ -31,7 +31,7 @@ internal interface EndpointDao {
         :body LIKE COALESCE(body, '%')
         """
     )
-    fun queryEndpoint(type: ApiType, httpMethod: HttpMethod, path: String, body: String): MockedEndpoint?
+    fun queryEndpoint(type: ApiType, httpMethod: HttpMethod, path: String, body: String): List<MockedEndpoint>
 
     @Transaction
     @Query("Select * FROM Request WHERE id = :id")

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/QueryParameterConverter.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/QueryParameterConverter.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.apifaker.db
+
+import androidx.room.TypeConverter
+import com.woocommerce.android.apifaker.models.QueryParameter
+
+internal class QueryParameterConverter {
+    @TypeConverter
+    fun fromQueryParameters(queryParameters: List<QueryParameter>?): String? {
+        return queryParameters?.joinToString("&") { "${it.name}:${it.value}" }
+    }
+
+    @TypeConverter
+    fun toQueryParameters(query: String?): List<QueryParameter>? {
+        return query?.split("&")?.map { parts ->
+            val (name, value) = parts.split(":")
+            QueryParameter(name, value)
+        }
+    }
+}

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/QueryParameterConverter.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/QueryParameterConverter.kt
@@ -5,15 +5,15 @@ import com.woocommerce.android.apifaker.models.QueryParameter
 
 internal class QueryParameterConverter {
     @TypeConverter
-    fun fromQueryParameters(queryParameters: List<QueryParameter>?): String? {
-        return queryParameters?.joinToString("&") { "${it.name}:${it.value}" }
+    fun fromQueryParameters(queryParameters: List<QueryParameter>): String {
+        return queryParameters.joinToString("&") { "${it.name}:${it.value}" }
     }
 
     @TypeConverter
-    fun toQueryParameters(query: String?): List<QueryParameter>? {
-        return query?.split("&")?.map { parts ->
+    fun toQueryParameters(query: String): List<QueryParameter> {
+        return query.takeIf { it.isNotBlank() }?.split("&")?.map { parts ->
             val (name, value) = parts.split(":")
             QueryParameter(name, value)
-        }
+        } ?: emptyList()
     }
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/di/ApiFakerModule.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/di/ApiFakerModule.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.apifaker.di
 
 import android.content.Context
+import com.woocommerce.android.apifaker.ApiFakerConfig
 import com.woocommerce.android.apifaker.ApiFakerInterceptor
 import com.woocommerce.android.apifaker.EndpointProcessor
 import com.woocommerce.android.apifaker.db.ApiFakerDatabase
@@ -23,9 +24,11 @@ object ApiFakerModule {
     @Provides
     internal fun providesEndpointDao(db: ApiFakerDatabase) = db.endpointDao
 
-    @Provides
-    @IntoSet
-    @Named("interceptors")
-    internal fun providesInterceptor(endpointProcessor: EndpointProcessor): Interceptor =
-        ApiFakerInterceptor(endpointProcessor)
-}
+        @Provides
+        @IntoSet
+        @Named("interceptors")
+        internal fun providesInterceptor(
+            apiFakerConfig: ApiFakerConfig,
+            endpointProcessor: EndpointProcessor
+        ): Interceptor = ApiFakerInterceptor(apiFakerConfig, endpointProcessor)
+    }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/di/ApiFakerModule.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/di/ApiFakerModule.kt
@@ -24,11 +24,11 @@ object ApiFakerModule {
     @Provides
     internal fun providesEndpointDao(db: ApiFakerDatabase) = db.endpointDao
 
-        @Provides
-        @IntoSet
-        @Named("interceptors")
-        internal fun providesInterceptor(
-            apiFakerConfig: ApiFakerConfig,
-            endpointProcessor: EndpointProcessor
-        ): Interceptor = ApiFakerInterceptor(apiFakerConfig, endpointProcessor)
-    }
+    @Provides
+    @IntoSet
+    @Named("interceptors")
+    internal fun providesInterceptor(
+        apiFakerConfig: ApiFakerConfig,
+        endpointProcessor: EndpointProcessor
+    ): Interceptor = ApiFakerInterceptor(apiFakerConfig, endpointProcessor)
+}

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/HttpMethod.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/HttpMethod.kt
@@ -1,5 +1,5 @@
 package com.woocommerce.android.apifaker.models
 
-enum class HttpMethod {
+internal enum class HttpMethod {
     GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD, TRACE, CONNECT
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/QueryParameter.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/QueryParameter.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.apifaker.models
+
+internal data class QueryParameter(
+    val name: String,
+    val value: String
+)

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Request.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Request.kt
@@ -7,7 +7,8 @@ import androidx.room.PrimaryKey
 internal data class Request(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val type: ApiType,
-    val httpMethod: HttpMethod?,
     val path: String,
-    val body: String?
+    val httpMethod: HttpMethod? = null,
+    val queryParameters: List<QueryParameter> = emptyList(),
+    val body: String? = null
 )

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Response.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Response.kt
@@ -17,5 +17,5 @@ import androidx.room.PrimaryKey
 internal data class Response(
     @PrimaryKey val endpointId: Long = 0,
     val statusCode: Int,
-    val body: String?,
+    val body: String? = null
 )

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/ApiFakerNavHost.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/ApiFakerNavHost.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.apifaker.ui
 
+import androidx.activity.ComponentActivity
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -17,6 +19,9 @@ fun ApiFakerNavHost(
     onExit: () -> Unit
 ) {
     val navController = rememberNavController()
+
+    // This might not be very safe, but since it's just for development purposes, it should be fine
+    val activity = LocalContext.current as ComponentActivity
 
     NavHost(
         navController = navController,

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/ApiFakerNavHost.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/ApiFakerNavHost.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.woocommerce.android.apifaker.ui.Screen
 import com.woocommerce.android.apifaker.ui.details.EndpointDetailsScreen
+import com.woocommerce.android.apifaker.ui.details.MISSING_ENDPOINT_ID
 import com.woocommerce.android.apifaker.ui.home.HomeScreen
 
 @Composable
@@ -25,11 +26,11 @@ fun ApiFakerNavHost(
             HomeScreen(viewModel = hiltViewModel(), navController = navController, onExit = onExit)
         }
         composable(
-            Screen.EndpointDetails.baseRoute,
+            Screen.EndpointDetails.routeTemplate,
             arguments = listOf(
-                navArgument("endpointId") {
+                navArgument(Screen.EndpointDetails.endpointIdArgumentName) {
                     type = NavType.LongType
-                    defaultValue = -1
+                    defaultValue = MISSING_ENDPOINT_ID
                 }
             )
         ) {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/ApiFakerNavHost.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/ApiFakerNavHost.kt
@@ -1,15 +1,12 @@
 package com.woocommerce.android.apifaker.ui
 
-import androidx.activity.ComponentActivity
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import com.woocommerce.android.apifaker.ui.Screen
 import com.woocommerce.android.apifaker.ui.details.EndpointDetailsScreen
 import com.woocommerce.android.apifaker.ui.details.MISSING_ENDPOINT_ID
 import com.woocommerce.android.apifaker.ui.home.HomeScreen
@@ -19,9 +16,6 @@ fun ApiFakerNavHost(
     onExit: () -> Unit
 ) {
     val navController = rememberNavController()
-
-    // This might not be very safe, but since it's just for development purposes, it should be fine
-    val activity = LocalContext.current as ComponentActivity
 
     NavHost(
         navController = navController,

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/ApiFakerNavHost.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/ApiFakerNavHost.kt
@@ -7,7 +7,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import com.woocommerce.android.apifaker.ui.Screen.EndpointDetails
+import com.woocommerce.android.apifaker.ui.Screen
+import com.woocommerce.android.apifaker.ui.details.EndpointDetailsScreen
 import com.woocommerce.android.apifaker.ui.home.HomeScreen
 
 @Composable
@@ -24,7 +25,7 @@ fun ApiFakerNavHost(
             HomeScreen(viewModel = hiltViewModel(), navController = navController, onExit = onExit)
         }
         composable(
-            EndpointDetails.baseRoute,
+            Screen.EndpointDetails.baseRoute,
             arguments = listOf(
                 navArgument("endpointId") {
                     type = NavType.LongType
@@ -32,7 +33,7 @@ fun ApiFakerNavHost(
                 }
             )
         ) {
-            TODO()
+            EndpointDetailsScreen(hiltViewModel(), navController)
         }
     }
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/DropDownMenu.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/DropDownMenu.kt
@@ -1,0 +1,60 @@
+package com.woocommerce.android.apifaker.ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ExposedDropdownMenuBox
+import androidx.compose.material.ExposedDropdownMenuDefaults
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+internal fun <T> DropDownMenu(
+    label: String,
+    currentValue: T,
+    values: List<T>,
+    onValueChange: (T) -> Unit,
+    modifier: Modifier = Modifier,
+    formatter: (T) -> String = { it.toString() },
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier
+    ) {
+        TextField(
+            readOnly = true,
+            label = { Text(label) },
+            value = formatter(currentValue), onValueChange = {},
+            trailingIcon = {
+                ExposedDropdownMenuDefaults.TrailingIcon(
+                    expanded = expanded
+                )
+            },
+            colors = ExposedDropdownMenuDefaults.textFieldColors(),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            values.forEach { value ->
+                DropdownMenuItem(onClick = {
+                    expanded = false
+                    onValueChange(value)
+                }) {
+                    Text(formatter(value))
+                }
+            }
+        }
+    }
+}

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/DropDownMenu.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/DropDownMenu.kt
@@ -5,8 +5,8 @@ import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ExposedDropdownMenuBox
 import androidx.compose.material.ExposedDropdownMenuDefaults
+import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
-import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -30,7 +30,7 @@ internal fun <T> DropDownMenu(
         onExpandedChange = { expanded = it },
         modifier = modifier
     ) {
-        TextField(
+        OutlinedTextField(
             readOnly = true,
             label = { Text(label) },
             value = formatter(currentValue), onValueChange = {},
@@ -39,7 +39,7 @@ internal fun <T> DropDownMenu(
                     expanded = expanded
                 )
             },
-            colors = ExposedDropdownMenuDefaults.textFieldColors(),
+            colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
             modifier = Modifier.fillMaxWidth()
         )
 

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/DropDownMenu.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/DropDownMenu.kt
@@ -33,7 +33,8 @@ internal fun <T> DropDownMenu(
         OutlinedTextField(
             readOnly = true,
             label = { Text(label) },
-            value = formatter(currentValue), onValueChange = {},
+            value = formatter(currentValue),
+            onValueChange = {},
             trailingIcon = {
                 ExposedDropdownMenuDefaults.TrailingIcon(
                     expanded = expanded

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/Screen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/Screen.kt
@@ -6,7 +6,8 @@ internal sealed class Screen(val baseRoute: String) {
     }
 
     object EndpointDetails : Screen("/endpoint-details") {
-        fun route(endpointId: Long) = "$baseRoute/$endpointId"
+        const val endpointIdArgumentName = "endpointId"
+        fun route(endpointId: Long) = "$baseRoute/endpointId=$endpointId"
 
         fun routeForCreation() = baseRoute
     }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/Screen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/Screen.kt
@@ -7,7 +7,9 @@ internal sealed class Screen(val baseRoute: String) {
 
     object EndpointDetails : Screen("/endpoint-details") {
         const val endpointIdArgumentName = "endpointId"
-        fun route(endpointId: Long) = "$baseRoute/endpointId=$endpointId"
+        val routeTemplate = "$baseRoute?$endpointIdArgumentName={$endpointIdArgumentName}"
+
+        fun route(endpointId: Long) = "$baseRoute?$endpointIdArgumentName=$endpointId"
 
         fun routeForCreation() = baseRoute
     }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Chip
 import androidx.compose.material.ChipDefaults
 import androidx.compose.material.Divider
@@ -44,7 +45,6 @@ import androidx.compose.ui.window.Dialog
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.woocommerce.android.apifaker.models.ApiType
-import com.woocommerce.android.apifaker.models.MockedEndpoint
 import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.ui.DropDownMenu
@@ -55,9 +55,14 @@ internal fun EndpointDetailsScreen(
     viewModel: EndpointDetailsViewModel,
     navController: NavController
 ) {
+    if (viewModel.state.isEndpointSaved) {
+        navController.navigateUp()
+    }
+
     EndpointDetailsScreen(
         state = viewModel.state,
         navController = navController,
+        onSaveClicked = viewModel::onSaveClicked,
         onEndpointTypeChanged = viewModel::onEndpointTypeChanged,
         onRequestPathChanged = viewModel::onRequestPathChanged,
         onRequestBodyChanged = viewModel::onRequestBodyChanged,
@@ -68,8 +73,9 @@ internal fun EndpointDetailsScreen(
 
 @Composable
 private fun EndpointDetailsScreen(
-    state: MockedEndpoint,
+    state: EndpointDetailsViewModel.UiState,
     navController: NavController,
+    onSaveClicked: () -> Unit = {},
     onEndpointTypeChanged: (ApiType) -> Unit = {},
     onRequestPathChanged: (String) -> Unit = {},
     onRequestBodyChanged: (String) -> Unit = {},
@@ -89,8 +95,14 @@ private fun EndpointDetailsScreen(
                     }
                 },
                 actions = {
-                    TextButton(onClick = { /*TODO*/ }) {
-                        Text(text = "Save")
+                    TextButton(
+                        onClick = onSaveClicked,
+                        enabled = state.isEndpointValid,
+                        colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colors.onPrimary)
+                    ) {
+                        Text(
+                            text = "Save"
+                        )
                     }
                 }
             )
@@ -422,7 +434,7 @@ private fun ResponseBodyField(
 private fun EndpointDetailsScreenPreview() {
     Surface(color = MaterialTheme.colors.background) {
         EndpointDetailsScreen(
-            state = MockedEndpoint(
+            state = EndpointDetailsViewModel.UiState(
                 request = Request(
                     type = ApiType.Custom("https://example.com"),
                     path = "/wc/v3/products",

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -63,7 +63,7 @@ internal fun EndpointDetailsScreen(
         state = viewModel.state,
         navController = navController,
         onSaveClicked = viewModel::onSaveClicked,
-        onEndpointTypeChanged = viewModel::onEndpointTypeChanged,
+        onApiTypeChanged = viewModel::onApiTypeChanged,
         onRequestPathChanged = viewModel::onRequestPathChanged,
         onRequestBodyChanged = viewModel::onRequestBodyChanged,
         onResponseStatusCodeChanged = viewModel::onResponseStatusCodeChanged,
@@ -76,7 +76,7 @@ private fun EndpointDetailsScreen(
     state: EndpointDetailsViewModel.UiState,
     navController: NavController,
     onSaveClicked: () -> Unit = {},
-    onEndpointTypeChanged: (ApiType) -> Unit = {},
+    onApiTypeChanged: (ApiType) -> Unit = {},
     onRequestPathChanged: (String) -> Unit = {},
     onRequestBodyChanged: (String) -> Unit = {},
     onResponseStatusCodeChanged: (Int) -> Unit = {},
@@ -116,7 +116,7 @@ private fun EndpointDetailsScreen(
         ) {
             RequestDefinitionSection(
                 request = state.request,
-                onEndpointTypeChanged = onEndpointTypeChanged,
+                onApiTypeChanged = onApiTypeChanged,
                 onPathChanged = onRequestPathChanged,
                 onBodyChanged = onRequestBodyChanged,
                 modifier = Modifier
@@ -143,7 +143,7 @@ private fun EndpointDetailsScreen(
 @Composable
 private fun RequestDefinitionSection(
     request: Request,
-    onEndpointTypeChanged: (ApiType) -> Unit,
+    onApiTypeChanged: (ApiType) -> Unit,
     onPathChanged: (String) -> Unit,
     onBodyChanged: (String) -> Unit,
     modifier: Modifier = Modifier
@@ -157,14 +157,14 @@ private fun RequestDefinitionSection(
             style = MaterialTheme.typography.h6
         )
         EndpointTypeField(
-            endpointType = request.type,
-            onEndpointTypeChanged = onEndpointTypeChanged,
+            apiType = request.type,
+            onApiTypeChanged = onApiTypeChanged,
             modifier = Modifier.fillMaxWidth()
         )
 
         PathField(
             path = request.path,
-            endpointType = request.type,
+            apiType = request.type,
             onPathChanged = onPathChanged,
             modifier = Modifier.fillMaxWidth()
         )
@@ -207,8 +207,8 @@ private fun ResponseSection(
 
 @Composable
 private fun EndpointTypeField(
-    endpointType: ApiType,
-    onEndpointTypeChanged: (ApiType) -> Unit,
+    apiType: ApiType,
+    onApiTypeChanged: (ApiType) -> Unit,
     modifier: Modifier = Modifier
 ) {
     fun ApiType.label() = when (this) {
@@ -219,17 +219,17 @@ private fun EndpointTypeField(
 
     DropDownMenu(
         label = "Type",
-        currentValue = endpointType,
+        currentValue = apiType,
         values = ApiType.defaultValues(),
-        onValueChange = onEndpointTypeChanged,
+        onValueChange = onApiTypeChanged,
         formatter = ApiType::label,
         modifier = modifier.fillMaxWidth()
     )
-    if (endpointType is ApiType.Custom) {
+    if (apiType is ApiType.Custom) {
         TextField(
             label = { Text(text = "Host (without scheme)") },
-            value = endpointType.host,
-            onValueChange = { onEndpointTypeChanged(endpointType.copy(host = it)) },
+            value = apiType.host,
+            onValueChange = { onApiTypeChanged(apiType.copy(host = it)) },
             modifier = Modifier.fillMaxWidth()
         )
     }
@@ -238,7 +238,7 @@ private fun EndpointTypeField(
 @Composable
 private fun PathField(
     path: String,
-    endpointType: ApiType,
+    apiType: ApiType,
     onPathChanged: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -249,7 +249,7 @@ private fun PathField(
             onValueChange = onPathChanged,
             modifier = Modifier.fillMaxWidth()
         )
-        val prefix = when (endpointType) {
+        val prefix = when (apiType) {
             ApiType.WPApi -> "/wp-json"
             ApiType.WPCom -> "/rest"
             is ApiType.Custom -> "host"

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -273,7 +273,10 @@ private fun PathField(
     onPathChanged: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier
+    ) {
         OutlinedTextField(
             label = { Text(text = "Path") },
             value = path,
@@ -311,7 +314,10 @@ private fun RequestBodyField(
     onBodyChanged: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier
+    ) {
         OutlinedTextField(
             label = { Text(text = "Body") },
             value = body.orEmpty(),

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -4,12 +4,17 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Chip
 import androidx.compose.material.ChipDefaults
@@ -28,6 +33,8 @@ import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -48,6 +55,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.woocommerce.android.apifaker.models.ApiType
 import com.woocommerce.android.apifaker.models.HttpMethod
+import com.woocommerce.android.apifaker.models.QueryParameter
 import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.ui.DropDownMenu
@@ -69,6 +77,8 @@ internal fun EndpointDetailsScreen(
         onApiTypeChanged = viewModel::onApiTypeChanged,
         onRequestHttpMethodChanged = viewModel::onRequestHttpMethodChanged,
         onRequestPathChanged = viewModel::onRequestPathChanged,
+        onQueryParameterAdded = viewModel::onQueryParameterAdded,
+        onQueryParameterDeleted = viewModel::onQueryParameterDeleted,
         onRequestBodyChanged = viewModel::onRequestBodyChanged,
         onResponseStatusCodeChanged = viewModel::onResponseStatusCodeChanged,
         onResponseBodyChanged = viewModel::onResponseBodyChanged,
@@ -83,6 +93,8 @@ private fun EndpointDetailsScreen(
     onApiTypeChanged: (ApiType) -> Unit = {},
     onRequestHttpMethodChanged: (HttpMethod?) -> Unit = {},
     onRequestPathChanged: (String) -> Unit = {},
+    onQueryParameterAdded: (String, String) -> Unit = { _, _ -> },
+    onQueryParameterDeleted: (QueryParameter) -> Unit = {},
     onRequestBodyChanged: (String) -> Unit = {},
     onResponseStatusCodeChanged: (Int) -> Unit = {},
     onResponseBodyChanged: (String) -> Unit = {},
@@ -126,6 +138,8 @@ private fun EndpointDetailsScreen(
                 onApiTypeChanged = onApiTypeChanged,
                 onHttpMethodChanged = onRequestHttpMethodChanged,
                 onPathChanged = onRequestPathChanged,
+                onQueryParameterAdded = onQueryParameterAdded,
+                onQueryParameterDeleted = onQueryParameterDeleted,
                 onBodyChanged = onRequestBodyChanged,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -154,6 +168,8 @@ private fun RequestDefinitionSection(
     onApiTypeChanged: (ApiType) -> Unit,
     onHttpMethodChanged: (HttpMethod?) -> Unit,
     onPathChanged: (String) -> Unit,
+    onQueryParameterAdded: (String, String) -> Unit,
+    onQueryParameterDeleted: (QueryParameter) -> Unit,
     onBodyChanged: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -181,6 +197,13 @@ private fun RequestDefinitionSection(
             path = request.path,
             apiType = request.type,
             onPathChanged = onPathChanged,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        QueryParametersField(
+            queryParameters = request.queryParameters,
+            onQueryParameterAdded = onQueryParameterAdded,
+            onQueryParameterDeleted = onQueryParameterDeleted,
             modifier = Modifier.fillMaxWidth()
         )
 
@@ -303,7 +326,122 @@ private fun PathField(
         }
         Text(
             text = caption,
-            style = MaterialTheme.typography.caption
+            style = MaterialTheme.typography.caption,
+            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+        )
+    }
+}
+
+@Composable
+private fun QueryParametersField(
+    queryParameters: List<QueryParameter>,
+    onQueryParameterAdded: (String, String) -> Unit,
+    onQueryParameterDeleted: (QueryParameter) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    @Composable
+    fun AddDialog(onAdd: (String, String) -> Unit, onDismiss: () -> Unit) {
+        var name by remember { mutableStateOf("") }
+        var value by remember { mutableStateOf("") }
+        Dialog(onDismissRequest = onDismiss) {
+            Column(
+                Modifier
+                    .background(MaterialTheme.colors.surface, MaterialTheme.shapes.medium)
+                    .padding(16.dp)
+            ) {
+                Text(text = "Add Query Parameter (unencoded)")
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    label = { Text(text = "Name") },
+                    value = name,
+                    onValueChange = { name = it },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    label = { Text(text = "Value") },
+                    value = value,
+                    onValueChange = { value = it },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    horizontalArrangement = Arrangement.End,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Button(onClick = onDismiss) {
+                        Text(text = "Cancel")
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Button(onClick = { onAdd(name, value) }) {
+                        Text(text = "Add")
+                    }
+                }
+
+            }
+        }
+    }
+
+    var isAddDialogShown by remember { mutableStateOf(false) }
+
+    Column(modifier) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = "Query Parameters",
+                style = MaterialTheme.typography.subtitle1
+            )
+            IconButton(
+                onClick = { isAddDialogShown = true },
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = "Add query parameter"
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "A request is matched only if it contains all the parameters listed here",
+            style = MaterialTheme.typography.caption,
+            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+        )
+        if (queryParameters.isNotEmpty()) {
+            queryParameters.forEach { queryParameter ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                ) {
+                    Text(
+                        text = "${queryParameter.name} = ${queryParameter.value}",
+                        style = MaterialTheme.typography.caption
+                    )
+                    IconButton(
+                        onClick = { onQueryParameterDeleted(queryParameter) },
+                        modifier = Modifier.size(32.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = "Delete query parameter"
+                        )
+                    }
+                }
+                Divider()
+            }
+        }
+    }
+
+    if (isAddDialogShown) {
+        AddDialog(onAdd = { name, value ->
+            onQueryParameterAdded(name, value)
+            isAddDialogShown = false
+        },
+            onDismiss = { isAddDialogShown = false }
         )
     }
 }
@@ -340,7 +478,8 @@ private fun RequestBodyField(
         }
         Text(
             text = caption,
-            style = MaterialTheme.typography.caption
+            style = MaterialTheme.typography.caption,
+            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
         )
     }
 }
@@ -480,6 +619,10 @@ private fun EndpointDetailsScreenPreview() {
                 request = Request(
                     type = ApiType.Custom("https://example.com"),
                     httpMethod = HttpMethod.GET,
+                    queryParameters = listOf(
+                        QueryParameter("name", "value"),
+                        QueryParameter("name2", "value2")
+                    ),
                     path = "/wc/v3/products",
                     body = null
                 ),

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -1,13 +1,21 @@
 package com.woocommerce.android.apifaker.ui.details
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Chip
+import androidx.compose.material.ChipDefaults
+import androidx.compose.material.Divider
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
@@ -18,9 +26,21 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.woocommerce.android.apifaker.models.ApiType
@@ -28,6 +48,7 @@ import com.woocommerce.android.apifaker.models.MockedEndpoint
 import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.ui.DropDownMenu
+import kotlin.math.min
 
 @Composable
 internal fun EndpointDetailsScreen(
@@ -37,7 +58,11 @@ internal fun EndpointDetailsScreen(
     EndpointDetailsScreen(
         state = viewModel.state,
         navController = navController,
-        onEndpointTypeChanged = viewModel::onEndpointTypeChanged
+        onEndpointTypeChanged = viewModel::onEndpointTypeChanged,
+        onRequestPathChanged = viewModel::onRequestPathChanged,
+        onRequestBodyChanged = viewModel::onRequestBodyChanged,
+        onResponseStatusCodeChanged = viewModel::onResponseStatusCodeChanged,
+        onResponseBodyChanged = viewModel::onResponseBodyChanged,
     )
 }
 
@@ -46,8 +71,10 @@ private fun EndpointDetailsScreen(
     state: MockedEndpoint,
     navController: NavController,
     onEndpointTypeChanged: (ApiType) -> Unit = {},
-    onPathChanged: (String) -> Unit = {},
-    onBodyChanged: (String) -> Unit = {}
+    onRequestPathChanged: (String) -> Unit = {},
+    onRequestBodyChanged: (String) -> Unit = {},
+    onResponseStatusCodeChanged: (Int) -> Unit = {},
+    onResponseBodyChanged: (String) -> Unit = {},
 ) {
     Scaffold(
         topBar = {
@@ -73,15 +100,29 @@ private fun EndpointDetailsScreen(
         Column(
             Modifier
                 .padding(paddingValues)
-                .padding(16.dp)
                 .verticalScroll(rememberScrollState())
         ) {
             RequestDefinitionSection(
                 request = state.request,
                 onEndpointTypeChanged = onEndpointTypeChanged,
-                onPathChanged = onPathChanged,
-                onBodyChanged = onBodyChanged,
-                modifier = Modifier.fillMaxWidth()
+                onPathChanged = onRequestPathChanged,
+                onBodyChanged = onRequestBodyChanged,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            )
+            Divider(
+                Modifier.padding(horizontal = 8.dp),
+                thickness = 2.dp
+            )
+
+            ResponseSection(
+                response = state.response,
+                onStatusCodeChanged = onResponseStatusCodeChanged,
+                onBodyChanged = onResponseBodyChanged,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
             )
         }
     }
@@ -96,34 +137,285 @@ private fun RequestDefinitionSection(
     modifier: Modifier = Modifier
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
         modifier = modifier
     ) {
-        DropDownMenu(
-            label = "Type",
-            currentValue = request.type,
-            values = ApiType.defaultValues(),
-            onValueChange = onEndpointTypeChanged,
-            formatter = ApiType::label,
+        Text(
+            text = "Endpoint Conditions",
+            style = MaterialTheme.typography.h6
+        )
+        EndpointTypeField(
+            endpointType = request.type,
+            onEndpointTypeChanged = onEndpointTypeChanged,
             modifier = Modifier.fillMaxWidth()
         )
-        if (request.type is ApiType.Custom) {
-            TextField(
-                label = { Text(text = "Host (without scheme)") },
-                value = request.type.host,
-                onValueChange = { onEndpointTypeChanged(request.type.copy(host = it)) },
-                modifier = Modifier.fillMaxWidth()
+
+        PathField(
+            path = request.path,
+            endpointType = request.type,
+            onPathChanged = onPathChanged,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        RequestBodyField(
+            body = request.body,
+            onBodyChanged = onBodyChanged,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun ResponseSection(
+    response: Response,
+    onStatusCodeChanged: (Int) -> Unit,
+    onBodyChanged: (String) -> Unit,
+    modifier: Modifier
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier
+    ) {
+        Text(
+            text = "Response",
+            style = MaterialTheme.typography.h6
+        )
+        StatusCodeField(
+            statusCode = response.statusCode,
+            onStatusCodeChanged = onStatusCodeChanged,
+            modifier = Modifier.fillMaxWidth()
+        )
+        ResponseBodyField(
+            body = response.body,
+            onBodyChanged = onBodyChanged,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun EndpointTypeField(
+    endpointType: ApiType,
+    onEndpointTypeChanged: (ApiType) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    fun ApiType.label() = when (this) {
+        ApiType.WPApi -> "WordPress REST API"
+        ApiType.WPCom -> "WordPress.com REST API"
+        is ApiType.Custom -> "Custom"
+    }
+
+    DropDownMenu(
+        label = "Type",
+        currentValue = endpointType,
+        values = ApiType.defaultValues(),
+        onValueChange = onEndpointTypeChanged,
+        formatter = ApiType::label,
+        modifier = modifier.fillMaxWidth()
+    )
+    if (endpointType is ApiType.Custom) {
+        TextField(
+            label = { Text(text = "Host (without scheme)") },
+            value = endpointType.host,
+            onValueChange = { onEndpointTypeChanged(endpointType.copy(host = it)) },
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun PathField(
+    path: String,
+    endpointType: ApiType,
+    onPathChanged: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier) {
+        TextField(
+            label = { Text(text = "Path") },
+            value = path,
+            onValueChange = onPathChanged,
+            modifier = Modifier.fillMaxWidth()
+        )
+        val prefix = when (endpointType) {
+            ApiType.WPApi -> "/wp-json"
+            ApiType.WPCom -> "/rest"
+            is ApiType.Custom -> "host"
+        }
+        val caption = buildAnnotatedString {
+            append("Enter the path after the")
+            withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                append(" $prefix ")
+            }
+            append("part, without the query arguments")
+            append("\n")
+            append("Use")
+            withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                append(" % ")
+            }
+            append("as a wildcard for one or more characters")
+        }
+        Text(
+            text = caption,
+            style = MaterialTheme.typography.caption
+        )
+    }
+}
+
+@Composable
+private fun RequestBodyField(
+    body: String?,
+    onBodyChanged: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier) {
+        TextField(
+            label = { Text(text = "Body") },
+            value = body.orEmpty(),
+            placeholder = { Text(text = "An empty value will match everything") },
+            textStyle = if (body != null) LocalTextStyle.current
+            else LocalTextStyle.current.copy(color = Color.Gray),
+            onValueChange = onBodyChanged,
+            modifier = Modifier.fillMaxWidth()
+        )
+        val caption = buildAnnotatedString {
+            append("Use")
+            withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                append(" % ")
+            }
+            append("as a wildcard for one or more characters")
+        }
+        Text(
+            text = caption,
+            style = MaterialTheme.typography.caption
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun StatusCodeField(
+    statusCode: Int,
+    onStatusCodeChanged: (Int) -> Unit,
+    modifier: Modifier
+) {
+    @Composable
+    fun StatusCodeChip(
+        text: String,
+        selected: Boolean,
+        onClick: () -> Unit,
+    ) {
+        Chip(
+            onClick = onClick,
+            border = ChipDefaults.outlinedBorder,
+            colors = ChipDefaults.outlinedChipColors(
+                backgroundColor = if (selected) MaterialTheme.colors.primary else MaterialTheme.colors.surface,
+                contentColor = if (selected) MaterialTheme.colors.onPrimary else MaterialTheme.colors.onSurface
+            )
+        ) {
+            Text(text = text)
+        }
+    }
+
+    @Composable
+    fun CustomStatusCodeDialog(
+        statusCode: Int,
+        onDismiss: () -> Unit,
+        onStatusCodeChanged: (Int) -> Unit
+    ) {
+        Dialog(onDismissRequest = onDismiss) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier
+                    .background(MaterialTheme.colors.surface, shape = MaterialTheme.shapes.medium)
+                    .padding(16.dp)
+            ) {
+                var fieldValue by remember {
+                    mutableStateOf(statusCode.toString())
+                }
+                TextField(
+                    label = { Text(text = "Custom status code") },
+                    value = fieldValue,
+                    onValueChange = {
+                        fieldValue = it.substring(0, min(it.length, 3))
+                    },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                TextButton(
+                    onClick = {
+                        onStatusCodeChanged(fieldValue.toInt())
+                    },
+                    enabled = fieldValue.length == 3 && fieldValue.toIntOrNull() != null,
+                    modifier = Modifier.align(Alignment.End)
+                ) {
+                    Text(text = "OK")
+                }
+            }
+        }
+    }
+
+    val defaultStatusCodes = remember {
+        arrayOf(200, 403, 404, 500)
+    }
+    val isUsingACustomValue = remember(statusCode) {
+        !defaultStatusCodes.contains(statusCode)
+    }
+
+    var showCustomStatusCodeDialog by remember {
+        mutableStateOf(false)
+    }
+
+    Column(modifier) {
+        Text(
+            text = "Status Code",
+            style = MaterialTheme.typography.subtitle1
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            defaultStatusCodes.forEach { code ->
+                StatusCodeChip(
+                    text = code.toString(),
+                    selected = statusCode == code,
+                    onClick = { onStatusCodeChanged(code) }
+                )
+            }
+
+            StatusCodeChip(
+                text = "Custom${if (isUsingACustomValue) " ($statusCode) " else ""}",
+                selected = isUsingACustomValue,
+                onClick = { showCustomStatusCodeDialog = true }
+            )
+        }
+        if (showCustomStatusCodeDialog) {
+            CustomStatusCodeDialog(
+                statusCode = statusCode,
+                onDismiss = { showCustomStatusCodeDialog = false },
+                onStatusCodeChanged = {
+                    showCustomStatusCodeDialog = false
+                    onStatusCodeChanged(it)
+                }
             )
         }
     }
 }
 
-private val ApiType.label
-    get() = when (this) {
-        ApiType.WPApi -> "WordPress REST API"
-        ApiType.WPCom -> "WordPress.com REST API"
-        is ApiType.Custom -> "Custom"
-    }
+@Composable
+private fun ResponseBodyField(
+    body: String?,
+    onBodyChanged: (String) -> Unit,
+    modifier: Modifier
+) {
+    TextField(
+        label = { Text(text = "Body") },
+        value = body.orEmpty(),
+        onValueChange = onBodyChanged,
+        modifier = modifier
+    )
+}
 
 @Composable
 @Preview
@@ -134,10 +426,10 @@ private fun EndpointDetailsScreenPreview() {
                 request = Request(
                     type = ApiType.Custom("https://example.com"),
                     path = "/wc/v3/products",
-                    body = "%"
+                    body = null
                 ),
                 response = Response(
-                    statusCode = 200,
+                    statusCode = 300,
                     body = ""
                 )
             ),

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -1,0 +1,147 @@
+package com.woocommerce.android.apifaker.ui.details
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.TextField
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.woocommerce.android.apifaker.models.ApiType
+import com.woocommerce.android.apifaker.models.MockedEndpoint
+import com.woocommerce.android.apifaker.models.Request
+import com.woocommerce.android.apifaker.models.Response
+import com.woocommerce.android.apifaker.ui.DropDownMenu
+
+@Composable
+internal fun EndpointDetailsScreen(
+    viewModel: EndpointDetailsViewModel,
+    navController: NavController
+) {
+    EndpointDetailsScreen(
+        state = viewModel.state,
+        navController = navController,
+        onEndpointTypeChanged = viewModel::onEndpointTypeChanged
+    )
+}
+
+@Composable
+private fun EndpointDetailsScreen(
+    state: MockedEndpoint,
+    navController: NavController,
+    onEndpointTypeChanged: (ApiType) -> Unit = {},
+    onPathChanged: (String) -> Unit = {},
+    onBodyChanged: (String) -> Unit = {}
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(text = "Endpoint Definition") },
+                navigationIcon = {
+                    IconButton(onClick = navController::navigateUp) {
+                        Icon(
+                            Icons.AutoMirrored.Default.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                actions = {
+                    TextButton(onClick = { /*TODO*/ }) {
+                        Text(text = "Save")
+                    }
+                }
+            )
+        },
+        backgroundColor = MaterialTheme.colors.surface
+    ) { paddingValues ->
+        Column(
+            Modifier
+                .padding(paddingValues)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            RequestDefinitionSection(
+                request = state.request,
+                onEndpointTypeChanged = onEndpointTypeChanged,
+                onPathChanged = onPathChanged,
+                onBodyChanged = onBodyChanged,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+private fun RequestDefinitionSection(
+    request: Request,
+    onEndpointTypeChanged: (ApiType) -> Unit,
+    onPathChanged: (String) -> Unit,
+    onBodyChanged: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier
+    ) {
+        DropDownMenu(
+            label = "Type",
+            currentValue = request.type,
+            values = ApiType.defaultValues(),
+            onValueChange = onEndpointTypeChanged,
+            formatter = ApiType::label,
+            modifier = Modifier.fillMaxWidth()
+        )
+        if (request.type is ApiType.Custom) {
+            TextField(
+                label = { Text(text = "Host (without scheme)") },
+                value = request.type.host,
+                onValueChange = { onEndpointTypeChanged(request.type.copy(host = it)) },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+private val ApiType.label
+    get() = when (this) {
+        ApiType.WPApi -> "WordPress REST API"
+        ApiType.WPCom -> "WordPress.com REST API"
+        is ApiType.Custom -> "Custom"
+    }
+
+@Composable
+@Preview
+private fun EndpointDetailsScreenPreview() {
+    Surface(color = MaterialTheme.colors.background) {
+        EndpointDetailsScreen(
+            state = MockedEndpoint(
+                request = Request(
+                    type = ApiType.Custom("https://example.com"),
+                    path = "/wc/v3/products",
+                    body = "%"
+                ),
+                response = Response(
+                    statusCode = 200,
+                    body = ""
+                )
+            ),
+            navController = rememberNavController()
+        )
+    }
+}

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.woocommerce.android.apifaker.models.ApiType
+import com.woocommerce.android.apifaker.models.HttpMethod
 import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.ui.DropDownMenu
@@ -64,6 +65,7 @@ internal fun EndpointDetailsScreen(
         navController = navController,
         onSaveClicked = viewModel::onSaveClicked,
         onApiTypeChanged = viewModel::onApiTypeChanged,
+        onRequestHttpMethodChanged = viewModel::onRequestHttpMethodChanged,
         onRequestPathChanged = viewModel::onRequestPathChanged,
         onRequestBodyChanged = viewModel::onRequestBodyChanged,
         onResponseStatusCodeChanged = viewModel::onResponseStatusCodeChanged,
@@ -77,6 +79,7 @@ private fun EndpointDetailsScreen(
     navController: NavController,
     onSaveClicked: () -> Unit = {},
     onApiTypeChanged: (ApiType) -> Unit = {},
+    onRequestHttpMethodChanged: (HttpMethod?) -> Unit = {},
     onRequestPathChanged: (String) -> Unit = {},
     onRequestBodyChanged: (String) -> Unit = {},
     onResponseStatusCodeChanged: (Int) -> Unit = {},
@@ -117,6 +120,7 @@ private fun EndpointDetailsScreen(
             RequestDefinitionSection(
                 request = state.request,
                 onApiTypeChanged = onApiTypeChanged,
+                onHttpMethodChanged = onRequestHttpMethodChanged,
                 onPathChanged = onRequestPathChanged,
                 onBodyChanged = onRequestBodyChanged,
                 modifier = Modifier
@@ -144,6 +148,7 @@ private fun EndpointDetailsScreen(
 private fun RequestDefinitionSection(
     request: Request,
     onApiTypeChanged: (ApiType) -> Unit,
+    onHttpMethodChanged: (HttpMethod?) -> Unit,
     onPathChanged: (String) -> Unit,
     onBodyChanged: (String) -> Unit,
     modifier: Modifier = Modifier
@@ -159,6 +164,12 @@ private fun RequestDefinitionSection(
         EndpointTypeField(
             apiType = request.type,
             onApiTypeChanged = onApiTypeChanged,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        HttpMethodField(
+            method = request.httpMethod,
+            onHttpMethodChanged = onHttpMethodChanged,
             modifier = Modifier.fillMaxWidth()
         )
 
@@ -233,6 +244,23 @@ private fun EndpointTypeField(
             modifier = Modifier.fillMaxWidth()
         )
     }
+}
+
+
+@Composable
+private fun HttpMethodField(
+    method: HttpMethod?,
+    onHttpMethodChanged: (HttpMethod?) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    DropDownMenu(
+        label = "HTTP Method",
+        currentValue = method,
+        values = listOf(null) + HttpMethod.values(),
+        onValueChange = onHttpMethodChanged,
+        formatter = { it?.name ?: "Any" },
+        modifier = modifier.fillMaxWidth()
+    )
 }
 
 @Composable
@@ -437,6 +465,7 @@ private fun EndpointDetailsScreenPreview() {
             state = EndpointDetailsViewModel.UiState(
                 request = Request(
                     type = ApiType.Custom("https://example.com"),
+                    httpMethod = HttpMethod.GET,
                     path = "/wc/v3/products",
                     body = null
                 ),

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -22,7 +23,8 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
-import androidx.compose.material.TextField
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -101,13 +103,15 @@ private fun EndpointDetailsScreen(
                     TextButton(
                         onClick = onSaveClicked,
                         enabled = state.isEndpointValid,
-                        colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colors.onPrimary)
+                        colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colors.onSurface)
                     ) {
                         Text(
                             text = "Save"
                         )
                     }
-                }
+                },
+                backgroundColor = MaterialTheme.colors.surface,
+                elevation = 4.dp
             )
         },
         backgroundColor = MaterialTheme.colors.surface
@@ -237,7 +241,7 @@ private fun EndpointTypeField(
         modifier = modifier.fillMaxWidth()
     )
     if (apiType is ApiType.Custom) {
-        TextField(
+        OutlinedTextField(
             label = { Text(text = "Host (without scheme)") },
             value = apiType.host,
             onValueChange = { onApiTypeChanged(apiType.copy(host = it)) },
@@ -271,7 +275,7 @@ private fun PathField(
     modifier: Modifier = Modifier
 ) {
     Column(modifier) {
-        TextField(
+        OutlinedTextField(
             label = { Text(text = "Path") },
             value = path,
             onValueChange = onPathChanged,
@@ -309,14 +313,15 @@ private fun RequestBodyField(
     modifier: Modifier = Modifier
 ) {
     Column(modifier) {
-        TextField(
+        OutlinedTextField(
             label = { Text(text = "Body") },
             value = body.orEmpty(),
             placeholder = { Text(text = "An empty value will match everything") },
             textStyle = if (body != null) LocalTextStyle.current
             else LocalTextStyle.current.copy(color = Color.Gray),
             onValueChange = onBodyChanged,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
         )
         val caption = buildAnnotatedString {
             append("Use")
@@ -373,7 +378,7 @@ private fun StatusCodeField(
                 var fieldValue by remember {
                     mutableStateOf(statusCode.toString())
                 }
-                TextField(
+                OutlinedTextField(
                     label = { Text(text = "Custom status code") },
                     value = fieldValue,
                     onValueChange = {
@@ -449,11 +454,12 @@ private fun ResponseBodyField(
     onBodyChanged: (String) -> Unit,
     modifier: Modifier
 ) {
-    TextField(
+    OutlinedTextField(
         label = { Text(text = "Body") },
         value = body.orEmpty(),
         onValueChange = onBodyChanged,
         modifier = modifier
+            .defaultMinSize(minHeight = TextFieldDefaults.MinHeight * 2)
     )
 }
 

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -376,7 +376,6 @@ private fun QueryParametersField(
                         Text(text = "Add")
                     }
                 }
-
             }
         }
     }
@@ -437,10 +436,11 @@ private fun QueryParametersField(
     }
 
     if (isAddDialogShown) {
-        AddDialog(onAdd = { name, value ->
-            onQueryParameterAdded(name, value)
-            isAddDialogShown = false
-        },
+        AddDialog(
+            onAdd = { name, value ->
+                onQueryParameterAdded(name, value)
+                isAddDialogShown = false
+            },
             onDismiss = { isAddDialogShown = false }
         )
     }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -19,11 +19,11 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
-import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
@@ -250,7 +250,6 @@ private fun EndpointTypeField(
     }
 }
 
-
 @Composable
 private fun HttpMethodField(
     method: HttpMethod?,
@@ -317,8 +316,11 @@ private fun RequestBodyField(
             label = { Text(text = "Body") },
             value = body.orEmpty(),
             placeholder = { Text(text = "An empty value will match everything") },
-            textStyle = if (body != null) LocalTextStyle.current
-            else LocalTextStyle.current.copy(color = Color.Gray),
+            textStyle = if (body != null) {
+                LocalTextStyle.current
+            } else {
+                LocalTextStyle.current.copy(color = Color.Gray)
+            },
             onValueChange = onBodyChanged,
             modifier = Modifier
                 .fillMaxWidth()

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.ApiType
 import com.woocommerce.android.apifaker.models.HttpMethod
+import com.woocommerce.android.apifaker.models.QueryParameter
 import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.ui.Screen
@@ -24,7 +25,7 @@ internal class EndpointDetailsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val endpointDao: EndpointDao
 ) : ViewModel() {
-    private val id = savedStateHandle.get<Long>(Screen.EndpointDetails.endpointIdArgumentName)!!
+    private val id = checkNotNull(savedStateHandle.get<Long>(Screen.EndpointDetails.endpointIdArgumentName))
 
     var state: UiState by mutableStateOf(defaultEndpoint())
         private set
@@ -50,6 +51,24 @@ internal class EndpointDetailsViewModel @Inject constructor(
     fun onRequestPathChanged(path: String) {
         withMutableSnapshot {
             state = state.copy(request = state.request.copy(path = path))
+        }
+    }
+
+    fun onQueryParameterAdded(name: String, value: String) {
+        val queryParameter = QueryParameter(name, value)
+        withMutableSnapshot {
+            state = state.copy(
+                request = state.request.copy(
+                    queryParameters = state.request.queryParameters + queryParameter
+                )
+            )
+        }
+    }
+
+    fun onQueryParameterDeleted(queryParameter: QueryParameter) {
+        withMutableSnapshot {
+            state =
+                state.copy(request = state.request.copy(queryParameters = state.request.queryParameters - queryParameter))
         }
     }
 

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -94,7 +94,7 @@ internal class EndpointDetailsViewModel @Inject constructor(
             id = MISSING_ENDPOINT_ID,
             type = ApiType.WPApi,
             path = "",
-            body = "%"
+            body = null
         ),
         Response(
             endpointId = MISSING_ENDPOINT_ID,

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -41,6 +41,30 @@ internal class EndpointDetailsViewModel @Inject constructor(
         }
     }
 
+    fun onRequestPathChanged(path: String) {
+        withMutableSnapshot {
+            state = state.copy(request = state.request.copy(path = path))
+        }
+    }
+
+    fun onRequestBodyChanged(body: String) {
+        withMutableSnapshot {
+            state = state.copy(request = state.request.copy(body = body.ifEmpty { null }))
+        }
+    }
+
+    fun onResponseStatusCodeChanged(statusCode: Int) {
+        withMutableSnapshot {
+            state = state.copy(response = state.response.copy(statusCode = statusCode))
+        }
+    }
+
+    fun onResponseBodyChanged(body: String) {
+        withMutableSnapshot {
+            state = state.copy(response = state.response.copy(body = body))
+        }
+    }
+
     private fun loadEndpoint() = viewModelScope.launch {
         state = endpointDao.getEndpoint(id)!!
     }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -1,0 +1,61 @@
+package com.woocommerce.android.apifaker.ui.details
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot.Companion.withMutableSnapshot
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.apifaker.db.EndpointDao
+import com.woocommerce.android.apifaker.models.ApiType
+import com.woocommerce.android.apifaker.models.MockedEndpoint
+import com.woocommerce.android.apifaker.models.Request
+import com.woocommerce.android.apifaker.models.Response
+import com.woocommerce.android.apifaker.ui.Screen
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+const val MISSING_ENDPOINT_ID = -1L
+
+@HiltViewModel
+internal class EndpointDetailsViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val endpointDao: EndpointDao
+) : ViewModel() {
+    private val id = savedStateHandle.get<Long>(Screen.EndpointDetails.endpointIdArgumentName)!!
+
+    var state: MockedEndpoint by mutableStateOf(defaultEndpoint())
+        private set
+
+    init {
+        if (id != MISSING_ENDPOINT_ID && state.request.id == MISSING_ENDPOINT_ID) {
+            loadEndpoint()
+        }
+    }
+
+    fun onEndpointTypeChanged(endpointType: ApiType) {
+        withMutableSnapshot {
+            state = state.copy(request = state.request.copy(type = endpointType))
+        }
+    }
+
+    private fun loadEndpoint() = viewModelScope.launch {
+        state = endpointDao.getEndpoint(id)!!
+    }
+
+    private fun defaultEndpoint() = MockedEndpoint(
+        Request(
+            id = MISSING_ENDPOINT_ID,
+            type = ApiType.WPApi,
+            path = "",
+            body = "%"
+        ),
+        Response(
+            endpointId = MISSING_ENDPOINT_ID,
+            statusCode = 200,
+            body = ""
+        )
+    )
+}

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -67,8 +67,11 @@ internal class EndpointDetailsViewModel @Inject constructor(
 
     fun onQueryParameterDeleted(queryParameter: QueryParameter) {
         withMutableSnapshot {
-            state =
-                state.copy(request = state.request.copy(queryParameters = state.request.queryParameters - queryParameter))
+            state = state.copy(
+                request = state.request.copy(
+                    queryParameters = state.request.queryParameters - queryParameter
+                )
+            )
         }
     }
 

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.ApiType
-import com.woocommerce.android.apifaker.models.MockedEndpoint
 import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.ui.Screen
@@ -26,7 +25,7 @@ internal class EndpointDetailsViewModel @Inject constructor(
 ) : ViewModel() {
     private val id = savedStateHandle.get<Long>(Screen.EndpointDetails.endpointIdArgumentName)!!
 
-    var state: MockedEndpoint by mutableStateOf(defaultEndpoint())
+    var state: UiState by mutableStateOf(defaultEndpoint())
         private set
 
     init {
@@ -65,11 +64,32 @@ internal class EndpointDetailsViewModel @Inject constructor(
         }
     }
 
-    private fun loadEndpoint() = viewModelScope.launch {
-        state = endpointDao.getEndpoint(id)!!
+    fun onSaveClicked() {
+        viewModelScope.launch {
+            endpointDao.insertEndpoint(state.request, state.response)
+            state = state.copy(isEndpointSaved = true)
+        }
     }
 
-    private fun defaultEndpoint() = MockedEndpoint(
+    private fun loadEndpoint() = viewModelScope.launch {
+        state = endpointDao.getEndpoint(id)!!.let {
+            UiState(
+                it.request,
+                it.response
+            )
+        }
+    }
+
+    data class UiState(
+        val request: Request,
+        val response: Response,
+        val isEndpointSaved: Boolean = false
+    ) {
+        val isEndpointValid: Boolean
+            get() = request.path.isNotBlank()
+    }
+
+    private fun defaultEndpoint() = UiState(
         Request(
             id = MISSING_ENDPOINT_ID,
             type = ApiType.WPApi,

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.ApiType
+import com.woocommerce.android.apifaker.models.HttpMethod
 import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.ui.Screen
@@ -37,6 +38,12 @@ internal class EndpointDetailsViewModel @Inject constructor(
     fun onApiTypeChanged(apiType: ApiType) {
         withMutableSnapshot {
             state = state.copy(request = state.request.copy(type = apiType))
+        }
+    }
+
+    fun onRequestHttpMethodChanged(httpMethod: HttpMethod?) {
+        withMutableSnapshot {
+            state = state.copy(request = state.request.copy(httpMethod = httpMethod))
         }
     }
 
@@ -93,6 +100,7 @@ internal class EndpointDetailsViewModel @Inject constructor(
         Request(
             id = MISSING_ENDPOINT_ID,
             type = ApiType.WPApi,
+            httpMethod = null,
             path = "",
             body = null
         ),

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -20,7 +20,7 @@ const val MISSING_ENDPOINT_ID = 0L
 
 @HiltViewModel
 internal class EndpointDetailsViewModel @Inject constructor(
-    private val savedStateHandle: SavedStateHandle,
+    savedStateHandle: SavedStateHandle,
     private val endpointDao: EndpointDao
 ) : ViewModel() {
     private val id = savedStateHandle.get<Long>(Screen.EndpointDetails.endpointIdArgumentName)!!
@@ -34,9 +34,9 @@ internal class EndpointDetailsViewModel @Inject constructor(
         }
     }
 
-    fun onEndpointTypeChanged(endpointType: ApiType) {
+    fun onApiTypeChanged(apiType: ApiType) {
         withMutableSnapshot {
-            state = state.copy(request = state.request.copy(type = endpointType))
+            state = state.copy(request = state.request.copy(type = apiType))
         }
     }
 

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -16,7 +16,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-const val MISSING_ENDPOINT_ID = -1L
+const val MISSING_ENDPOINT_ID = 0L
 
 @HiltViewModel
 internal class EndpointDetailsViewModel @Inject constructor(

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
@@ -88,7 +88,8 @@ private fun HomeScreen(
                 actions = {
                     Switch(checked = isEnabled, onCheckedChange = onMockingToggleChanged)
                 },
-                backgroundColor = MaterialTheme.colors.surface
+                backgroundColor = MaterialTheme.colors.surface,
+                elevation = 4.dp
             )
         }
     ) { paddingValues ->

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
@@ -181,8 +181,7 @@ private fun EndpointItem(
                             style = MaterialTheme.typography.subtitle1,
                             fontWeight = FontWeight.SemiBold
                         )
-                        val pathLine = endpoint.request.httpMethod?.let { "$it " }.orEmpty() +
-                                endpoint.request.path
+                        val pathLine = endpoint.request.httpMethod?.let { "$it " }.orEmpty() + endpoint.request.path
                         Text(
                             text = pathLine,
                             style = MaterialTheme.typography.body1

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.apifaker.ui.home
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,21 +14,28 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Card
+import androidx.compose.material.DismissDirection.EndToStart
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.FractionalThreshold
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
+import androidx.compose.material.SwipeToDismiss
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.rememberDismissState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -38,6 +46,7 @@ import com.woocommerce.android.apifaker.models.MockedEndpoint
 import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.ui.Screen
+import com.woocommerce.android.apifaker.ui.Screen.EndpointDetails
 
 @Composable
 internal fun HomeScreen(
@@ -49,6 +58,7 @@ internal fun HomeScreen(
         endpoints = viewModel.endpoints.collectAsState().value,
         isEnabled = viewModel.isEnabled.collectAsState(initial = false).value,
         navController = navController,
+        onRemoveRequest = viewModel::onRemoveRequest,
         onMockingToggleChanged = viewModel::onMockingToggleChanged,
         onExit = onExit
     )
@@ -59,8 +69,9 @@ private fun HomeScreen(
     endpoints: List<MockedEndpoint>,
     isEnabled: Boolean,
     navController: NavController,
+    onRemoveRequest: (Request) -> Unit,
     onMockingToggleChanged: (Boolean) -> Unit,
-    onExit: () -> Unit,
+    onExit: () -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -89,8 +100,13 @@ private fun HomeScreen(
         ) {
             if (endpoints.isNotEmpty()) {
                 LazyColumn {
-                    items(endpoints) { endpoint ->
-                        EndpointItem(endpoint, navController, Modifier.padding(vertical = 8.dp))
+                    items(endpoints, { endpoint -> endpoint.request.id }) { endpoint ->
+                        EndpointItem(
+                            endpoint,
+                            onRemoveRequest = onRemoveRequest,
+                            navController,
+                            Modifier.padding(vertical = 8.dp)
+                        )
                     }
                 }
             } else {
@@ -109,47 +125,77 @@ private fun HomeScreen(
     }
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun EndpointItem(
     endpoint: MockedEndpoint,
+    onRemoveRequest: (Request) -> Unit,
     navController: NavController,
     modifier: Modifier = Modifier
 ) {
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = { navController.navigate(Screen.EndpointDetails.route(endpoint.request.id)) }),
-        elevation = 4.dp
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(8.dp)
-        ) {
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text(
-                    text = when (endpoint.request.type) {
-                        ApiType.WPApi -> "WordPress API"
-                        ApiType.WPCom -> "WordPress.com API"
-                        is ApiType.Custom -> "Host: ${endpoint.request.type.host}"
-                    },
-                    style = MaterialTheme.typography.subtitle1
-                )
-                Text(
-                    text = endpoint.request.path,
-                    style = MaterialTheme.typography.body1
+    val dismissState = rememberDismissState {
+        onRemoveRequest(endpoint.request)
+        true
+    }
+    SwipeToDismiss(
+        state = dismissState,
+        directions = setOf(EndToStart),
+        dismissThresholds = {
+            FractionalThreshold(0.3f)
+        },
+        modifier = modifier,
+        background = {
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .background(Color.Red, MaterialTheme.shapes.medium)
+                    .padding(horizontal = 20.dp),
+                contentAlignment = Alignment.CenterEnd
+            ) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = "Delete"
                 )
             }
-            Spacer(
+        },
+        dismissContent = {
+            Card(
                 modifier = Modifier
-                    .weight(1f)
-                    .defaultMinSize(minWidth = 16.dp)
-            )
-            Text(
-                text = endpoint.response.statusCode.toString(),
-                style = MaterialTheme.typography.subtitle1
-            )
+                    .fillMaxWidth()
+                    .clickable(onClick = { navController.navigate(EndpointDetails.route(endpoint.request.id)) }),
+                elevation = 4.dp
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(8.dp)
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text(
+                            text = when (endpoint.request.type) {
+                                ApiType.WPApi -> "WordPress API"
+                                ApiType.WPCom -> "WordPress.com API"
+                                is ApiType.Custom -> "Host: ${endpoint.request.type.host}"
+                            },
+                            style = MaterialTheme.typography.subtitle1
+                        )
+                        Text(
+                            text = endpoint.request.path,
+                            style = MaterialTheme.typography.body1
+                        )
+                    }
+                    Spacer(
+                        modifier = Modifier
+                            .weight(1f)
+                            .defaultMinSize(minWidth = 16.dp)
+                    )
+                    Text(
+                        text = endpoint.response.statusCode.toString(),
+                        style = MaterialTheme.typography.subtitle1
+                    )
+                }
+            }
         }
-    }
+    )
 }
 
 @Composable
@@ -178,6 +224,7 @@ private fun HomeScreenPreview() {
         ),
         isEnabled = true,
         navController = rememberNavController(),
+        onRemoveRequest = {},
         onMockingToggleChanged = {},
         onExit = {}
     )

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Card
-import androidx.compose.material.DismissDirection.EndToStart
+import androidx.compose.material.DismissDirection
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.FractionalThreshold
@@ -36,6 +36,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -46,7 +47,6 @@ import com.woocommerce.android.apifaker.models.MockedEndpoint
 import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.ui.Screen
-import com.woocommerce.android.apifaker.ui.Screen.EndpointDetails
 
 @Composable
 internal fun HomeScreen(
@@ -133,13 +133,14 @@ private fun EndpointItem(
     navController: NavController,
     modifier: Modifier = Modifier
 ) {
-    val dismissState = rememberDismissState {
+    val dismissState = rememberDismissState()
+
+    if (dismissState.isDismissed(DismissDirection.EndToStart)) {
         onRemoveRequest(endpoint.request)
-        true
     }
     SwipeToDismiss(
         state = dismissState,
-        directions = setOf(EndToStart),
+        directions = setOf(DismissDirection.EndToStart),
         dismissThresholds = {
             FractionalThreshold(0.3f)
         },
@@ -162,7 +163,7 @@ private fun EndpointItem(
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable(onClick = { navController.navigate(EndpointDetails.route(endpoint.request.id)) }),
+                    .clickable(onClick = { navController.navigate(Screen.EndpointDetails.route(endpoint.request.id)) }),
                 elevation = 4.dp
             ) {
                 Row(
@@ -176,10 +177,13 @@ private fun EndpointItem(
                                 ApiType.WPCom -> "WordPress.com API"
                                 is ApiType.Custom -> "Host: ${endpoint.request.type.host}"
                             },
-                            style = MaterialTheme.typography.subtitle1
+                            style = MaterialTheme.typography.subtitle1,
+                            fontWeight = FontWeight.SemiBold
                         )
+                        val pathLine = endpoint.request.httpMethod?.let { "$it " }.orEmpty() +
+                            endpoint.request.path
                         Text(
-                            text = endpoint.request.path,
+                            text = pathLine,
                             style = MaterialTheme.typography.body1
                         )
                     }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.Card
 import androidx.compose.material.DismissDirection
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FloatingActionButton
-import androidx.compose.material.FractionalThreshold
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -143,7 +142,8 @@ private fun EndpointItem(
         state = dismissState,
         directions = setOf(DismissDirection.EndToStart),
         dismissThresholds = {
-            FractionalThreshold(0.3f)
+            @Suppress("DEPRECATION")
+            androidx.compose.material.FractionalThreshold(0.3f)
         },
         modifier = modifier,
         background = {
@@ -182,7 +182,7 @@ private fun EndpointItem(
                             fontWeight = FontWeight.SemiBold
                         )
                         val pathLine = endpoint.request.httpMethod?.let { "$it " }.orEmpty() +
-                            endpoint.request.path
+                                endpoint.request.path
                         Text(
                             text = pathLine,
                             style = MaterialTheme.typography.body1

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeScreen.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -168,10 +166,14 @@ private fun EndpointItem(
                 elevation = 4.dp
             ) {
                 Row(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.padding(8.dp)
                 ) {
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                        modifier = Modifier.weight(1f)
+                    ) {
                         Text(
                             text = when (endpoint.request.type) {
                                 ApiType.WPApi -> "WordPress API"
@@ -187,11 +189,6 @@ private fun EndpointItem(
                             style = MaterialTheme.typography.body1
                         )
                     }
-                    Spacer(
-                        modifier = Modifier
-                            .weight(1f)
-                            .defaultMinSize(minWidth = 16.dp)
-                    )
                     Text(
                         text = endpoint.response.statusCode.toString(),
                         style = MaterialTheme.typography.subtitle1

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.apifaker.db.EndpointDao
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -21,6 +22,8 @@ internal class HomeViewModel @Inject constructor(
     val isEnabled = config.enabled
 
     fun onMockingToggleChanged(enabled: Boolean) {
-        config.setStatus(enabled)
+        viewModelScope.launch {
+            config.setStatus(enabled)
+        }
     }
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/home/HomeViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.apifaker.ApiFakerConfig
 import com.woocommerce.android.apifaker.db.EndpointDao
+import com.woocommerce.android.apifaker.models.Request
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
@@ -12,7 +13,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 internal class HomeViewModel @Inject constructor(
-    endpointDao: EndpointDao,
+    private val endpointDao: EndpointDao,
     private val config: ApiFakerConfig
 ) : ViewModel() {
     @Suppress("MagicNumber")
@@ -24,6 +25,12 @@ internal class HomeViewModel @Inject constructor(
     fun onMockingToggleChanged(enabled: Boolean) {
         viewModelScope.launch {
             config.setStatus(enabled)
+        }
+    }
+
+    fun onRemoveRequest(request: Request) {
+        viewModelScope.launch {
+            endpointDao.deleteRequest(request)
         }
     }
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/util/JSONObjectProvider.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/util/JSONObjectProvider.kt
@@ -3,6 +3,6 @@ package com.woocommerce.android.apifaker.util
 import org.json.JSONObject
 import javax.inject.Inject
 
-class JSONObjectProvider @Inject constructor() {
+internal class JSONObjectProvider @Inject constructor() {
     fun parseString(content: String): JSONObject = JSONObject(content)
 }

--- a/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/EndpointProcessorTest.kt
+++ b/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/EndpointProcessorTest.kt
@@ -4,9 +4,10 @@ import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.ApiType
 import com.woocommerce.android.apifaker.models.HttpMethod
 import com.woocommerce.android.apifaker.models.MockedEndpoint
+import com.woocommerce.android.apifaker.models.QueryParameter
+import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.util.JSONObjectProvider
-import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
 import org.junit.Test
@@ -14,6 +15,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import okhttp3.Request as OkHttpRequest
 
 class EndpointProcessorTest {
     private val endpointDaoMock = mock<EndpointDao>()
@@ -25,7 +27,7 @@ class EndpointProcessorTest {
 
     @Test
     fun `when processing a GET WPCom endpoint, then extract data correctly`() {
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("GET", null)
             .url("https://public-api.wordpress.com/rest/v1.1/me?param=value")
             .build()
@@ -43,7 +45,7 @@ class EndpointProcessorTest {
     @Test
     fun `when processing a POST WPCom endpoint, then extract data correctly`() {
         val body = "Test Body"
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("POST", body.toRequestBody())
             .url("https://public-api.wordpress.com/rest/v1.1/me?param=value")
             .build()
@@ -60,7 +62,7 @@ class EndpointProcessorTest {
 
     @Test
     fun `when processing a GET Jetpack Tunnel endpoint, then extract data correctly`() {
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("GET", null)
             .url(
                 "https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/161477129/rest-api/" +
@@ -91,7 +93,7 @@ class EndpointProcessorTest {
         }
         whenever(jsonObjectProvider.parseString(body)).thenReturn(jsonObject)
 
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("POST", body.toRequestBody())
             .url("https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/161477129/rest-api")
             .build()
@@ -108,7 +110,7 @@ class EndpointProcessorTest {
 
     @Test
     fun `when processing a GET WPApi endpoint, then extract data correctly`() {
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("GET", null)
             .url("https://test-site.com/wp-json/wc/v3/products?param=value")
             .build()
@@ -126,7 +128,7 @@ class EndpointProcessorTest {
     @Test
     fun `when processing a POST WPApi endpoint, then extract data correctly`() {
         val body = "Test Body"
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("POST", body.toRequestBody())
             .url("https://test-site.com/wp-json/wc/v3/products")
             .build()
@@ -143,7 +145,7 @@ class EndpointProcessorTest {
 
     @Test
     fun `when processing a GET Custom endpoint, then extract data correctly`() {
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("GET", null)
             .url("https://test-site.com/an/endpoint?param=value")
             .build()
@@ -161,7 +163,7 @@ class EndpointProcessorTest {
     @Test
     fun `when processing a POST Custom endpoint, then extract data correctly`() {
         val body = "Test Body"
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("POST", body.toRequestBody())
             .url("https://test-site.com/an/endpoint")
             .build()
@@ -179,7 +181,7 @@ class EndpointProcessorTest {
     @Test
     fun `when processing a GET jetpack tunnel endpoint, then wrap body if necessary`() {
         val mockEndpoint = MockedEndpoint(
-            request = com.woocommerce.android.apifaker.models.Request(
+            request = Request(
                 id = 0,
                 type = ApiType.WPApi,
                 httpMethod = HttpMethod.GET,
@@ -199,9 +201,9 @@ class EndpointProcessorTest {
                 path = mockEndpoint.request.path,
                 body = mockEndpoint.request.body.orEmpty()
             )
-        ).thenReturn(mockEndpoint)
+        ).thenReturn(listOf(mockEndpoint))
 
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method(mockEndpoint.request.httpMethod.name, null)
             .url(
                 "https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/161477129/rest-api/" +
@@ -211,5 +213,86 @@ class EndpointProcessorTest {
 
         val response = endpointProcessor.fakeRequestIfNeeded(request)
         assert(response?.body == "{\"data\": {\"key\":\"value\"}}")
+    }
+
+    @Test
+    fun `when processing a GET jetpack tunnel endpoint with query parameters, then check query parameters`() {
+        val mockEndpoint = MockedEndpoint(
+            request = Request(
+                id = 0,
+                type = ApiType.WPApi,
+                httpMethod = HttpMethod.GET,
+                path = "/wc/v3/products",
+                queryParameters = listOf(
+                    QueryParameter("param", "value")
+                ),
+                body = null
+            ),
+            response = Response(
+                endpointId = 0,
+                statusCode = 200
+            )
+        )
+        whenever(
+            endpointDaoMock.queryEndpoint(
+                type = mockEndpoint.request.type,
+                httpMethod = mockEndpoint.request.httpMethod!!,
+                path = mockEndpoint.request.path,
+                body = mockEndpoint.request.body.orEmpty()
+            )
+        ).thenReturn(listOf(mockEndpoint))
+        val jsonObject = mock<JSONObject> {
+            on { keys() } doReturn listOf("param").iterator()
+            on { getString("param") } doReturn "value"
+        }
+        whenever(jsonObjectProvider.parseString("{\"param\":\"value\"}")).thenReturn(jsonObject)
+
+        val request = OkHttpRequest.Builder()
+            .method(mockEndpoint.request.httpMethod.name, null)
+            .url(
+                "https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/161477129/rest-api/" +
+                    "?path=${mockEndpoint.request.path}&_method=${mockEndpoint.request.httpMethod.name}" +
+                    "&query={\"param\":\"value\"}"
+            )
+            .build()
+
+        val response = endpointProcessor.fakeRequestIfNeeded(request)
+        assert(response?.statusCode == 200)
+    }
+
+    @Test
+    fun `when processing a regular endpoint with query parameters, then check query parameters`() {
+        val mockEndpoint = MockedEndpoint(
+            request = Request(
+                id = 0,
+                type = ApiType.WPApi,
+                httpMethod = HttpMethod.GET,
+                path = "/wc/v3/products",
+                queryParameters = listOf(
+                    QueryParameter("param", "value")
+                ),
+                body = null
+            ),
+            response = Response(
+                endpointId = 0,
+                statusCode = 200
+            )
+        )
+        whenever(
+            endpointDaoMock.queryEndpoint(
+                type = mockEndpoint.request.type,
+                httpMethod = mockEndpoint.request.httpMethod!!,
+                path = mockEndpoint.request.path,
+                body = mockEndpoint.request.body.orEmpty()
+            )
+        ).thenReturn(listOf(mockEndpoint))
+
+        val request = OkHttpRequest.Builder()
+            .method(mockEndpoint.request.httpMethod.name, null)
+            .url("https://test-site.com/wp-json/wc/v3/products?param=value")
+            .build()
+
+        val response = endpointProcessor.fakeRequestIfNeeded(request)
+        assert(response?.statusCode == 200)
     }
 }


### PR DESCRIPTION
### Description
As part of my Hack Week, I'm bringing back the ApiFaker project paqN3M-SI-p2, and I'm splitting the feature into multiple PRs.

This PR adds the endpoint details screen, which is used to add or edit the endpoint details, it also adds logic for deleting endpoints.

**Sorry for the size of the PR, but I couldn't split it further.**

### Steps to reproduce
1. Use a debug build.
2. Open the settings page.
3. Tap on Developer Options.
4. Tap on ApiFaker.

### Testing information
- Test adding, editing, and deleting endpoints.
- Test endpoint faking logic (preferably using both WordPress.com and site credentials logins)

### The tests that have been performed
^

### Images/gif
<img src=https://github.com/user-attachments/assets/31e5762a-0c00-466e-aa98-319a3c63937f width=360 />
<img src=https://github.com/user-attachments/assets/82e935a7-c150-42b5-a20f-e23555c67a6c width=360 />

</br>
</br>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->