### PR TITLE
[Product List] Avoid direct binding reference with bangs

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListFragment.kt
@@ -225,7 +225,7 @@ class ProductListFragment :
     }
 
     private fun enableProductsRefresh(enable: Boolean) {
-        binding.productsRefreshLayout.isEnabled = enable
+        _binding?.productsRefreshLayout?.isEnabled = enable
     }
 
     private fun initAddProductFab(fabButton: FloatingActionButton) {


### PR DESCRIPTION
How
==========
Fix issue #13030 by avoiding using the ProductListFragment `binding` reference directly when updating the `productsRefreshLayout` enabled state. 

Why
==========
During the introduction of a fix for the Product trashing logic in https://github.com/woocommerce/woocommerce-android/pull/12834, we added a `pull-to-refresh` control to avoid allowing someone to trigger a Product List refresh while the UI is waiting for a trashing to be confirmed.

However, this introduced a bug: the `pull-to-refresh` state control will be triggered from an async call, and can end up being triggered when the view no longer exists. Since the Product List binding is declared as `binding!!` this introduced an NPE. 

The fix is to simply use the optional `binding?` reference instead, so if the UI doesn't exist anymore, we don't need to bother updating the pull-to-refresh control state since this is not related to any user data retention.

How to Test
==========
There's no clear path to test this, since this is a crash report from Sentry we will have to observe if this fix manages to cover the problem.

Also, since this is a UI binding reference, we can't add an actual unit test as this is not related to any business logic.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on big (tablet) and small (phone) in case of UI changes, and no regressions are added.