### PR TITLE
[Hack Week] ApiFaker: display a hint on the main app UI when the ApiFaker is enabled

### DIFF
--- a/WooCommerce/src/debug/kotlin/com/woocommerce/android/WooCommerceDebug.kt
+++ b/WooCommerce/src/debug/kotlin/com/woocommerce/android/WooCommerceDebug.kt
@@ -12,13 +12,18 @@ import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
 import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin
 import com.facebook.soloader.SoLoader
+import com.woocommerce.android.apifaker.ApiFakerUiHelper
 import com.woocommerce.android.util.SystemVersionUtils
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
 class WooCommerceDebug : WooCommerce() {
+    @Inject
+    lateinit var apiFakerUiHelper: ApiFakerUiHelper
+
     override fun onCreate() {
         if (FlipperUtils.shouldEnableFlipper(this)) {
             SoLoader.init(this, false)
@@ -33,6 +38,7 @@ class WooCommerceDebug : WooCommerce() {
         enableWebContentDebugging()
         super.onCreate()
         enableStrictMode()
+        apiFakerUiHelper.attachToApplication(this)
     }
 
     /**

--- a/libs/apifaker/build.gradle
+++ b/libs/apifaker/build.gradle
@@ -51,6 +51,7 @@ android {
 
 dependencies {
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.appcompat)
     implementation(libs.androidx.navigation.compose)
 
     implementation(platform(libs.androidx.compose.bom))

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerInterceptor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerInterceptor.kt
@@ -7,6 +7,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.internal.EMPTY_RESPONSE
 import javax.inject.Inject
 
 private const val ARTIFICIAL_DELAY_MS = 500L
@@ -39,7 +40,10 @@ internal class ApiFakerInterceptor @Inject constructor(
                 .message("Fake Response")
                 .code(fakeResponse.statusCode)
                 // TODO check if it's safe to always use JSON as the content type
-                .body(fakeResponse.body?.toResponseBody("application/json".toMediaType()))
+                .body(
+                    fakeResponse.body?.toResponseBody("application/json".toMediaType())
+                        ?: EMPTY_RESPONSE
+                )
                 .addHeader("content-type", "application/json")
                 .build()
         } else {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerUiHelper.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerUiHelper.kt
@@ -1,0 +1,108 @@
+package com.woocommerce.android.apifaker
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.app.Application
+import android.app.Application.ActivityLifecycleCallbacks
+import android.graphics.Color
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewGroup.MarginLayoutParams
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.core.view.doOnLayout
+import androidx.core.view.updateLayoutParams
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+import java.lang.ref.WeakReference
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ApiFakerUiHelper @Inject constructor() : ActivityLifecycleCallbacks {
+    @Inject
+    internal lateinit var apiFakerConfig: ApiFakerConfig
+
+    private val apiFakerHintId = View.generateViewId()
+
+    fun attachToApplication(application: Application) {
+        application.registerActivityLifecycleCallbacks(this)
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        (activity as LifecycleOwner).lifecycleScope.launch {
+            updateApiFakerHint(WeakReference(activity))
+        }
+    }
+
+    override fun onActivityStarted(activity: Activity) {}
+
+    override fun onActivityResumed(activity: Activity) {}
+
+    override fun onActivityPaused(activity: Activity) {}
+
+    override fun onActivityStopped(activity: Activity) {}
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+
+    override fun onActivityDestroyed(activity: Activity) {}
+
+    private suspend fun updateApiFakerHint(
+        activityReference: WeakReference<Activity>
+    ) {
+        apiFakerConfig.enabled.collect { enabled ->
+            activityReference.get()?.let { activity ->
+                if (enabled) {
+                    activity.window.decorView.post {
+                        activity.window.decorView.showApiFakerHint()
+                    }
+                } else {
+                    activity.window.decorView.post {
+                        activity.window.decorView.hideApiFakerHint()
+                    }
+                }
+            }
+        }
+    }
+
+    @SuppressLint("SetTextI18n")
+    private fun View.showApiFakerHint() {
+        // This works only for activities that has the content view as a direct child of the FrameLayout, which is true
+        // for all AppCompat activities, so it should work for all the cases we need.
+        val contentLayout = findViewById<View>(android.R.id.content) as? FrameLayout ?: return
+        val activityLayout = contentLayout.getChildAt(0)
+
+        val apiFakerHint = FrameLayout(context).apply {
+            id = apiFakerHintId
+            setBackgroundColor(Color.RED)
+            addView(
+                TextView(context).apply {
+                    text = "ApiFaker Enabled"
+                    textAlignment = View.TEXT_ALIGNMENT_CENTER
+                }
+            )
+        }
+        contentLayout.addView(
+            apiFakerHint,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT
+            ).apply {
+                gravity = android.view.Gravity.BOTTOM
+            }
+        )
+
+        apiFakerHint.doOnLayout { view ->
+            activityLayout.updateLayoutParams<MarginLayoutParams> { bottomMargin = view.measuredHeight }
+        }
+    }
+
+    private fun View.hideApiFakerHint() {
+        val contentLayout = findViewById<ViewGroup>(android.R.id.content)
+        contentLayout.findViewById<View>(apiFakerHintId)?.let { apiFakerHint ->
+            contentLayout.removeView(apiFakerHint)
+        }
+    }
+}

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerUiHelper.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerUiHelper.kt
@@ -38,17 +38,17 @@ class ApiFakerUiHelper @Inject constructor() : ActivityLifecycleCallbacks {
         }
     }
 
-    override fun onActivityStarted(activity: Activity) {}
+    override fun onActivityStarted(activity: Activity) = Unit
 
-    override fun onActivityResumed(activity: Activity) {}
+    override fun onActivityResumed(activity: Activity) = Unit
 
-    override fun onActivityPaused(activity: Activity) {}
+    override fun onActivityPaused(activity: Activity) = Unit
 
-    override fun onActivityStopped(activity: Activity) {}
+    override fun onActivityStopped(activity: Activity) = Unit
 
-    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
 
-    override fun onActivityDestroyed(activity: Activity) {}
+    override fun onActivityDestroyed(activity: Activity) = Unit
 
     private suspend fun updateApiFakerHint(
         activityReference: WeakReference<ComponentActivity>

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerUiHelper.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerUiHelper.kt
@@ -82,6 +82,7 @@ class ApiFakerUiHelper @Inject constructor() : ActivityLifecycleCallbacks {
                 TextView(context).apply {
                     text = "ApiFaker Enabled"
                     textAlignment = View.TEXT_ALIGNMENT_CENTER
+                    setTextColor(Color.WHITE)
                 }
             )
             setOnClickListener {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
@@ -36,7 +36,7 @@ internal class EndpointProcessor @Inject constructor(
 
     private fun Request.extractDataFromWPComEndpoint(): EndpointData {
         val originalBody = readBody()
-        return if (url.encodedPath.trimEnd('/').matches(Regex(JETPACK_TUNNEL_REGEX))) {
+        return if (url.isJetpackTunnelRequest) {
             val (path, method, body) = if (method == "GET") {
                 Triple(
                     url.queryParameter("path")!!.substringBefore("&"),
@@ -89,11 +89,22 @@ internal class EndpointProcessor @Inject constructor(
         )
     }
 
-    private fun HttpUrl.checkQueryParameters(queryParameters: List<QueryParameter>): Boolean {
-        if (queryParameters.isEmpty()) return true
+    private fun HttpUrl.checkQueryParameters(mockedQueryParameters: List<QueryParameter>): Boolean {
+        if (mockedQueryParameters.isEmpty()) return true
 
-        return queryParameters.all { queryParameter ->
-            queryParameter(queryParameter.name) == queryParameter.value
+        val requestQueryParameters = if (isJetpackTunnelRequest) {
+            queryParameter("query")?.let {
+                val json = jsonObjectProvider.parseString(it)
+                json.keys().asSequence().map { key ->
+                    key to json.getString(key)
+                }.toMap()
+            } ?: emptyMap()
+        } else {
+            queryParameterNames.associateWith { queryParameter(it) }
+        }
+
+        return mockedQueryParameters.all { queryParameter ->
+            requestQueryParameters[queryParameter.name] == queryParameter.value
         }
     }
 
@@ -110,8 +121,7 @@ internal class EndpointProcessor @Inject constructor(
     }
 
     private fun String.wrapBodyIfNecessary(url: HttpUrl): String {
-        return if (url.host == WPCOM_HOST &&
-            url.encodedPath.trimEnd('/').matches(Regex(JETPACK_TUNNEL_REGEX)) &&
+        return if (url.isJetpackTunnelRequest &&
             !startsWith("{\"data\":")
         ) {
             "{\"data\": $this}"
@@ -122,6 +132,9 @@ internal class EndpointProcessor @Inject constructor(
 
     private val Request.httpMethod
         get() = HttpMethod.valueOf(this.method.uppercase())
+
+    private val HttpUrl.isJetpackTunnelRequest
+        get() = host == WPCOM_HOST && encodedPath.trimEnd('/').matches(Regex(JETPACK_TUNNEL_REGEX))
 
     private data class EndpointData(
         val apiType: ApiType,

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.apifaker
 
+import android.util.Log
 import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.ApiType
 import com.woocommerce.android.apifaker.models.HttpMethod
@@ -27,6 +28,15 @@ internal class EndpointProcessor @Inject constructor(
 
         return with(endpointData) {
             endpointDao.queryEndpoint(apiType, endpointData.httpMethod, path.trimEnd('/'), body.orEmpty())
+        }.also {
+            if (it.size > 1) {
+                Log.w(
+                    LOG_TAG,
+                    "More than one endpoint matched the request: $request, " +
+                        "the endpoints matched are\n$it\n" +
+                        "The first one will be used."
+                )
+            }
         }.firstOrNull {
             request.url.checkQueryParameters(it.request.queryParameters)
         }?.response?.let {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.apifaker
 import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.ApiType
 import com.woocommerce.android.apifaker.models.HttpMethod
+import com.woocommerce.android.apifaker.models.QueryParameter
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.util.JSONObjectProvider
 import okhttp3.HttpUrl
@@ -18,7 +19,6 @@ internal class EndpointProcessor @Inject constructor(
     private val jsonObjectProvider: JSONObjectProvider
 ) {
     fun fakeRequestIfNeeded(request: Request): Response? {
-        // TODO match against method and query parameters too
         val endpointData = when {
             request.url.host == WPCOM_HOST -> request.extractDataFromWPComEndpoint()
             request.url.encodedPath.startsWith("/wp-json") -> request.extractDataFromWPApiEndpoint()
@@ -27,6 +27,8 @@ internal class EndpointProcessor @Inject constructor(
 
         return with(endpointData) {
             endpointDao.queryEndpoint(apiType, endpointData.httpMethod, path.trimEnd('/'), body.orEmpty())
+        }.firstOrNull {
+            request.url.checkQueryParameters(it.request.queryParameters)
         }?.response?.let {
             it.copy(body = it.body?.wrapBodyIfNecessary(request.url))
         }
@@ -85,6 +87,14 @@ internal class EndpointProcessor @Inject constructor(
             path = url.encodedPath,
             body = readBody()
         )
+    }
+
+    private fun HttpUrl.checkQueryParameters(queryParameters: List<QueryParameter>): Boolean {
+        if (queryParameters.isEmpty()) return true
+
+        return queryParameters.all { queryParameter ->
+            queryParameter(queryParameter.name) == queryParameter.value
+        }
     }
 
     private fun Request.readBody(): String {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
@@ -27,7 +27,7 @@ internal class EndpointProcessor @Inject constructor(
         }
 
         return with(endpointData) {
-            endpointDao.queryEndpoint(apiType, endpointData.httpMethod, path.trimEnd('/'), body.orEmpty())
+            endpointDao.queryEndpoint(apiType, httpMethod, path.trimEnd('/'), body.orEmpty())
         }.also {
             if (it.size > 1) {
                 Log.w(

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/EndpointProcessor.kt
@@ -28,6 +28,8 @@ internal class EndpointProcessor @Inject constructor(
 
         return with(endpointData) {
             endpointDao.queryEndpoint(apiType, httpMethod, path.trimEnd('/'), body.orEmpty())
+        }.filter {
+            request.url.checkQueryParameters(it.request.queryParameters)
         }.also {
             if (it.size > 1) {
                 Log.w(
@@ -37,9 +39,7 @@ internal class EndpointProcessor @Inject constructor(
                         "The first one will be used."
                 )
             }
-        }.firstOrNull {
-            request.url.checkQueryParameters(it.request.queryParameters)
-        }?.response?.let {
+        }.firstOrNull()?.response?.let {
             it.copy(body = it.body?.wrapBodyIfNecessary(request.url))
         }
     }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/ApiFakerDatabase.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/ApiFakerDatabase.kt
@@ -13,7 +13,7 @@ import com.woocommerce.android.apifaker.models.Response
         Request::class,
         Response::class
     ],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 @TypeConverters(

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/ApiFakerDatabase.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/ApiFakerDatabase.kt
@@ -16,7 +16,10 @@ import com.woocommerce.android.apifaker.models.Response
     version = 1,
     exportSchema = false
 )
-@TypeConverters(EndpointTypeConverter::class)
+@TypeConverters(
+    EndpointTypeConverter::class,
+    QueryParameterConverter::class
+)
 internal abstract class ApiFakerDatabase : RoomDatabase() {
     companion object {
         fun buildDb(applicationContext: Context) = Room

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/EndpointDao.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/EndpointDao.kt
@@ -31,7 +31,7 @@ internal interface EndpointDao {
         :body LIKE COALESCE(body, '%')
         """
     )
-    fun queryEndpoint(type: ApiType, httpMethod: HttpMethod, path: String, body: String): MockedEndpoint?
+    fun queryEndpoint(type: ApiType, httpMethod: HttpMethod, path: String, body: String): List<MockedEndpoint>
 
     @Transaction
     @Query("Select * FROM Request WHERE id = :id")

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/QueryParameterConverter.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/QueryParameterConverter.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.apifaker.db
+
+import androidx.room.TypeConverter
+import com.woocommerce.android.apifaker.models.QueryParameter
+
+internal class QueryParameterConverter {
+    @TypeConverter
+    fun fromQueryParameters(queryParameters: List<QueryParameter>?): String? {
+        return queryParameters?.joinToString("&") { "${it.name}:${it.value}" }
+    }
+
+    @TypeConverter
+    fun toQueryParameters(query: String?): List<QueryParameter>? {
+        return query?.split("&")?.map { parts ->
+            val (name, value) = parts.split(":")
+            QueryParameter(name, value)
+        }
+    }
+}

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/QueryParameterConverter.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/QueryParameterConverter.kt
@@ -5,15 +5,15 @@ import com.woocommerce.android.apifaker.models.QueryParameter
 
 internal class QueryParameterConverter {
     @TypeConverter
-    fun fromQueryParameters(queryParameters: List<QueryParameter>?): String? {
-        return queryParameters?.joinToString("&") { "${it.name}:${it.value}" }
+    fun fromQueryParameters(queryParameters: List<QueryParameter>): String {
+        return queryParameters.joinToString("&") { "${it.name}:${it.value}" }
     }
 
     @TypeConverter
-    fun toQueryParameters(query: String?): List<QueryParameter>? {
-        return query?.split("&")?.map { parts ->
+    fun toQueryParameters(query: String): List<QueryParameter> {
+        return query.takeIf { it.isNotBlank() }?.split("&")?.map { parts ->
             val (name, value) = parts.split(":")
             QueryParameter(name, value)
-        }
+        } ?: emptyList()
     }
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/QueryParameter.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/QueryParameter.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.apifaker.models
+
+internal data class QueryParameter(
+    val name: String,
+    val value: String
+)

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Request.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Request.kt
@@ -7,7 +7,8 @@ import androidx.room.PrimaryKey
 internal data class Request(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val type: ApiType,
-    val httpMethod: HttpMethod?,
     val path: String,
-    val body: String?
+    val httpMethod: HttpMethod? = null,
+    val queryParameters: List<QueryParameter> = emptyList(),
+    val body: String? = null
 )

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Response.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/models/Response.kt
@@ -17,5 +17,5 @@ import androidx.room.PrimaryKey
 internal data class Response(
     @PrimaryKey val endpointId: Long = 0,
     val statusCode: Int,
-    val body: String?,
+    val body: String? = null
 )

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -4,12 +4,17 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Chip
 import androidx.compose.material.ChipDefaults
@@ -28,6 +33,8 @@ import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -48,6 +55,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.woocommerce.android.apifaker.models.ApiType
 import com.woocommerce.android.apifaker.models.HttpMethod
+import com.woocommerce.android.apifaker.models.QueryParameter
 import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.ui.DropDownMenu
@@ -69,6 +77,8 @@ internal fun EndpointDetailsScreen(
         onApiTypeChanged = viewModel::onApiTypeChanged,
         onRequestHttpMethodChanged = viewModel::onRequestHttpMethodChanged,
         onRequestPathChanged = viewModel::onRequestPathChanged,
+        onQueryParameterAdded = viewModel::onQueryParameterAdded,
+        onQueryParameterDeleted = viewModel::onQueryParameterDeleted,
         onRequestBodyChanged = viewModel::onRequestBodyChanged,
         onResponseStatusCodeChanged = viewModel::onResponseStatusCodeChanged,
         onResponseBodyChanged = viewModel::onResponseBodyChanged,
@@ -83,6 +93,8 @@ private fun EndpointDetailsScreen(
     onApiTypeChanged: (ApiType) -> Unit = {},
     onRequestHttpMethodChanged: (HttpMethod?) -> Unit = {},
     onRequestPathChanged: (String) -> Unit = {},
+    onQueryParameterAdded: (String, String) -> Unit = { _, _ -> },
+    onQueryParameterDeleted: (QueryParameter) -> Unit = {},
     onRequestBodyChanged: (String) -> Unit = {},
     onResponseStatusCodeChanged: (Int) -> Unit = {},
     onResponseBodyChanged: (String) -> Unit = {},
@@ -126,6 +138,8 @@ private fun EndpointDetailsScreen(
                 onApiTypeChanged = onApiTypeChanged,
                 onHttpMethodChanged = onRequestHttpMethodChanged,
                 onPathChanged = onRequestPathChanged,
+                onQueryParameterAdded = onQueryParameterAdded,
+                onQueryParameterDeleted = onQueryParameterDeleted,
                 onBodyChanged = onRequestBodyChanged,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -154,6 +168,8 @@ private fun RequestDefinitionSection(
     onApiTypeChanged: (ApiType) -> Unit,
     onHttpMethodChanged: (HttpMethod?) -> Unit,
     onPathChanged: (String) -> Unit,
+    onQueryParameterAdded: (String, String) -> Unit,
+    onQueryParameterDeleted: (QueryParameter) -> Unit,
     onBodyChanged: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -181,6 +197,13 @@ private fun RequestDefinitionSection(
             path = request.path,
             apiType = request.type,
             onPathChanged = onPathChanged,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        QueryParametersField(
+            queryParameters = request.queryParameters,
+            onQueryParameterAdded = onQueryParameterAdded,
+            onQueryParameterDeleted = onQueryParameterDeleted,
             modifier = Modifier.fillMaxWidth()
         )
 
@@ -303,7 +326,122 @@ private fun PathField(
         }
         Text(
             text = caption,
-            style = MaterialTheme.typography.caption
+            style = MaterialTheme.typography.caption,
+            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+        )
+    }
+}
+
+@Composable
+private fun QueryParametersField(
+    queryParameters: List<QueryParameter>,
+    onQueryParameterAdded: (String, String) -> Unit,
+    onQueryParameterDeleted: (QueryParameter) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    @Composable
+    fun AddDialog(onAdd: (String, String) -> Unit, onDismiss: () -> Unit) {
+        var name by remember { mutableStateOf("") }
+        var value by remember { mutableStateOf("") }
+        Dialog(onDismissRequest = onDismiss) {
+            Column(
+                Modifier
+                    .background(MaterialTheme.colors.surface, MaterialTheme.shapes.medium)
+                    .padding(16.dp)
+            ) {
+                Text(text = "Add Query Parameter (unencoded)")
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    label = { Text(text = "Name") },
+                    value = name,
+                    onValueChange = { name = it },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    label = { Text(text = "Value") },
+                    value = value,
+                    onValueChange = { value = it },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    horizontalArrangement = Arrangement.End,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Button(onClick = onDismiss) {
+                        Text(text = "Cancel")
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Button(onClick = { onAdd(name, value) }) {
+                        Text(text = "Add")
+                    }
+                }
+
+            }
+        }
+    }
+
+    var isAddDialogShown by remember { mutableStateOf(false) }
+
+    Column(modifier) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = "Query Parameters",
+                style = MaterialTheme.typography.subtitle1
+            )
+            IconButton(
+                onClick = { isAddDialogShown = true },
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = "Add query parameter"
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "A request is matched only if it contains all the parameters listed here",
+            style = MaterialTheme.typography.caption,
+            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+        )
+        if (queryParameters.isNotEmpty()) {
+            queryParameters.forEach { queryParameter ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                ) {
+                    Text(
+                        text = "${queryParameter.name} = ${queryParameter.value}",
+                        style = MaterialTheme.typography.caption
+                    )
+                    IconButton(
+                        onClick = { onQueryParameterDeleted(queryParameter) },
+                        modifier = Modifier.size(32.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = "Delete query parameter"
+                        )
+                    }
+                }
+                Divider()
+            }
+        }
+    }
+
+    if (isAddDialogShown) {
+        AddDialog(onAdd = { name, value ->
+            onQueryParameterAdded(name, value)
+            isAddDialogShown = false
+        },
+            onDismiss = { isAddDialogShown = false }
         )
     }
 }
@@ -340,7 +478,8 @@ private fun RequestBodyField(
         }
         Text(
             text = caption,
-            style = MaterialTheme.typography.caption
+            style = MaterialTheme.typography.caption,
+            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
         )
     }
 }
@@ -480,6 +619,10 @@ private fun EndpointDetailsScreenPreview() {
                 request = Request(
                     type = ApiType.Custom("https://example.com"),
                     httpMethod = HttpMethod.GET,
+                    queryParameters = listOf(
+                        QueryParameter("name", "value"),
+                        QueryParameter("name2", "value2")
+                    ),
                     path = "/wc/v3/products",
                     body = null
                 ),

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsScreen.kt
@@ -376,7 +376,6 @@ private fun QueryParametersField(
                         Text(text = "Add")
                     }
                 }
-
             }
         }
     }
@@ -437,10 +436,11 @@ private fun QueryParametersField(
     }
 
     if (isAddDialogShown) {
-        AddDialog(onAdd = { name, value ->
-            onQueryParameterAdded(name, value)
-            isAddDialogShown = false
-        },
+        AddDialog(
+            onAdd = { name, value ->
+                onQueryParameterAdded(name, value)
+                isAddDialogShown = false
+            },
             onDismiss = { isAddDialogShown = false }
         )
     }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.ApiType
 import com.woocommerce.android.apifaker.models.HttpMethod
+import com.woocommerce.android.apifaker.models.QueryParameter
 import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.ui.Screen
@@ -24,7 +25,7 @@ internal class EndpointDetailsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val endpointDao: EndpointDao
 ) : ViewModel() {
-    private val id = savedStateHandle.get<Long>(Screen.EndpointDetails.endpointIdArgumentName)!!
+    private val id = checkNotNull(savedStateHandle.get<Long>(Screen.EndpointDetails.endpointIdArgumentName))
 
     var state: UiState by mutableStateOf(defaultEndpoint())
         private set
@@ -50,6 +51,24 @@ internal class EndpointDetailsViewModel @Inject constructor(
     fun onRequestPathChanged(path: String) {
         withMutableSnapshot {
             state = state.copy(request = state.request.copy(path = path))
+        }
+    }
+
+    fun onQueryParameterAdded(name: String, value: String) {
+        val queryParameter = QueryParameter(name, value)
+        withMutableSnapshot {
+            state = state.copy(
+                request = state.request.copy(
+                    queryParameters = state.request.queryParameters + queryParameter
+                )
+            )
+        }
+    }
+
+    fun onQueryParameterDeleted(queryParameter: QueryParameter) {
+        withMutableSnapshot {
+            state =
+                state.copy(request = state.request.copy(queryParameters = state.request.queryParameters - queryParameter))
         }
     }
 

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ui/details/EndpointDetailsViewModel.kt
@@ -67,8 +67,11 @@ internal class EndpointDetailsViewModel @Inject constructor(
 
     fun onQueryParameterDeleted(queryParameter: QueryParameter) {
         withMutableSnapshot {
-            state =
-                state.copy(request = state.request.copy(queryParameters = state.request.queryParameters - queryParameter))
+            state = state.copy(
+                request = state.request.copy(
+                    queryParameters = state.request.queryParameters - queryParameter
+                )
+            )
         }
     }
 

--- a/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/EndpointProcessorTest.kt
+++ b/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/EndpointProcessorTest.kt
@@ -4,9 +4,10 @@ import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.models.ApiType
 import com.woocommerce.android.apifaker.models.HttpMethod
 import com.woocommerce.android.apifaker.models.MockedEndpoint
+import com.woocommerce.android.apifaker.models.QueryParameter
+import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import com.woocommerce.android.apifaker.util.JSONObjectProvider
-import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
 import org.junit.Test
@@ -14,6 +15,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import okhttp3.Request as OkHttpRequest
 
 class EndpointProcessorTest {
     private val endpointDaoMock = mock<EndpointDao>()
@@ -25,7 +27,7 @@ class EndpointProcessorTest {
 
     @Test
     fun `when processing a GET WPCom endpoint, then extract data correctly`() {
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("GET", null)
             .url("https://public-api.wordpress.com/rest/v1.1/me?param=value")
             .build()
@@ -43,7 +45,7 @@ class EndpointProcessorTest {
     @Test
     fun `when processing a POST WPCom endpoint, then extract data correctly`() {
         val body = "Test Body"
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("POST", body.toRequestBody())
             .url("https://public-api.wordpress.com/rest/v1.1/me?param=value")
             .build()
@@ -60,7 +62,7 @@ class EndpointProcessorTest {
 
     @Test
     fun `when processing a GET Jetpack Tunnel endpoint, then extract data correctly`() {
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("GET", null)
             .url(
                 "https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/161477129/rest-api/" +
@@ -91,7 +93,7 @@ class EndpointProcessorTest {
         }
         whenever(jsonObjectProvider.parseString(body)).thenReturn(jsonObject)
 
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("POST", body.toRequestBody())
             .url("https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/161477129/rest-api")
             .build()
@@ -108,7 +110,7 @@ class EndpointProcessorTest {
 
     @Test
     fun `when processing a GET WPApi endpoint, then extract data correctly`() {
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("GET", null)
             .url("https://test-site.com/wp-json/wc/v3/products?param=value")
             .build()
@@ -126,7 +128,7 @@ class EndpointProcessorTest {
     @Test
     fun `when processing a POST WPApi endpoint, then extract data correctly`() {
         val body = "Test Body"
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("POST", body.toRequestBody())
             .url("https://test-site.com/wp-json/wc/v3/products")
             .build()
@@ -143,7 +145,7 @@ class EndpointProcessorTest {
 
     @Test
     fun `when processing a GET Custom endpoint, then extract data correctly`() {
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("GET", null)
             .url("https://test-site.com/an/endpoint?param=value")
             .build()
@@ -161,7 +163,7 @@ class EndpointProcessorTest {
     @Test
     fun `when processing a POST Custom endpoint, then extract data correctly`() {
         val body = "Test Body"
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method("POST", body.toRequestBody())
             .url("https://test-site.com/an/endpoint")
             .build()
@@ -179,7 +181,7 @@ class EndpointProcessorTest {
     @Test
     fun `when processing a GET jetpack tunnel endpoint, then wrap body if necessary`() {
         val mockEndpoint = MockedEndpoint(
-            request = com.woocommerce.android.apifaker.models.Request(
+            request = Request(
                 id = 0,
                 type = ApiType.WPApi,
                 httpMethod = HttpMethod.GET,
@@ -199,9 +201,9 @@ class EndpointProcessorTest {
                 path = mockEndpoint.request.path,
                 body = mockEndpoint.request.body.orEmpty()
             )
-        ).thenReturn(mockEndpoint)
+        ).thenReturn(listOf(mockEndpoint))
 
-        val request = Request.Builder()
+        val request = OkHttpRequest.Builder()
             .method(mockEndpoint.request.httpMethod.name, null)
             .url(
                 "https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/161477129/rest-api/" +
@@ -211,5 +213,86 @@ class EndpointProcessorTest {
 
         val response = endpointProcessor.fakeRequestIfNeeded(request)
         assert(response?.body == "{\"data\": {\"key\":\"value\"}}")
+    }
+
+    @Test
+    fun `when processing a GET jetpack tunnel endpoint with query parameters, then check query parameters`() {
+        val mockEndpoint = MockedEndpoint(
+            request = Request(
+                id = 0,
+                type = ApiType.WPApi,
+                httpMethod = HttpMethod.GET,
+                path = "/wc/v3/products",
+                queryParameters = listOf(
+                    QueryParameter("param", "value")
+                ),
+                body = null
+            ),
+            response = Response(
+                endpointId = 0,
+                statusCode = 200
+            )
+        )
+        whenever(
+            endpointDaoMock.queryEndpoint(
+                type = mockEndpoint.request.type,
+                httpMethod = mockEndpoint.request.httpMethod!!,
+                path = mockEndpoint.request.path,
+                body = mockEndpoint.request.body.orEmpty()
+            )
+        ).thenReturn(listOf(mockEndpoint))
+        val jsonObject = mock<JSONObject> {
+            on { keys() } doReturn listOf("param").iterator()
+            on { getString("param") } doReturn "value"
+        }
+        whenever(jsonObjectProvider.parseString("{\"param\":\"value\"}")).thenReturn(jsonObject)
+
+        val request = OkHttpRequest.Builder()
+            .method(mockEndpoint.request.httpMethod.name, null)
+            .url(
+                "https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/161477129/rest-api/" +
+                    "?path=${mockEndpoint.request.path}&_method=${mockEndpoint.request.httpMethod.name}" +
+                    "&query={\"param\":\"value\"}"
+            )
+            .build()
+
+        val response = endpointProcessor.fakeRequestIfNeeded(request)
+        assert(response?.statusCode == 200)
+    }
+
+    @Test
+    fun `when processing a regular endpoint with query parameters, then check query parameters`() {
+        val mockEndpoint = MockedEndpoint(
+            request = Request(
+                id = 0,
+                type = ApiType.WPApi,
+                httpMethod = HttpMethod.GET,
+                path = "/wc/v3/products",
+                queryParameters = listOf(
+                    QueryParameter("param", "value")
+                ),
+                body = null
+            ),
+            response = Response(
+                endpointId = 0,
+                statusCode = 200
+            )
+        )
+        whenever(
+            endpointDaoMock.queryEndpoint(
+                type = mockEndpoint.request.type,
+                httpMethod = mockEndpoint.request.httpMethod!!,
+                path = mockEndpoint.request.path,
+                body = mockEndpoint.request.body.orEmpty()
+            )
+        ).thenReturn(listOf(mockEndpoint))
+
+        val request = OkHttpRequest.Builder()
+            .method(mockEndpoint.request.httpMethod.name, null)
+            .url("https://test-site.com/wp-json/wc/v3/products?param=value")
+            .build()
+
+        val response = endpointProcessor.fakeRequestIfNeeded(request)
+        assert(response?.statusCode == 200)
     }
 }


### PR DESCRIPTION
### Description
As part of my Hack Week, I'm bringing back the ApiFaker project paqN3M-SI-p2, and I'm splitting the feature into multiple PRs.

This PR adds a UI bottom banner to the main app when the ApiFaker is enabled, and the banner allows an easy path to disabling the ApiFaker.

I added `unit-tests-exemption` label because the class ApiFakerUiHelper has UI logic and can't be unit tested.
 
### Steps to reproduce
1. Use a debug build.
2. Open the app settings.
3. Tap on Developer Options.
4. Tap on ApiFaker.
5. Add some fake endpoints definitions.
6. Enable the ApiFaker.

### Testing information
- Confirm that when enabled, a bottom banner is shown on all app Activities (Login, MainActivity, Settings)
- Confirm that tapping on the banner shows a dialog that allows disabling the ApiFaker.

### The tests that have been performed
^

### Images/gif
<img src=https://github.com/user-attachments/assets/f280cb93-24ae-4ac6-b342-ddaa05d900d2 width=360/>
<img src=https://github.com/user-attachments/assets/9e85129b-267e-4f5e-8d8a-62aefd6eba8e width=360/>

</br></br>

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->